### PR TITLE
refactor: batch extract admin page redirects

### DIFF
--- a/docs/INDEX_JS_SPLIT_PLAN.md
+++ b/docs/INDEX_JS_SPLIT_PLAN.md
@@ -198,6 +198,21 @@ Phase 1B status:
 - Risk is low, but `/admin-legacy.html` still depends on the existing earlier admin HTML guard behavior staying in `index.js`.
 - Rollback: remove only `/admin-legacy` and `/admin-legacy.html` handlers from `server/routes/pages/index.js`, restore the two original inline redirect handlers in the bottom static page route area, then run syntax checks.
 
+### Phase 2N: Static Page Redirect Batch
+
+- Six redirect-only page aliases have been extracted to `server/routes/pages/index.js`.
+- Moved routes:
+  - `GET /admin` -> `/admin-review-v2.html`
+  - `GET /admin.html` -> `/admin-review-v2.html`
+  - `GET /admin-tech` -> `/admin-review-v2.html`
+  - `GET /admin-tech.html` -> `/admin-review-v2.html`
+  - `GET /add-job` -> `/admin-add-v2.html`
+  - `GET /add-job.html` -> `/admin-add-v2.html`
+- Current mount remains `app.use(createPageRoutes({ sendHtml }))` in the bottom static page route area, after `express.static(FRONTEND_DIR)` and `express.static(ROOT_DIR)`.
+- These routes use only `res.redirect(302, ...)`; no DB, request body, auth/session core, pricing, booking, technician income, job close, customer flow, external API, or mutable cache was touched.
+- Skipped active sendFile/static pages, customer/track/register/quote pages, partner pages, `/`, `/tech`, `/tech.html`, `POST /login`, and all API/business routes.
+- Rollback: remove only the six Phase 2N handlers from `server/routes/pages/index.js`, restore the six original inline redirect handlers in `index.js`, then run syntax checks.
+
 ### Phase 2: Read-Only Technician Routes
 
 - Move read-only technician routes with no DB writes.

--- a/docs/PHASE2N_STATIC_PAGE_BATCH_EXTRACTION.md
+++ b/docs/PHASE2N_STATIC_PAGE_BATCH_EXTRACTION.md
@@ -1,0 +1,133 @@
+# Phase 2N Static Page Batch Extraction
+
+Date: 2026-05-11
+
+Scope: extract a small batch of redirect-only static page aliases from `index.js` into the existing page router.
+
+## Routes Moved
+
+| Route | Old location | Previous behavior | New module | Dependencies | Risk |
+| --- | --- | --- | --- | --- | --- |
+| `GET /admin` | `index.js:26875` | `res.redirect(302, "/admin-review-v2.html")` | `server/routes/pages/index.js` | `res.redirect` | Low |
+| `GET /admin.html` | `index.js:26898` | `res.redirect(302, "/admin-review-v2.html")` | `server/routes/pages/index.js` | `res.redirect` | Low |
+| `GET /admin-tech` | `index.js:26880` | `res.redirect(302, "/admin-review-v2.html")` | `server/routes/pages/index.js` | `res.redirect` | Low |
+| `GET /admin-tech.html` | `index.js:26903` | `res.redirect(302, "/admin-review-v2.html")` | `server/routes/pages/index.js` | `res.redirect` | Low |
+| `GET /add-job` | `index.js:26884` | `res.redirect(302, "/admin-add-v2.html")` | `server/routes/pages/index.js` | `res.redirect` | Low-medium |
+| `GET /add-job.html` | `index.js:26906` | `res.redirect(302, "/admin-add-v2.html")` | `server/routes/pages/index.js` | `res.redirect` | Low-medium |
+
+All moved routes are redirect-only. They do not use DB access, request bodies, auth/session middleware inside the handler, pricing or promotion logic, customer booking/tracking logic, technician income, job close logic, external APIs, or shared mutable caches.
+
+## Mount Location
+
+The existing page router mount remains in `index.js`:
+
+```js
+app.use(createPageRoutes({ sendHtml }));
+```
+
+It is still mounted in the bottom static page route area after:
+
+```js
+if (fs.existsSync(FRONTEND_DIR)) app.use(express.static(FRONTEND_DIR));
+app.use(express.static(ROOT_DIR));
+```
+
+No new `index.js` logic was added.
+
+## Routes Explicitly Skipped
+
+Skipped because they are active static sendFile page routes or should stay out of this batch:
+
+- `GET /admin-add`
+- `GET /admin-review`
+- `GET /admin-queue`
+- `GET /admin-history`
+- `GET /admin-add-v2.html`
+- `GET /admin-review-v2.html`
+- `GET /admin-queue-v2.html`
+- `GET /admin-history-v2.html`
+- `GET /edit-profile`
+- `GET /edit-profile.html`
+- `GET /customer`
+- `GET /track`
+- `GET /register`
+- `GET /register.html`
+- `GET /install-quote`
+- `GET /install-quote.html`
+- Partner page routes, including Partner Academy routes
+
+Skipped because they are explicitly frozen for this project phase:
+
+- `GET /promotions`
+- `POST /login`
+- `GET /`
+- `GET /tech`
+- `GET /tech.html`
+- `POST /service_zones/detect`
+- `GET /technicians/:username/profile`
+- `/attendance/*`
+- `/api/maps/resolve`
+- Public booking, availability, and tracking routes
+- Job, offer, close-job, photo, unit, and evidence routes
+- Technician income and payout routes
+- Accounting, tax, and VAT routes
+- Auth/session core and LINE login routes
+
+## Tests Run
+
+```bash
+node --check index.js
+node --check server/routes/pages/index.js
+node --check server/routes/serviceZones/index.js
+node --check server/routes/catalog/items.js
+node --check server/routes/system/index.js
+node --check server/routes/users/technicians.js
+node --check server/db/pool.js
+```
+
+## Manual Smoke Checklist
+
+- App starts with `node index.js`.
+- All moved routes still redirect exactly as before.
+- `GET /admin` redirects to `/admin-review-v2.html`.
+- `GET /admin.html` redirects to `/admin-review-v2.html`.
+- `GET /admin-tech` redirects to `/admin-review-v2.html`.
+- `GET /admin-tech.html` redirects to `/admin-review-v2.html`.
+- `GET /add-job` redirects to `/admin-add-v2.html`.
+- `GET /add-job.html` redirects to `/admin-add-v2.html`.
+- `/login` works.
+- `/login.html` works.
+- `POST /login` still works.
+- `/` still works.
+- `/tech` and `/tech.html` still work.
+- `/admin-review-v2.html` still works.
+- Admin static pages still load.
+- Existing admin HTML guard behavior still works.
+- `/service_zones` still works.
+- `POST /service_zones/detect` still works.
+- No regression in technician job page.
+
+## Rollback Plan
+
+If this extraction causes any issue:
+
+1. Remove only these handlers from `server/routes/pages/index.js`:
+
+```js
+router.get("/admin", (req, res) => res.redirect(302, "/admin-review-v2.html"));
+router.get("/admin.html", (req, res) => res.redirect(302, "/admin-review-v2.html"));
+router.get("/admin-tech", (req, res) => res.redirect(302, "/admin-review-v2.html"));
+router.get("/admin-tech.html", (req, res) => res.redirect(302, "/admin-review-v2.html"));
+router.get("/add-job", (req, res) => res.redirect(302, "/admin-add-v2.html"));
+router.get("/add-job.html", (req, res) => res.redirect(302, "/admin-add-v2.html"));
+```
+
+2. Restore the original inline handlers in `index.js` at the bottom static page route area.
+3. Run:
+
+```bash
+node --check index.js
+node --check server/routes/pages/index.js
+```
+
+4. Smoke test all moved routes plus `/login`, `/tech`, and `/service_zones`.

--- a/index.js
+++ b/index.js
@@ -26872,16 +26872,13 @@ app.use(express.static(ROOT_DIR));
 // - ตัวอย่าง: /tech, /admin, /track, /customer
 app.use(createPageRoutes({ sendHtml }));
 // Admin landing: ใช้ V2 เป็นหลัก (หน้าเก่าเลิกใช้แล้ว)
-app.get("/admin", (req, res) => res.redirect(302, "/admin-review-v2.html"));
 app.get("/admin-add", (req, res) => res.sendFile(sendHtml("admin-add-v2.html")));
 app.get("/admin-review", (req, res) => res.sendFile(sendHtml("admin-review-v2.html")));
 app.get("/admin-queue", (req, res) => res.sendFile(sendHtml("admin-queue-v2.html")));
 app.get("/admin-history", (req, res) => res.sendFile(sendHtml("admin-history-v2.html")));
-app.get("/admin-tech", (req, res) => res.redirect(302, "/admin-review-v2.html"));
 // หน้า legacy เลิกใช้แล้ว ให้ redirect ไป V2
 app.get("/edit-profile", (req, res) => res.sendFile(sendHtml("edit-profile.html")));
 app.get("/tech", (req, res) => res.sendFile(sendHtml("tech.html")));
-app.get("/add-job", (req, res) => res.redirect(302, "/admin-add-v2.html"));
 app.get("/customer", (req, res) => res.sendFile(sendHtml("customer.html")));
 app.get("/partner-apply", (req, res) => res.sendFile(sendHtml("partner-apply.html")));
 app.get("/partner-status", (req, res) => res.sendFile(sendHtml("partner-status.html")));
@@ -26895,15 +26892,12 @@ app.get("/register", (req, res) => res.sendFile(sendHtml("register.html")));
 app.get("/track", (req, res) => res.sendFile(sendHtml("track.html")));
 app.get("/home", (req, res) => res.sendFile(sendHtml("index.html")));
 
-app.get("/admin.html", (req, res) => res.redirect(302, "/admin-review-v2.html"));
 app.get("/admin-add-v2.html", (req, res) => res.sendFile(sendHtml("admin-add-v2.html")));
 app.get("/admin-review-v2.html", (req, res) => res.sendFile(sendHtml("admin-review-v2.html")));
 app.get("/admin-queue-v2.html", (req, res) => res.sendFile(sendHtml("admin-queue-v2.html")));
 app.get("/admin-history-v2.html", (req, res) => res.sendFile(sendHtml("admin-history-v2.html")));
-app.get("/admin-tech.html", (req, res) => res.redirect(302, "/admin-review-v2.html"));
 app.get("/edit-profile.html", (req, res) => res.sendFile(sendHtml("edit-profile.html")));
 app.get("/tech.html", (req, res) => res.sendFile(sendHtml("tech.html")));
-app.get("/add-job.html", (req, res) => res.redirect(302, "/admin-add-v2.html"));
 app.get("/register.html", (req, res) => res.sendFile(sendHtml("register.html")));
 app.get("/partner-apply.html", (req, res) => res.sendFile(sendHtml("partner-apply.html")));
 app.get("/partner-status.html", (req, res) => res.sendFile(sendHtml("partner-status.html")));

--- a/server/routes/pages/index.js
+++ b/server/routes/pages/index.js
@@ -7,6 +7,12 @@ module.exports = function createPageRoutes(deps = {}) {
   router.get("/login.html", (req, res) => res.sendFile(sendHtml("login.html")));
   router.get("/admin-legacy", (req, res) => res.redirect(302, "/admin-review-v2.html"));
   router.get("/admin-legacy.html", (req, res) => res.redirect(302, "/admin-review-v2.html"));
+  router.get("/admin", (req, res) => res.redirect(302, "/admin-review-v2.html"));
+  router.get("/admin.html", (req, res) => res.redirect(302, "/admin-review-v2.html"));
+  router.get("/admin-tech", (req, res) => res.redirect(302, "/admin-review-v2.html"));
+  router.get("/admin-tech.html", (req, res) => res.redirect(302, "/admin-review-v2.html"));
+  router.get("/add-job", (req, res) => res.redirect(302, "/admin-add-v2.html"));
+  router.get("/add-job.html", (req, res) => res.redirect(302, "/admin-add-v2.html"));
 
   return router;
 };


### PR DESCRIPTION
## Summary

- Batch extract six redirect-only static page aliases into the existing `server/routes/pages/index.js` router
- Move only:
  - `GET /admin`
  - `GET /admin.html`
  - `GET /admin-tech`
  - `GET /admin-tech.html`
  - `GET /add-job`
  - `GET /add-job.html`
- Preserve exact redirect targets and HTTP 302 behavior
- Add Phase 2N documentation with routes moved, skips, checks, smoke checklist, and rollback

## Safety

- Redirect-only routes, no DB or request body usage
- No new route module created
- No new logic added to `index.js`
- Did not touch `GET /promotions`, `POST /login`, `GET /`, `GET /tech`, `GET /tech.html`, `POST /service_zones/detect`, `/attendance/*`, `/api/maps/resolve`, public booking/availability/tracking routes, job/offer/close-job/photo/evidence routes, technician income/payout routes, accounting/tax/VAT, Partner Academy routes, auth/session core, or LINE login
- Did not change `sendHtml()` or frontend files
- Did not touch app.js, tech.html, sw.js, package.json, db.js, or migrations

## Verification

- Read `CWF_Technician_App_Master_Spec.md` first
- `node --check index.js`
- `node --check server/routes/pages/index.js`
- `node --check server/routes/serviceZones/index.js`
- `node --check server/routes/catalog/items.js`
- `node --check server/routes/system/index.js`
- `node --check server/routes/users/technicians.js`
- `node --check server/db/pool.js`

## Manual smoke checklist

- App starts with `node index.js`
- All moved routes still return or redirect exactly as before
- `/login` works
- `/login.html` works
- `POST /login` still works
- `/` still works
- `/tech` and `/tech.html` still work
- `/admin-review-v2.html` still works
- Admin static pages still load
- Existing admin HTML guard behavior still works
- `/service_zones` still works
- `POST /service_zones/detect` still works
- No regression in technician job page