### PR TITLE
CWF Partner Onboarding End-to-End Guarded

### DIFF
--- a/admin-partner-onboarding.html
+++ b/admin-partner-onboarding.html
@@ -34,8 +34,11 @@
     .grid2{display:grid;grid-template-columns:1fr 1fr;gap:10px}.grid3{display:grid;grid-template-columns:1fr 1fr 1fr;gap:10px}
     .doc{border:1px solid var(--line);border-radius:8px;padding:10px;background:#fff;margin-top:8px}
     .docTop{display:flex;justify-content:space-between;gap:8px;align-items:flex-start}
+    .miniGrid{display:grid;grid-template-columns:repeat(3,minmax(0,1fr));gap:10px}
+    .miniCard{border:1px solid var(--line);border-radius:8px;padding:10px;background:#fbfdff}
+    .miniCard b{display:block;margin-bottom:4px}.actions{display:flex;gap:8px;flex-wrap:wrap;margin-top:8px}
     .timeline{display:flex;flex-direction:column;gap:8px}.event{border-left:3px solid #bdd2ff;padding:4px 0 4px 10px;font-size:13px}
-    @media(max-width:860px){.toolbar,.list,.grid2,.grid3{grid-template-columns:1fr}.app{padding-top:82px}.hero h1{font-size:22px}}
+    @media(max-width:860px){.toolbar,.list,.grid2,.grid3,.miniGrid{grid-template-columns:1fr}.app{padding-top:82px}.hero h1{font-size:22px}}
   </style>
 </head>
 <body>
@@ -105,6 +108,26 @@
 
       <h3>เอกสาร</h3>
       <div id="documents"></div>
+
+      <h3>Onboarding</h3>
+      <div class="miniGrid" id="onboardingSummary"></div>
+
+      <h3>Certifications</h3>
+      <div class="grid2">
+        <div id="certifications"></div>
+        <div>
+          <label>สร้าง Trial Job สำหรับ Certification</label>
+          <select id="trialCertification"></select>
+          <label style="margin-top:8px">Job ID (ถ้ามี)</label>
+          <input id="trialJobId" placeholder="เว้นว่างได้">
+          <label style="margin-top:8px">หมายเหตุ Trial</label>
+          <textarea id="trialNote"></textarea>
+          <button class="secondary" id="btnCreateTrial" type="button" style="margin-top:8px">อนุมัติ Trial</button>
+        </div>
+      </div>
+
+      <h3>Trial Jobs</h3>
+      <div id="trialJobs"></div>
 
       <h3>Timeline</h3>
       <div class="timeline" id="events"></div>

--- a/admin-partner-onboarding.js
+++ b/admin-partner-onboarding.js
@@ -1,28 +1,31 @@
 (function(){
   const STATUS_LABELS = {
-    draft:'ร่าง',
-    submitted:'ส่งใบสมัครแล้ว',
-    under_review:'กำลังตรวจสอบ',
-    need_more_documents:'ขอเอกสารเพิ่ม',
-    rejected:'ไม่ผ่าน',
-    approved_for_training:'อนุมัติเข้าอบรม',
-    uploaded:'อัปโหลดแล้ว',
-    approved:'อนุมัติ',
-    need_reupload:'ขออัปโหลดใหม่'
+    draft:'ร่าง', submitted:'ส่งใบสมัครแล้ว', under_review:'กำลังตรวจสอบ', need_more_documents:'ขอเอกสารเพิ่ม',
+    rejected:'ไม่ผ่าน', approved_for_training:'อนุมัติเข้าอบรม',
+    uploaded:'อัปโหลดแล้ว', approved:'อนุมัติ', need_reupload:'ขออัปโหลดใหม่',
+    not_started:'ยังไม่เริ่ม', in_training:'กำลังอบรม', exam_ready:'พร้อมสอบ', exam_failed:'สอบไม่ผ่าน',
+    exam_passed:'สอบผ่าน', trial_unlocked:'Trial', suspended:'ระงับ', revoked:'ยกเลิก'
   };
   const DOC_LABELS = {
-    id_card:'บัตรประชาชน',
-    profile_photo:'รูปโปรไฟล์',
-    bank_book:'หน้าสมุดบัญชี',
-    tools_photo:'รูปเครื่องมือ',
-    vehicle_photo:'รูปยานพาหนะ',
-    certificate_or_portfolio:'ใบรับรอง/ผลงาน',
-    other:'เอกสารอื่น'
+    id_card:'บัตรประชาชน', profile_photo:'รูปโปรไฟล์', bank_book:'หน้าสมุดบัญชี', tools_photo:'รูปเครื่องมือ',
+    vehicle_photo:'รูปยานพาหนะ', certificate_or_portfolio:'ใบรับรอง/ผลงาน', other:'เอกสารอื่น'
+  };
+  const CERT_LABELS = {
+    cwf_basic_partner:'Basic Partner', clean_wall_normal:'ล้างผนังปกติ', clean_wall_premium:'ล้างผนังพรีเมียม',
+    clean_wall_hanging_coil:'ล้างแขวนคอยล์', clean_wall_overhaul:'ตัดล้างใหญ่',
+    clean_ceiling_suspended:'ล้างแขวน/เปลือยใต้ฝ้า', clean_cassette_4way:'ล้างแอร์สี่ทิศทาง',
+    clean_duct_type:'ล้างแอร์ท่อลม', repair_diagnosis_basic:'ตรวจเช็กอาการ', repair_water_leak:'แก้น้ำรั่ว',
+    repair_electrical_basic:'งานไฟฟ้าเบื้องต้น', repair_refrigerant_basic:'เติมน้ำยา/ระบบน้ำยา',
+    repair_parts_replacement:'เปลี่ยนอะไหล่', install_wall_standard:'ติดตั้งแอร์ผนัง',
+    install_condo:'ติดตั้งคอนโด', install_relocation:'ย้ายแอร์'
   };
   const DOC_STATUSES = ['uploaded','approved','rejected','need_reupload'];
+  const CERT_STATUSES = ['not_started','in_training','exam_ready','exam_failed','exam_passed','trial_unlocked','approved','suspended','revoked'];
+  const CERT_CODES = Object.keys(CERT_LABELS);
 
   let activeId = null;
   let activeDetail = null;
+  let activeExtra = {};
 
   const $ = (id)=>document.getElementById(id);
   const esc = (s)=>String(s ?? '').replace(/[&<>"']/g, c=>({ '&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;' }[c]));
@@ -36,6 +39,10 @@
     const data = await res.json().catch(()=>null);
     if (!res.ok) throw new Error(data?.error || 'Request failed');
     return data;
+  }
+
+  function kv(label, value){
+    return `<div style="margin:0 0 8px"><div class="muted">${esc(label)}</div><b>${esc(value || '-')}</b></div>`;
   }
 
   function renderList(rows){
@@ -73,10 +80,6 @@
     renderList(data.applications || []);
   }
 
-  function kv(label, value){
-    return `<div style="margin:0 0 8px"><div class="muted">${esc(label)}</div><b>${esc(value || '-')}</b></div>`;
-  }
-
   function renderDetail(data){
     activeDetail = data;
     const a = data.application;
@@ -98,7 +101,9 @@
     `;
     renderDocuments(data.documents || []);
     renderEvents(data.events || []);
+    renderExtraPlaceholders();
     $('detailDrawer').classList.add('open');
+    loadExtra(a.id);
   }
 
   function renderDocuments(docs){
@@ -118,20 +123,116 @@
             <div><label>สถานะเอกสาร</label><select data-doc-status>${options}</select></div>
             <div style="grid-column:span 2"><label>หมายเหตุ</label><input data-doc-note value="${esc(d.admin_note || '')}"></div>
           </div>
-          <div style="margin-top:8px"><button class="ghost" type="button" data-save-doc="${esc(d.id)}">บันทึกเอกสาร</button></div>
-        </div>`;
+          <button class="ghost" data-save-doc type="button" style="margin-top:8px">บันทึกเอกสาร</button>
+        </div>
+      `;
     }).join('') : '<div class="muted">ยังไม่มีเอกสาร</div>';
   }
 
   function renderEvents(events){
     $('events').innerHTML = events.length ? events.map(e=>`
       <div class="event">
-        <b>${esc(e.event_type)}</b>
-        <div class="muted">${fmtDate(e.created_at)} • ${esc(e.actor_username || e.actor_type || '-')}</div>
-        <div>${e.from_status ? `${esc(STATUS_LABELS[e.from_status] || e.from_status)} -> ` : ''}${e.to_status ? esc(STATUS_LABELS[e.to_status] || e.to_status) : ''}</div>
-        ${e.note ? `<div>${esc(e.note)}</div>` : ''}
+        <b>${esc(e.event_type)}</b> ${e.from_status || e.to_status ? `<span class="muted">${esc(e.from_status || '-')} → ${esc(e.to_status || '-')}</span>` : ''}
+        <div>${esc(e.note || '')}</div>
+        <div class="muted">${esc(e.actor_type || '-')} ${esc(e.actor_username || '')} • ${fmtDate(e.created_at)}</div>
       </div>
     `).join('') : '<div class="muted">ยังไม่มี timeline</div>';
+  }
+
+  function renderExtraPlaceholders(){
+    $('onboardingSummary').innerHTML = '<div class="muted">กำลังโหลดข้อมูล onboarding...</div>';
+    $('certifications').innerHTML = '<div class="muted">กำลังโหลด certifications...</div>';
+    $('trialJobs').innerHTML = '<div class="muted">กำลังโหลด trial jobs...</div>';
+  }
+
+  async function loadExtra(id){
+    try {
+      const [agreement, academy, exams, certifications, trials] = await Promise.all([
+        api(`/admin/partners/applications/${id}/agreement`),
+        api(`/admin/partners/applications/${id}/academy`),
+        api(`/admin/partners/applications/${id}/exams`),
+        api(`/admin/partners/applications/${id}/certifications`),
+        api(`/admin/partners/applications/${id}/trial-jobs`)
+      ]);
+      activeExtra = { agreement, academy, exams, certifications, trials };
+      renderOnboardingSummary();
+      renderCertifications(certifications.certifications || []);
+      renderTrials(trials.trial_jobs || []);
+    } catch (e) {
+      $('onboardingSummary').innerHTML = `<div class="muted">${esc(e.message)}</div>`;
+    }
+  }
+
+  function renderOnboardingSummary(){
+    const sigs = activeExtra.agreement?.signatures || [];
+    const lessons = activeExtra.academy?.lessons || [];
+    const attempts = activeExtra.exams?.attempts || [];
+    const trials = activeExtra.trials?.trial_jobs || [];
+    const doneLessons = lessons.filter(l=>l.completed).length;
+    const bestExam = attempts[0];
+    $('onboardingSummary').innerHTML = `
+      <div class="miniCard"><b>Agreement</b>${sigs.length ? badge('approved') : badge('not_started')}<div class="muted">${sigs[0] ? fmtDate(sigs[0].signed_at) : 'ยังไม่เซ็น'}</div></div>
+      <div class="miniCard"><b>Academy</b><span class="badge">${doneLessons}/${lessons.length || 0}</span><div class="muted">บทเรียนที่ทำแล้ว</div></div>
+      <div class="miniCard"><b>Exam</b>${bestExam ? badge(bestExam.passed ? 'exam_passed' : 'exam_failed') : badge('not_started')}<div class="muted">${bestExam ? `${Number(bestExam.score_percent)}% • ${fmtDate(bestExam.submitted_at)}` : 'ยังไม่สอบ'}</div></div>
+      <div class="miniCard"><b>Trial</b><span class="badge">${trials.length}</span><div class="muted">งานทดลอง</div></div>
+    `;
+  }
+
+  function certStatus(code, rows){
+    return rows.find(r=>r.certification_code === code) || { certification_code: code, status: 'not_started' };
+  }
+
+  function renderCertifications(rows){
+    $('trialCertification').innerHTML = CERT_CODES.map(code=>`<option value="${esc(code)}">${esc(CERT_LABELS[code])}</option>`).join('');
+    $('certifications').innerHTML = CERT_CODES.map(code=>{
+      const row = certStatus(code, rows);
+      const options = CERT_STATUSES.map(s=>`<option value="${s}" ${row.status === s ? 'selected' : ''}>${esc(STATUS_LABELS[s] || s)}</option>`).join('');
+      return `
+        <div class="doc" data-cert-code="${esc(code)}">
+          <div class="docTop">
+            <div><b>${esc(CERT_LABELS[code])}</b><div class="muted">${esc(code)}</div></div>
+            ${badge(row.status)}
+          </div>
+          <div class="grid2" style="margin-top:8px">
+            <div><label>สถานะ</label><select data-cert-status>${options}</select></div>
+            <div><label>หมายเหตุ</label><input data-cert-note value="${esc(row.admin_note || '')}"></div>
+          </div>
+          <div class="actions">
+            <button class="ghost" data-quick-cert="in_training" type="button">approve training</button>
+            <button class="ghost" data-quick-cert="trial_unlocked" type="button">unlock trial</button>
+            <button class="primary" data-quick-cert="approved" type="button">approve full</button>
+            <button class="ghost" data-quick-cert="exam_ready" type="button">require retake</button>
+            <button class="ghost" data-quick-cert="suspended" type="button">suspend</button>
+            <button class="ghost" data-quick-cert="revoked" type="button">revoke</button>
+          </div>
+        </div>
+      `;
+    }).join('');
+  }
+
+  function renderTrials(rows){
+    $('trialJobs').innerHTML = rows.length ? rows.map(t=>`
+      <div class="doc" data-trial-id="${esc(t.id)}">
+        <div class="docTop">
+          <div>
+            <b>${esc(CERT_LABELS[t.certification_code] || t.certification_code)}</b>
+            <div class="muted">Trial #${esc(t.id)} • ${fmtDate(t.created_at)} ${t.job_id ? `• Job ${esc(t.job_id)}` : ''}</div>
+          </div>
+          ${badge(t.status || 'trial_unlocked')}
+        </div>
+        <div class="grid3" style="margin-top:8px">
+          <div><label>ตรงเวลา</label><input type="number" min="0" max="5" data-eval="punctuality_score"></div>
+          <div><label>เครื่องแบบ</label><input type="number" min="0" max="5" data-eval="uniform_score"></div>
+          <div><label>สื่อสาร</label><input type="number" min="0" max="5" data-eval="communication_score"></div>
+          <div><label>รูปถ่าย</label><input type="number" min="0" max="5" data-eval="photo_quality_score"></div>
+          <div><label>คุณภาพงาน</label><input type="number" min="0" max="5" data-eval="job_quality_score"></div>
+          <div><label>ผล</label><select data-eval="result"><option value="passed">passed</option><option value="failed">failed</option><option value="needs_more_trial">needs_more_trial</option></select></div>
+        </div>
+        <label style="margin-top:8px">ปัญหาลูกค้า</label><input data-eval="customer_issue">
+        <label style="margin-top:8px">หมายเหตุ</label><input data-eval="admin_note">
+        <button class="secondary" data-save-eval type="button" style="margin-top:8px">บันทึกประเมิน</button>
+      </div>
+    `).join('') : '<div class="muted">ยังไม่มี trial job</div>';
   }
 
   async function openDetail(id){
@@ -141,43 +242,80 @@
 
   async function saveApplicationStatus(){
     if (!activeId) return;
-    const status = $('applicationStatus').value;
-    const admin_note = $('applicationNote').value.trim();
-    await api(`/admin/partners/applications/${encodeURIComponent(activeId)}/status`, {
+    const data = await api(`/admin/partners/applications/${activeId}/status`, {
       method:'PUT',
-      body:JSON.stringify({ status, admin_note })
+      body: JSON.stringify({ status:$('applicationStatus').value, admin_note:$('applicationNote').value.trim() })
     });
-    await openDetail(activeId);
+    await openDetail(data.application.id);
     await loadList();
   }
 
-  async function saveDocumentStatus(documentId){
-    if (!activeId) return;
-    const card = document.querySelector(`.doc[data-doc-id="${CSS.escape(String(documentId))}"]`);
-    const status = card?.querySelector('[data-doc-status]')?.value || '';
-    const admin_note = card?.querySelector('[data-doc-note]')?.value || '';
-    await api(`/admin/partners/applications/${encodeURIComponent(activeId)}/documents/${encodeURIComponent(documentId)}/status`, {
+  async function saveDocument(card){
+    const docId = card.dataset.docId;
+    await api(`/admin/partners/applications/${activeId}/documents/${docId}/status`, {
       method:'PUT',
-      body:JSON.stringify({ status, admin_note })
+      body: JSON.stringify({ status:card.querySelector('[data-doc-status]').value, admin_note:card.querySelector('[data-doc-note]').value.trim() })
     });
     await openDetail(activeId);
-    await loadList();
   }
 
-  $('btnReload').addEventListener('click', ()=>loadList().catch(err=>alert(err.message)));
-  $('statusFilter').addEventListener('change', ()=>loadList().catch(err=>alert(err.message)));
-  $('searchInput').addEventListener('keydown', (e)=>{ if(e.key === 'Enter') loadList().catch(err=>alert(err.message)); });
-  $('applicationList').addEventListener('click', (e)=>{
+  async function updateCertification(card, statusOverride){
+    const code = card.dataset.certCode;
+    const status = statusOverride || card.querySelector('[data-cert-status]').value;
+    const noteEl = card.querySelector('[data-cert-note]');
+    await api(`/admin/partners/applications/${activeId}/certifications/${encodeURIComponent(code)}/status`, {
+      method:'PUT',
+      body: JSON.stringify({ status, admin_note: noteEl ? noteEl.value.trim() : '' })
+    });
+    await loadExtra(activeId);
+  }
+
+  async function createTrial(){
+    const certification_code = $('trialCertification').value;
+    await api(`/admin/partners/applications/${activeId}/trial-jobs`, {
+      method:'POST',
+      body: JSON.stringify({ certification_code, job_id:$('trialJobId').value.trim() || null, admin_note:$('trialNote').value.trim() })
+    });
+    $('trialJobId').value = '';
+    $('trialNote').value = '';
+    await loadExtra(activeId);
+  }
+
+  async function saveEvaluation(card){
+    const payload = {};
+    card.querySelectorAll('[data-eval]').forEach(el => {
+      const key = el.dataset.eval;
+      payload[key] = key.endsWith('_score') ? Number(el.value || 0) : el.value;
+    });
+    await api(`/admin/partners/trial-jobs/${card.dataset.trialId}/evaluate`, { method:'POST', body:JSON.stringify(payload) });
+    await loadExtra(activeId);
+  }
+
+  $('btnReload').addEventListener('click', loadList);
+  $('statusFilter').addEventListener('change', loadList);
+  $('searchInput').addEventListener('keydown', e=>{ if(e.key === 'Enter') loadList(); });
+  $('applicationList').addEventListener('click', e=>{
     const item = e.target.closest('[data-id]');
-    if (item) openDetail(item.getAttribute('data-id')).catch(err=>alert(err.message));
+    if (item) openDetail(item.dataset.id).catch(err=>alert(err.message));
   });
   $('btnClose').addEventListener('click', ()=>$('detailDrawer').classList.remove('open'));
-  $('detailDrawer').addEventListener('click', (e)=>{ if(e.target.id === 'detailDrawer') $('detailDrawer').classList.remove('open'); });
-  $('btnSaveStatus').addEventListener('click', ()=>saveApplicationStatus().catch(err=>alert(err.message)));
-  $('documents').addEventListener('click', (e)=>{
+  $('btnSaveStatus').addEventListener('click', () => saveApplicationStatus().catch(err=>alert(err.message)));
+  $('documents').addEventListener('click', e=>{
     const btn = e.target.closest('[data-save-doc]');
-    if (btn) saveDocumentStatus(btn.getAttribute('data-save-doc')).catch(err=>alert(err.message));
+    if (btn) saveDocument(btn.closest('[data-doc-id]')).catch(err=>alert(err.message));
+  });
+  $('certifications').addEventListener('click', e=>{
+    const quick = e.target.closest('[data-quick-cert]');
+    if (quick) updateCertification(quick.closest('[data-cert-code]'), quick.dataset.quickCert).catch(err=>alert(err.message));
+  });
+  $('certifications').addEventListener('change', e=>{
+    if (e.target.matches('[data-cert-status]')) updateCertification(e.target.closest('[data-cert-code]')).catch(err=>alert(err.message));
+  });
+  $('btnCreateTrial').addEventListener('click', () => createTrial().catch(err=>alert(err.message)));
+  $('trialJobs').addEventListener('click', e=>{
+    const btn = e.target.closest('[data-save-eval]');
+    if (btn) saveEvaluation(btn.closest('[data-trial-id]')).catch(err=>alert(err.message));
   });
 
-  loadList().catch(err=>alert(err.message));
+  loadList().catch(err=>{ $('applicationList').innerHTML = `<div class="muted">${esc(err.message)}</div>`; });
 })();

--- a/index.js
+++ b/index.js
@@ -1036,6 +1036,60 @@ const PARTNER_DOCUMENT_STATUSES = new Set([
   'need_reupload',
 ]);
 
+const PARTNER_CERTIFICATION_CODES = [
+  'cwf_basic_partner',
+  'clean_wall_normal',
+  'clean_wall_premium',
+  'clean_wall_hanging_coil',
+  'clean_wall_overhaul',
+  'clean_ceiling_suspended',
+  'clean_cassette_4way',
+  'clean_duct_type',
+  'repair_diagnosis_basic',
+  'repair_water_leak',
+  'repair_electrical_basic',
+  'repair_refrigerant_basic',
+  'repair_parts_replacement',
+  'install_wall_standard',
+  'install_condo',
+  'install_relocation',
+];
+
+const PARTNER_CERTIFICATION_STATUSES = new Set([
+  'not_started',
+  'in_training',
+  'exam_ready',
+  'exam_failed',
+  'exam_passed',
+  'trial_unlocked',
+  'approved',
+  'suspended',
+  'revoked',
+]);
+
+const PARTNER_TRIAL_RESULTS = new Set(['passed', 'failed', 'needs_more_trial']);
+
+const BASIC_PARTNER_LESSONS = [
+  'มาตรฐานแบรนด์ CWF',
+  'การแต่งกายและมารยาทหน้างาน',
+  'การสื่อสารกับลูกค้า',
+  'การเช็กอิน',
+  'การถ่ายรูปก่อนและหลังงาน',
+  'ห้ามเปลี่ยนราคาเอง',
+  'ห้ามรับเงินนอกระบบ',
+  'วิธีปิดงาน',
+  'ความรับผิดชอบงานรับประกัน',
+  'กติกางานทดลอง',
+];
+
+const BASIC_PARTNER_EXAM_QUESTIONS = [
+  { q: 'เมื่อถึงหน้างานควรทำอะไรเป็นอันดับแรก', choices: ['เช็กอินและทักทายลูกค้า', 'เริ่มงานทันทีโดยไม่แจ้ง', 'ขอเงินก่อนเริ่มงาน'], answer: 0 },
+  { q: 'หากต้องเปลี่ยนราคา ควรทำอย่างไร', choices: ['แจ้งแอดมินเพื่ออนุมัติก่อน', 'ตกลงกับลูกค้าเอง', 'เก็บเงินสดเพิ่มทันที'], answer: 0 },
+  { q: 'รูปก่อนและหลังงานมีไว้เพื่ออะไร', choices: ['เป็นหลักฐานคุณภาพงาน', 'ใช้แทนการปิดงานได้ทั้งหมด', 'ไม่จำเป็นต้องถ่าย'], answer: 0 },
+  { q: 'การรับเงินนอกระบบ CWF ทำได้หรือไม่', choices: ['ไม่ได้', 'ได้ถ้าลูกค้าสะดวก', 'ได้เฉพาะงานด่วน'], answer: 0 },
+  { q: 'งานทดลองผ่านแล้วจะรับงานจริงได้ทันทีหรือไม่', choices: ['ต้องรอแอดมินอนุมัติสิทธิ์', 'ได้ทันทีทุกประเภท', 'ได้เฉพาะถ้าไม่มีเอกสาร'], answer: 0 },
+];
+
 function normalizeJsonArrayInput(value) {
   if (Array.isArray(value)) return value.map(v => String(v || '').trim()).filter(Boolean);
   const raw = String(value || '').trim();
@@ -1201,6 +1255,81 @@ function partnerApplicationPublicShape(row, docs = [], events = []) {
     documents: docs,
     events,
   };
+}
+
+function getPartnerOnboardingEnabled() {
+  return envBool('PARTNER_ONBOARDING_ENABLED', true);
+}
+
+function getCertificationEnforcementMode() {
+  const mode = String(process.env.CERTIFICATION_ENFORCEMENT || 'off').trim().toLowerCase();
+  return ['off', 'partner_soft', 'partner_strict', 'all_strict'].includes(mode) ? mode : 'off';
+}
+
+function getRequiredCertificationCodesForJob(payload = {}) {
+  const jobType = String(payload.job_type || payload.jobType || '').trim();
+  const acType = String(payload.ac_type || payload.acType || payload.air_type || '').trim();
+  const washVariant = String(payload.wash_variant || payload.washVariant || '').trim();
+  const repairVariant = String(payload.repair_variant || payload.repairVariant || '').trim();
+  const installVariant = String(payload.install_variant || payload.installVariant || '').trim();
+  const out = new Set();
+
+  if (jobType === 'ล้าง') {
+    if (acType.includes('สี่ทิศ')) out.add('clean_cassette_4way');
+    else if (acType.includes('ท่อลม')) out.add('clean_duct_type');
+    else if (acType.includes('แขวน') || acType.includes('ใต้ฝ้า') || acType.includes('เปลือย')) out.add('clean_ceiling_suspended');
+    else if (washVariant.includes('พรีเมียม')) out.add('clean_wall_premium');
+    else if (washVariant.includes('แขวนคอย')) out.add('clean_wall_hanging_coil');
+    else if (washVariant.includes('ตัดล้าง') || washVariant.includes('ใหญ่')) out.add('clean_wall_overhaul');
+    else out.add('clean_wall_normal');
+  }
+  if (jobType === 'ซ่อม') {
+    if (repairVariant.includes('น้ำรั่ว')) out.add('repair_water_leak');
+    else if (repairVariant.includes('ไฟ')) out.add('repair_electrical_basic');
+    else if (repairVariant.includes('น้ำยา')) out.add('repair_refrigerant_basic');
+    else if (repairVariant.includes('อะไหล่')) out.add('repair_parts_replacement');
+    else out.add('repair_diagnosis_basic');
+  }
+  if (jobType === 'ติดตั้ง') {
+    out.add('install_wall_standard');
+    if (installVariant.includes('คอนโด') || acType.includes('คอนโด')) out.add('install_condo');
+  }
+  if (jobType === 'ย้าย') out.add('install_relocation');
+  return Array.from(out);
+}
+
+async function technicianHasRequiredCertifications(username, requiredCodes = [], opts = {}) {
+  const codes = (requiredCodes || []).filter(Boolean);
+  if (!codes.length) return { ok: true, missing: [], blocked: [] };
+  const r = await pool.query(
+    `SELECT certification_code, status
+     FROM public.technician_certifications
+     WHERE technician_username=$1 AND certification_code = ANY($2::text[])`,
+    [username, codes]
+  );
+  const statusMap = new Map((r.rows || []).map(x => [String(x.certification_code), String(x.status || '')]));
+  const missing = codes.filter(code => statusMap.get(code) !== 'approved');
+  const blocked = codes.filter(code => ['suspended', 'revoked'].includes(statusMap.get(code)));
+  return { ok: missing.length === 0 && blocked.length === 0, missing, blocked, statuses: Object.fromEntries(statusMap) };
+}
+
+function explainCertificationBlockReason({ mode, username, required = [], missing = [], blocked = [] } = {}) {
+  if (!missing.length && !blocked.length) return '';
+  return `CERTIFICATION_BLOCK mode=${mode || 'off'} tech=${username || '-'} required=${required.join(',')} missing=${missing.join(',')} blocked=${blocked.join(',')}`;
+}
+
+async function getPartnerApplicationByCode(applicationCode, client = pool) {
+  const code = sanitizePartnerApplicationCode(applicationCode);
+  if (!code) return null;
+  const r = await client.query(`SELECT * FROM public.partner_applications WHERE application_code=$1 LIMIT 1`, [code]);
+  return r.rows[0] || null;
+}
+
+async function getPartnerApplicationById(id, client = pool) {
+  const n = Number(id);
+  if (!Number.isFinite(n) || n <= 0) return null;
+  const r = await client.query(`SELECT * FROM public.partner_applications WHERE id=$1 LIMIT 1`, [n]);
+  return r.rows[0] || null;
 }
 
 // =======================================
@@ -1536,6 +1665,440 @@ app.put('/admin/partners/applications/:id/documents/:document_id/status', requir
     await client.query('ROLLBACK');
     console.error('PUT partner document status error:', e);
     return res.status(500).json({ error: 'อัปเดตสถานะเอกสารไม่สำเร็จ' });
+  } finally {
+    client.release();
+  }
+});
+
+// =======================================
+// Partner Agreement / Academy / Exam / Certification / Trial
+// Enforcement helpers are available above, but job-blocking remains OFF by default.
+// =======================================
+app.get('/partner/agreement/:application_code', async (req, res) => {
+  try {
+    const appRow = await getPartnerApplicationByCode(req.params.application_code);
+    if (!appRow) return res.status(404).json({ error: 'ไม่พบใบสมัคร' });
+    const tpl = await pool.query(
+      `SELECT * FROM public.agreement_templates WHERE template_code='partner_standard' AND is_active=TRUE ORDER BY version DESC LIMIT 1`
+    );
+    const sig = await pool.query(
+      `SELECT id, template_id, template_version, signer_full_name, signed_at
+       FROM public.agreement_signatures
+       WHERE application_id=$1
+       ORDER BY signed_at DESC LIMIT 1`,
+      [appRow.id]
+    );
+    return res.json({ ok: true, application: partnerApplicationPublicShape(appRow), template: tpl.rows[0] || null, signature: sig.rows[0] || null });
+  } catch (e) {
+    console.error('GET partner agreement error:', e);
+    return res.status(500).json({ error: 'โหลดสัญญาไม่สำเร็จ' });
+  }
+});
+
+app.post('/partner/agreement/:application_code/sign', async (req, res) => {
+  const applicationCode = sanitizePartnerApplicationCode(req.params.application_code);
+  const signer = String(req.body?.signer_full_name || '').trim();
+  const consent = req.body?.consent === true || req.body?.consent === 'true' || req.body?.consent === 1 || req.body?.consent === '1';
+  if (!signer) return res.status(400).json({ error: 'กรุณาพิมพ์ชื่อ-นามสกุลเพื่อเซ็นสัญญา' });
+  if (!consent) return res.status(400).json({ error: 'กรุณายืนยันการยอมรับสัญญา' });
+  const client = await pool.connect();
+  try {
+    await client.query('BEGIN');
+    const appR = await client.query(`SELECT * FROM public.partner_applications WHERE application_code=$1 FOR UPDATE`, [applicationCode]);
+    if (!appR.rows.length) {
+      await client.query('ROLLBACK');
+      return res.status(404).json({ error: 'ไม่พบใบสมัคร' });
+    }
+    const tplR = await client.query(
+      `SELECT * FROM public.agreement_templates WHERE template_code='partner_standard' AND is_active=TRUE ORDER BY version DESC LIMIT 1`
+    );
+    if (!tplR.rows.length) throw new Error('ไม่พบ template สัญญาที่เปิดใช้งาน');
+    const tpl = tplR.rows[0];
+    const sig = await client.query(
+      `INSERT INTO public.agreement_signatures
+        (application_id, template_id, template_version, signer_full_name, consent_terms, signed_ip, signed_user_agent, signed_at)
+       VALUES ($1,$2,$3,$4,TRUE,$5,$6,NOW())
+       RETURNING id, template_id, template_version, signer_full_name, signed_at`,
+      [appR.rows[0].id, tpl.id, tpl.version, signer, req.ip || null, String(req.headers['user-agent'] || '').slice(0, 500)]
+    );
+    await logPartnerOnboardingEvent(client, {
+      application_id: appR.rows[0].id,
+      actor_type: 'applicant',
+      event_type: 'agreement_signed',
+      note: `version ${tpl.version}`,
+      metadata: { signature_id: sig.rows[0].id, template_code: tpl.template_code },
+    });
+    await client.query('COMMIT');
+    return res.json({ ok: true, signature: sig.rows[0] });
+  } catch (e) {
+    await client.query('ROLLBACK');
+    console.error('POST partner agreement sign error:', e);
+    return res.status(500).json({ error: e.message || 'เซ็นสัญญาไม่สำเร็จ' });
+  } finally {
+    client.release();
+  }
+});
+
+app.get('/partner/academy/:application_code', async (req, res) => {
+  try {
+    const appRow = await getPartnerApplicationByCode(req.params.application_code);
+    if (!appRow) return res.status(404).json({ error: 'ไม่พบใบสมัคร' });
+    const courseR = await pool.query(`SELECT * FROM public.academy_courses WHERE course_code='cwf_basic_partner' LIMIT 1`);
+    const course = courseR.rows[0] || null;
+    const lessonsR = course
+      ? await pool.query(
+          `SELECT l.*, COALESCE(p.completed,FALSE) AS completed, p.completed_at
+           FROM public.academy_lessons l
+           LEFT JOIN public.academy_progress p ON p.lesson_id=l.id AND p.application_id=$2
+           WHERE l.course_id=$1 AND l.is_active=TRUE
+           ORDER BY l.sort_order ASC, l.id ASC`,
+          [course.id, appRow.id]
+        )
+      : { rows: [] };
+    return res.json({ ok: true, application: partnerApplicationPublicShape(appRow), course, lessons: lessonsR.rows });
+  } catch (e) {
+    console.error('GET partner academy error:', e);
+    return res.status(500).json({ error: 'โหลด Academy ไม่สำเร็จ' });
+  }
+});
+
+app.post('/partner/academy/:application_code/lessons/:lesson_id/complete', async (req, res) => {
+  const client = await pool.connect();
+  try {
+    await client.query('BEGIN');
+    const appRow = await getPartnerApplicationByCode(req.params.application_code, client);
+    if (!appRow) {
+      await client.query('ROLLBACK');
+      return res.status(404).json({ error: 'ไม่พบใบสมัคร' });
+    }
+    const lessonId = Number(req.params.lesson_id);
+    if (!Number.isFinite(lessonId) || lessonId <= 0) {
+      await client.query('ROLLBACK');
+      return res.status(400).json({ error: 'lesson_id ไม่ถูกต้อง' });
+    }
+    const lessonR = await client.query(`SELECT id, course_id, lesson_title FROM public.academy_lessons WHERE id=$1 AND is_active=TRUE LIMIT 1`, [lessonId]);
+    if (!lessonR.rows.length) throw new Error('ไม่พบบทเรียน');
+    const saved = await client.query(
+      `INSERT INTO public.academy_progress(application_id, course_id, lesson_id, completed, completed_at, updated_at)
+       VALUES($1,$2,$3,TRUE,NOW(),NOW())
+       ON CONFLICT(application_id, lesson_id) DO UPDATE SET completed=TRUE, completed_at=COALESCE(public.academy_progress.completed_at,NOW()), updated_at=NOW()
+       RETURNING *`,
+      [appRow.id, lessonR.rows[0].course_id, lessonId]
+    );
+    await logPartnerOnboardingEvent(client, {
+      application_id: appRow.id,
+      actor_type: 'applicant',
+      event_type: 'academy_lesson_completed',
+      note: lessonR.rows[0].lesson_title,
+      metadata: { lesson_id: lessonId },
+    });
+    await client.query('COMMIT');
+    return res.json({ ok: true, progress: saved.rows[0] });
+  } catch (e) {
+    await client.query('ROLLBACK');
+    console.error('POST lesson complete error:', e);
+    return res.status(500).json({ error: e.message || 'บันทึกบทเรียนไม่สำเร็จ' });
+  } finally {
+    client.release();
+  }
+});
+
+app.get('/partner/academy/:application_code/exam', async (req, res) => {
+  try {
+    const appRow = await getPartnerApplicationByCode(req.params.application_code);
+    if (!appRow) return res.status(404).json({ error: 'ไม่พบใบสมัคร' });
+    const examR = await pool.query(
+      `SELECT e.* FROM public.academy_exams e JOIN public.academy_courses c ON c.id=e.course_id WHERE c.course_code='cwf_basic_partner' AND e.is_active=TRUE ORDER BY e.id DESC LIMIT 1`
+    );
+    if (!examR.rows.length) return res.status(404).json({ error: 'ไม่พบข้อสอบ' });
+    const qR = await pool.query(
+      `SELECT id, question_text, choices_json, sort_order FROM public.academy_exam_questions WHERE exam_id=$1 ORDER BY sort_order ASC, id ASC`,
+      [examR.rows[0].id]
+    );
+    return res.json({ ok: true, exam: examR.rows[0], questions: qR.rows.map(q => ({ id: q.id, question_text: q.question_text, choices_json: q.choices_json, sort_order: q.sort_order })) });
+  } catch (e) {
+    console.error('GET partner exam error:', e);
+    return res.status(500).json({ error: 'โหลดข้อสอบไม่สำเร็จ' });
+  }
+});
+
+app.post('/partner/academy/:application_code/exam/submit', async (req, res) => {
+  const answers = (req.body && typeof req.body.answers === 'object' && !Array.isArray(req.body.answers)) ? req.body.answers : {};
+  const client = await pool.connect();
+  try {
+    await client.query('BEGIN');
+    const appRow = await getPartnerApplicationByCode(req.params.application_code, client);
+    if (!appRow) {
+      await client.query('ROLLBACK');
+      return res.status(404).json({ error: 'ไม่พบใบสมัคร' });
+    }
+    const examR = await client.query(
+      `SELECT e.* FROM public.academy_exams e JOIN public.academy_courses c ON c.id=e.course_id WHERE c.course_code='cwf_basic_partner' AND e.is_active=TRUE ORDER BY e.id DESC LIMIT 1`
+    );
+    if (!examR.rows.length) throw new Error('ไม่พบข้อสอบ');
+    const questions = await client.query(`SELECT id, correct_choice_index FROM public.academy_exam_questions WHERE exam_id=$1`, [examR.rows[0].id]);
+    const total = questions.rows.length;
+    const correct = questions.rows.reduce((sum, q) => sum + (Number(answers[String(q.id)]) === Number(q.correct_choice_index) ? 1 : 0), 0);
+    const score = total ? Math.round((correct / total) * 10000) / 100 : 0;
+    const passed = score >= Number(examR.rows[0].passing_score_percent || 80);
+    const saved = await client.query(
+      `INSERT INTO public.academy_exam_attempts(application_id, exam_id, answers_json, score_percent, passed, submitted_at)
+       VALUES($1,$2,$3::jsonb,$4,$5,NOW())
+       RETURNING *`,
+      [appRow.id, examR.rows[0].id, JSON.stringify(answers), score, passed]
+    );
+    await client.query(
+      `INSERT INTO public.technician_certifications(application_id, technician_username, certification_code, status, updated_by, updated_at)
+       VALUES($1,$2,'cwf_basic_partner',$3,'exam',NOW())
+       ON CONFLICT(application_id, certification_code) DO UPDATE SET status=EXCLUDED.status, updated_by='exam', updated_at=NOW()`,
+      [appRow.id, appRow.technician_username || null, passed ? 'exam_passed' : 'exam_failed']
+    );
+    await logPartnerOnboardingEvent(client, {
+      application_id: appRow.id,
+      actor_type: 'applicant',
+      event_type: 'exam_submitted',
+      note: `${score}% ${passed ? 'passed' : 'failed'}`,
+      metadata: { attempt_id: saved.rows[0].id, passed, score },
+    });
+    await client.query('COMMIT');
+    return res.json({ ok: true, attempt: saved.rows[0], passed });
+  } catch (e) {
+    await client.query('ROLLBACK');
+    console.error('POST exam submit error:', e);
+    return res.status(500).json({ error: e.message || 'ส่งข้อสอบไม่สำเร็จ' });
+  } finally {
+    client.release();
+  }
+});
+
+app.get('/admin/partners/applications/:id/agreement', requireAdminSession, async (req, res) => {
+  try {
+    const appRow = await getPartnerApplicationById(req.params.id);
+    if (!appRow) return res.status(404).json({ error: 'ไม่พบใบสมัคร' });
+    const sig = await pool.query(
+      `SELECT s.id, s.template_version, s.signer_full_name, s.signed_ip, s.signed_user_agent, s.signed_at, t.template_code, t.title
+       FROM public.agreement_signatures s
+       JOIN public.agreement_templates t ON t.id=s.template_id
+       WHERE s.application_id=$1
+       ORDER BY s.signed_at DESC`,
+      [appRow.id]
+    );
+    return res.json({ ok: true, signatures: sig.rows });
+  } catch (e) {
+    console.error('GET admin agreement error:', e);
+    return res.status(500).json({ error: 'โหลดสถานะสัญญาไม่สำเร็จ' });
+  }
+});
+
+app.get('/admin/partners/applications/:id/academy', requireAdminSession, async (req, res) => {
+  try {
+    const appRow = await getPartnerApplicationById(req.params.id);
+    if (!appRow) return res.status(404).json({ error: 'ไม่พบใบสมัคร' });
+    const r = await pool.query(
+      `SELECT c.course_code, c.title, COUNT(l.id)::int AS lesson_count,
+              COUNT(p.lesson_id) FILTER (WHERE p.completed=TRUE)::int AS completed_count
+       FROM public.academy_courses c
+       LEFT JOIN public.academy_lessons l ON l.course_id=c.id AND l.is_active=TRUE
+       LEFT JOIN public.academy_progress p ON p.lesson_id=l.id AND p.application_id=$1
+       WHERE c.course_code='cwf_basic_partner'
+       GROUP BY c.id`,
+      [appRow.id]
+    );
+    return res.json({ ok: true, academy: r.rows[0] || null });
+  } catch (e) {
+    console.error('GET admin academy error:', e);
+    return res.status(500).json({ error: 'โหลด Academy ไม่สำเร็จ' });
+  }
+});
+
+app.get('/admin/partners/applications/:id/exams', requireAdminSession, async (req, res) => {
+  try {
+    const appRow = await getPartnerApplicationById(req.params.id);
+    if (!appRow) return res.status(404).json({ error: 'ไม่พบใบสมัคร' });
+    const r = await pool.query(
+      `SELECT a.*, e.exam_code, e.title FROM public.academy_exam_attempts a JOIN public.academy_exams e ON e.id=a.exam_id WHERE a.application_id=$1 ORDER BY a.submitted_at DESC`,
+      [appRow.id]
+    );
+    return res.json({ ok: true, attempts: r.rows });
+  } catch (e) {
+    console.error('GET admin exams error:', e);
+    return res.status(500).json({ error: 'โหลดผลสอบไม่สำเร็จ' });
+  }
+});
+
+app.get('/admin/partners/applications/:id/certifications', requireAdminSession, async (req, res) => {
+  try {
+    const appRow = await getPartnerApplicationById(req.params.id);
+    if (!appRow) return res.status(404).json({ error: 'ไม่พบใบสมัคร' });
+    const r = await pool.query(
+      `SELECT certification_code, status, approved_by, approved_at, expires_at, admin_note, updated_by, updated_at
+       FROM public.technician_certifications
+       WHERE application_id=$1
+       ORDER BY certification_code ASC`,
+      [appRow.id]
+    );
+    const map = new Map((r.rows || []).map(x => [x.certification_code, x]));
+    return res.json({ ok: true, certifications: PARTNER_CERTIFICATION_CODES.map(code => map.get(code) || { certification_code: code, status: 'not_started' }) });
+  } catch (e) {
+    console.error('GET admin certifications error:', e);
+    return res.status(500).json({ error: 'โหลด Certification ไม่สำเร็จ' });
+  }
+});
+
+app.put('/admin/partners/applications/:id/certifications/:certification_code/status', requireAdminSession, async (req, res) => {
+  const appId = Number(req.params.id);
+  const code = String(req.params.certification_code || '').trim();
+  const status = String(req.body?.status || '').trim();
+  const admin_note = req.body?.admin_note == null ? null : String(req.body.admin_note || '').trim();
+  if (!PARTNER_CERTIFICATION_CODES.includes(code)) return res.status(400).json({ error: 'certification_code ไม่ถูกต้อง' });
+  if (!PARTNER_CERTIFICATION_STATUSES.has(status)) return res.status(400).json({ error: 'status ไม่ถูกต้อง' });
+  const client = await pool.connect();
+  try {
+    await client.query('BEGIN');
+    const appRow = await getPartnerApplicationById(appId, client);
+    if (!appRow) {
+      await client.query('ROLLBACK');
+      return res.status(404).json({ error: 'ไม่พบใบสมัคร' });
+    }
+    const actor = req.actor?.username || req.auth?.username || null;
+    const saved = await client.query(
+      `INSERT INTO public.technician_certifications(application_id, technician_username, certification_code, status, admin_note, approved_by, approved_at, updated_by, updated_at)
+       VALUES($1,$2,$3,$4,$5,$6,CASE WHEN $4='approved' THEN NOW() ELSE NULL END,$6,NOW())
+       ON CONFLICT(application_id, certification_code) DO UPDATE SET
+         technician_username=EXCLUDED.technician_username,
+         status=EXCLUDED.status,
+         admin_note=EXCLUDED.admin_note,
+         approved_by=CASE WHEN EXCLUDED.status='approved' THEN EXCLUDED.approved_by ELSE public.technician_certifications.approved_by END,
+         approved_at=CASE WHEN EXCLUDED.status='approved' THEN NOW() ELSE public.technician_certifications.approved_at END,
+         updated_by=EXCLUDED.updated_by,
+         updated_at=NOW()
+       RETURNING *`,
+      [appRow.id, appRow.technician_username || null, code, status, admin_note, actor]
+    );
+    await logPartnerOnboardingEvent(client, {
+      application_id: appRow.id,
+      actor_type: 'admin',
+      actor_username: actor,
+      event_type: 'certification_status_changed',
+      to_status: status,
+      note: `${code}: ${admin_note || ''}`.trim(),
+      metadata: { certification_code: code },
+    });
+    await client.query('COMMIT');
+    await auditLog(req, { action: 'PARTNER_CERTIFICATION_STATUS_UPDATE', target_username: appRow.application_code, target_role: 'partner_application', meta: { certification_code: code, status, admin_note } });
+    return res.json({ ok: true, certification: saved.rows[0] });
+  } catch (e) {
+    await client.query('ROLLBACK');
+    console.error('PUT certification status error:', e);
+    return res.status(500).json({ error: 'อัปเดต Certification ไม่สำเร็จ' });
+  } finally {
+    client.release();
+  }
+});
+
+app.post('/admin/partners/certification-dry-run', requireAdminSession, async (req, res) => {
+  try {
+    const technicianUsername = String(req.body?.technician_username || '').trim();
+    const requiredCodes = getRequiredCertificationCodesForJob(req.body || {});
+    const check = await technicianHasRequiredCertifications(technicianUsername, requiredCodes, { partnerOnly: false });
+    return res.json({
+      ok: true,
+      mode: getCertificationEnforcementMode(),
+      technician_username: technicianUsername,
+      required_certifications: requiredCodes,
+      ...check,
+      block_reason: check.ok ? null : explainCertificationBlockReason(requiredCodes, check.missing || []),
+    });
+  } catch (e) {
+    console.error('POST certification dry-run error:', e);
+    return res.status(500).json({ error: 'ตรวจ certification dry-run ไม่สำเร็จ' });
+  }
+});
+
+app.post('/admin/partners/applications/:id/trial-jobs', requireAdminSession, async (req, res) => {
+  const appId = Number(req.params.id);
+  const certification_code = String(req.body?.certification_code || '').trim();
+  const job_id = req.body?.job_id == null || String(req.body.job_id).trim() === '' ? null : Number(req.body.job_id);
+  if (!PARTNER_CERTIFICATION_CODES.includes(certification_code)) return res.status(400).json({ error: 'certification_code ไม่ถูกต้อง' });
+  const client = await pool.connect();
+  try {
+    await client.query('BEGIN');
+    const appRow = await getPartnerApplicationById(appId, client);
+    if (!appRow) {
+      await client.query('ROLLBACK');
+      return res.status(404).json({ error: 'ไม่พบใบสมัคร' });
+    }
+    const actor = req.actor?.username || req.auth?.username || null;
+    const saved = await client.query(
+      `INSERT INTO public.partner_trial_jobs(application_id, technician_username, certification_code, job_id, status, admin_note, created_by)
+       VALUES($1,$2,$3,$4,'unlocked',$5,$6)
+       RETURNING *`,
+      [appRow.id, appRow.technician_username || null, certification_code, Number.isFinite(job_id) ? job_id : null, req.body?.admin_note || null, actor]
+    );
+    await client.query(
+      `INSERT INTO public.technician_certifications(application_id, technician_username, certification_code, status, updated_by, updated_at)
+       VALUES($1,$2,$3,'trial_unlocked',$4,NOW())
+       ON CONFLICT(application_id, certification_code) DO UPDATE SET status='trial_unlocked', updated_by=$4, updated_at=NOW()`,
+      [appRow.id, appRow.technician_username || null, certification_code, actor]
+    );
+    await logPartnerOnboardingEvent(client, { application_id: appRow.id, actor_type: 'admin', actor_username: actor, event_type: 'trial_unlocked', to_status: 'trial_unlocked', note: certification_code, metadata: { trial_job_id: saved.rows[0].id } });
+    await client.query('COMMIT');
+    await auditLog(req, { action: 'PARTNER_TRIAL_UNLOCKED', target_username: appRow.application_code, target_role: 'partner_application', meta: { certification_code, trial_job_id: saved.rows[0].id } });
+    return res.json({ ok: true, trial_job: saved.rows[0] });
+  } catch (e) {
+    await client.query('ROLLBACK');
+    console.error('POST trial job error:', e);
+    return res.status(500).json({ error: 'ปลดล็อก Trial ไม่สำเร็จ' });
+  } finally {
+    client.release();
+  }
+});
+
+app.get('/admin/partners/applications/:id/trial-jobs', requireAdminSession, async (req, res) => {
+  try {
+    const appRow = await getPartnerApplicationById(req.params.id);
+    if (!appRow) return res.status(404).json({ error: 'ไม่พบใบสมัคร' });
+    const trials = await pool.query(`SELECT * FROM public.partner_trial_jobs WHERE application_id=$1 ORDER BY created_at DESC`, [appRow.id]);
+    const evals = await pool.query(`SELECT * FROM public.partner_evaluations WHERE application_id=$1 ORDER BY evaluated_at DESC`, [appRow.id]);
+    return res.json({ ok: true, trial_jobs: trials.rows, evaluations: evals.rows });
+  } catch (e) {
+    console.error('GET trial jobs error:', e);
+    return res.status(500).json({ error: 'โหลด Trial ไม่สำเร็จ' });
+  }
+});
+
+app.post('/admin/partners/trial-jobs/:trial_job_id/evaluate', requireAdminSession, async (req, res) => {
+  const trialId = Number(req.params.trial_job_id);
+  const result = String(req.body?.result || '').trim();
+  if (!Number.isFinite(trialId) || trialId <= 0) return res.status(400).json({ error: 'trial_job_id ไม่ถูกต้อง' });
+  if (!PARTNER_TRIAL_RESULTS.has(result)) return res.status(400).json({ error: 'result ไม่ถูกต้อง' });
+  const score = (v) => Math.max(0, Math.min(5, Number(v || 0)));
+  const client = await pool.connect();
+  try {
+    await client.query('BEGIN');
+    const trialR = await client.query(`SELECT * FROM public.partner_trial_jobs WHERE id=$1 FOR UPDATE`, [trialId]);
+    if (!trialR.rows.length) {
+      await client.query('ROLLBACK');
+      return res.status(404).json({ error: 'ไม่พบ Trial job' });
+    }
+    const trial = trialR.rows[0];
+    const actor = req.actor?.username || req.auth?.username || null;
+    const saved = await client.query(
+      `INSERT INTO public.partner_evaluations
+        (trial_job_id, application_id, evaluator_username, punctuality_score, uniform_score, communication_score, photo_quality_score, job_quality_score, customer_issue, admin_note, result, evaluated_at)
+       VALUES($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,NOW())
+       RETURNING *`,
+      [trial.id, trial.application_id, actor, score(req.body?.punctuality_score), score(req.body?.uniform_score), score(req.body?.communication_score), score(req.body?.photo_quality_score), score(req.body?.job_quality_score), !!req.body?.customer_issue, req.body?.admin_note || null, result]
+    );
+    await client.query(`UPDATE public.partner_trial_jobs SET status=$1, evaluated_at=NOW(), updated_at=NOW() WHERE id=$2`, [result, trial.id]);
+    await logPartnerOnboardingEvent(client, { application_id: trial.application_id, actor_type: 'admin', actor_username: actor, event_type: 'trial_evaluated', to_status: result, note: req.body?.admin_note || null, metadata: { trial_job_id: trial.id, evaluation_id: saved.rows[0].id } });
+    await client.query('COMMIT');
+    await auditLog(req, { action: 'PARTNER_TRIAL_EVALUATED', target_role: 'partner_application', meta: { trial_job_id: trial.id, result } });
+    return res.json({ ok: true, evaluation: saved.rows[0] });
+  } catch (e) {
+    await client.query('ROLLBACK');
+    console.error('POST trial evaluate error:', e);
+    return res.status(500).json({ error: 'บันทึกประเมิน Trial ไม่สำเร็จ' });
   } finally {
     client.release();
   }
@@ -6350,6 +6913,231 @@ await pool.query(`
   )
 `);
 await pool.query(`CREATE INDEX IF NOT EXISTS idx_partner_events_application_created ON public.partner_onboarding_events(application_id, created_at DESC)`);
+
+// 4.2) Partner Onboarding: agreement, academy, exams, certification, trial/evaluation
+await pool.query(`
+  CREATE TABLE IF NOT EXISTS public.agreement_templates (
+    id BIGSERIAL PRIMARY KEY,
+    template_code TEXT NOT NULL,
+    version INT NOT NULL DEFAULT 1,
+    title TEXT NOT NULL,
+    body_text TEXT NOT NULL,
+    is_active BOOLEAN NOT NULL DEFAULT TRUE,
+    created_at TIMESTAMPTZ DEFAULT NOW(),
+    updated_at TIMESTAMPTZ DEFAULT NOW(),
+    UNIQUE(template_code, version)
+  )
+`);
+await pool.query(`CREATE INDEX IF NOT EXISTS idx_agreement_templates_active ON public.agreement_templates(template_code, is_active, version DESC)`);
+
+await pool.query(`
+  CREATE TABLE IF NOT EXISTS public.agreement_signatures (
+    id BIGSERIAL PRIMARY KEY,
+    application_id BIGINT NOT NULL REFERENCES public.partner_applications(id) ON DELETE CASCADE,
+    template_id BIGINT NOT NULL REFERENCES public.agreement_templates(id),
+    template_version INT NOT NULL,
+    signer_full_name TEXT NOT NULL,
+    consent_terms BOOLEAN NOT NULL DEFAULT FALSE,
+    signed_ip TEXT,
+    signed_user_agent TEXT,
+    signed_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    created_at TIMESTAMPTZ DEFAULT NOW()
+  )
+`);
+await pool.query(`CREATE INDEX IF NOT EXISTS idx_agreement_signatures_application ON public.agreement_signatures(application_id, signed_at DESC)`);
+
+await pool.query(`
+  CREATE TABLE IF NOT EXISTS public.academy_courses (
+    id BIGSERIAL PRIMARY KEY,
+    course_code TEXT NOT NULL UNIQUE,
+    title TEXT NOT NULL,
+    description TEXT,
+    is_active BOOLEAN NOT NULL DEFAULT TRUE,
+    created_at TIMESTAMPTZ DEFAULT NOW(),
+    updated_at TIMESTAMPTZ DEFAULT NOW()
+  )
+`);
+await pool.query(`
+  CREATE TABLE IF NOT EXISTS public.academy_lessons (
+    id BIGSERIAL PRIMARY KEY,
+    course_id BIGINT NOT NULL REFERENCES public.academy_courses(id) ON DELETE CASCADE,
+    lesson_title TEXT NOT NULL,
+    body_text TEXT,
+    sort_order INT NOT NULL DEFAULT 0,
+    is_active BOOLEAN NOT NULL DEFAULT TRUE,
+    created_at TIMESTAMPTZ DEFAULT NOW(),
+    updated_at TIMESTAMPTZ DEFAULT NOW(),
+    UNIQUE(course_id, sort_order)
+  )
+`);
+await pool.query(`
+  CREATE TABLE IF NOT EXISTS public.academy_progress (
+    id BIGSERIAL PRIMARY KEY,
+    application_id BIGINT NOT NULL REFERENCES public.partner_applications(id) ON DELETE CASCADE,
+    course_id BIGINT NOT NULL REFERENCES public.academy_courses(id) ON DELETE CASCADE,
+    lesson_id BIGINT NOT NULL REFERENCES public.academy_lessons(id) ON DELETE CASCADE,
+    completed BOOLEAN NOT NULL DEFAULT FALSE,
+    completed_at TIMESTAMPTZ,
+    created_at TIMESTAMPTZ DEFAULT NOW(),
+    updated_at TIMESTAMPTZ DEFAULT NOW(),
+    UNIQUE(application_id, lesson_id)
+  )
+`);
+await pool.query(`CREATE INDEX IF NOT EXISTS idx_academy_progress_application ON public.academy_progress(application_id, course_id)`);
+
+await pool.query(`
+  CREATE TABLE IF NOT EXISTS public.academy_exams (
+    id BIGSERIAL PRIMARY KEY,
+    course_id BIGINT NOT NULL REFERENCES public.academy_courses(id) ON DELETE CASCADE,
+    exam_code TEXT NOT NULL UNIQUE,
+    title TEXT NOT NULL,
+    passing_score_percent NUMERIC(5,2) NOT NULL DEFAULT 80,
+    is_active BOOLEAN NOT NULL DEFAULT TRUE,
+    created_at TIMESTAMPTZ DEFAULT NOW(),
+    updated_at TIMESTAMPTZ DEFAULT NOW()
+  )
+`);
+await pool.query(`
+  CREATE TABLE IF NOT EXISTS public.academy_exam_questions (
+    id BIGSERIAL PRIMARY KEY,
+    exam_id BIGINT NOT NULL REFERENCES public.academy_exams(id) ON DELETE CASCADE,
+    question_text TEXT NOT NULL,
+    choices_json JSONB NOT NULL DEFAULT '[]'::jsonb,
+    correct_choice_index INT NOT NULL DEFAULT 0,
+    sort_order INT NOT NULL DEFAULT 0,
+    created_at TIMESTAMPTZ DEFAULT NOW(),
+    updated_at TIMESTAMPTZ DEFAULT NOW(),
+    UNIQUE(exam_id, sort_order)
+  )
+`);
+await pool.query(`
+  CREATE TABLE IF NOT EXISTS public.academy_exam_attempts (
+    id BIGSERIAL PRIMARY KEY,
+    application_id BIGINT NOT NULL REFERENCES public.partner_applications(id) ON DELETE CASCADE,
+    exam_id BIGINT NOT NULL REFERENCES public.academy_exams(id) ON DELETE CASCADE,
+    answers_json JSONB NOT NULL DEFAULT '{}'::jsonb,
+    score_percent NUMERIC(5,2) NOT NULL DEFAULT 0,
+    passed BOOLEAN NOT NULL DEFAULT FALSE,
+    submitted_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    created_at TIMESTAMPTZ DEFAULT NOW()
+  )
+`);
+await pool.query(`CREATE INDEX IF NOT EXISTS idx_exam_attempts_application ON public.academy_exam_attempts(application_id, submitted_at DESC)`);
+
+await pool.query(`
+  CREATE TABLE IF NOT EXISTS public.technician_certifications (
+    id BIGSERIAL PRIMARY KEY,
+    application_id BIGINT REFERENCES public.partner_applications(id) ON DELETE CASCADE,
+    technician_username TEXT,
+    certification_code TEXT NOT NULL,
+    status TEXT NOT NULL DEFAULT 'not_started' CHECK (status IN ('not_started','in_training','exam_ready','exam_failed','exam_passed','trial_unlocked','approved','suspended','revoked')),
+    approved_by TEXT,
+    approved_at TIMESTAMPTZ,
+    expires_at TIMESTAMPTZ,
+    admin_note TEXT,
+    updated_by TEXT,
+    created_at TIMESTAMPTZ DEFAULT NOW(),
+    updated_at TIMESTAMPTZ DEFAULT NOW(),
+    UNIQUE(application_id, certification_code)
+  )
+`);
+await pool.query(`CREATE INDEX IF NOT EXISTS idx_tech_cert_username_code ON public.technician_certifications(technician_username, certification_code, status)`);
+
+await pool.query(`
+  CREATE TABLE IF NOT EXISTS public.partner_trial_jobs (
+    id BIGSERIAL PRIMARY KEY,
+    application_id BIGINT NOT NULL REFERENCES public.partner_applications(id) ON DELETE CASCADE,
+    technician_username TEXT,
+    certification_code TEXT NOT NULL,
+    job_id BIGINT,
+    status TEXT NOT NULL DEFAULT 'unlocked',
+    admin_note TEXT,
+    created_by TEXT,
+    created_at TIMESTAMPTZ DEFAULT NOW(),
+    evaluated_at TIMESTAMPTZ,
+    updated_at TIMESTAMPTZ DEFAULT NOW()
+  )
+`);
+await pool.query(`CREATE INDEX IF NOT EXISTS idx_partner_trial_jobs_application ON public.partner_trial_jobs(application_id, created_at DESC)`);
+
+await pool.query(`
+  CREATE TABLE IF NOT EXISTS public.partner_evaluations (
+    id BIGSERIAL PRIMARY KEY,
+    trial_job_id BIGINT NOT NULL REFERENCES public.partner_trial_jobs(id) ON DELETE CASCADE,
+    application_id BIGINT NOT NULL REFERENCES public.partner_applications(id) ON DELETE CASCADE,
+    evaluator_username TEXT,
+    punctuality_score NUMERIC(4,2) NOT NULL DEFAULT 0,
+    uniform_score NUMERIC(4,2) NOT NULL DEFAULT 0,
+    communication_score NUMERIC(4,2) NOT NULL DEFAULT 0,
+    photo_quality_score NUMERIC(4,2) NOT NULL DEFAULT 0,
+    job_quality_score NUMERIC(4,2) NOT NULL DEFAULT 0,
+    customer_issue BOOLEAN NOT NULL DEFAULT FALSE,
+    admin_note TEXT,
+    result TEXT NOT NULL CHECK (result IN ('passed','failed','needs_more_trial')),
+    evaluated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    created_at TIMESTAMPTZ DEFAULT NOW()
+  )
+`);
+await pool.query(`CREATE INDEX IF NOT EXISTS idx_partner_evaluations_application ON public.partner_evaluations(application_id, evaluated_at DESC)`);
+
+await pool.query(`
+  CREATE TABLE IF NOT EXISTS public.partner_incidents (
+    id BIGSERIAL PRIMARY KEY,
+    application_id BIGINT NOT NULL REFERENCES public.partner_applications(id) ON DELETE CASCADE,
+    trial_job_id BIGINT REFERENCES public.partner_trial_jobs(id) ON DELETE SET NULL,
+    incident_type TEXT,
+    severity TEXT,
+    note TEXT,
+    created_by TEXT,
+    created_at TIMESTAMPTZ DEFAULT NOW()
+  )
+`);
+await pool.query(`CREATE INDEX IF NOT EXISTS idx_partner_incidents_application ON public.partner_incidents(application_id, created_at DESC)`);
+
+try {
+  await pool.query(
+    `INSERT INTO public.agreement_templates(template_code, version, title, body_text, is_active)
+     VALUES('partner_standard', 1, 'CWF Partner Service Agreement', $1, TRUE)
+     ON CONFLICT(template_code, version) DO NOTHING`,
+    ['ข้อตกลงพาร์ทเนอร์ CWF: ผู้สมัครยืนยันว่าจะปฏิบัติตามมาตรฐานแบรนด์ การสื่อสาร การถ่ายรูปหลักฐาน การไม่เปลี่ยนราคาเอง และไม่รับเงินนอกระบบ จนกว่าจะมีสัญญาฉบับเต็มในระบบ']
+  );
+  const courseR = await pool.query(
+    `INSERT INTO public.academy_courses(course_code, title, description, is_active)
+     VALUES('cwf_basic_partner', 'Basic Partner Course', 'หลักสูตรพื้นฐานสำหรับพาร์ทเนอร์ CWF', TRUE)
+     ON CONFLICT(course_code) DO UPDATE SET title=EXCLUDED.title
+     RETURNING id`
+  );
+  const courseId = courseR.rows[0]?.id;
+  if (courseId) {
+    for (let i = 0; i < BASIC_PARTNER_LESSONS.length; i++) {
+      await pool.query(
+        `INSERT INTO public.academy_lessons(course_id, lesson_title, body_text, sort_order, is_active)
+         VALUES($1,$2,$3,$4,TRUE)
+         ON CONFLICT(course_id, sort_order) DO UPDATE SET lesson_title=EXCLUDED.lesson_title, body_text=EXCLUDED.body_text, is_active=TRUE`,
+        [courseId, BASIC_PARTNER_LESSONS[i], BASIC_PARTNER_LESSONS[i], i + 1]
+      );
+    }
+    const examR = await pool.query(
+      `INSERT INTO public.academy_exams(course_id, exam_code, title, passing_score_percent, is_active)
+       VALUES($1,'cwf_basic_partner_exam','Basic Partner Exam',80,TRUE)
+       ON CONFLICT(exam_code) DO UPDATE SET title=EXCLUDED.title, passing_score_percent=80, is_active=TRUE
+       RETURNING id`,
+      [courseId]
+    );
+    const examId = examR.rows[0]?.id;
+    for (let i = 0; examId && i < BASIC_PARTNER_EXAM_QUESTIONS.length; i++) {
+      const q = BASIC_PARTNER_EXAM_QUESTIONS[i];
+      await pool.query(
+        `INSERT INTO public.academy_exam_questions(exam_id, question_text, choices_json, correct_choice_index, sort_order)
+         VALUES($1,$2,$3::jsonb,$4,$5)
+         ON CONFLICT(exam_id, sort_order) DO UPDATE SET question_text=EXCLUDED.question_text, choices_json=EXCLUDED.choices_json, correct_choice_index=EXCLUDED.correct_choice_index`,
+        [examId, q.q, JSON.stringify(q.choices), q.answer, i + 1]
+      );
+    }
+  }
+} catch (e) {
+  console.warn('[ensureSchema] seed partner academy/agreement skipped:', e.message);
+}
 
 
 // 5) auth sessions (server-side) - for Super Admin impersonation & real logout
@@ -15650,6 +16438,8 @@ app.get("/tech", (req, res) => res.sendFile(sendHtml("tech.html")));
 app.get("/add-job", (req, res) => res.redirect(302, "/admin-add-v2.html"));
 app.get("/customer", (req, res) => res.sendFile(sendHtml("customer.html")));
 app.get("/partner-apply", (req, res) => res.sendFile(sendHtml("partner-apply.html")));
+app.get("/partner-agreement", (req, res) => res.sendFile(sendHtml("partner-agreement.html")));
+app.get("/partner-academy", (req, res) => res.sendFile(sendHtml("partner-academy.html")));
 // ✅ หน้าใหม่: คำนวณราคาติดตั้งแอร์ (ลูกค้า)
 app.get("/install-quote", (req, res) => res.sendFile(sendHtml("install-quote.html")));
 // Canonical path: keep short URL, redirect direct-file access
@@ -15671,6 +16461,8 @@ app.get("/tech.html", (req, res) => res.sendFile(sendHtml("tech.html")));
 app.get("/add-job.html", (req, res) => res.redirect(302, "/admin-add-v2.html"));
 app.get("/register.html", (req, res) => res.sendFile(sendHtml("register.html")));
 app.get("/partner-apply.html", (req, res) => res.sendFile(sendHtml("partner-apply.html")));
+app.get("/partner-agreement.html", (req, res) => res.sendFile(sendHtml("partner-agreement.html")));
+app.get("/partner-academy.html", (req, res) => res.sendFile(sendHtml("partner-academy.html")));
 app.get("/index.html", (req, res) => res.sendFile(sendHtml("index.html")));
 app.get("/", (req, res) => res.sendFile(sendHtml("login.html")));
 

--- a/migrations/partner_onboarding_phase1b.sql
+++ b/migrations/partner_onboarding_phase1b.sql
@@ -1,0 +1,210 @@
+-- Partner Onboarding remaining modules: agreement, academy, exams, certification, trial evaluation.
+-- Backward-compatible only. Job-blocking enforcement remains controlled by CERTIFICATION_ENFORCEMENT.
+
+CREATE TABLE IF NOT EXISTS public.agreement_templates (
+  id BIGSERIAL PRIMARY KEY,
+  template_code TEXT NOT NULL,
+  version INT NOT NULL DEFAULT 1,
+  title TEXT NOT NULL,
+  body_text TEXT NOT NULL,
+  is_active BOOLEAN NOT NULL DEFAULT TRUE,
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  updated_at TIMESTAMPTZ DEFAULT NOW(),
+  UNIQUE(template_code, version)
+);
+CREATE INDEX IF NOT EXISTS idx_agreement_templates_active ON public.agreement_templates(template_code, is_active, version DESC);
+
+CREATE TABLE IF NOT EXISTS public.agreement_signatures (
+  id BIGSERIAL PRIMARY KEY,
+  application_id BIGINT NOT NULL REFERENCES public.partner_applications(id) ON DELETE CASCADE,
+  template_id BIGINT NOT NULL REFERENCES public.agreement_templates(id),
+  template_version INT NOT NULL,
+  signer_full_name TEXT NOT NULL,
+  consent_terms BOOLEAN NOT NULL DEFAULT FALSE,
+  signed_ip TEXT,
+  signed_user_agent TEXT,
+  signed_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  created_at TIMESTAMPTZ DEFAULT NOW()
+);
+CREATE INDEX IF NOT EXISTS idx_agreement_signatures_application ON public.agreement_signatures(application_id, signed_at DESC);
+
+CREATE TABLE IF NOT EXISTS public.academy_courses (
+  id BIGSERIAL PRIMARY KEY,
+  course_code TEXT NOT NULL UNIQUE,
+  title TEXT NOT NULL,
+  description TEXT,
+  is_active BOOLEAN NOT NULL DEFAULT TRUE,
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  updated_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS public.academy_lessons (
+  id BIGSERIAL PRIMARY KEY,
+  course_id BIGINT NOT NULL REFERENCES public.academy_courses(id) ON DELETE CASCADE,
+  lesson_title TEXT NOT NULL,
+  body_text TEXT,
+  sort_order INT NOT NULL DEFAULT 0,
+  is_active BOOLEAN NOT NULL DEFAULT TRUE,
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  updated_at TIMESTAMPTZ DEFAULT NOW(),
+  UNIQUE(course_id, sort_order)
+);
+
+CREATE TABLE IF NOT EXISTS public.academy_progress (
+  id BIGSERIAL PRIMARY KEY,
+  application_id BIGINT NOT NULL REFERENCES public.partner_applications(id) ON DELETE CASCADE,
+  course_id BIGINT NOT NULL REFERENCES public.academy_courses(id) ON DELETE CASCADE,
+  lesson_id BIGINT NOT NULL REFERENCES public.academy_lessons(id) ON DELETE CASCADE,
+  completed BOOLEAN NOT NULL DEFAULT FALSE,
+  completed_at TIMESTAMPTZ,
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  updated_at TIMESTAMPTZ DEFAULT NOW(),
+  UNIQUE(application_id, lesson_id)
+);
+CREATE INDEX IF NOT EXISTS idx_academy_progress_application ON public.academy_progress(application_id, course_id);
+
+CREATE TABLE IF NOT EXISTS public.academy_exams (
+  id BIGSERIAL PRIMARY KEY,
+  course_id BIGINT NOT NULL REFERENCES public.academy_courses(id) ON DELETE CASCADE,
+  exam_code TEXT NOT NULL UNIQUE,
+  title TEXT NOT NULL,
+  passing_score_percent NUMERIC(5,2) NOT NULL DEFAULT 80,
+  is_active BOOLEAN NOT NULL DEFAULT TRUE,
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  updated_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS public.academy_exam_questions (
+  id BIGSERIAL PRIMARY KEY,
+  exam_id BIGINT NOT NULL REFERENCES public.academy_exams(id) ON DELETE CASCADE,
+  question_text TEXT NOT NULL,
+  choices_json JSONB NOT NULL DEFAULT '[]'::jsonb,
+  correct_choice_index INT NOT NULL DEFAULT 0,
+  sort_order INT NOT NULL DEFAULT 0,
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  updated_at TIMESTAMPTZ DEFAULT NOW(),
+  UNIQUE(exam_id, sort_order)
+);
+
+CREATE TABLE IF NOT EXISTS public.academy_exam_attempts (
+  id BIGSERIAL PRIMARY KEY,
+  application_id BIGINT NOT NULL REFERENCES public.partner_applications(id) ON DELETE CASCADE,
+  exam_id BIGINT NOT NULL REFERENCES public.academy_exams(id) ON DELETE CASCADE,
+  answers_json JSONB NOT NULL DEFAULT '{}'::jsonb,
+  score_percent NUMERIC(5,2) NOT NULL DEFAULT 0,
+  passed BOOLEAN NOT NULL DEFAULT FALSE,
+  submitted_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  created_at TIMESTAMPTZ DEFAULT NOW()
+);
+CREATE INDEX IF NOT EXISTS idx_exam_attempts_application ON public.academy_exam_attempts(application_id, submitted_at DESC);
+
+CREATE TABLE IF NOT EXISTS public.technician_certifications (
+  id BIGSERIAL PRIMARY KEY,
+  application_id BIGINT REFERENCES public.partner_applications(id) ON DELETE CASCADE,
+  technician_username TEXT,
+  certification_code TEXT NOT NULL,
+  status TEXT NOT NULL DEFAULT 'not_started' CHECK (status IN ('not_started','in_training','exam_ready','exam_failed','exam_passed','trial_unlocked','approved','suspended','revoked')),
+  approved_by TEXT,
+  approved_at TIMESTAMPTZ,
+  expires_at TIMESTAMPTZ,
+  admin_note TEXT,
+  updated_by TEXT,
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  updated_at TIMESTAMPTZ DEFAULT NOW(),
+  UNIQUE(application_id, certification_code)
+);
+CREATE INDEX IF NOT EXISTS idx_tech_cert_username_code ON public.technician_certifications(technician_username, certification_code, status);
+
+CREATE TABLE IF NOT EXISTS public.partner_trial_jobs (
+  id BIGSERIAL PRIMARY KEY,
+  application_id BIGINT NOT NULL REFERENCES public.partner_applications(id) ON DELETE CASCADE,
+  technician_username TEXT,
+  certification_code TEXT NOT NULL,
+  job_id BIGINT,
+  status TEXT NOT NULL DEFAULT 'unlocked',
+  admin_note TEXT,
+  created_by TEXT,
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  evaluated_at TIMESTAMPTZ,
+  updated_at TIMESTAMPTZ DEFAULT NOW()
+);
+CREATE INDEX IF NOT EXISTS idx_partner_trial_jobs_application ON public.partner_trial_jobs(application_id, created_at DESC);
+
+CREATE TABLE IF NOT EXISTS public.partner_evaluations (
+  id BIGSERIAL PRIMARY KEY,
+  trial_job_id BIGINT NOT NULL REFERENCES public.partner_trial_jobs(id) ON DELETE CASCADE,
+  application_id BIGINT NOT NULL REFERENCES public.partner_applications(id) ON DELETE CASCADE,
+  evaluator_username TEXT,
+  punctuality_score NUMERIC(4,2) NOT NULL DEFAULT 0,
+  uniform_score NUMERIC(4,2) NOT NULL DEFAULT 0,
+  communication_score NUMERIC(4,2) NOT NULL DEFAULT 0,
+  photo_quality_score NUMERIC(4,2) NOT NULL DEFAULT 0,
+  job_quality_score NUMERIC(4,2) NOT NULL DEFAULT 0,
+  customer_issue BOOLEAN NOT NULL DEFAULT FALSE,
+  admin_note TEXT,
+  result TEXT NOT NULL CHECK (result IN ('passed','failed','needs_more_trial')),
+  evaluated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  created_at TIMESTAMPTZ DEFAULT NOW()
+);
+CREATE INDEX IF NOT EXISTS idx_partner_evaluations_application ON public.partner_evaluations(application_id, evaluated_at DESC);
+
+CREATE TABLE IF NOT EXISTS public.partner_incidents (
+  id BIGSERIAL PRIMARY KEY,
+  application_id BIGINT NOT NULL REFERENCES public.partner_applications(id) ON DELETE CASCADE,
+  trial_job_id BIGINT REFERENCES public.partner_trial_jobs(id) ON DELETE SET NULL,
+  incident_type TEXT,
+  severity TEXT,
+  note TEXT,
+  created_by TEXT,
+  created_at TIMESTAMPTZ DEFAULT NOW()
+);
+CREATE INDEX IF NOT EXISTS idx_partner_incidents_application ON public.partner_incidents(application_id, created_at DESC);
+
+INSERT INTO public.agreement_templates(template_code, version, title, body_text, is_active)
+VALUES (
+  'partner_standard',
+  1,
+  'CWF Partner Agreement',
+  'สัญญาพาร์ทเนอร์ CWF เวอร์ชันพื้นฐาน: ผู้ให้บริการต้องรักษามาตรฐานแบรนด์ แต่งกายสุภาพ สื่อสารกับลูกค้าอย่างมืออาชีพ เช็กอิน/ปิดงานตามระบบ ห้ามเปลี่ยนราคาเอง ห้ามรับเงินนอกระบบ และรับผิดชอบงานรับประกันตามนโยบาย CWF',
+  TRUE
+)
+ON CONFLICT(template_code, version) DO NOTHING;
+
+DO $$
+DECLARE
+  course_id BIGINT;
+  exam_id BIGINT;
+BEGIN
+  INSERT INTO public.academy_courses(course_code, title, description, is_active)
+  VALUES ('cwf_basic_partner', 'CWF Basic Partner', 'หลักสูตรพื้นฐานสำหรับ Partner ก่อนรับงานทดลอง', TRUE)
+  ON CONFLICT(course_code) DO UPDATE SET title=EXCLUDED.title, description=EXCLUDED.description, is_active=TRUE, updated_at=NOW()
+  RETURNING id INTO course_id;
+
+  INSERT INTO public.academy_lessons(course_id, lesson_title, body_text, sort_order, is_active)
+  VALUES
+    (course_id, 'มาตรฐานแบรนด์ CWF', 'รักษาความสุภาพ ความตรงเวลา และคุณภาพงานตามมาตรฐาน CWF', 1, TRUE),
+    (course_id, 'การแต่งกายและมารยาทหน้างาน', 'แต่งกายสะอาด สุภาพ และเคารพพื้นที่ลูกค้า', 2, TRUE),
+    (course_id, 'การสื่อสารกับลูกค้า', 'แจ้งขั้นตอนงานและปัญหาด้วยภาษาที่ชัดเจน ไม่กดดันลูกค้า', 3, TRUE),
+    (course_id, 'การเช็กอิน', 'เช็กอินตามระบบเมื่อถึงหน้างานเพื่อให้ทีมติดตามได้', 4, TRUE),
+    (course_id, 'การถ่ายรูปก่อนและหลังงาน', 'ถ่ายรูปให้ครบ ชัด และเห็นสภาพก่อน/หลังงาน', 5, TRUE),
+    (course_id, 'ห้ามเปลี่ยนราคาเอง', 'ราคาและรายการเพิ่มต้องผ่านระบบหรือแอดมินเท่านั้น', 6, TRUE),
+    (course_id, 'ห้ามรับเงินนอกระบบ', 'รับชำระตามช่องทางที่ CWF กำหนดเท่านั้น', 7, TRUE),
+    (course_id, 'วิธีปิดงาน', 'ตรวจงาน สรุปรายการ และปิดงานในระบบให้ครบ', 8, TRUE),
+    (course_id, 'ความรับผิดชอบงานรับประกัน', 'รับผิดชอบการแก้ไขตามนโยบายรับประกันของ CWF', 9, TRUE),
+    (course_id, 'กติกางานทดลอง', 'งานทดลองใช้ประเมินมาตรฐานก่อนเปิดสิทธิ์รับงานจริง', 10, TRUE)
+  ON CONFLICT(course_id, sort_order) DO UPDATE SET lesson_title=EXCLUDED.lesson_title, body_text=EXCLUDED.body_text, is_active=TRUE, updated_at=NOW();
+
+  INSERT INTO public.academy_exams(course_id, exam_code, title, passing_score_percent, is_active)
+  VALUES (course_id, 'cwf_basic_partner_exam', 'แบบทดสอบ CWF Basic Partner', 80, TRUE)
+  ON CONFLICT(exam_code) DO UPDATE SET course_id=EXCLUDED.course_id, title=EXCLUDED.title, passing_score_percent=80, is_active=TRUE, updated_at=NOW()
+  RETURNING id INTO exam_id;
+
+  INSERT INTO public.academy_exam_questions(exam_id, question_text, choices_json, correct_choice_index, sort_order)
+  VALUES
+    (exam_id, 'หากพบว่าต้องเพิ่มราคา Partner ควรทำอย่างไร', '["แจ้งลูกค้าและเก็บเพิ่มเอง","แจ้งแอดมิน/ทำตามระบบ CWF","ยกเลิกงานทันที"]'::jsonb, 1, 1),
+    (exam_id, 'รูปก่อนและหลังงานควรเป็นอย่างไร', '["ถ่ายเท่าที่สะดวก","ถ่ายให้ครบ ชัด เห็นสภาพงาน","ไม่จำเป็นถ้าลูกค้ารีบ"]'::jsonb, 1, 2),
+    (exam_id, 'การรับเงินนอกระบบทำได้หรือไม่', '["ทำได้ถ้าลูกค้ายินยอม","ทำได้เฉพาะงานเล็ก","ห้ามรับเงินนอกระบบ"]'::jsonb, 2, 3),
+    (exam_id, 'เมื่อถึงหน้างานควรทำอะไรในระบบก่อน', '["เช็กอิน","ปิดงาน","ขอรีวิว"]'::jsonb, 0, 4),
+    (exam_id, 'งานทดลองมีไว้เพื่ออะไร', '["ประเมินมาตรฐานก่อนเปิดสิทธิ์งานจริง","เพิ่มราคา","ข้ามขั้นตอนเอกสาร"]'::jsonb, 0, 5)
+  ON CONFLICT(exam_id, sort_order) DO UPDATE SET question_text=EXCLUDED.question_text, choices_json=EXCLUDED.choices_json, correct_choice_index=EXCLUDED.correct_choice_index, updated_at=NOW();
+END $$;

--- a/partner-academy.html
+++ b/partner-academy.html
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+<html lang="th">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>CWF Partner Academy</title>
+  <style>
+    :root{--navy:#071b4d;--blue:#0b4bb3;--yellow:#ffcc00;--ink:#0f172a;--muted:#64748b;--line:#dbe7ff;--bg:#f6f8fc;--ok:#166534;--bad:#b91c1c}
+    *{box-sizing:border-box}
+    body{margin:0;font-family:Arial,"Noto Sans Thai",sans-serif;background:linear-gradient(180deg,var(--navy),var(--blue) 260px,var(--bg) 260px);color:var(--ink)}
+    .wrap{max-width:1040px;margin:0 auto;padding:28px 14px 64px}
+    .brand{color:#fff;margin:8px 0 18px}.brand h1{margin:0;font-size:28px}.brand p{margin:6px 0 0;color:rgba(255,255,255,.82);font-weight:800}
+    .panel{background:#fff;border:1px solid var(--line);border-radius:8px;box-shadow:0 14px 34px rgba(2,6,23,.12);padding:16px;margin-bottom:14px}
+    .row{display:grid;grid-template-columns:1fr auto;gap:10px;align-items:end}
+    .grid{display:grid;grid-template-columns:1fr 1fr;gap:12px}.lesson,.question{border:1px solid var(--line);border-radius:8px;padding:12px;background:#fff}
+    label{display:block;font-size:12px;font-weight:900;color:#334155;margin-bottom:6px}
+    input{width:100%;border:1px solid #c9d7f2;border-radius:8px;padding:11px 12px;font:inherit;font-weight:700;background:#fff}
+    button{border:0;border-radius:8px;padding:10px 13px;font-weight:1000;cursor:pointer}.primary{background:var(--yellow);color:var(--navy)}.secondary{background:var(--blue);color:#fff}.ghost{background:#eef4ff;color:var(--navy)}
+    .muted{color:var(--muted);font-weight:800}.badge{display:inline-flex;border-radius:999px;padding:5px 10px;font-weight:1000;font-size:12px;background:#e2e8f0}.badge.ok{background:#dcfce7;color:var(--ok)}.badge.bad{background:#fee2e2;color:var(--bad)}
+    .top{display:flex;justify-content:space-between;gap:10px;align-items:flex-start}.choices{display:grid;gap:8px;margin-top:8px}.choice{display:flex;gap:8px;align-items:flex-start;font-weight:800}.choice input{width:auto;margin-top:3px}
+    .hidden{display:none}.msg{font-weight:900;margin-top:10px}.msg.err{color:var(--bad)}.msg.ok{color:var(--ok)}
+    @media(max-width:760px){.row,.grid{grid-template-columns:1fr}.brand h1{font-size:23px}}
+  </style>
+</head>
+<body>
+  <main class="wrap">
+    <section class="brand">
+      <h1>CWF Partner Academy</h1>
+      <p>อบรมพื้นฐาน ทำบทเรียน และสอบ Basic Partner</p>
+    </section>
+
+    <section class="panel">
+      <div class="row">
+        <div>
+          <label for="applicationCode">รหัสใบสมัคร</label>
+          <input id="applicationCode" autocomplete="off" placeholder="เช่น CWF-P20260428-XXXXXXXX">
+        </div>
+        <button class="secondary" id="btnLoad" type="button">โหลด Academy</button>
+      </div>
+      <div id="message" class="msg"></div>
+    </section>
+
+    <section class="panel hidden" id="academyPanel">
+      <div class="top">
+        <div>
+          <h2 id="courseTitle" style="margin:0">-</h2>
+          <div class="muted" id="applicantName">-</div>
+        </div>
+        <span class="badge" id="progressBadge">0%</span>
+      </div>
+      <div class="grid" id="lessons" style="margin-top:12px"></div>
+    </section>
+
+    <section class="panel hidden" id="examPanel">
+      <div class="top">
+        <div>
+          <h2 style="margin:0">แบบทดสอบ</h2>
+          <div class="muted" id="examMeta">ผ่านที่ 80%</div>
+        </div>
+        <button class="primary" id="btnSubmitExam" type="button">ส่งข้อสอบ</button>
+      </div>
+      <div id="questions" style="display:grid;gap:10px;margin-top:12px"></div>
+    </section>
+  </main>
+  <script src="/partner-academy.js"></script>
+</body>
+</html>

--- a/partner-academy.js
+++ b/partner-academy.js
@@ -1,0 +1,140 @@
+(function(){
+  const $ = (id) => document.getElementById(id);
+  const state = { applicationCode: '', lessons: [], exam: null, questions: [] };
+
+  function esc(s){
+    return String(s ?? '').replace(/[&<>"']/g, (c) => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c]));
+  }
+
+  function setMessage(text, type){
+    const el = $('message');
+    el.textContent = text || '';
+    el.className = `msg ${type || ''}`;
+  }
+
+  async function api(url, opts){
+    const res = await fetch(url, {
+      credentials: 'include',
+      headers: { 'Content-Type': 'application/json', ...(opts && opts.headers ? opts.headers : {}) },
+      ...(opts || {})
+    });
+    const data = await res.json().catch(() => null);
+    if (!res.ok) throw new Error((data && data.error) || 'Request failed');
+    return data;
+  }
+
+  function completionPercent(){
+    if (!state.lessons.length) return 0;
+    const done = state.lessons.filter((l) => l.completed).length;
+    return Math.round((done / state.lessons.length) * 100);
+  }
+
+  function renderLessons(data){
+    const app = data.application || {};
+    const course = data.course || {};
+    state.lessons = data.lessons || [];
+    $('academyPanel').classList.remove('hidden');
+    $('courseTitle').textContent = course.title || course.course_title || 'CWF Basic Partner';
+    $('applicantName').textContent = `${app.full_name || '-'} • ${app.application_code || state.applicationCode}`;
+    const percent = completionPercent();
+    $('progressBadge').textContent = `${percent}%`;
+    $('progressBadge').className = `badge ${percent === 100 ? 'ok' : ''}`;
+    $('lessons').innerHTML = state.lessons.map((lesson) => `
+      <article class="lesson">
+        <div class="top">
+          <div>
+            <b>${esc(lesson.sort_order || '')}. ${esc(lesson.lesson_title)}</b>
+            <div class="muted">${lesson.completed ? `เสร็จแล้ว ${new Date(lesson.completed_at).toLocaleString('th-TH')}` : 'ยังไม่เสร็จ'}</div>
+          </div>
+          <span class="badge ${lesson.completed ? 'ok' : ''}">${lesson.completed ? 'เสร็จแล้ว' : 'รอทำ'}</span>
+        </div>
+        <button class="${lesson.completed ? 'ghost' : 'primary'}" data-complete="${esc(lesson.id)}" type="button" style="margin-top:10px">${lesson.completed ? 'ทำซ้ำ/ยืนยัน' : 'ทำบทเรียนนี้เสร็จ'}</button>
+      </article>
+    `).join('');
+  }
+
+  function renderExam(data){
+    state.exam = data.exam || null;
+    state.questions = data.questions || [];
+    if (!state.exam) return;
+    $('examPanel').classList.remove('hidden');
+    $('examMeta').textContent = `ผ่านที่ ${Number(state.exam.passing_score_percent || 80)}%`;
+    $('questions').innerHTML = state.questions.map((q, idx) => {
+      const choices = Array.isArray(q.choices_json) ? q.choices_json : [];
+      return `
+        <article class="question">
+          <b>${idx + 1}. ${esc(q.question_text)}</b>
+          <div class="choices">
+            ${choices.map((choice, cidx) => `
+              <label class="choice">
+                <input type="radio" name="q_${esc(q.id)}" value="${cidx}">
+                <span>${esc(choice)}</span>
+              </label>
+            `).join('')}
+          </div>
+        </article>
+      `;
+    }).join('');
+  }
+
+  async function loadAcademy(){
+    try {
+      setMessage('', '');
+      state.applicationCode = $('applicationCode').value.trim().toUpperCase();
+      if (!state.applicationCode) throw new Error('กรุณากรอกรหัสใบสมัคร');
+      const academy = await api(`/partner/academy/${encodeURIComponent(state.applicationCode)}`);
+      renderLessons(academy);
+      const exam = await api(`/partner/academy/${encodeURIComponent(state.applicationCode)}/exam`);
+      renderExam(exam);
+    } catch (e) {
+      setMessage(e.message, 'err');
+    }
+  }
+
+  async function completeLesson(lessonId){
+    try {
+      await api(`/partner/academy/${encodeURIComponent(state.applicationCode)}/lessons/${encodeURIComponent(lessonId)}/complete`, { method: 'POST', body: '{}' });
+      const academy = await api(`/partner/academy/${encodeURIComponent(state.applicationCode)}`);
+      renderLessons(academy);
+      setMessage('บันทึกบทเรียนเรียบร้อย', 'ok');
+    } catch (e) {
+      setMessage(e.message, 'err');
+    }
+  }
+
+  async function submitExam(){
+    try {
+      const answers = {};
+      for (const q of state.questions) {
+        const picked = document.querySelector(`input[name="q_${CSS.escape(String(q.id))}"]:checked`);
+        if (!picked) throw new Error('กรุณาตอบข้อสอบให้ครบทุกข้อ');
+        answers[String(q.id)] = Number(picked.value);
+      }
+      const data = await api(`/partner/academy/${encodeURIComponent(state.applicationCode)}/exam/submit`, {
+        method: 'POST',
+        body: JSON.stringify({ answers })
+      });
+      const score = Number(data.attempt && data.attempt.score_percent);
+      setMessage(`ส่งข้อสอบแล้ว คะแนน ${score}% ${data.passed ? 'ผ่าน' : 'ยังไม่ผ่าน'}`, data.passed ? 'ok' : 'err');
+    } catch (e) {
+      setMessage(e.message, 'err');
+    }
+  }
+
+  $('btnLoad').addEventListener('click', loadAcademy);
+  $('btnSubmitExam').addEventListener('click', submitExam);
+  $('lessons').addEventListener('click', (e) => {
+    const btn = e.target.closest('[data-complete]');
+    if (btn) completeLesson(btn.dataset.complete);
+  });
+  $('applicationCode').addEventListener('keydown', (e) => {
+    if (e.key === 'Enter') loadAcademy();
+  });
+
+  const params = new URLSearchParams(location.search);
+  const code = params.get('code') || params.get('application_code');
+  if (code) {
+    $('applicationCode').value = code;
+    loadAcademy();
+  }
+})();

--- a/partner-agreement.html
+++ b/partner-agreement.html
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+<html lang="th">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>CWF Partner Agreement</title>
+  <style>
+    :root{--navy:#071b4d;--blue:#0b4bb3;--yellow:#ffcc00;--ink:#0f172a;--muted:#64748b;--line:#dbe7ff;--bg:#f6f8fc}
+    *{box-sizing:border-box}
+    body{margin:0;font-family:Arial,"Noto Sans Thai",sans-serif;background:linear-gradient(180deg,var(--navy),var(--blue) 260px,var(--bg) 260px);color:var(--ink)}
+    .wrap{max-width:920px;margin:0 auto;padding:28px 14px 64px}
+    .brand{color:#fff;margin:8px 0 18px}
+    .brand h1{margin:0;font-size:28px}.brand p{margin:6px 0 0;color:rgba(255,255,255,.82);font-weight:800}
+    .panel{background:#fff;border:1px solid var(--line);border-radius:8px;box-shadow:0 14px 34px rgba(2,6,23,.12);padding:16px;margin-bottom:14px}
+    .row{display:grid;grid-template-columns:1fr auto;gap:10px;align-items:end}
+    label{display:block;font-size:12px;font-weight:900;color:#334155;margin-bottom:6px}
+    input,textarea{width:100%;border:1px solid #c9d7f2;border-radius:8px;padding:11px 12px;font:inherit;font-weight:700;background:#fff}
+    button{border:0;border-radius:8px;padding:11px 14px;font-weight:1000;cursor:pointer}
+    .primary{background:var(--yellow);color:var(--navy)}.secondary{background:var(--blue);color:#fff}
+    .muted{color:var(--muted);font-weight:800}.badge{display:inline-flex;border-radius:999px;padding:5px 10px;font-weight:1000;font-size:12px;background:#e2e8f0}
+    .badge.ok{background:#dcfce7;color:#166534}.contract{white-space:pre-wrap;line-height:1.7;border:1px solid var(--line);border-radius:8px;padding:14px;background:#fbfdff;max-height:48vh;overflow:auto}
+    .check{display:flex;gap:10px;align-items:flex-start;margin:14px 0}.check input{width:auto;margin-top:4px}
+    .hidden{display:none}.msg{font-weight:900;margin-top:10px}.msg.err{color:#b91c1c}.msg.ok{color:#166534}
+    @media(max-width:720px){.row{grid-template-columns:1fr}.brand h1{font-size:23px}}
+  </style>
+</head>
+<body>
+  <main class="wrap">
+    <section class="brand">
+      <h1>CWF Partner Agreement</h1>
+      <p>อ่านสัญญาและยืนยันลายเซ็นสำหรับ Partner</p>
+    </section>
+
+    <section class="panel">
+      <div class="row">
+        <div>
+          <label for="applicationCode">รหัสใบสมัคร</label>
+          <input id="applicationCode" autocomplete="off" placeholder="เช่น CWF-P20260428-XXXXXXXX">
+        </div>
+        <button class="secondary" id="btnLoad" type="button">โหลดสัญญา</button>
+      </div>
+      <div id="message" class="msg"></div>
+    </section>
+
+    <section class="panel hidden" id="agreementPanel">
+      <div style="display:flex;justify-content:space-between;gap:10px;align-items:flex-start;flex-wrap:wrap">
+        <div>
+          <h2 id="templateTitle" style="margin:0 0 4px">-</h2>
+          <div class="muted" id="applicantName">-</div>
+        </div>
+        <span class="badge" id="signatureBadge">ยังไม่เซ็น</span>
+      </div>
+      <div class="contract" id="contractBody" style="margin-top:12px"></div>
+      <div id="signatureForm">
+        <label class="check">
+          <input id="consent" type="checkbox">
+          <span>ข้าพเจ้าอ่านและยอมรับเงื่อนไขในสัญญา Partner ของ CWF</span>
+        </label>
+        <label for="signerName">พิมพ์ชื่อ-นามสกุลเป็นลายเซ็น</label>
+        <input id="signerName" autocomplete="name" placeholder="ชื่อ-นามสกุลตรงกับใบสมัคร">
+        <button class="primary" id="btnSign" type="button" style="margin-top:12px">เซ็นสัญญา</button>
+      </div>
+    </section>
+  </main>
+  <script src="/partner-agreement.js"></script>
+</body>
+</html>

--- a/partner-agreement.js
+++ b/partner-agreement.js
@@ -1,0 +1,95 @@
+(function(){
+  const $ = (id) => document.getElementById(id);
+  const state = { applicationCode: '', loaded: null };
+
+  function esc(s){
+    return String(s ?? '').replace(/[&<>"']/g, (c) => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c]));
+  }
+
+  function setMessage(text, type){
+    const el = $('message');
+    el.textContent = text || '';
+    el.className = `msg ${type || ''}`;
+  }
+
+  function codeFromInput(){
+    return $('applicationCode').value.trim().toUpperCase();
+  }
+
+  async function api(url, opts){
+    const res = await fetch(url, {
+      credentials: 'include',
+      headers: { 'Content-Type': 'application/json', ...(opts && opts.headers ? opts.headers : {}) },
+      ...(opts || {})
+    });
+    const data = await res.json().catch(() => null);
+    if (!res.ok) throw new Error((data && data.error) || 'Request failed');
+    return data;
+  }
+
+  function render(data){
+    state.loaded = data;
+    const app = data.application || {};
+    const template = data.template || {};
+    const signature = data.signature || null;
+    $('agreementPanel').classList.remove('hidden');
+    $('templateTitle').textContent = template.title || 'CWF Partner Agreement';
+    $('applicantName').textContent = `${app.full_name || '-'} • ${app.application_code || state.applicationCode}`;
+    $('contractBody').innerHTML = esc(template.body_text || 'ยังไม่มี template สัญญาที่เปิดใช้งาน');
+    $('signerName').value = app.full_name || '';
+    if (signature) {
+      $('signatureBadge').textContent = `เซ็นแล้ว ${new Date(signature.signed_at).toLocaleString('th-TH')}`;
+      $('signatureBadge').className = 'badge ok';
+      $('signatureForm').classList.add('hidden');
+    } else {
+      $('signatureBadge').textContent = 'ยังไม่เซ็น';
+      $('signatureBadge').className = 'badge';
+      $('signatureForm').classList.remove('hidden');
+    }
+  }
+
+  async function loadAgreement(){
+    try {
+      setMessage('', '');
+      state.applicationCode = codeFromInput();
+      if (!state.applicationCode) throw new Error('กรุณากรอกรหัสใบสมัคร');
+      const data = await api(`/partner/agreement/${encodeURIComponent(state.applicationCode)}`);
+      render(data);
+    } catch (e) {
+      $('agreementPanel').classList.add('hidden');
+      setMessage(e.message, 'err');
+    }
+  }
+
+  async function signAgreement(){
+    try {
+      if (!state.applicationCode) throw new Error('กรุณาโหลดสัญญาก่อน');
+      const signer = $('signerName').value.trim();
+      const consent = $('consent').checked;
+      if (!signer) throw new Error('กรุณาพิมพ์ชื่อ-นามสกุล');
+      if (!consent) throw new Error('กรุณายืนยันการยอมรับสัญญา');
+      const data = await api(`/partner/agreement/${encodeURIComponent(state.applicationCode)}/sign`, {
+        method: 'POST',
+        body: JSON.stringify({ signer_full_name: signer, consent })
+      });
+      setMessage('บันทึกลายเซ็นเรียบร้อย', 'ok');
+      const latest = await api(`/partner/agreement/${encodeURIComponent(state.applicationCode)}`);
+      render({ ...latest, signature: data.signature || latest.signature });
+    } catch (e) {
+      setMessage(e.message, 'err');
+    }
+  }
+
+  $('btnLoad').addEventListener('click', loadAgreement);
+  $('btnSign').addEventListener('click', signAgreement);
+  $('applicationCode').addEventListener('keydown', (e) => {
+    if (e.key === 'Enter') loadAgreement();
+  });
+
+  const params = new URLSearchParams(location.search);
+  const code = params.get('code') || params.get('application_code');
+  if (code) {
+    $('applicationCode').value = code;
+    loadAgreement();
+  }
+})();


### PR DESCRIPTION
## Summary
- Adds full Partner Onboarding flow on top of Phase 1A: application, document review, agreement signing, academy, exam attempts, certification core, trial jobs, and evaluations.
- Adds guarded certification helper logic with CERTIFICATION_ENFORCEMENT=off by default.
- Keeps booking, dispatch, payout, tracking, E-slip, LINE login, technician flow, app.js, customer.html, tech.html, sw.js, and unrelated admin pages out of scope.

## Safety
- Admin routes use strict admin session middleware.
- Public applicant routes continue using application code as the temporary lookup token and do not expose private storage fields.
- Job-blocking certification enforcement is not enabled by default and is not wired to live booking/dispatch flows in this PR.
- No deploy from Codex.

## Validation
- git diff --name-only
- node --check index.js
- node --check partner-apply.js
- node --check partner-agreement.js
- node --check partner-academy.js
- node --check admin-partner-onboarding.js
- node --check admin-v2-common.js