### PR TITLE
refactor: extract login page routes

### DIFF
--- a/docs/INDEX_JS_SPLIT_PLAN.md
+++ b/docs/INDEX_JS_SPLIT_PLAN.md
@@ -171,6 +171,21 @@ Phase 1B status:
 - Risk remains medium-high because service zones affect admin add-job and technician zone detection flows.
 - Rollback: remove the `createServiceZoneRoutes` import and mount from `index.js`, restore the original inline `app.get("/service_zones", ...)` block immediately before `POST /service_zones/detect`, delete `server/routes/serviceZones/index.js`, then run syntax checks.
 
+### Phase 2K: Login Static Page Routes
+
+- `GET /login` and `GET /login.html` have been extracted to `server/routes/pages/index.js`.
+- Old locations:
+  - `GET /login`: `index.js:26872`
+  - `GET /login.html`: `index.js:26898`
+- Current mount: `app.use(createPageRoutes({ sendHtml }))` in the bottom static page route area, after `express.static(FRONTEND_DIR)` and `express.static(ROOT_DIR)`.
+- Dependencies are passed from `index.js`: `sendHtml`.
+- The new page router contains only:
+  - `GET /login`
+  - `GET /login.html`
+- `sendHtml()`, `POST /login`, `GET /`, `GET /tech`, `GET /tech.html`, protected admin/partner pages, and frontend files were not changed.
+- Risk is low for `/login` and low-medium for `/login.html` because `express.static(ROOT_DIR)` is mounted before the explicit static page route area.
+- Rollback: remove the `createPageRoutes` import and mount from `index.js`, restore the original inline `app.get("/login", ...)` and `app.get("/login.html", ...)` handlers at the bottom static page route area, delete `server/routes/pages/index.js`, then run syntax checks.
+
 ### Phase 2: Read-Only Technician Routes
 
 - Move read-only technician routes with no DB writes.

--- a/docs/PHASE2J_STATIC_PAGE_ROUTE_AUDIT.md
+++ b/docs/PHASE2J_STATIC_PAGE_ROUTE_AUDIT.md
@@ -1,0 +1,178 @@
+# Phase 2J Static Page Route Audit
+
+Date: 2026-05-11
+
+Scope: Phase 2J was audit only. No runtime code was changed, no route was moved, and no new module was created.
+
+Phase 2K update: `GET /login` and `GET /login.html` have been extracted to `server/routes/pages/index.js`. The router is mounted with `app.use(createPageRoutes({ sendHtml }))` in the bottom static page route area after `express.static(FRONTEND_DIR)` and `express.static(ROOT_DIR)`.
+
+This audit reviews only the bottom static login page routes as the next possible low-risk extraction candidate after Phase 2I.
+
+## Candidate Summary
+
+| Route | Method | Current location | Current handler | Dependencies | DB | Auth/session | Frontend/static sensitivity | Risk | Recommendation |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| `/login` | GET | `index.js:26872` | `res.sendFile(sendHtml("login.html"))` | `sendHtml`, `res.sendFile` | No | No | Must remain after `express.static(FRONTEND_DIR)` and `express.static(ROOT_DIR)` to preserve current order | Low | Best first Phase 2K candidate |
+| `/login.html` | GET | `index.js:26898` | `res.sendFile(sendHtml("login.html"))` | `sendHtml`, `res.sendFile` | No | No | Highly order-sensitive because `express.static(ROOT_DIR)` is mounted before this route and root `login.html` exists | Low-medium | Move only with `/login` if preserving exact mount location after static middleware |
+
+## Current Location And Order
+
+Relevant current order in `index.js`:
+
+```text
+26856: function sendHtml(file) { ... }
+26867: if (fs.existsSync(FRONTEND_DIR)) app.use(express.static(FRONTEND_DIR));
+26868: app.use(express.static(ROOT_DIR));
+26872: app.get("/login", (req, res) => res.sendFile(sendHtml("login.html")));
+26898: app.get("/login.html", (req, res) => res.sendFile(sendHtml("login.html")));
+26915: app.get("/", (req, res) => res.sendFile(sendHtml("login.html")));
+```
+
+`login.html` exists at the repository root. Because `express.static(ROOT_DIR)` is mounted before `app.get("/login.html", ...)`, a request to `/login.html` may be served by static middleware before reaching the explicit route. This means any extraction must preserve the mount location after static middleware to avoid changing current request ordering.
+
+## Dependency Review
+
+Both candidate handlers use only:
+
+- `sendHtml("login.html")`
+- `res.sendFile(...)`
+
+`sendHtml(file)` checks:
+
+1. `frontend/<file>`
+2. repo root `<file>`
+
+and returns the frontend path if present, otherwise the root path.
+
+No DB access, no `pool`, no upload middleware, no auth/session middleware, no pricing, no promotion helper, no external API, and no mutable cache are used by either candidate route.
+
+## Static And Redirect Sensitivity
+
+Known nearby login-related behavior:
+
+- LINE callback failures redirect to `/login.html?...`.
+- Auth helpers redirect HTML requests to `/login.html`.
+- `POST /login` remains in `index.js` and must not move with this page-route extraction.
+- `/` also serves `login.html` at `index.js:26915`, but it should not move in the first Phase 2K extraction because it is the default app landing route.
+
+Important order rule:
+
+- Do not mount any future page router before `express.static(FRONTEND_DIR)` or `express.static(ROOT_DIR)`.
+- Do not include protected admin/partner page routes in the same extraction, because protected routes rely on auth middleware and order relative to static serving.
+
+## Extract One Or Both?
+
+Phase 2K extraction:
+
+```text
+GET /login
+GET /login.html
+```
+
+Reason:
+
+- They are a tiny pair serving the same file with the same dependency.
+- Moving only `/login` is the absolute smallest change, but leaves the alias route split across two locations.
+- Moving both together is still narrow and easier to verify, as long as the mount remains at the same bottom static-page location after `express.static(...)`.
+
+Do not include:
+
+- `GET /`
+- `POST /login`
+- protected admin/partner static page routes
+- `/tech` or `/tech.html`
+- any customer, booking, tracking, pricing, promotion, auth/session core, technician income, accounting, tax/VAT, or attendance route
+
+## Phase 2K Target
+
+Target module:
+
+```text
+server/routes/pages/index.js
+```
+
+Factory pattern:
+
+```js
+module.exports = function createPageRoutes(deps = {}) {
+  const express = require("express");
+  const router = express.Router();
+  const sendHtml = deps.sendHtml;
+
+  router.get("/login", (req, res) => res.sendFile(sendHtml("login.html")));
+  router.get("/login.html", (req, res) => res.sendFile(sendHtml("login.html")));
+
+  return router;
+};
+```
+
+Mount plan:
+
+```js
+app.use(createPageRoutes({ sendHtml }));
+```
+
+Mount location:
+
+- Replaced only the existing `/login` and `/login.html` inline route handlers.
+- Mounted after:
+  - `if (fs.existsSync(FRONTEND_DIR)) app.use(express.static(FRONTEND_DIR));`
+  - `app.use(express.static(ROOT_DIR));`
+- Kept all other static page routes in `index.js`.
+
+## Manual Smoke Checklist
+
+For the Phase 2K extraction:
+
+- App starts with `node index.js`.
+- `GET /login` returns the login page.
+- `GET /login.html` returns the login page or continues to be served by static middleware exactly as before.
+- `GET /` still returns the login page.
+- LINE login failure redirects to `/login.html?...` and still displays the login page.
+- Auth/session redirects to `/login.html` still display the login page.
+- `POST /login` still authenticates exactly as before.
+- `GET /tech` and `GET /tech.html` still load the technician app.
+- Admin page redirects and static page aliases still work.
+
+## Rollback Plan
+
+If the extraction causes any issue:
+
+1. Remove the `createPageRoutes` import from `index.js`.
+2. Remove the `app.use(createPageRoutes({ sendHtml }))` mount from `index.js`.
+3. Restore these exact inline handlers at the bottom static-page location:
+
+```js
+app.get("/login", (req, res) => res.sendFile(sendHtml("login.html")));
+app.get("/login.html", (req, res) => res.sendFile(sendHtml("login.html")));
+```
+
+4. Delete `server/routes/pages/index.js`.
+5. Run:
+
+```bash
+node --check index.js
+```
+
+6. Manually smoke test `/login`, `/login.html`, `/`, and `POST /login`.
+
+## Risk And Protections
+
+Risk level:
+
+```text
+Low for /login
+Low-medium for /login.html because of static middleware order
+```
+
+Protections for Phase 2K:
+
+- Keep the mount after both static middlewares.
+- Move only `/login` and `/login.html`.
+- Do not move `POST /login`.
+- Do not move `/`.
+- Do not move `/tech` or `/tech.html`.
+- Do not include protected routes.
+- Do not change `sendHtml`.
+- Do not change frontend files.
+- Do not touch auth/session core logic.

--- a/index.js
+++ b/index.js
@@ -35,6 +35,7 @@ const createSystemRoutes = require("./server/routes/system");
 const createTechnicianDirectoryRoutes = require("./server/routes/users/technicians");
 const createCatalogItemRoutes = require("./server/routes/catalog/items");
 const createServiceZoneRoutes = require("./server/routes/serviceZones");
+const createPageRoutes = require("./server/routes/pages");
 
 // =======================================
 // 🔔 Web Push Notifications (optional / fail-open)
@@ -26869,7 +26870,7 @@ app.use(express.static(ROOT_DIR));
 
 // ✅ รองรับ Refresh/Deep-link แบบ "ไม่ต้องมี .html" (กันรีเฟรชเด้งไปหน้าแรก)
 // - ตัวอย่าง: /tech, /admin, /track, /customer
-app.get("/login", (req, res) => res.sendFile(sendHtml("login.html")));
+app.use(createPageRoutes({ sendHtml }));
 // Admin landing: ใช้ V2 เป็นหลัก (หน้าเก่าเลิกใช้แล้ว)
 app.get("/admin", (req, res) => res.redirect(302, "/admin-review-v2.html"));
 app.get("/admin-add", (req, res) => res.sendFile(sendHtml("admin-add-v2.html")));
@@ -26895,7 +26896,6 @@ app.get("/register", (req, res) => res.sendFile(sendHtml("register.html")));
 app.get("/track", (req, res) => res.sendFile(sendHtml("track.html")));
 app.get("/home", (req, res) => res.sendFile(sendHtml("index.html")));
 
-app.get("/login.html", (req, res) => res.sendFile(sendHtml("login.html")));
 app.get("/admin.html", (req, res) => res.redirect(302, "/admin-review-v2.html"));
 app.get("/admin-add-v2.html", (req, res) => res.sendFile(sendHtml("admin-add-v2.html")));
 app.get("/admin-review-v2.html", (req, res) => res.sendFile(sendHtml("admin-review-v2.html")));

--- a/server/routes/pages/index.js
+++ b/server/routes/pages/index.js
@@ -1,0 +1,10 @@
+module.exports = function createPageRoutes(deps = {}) {
+  const express = require("express");
+  const router = express.Router();
+  const sendHtml = deps.sendHtml;
+
+  router.get("/login", (req, res) => res.sendFile(sendHtml("login.html")));
+  router.get("/login.html", (req, res) => res.sendFile(sendHtml("login.html")));
+
+  return router;
+};


### PR DESCRIPTION
## Summary

- Extract only `GET /login` and `GET /login.html` into `server/routes/pages/index.js`
- Mount the page router with `createPageRoutes({ sendHtml })` in the existing bottom static page route area after static middleware
- Keep `POST /login`, `GET /`, `GET /tech`, `GET /tech.html`, protected admin/partner pages, and frontend files unchanged
- Add/update docs for Phase 2J/2K audit and rollback notes

## Safety

- Moved only the static login page GET routes
- Did not change `sendHtml()` or `login.html`
- Did not touch `app.js`, `tech.html`, `sw.js`, `package.json`, `db.js`, or migrations
- Did not touch customer booking/tracking, pricing/promotion, auth/session core, technician income, accounting/tax/VAT, admin job edit, close-job flow, LINE login, service-zone detection, attendance, maps, or technician profile routes

## Verification

- Read `CWF_Technician_App_Master_Spec.md` first
- `node --check index.js`
- `node --check server/routes/pages/index.js`
- `node --check server/routes/serviceZones/index.js`
- `node --check server/routes/catalog/items.js`
- `node --check server/routes/system/index.js`
- `node --check server/routes/users/technicians.js`
- `node --check server/db/pool.js`

## Manual smoke checklist

- App starts with `node index.js`
- `GET /login` displays the login page
- `GET /login.html` displays the login page or remains served the same as before
- `GET /` still displays the login page as before
- `POST /login` still works
- LINE login failure redirect to `/login.html?...` still opens the login page
- Auth/session redirect to `/login.html` still opens the login page
- `GET /tech` and `GET /tech.html` still load the technician app
- Admin page redirects/static aliases still work
- No regression in `GET /service_zones`
- No regression in `POST /service_zones/detect`