### PR TITLE
refactor: extract admin legacy page redirects

### DIFF
--- a/docs/INDEX_JS_SPLIT_PLAN.md
+++ b/docs/INDEX_JS_SPLIT_PLAN.md
@@ -186,6 +186,18 @@ Phase 1B status:
 - Risk is low for `/login` and low-medium for `/login.html` because `express.static(ROOT_DIR)` is mounted before the explicit static page route area.
 - Rollback: remove the `createPageRoutes` import and mount from `index.js`, restore the original inline `app.get("/login", ...)` and `app.get("/login.html", ...)` handlers at the bottom static page route area, delete `server/routes/pages/index.js`, then run syntax checks.
 
+### Phase 2M: Admin Legacy Redirect Routes
+
+- `GET /admin-legacy` and `GET /admin-legacy.html` have been extracted to `server/routes/pages/index.js`.
+- Old locations:
+  - `GET /admin-legacy`: `index.js:26882`
+  - `GET /admin-legacy.html`: `index.js:26905`
+- Current mount remains `app.use(createPageRoutes({ sendHtml }))` in the bottom static page route area, after `express.static(FRONTEND_DIR)` and `express.static(ROOT_DIR)`.
+- The extracted routes are redirect-only and preserve the exact target: HTTP 302 to `/admin-review-v2.html`.
+- No auth middleware, admin HTML guard, protected admin page route, frontend file, `sendHtml()`, `POST /login`, `GET /`, `GET /tech`, or `GET /tech.html` behavior was changed.
+- Risk is low, but `/admin-legacy.html` still depends on the existing earlier admin HTML guard behavior staying in `index.js`.
+- Rollback: remove only `/admin-legacy` and `/admin-legacy.html` handlers from `server/routes/pages/index.js`, restore the two original inline redirect handlers in the bottom static page route area, then run syntax checks.
+
 ### Phase 2: Read-Only Technician Routes
 
 - Move read-only technician routes with no DB writes.

--- a/docs/PHASE2L_NEXT_ROUTE_AUDIT.md
+++ b/docs/PHASE2L_NEXT_ROUTE_AUDIT.md
@@ -2,7 +2,9 @@
 
 Date: 2026-05-11
 
-Scope: audit only. No runtime code was changed, no route was moved, and no new module was created.
+Scope: Phase 2L was audit only. No runtime code was changed, no route was moved, and no new module was created.
+
+Phase 2M update: `GET /admin-legacy` and `GET /admin-legacy.html` have been extracted to `server/routes/pages/index.js`. Both routes remain redirect-only and still return HTTP 302 to `/admin-review-v2.html`.
 
 This audit reviews the remaining `index.js` route groups after:
 
@@ -40,9 +42,9 @@ The safest remaining candidates are still in the bottom static page route area a
 | `/partner-status` + `/partner-status.html` | GET | `index.js:26888`, `index.js:26911` | Sends `partner-status.html` | `sendHtml`, `res.sendFile` | Medium | Move as a pair only if Partner project resumes | `server/routes/pages/index.js` | Not part of Technician App Stable |
 | `/partner-academy` + `/partner-academy.html` | GET | `index.js:26890`, `index.js:26913` | Sends `partner-academy.html` | `sendHtml`, `res.sendFile` | Medium | Move as a pair only if Partner project resumes | `server/routes/pages/index.js` | Do not select for this project |
 
-## Recommended Phase 2M Candidate
+## Phase 2M Extracted Candidate
 
-Recommended next extraction:
+Extracted routes:
 
 ```text
 GET /admin-legacy
@@ -65,7 +67,7 @@ app.get(/^\/admin-[^\s]+\.html$/i, requireAdminSession, (req, res, next) => next
 
 That guard must remain in `index.js` and must not be moved in Phase 2M. The future page-router mount should stay after both static middlewares, in the same bottom route area, and should only add these redirect handlers to `server/routes/pages/index.js`.
 
-## Proposed Phase 2M Target
+## Phase 2M Target
 
 Target module:
 
@@ -73,7 +75,7 @@ Target module:
 server/routes/pages/index.js
 ```
 
-Proposed factory addition:
+Factory addition:
 
 ```js
 router.get("/admin-legacy", (req, res) => res.redirect(302, "/admin-review-v2.html"));
@@ -85,7 +87,7 @@ Mount plan:
 - Keep the existing `app.use(createPageRoutes({ sendHtml }))` mount after:
   - `if (fs.existsSync(FRONTEND_DIR)) app.use(express.static(FRONTEND_DIR));`
   - `app.use(express.static(ROOT_DIR));`
-- Remove only the old inline `app.get("/admin-legacy", ...)` and `app.get("/admin-legacy.html", ...)` handlers from `index.js`.
+- Removed only the old inline `app.get("/admin-legacy", ...)` and `app.get("/admin-legacy.html", ...)` handlers from `index.js`.
 - Do not move `GET /admin`, `GET /admin.html`, `GET /admin-add`, `GET /admin-review`, `GET /admin-tech`, protected admin/partner pages, or any admin API route.
 
 ## Manual Smoke Checklist For Phase 2M

--- a/index.js
+++ b/index.js
@@ -26879,7 +26879,6 @@ app.get("/admin-queue", (req, res) => res.sendFile(sendHtml("admin-queue-v2.html
 app.get("/admin-history", (req, res) => res.sendFile(sendHtml("admin-history-v2.html")));
 app.get("/admin-tech", (req, res) => res.redirect(302, "/admin-review-v2.html"));
 // หน้า legacy เลิกใช้แล้ว ให้ redirect ไป V2
-app.get("/admin-legacy", (req, res) => res.redirect(302, "/admin-review-v2.html"));
 app.get("/edit-profile", (req, res) => res.sendFile(sendHtml("edit-profile.html")));
 app.get("/tech", (req, res) => res.sendFile(sendHtml("tech.html")));
 app.get("/add-job", (req, res) => res.redirect(302, "/admin-add-v2.html"));
@@ -26902,7 +26901,6 @@ app.get("/admin-review-v2.html", (req, res) => res.sendFile(sendHtml("admin-revi
 app.get("/admin-queue-v2.html", (req, res) => res.sendFile(sendHtml("admin-queue-v2.html")));
 app.get("/admin-history-v2.html", (req, res) => res.sendFile(sendHtml("admin-history-v2.html")));
 app.get("/admin-tech.html", (req, res) => res.redirect(302, "/admin-review-v2.html"));
-app.get("/admin-legacy.html", (req, res) => res.redirect(302, "/admin-review-v2.html"));
 app.get("/edit-profile.html", (req, res) => res.sendFile(sendHtml("edit-profile.html")));
 app.get("/tech.html", (req, res) => res.sendFile(sendHtml("tech.html")));
 app.get("/add-job.html", (req, res) => res.redirect(302, "/admin-add-v2.html"));

--- a/server/routes/pages/index.js
+++ b/server/routes/pages/index.js
@@ -5,6 +5,8 @@ module.exports = function createPageRoutes(deps = {}) {
 
   router.get("/login", (req, res) => res.sendFile(sendHtml("login.html")));
   router.get("/login.html", (req, res) => res.sendFile(sendHtml("login.html")));
+  router.get("/admin-legacy", (req, res) => res.redirect(302, "/admin-review-v2.html"));
+  router.get("/admin-legacy.html", (req, res) => res.redirect(302, "/admin-review-v2.html"));
 
   return router;
 };


### PR DESCRIPTION
## Summary

- Extract only `GET /admin-legacy` and `GET /admin-legacy.html` into the existing `server/routes/pages/index.js` router
- Preserve the exact redirect behavior: HTTP 302 to `/admin-review-v2.html`
- Remove only the old inline admin legacy redirect handlers from `index.js`
- Update Phase 2M docs and rollback notes

## Safety

- No new route module created
- No auth middleware added or changed
- No admin HTML guard behavior changed
- Did not move protected admin pages or other admin routes
- Did not touch `POST /login`, `GET /`, `GET /tech`, `GET /tech.html`, `sendHtml()`, or frontend files
- Did not touch app.js, tech.html, sw.js, package.json, db.js, migrations, booking, tracking, pricing/promotion, auth/session core, LINE login, technician income, accounting/tax/VAT, admin job edit, close-job flow, service-zone detect, technician profile, attendance, or maps

## Verification

- Read `CWF_Technician_App_Master_Spec.md` first
- `node --check index.js`
- `node --check server/routes/pages/index.js`
- `node --check server/routes/serviceZones/index.js`
- `node --check server/routes/catalog/items.js`
- `node --check server/routes/system/index.js`
- `node --check server/routes/users/technicians.js`
- `node --check server/db/pool.js`

## Manual smoke checklist

- App starts with `node index.js`
- `GET /admin-legacy` redirects exactly as before
- `GET /admin-legacy.html` redirects exactly as before
- Redirect target `/admin-review-v2.html` still opens as before
- Existing admin pages still load
- Admin HTML guard behavior still works
- `GET /login` still works
- `GET /login.html` still works
- `POST /login` still works
- `GET /` still works
- `GET /tech` and `GET /tech.html` still work
- `GET /service_zones` still works
- `POST /service_zones/detect` still works