### PR TITLE
Prepare repository architecture docs and safe system route extraction

### DIFF
--- a/docs/AI_EDITING_GUIDE.md
+++ b/docs/AI_EDITING_GUIDE.md
@@ -1,0 +1,119 @@
+# AI Editing Guide For CWF
+
+CWF is a production app. Future Codex tasks must treat this repository as high risk unless the requested change is narrow and fully traced.
+
+## Required Before Editing
+
+- Always pull/read the latest repo files directly.
+- Always read `CODEX_INSTRUCTIONS.md`, `README.md`, `package.json`, and relevant docs.
+- Always grep the route before editing.
+- Always identify the exact route and function.
+- Always identify frontend callers if the change touches an API.
+- Always state files to edit before editing.
+- Always inspect `git diff` before finishing.
+
+## Hard Rules
+
+- Never rewrite `index.js`.
+- Never do broad cleanup in the same patch as a behavior fix.
+- Never create duplicate logic.
+- Never change route paths during extraction.
+- Never change DB queries unless the task explicitly requires it.
+- Never change auth/session as a side effect.
+- Never change pricing, booking, availability, LINE login, accounting, tax/VAT, technician income, payout, close-job, or tracking behavior during unrelated work.
+- Preserve CommonJS style.
+- Production must still start with `node index.js`.
+
+## Preferred Extraction Pattern
+
+Prefer route factory modules:
+
+```js
+module.exports = function createXRoutes(deps) {
+  const router = deps.express.Router();
+
+  router.get("/existing/path", deps.requireAdminSession, async (req, res) => {
+    // moved handler only after tests pass
+  });
+
+  return router;
+};
+```
+
+Guidelines:
+
+- Pass dependencies explicitly.
+- Keep route paths exactly the same.
+- Keep response shapes exactly the same.
+- Keep middleware order exactly the same.
+- Keep SQL text and parameters exactly the same unless the task is a DB fix.
+- If extracting, delete the old duplicate route from `index.js` in the same patch only after tests pass.
+- If unsure, stop and document instead of editing.
+
+## How To Work With index.js
+
+1. Search for the exact route path:
+
+```bash
+rg -n "route_or_function_name" index.js
+```
+
+2. Read enough surrounding context to understand:
+
+- middleware
+- shared helpers
+- DB tables
+- request payload
+- response shape
+- frontend caller
+- cache/PWA impact
+
+3. Make the smallest patch possible.
+
+4. Run syntax checks:
+
+```bash
+node --check index.js
+```
+
+5. If any JS file changed, run `node --check` on it.
+
+6. Re-open `git diff` and confirm only intended files changed.
+
+## High-Risk Frozen Areas
+
+DO NOT MOVE YET:
+
+- `/public/book`
+- `/public/availability_v2`
+- `/public/pricing_preview`
+- `/admin/book_v2`
+- `/admin/job_v2` edit logic
+- auth/session routes
+- LINE login routes
+- payout calculation
+- technician finalize/close job
+- accounting documents and tax routes
+- customer tracking
+
+## Manual Test Checklist For Future Phases
+
+Run the relevant checks for the phase being changed:
+
+- App starts with `node index.js`.
+- Login works.
+- Technician page loads.
+- Technician current job tab loads.
+- Technician history tab loads.
+- Technician income tab loads.
+- Admin add job still works.
+- Admin job edit still works if touched.
+- Public booking still works.
+- Public availability still returns correct slots.
+- Public tracking still works.
+- Close job still works.
+- Photos and per-unit evidence still work.
+- Payout and technician income displays still match prior behavior.
+- Accounting/tax documents still render if touched.
+- PWA cache refreshed when frontend JS changes.
+

--- a/docs/CWF_TECHNICIAN_SPEC_MISSING.md
+++ b/docs/CWF_TECHNICIAN_SPEC_MISSING.md
@@ -1,0 +1,34 @@
+# CWF Technician Master Spec Missing
+
+The expected central technician specification file is not present in this repository:
+
+```text
+CWF_Technician_App_Master_Spec.md
+```
+
+Future AI/code agents must be given the master technician app spec before modifying technician app files or technician backend routes.
+
+## Files And Areas Covered By This Warning
+
+Do not modify these areas without the master spec and a targeted task:
+
+- `tech.html`
+- technician-facing JavaScript and preload files
+- technician route handlers in `index.js`
+- technician income display routes
+- technician payout routes
+- technician close-job/finalize routes
+- technician photos, `job_units`, and evidence routes
+- technician work calendar/readiness routes
+- technician LINE/session behavior
+
+## Required Future Workflow
+
+Before changing technician behavior:
+
+- Provide or restore `CWF_Technician_App_Master_Spec.md`.
+- Read `CODEX_INSTRUCTIONS.md`.
+- Grep the exact route or frontend function before editing.
+- Identify the exact frontend caller, backend route, database tables, cache/PWA impact, and regression checklist.
+- Stop and document instead of editing if the spec is unavailable or conflicts with the requested change.
+

--- a/docs/DB_POOL_EXTRACTION_PLAN.md
+++ b/docs/DB_POOL_EXTRACTION_PLAN.md
@@ -1,0 +1,133 @@
+# DB Pool Extraction Plan
+
+Date: 2026-05-10
+
+This document records the Phase 2A database pool audit and preparation. It does not move queries, change connection settings, or change runtime behavior.
+
+## Current Pool Source
+
+Current single source of truth:
+
+```text
+db.js
+```
+
+`db.js` creates the PostgreSQL pool:
+
+```js
+const { Pool } = require("pg");
+const pool = new Pool({ ... });
+module.exports = pool;
+```
+
+The exported value is the pool object itself, not an object shaped like `{ pool }`.
+
+## Current Import/Export Shape
+
+Current root import in `index.js`:
+
+```js
+const pool = require("./db");
+```
+
+Other direct DB import found:
+
+```js
+cwf-revisit-tech-preload.js
+try { pool = require('./db'); } catch (e) { ... }
+```
+
+No other JavaScript file was found creating `new Pool(...)`. Existing server helper modules either do not use the DB directly or accept `pool` through dependency injection.
+
+## Phase 2A Preparation
+
+Created:
+
+```text
+server/db/pool.js
+```
+
+Current contents:
+
+```js
+module.exports = require("../../db");
+```
+
+This preserves the exact export shape from `db.js`. Future route and service modules can import:
+
+```js
+const pool = require("../../db/pool");
+```
+
+from files under `server/routes/...`, adjusting the relative path as needed.
+
+## Why This Does Not Create A Second Pool
+
+`server/db/pool.js` does not call `new Pool(...)`. It only re-exports the existing root `db.js` module. Node resolves `../../db` to the same root file, so the root module remains the only place that creates the pool.
+
+## index.js Status
+
+`index.js` was not changed in Phase 2A.
+
+Reason:
+
+- Keeping `const pool = require("./db")` avoids any startup behavior change.
+- Future modules can use `server/db/pool.js` without forcing a large `index.js` diff.
+- A later cleanup may switch `index.js` to `require("./server/db/pool")`, but only after a focused check confirms shape and startup behavior.
+
+## Recommended Future Import Style
+
+For new modules under `server/routes` or `server/services`, prefer importing the shared wrapper:
+
+```js
+const pool = require("../../db/pool");
+```
+
+For route factory modules, prefer dependency injection when the route already receives dependencies from `index.js`:
+
+```js
+module.exports = function createSomeRoutes(deps = {}) {
+  const pool = deps.pool || require("../../db/pool");
+};
+```
+
+Use one style per module. Do not create a new `Pool`.
+
+## Risks
+
+- `db.js` logs DB config when required. Any module importing `server/db/pool.js` will trigger the same root `db.js` behavior if it has not already been loaded.
+- `cwf-revisit-tech-preload.js` still imports `./db` directly. Do not change preload behavior without a separate audit.
+- Some existing helper modules accept `pool` through dependency injection. Do not replace injected dependencies casually.
+- `index.js` contains many direct `pool.query` and `pool.connect` calls; moving those calls requires route-by-route extraction, not a broad DB refactor.
+
+## Rollback
+
+If the wrapper causes any issue:
+
+1. Remove `server/db/pool.js`.
+2. Keep all existing imports pointed at `./db`.
+3. Run `node --check index.js`.
+4. Run `node --check server/routes/system/index.js`.
+
+Because Phase 2A does not change `index.js`, rollback is low risk.
+
+## Files To Migrate First Later
+
+Recommended first future migrations:
+
+- New low-risk route modules that need read-only DB access.
+- Small service modules created during future route extraction.
+- Avoid high-risk areas until dedicated route maps and tests exist.
+
+Do not migrate first:
+
+- auth/session
+- LINE login
+- public booking
+- availability/timezone
+- pricing
+- technician income and payouts
+- close-job/finalize/unit evidence
+- accounting/tax/VAT
+- `cwf-revisit-tech-preload.js`
+

--- a/docs/DB_POOL_EXTRACTION_PLAN.md
+++ b/docs/DB_POOL_EXTRACTION_PLAN.md
@@ -67,13 +67,20 @@ from files under `server/routes/...`, adjusting the relative path as needed.
 
 ## index.js Status
 
-`index.js` was not changed in Phase 2A.
+Phase 2A did not change `index.js`.
 
 Reason:
 
 - Keeping `const pool = require("./db")` avoids any startup behavior change.
 - Future modules can use `server/db/pool.js` without forcing a large `index.js` diff.
 - A later cleanup may switch `index.js` to `require("./server/db/pool")`, but only after a focused check confirms shape and startup behavior.
+
+Phase 2C update:
+
+- `index.js` still imports the root pool with `const pool = require("./db")`.
+- `index.js` now passes that existing pool into the system router with `app.use(createSystemRoutes({ pool }))`.
+- `server/routes/system/index.js` can fall back to `server/db/pool.js`, but the production mount receives the existing pool explicitly.
+- No second pool was created.
 
 ## Recommended Future Import Style
 
@@ -130,4 +137,3 @@ Do not migrate first:
 - close-job/finalize/unit evidence
 - accounting/tax/VAT
 - `cwf-revisit-tech-preload.js`
-

--- a/docs/INDEX_JS_SPLIT_PLAN.md
+++ b/docs/INDEX_JS_SPLIT_PLAN.md
@@ -101,6 +101,12 @@ Rules:
 - No business calculations.
 - Confirm `node index.js` still starts.
 
+Phase 1A status:
+
+- `GET /api/version` has been extracted to `server/routes/system/index.js`.
+- `index.js` imports `./server/routes/system` and mounts it at the existing `Health / Version` location before `/api/maps/resolve`.
+- Rollback: remove the system route import and mount from `index.js`, restore the original inline `app.get("/api/version", ...)` block at the same marker, delete `server/routes/system/index.js`, then run `node --check index.js`.
+
 ### Phase 2: Read-Only Technician Routes
 
 - Move read-only technician routes with no DB writes.
@@ -157,4 +163,3 @@ Before extracting any route:
 - Add or update a focused test/checklist.
 - Run `node --check index.js` and `node --check` on every changed JS file.
 - Run manual smoke tests for the relevant user flow.
-

--- a/docs/INDEX_JS_SPLIT_PLAN.md
+++ b/docs/INDEX_JS_SPLIT_PLAN.md
@@ -1,0 +1,160 @@
+# index.js Split Plan
+
+This plan is intentionally conservative. Do not extract production logic from `index.js` until each phase has a route map, dependency list, syntax check, and manual regression checklist.
+
+## Target Structure
+
+Recommended future structure:
+
+```text
+server/
+  db/
+    pool.js
+  middleware/
+    auth.js
+    upload.js
+  routes/
+    technician/
+      jobs.js
+      income.js
+      payouts.js
+      rework.js
+      evidence.js
+    admin/
+      jobs.js
+      booking.js
+      deductions.js
+      rework.js
+      payouts.js
+      accounting.js
+    public/
+      booking.js
+      tracking.js
+      pricingPreview.js
+    partner/
+      applications.js
+      agreement.js
+      academy.js
+    docs/
+      receipts.js
+      quotes.js
+      eslip.js
+  services/
+    jobs/
+      jobItems.js
+      jobUnits.js
+      closeJob.js
+      closeJobValidation.js
+    technician/
+      incomeDisplay.js
+      payoutPeriods.js
+      identity.js
+    admin/
+      bookingService.js
+    public/
+      availabilityService.js
+  utils/
+    dates.js
+    money.js
+    asyncHandler.js
+```
+
+## Module Pattern For Future Route Extraction
+
+Prefer route factory modules that receive all dependencies explicitly:
+
+```js
+module.exports = function createXRoutes(deps) {
+  const router = deps.express.Router();
+
+  router.get("/existing/path", deps.requireAdminSession, async (req, res) => {
+    // moved handler only after tests pass
+  });
+
+  return router;
+};
+```
+
+Rules:
+
+- Keep CommonJS.
+- Keep route paths exactly the same.
+- Pass dependencies explicitly.
+- Do not import global app state from `index.js`.
+- Do not create duplicate route logic.
+- If extracting, delete the old duplicate route from `index.js` in the same patch only after tests pass.
+
+## Safe Phased Plan
+
+### Phase 0: Documentation and Folder Boundaries Only
+
+- Add architecture docs.
+- Add empty/skeleton folders with README files.
+- Do not change runtime code.
+- Do not import new modules into `index.js`.
+
+### Phase 1: Tiny Low-Risk Routes Only
+
+- Move only pure health/status routes, such as `/api/version`, or pure health checks.
+- No DB writes.
+- No auth/session changes.
+- No business calculations.
+- Confirm `node index.js` still starts.
+
+### Phase 2: Read-Only Technician Routes
+
+- Move read-only technician routes with no DB writes.
+- Confirm route paths and response shapes are identical.
+- Keep technician session middleware behavior unchanged.
+- Avoid current job, close job, photos, evidence, payout, and income write paths.
+
+### Phase 3: Technician Income Display Routes
+
+- Move technician income display routes only if they already use:
+  - `server/technicianIncome.js`
+  - `server/technicianJobIncomeDisplay.js`
+  - `server/technicianJobMoneySummary.js`
+- Preserve calculation helpers and response fields exactly.
+- Do not modify payout generation, settlement, withdrawal, or accounting flows.
+
+### Phase 4: job_units and Evidence Helpers
+
+- Move `job_units`, photo metadata, upload, and evidence helpers only after dedicated tests exist.
+- Validate close-job and per-unit evidence behavior before and after extraction.
+- Keep upload middleware and Cloudinary behavior unchanged.
+
+### Phase 5: Admin Job Routes
+
+- Move admin job routes only after a route map and regression checklist exist.
+- Freeze `/admin/book_v2` and `/admin/job_v2` edit logic until there are focused tests.
+- Preserve admin soft/session middleware behavior exactly.
+
+## High-Risk Frozen Areas
+
+Explicitly DO NOT MOVE YET:
+
+- `/public/book`
+- `/public/availability_v2`
+- `/public/pricing_preview`
+- `/admin/book_v2`
+- `/admin/job_v2` edit logic
+- auth/session routes
+- LINE login routes
+- payout calculation
+- technician finalize/close job
+- accounting documents and tax routes
+- customer tracking
+
+## Split Readiness Checklist
+
+Before extracting any route:
+
+- Grep the route path and confirm there is exactly one production handler.
+- Identify helper functions used by the route.
+- Identify middleware used by the route.
+- Identify database tables and columns touched by the route.
+- Identify frontend callers and expected response shape.
+- Add or update a focused test/checklist.
+- Run `node --check index.js` and `node --check` on every changed JS file.
+- Run manual smoke tests for the relevant user flow.
+

--- a/docs/INDEX_JS_SPLIT_PLAN.md
+++ b/docs/INDEX_JS_SPLIT_PLAN.md
@@ -117,6 +117,14 @@ Phase 1B status:
   - Other `status` routes are partner, technician, admin, attendance, or job business-flow routes.
 - Rollback: no runtime rollback is needed for Phase 1B because it is docs-only. Revert the Phase 1B docs commit if the finding needs to be removed.
 
+### Phase 2A: DB Pool Preparation
+
+- Root `db.js` remains the single source of truth and still exports the pool object directly.
+- `server/db/pool.js` re-exports `../../db` for future route/service modules.
+- `index.js` was not changed in Phase 2A to avoid startup behavior risk.
+- Do not create another `new Pool(...)` anywhere else.
+- See `docs/DB_POOL_EXTRACTION_PLAN.md` before moving DB-backed routes.
+
 ### Phase 2: Read-Only Technician Routes
 
 - Move read-only technician routes with no DB writes.

--- a/docs/INDEX_JS_SPLIT_PLAN.md
+++ b/docs/INDEX_JS_SPLIT_PLAN.md
@@ -107,6 +107,16 @@ Phase 1A status:
 - `index.js` imports `./server/routes/system` and mounts it at the existing `Health / Version` location before `/api/maps/resolve`.
 - Rollback: remove the system route import and mount from `index.js`, restore the original inline `app.get("/api/version", ...)` block at the same marker, delete `server/routes/system/index.js`, then run `node --check index.js`.
 
+Phase 1B status:
+
+- No additional route was extracted.
+- Rechecked the next apparent health/status candidates:
+  - `/test-db` uses DB access.
+  - `/admin/debug/status` uses admin middleware and runtime debug state.
+  - `/public/line_config` is LINE-adjacent configuration.
+  - Other `status` routes are partner, technician, admin, attendance, or job business-flow routes.
+- Rollback: no runtime rollback is needed for Phase 1B because it is docs-only. Revert the Phase 1B docs commit if the finding needs to be removed.
+
 ### Phase 2: Read-Only Technician Routes
 
 - Move read-only technician routes with no DB writes.

--- a/docs/INDEX_JS_SPLIT_PLAN.md
+++ b/docs/INDEX_JS_SPLIT_PLAN.md
@@ -125,6 +125,16 @@ Phase 1B status:
 - Do not create another `new Pool(...)` anywhere else.
 - See `docs/DB_POOL_EXTRACTION_PLAN.md` before moving DB-backed routes.
 
+### Phase 2C: Small DB Health Route
+
+- `GET /test-db` has been extracted into `server/routes/system/index.js`.
+- `index.js` now mounts the system router with the existing pool: `app.use(createSystemRoutes({ pool }))`.
+- SQL and response shapes are unchanged:
+  - success: `{ ok: true, now }`
+  - error: HTTP 500 with `{ ok: false, error: "db connection failed" }`
+- No new PostgreSQL pool was created.
+- Rollback: remove the `/test-db` route from `server/routes/system/index.js`, restore the old inline `app.get("/test-db", ...)` block at the `TEST DB` marker in `index.js`, and restore `app.use(createSystemRoutes({}))` if the system router no longer needs the pool.
+
 ### Phase 2: Read-Only Technician Routes
 
 - Move read-only technician routes with no DB writes.

--- a/docs/PHASE1_LOW_RISK_ROUTE_MAP.md
+++ b/docs/PHASE1_LOW_RISK_ROUTE_MAP.md
@@ -1,0 +1,146 @@
+# Phase 1 Low-Risk Route Map
+
+Date: 2026-05-10
+
+This document prepares the first safe route extraction from `index.js`. It is a route map only. Do not move routes in this phase.
+
+## Scope
+
+Recommended first route group:
+
+- `/api/version`
+- Health/status/pure read-only routes if they exist.
+
+Current audit result:
+
+- `/api/version` exists and is the safest first extraction candidate.
+- No separate `/health` or `/status` route was found in `index.js`.
+- `/test-db` exists but uses the database, so it is not the first extraction candidate.
+- `/admin/debug/status` exists but uses admin middleware and availability debug state, so it should not move before `/api/version`.
+- `/public/line_config`, `/public/me`, and `/api/auth/me` are read-like routes, but they touch LINE config, JWT/session, or auth context and are not Phase 1 first candidates.
+
+## Candidate Route Matrix
+
+| Route | Current location | Nearby marker | Dependencies | DB | Auth/session | Upload | Pricing | External APIs | Phase 1 recommendation |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| `GET /api/version` | `index.js:10665` | `Health / Version` marker | `res`, `Date` | No | No | No | No | No | Move first. Lowest risk. |
+| `GET /test-db` | `index.js:12841` | `TEST DB` | `pool.query`, `console.error` | Yes, read-only `SELECT NOW()` | No | No | No | No | Do not move first. Candidate only after `/api/version`. |
+| `GET /admin/debug/status` | `index.js:25201` | `Admin Debug Controls (availability logging)` | `requireAdminSoft`, `ENABLE_AVAILABILITY_DEBUG`, `RUNTIME_AVAILABILITY_DEBUG`, `process.env.TZ` | No | Yes, admin soft guard | No | No | No | Do not move first. Requires middleware dependency mapping. |
+| `GET /public/line_config` | `index.js:1011` | `Public LINE config (debug only - no secrets)` | `process.env`, `getReqBaseUrl(req)` | No | No | No | No | No direct call, but LINE env/callback config | Do not move in Phase 1. LINE-adjacent. |
+| `GET /public/me` | `index.js:969` | public customer session area | `getJwtSecret`, `parseCookieValue`, `jwtVerify`, `pool.query` for customer profile | Yes, conditional profile read | Yes, customer JWT/cookie | No | No | No | Frozen. Auth/session/customer profile. |
+| `GET /api/auth/me` | `index.js:4312` | `Session check for frontend guards` | `getAuthContext`, `isSuperAdmin` | Possible through auth context | Yes | No | No | No | Frozen. Auth/session. |
+
+## Safest First Extraction Candidate
+
+Move only:
+
+```text
+GET /api/version
+```
+
+Why:
+
+- No database access.
+- No auth/session middleware.
+- No upload middleware.
+- No pricing helpers.
+- No external APIs.
+- No business logic.
+- Response shape is tiny and easy to compare:
+
+```js
+{ ok: true, version: "gps-v4", ts: new Date().toISOString() }
+```
+
+Risk note: the timestamp is intentionally dynamic. Future tests should validate shape and parseability, not exact `ts` value.
+
+## Proposed New File Path
+
+Use this path for the first extraction patch:
+
+```text
+server/routes/system/index.js
+```
+
+Do not create or import this runtime file until the actual extraction task.
+
+## Proposed Factory Pattern
+
+```js
+module.exports = function createSystemRoutes(deps) {
+  const router = deps.express.Router();
+
+  router.get("/api/version", (req, res) => {
+    res.json({ ok: true, version: "gps-v4", ts: new Date().toISOString() });
+  });
+
+  return router;
+};
+```
+
+Notes:
+
+- Keep CommonJS.
+- Pass `express` explicitly through `deps`.
+- Keep the route path exactly `/api/version`.
+- Do not add middleware.
+- Do not change the response fields or version string.
+
+## Exact index.js Mount Plan For Future Extraction
+
+Future extraction patch should do exactly this and no more:
+
+1. Add `server/routes/system/index.js`.
+2. Near the existing route dependencies in `index.js`, add:
+
+```js
+const createSystemRoutes = require("./server/routes/system");
+```
+
+3. Replace only the current inline route at `index.js:10665`:
+
+```js
+app.get("/api/version", (req, res) => {
+  res.json({ ok: true, version: "gps-v4", ts: new Date().toISOString() });
+});
+```
+
+with:
+
+```js
+app.use(createSystemRoutes({ express }));
+```
+
+4. Keep the mount in the same general location as the current `Health / Version` marker, before `/api/maps/resolve`.
+5. Do not move `/api/maps/resolve`.
+6. Do not touch `/test-db`.
+7. Do not touch auth/session, LINE login, pricing, booking, availability, accounting/tax/VAT, public tracking, technician income, payout, or close-job/finalize logic.
+
+## Manual Test Checklist
+
+For the future extraction patch:
+
+- Run `node --check index.js`.
+- Run `node --check server/routes/system/index.js`.
+- Start the app with `node index.js`.
+- Call `GET /api/version`.
+- Confirm response has:
+  - `ok: true`
+  - `version: "gps-v4"`
+  - `ts` as a valid ISO timestamp string.
+- Confirm login page still loads.
+- Confirm no PWA/cache bump is needed because no frontend JS changed.
+- Confirm `git diff` touches only `index.js` and `server/routes/system/index.js` for the extraction task.
+
+## Rollback Plan
+
+If the future extraction causes any startup or routing issue:
+
+1. Remove the `createSystemRoutes` require from `index.js`.
+2. Remove the `app.use(createSystemRoutes({ express }))` mount.
+3. Restore the original inline `app.get("/api/version", ...)` block in the same location.
+4. Delete `server/routes/system/index.js`.
+5. Run `node --check index.js`.
+6. Restart and re-check `GET /api/version`.
+
+Because `/api/version` has no DB, auth, upload, pricing, or external API dependencies, rollback should be low risk.

--- a/docs/PHASE1_LOW_RISK_ROUTE_MAP.md
+++ b/docs/PHASE1_LOW_RISK_ROUTE_MAP.md
@@ -2,7 +2,9 @@
 
 Date: 2026-05-10
 
-This document prepares the first safe route extraction from `index.js`. It is a route map only. Do not move routes in this phase.
+This document prepared the first safe route extraction from `index.js`.
+
+Phase 1A status: `GET /api/version` has been extracted to `server/routes/system/index.js` and mounted from the existing `Health / Version` location in `index.js`.
 
 ## Scope
 
@@ -23,7 +25,7 @@ Current audit result:
 
 | Route | Current location | Nearby marker | Dependencies | DB | Auth/session | Upload | Pricing | External APIs | Phase 1 recommendation |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| `GET /api/version` | `index.js:10665` | `Health / Version` marker | `res`, `Date` | No | No | No | No | No | Move first. Lowest risk. |
+| `GET /api/version` | `index.js` `Health / Version` marker | `Health / Version` marker | `res`, `Date` | No | No | No | No | No | Extracted in Phase 1A to `server/routes/system/index.js`. |
 | `GET /test-db` | `index.js:12841` | `TEST DB` | `pool.query`, `console.error` | Yes, read-only `SELECT NOW()` | No | No | No | No | Do not move first. Candidate only after `/api/version`. |
 | `GET /admin/debug/status` | `index.js:25201` | `Admin Debug Controls (availability logging)` | `requireAdminSoft`, `ENABLE_AVAILABILITY_DEBUG`, `RUNTIME_AVAILABILITY_DEBUG`, `process.env.TZ` | No | Yes, admin soft guard | No | No | No | Do not move first. Requires middleware dependency mapping. |
 | `GET /public/line_config` | `index.js:1011` | `Public LINE config (debug only - no secrets)` | `process.env`, `getReqBaseUrl(req)` | No | No | No | No | No direct call, but LINE env/callback config | Do not move in Phase 1. LINE-adjacent. |
@@ -32,7 +34,7 @@ Current audit result:
 
 ## Safest First Extraction Candidate
 
-Move only:
+Moved only:
 
 ```text
 GET /api/version
@@ -56,19 +58,20 @@ Risk note: the timestamp is intentionally dynamic. Future tests should validate 
 
 ## Proposed New File Path
 
-Use this path for the first extraction patch:
+Phase 1A uses this path:
 
 ```text
 server/routes/system/index.js
 ```
 
-Do not create or import this runtime file until the actual extraction task.
+This runtime file now exists and is mounted from `index.js`.
 
 ## Proposed Factory Pattern
 
 ```js
-module.exports = function createSystemRoutes(deps) {
-  const router = deps.express.Router();
+module.exports = function createSystemRoutes(deps = {}) {
+  const express = require("express");
+  const router = express.Router();
 
   router.get("/api/version", (req, res) => {
     res.json({ ok: true, version: "gps-v4", ts: new Date().toISOString() });
@@ -88,16 +91,16 @@ Notes:
 
 ## Exact index.js Mount Plan For Future Extraction
 
-Future extraction patch should do exactly this and no more:
+Phase 1A did exactly this and no more:
 
-1. Add `server/routes/system/index.js`.
-2. Near the existing route dependencies in `index.js`, add:
+1. Added `server/routes/system/index.js`.
+2. Near the existing route dependencies in `index.js`, added:
 
 ```js
 const createSystemRoutes = require("./server/routes/system");
 ```
 
-3. Replace only the current inline route at `index.js:10665`:
+3. Replaced only the previous inline route:
 
 ```js
 app.get("/api/version", (req, res) => {
@@ -108,17 +111,17 @@ app.get("/api/version", (req, res) => {
 with:
 
 ```js
-app.use(createSystemRoutes({ express }));
+app.use(createSystemRoutes({}));
 ```
 
-4. Keep the mount in the same general location as the current `Health / Version` marker, before `/api/maps/resolve`.
-5. Do not move `/api/maps/resolve`.
-6. Do not touch `/test-db`.
-7. Do not touch auth/session, LINE login, pricing, booking, availability, accounting/tax/VAT, public tracking, technician income, payout, or close-job/finalize logic.
+4. The mount remains in the same general location as the current `Health / Version` marker, before `/api/maps/resolve`.
+5. `/api/maps/resolve` was not moved.
+6. `/test-db` was not touched.
+7. Auth/session, LINE login, pricing, booking, availability, accounting/tax/VAT, public tracking, technician income, payout, and close-job/finalize logic were not touched.
 
 ## Manual Test Checklist
 
-For the future extraction patch:
+For Phase 1A and future checks:
 
 - Run `node --check index.js`.
 - Run `node --check server/routes/system/index.js`.
@@ -130,14 +133,14 @@ For the future extraction patch:
   - `ts` as a valid ISO timestamp string.
 - Confirm login page still loads.
 - Confirm no PWA/cache bump is needed because no frontend JS changed.
-- Confirm `git diff` touches only `index.js` and `server/routes/system/index.js` for the extraction task.
+- Confirm runtime `git diff` touches only `index.js` and `server/routes/system/index.js` for the extraction task.
 
 ## Rollback Plan
 
-If the future extraction causes any startup or routing issue:
+If the Phase 1A extraction causes any startup or routing issue:
 
 1. Remove the `createSystemRoutes` require from `index.js`.
-2. Remove the `app.use(createSystemRoutes({ express }))` mount.
+2. Remove the `app.use(createSystemRoutes({}))` mount.
 3. Restore the original inline `app.get("/api/version", ...)` block in the same location.
 4. Delete `server/routes/system/index.js`.
 5. Run `node --check index.js`.

--- a/docs/PHASE1_LOW_RISK_ROUTE_MAP.md
+++ b/docs/PHASE1_LOW_RISK_ROUTE_MAP.md
@@ -6,6 +6,8 @@ This document prepared the first safe route extraction from `index.js`.
 
 Phase 1A status: `GET /api/version` has been extracted to `server/routes/system/index.js` and mounted from the existing `Health / Version` location in `index.js`.
 
+Phase 1B status: no additional route was extracted. The next visible health/status candidates all require DB, auth/session, LINE-adjacent config, or business-flow context, so moving them would exceed the Phase 1 low-risk boundary.
+
 ## Scope
 
 Recommended first route group:
@@ -20,6 +22,7 @@ Current audit result:
 - `/test-db` exists but uses the database, so it is not the first extraction candidate.
 - `/admin/debug/status` exists but uses admin middleware and availability debug state, so it should not move before `/api/version`.
 - `/public/line_config`, `/public/me`, and `/api/auth/me` are read-like routes, but they touch LINE config, JWT/session, or auth context and are not Phase 1 first candidates.
+- Phase 1B rechecked health/status/system candidates after Phase 1A and found no next route that meets all constraints: no DB, no auth/session, no upload, no pricing, no external APIs, no state mutation, and no technician/admin/customer/business-flow impact.
 
 ## Candidate Route Matrix
 
@@ -31,6 +34,32 @@ Current audit result:
 | `GET /public/line_config` | `index.js:1011` | `Public LINE config (debug only - no secrets)` | `process.env`, `getReqBaseUrl(req)` | No | No | No | No | No direct call, but LINE env/callback config | Do not move in Phase 1. LINE-adjacent. |
 | `GET /public/me` | `index.js:969` | public customer session area | `getJwtSecret`, `parseCookieValue`, `jwtVerify`, `pool.query` for customer profile | Yes, conditional profile read | Yes, customer JWT/cookie | No | No | No | Frozen. Auth/session/customer profile. |
 | `GET /api/auth/me` | `index.js:4312` | `Session check for frontend guards` | `getAuthContext`, `isSuperAdmin` | Possible through auth context | Yes | No | No | No | Frozen. Auth/session. |
+
+## Phase 1B Finding
+
+No route was moved in Phase 1B.
+
+Rejected candidates:
+
+- `GET /test-db` at previous `index.js:12840`: uses `pool.query("SELECT NOW() as now")`, returns database time, and may fail based on DB connectivity. It is read-only but not DB-free.
+- `GET /admin/debug/status` at previous `index.js:25200`: uses `requireAdminSoft`, `ENABLE_AVAILABILITY_DEBUG`, `RUNTIME_AVAILABILITY_DEBUG`, and `process.env.TZ`. It is read-only but auth/session and runtime debug-state adjacent.
+- `GET /public/line_config` at `index.js:1012`: reads LINE/JWT environment configuration and builds callback/base URLs through `getReqBaseUrl(req)`. It is LINE-adjacent and should stay frozen for now.
+- Other `status` routes found by grep are partner, technician, admin, attendance, or job business-flow routes. They are outside the system/health scope.
+
+Dependencies used by the route extracted so far:
+
+- `GET /api/version`: `Date`, `res.json`.
+- DB: no.
+- Auth/session: no.
+- Upload: no.
+- Pricing: no.
+- External APIs: no.
+- State mutation: no.
+
+Phase 1B rollback instruction:
+
+- No runtime rollback is needed because Phase 1B did not move a route.
+- To roll back the documentation-only Phase 1B note, revert this docs commit.
 
 ## Safest First Extraction Candidate
 
@@ -134,6 +163,14 @@ For Phase 1A and future checks:
 - Confirm login page still loads.
 - Confirm no PWA/cache bump is needed because no frontend JS changed.
 - Confirm runtime `git diff` touches only `index.js` and `server/routes/system/index.js` for the extraction task.
+
+For Phase 1B:
+
+- Run `node --check index.js`.
+- Run `node --check server/routes/system/index.js`.
+- Confirm no runtime route diff exists.
+- Confirm `server/routes/system/index.js` still exposes only `GET /api/version`.
+- Confirm no PWA/cache bump is needed because no frontend JS changed.
 
 ## Rollback Plan
 

--- a/docs/PHASE2B_READONLY_DB_ROUTE_CANDIDATES.md
+++ b/docs/PHASE2B_READONLY_DB_ROUTE_CANDIDATES.md
@@ -1,0 +1,157 @@
+# Phase 2B Read-Only DB Route Candidates
+
+Date: 2026-05-10
+
+This document audits small DB-backed GET routes for a future extraction. No route was moved in Phase 2B.
+
+## Summary
+
+Recommended Phase 2C candidate:
+
+```text
+GET /test-db
+```
+
+Why:
+
+- It is the smallest DB-backed GET route found.
+- It uses only `pool.query`.
+- It has no auth/session middleware.
+- It has no upload middleware.
+- It has no pricing, booking, availability, LINE, accounting, income, close-job, or technician evidence dependency.
+- It does not mutate state.
+- It has a very small response shape.
+
+## Candidate Routes Inspected
+
+| Route | Method | Current location | SQL used | Dependencies | Auth/session | Side effects | Response shape | Risk | Recommendation |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| `/test-db` | GET | `index.js:12840` | `SELECT NOW() as now` | `pool.query`, `console.error` | No | No DB mutation; does require DB connectivity | Success: `{ ok: true, now }`; failure: `{ ok: false, error: "db connection failed" }` | Low | Recommended for Phase 2C. |
+| `/users/technicians` | GET | `index.js:12919` | `SELECT username FROM public.users WHERE role='technician' ORDER BY username` | `pool.query`, `console.error` | No | No mutation | Array of `{ username }`; failure `{ error }` | Medium | Do not move yet. User/technician directory may affect admin booking/assignment UI. |
+| `/catalog/items` | GET | `index.js:12938` | Dynamic `SELECT item_id, item_name, item_category, base_price, unit_label, is_active, job_category, ac_type, btu_min, btu_max, is_customer_visible FROM public.catalog_items WHERE ... ORDER BY item_category, item_name` | `pool.query`, request query filters | No | No mutation | Array of catalog item rows; failure `{ error }` | High | Do not move yet. Catalog/pricing-adjacent and customer-visible. |
+| `/promotions` | GET | `index.js:13003` | `getPromotionColumns()` reads `information_schema.columns`; route then queries `public.promotions` with dynamic selected columns | `pool.query`, `getPromotionColumns`, in-memory column cache, request query filters | No | No DB mutation; mutates in-memory column cache | Array of promotion rows; failure `{ error }` | High | Do not move yet. Promotion/pricing/customer-visible behavior. |
+| `/service_zones` | GET | `index.js:21336` | Via `getServiceZones()`: `SELECT zone_code, zone_name, zone_label, province_group, color_hex, is_active, sort_order FROM public.service_zones WHERE is_active=TRUE ORDER BY sort_order, zone_code` | `getServiceZones`, `pool.query`, `SERVICE_ZONE_SEEDS`, `ENABLE_SERVICE_ZONE_FILTER` | No | No mutation; has fallback seed behavior | `{ ok: true, zones, filter_enabled }`; failure `{ error }` | Medium | Do not move yet. Availability/service-zone behavior affects booking and technician assignment. |
+| `/public/line_config` | GET | `index.js:1012` | None | `process.env`, `getReqBaseUrl(req)` | No | No mutation | `{ ok, env, callback_url, base_url }`; failure `{ ok: false, error }` | High | Do not move. LINE-adjacent config is frozen. |
+| `/admin/debug/status` | GET | `index.js:25200` | None | `requireAdminSoft`, `ENABLE_AVAILABILITY_DEBUG`, `RUNTIME_AVAILABILITY_DEBUG`, `process.env.TZ` | Yes, admin soft guard | No mutation in GET, but runtime debug-state adjacent | `{ success, availability_debug_env, availability_debug_runtime, tz }`; failure `{ error }` | Medium | Do not move yet. Middleware and debug-state dependency. |
+
+## Recommended Phase 2C Extraction Candidate
+
+Move only:
+
+```text
+GET /test-db
+```
+
+Current handler:
+
+```js
+app.get("/test-db", async (req, res) => {
+  try {
+    const r = await pool.query("SELECT NOW() as now");
+    res.json({ ok: true, now: r.rows[0].now });
+  } catch (e) {
+    console.error(e);
+    res.status(500).json({ ok: false, error: "db connection failed" });
+  }
+});
+```
+
+## Proposed Target Module
+
+Use a new DB-backed system route module:
+
+```text
+server/routes/system/dbHealth.js
+```
+
+Keep `server/routes/system/index.js` as the system route aggregator.
+
+## Proposed Dependency Pattern
+
+Prefer explicit dependency injection from `index.js` for the first DB-backed extraction:
+
+```js
+module.exports = function createDbHealthRoutes(deps = {}) {
+  const express = require("express");
+  const router = express.Router();
+  const pool = deps.pool || require("../../db/pool");
+
+  router.get("/test-db", async (req, res) => {
+    try {
+      const r = await pool.query("SELECT NOW() as now");
+      res.json({ ok: true, now: r.rows[0].now });
+    } catch (e) {
+      console.error(e);
+      res.status(500).json({ ok: false, error: "db connection failed" });
+    }
+  });
+
+  return router;
+};
+```
+
+Future `index.js` mount should pass the existing pool to avoid changing pool initialization behavior:
+
+```js
+app.use(createSystemRoutes({ pool }));
+```
+
+Then `server/routes/system/index.js` can mount both:
+
+```js
+router.use(createDbHealthRoutes({ pool: deps.pool }));
+```
+
+Do not create a new `Pool`.
+
+## Exact Tests For Phase 2C
+
+Syntax checks:
+
+```bash
+node --check index.js
+node --check server/routes/system/index.js
+node --check server/routes/system/dbHealth.js
+node --check server/db/pool.js
+```
+
+Route shape checks without production DB:
+
+- Inspect Express router stack and confirm `/api/version` is still GET.
+- Inspect Express router stack and confirm `/test-db` is GET after extraction.
+
+Manual check only in a safe environment:
+
+- Start app with safe non-production DB configuration.
+- Call `GET /test-db`.
+- Confirm success response shape is still `{ ok: true, now }`.
+- If DB is unavailable, confirm failure response shape is still `{ ok: false, error: "db connection failed" }` with HTTP 500.
+
+## Rollback Plan For Phase 2C
+
+If extraction causes any startup or routing issue:
+
+1. Remove the `dbHealth` route import/mount from `server/routes/system/index.js`.
+2. Restore the original inline `app.get("/test-db", ...)` block in `index.js` at the `TEST DB` marker.
+3. Restore the previous `app.use(createSystemRoutes({}))` mount if it was changed.
+4. Delete `server/routes/system/dbHealth.js`.
+5. Run:
+
+```bash
+node --check index.js
+node --check server/routes/system/index.js
+node --check server/db/pool.js
+```
+
+## Do Not Move In Phase 2C
+
+Do not move:
+
+- `/users/technicians`
+- `/catalog/items`
+- `/promotions`
+- `/service_zones`
+- `/public/line_config`
+- `/admin/debug/status`
+- Any technician, admin, customer booking, pricing, availability, LINE, accounting, income, close-job, or unit evidence route.
+

--- a/docs/PHASE2B_READONLY_DB_ROUTE_CANDIDATES.md
+++ b/docs/PHASE2B_READONLY_DB_ROUTE_CANDIDATES.md
@@ -2,7 +2,9 @@
 
 Date: 2026-05-10
 
-This document audits small DB-backed GET routes for a future extraction. No route was moved in Phase 2B.
+This document audits small DB-backed GET routes for extraction. No route was moved in Phase 2B.
+
+Phase 2C status: `GET /test-db` has been extracted into `server/routes/system/index.js` and is mounted through the existing system router from `index.js`.
 
 ## Summary
 
@@ -26,7 +28,7 @@ Why:
 
 | Route | Method | Current location | SQL used | Dependencies | Auth/session | Side effects | Response shape | Risk | Recommendation |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| `/test-db` | GET | `index.js:12840` | `SELECT NOW() as now` | `pool.query`, `console.error` | No | No DB mutation; does require DB connectivity | Success: `{ ok: true, now }`; failure: `{ ok: false, error: "db connection failed" }` | Low | Recommended for Phase 2C. |
+| `/test-db` | GET | Was `index.js:12840`; now `server/routes/system/index.js` | `SELECT NOW() as now` | `pool.query`, `console.error` | No | No DB mutation; does require DB connectivity | Success: `{ ok: true, now }`; failure: `{ ok: false, error: "db connection failed" }` | Low | Extracted in Phase 2C. |
 | `/users/technicians` | GET | `index.js:12919` | `SELECT username FROM public.users WHERE role='technician' ORDER BY username` | `pool.query`, `console.error` | No | No mutation | Array of `{ username }`; failure `{ error }` | Medium | Do not move yet. User/technician directory may affect admin booking/assignment UI. |
 | `/catalog/items` | GET | `index.js:12938` | Dynamic `SELECT item_id, item_name, item_category, base_price, unit_label, is_active, job_category, ac_type, btu_min, btu_max, is_customer_visible FROM public.catalog_items WHERE ... ORDER BY item_category, item_name` | `pool.query`, request query filters | No | No mutation | Array of catalog item rows; failure `{ error }` | High | Do not move yet. Catalog/pricing-adjacent and customer-visible. |
 | `/promotions` | GET | `index.js:13003` | `getPromotionColumns()` reads `information_schema.columns`; route then queries `public.promotions` with dynamic selected columns | `pool.query`, `getPromotionColumns`, in-memory column cache, request query filters | No | No DB mutation; mutates in-memory column cache | Array of promotion rows; failure `{ error }` | High | Do not move yet. Promotion/pricing/customer-visible behavior. |
@@ -34,9 +36,9 @@ Why:
 | `/public/line_config` | GET | `index.js:1012` | None | `process.env`, `getReqBaseUrl(req)` | No | No mutation | `{ ok, env, callback_url, base_url }`; failure `{ ok: false, error }` | High | Do not move. LINE-adjacent config is frozen. |
 | `/admin/debug/status` | GET | `index.js:25200` | None | `requireAdminSoft`, `ENABLE_AVAILABILITY_DEBUG`, `RUNTIME_AVAILABILITY_DEBUG`, `process.env.TZ` | Yes, admin soft guard | No mutation in GET, but runtime debug-state adjacent | `{ success, availability_debug_env, availability_debug_runtime, tz }`; failure `{ error }` | Medium | Do not move yet. Middleware and debug-state dependency. |
 
-## Recommended Phase 2C Extraction Candidate
+## Phase 2C Extracted Route
 
-Move only:
+Moved only:
 
 ```text
 GET /test-db
@@ -56,50 +58,26 @@ app.get("/test-db", async (req, res) => {
 });
 ```
 
-## Proposed Target Module
+## Target Module
 
-Use a new DB-backed system route module:
+Phase 2C kept the route in the existing system router:
 
 ```text
-server/routes/system/dbHealth.js
+server/routes/system/index.js
 ```
 
-Keep `server/routes/system/index.js` as the system route aggregator.
+## Dependency Pattern
 
-## Proposed Dependency Pattern
-
-Prefer explicit dependency injection from `index.js` for the first DB-backed extraction:
-
-```js
-module.exports = function createDbHealthRoutes(deps = {}) {
-  const express = require("express");
-  const router = express.Router();
-  const pool = deps.pool || require("../../db/pool");
-
-  router.get("/test-db", async (req, res) => {
-    try {
-      const r = await pool.query("SELECT NOW() as now");
-      res.json({ ok: true, now: r.rows[0].now });
-    } catch (e) {
-      console.error(e);
-      res.status(500).json({ ok: false, error: "db connection failed" });
-    }
-  });
-
-  return router;
-};
-```
-
-Future `index.js` mount should pass the existing pool to avoid changing pool initialization behavior:
+`index.js` now passes the existing root pool into the system router:
 
 ```js
 app.use(createSystemRoutes({ pool }));
 ```
 
-Then `server/routes/system/index.js` can mount both:
+`server/routes/system/index.js` uses the injected pool and keeps a fallback to the shared wrapper:
 
 ```js
-router.use(createDbHealthRoutes({ pool: deps.pool }));
+const pool = deps.pool || require("../../db/pool");
 ```
 
 Do not create a new `Pool`.
@@ -111,7 +89,6 @@ Syntax checks:
 ```bash
 node --check index.js
 node --check server/routes/system/index.js
-node --check server/routes/system/dbHealth.js
 node --check server/db/pool.js
 ```
 
@@ -131,11 +108,10 @@ Manual check only in a safe environment:
 
 If extraction causes any startup or routing issue:
 
-1. Remove the `dbHealth` route import/mount from `server/routes/system/index.js`.
+1. Remove the `router.get("/test-db", ...)` block from `server/routes/system/index.js`.
 2. Restore the original inline `app.get("/test-db", ...)` block in `index.js` at the `TEST DB` marker.
-3. Restore the previous `app.use(createSystemRoutes({}))` mount if it was changed.
-4. Delete `server/routes/system/dbHealth.js`.
-5. Run:
+3. Restore `app.use(createSystemRoutes({}))` if the system router no longer needs `pool`.
+4. Run:
 
 ```bash
 node --check index.js
@@ -154,4 +130,3 @@ Do not move:
 - `/public/line_config`
 - `/admin/debug/status`
 - Any technician, admin, customer booking, pricing, availability, LINE, accounting, income, close-job, or unit evidence route.
-

--- a/docs/REFACTOR_ROADMAP.md
+++ b/docs/REFACTOR_ROADMAP.md
@@ -2,8 +2,6 @@
 
 This roadmap prepares CWF for safer modularization. It intentionally starts with documentation and folder boundaries only.
 
-Note: the filename uses `REFRACTOR` because that was the requested deliverable name. The intended topic is the repository refactor roadmap.
-
 ## Goal
 
 Make the repository easier for humans and Codex to read before extracting routes from the very large `index.js`.
@@ -151,4 +149,3 @@ Use this checklist for every future extraction phase:
 - Public booking still works.
 - Close job still works.
 - PWA cache refreshed if frontend JS changed.
-

--- a/docs/REFRACTOR_ROADMAP.md
+++ b/docs/REFRACTOR_ROADMAP.md
@@ -1,0 +1,154 @@
+# CWF Refactor Roadmap
+
+This roadmap prepares CWF for safer modularization. It intentionally starts with documentation and folder boundaries only.
+
+Note: the filename uses `REFRACTOR` because that was the requested deliverable name. The intended topic is the repository refactor roadmap.
+
+## Goal
+
+Make the repository easier for humans and Codex to read before extracting routes from the very large `index.js`.
+
+## Non-Goals For Phase 0
+
+- Do not move business logic.
+- Do not rewrite `index.js`.
+- Do not remove routes from `index.js`.
+- Do not change runtime behavior.
+- Do not change DB queries.
+- Do not introduce a new framework.
+- Do not import new route modules into production.
+
+## Phase 0: Documentation And Folder Boundaries
+
+Status: this patch.
+
+Deliverables:
+
+- Architecture audit.
+- Index split plan.
+- AI editing guide.
+- Future folder README boundaries.
+- No runtime code changes.
+
+Validation:
+
+- `node --check index.js`
+- Confirm `index.js`, `app.js`, `tech.html`, and `sw.js` runtime logic were not modified by this patch.
+
+## Phase 1: Health And Version Routes
+
+Candidate routes:
+
+- `/api/version`
+- Pure health checks with no DB writes.
+
+Requirements:
+
+- Use a route factory module.
+- Keep route path and response shape unchanged.
+- Pass dependencies explicitly.
+- Delete the old route from `index.js` only after checks pass.
+
+Manual checks:
+
+- App starts.
+- `/api/version` response is unchanged.
+- Login page still loads.
+
+## Phase 2: Read-Only Technician Routes
+
+Candidate scope:
+
+- Read-only technician display routes with no DB writes.
+- Avoid close job, photos, evidence, payout, income calculation writes, and work calendar writes.
+
+Requirements:
+
+- Confirm middleware behavior.
+- Confirm response shape.
+- Confirm frontend tabs still load.
+
+Manual checks:
+
+- Login works.
+- Technician page loads.
+- Current job, history, and income tabs load.
+
+## Phase 3: Technician Income Display
+
+Candidate scope:
+
+- Technician income display routes that already rely on existing modules:
+  - `server/technicianIncome.js`
+  - `server/technicianJobIncomeDisplay.js`
+  - `server/technicianJobMoneySummary.js`
+
+Do not touch:
+
+- payout generation
+- payout locking
+- payout payment
+- withdrawal requests
+- accounting settlement
+
+Manual checks:
+
+- Technician income tabs match current output.
+- Admin/super income previews still match current output.
+- Payout screens are unchanged.
+
+## Phase 4: job_units, Photos, And Evidence
+
+Candidate scope:
+
+- Job unit helper functions.
+- Evidence metadata helpers.
+- Upload wrappers only after dedicated tests.
+
+Requirements:
+
+- Dedicated tests or a precise manual test script.
+- Verify Cloudinary and local fallback behavior.
+- Verify close-job validation before and after.
+
+Manual checks:
+
+- Upload photo.
+- Add/check unit evidence.
+- Close job with required evidence.
+- Re-open job details and confirm evidence persists.
+
+## Phase 5: Admin Job Routes
+
+Candidate scope:
+
+- Admin job read/edit routes only after full route map.
+
+Frozen until then:
+
+- `/admin/book_v2`
+- `/admin/job_v2` edit logic
+- admin assignment and dispatch logic
+- warranty/rework/return flows
+
+Manual checks:
+
+- Admin add job still works.
+- Admin edit job still works.
+- Admin schedule still works.
+- Technician assignment still works.
+- Public tracking reflects correct job state.
+
+## Global Regression Checklist
+
+Use this checklist for every future extraction phase:
+
+- App starts with `node index.js`.
+- Login works.
+- Technician page loads.
+- Technician current/history/income tabs load.
+- Admin add job still works.
+- Public booking still works.
+- Close job still works.
+- PWA cache refreshed if frontend JS changed.
+

--- a/docs/REPO_ARCHITECTURE_AUDIT.md
+++ b/docs/REPO_ARCHITECTURE_AUDIT.md
@@ -1,0 +1,143 @@
+# CWF Repository Architecture Audit
+
+Date: 2026-05-10
+
+This document records the current production repository shape after pulling the latest `main` branch. It is a preparation artifact only. It does not authorize moving business logic, changing route paths, or editing production runtime behavior.
+
+## Current Repo Summary
+
+- Main backend entry: `index.js`
+  - `package.json` points `main` to `index.js`.
+  - Production start command remains `node index.js`.
+  - The file currently contains Express setup, middleware, auth/session helpers, route handlers, database queries, PDF/document generation, pricing, availability, technician, admin, public booking, partner, accounting, and static page routing.
+- Database pool entry: `db.js`
+  - CommonJS module exporting a PostgreSQL pool.
+- Frontend files:
+  - Large shared/customer technician UI files include `app.js`, `tech.html`, `customer.html`, `track.html`, `install-quote.html`, and `style.css`.
+  - Admin v2 screens are split into many `admin-*-v2.html` and `admin-*-v2.js` files.
+  - Partner screens include `partner-apply`, `partner-status`, `partner-agreement`, `partner-academy`, and `partner-dashboard` HTML/JS pairs.
+- PWA files:
+  - `sw.js`
+  - `manifest.json`
+  - `mainfest.json` appears to be a legacy or misspelled manifest file and should not be removed without a separate audit.
+  - `cwf-pwa.js`
+  - `cwf-loader.js` and `cwf-loader.css`
+  - icon assets in the repository root.
+- Existing server modules:
+  - `server/customerLookup.js`
+  - `server/normalizers.js`
+  - `server/pricing.js`
+  - `server/technicianIncome.js`
+  - `server/technicianJobIncomeDisplay.js`
+  - `server/technicianJobMoneySummary.js`
+  - `server/technicianRework.js`
+- Migrations folder:
+  - Contains partner onboarding, LINE login, technician base status, and deduction/rework center migrations.
+  - Treat migrations as production history. Do not rewrite or reorder existing migrations.
+- Existing docs:
+  - `CODEX_INSTRUCTIONS.md`
+  - `README.md`
+  - `docs/CWF_SOURCE_OF_TRUTH.md`
+  - `docs/CWF_SERVICE_AND_PRICING_RULES.md`
+  - `docs/INDEX_SPLIT_NOTES.md`
+  - Snapshot copies under `docs/index.js`, `docs/app.js`, `docs/tech.html`, and `docs/sw.js`.
+
+## Risk Notes
+
+This repo serves a production app with tightly coupled flows. Broad refactors are unsafe until route maps, dependency maps, and regression tests exist.
+
+High-risk systems include:
+
+- auth/session
+- public booking
+- availability/timezone
+- customer pricing
+- LINE login
+- technician close job/finalize
+- photos, `job_units`, and per-unit evidence
+- payout and technician income
+- accounting, tax, VAT, receipts, slips, and withholding documents
+- customer tracking
+- admin booking and job edit flows
+
+## index.js Audit
+
+- Approximate line count: 27,007 lines.
+- Approximate route registration count: 348 `app.get/post/put/patch/delete/use` registrations.
+- Route registration groups detected by path prefix:
+  - `admin`: about 172
+  - `tech`: about 59
+  - `jobs`: about 29
+  - static/html/other: about 20
+  - `partner`: about 18
+  - `public`: about 12
+  - `api`: about 10
+  - `auth`: about 7
+  - smaller groups include `offers`, `docs`, `attendance`, `catalog`, `promotions`, `users`, `internal`, `uploads`, `login`, and `test-db`.
+
+### Major Route Groups
+
+- Auth and session:
+  - LINE login and callbacks.
+  - Public customer JWT helpers and logout/register/profile routes.
+  - Admin/technician session guards.
+- Partner onboarding:
+  - Application submission, document upload, status, agreement, academy, certification, interview, and trial job routes.
+- Admin:
+  - Dashboard, profile, super admin, users, technician income rates, payouts, deductions, rework, job management, schedule, promotions, media retention, accounting, tax, reports, and debug routes.
+- Technician:
+  - Payouts, income summaries, work calendar, readiness, service matrix, base status, push notifications, offers, job status changes, photos, job units, finalize, and assignment completion.
+- Public/customer:
+  - Pricing preview, availability, public booking, tracking, review submission, and customer profile/session routes.
+- Documents:
+  - Quotes, receipts, e-slip, accounting documents, tax documents, and print routes.
+- Static HTML:
+  - Login/admin/technician/customer/partner/static page routing and redirects.
+
+### Major Helper Groups
+
+- Environment flags and feature gates.
+- Service zone and map coordinate parsing.
+- Cloudinary upload and deletion helpers.
+- JWT/cookie helpers.
+- Auth/session middleware.
+- Pricing and normalizer helpers from `server/pricing.js` and `server/normalizers.js`.
+- Technician income helpers from `server/technicianIncome.js`, `server/technicianJobIncomeDisplay.js`, and `server/technicianJobMoneySummary.js`.
+- Technician rework helpers from `server/technicianRework.js`.
+- Job item/unit/photo/evidence helpers.
+- Payout period, payout generation, and technician money summary helpers.
+- Accounting, tax, VAT, document, and PDF helpers.
+- Public availability and booking helpers.
+
+### Shared Dependencies
+
+- Express app instance and middleware.
+- `pool` from `./db`.
+- `upload` from Multer.
+- `path`, `fs`, `crypto`, and `https`.
+- Environment variables and feature flags.
+- Session helpers such as admin, super admin, technician, customer JWT, and internal API key guards.
+- Pricing, income, rework, normalizer, and customer lookup modules under `server/`.
+
+### Parts That Should Stay Frozen For Now
+
+Do not move or rewrite these areas until tests and route maps exist:
+
+- `/public/book`
+- `/public/availability_v2`
+- `/public/pricing_preview`
+- `/admin/book_v2`
+- `/admin/job_v2` edit logic
+- auth/session routes
+- LINE login routes
+- payout calculation
+- technician finalize/close job
+- accounting documents and tax routes
+- customer tracking
+
+## Current Structural Problem
+
+The repository is difficult for AI and humans to safely edit because one very large `index.js` mixes app setup, shared dependencies, helpers, route definitions, business logic, SQL queries, and document generation. This makes context loading expensive and increases the risk of accidental duplicate logic or behavior changes.
+
+The safe first step is not route extraction. The safe first step is documentation and empty folder boundaries so future tasks can target a small area with an explicit migration pattern.
+

--- a/index.js
+++ b/index.js
@@ -31,6 +31,7 @@ const customerLookupHelpers = require("./server/customerLookup");
 const technicianJobIncomeDisplayHelpers = require("./server/technicianJobIncomeDisplay");
 const technicianReworkHelpers = require("./server/technicianRework");
 const { createTechnicianJobMoneyHelpers } = require("./server/technicianJobMoneySummary");
+const createSystemRoutes = require("./server/routes/system");
 
 // =======================================
 // 🔔 Web Push Notifications (optional / fail-open)
@@ -10662,9 +10663,7 @@ async function requireAdminForRank(req, res, next) {
 // =======================================
 // 🔎 Health / Version (ใช้เช็คว่า deploy ล่าสุดจริง)
 // =======================================
-app.get("/api/version", (req, res) => {
-  res.json({ ok: true, version: "gps-v4", ts: new Date().toISOString() });
-});
+app.use(createSystemRoutes({}));
 
 // =======================================
 // 📍 Resolve Google Maps URL -> lat/lng (best-effort)

--- a/index.js
+++ b/index.js
@@ -10663,7 +10663,7 @@ async function requireAdminForRank(req, res, next) {
 // =======================================
 // 🔎 Health / Version (ใช้เช็คว่า deploy ล่าสุดจริง)
 // =======================================
-app.use(createSystemRoutes({}));
+app.use(createSystemRoutes({ pool }));
 
 // =======================================
 // 📍 Resolve Google Maps URL -> lat/lng (best-effort)
@@ -12833,19 +12833,6 @@ async function isTechReady(username) {
     return false; // fail-closed for urgent offer flow
   }
 }
-
-// =======================================
-// ✅ TEST DB
-// =======================================
-app.get("/test-db", async (req, res) => {
-  try {
-    const r = await pool.query("SELECT NOW() as now");
-    res.json({ ok: true, now: r.rows[0].now });
-  } catch (e) {
-    console.error(e);
-    res.status(500).json({ ok: false, error: "db connection failed" });
-  }
-});
 
 // =======================================
 // 🔐 LOGIN

--- a/server/db/README.md
+++ b/server/db/README.md
@@ -2,9 +2,10 @@
 
 Future home for database connection helpers.
 
-Candidate file later:
+Current helper:
 
 - `pool.js`
 
-Current pool entry is `db.js` at the repository root. Do not move it until all imports are mapped and `node index.js` startup is verified.
+Current pool entry is still `db.js` at the repository root. `server/db/pool.js` re-exports `../../db` so future modules can share the same pool without creating another PostgreSQL pool.
 
+Do not move root `db.js` or change connection settings until all imports are mapped and `node index.js` startup is verified.

--- a/server/db/README.md
+++ b/server/db/README.md
@@ -1,0 +1,10 @@
+# Server DB
+
+Future home for database connection helpers.
+
+Candidate file later:
+
+- `pool.js`
+
+Current pool entry is `db.js` at the repository root. Do not move it until all imports are mapped and `node index.js` startup is verified.
+

--- a/server/db/pool.js
+++ b/server/db/pool.js
@@ -1,0 +1,1 @@
+module.exports = require("../../db");

--- a/server/middleware/README.md
+++ b/server/middleware/README.md
@@ -1,0 +1,11 @@
+# Server Middleware
+
+Future home for shared middleware extracted from `index.js`.
+
+Candidate files later:
+
+- `auth.js`
+- `upload.js`
+
+Auth/session middleware and upload behavior are high risk. Do not move them until all route dependencies and cookie/session behavior are mapped.
+

--- a/server/routes/README.md
+++ b/server/routes/README.md
@@ -1,0 +1,17 @@
+# Server Routes
+
+Future home for Express route modules extracted from `index.js`.
+
+Do not import these folders into production until an extraction phase explicitly moves a route and deletes the old duplicate handler from `index.js` after checks pass.
+
+Preferred pattern:
+
+```js
+module.exports = function createRoutes(deps) {
+  const router = deps.express.Router();
+  return router;
+};
+```
+
+Keep route paths, middleware order, request payloads, response shapes, and SQL behavior unchanged during extraction.
+

--- a/server/routes/admin/README.md
+++ b/server/routes/admin/README.md
@@ -1,0 +1,15 @@
+# Admin Routes
+
+Future home for admin route modules.
+
+Candidate files later:
+
+- `jobs.js`
+- `booking.js`
+- `deductions.js`
+- `rework.js`
+- `payouts.js`
+- `accounting.js`
+
+Do not move `/admin/book_v2`, `/admin/job_v2` edit logic, payout calculation, accounting, tax, or VAT routes until dedicated route maps and regression tests exist.
+

--- a/server/routes/docs/README.md
+++ b/server/routes/docs/README.md
@@ -1,0 +1,12 @@
+# Document Routes
+
+Future home for document route modules.
+
+Candidate files later:
+
+- `receipts.js`
+- `quotes.js`
+- `eslip.js`
+
+Document generation touches accounting, tax, VAT, PDF templates, and customer/technician payment state. Do not move these routes until the accounting regression checklist exists.
+

--- a/server/routes/partner/README.md
+++ b/server/routes/partner/README.md
@@ -1,0 +1,12 @@
+# Partner Routes
+
+Future home for partner onboarding route modules.
+
+Candidate files later:
+
+- `applications.js`
+- `agreement.js`
+- `academy.js`
+
+Preserve existing application codes, document upload behavior, agreement signing behavior, academy completion behavior, and admin review behavior during any future extraction.
+

--- a/server/routes/public/README.md
+++ b/server/routes/public/README.md
@@ -1,0 +1,17 @@
+# Public Routes
+
+Future home for customer/public route modules.
+
+Candidate files later:
+
+- `booking.js`
+- `tracking.js`
+- `pricingPreview.js`
+
+Frozen for now:
+
+- `/public/book`
+- `/public/availability_v2`
+- `/public/pricing_preview`
+- customer tracking
+

--- a/server/routes/system/index.js
+++ b/server/routes/system/index.js
@@ -1,0 +1,11 @@
+module.exports = function createSystemRoutes(deps = {}) {
+  const express = require("express");
+  const router = express.Router();
+
+  router.get("/api/version", (req, res) => {
+    // Keep the exact same logic and response shape as the old inline route.
+    res.json({ ok: true, version: "gps-v4", ts: new Date().toISOString() });
+  });
+
+  return router;
+};

--- a/server/routes/system/index.js
+++ b/server/routes/system/index.js
@@ -1,10 +1,21 @@
 module.exports = function createSystemRoutes(deps = {}) {
   const express = require("express");
   const router = express.Router();
+  const pool = deps.pool || require("../../db/pool");
 
   router.get("/api/version", (req, res) => {
     // Keep the exact same logic and response shape as the old inline route.
     res.json({ ok: true, version: "gps-v4", ts: new Date().toISOString() });
+  });
+
+  router.get("/test-db", async (req, res) => {
+    try {
+      const r = await pool.query("SELECT NOW() as now");
+      res.json({ ok: true, now: r.rows[0].now });
+    } catch (e) {
+      console.error(e);
+      res.status(500).json({ ok: false, error: "db connection failed" });
+    }
   });
 
   return router;

--- a/server/routes/technician/README.md
+++ b/server/routes/technician/README.md
@@ -1,0 +1,14 @@
+# Technician Routes
+
+Future home for technician-facing route modules.
+
+Candidate files later:
+
+- `jobs.js`
+- `income.js`
+- `payouts.js`
+- `rework.js`
+- `evidence.js`
+
+Do not move close-job/finalize, photos, job units, payout, or income calculation behavior until the matching phase has tests and a regression checklist.
+

--- a/server/services/README.md
+++ b/server/services/README.md
@@ -1,0 +1,8 @@
+# Server Services
+
+Future home for pure service modules extracted from route handlers.
+
+Services should not depend on the Express app instance. Pass dependencies explicitly, especially `pool`, date helpers, money helpers, and feature flags.
+
+Do not create new service logic by copying behavior unless the old duplicate code is removed in the same tested patch.
+

--- a/server/services/admin/README.md
+++ b/server/services/admin/README.md
@@ -1,0 +1,10 @@
+# Admin Services
+
+Future home for admin service modules.
+
+Candidate files later:
+
+- `bookingService.js`
+
+Admin booking and job edit logic are frozen until a route map and regression checklist exist.
+

--- a/server/services/jobs/README.md
+++ b/server/services/jobs/README.md
@@ -1,0 +1,13 @@
+# Job Services
+
+Future home for job-related services.
+
+Candidate files later:
+
+- `jobItems.js`
+- `jobUnits.js`
+- `closeJob.js`
+- `closeJobValidation.js`
+
+Close-job, job units, photos, and per-unit evidence are high risk. Extract only after dedicated tests exist.
+

--- a/server/services/public/README.md
+++ b/server/services/public/README.md
@@ -1,0 +1,10 @@
+# Public Services
+
+Future home for public/customer service modules.
+
+Candidate files later:
+
+- `availabilityService.js`
+
+Availability, timezone handling, public booking, and pricing preview are frozen until dedicated tests exist.
+

--- a/server/services/technician/README.md
+++ b/server/services/technician/README.md
@@ -1,0 +1,17 @@
+# Technician Services
+
+Future home for technician service modules.
+
+Candidate files later:
+
+- `incomeDisplay.js`
+- `payoutPeriods.js`
+- `identity.js`
+
+Prefer reusing existing modules before creating new ones:
+
+- `server/technicianIncome.js`
+- `server/technicianJobIncomeDisplay.js`
+- `server/technicianJobMoneySummary.js`
+- `server/technicianRework.js`
+

--- a/server/utils/README.md
+++ b/server/utils/README.md
@@ -1,0 +1,12 @@
+# Server Utils
+
+Future home for small shared utilities.
+
+Candidate files later:
+
+- `dates.js`
+- `money.js`
+- `asyncHandler.js`
+
+Utilities should be pure where possible and should not depend on the Express app instance.
+


### PR DESCRIPTION
## Summary
- Add repository architecture audit, AI editing guide, refactor roadmap, and safe folder boundary READMEs.
- Add `server/routes/system/index.js` and extract only `GET /api/version` and `GET /test-db` from `index.js`.
- Add `server/db/pool.js` as a re-export of root `db.js` so future modules can share the existing pool without creating a second PostgreSQL pool.

## Safety notes
- No business routes were moved.
- `app.js`, `tech.html`, `sw.js`, `package.json`, `db.js`, and migrations are unchanged in this PR diff.
- System router contains only `GET /api/version` and `GET /test-db`.
- No new `new Pool(...)` was introduced; the only pool creation remains in `db.js`.

## Tests
- `node --check index.js`
- `node --check server/routes/system/index.js`
- `node --check server/db/pool.js`
- Router stack inspection confirmed only `/api/version` and `/test-db` are registered in the system router.

## Rollback
Revert this PR. If rolling back manually, remove the system router import/mount from `index.js`, restore the inline `/api/version` and `/test-db` handlers, and delete `server/routes/system/index.js` and `server/db/pool.js`.