### PR TITLE
refactor: extract service zones route

### DIFF
--- a/docs/INDEX_JS_SPLIT_PLAN.md
+++ b/docs/INDEX_JS_SPLIT_PLAN.md
@@ -159,6 +159,18 @@ Phase 1B status:
 - Risk remains medium because the route is catalog/pricing-adjacent and used by the admin add-job flow.
 - Rollback: remove the `createCatalogItemRoutes` import and mount from `index.js`, restore the original inline `app.get("/catalog/items", ...)` block before `POST /catalog/items`, delete `server/routes/catalog/items.js`, then run syntax checks.
 
+### Phase 2I: Service Zones Route
+
+- `GET /service_zones` has been extracted to `server/routes/serviceZones/index.js`.
+- Old location: `index.js:21281`, immediately before `POST /service_zones/detect`.
+- Current mount: `app.use(createServiceZoneRoutes({ getServiceZones, SERVICE_ZONE_SEEDS, ENABLE_SERVICE_ZONE_FILTER }))` at the same old inline route location.
+- Dependencies are passed from `index.js`: `getServiceZones`, `SERVICE_ZONE_SEEDS`, and `ENABLE_SERVICE_ZONE_FILTER`.
+- Success response remains `{ ok: true, zones, filter_enabled }`.
+- Error response remains HTTP 500 with `{ error: "LOAD_SERVICE_ZONES_FAILED" }`, and `console.error("GET /service_zones", e)` is preserved.
+- `getServiceZones()`, `SERVICE_ZONE_SEEDS`, `ENABLE_SERVICE_ZONE_FILTER`, and `POST /service_zones/detect` were not moved or changed.
+- Risk remains medium-high because service zones affect admin add-job and technician zone detection flows.
+- Rollback: remove the `createServiceZoneRoutes` import and mount from `index.js`, restore the original inline `app.get("/service_zones", ...)` block immediately before `POST /service_zones/detect`, delete `server/routes/serviceZones/index.js`, then run syntax checks.
+
 ### Phase 2: Read-Only Technician Routes
 
 - Move read-only technician routes with no DB writes.

--- a/docs/PHASE2H_PROMOTIONS_SERVICE_ZONES_ROUTE_AUDIT.md
+++ b/docs/PHASE2H_PROMOTIONS_SERVICE_ZONES_ROUTE_AUDIT.md
@@ -2,13 +2,15 @@
 
 Date: 2026-05-11
 
-Scope: audit only. No route was moved in Phase 2H, and no runtime file was changed.
+Scope: Phase 2H was audit only. No route was moved in Phase 2H, and no runtime file was changed.
+
+Phase 2I update: `GET /service_zones` has been extracted to `server/routes/serviceZones/index.js`. The mount remains in `index.js` immediately before `POST /service_zones/detect`, and the route receives `getServiceZones`, `SERVICE_ZONE_SEEDS`, and `ENABLE_SERVICE_ZONE_FILTER` from `index.js`.
 
 This audit compares the two remaining read-only candidates from Phase 2F after `GET /catalog/items` was extracted in Phase 2G.
 
 ## Summary Recommendation
 
-Recommended next extraction candidate:
+Recommended Phase 2I extraction candidate:
 
 ```text
 GET /service_zones
@@ -23,7 +25,7 @@ Reason:
 - It does not call pricing or promotion helpers.
 - It is not directly called by the customer booking promotion UI.
 
-Risk remains **medium-high**, not low. The route depends on top-level service-zone helpers and flags that are shared with admin add-job, technician home-zone detection, and service-zone assignment behavior. Extract it only if the next PR moves **only** `GET /service_zones`, injects existing dependencies, keeps the old mount location, and does not move `POST /service_zones/detect`.
+Risk remains **medium-high**, not low. The route depends on top-level service-zone helpers and flags that are shared with admin add-job, technician home-zone detection, and service-zone assignment behavior. Phase 2I moved **only** `GET /service_zones`, injected existing dependencies, kept the old mount location, and did not move `POST /service_zones/detect`.
 
 Do **not** extract `GET /promotions` next. It is customer-public, promotion/pricing-adjacent, calls `getPromotionColumns()`, and mutates the in-memory `__promoColsCache`.
 
@@ -129,6 +131,17 @@ app.get("/service_zones", async (req, res) => {
 });
 ```
 
+Phase 2I extraction status:
+
+- New module: `server/routes/serviceZones/index.js`.
+- Current mount in `index.js`: immediately before `POST /service_zones/detect`.
+- Dependencies passed from `index.js`:
+  - `getServiceZones`
+  - `SERVICE_ZONE_SEEDS`
+  - `ENABLE_SERVICE_ZONE_FILTER`
+- `getServiceZones()`, `SERVICE_ZONE_SEEDS`, `ENABLE_SERVICE_ZONE_FILTER`, and detection helpers remain in `index.js`.
+- `POST /service_zones/detect` was not moved.
+
 Helper:
 
 ```text
@@ -167,16 +180,18 @@ server/routes/serviceZones/index.js
 Required dependencies for future extraction:
 
 - `getServiceZones`
+- `SERVICE_ZONE_SEEDS`
 - `ENABLE_SERVICE_ZONE_FILTER`
 - `express`
 
-Recommended future factory:
+Current factory pattern:
 
 ```js
 module.exports = function createServiceZoneRoutes(deps = {}) {
   const express = require("express");
   const router = express.Router();
   const getServiceZones = deps.getServiceZones;
+  const SERVICE_ZONE_SEEDS = deps.SERVICE_ZONE_SEEDS;
   const ENABLE_SERVICE_ZONE_FILTER = deps.ENABLE_SERVICE_ZONE_FILTER;
 
   router.get("/service_zones", async (req, res) => {
@@ -187,10 +202,10 @@ module.exports = function createServiceZoneRoutes(deps = {}) {
 };
 ```
 
-Future mount location:
+Current mount location:
 
-- Mount at the exact old inline route location before `POST /service_zones/detect`.
-- Remove only the old inline `app.get("/service_zones", ...)` block.
+- Mounted at the exact old inline route location before `POST /service_zones/detect`.
+- Only the old inline `app.get("/service_zones", ...)` block was removed.
 
 Extraction protection:
 
@@ -202,7 +217,7 @@ Extraction protection:
 
 ## Manual Test Checklist
 
-For a future `GET /service_zones` extraction:
+For the Phase 2I `GET /service_zones` extraction:
 
 - App starts with `node index.js`.
 - `GET /service_zones` returns `{ ok: true, zones, filter_enabled }`.
@@ -253,7 +268,7 @@ node --check server/db/pool.js
 
 For `GET /service_zones` specifically:
 
-1. Remove the future `createServiceZoneRoutes` import and mount from `index.js`.
+1. Remove the `createServiceZoneRoutes` import and mount from `index.js`.
 2. Restore the original inline `app.get("/service_zones", ...)` block before `POST /service_zones/detect`.
 3. Delete `server/routes/serviceZones/index.js`.
 4. Confirm `POST /service_zones/detect` was never moved.

--- a/index.js
+++ b/index.js
@@ -34,6 +34,7 @@ const { createTechnicianJobMoneyHelpers } = require("./server/technicianJobMoney
 const createSystemRoutes = require("./server/routes/system");
 const createTechnicianDirectoryRoutes = require("./server/routes/users/technicians");
 const createCatalogItemRoutes = require("./server/routes/catalog/items");
+const createServiceZoneRoutes = require("./server/routes/serviceZones");
 
 // =======================================
 // 🔔 Web Push Notifications (optional / fail-open)
@@ -21278,14 +21279,11 @@ app.put("/technicians/:username/zone", async (req, res) => {
 // =======================================
 // 👤 TECHNICIAN PROFILE (v4)
 // =======================================
-app.get("/service_zones", async (req, res) => {
-  try {
-    res.json({ ok: true, zones: await getServiceZones(), filter_enabled: ENABLE_SERVICE_ZONE_FILTER });
-  } catch (e) {
-    console.error("GET /service_zones", e);
-    res.status(500).json({ error: "LOAD_SERVICE_ZONES_FAILED" });
-  }
-});
+app.use(createServiceZoneRoutes({
+  getServiceZones,
+  SERVICE_ZONE_SEEDS,
+  ENABLE_SERVICE_ZONE_FILTER
+}));
 
 app.post("/service_zones/detect", async (req, res) => {
   try {

--- a/server/routes/serviceZones/index.js
+++ b/server/routes/serviceZones/index.js
@@ -1,0 +1,19 @@
+module.exports = function createServiceZoneRoutes(deps = {}) {
+  const express = require("express");
+  const router = express.Router();
+
+  const getServiceZones = deps.getServiceZones;
+  const SERVICE_ZONE_SEEDS = deps.SERVICE_ZONE_SEEDS;
+  const ENABLE_SERVICE_ZONE_FILTER = deps.ENABLE_SERVICE_ZONE_FILTER;
+
+  router.get("/service_zones", async (req, res) => {
+    try {
+      res.json({ ok: true, zones: await getServiceZones(), filter_enabled: ENABLE_SERVICE_ZONE_FILTER });
+    } catch (e) {
+      console.error("GET /service_zones", e);
+      res.status(500).json({ error: "LOAD_SERVICE_ZONES_FAILED" });
+    }
+  });
+
+  return router;
+};


### PR DESCRIPTION
## Summary

- Extract `GET /service_zones` into `server/routes/serviceZones/index.js`
- Mount the new service-zone router at the same location in `index.js`, immediately before `POST /service_zones/detect`
- Pass the existing `getServiceZones`, `SERVICE_ZONE_SEEDS`, and `ENABLE_SERVICE_ZONE_FILTER` dependencies from `index.js`
- Update Phase 2H and split-plan docs with Phase 2I extraction notes, manual checks, and rollback steps

## Safety

- Moved only `GET /service_zones`
- Did not move `GET /promotions` or `POST /service_zones/detect`
- Did not change route path, response shape, fallback behavior, helper behavior, or DB connection settings
- Did not create a new PostgreSQL Pool; `new Pool(...)` remains only in `db.js`
- No frontend files changed: `app.js`, `tech.html`, and `sw.js` untouched
- No `package.json`, `db.js`, or migration changes

## Verification

- Read `CWF_Technician_App_Master_Spec.md` first
- `node --check index.js`
- `node --check server/routes/serviceZones/index.js`
- `node --check server/routes/catalog/items.js`
- `node --check server/routes/system/index.js`
- `node --check server/routes/users/technicians.js`
- `node --check server/db/pool.js`