### PR TITLE
docs: map technician directory route extraction candidate

### DIFF
--- a/docs/INDEX_JS_SPLIT_PLAN.md
+++ b/docs/INDEX_JS_SPLIT_PLAN.md
@@ -135,6 +135,17 @@ Phase 1B status:
 - No new PostgreSQL pool was created.
 - Rollback: remove the `/test-db` route from `server/routes/system/index.js`, restore the old inline `app.get("/test-db", ...)` block at the `TEST DB` marker in `index.js`, and restore `app.use(createSystemRoutes({}))` if the system router no longer needs the pool.
 
+### Phase 2D: Technician Directory Route Map
+
+- `GET /users/technicians` was audited as the next smallest DB-backed read-only candidate.
+- No route was moved and no runtime file was changed in Phase 2D.
+- Current location: `index.js:12906`, between the password change route block and the `CATALOG` marker.
+- Dependencies: `pool.query` and `console.error`.
+- SQL: `SELECT username FROM public.users WHERE role='technician' ORDER BY username`.
+- This route should not be added to `server/routes/system/index.js` because it is a technician directory endpoint, not a health/status endpoint.
+- Recommended future target: `server/routes/users/technicians.js`, mounted at the old inline route location with `app.use(createUserTechnicianRoutes({ pool }))`.
+- See `docs/PHASE2D_TECHNICIAN_DIRECTORY_ROUTE_MAP.md` before extracting.
+
 ### Phase 2: Read-Only Technician Routes
 
 - Move read-only technician routes with no DB writes.

--- a/docs/PHASE2B_READONLY_DB_ROUTE_CANDIDATES.md
+++ b/docs/PHASE2B_READONLY_DB_ROUTE_CANDIDATES.md
@@ -6,6 +6,8 @@ This document audits small DB-backed GET routes for extraction. No route was mov
 
 Phase 2C status: `GET /test-db` has been extracted into `server/routes/system/index.js` and is mounted through the existing system router from `index.js`.
 
+Phase 2D status: `GET /users/technicians` was audited in `docs/PHASE2D_TECHNICIAN_DIRECTORY_ROUTE_MAP.md`. No route was moved in Phase 2D.
+
 ## Summary
 
 Recommended Phase 2C candidate:
@@ -29,7 +31,7 @@ Why:
 | Route | Method | Current location | SQL used | Dependencies | Auth/session | Side effects | Response shape | Risk | Recommendation |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
 | `/test-db` | GET | Was `index.js:12840`; now `server/routes/system/index.js` | `SELECT NOW() as now` | `pool.query`, `console.error` | No | No DB mutation; does require DB connectivity | Success: `{ ok: true, now }`; failure: `{ ok: false, error: "db connection failed" }` | Low | Extracted in Phase 2C. |
-| `/users/technicians` | GET | `index.js:12919` | `SELECT username FROM public.users WHERE role='technician' ORDER BY username` | `pool.query`, `console.error` | No | No mutation | Array of `{ username }`; failure `{ error }` | Medium | Do not move yet. User/technician directory may affect admin booking/assignment UI. |
+| `/users/technicians` | GET | `index.js:12906` | `SELECT username FROM public.users WHERE role='technician' ORDER BY username` | `pool.query`, `console.error` | No | No mutation | Array of `{ username }`; failure `{ error }` | Low-to-medium | Audited in Phase 2D. Candidate for a future dedicated users route module only after confirming no hidden caller depends on the legacy endpoint. |
 | `/catalog/items` | GET | `index.js:12938` | Dynamic `SELECT item_id, item_name, item_category, base_price, unit_label, is_active, job_category, ac_type, btu_min, btu_max, is_customer_visible FROM public.catalog_items WHERE ... ORDER BY item_category, item_name` | `pool.query`, request query filters | No | No mutation | Array of catalog item rows; failure `{ error }` | High | Do not move yet. Catalog/pricing-adjacent and customer-visible. |
 | `/promotions` | GET | `index.js:13003` | `getPromotionColumns()` reads `information_schema.columns`; route then queries `public.promotions` with dynamic selected columns | `pool.query`, `getPromotionColumns`, in-memory column cache, request query filters | No | No DB mutation; mutates in-memory column cache | Array of promotion rows; failure `{ error }` | High | Do not move yet. Promotion/pricing/customer-visible behavior. |
 | `/service_zones` | GET | `index.js:21336` | Via `getServiceZones()`: `SELECT zone_code, zone_name, zone_label, province_group, color_hex, is_active, sort_order FROM public.service_zones WHERE is_active=TRUE ORDER BY sort_order, zone_code` | `getServiceZones`, `pool.query`, `SERVICE_ZONE_SEEDS`, `ENABLE_SERVICE_ZONE_FILTER` | No | No mutation; has fallback seed behavior | `{ ok: true, zones, filter_enabled }`; failure `{ error }` | Medium | Do not move yet. Availability/service-zone behavior affects booking and technician assignment. |
@@ -130,3 +132,7 @@ Do not move:
 - `/public/line_config`
 - `/admin/debug/status`
 - Any technician, admin, customer booking, pricing, availability, LINE, accounting, income, close-job, or unit evidence route.
+
+## Phase 2D Follow-Up
+
+`GET /users/technicians` is the next smallest DB-backed read-only candidate, but it should not be placed in the existing system router. See `docs/PHASE2D_TECHNICIAN_DIRECTORY_ROUTE_MAP.md` for the dedicated future mount plan, dependency notes, caller audit, manual tests, and rollback steps.

--- a/docs/PHASE2D_TECHNICIAN_DIRECTORY_ROUTE_MAP.md
+++ b/docs/PHASE2D_TECHNICIAN_DIRECTORY_ROUTE_MAP.md
@@ -1,0 +1,213 @@
+# Phase 2D Technician Directory Route Map
+
+Date: 2026-05-10
+
+Scope: audit and preparation only. No route was moved in Phase 2D, and no runtime file was changed.
+
+## Candidate Summary
+
+Recommended future candidate:
+
+```text
+GET /users/technicians
+```
+
+This is the smallest currently inline DB-backed read-only route after `/test-db`. It should not be extracted into the system router because it is not a health/status route. If extracted later, it should go into a dedicated user or directory route module.
+
+## Current Location
+
+Current route location:
+
+```text
+index.js:12906
+```
+
+Nearby markers:
+
+- Immediately after the password change route block.
+- Immediately before the `CATALOG` section marker.
+
+Current handler:
+
+```js
+app.get("/users/technicians", async (req, res) => {
+  try {
+    const r = await pool.query(
+      `SELECT username FROM public.users WHERE role='technician' ORDER BY username`
+    );
+    res.json(r.rows);
+  } catch (e) {
+    console.error(e);
+    res.status(500).json({ error: "โหลดรายชื่อช่างไม่สำเร็จ" });
+  }
+});
+```
+
+## Dependencies
+
+- `pool.query`
+- `console.error`
+
+SQL:
+
+```sql
+SELECT username FROM public.users WHERE role='technician' ORDER BY username
+```
+
+No direct dependency found on:
+
+- Auth/session middleware
+- Upload middleware
+- Pricing helpers
+- Booking helpers
+- Availability helpers
+- LINE APIs
+- Accounting, tax, or VAT helpers
+- Technician income helpers
+- Close-job or unit evidence helpers
+- External APIs
+
+## Behavior And Response Shape
+
+Success response:
+
+```js
+[
+  { username: "..." }
+]
+```
+
+Failure response:
+
+```js
+res.status(500).json({ error: "โหลดรายชื่อช่างไม่สำเร็จ" });
+```
+
+Side effects:
+
+- No DB mutation.
+- No state mutation.
+- No external API call.
+
+## Caller Audit
+
+Searches for `users/technicians` and `/users/technicians` found:
+
+- `index.js` current route definition.
+- `docs/index.js` historical snapshot only.
+
+No current `.js` or `.html` frontend caller was found for `/users/technicians`.
+
+Admin screens currently use separate admin routes such as:
+
+- `GET /admin/technicians`
+- `GET /admin/technicians/work-readiness`
+- Other `/admin/technicians/:username/...` routes
+
+Because hidden external callers or older deployed pages may still depend on `/users/technicians`, validate production access logs or a staging smoke test before extraction.
+
+## Risk Rating
+
+Risk: low-to-medium.
+
+Technical complexity is low because the route is a single GET handler with one `pool.query` call and a small response shape.
+
+Product risk is medium because it exposes a technician directory from `public.users`, has no auth/session middleware, and may be a legacy endpoint used by older admin assignment flows or external tooling that is not visible in the repo.
+
+## Recommendation
+
+Do not move this route in the same patch as this audit.
+
+If Phase 2E proceeds, extract only `GET /users/technicians` after confirming no hidden caller relies on route placement or startup ordering.
+
+Recommended target path:
+
+```text
+server/routes/users/technicians.js
+```
+
+If the repo wants folder boundaries first, create:
+
+```text
+server/routes/users/README.md
+```
+
+## Proposed Factory Pattern
+
+```js
+module.exports = function createUserTechnicianRoutes(deps = {}) {
+  const express = require("express");
+  const router = express.Router();
+  const pool = deps.pool || require("../../db/pool");
+
+  router.get("/users/technicians", async (req, res) => {
+    try {
+      const r = await pool.query(
+        `SELECT username FROM public.users WHERE role='technician' ORDER BY username`
+      );
+      res.json(r.rows);
+    } catch (e) {
+      console.error(e);
+      res.status(500).json({ error: "โหลดรายชื่อช่างไม่สำเร็จ" });
+    }
+  });
+
+  return router;
+};
+```
+
+## Exact Mount Plan For A Future Extraction
+
+In `index.js`:
+
+1. Import the future route factory near other route module imports:
+
+```js
+const createUserTechnicianRoutes = require("./server/routes/users/technicians");
+```
+
+2. Mount the new router at the exact old route location, between the password change route block and the `CATALOG` marker:
+
+```js
+app.use(createUserTechnicianRoutes({ pool }));
+```
+
+3. Remove only the old inline `app.get("/users/technicians", ...)` block.
+
+Do not change route path, SQL, response shape, middleware behavior, or surrounding business routes.
+
+## Tests For A Future Extraction
+
+Syntax checks:
+
+```bash
+node --check index.js
+node --check server/routes/users/technicians.js
+node --check server/db/pool.js
+```
+
+Route behavior checks in a safe environment:
+
+- Call `GET /users/technicians`.
+- Confirm success response is still an array of rows containing `username`.
+- Confirm SQL is still `SELECT username FROM public.users WHERE role='technician' ORDER BY username`.
+- Confirm DB error response is still HTTP 500 with `{ error: "โหลดรายชื่อช่างไม่สำเร็จ" }`.
+- Confirm no auth/session, upload, pricing, booking, availability, LINE, accounting, income, close-job, or evidence code changed.
+
+Regression smoke checklist:
+
+- App starts with `node index.js`.
+- Admin technician list still loads through `/admin/technicians`.
+- Admin add-job technician selection still works.
+- Technician page still opens.
+- Public booking still opens.
+
+## Rollback Plan For A Future Extraction
+
+If extraction causes any issue:
+
+1. Remove the `createUserTechnicianRoutes` import from `index.js`.
+2. Remove the `app.use(createUserTechnicianRoutes({ pool }))` mount from `index.js`.
+3. Restore the original inline `app.get("/users/technicians", ...)` block at the old location.
+4. Delete `server/routes/users/technicians.js` if it is no longer used.
+5. Run syntax checks again.


### PR DESCRIPTION
## Summary

- Add Phase 2D docs-only route map for `GET /users/technicians`
- Update the split plan and Phase 2B candidate table with the Phase 2D finding
- Recommend a future dedicated users route module instead of putting this endpoint in the system router

## Safety

- Docs only
- No route moved
- No runtime files changed
- No `index.js`, `app.js`, `tech.html`, `sw.js`, `package.json`, `db.js`, or migration changes

## Checks

- `node --check index.js`
- `node --check server/routes/system/index.js`
- `node --check server/db/pool.js`