### PR TITLE
refactor: batch extract admin static page routes

### DIFF
--- a/docs/INDEX_JS_SPLIT_PLAN.md
+++ b/docs/INDEX_JS_SPLIT_PLAN.md
@@ -213,6 +213,23 @@ Phase 1B status:
 - Skipped active sendFile/static pages, customer/track/register/quote pages, partner pages, `/`, `/tech`, `/tech.html`, `POST /login`, and all API/business routes.
 - Rollback: remove only the six Phase 2N handlers from `server/routes/pages/index.js`, restore the six original inline redirect handlers in `index.js`, then run syntax checks.
 
+### Phase 2O: Admin Static Page SendFile Batch
+
+- Eight admin static page aliases have been extracted to `server/routes/pages/index.js`.
+- Moved routes:
+  - `GET /admin-add` -> `sendHtml("admin-add-v2.html")`
+  - `GET /admin-review` -> `sendHtml("admin-review-v2.html")`
+  - `GET /admin-queue` -> `sendHtml("admin-queue-v2.html")`
+  - `GET /admin-history` -> `sendHtml("admin-history-v2.html")`
+  - `GET /admin-add-v2.html` -> `sendHtml("admin-add-v2.html")`
+  - `GET /admin-review-v2.html` -> `sendHtml("admin-review-v2.html")`
+  - `GET /admin-queue-v2.html` -> `sendHtml("admin-queue-v2.html")`
+  - `GET /admin-history-v2.html` -> `sendHtml("admin-history-v2.html")`
+- Current mount remains `app.use(createPageRoutes({ sendHtml }))` in the bottom static page route area, after the existing admin HTML guard and static middleware.
+- These routes use only `res.sendFile(sendHtml(...))`; no DB, request body, auth/session core, pricing, booking, technician income, job close, customer flow, external API, or mutable cache was touched.
+- Skipped `/`, `/tech`, `/tech.html`, `POST /login`, customer/track/install quote/register pages, partner pages, service zone detect, profile, attendance, maps, and all API/business routes.
+- Rollback: remove only the eight Phase 2O handlers from `server/routes/pages/index.js`, restore the eight original inline sendFile handlers in `index.js`, then run syntax checks and smoke tests.
+
 ### Phase 2: Read-Only Technician Routes
 
 - Move read-only technician routes with no DB writes.

--- a/docs/PHASE2O_STATIC_PAGE_BATCH_EXTRACTION.md
+++ b/docs/PHASE2O_STATIC_PAGE_BATCH_EXTRACTION.md
@@ -1,0 +1,132 @@
+# Phase 2O Static Page Batch Extraction
+
+Date: 2026-05-11
+
+Scope: extract the next safe batch of static admin page aliases from `index.js` into the existing page router.
+
+## Routes Moved
+
+| Route | Old location | Previous behavior | New module | Dependencies | Risk |
+| --- | --- | --- | --- | --- | --- |
+| `GET /admin-add` | `index.js:26875` | `res.sendFile(sendHtml("admin-add-v2.html"))` | `server/routes/pages/index.js` | `sendHtml` | Medium |
+| `GET /admin-review` | `index.js:26876` | `res.sendFile(sendHtml("admin-review-v2.html"))` | `server/routes/pages/index.js` | `sendHtml` | Medium |
+| `GET /admin-queue` | `index.js:26877` | `res.sendFile(sendHtml("admin-queue-v2.html"))` | `server/routes/pages/index.js` | `sendHtml` | Medium |
+| `GET /admin-history` | `index.js:26878` | `res.sendFile(sendHtml("admin-history-v2.html"))` | `server/routes/pages/index.js` | `sendHtml` | Medium |
+| `GET /admin-add-v2.html` | `index.js:26895` | `res.sendFile(sendHtml("admin-add-v2.html"))` | `server/routes/pages/index.js` | `sendHtml` | Medium |
+| `GET /admin-review-v2.html` | `index.js:26896` | `res.sendFile(sendHtml("admin-review-v2.html"))` | `server/routes/pages/index.js` | `sendHtml` | Medium |
+| `GET /admin-queue-v2.html` | `index.js:26897` | `res.sendFile(sendHtml("admin-queue-v2.html"))` | `server/routes/pages/index.js` | `sendHtml` | Medium |
+| `GET /admin-history-v2.html` | `index.js:26898` | `res.sendFile(sendHtml("admin-history-v2.html"))` | `server/routes/pages/index.js` | `sendHtml` | Medium |
+
+All moved routes are GET-only static page aliases. They do not use DB access, request bodies, auth/session middleware inside the handler, pricing or promotion logic, customer booking/tracking logic, technician income, job close logic, external APIs, or shared mutable caches.
+
+## Mount Location
+
+The existing page router mount remains in `index.js`:
+
+```js
+app.use(createPageRoutes({ sendHtml }));
+```
+
+It is still mounted in the bottom static page route area after the existing protected admin HTML guard and after:
+
+```js
+if (fs.existsSync(FRONTEND_DIR)) app.use(express.static(FRONTEND_DIR));
+app.use(express.static(ROOT_DIR));
+```
+
+No new `index.js` logic was added. `sendHtml()` was not changed.
+
+## Routes Explicitly Skipped
+
+Skipped because they are frozen for this phase or tied to technician/auth/customer behavior:
+
+- `GET /`
+- `GET /tech`
+- `GET /tech.html`
+- `POST /login`
+- `GET /promotions`
+- `POST /service_zones/detect`
+- `GET /technicians/:username/profile`
+- `/attendance/*`
+- `/api/maps/resolve`
+- Public booking, availability, and tracking routes
+- Job, offer, close-job, photo, unit, and evidence routes
+- Technician income and payout routes
+- Accounting, tax, and VAT routes
+- Auth/session core and LINE login routes
+
+Skipped because they are customer, registration, install quote, profile, or partner-facing pages outside this admin static batch:
+
+- `GET /edit-profile`
+- `GET /edit-profile.html`
+- `GET /customer`
+- `GET /track`
+- `GET /register`
+- `GET /register.html`
+- `GET /install-quote`
+- `GET /install-quote.html`
+- `GET /home`
+- `GET /index.html`
+- Partner page routes, including Partner Academy routes
+
+## Tests Run
+
+```bash
+node --check index.js
+node --check server/routes/pages/index.js
+node --check server/routes/serviceZones/index.js
+node --check server/routes/catalog/items.js
+node --check server/routes/system/index.js
+node --check server/routes/users/technicians.js
+node --check server/db/pool.js
+```
+
+## Manual Smoke Checklist
+
+- App starts with `node index.js`.
+- All moved routes still return exactly as before.
+- `GET /admin-add` opens `admin-add-v2.html`.
+- `GET /admin-review` opens `admin-review-v2.html`.
+- `GET /admin-queue` opens `admin-queue-v2.html`.
+- `GET /admin-history` opens `admin-history-v2.html`.
+- `GET /admin-add-v2.html` opens `admin-add-v2.html`.
+- `GET /admin-review-v2.html` opens `admin-review-v2.html`.
+- `GET /admin-queue-v2.html` opens `admin-queue-v2.html`.
+- `GET /admin-history-v2.html` opens `admin-history-v2.html`.
+- `/login` works.
+- `/login.html` works.
+- `POST /login` still works.
+- `/` still works.
+- `/tech` and `/tech.html` still work.
+- Admin static pages still load.
+- Existing admin HTML guard behavior still works.
+- `/service_zones` still works.
+- `POST /service_zones/detect` still works.
+- No regression in technician job page.
+
+## Rollback Plan
+
+If this extraction causes any issue:
+
+1. Remove only these handlers from `server/routes/pages/index.js`:
+
+```js
+router.get("/admin-add", (req, res) => res.sendFile(sendHtml("admin-add-v2.html")));
+router.get("/admin-review", (req, res) => res.sendFile(sendHtml("admin-review-v2.html")));
+router.get("/admin-queue", (req, res) => res.sendFile(sendHtml("admin-queue-v2.html")));
+router.get("/admin-history", (req, res) => res.sendFile(sendHtml("admin-history-v2.html")));
+router.get("/admin-add-v2.html", (req, res) => res.sendFile(sendHtml("admin-add-v2.html")));
+router.get("/admin-review-v2.html", (req, res) => res.sendFile(sendHtml("admin-review-v2.html")));
+router.get("/admin-queue-v2.html", (req, res) => res.sendFile(sendHtml("admin-queue-v2.html")));
+router.get("/admin-history-v2.html", (req, res) => res.sendFile(sendHtml("admin-history-v2.html")));
+```
+
+2. Restore the original inline handlers in `index.js` at the bottom static page route area.
+3. Run:
+
+```bash
+node --check index.js
+node --check server/routes/pages/index.js
+```
+
+4. Smoke test all moved routes plus `/login`, `/tech`, `/service_zones`, and `POST /service_zones/detect`.

--- a/index.js
+++ b/index.js
@@ -26872,10 +26872,6 @@ app.use(express.static(ROOT_DIR));
 // - ตัวอย่าง: /tech, /admin, /track, /customer
 app.use(createPageRoutes({ sendHtml }));
 // Admin landing: ใช้ V2 เป็นหลัก (หน้าเก่าเลิกใช้แล้ว)
-app.get("/admin-add", (req, res) => res.sendFile(sendHtml("admin-add-v2.html")));
-app.get("/admin-review", (req, res) => res.sendFile(sendHtml("admin-review-v2.html")));
-app.get("/admin-queue", (req, res) => res.sendFile(sendHtml("admin-queue-v2.html")));
-app.get("/admin-history", (req, res) => res.sendFile(sendHtml("admin-history-v2.html")));
 // หน้า legacy เลิกใช้แล้ว ให้ redirect ไป V2
 app.get("/edit-profile", (req, res) => res.sendFile(sendHtml("edit-profile.html")));
 app.get("/tech", (req, res) => res.sendFile(sendHtml("tech.html")));
@@ -26892,10 +26888,6 @@ app.get("/register", (req, res) => res.sendFile(sendHtml("register.html")));
 app.get("/track", (req, res) => res.sendFile(sendHtml("track.html")));
 app.get("/home", (req, res) => res.sendFile(sendHtml("index.html")));
 
-app.get("/admin-add-v2.html", (req, res) => res.sendFile(sendHtml("admin-add-v2.html")));
-app.get("/admin-review-v2.html", (req, res) => res.sendFile(sendHtml("admin-review-v2.html")));
-app.get("/admin-queue-v2.html", (req, res) => res.sendFile(sendHtml("admin-queue-v2.html")));
-app.get("/admin-history-v2.html", (req, res) => res.sendFile(sendHtml("admin-history-v2.html")));
 app.get("/edit-profile.html", (req, res) => res.sendFile(sendHtml("edit-profile.html")));
 app.get("/tech.html", (req, res) => res.sendFile(sendHtml("tech.html")));
 app.get("/register.html", (req, res) => res.sendFile(sendHtml("register.html")));

--- a/server/routes/pages/index.js
+++ b/server/routes/pages/index.js
@@ -13,6 +13,14 @@ module.exports = function createPageRoutes(deps = {}) {
   router.get("/admin-tech.html", (req, res) => res.redirect(302, "/admin-review-v2.html"));
   router.get("/add-job", (req, res) => res.redirect(302, "/admin-add-v2.html"));
   router.get("/add-job.html", (req, res) => res.redirect(302, "/admin-add-v2.html"));
+  router.get("/admin-add", (req, res) => res.sendFile(sendHtml("admin-add-v2.html")));
+  router.get("/admin-review", (req, res) => res.sendFile(sendHtml("admin-review-v2.html")));
+  router.get("/admin-queue", (req, res) => res.sendFile(sendHtml("admin-queue-v2.html")));
+  router.get("/admin-history", (req, res) => res.sendFile(sendHtml("admin-history-v2.html")));
+  router.get("/admin-add-v2.html", (req, res) => res.sendFile(sendHtml("admin-add-v2.html")));
+  router.get("/admin-review-v2.html", (req, res) => res.sendFile(sendHtml("admin-review-v2.html")));
+  router.get("/admin-queue-v2.html", (req, res) => res.sendFile(sendHtml("admin-queue-v2.html")));
+  router.get("/admin-history-v2.html", (req, res) => res.sendFile(sendHtml("admin-history-v2.html")));
 
   return router;
 };


### PR DESCRIPTION
## Summary

- Batch extract eight static admin page aliases into the existing `server/routes/pages/index.js` router
- Move only:
  - `GET /admin-add`
  - `GET /admin-review`
  - `GET /admin-queue`
  - `GET /admin-history`
  - `GET /admin-add-v2.html`
  - `GET /admin-review-v2.html`
  - `GET /admin-queue-v2.html`
  - `GET /admin-history-v2.html`
- Preserve exact `res.sendFile(sendHtml(...))` targets
- Add Phase 2O documentation with moved routes, skipped routes, checks, smoke checklist, and rollback

## Safety

- Static GET page aliases only, no DB or request body usage
- Reuses existing `createPageRoutes({ sendHtml })` factory and mount location
- No new route module created
- No new logic added to `index.js`
- Did not touch `GET /promotions`, `POST /login`, `GET /`, `GET /tech`, `GET /tech.html`, `POST /service_zones/detect`, `/attendance/*`, `/api/maps/resolve`, public booking/availability/tracking routes, job/offer/close-job/photo/evidence routes, technician income/payout routes, accounting/tax/VAT, Partner Academy routes, auth/session core, or LINE login
- Did not change `sendHtml()` or frontend files
- Did not touch app.js, tech.html, sw.js, package.json, db.js, or migrations

## Verification

- Read `CWF_Technician_App_Master_Spec.md` first
- `node --check index.js`
- `node --check server/routes/pages/index.js`
- `node --check server/routes/serviceZones/index.js`
- `node --check server/routes/catalog/items.js`
- `node --check server/routes/system/index.js`
- `node --check server/routes/users/technicians.js`
- `node --check server/db/pool.js`

## Manual smoke checklist

- App starts with `node index.js`
- All moved routes still return exactly as before
- `/admin-add` opens `admin-add-v2.html`
- `/admin-review` opens `admin-review-v2.html`
- `/admin-queue` opens `admin-queue-v2.html`
- `/admin-history` opens `admin-history-v2.html`
- `/admin-add-v2.html` opens `admin-add-v2.html`
- `/admin-review-v2.html` opens `admin-review-v2.html`
- `/admin-queue-v2.html` opens `admin-queue-v2.html`
- `/admin-history-v2.html` opens `admin-history-v2.html`
- `/login` works
- `/login.html` works
- `POST /login` still works
- `/` still works
- `/tech` and `/tech.html` still work
- Admin static pages still load
- Existing admin HTML guard behavior still works
- `/service_zones` still works
- `POST /service_zones/detect` still works
- No regression in technician job page