### PR TITLE
refactor: batch extract admin static page routes

### DIFF
--- a/docs/INDEX_JS_SPLIT_PLAN.md
+++ b/docs/INDEX_JS_SPLIT_PLAN.md
@@ -213,6 +213,23 @@ Phase 1B status:
 - Skipped active sendFile/static pages, customer/track/register/quote pages, partner pages, `/`, `/tech`, `/tech.html`, `POST /login`, and all API/business routes.
 - Rollback: remove only the six Phase 2N handlers from `server/routes/pages/index.js`, restore the six original inline redirect handlers in `index.js`, then run syntax checks.
 
+### Phase 3A: Major Page Route Extraction Pass
+
+- The latest `main` audit found that only eight remaining page routes were clearly safe to move under the current production constraints.
+- Moved routes:
+  - `GET /admin-add`
+  - `GET /admin-review`
+  - `GET /admin-queue`
+  - `GET /admin-history`
+  - `GET /admin-add-v2.html`
+  - `GET /admin-review-v2.html`
+  - `GET /admin-queue-v2.html`
+  - `GET /admin-history-v2.html`
+- All eight routes remain in the existing `server/routes/pages/index.js` router and use only `res.sendFile(sendHtml(...))`.
+- Estimated `index.js` reduction for this pass: 8 route lines removed.
+- Routes intentionally not moved in this pass include `/edit-profile*`, `/home`, `/index.html`, `/register*`, customer/track pages, install quote pages, partner pages, `/tech*`, `/`, protected admin pages, and all API/business routes.
+- Rollback: remove only the eight Phase 3A handlers from `server/routes/pages/index.js`, restore the original inline handlers in `index.js`, then run syntax checks and smoke tests.
+
 ### Phase 2: Read-Only Technician Routes
 
 - Move read-only technician routes with no DB writes.

--- a/docs/PHASE3A_MAJOR_PAGE_ROUTE_EXTRACTION.md
+++ b/docs/PHASE3A_MAJOR_PAGE_ROUTE_EXTRACTION.md
@@ -1,0 +1,123 @@
+# Phase 3A Major Page Route Extraction
+
+Date: 2026-05-16
+
+## Current Repo / PR Status
+
+- `main` has advanced beyond PR #14.
+- PR #15 (`refactor: batch extract admin static page routes`) is still open, based on an older `main`, and is no longer mergeable cleanly with the latest branch state.
+- Decision: supersede PR #15 with this fresh branch from current `main` instead of merging an outdated branch first. The eight safe routes from PR #15 are included here unchanged.
+
+## Before / After Summary
+
+- Before: 8 clearly safe admin static page aliases still lived inline in `index.js`.
+- After: those 8 routes live in `server/routes/pages/index.js`.
+- Estimated `index.js` line reduction: 8 route lines.
+- Module structure stays simple:
+  - `server/routes/pages/index.js`
+
+## Routes Moved
+
+| Route | Old location | Previous behavior | New module | Dependencies | Risk |
+| --- | --- | --- | --- | --- | --- |
+| `GET /admin-add` | `index.js:26822` | `res.sendFile(sendHtml("admin-add-v2.html"))` | `server/routes/pages/index.js` | `sendHtml` | Medium |
+| `GET /admin-review` | `index.js:26823` | `res.sendFile(sendHtml("admin-review-v2.html"))` | `server/routes/pages/index.js` | `sendHtml` | Medium |
+| `GET /admin-queue` | `index.js:26824` | `res.sendFile(sendHtml("admin-queue-v2.html"))` | `server/routes/pages/index.js` | `sendHtml` | Medium |
+| `GET /admin-history` | `index.js:26825` | `res.sendFile(sendHtml("admin-history-v2.html"))` | `server/routes/pages/index.js` | `sendHtml` | Medium |
+| `GET /admin-add-v2.html` | `index.js:26842` | `res.sendFile(sendHtml("admin-add-v2.html"))` | `server/routes/pages/index.js` | `sendHtml` | Medium |
+| `GET /admin-review-v2.html` | `index.js:26843` | `res.sendFile(sendHtml("admin-review-v2.html"))` | `server/routes/pages/index.js` | `sendHtml` | Medium |
+| `GET /admin-queue-v2.html` | `index.js:26844` | `res.sendFile(sendHtml("admin-queue-v2.html"))` | `server/routes/pages/index.js` | `sendHtml` | Medium |
+| `GET /admin-history-v2.html` | `index.js:26845` | `res.sendFile(sendHtml("admin-history-v2.html"))` | `server/routes/pages/index.js` | `sendHtml` | Medium |
+
+These routes are GET-only static page aliases. They use no DB, request body, business logic, external API, pricing, booking, technician income, close-job flow, or shared mutable cache.
+
+## Routes Skipped And Why
+
+### Maybe safe, but needs a separate review
+
+- `GET /edit-profile`
+- `GET /edit-profile.html`
+- `GET /home`
+- `GET /index.html`
+
+These are static-only, but they touch technician/profile or public entry surfaces and are not necessary to complete this pass safely.
+
+### Do not touch in this phase
+
+- `GET /`
+- `GET /tech`
+- `GET /tech.html`
+- `POST /login`
+- `GET /promotions`
+- `POST /service_zones/detect`
+- `GET /technicians/:username/profile`
+- `/attendance/*`
+- `/api/maps/resolve`
+- Public booking, availability, customer tracking, and install quote routes
+- `GET /customer`
+- `GET /track`
+- `GET /register`
+- `GET /register.html`
+- Partner page routes, including Partner Academy routes
+- Protected admin pages using auth middleware
+- Technician income/payout routes
+- Job, offer, close-job, photo, unit, and evidence routes
+- Accounting, tax, VAT, auth/session core, and LINE login routes
+
+## Risk
+
+- Overall risk: Medium.
+- Why not low: these are admin-facing page aliases, and several HTML paths rely on the existing admin guard/static middleware ordering staying unchanged.
+- Protections:
+  - same route paths
+  - same `sendHtml(...)` targets
+  - same mount position via existing page router
+  - no frontend, DB, package, migration, or middleware changes
+
+## Tests Run
+
+```bash
+node --check index.js
+node --check server/routes/pages/index.js
+node --check server/routes/serviceZones/index.js
+node --check server/routes/catalog/items.js
+node --check server/routes/system/index.js
+node --check server/routes/users/technicians.js
+node --check server/db/pool.js
+```
+
+## Manual Smoke Checklist
+
+- App starts.
+- All moved routes still return exactly as before.
+- `/login` still works.
+- `/login.html` still works.
+- `POST /login` still works.
+- `/` still works.
+- `/tech` and `/tech.html` still work.
+- All moved admin static pages still open.
+- Admin guard behavior still works.
+- `/service_zones` still works.
+- `POST /service_zones/detect` still works.
+- Technician job page has no regression.
+- Customer/public pages that were not moved still work.
+- No regression in booking, pricing, income, or close-job flows.
+
+## Rollback Plan
+
+1. Remove only these handlers from `server/routes/pages/index.js`:
+
+```js
+router.get("/admin-add", (req, res) => res.sendFile(sendHtml("admin-add-v2.html")));
+router.get("/admin-review", (req, res) => res.sendFile(sendHtml("admin-review-v2.html")));
+router.get("/admin-queue", (req, res) => res.sendFile(sendHtml("admin-queue-v2.html")));
+router.get("/admin-history", (req, res) => res.sendFile(sendHtml("admin-history-v2.html")));
+router.get("/admin-add-v2.html", (req, res) => res.sendFile(sendHtml("admin-add-v2.html")));
+router.get("/admin-review-v2.html", (req, res) => res.sendFile(sendHtml("admin-review-v2.html")));
+router.get("/admin-queue-v2.html", (req, res) => res.sendFile(sendHtml("admin-queue-v2.html")));
+router.get("/admin-history-v2.html", (req, res) => res.sendFile(sendHtml("admin-history-v2.html")));
+```
+
+2. Restore the original inline handlers in `index.js` at the same bottom static page locations.
+3. Run syntax checks.
+4. Smoke test all moved routes plus `/login`, `/tech`, `/service_zones`, and `POST /service_zones/detect`.

--- a/index.js
+++ b/index.js
@@ -26819,10 +26819,6 @@ app.use(express.static(ROOT_DIR));
 // - ตัวอย่าง: /tech, /admin, /track, /customer
 app.use(createPageRoutes({ sendHtml }));
 // Admin landing: ใช้ V2 เป็นหลัก (หน้าเก่าเลิกใช้แล้ว)
-app.get("/admin-add", (req, res) => res.sendFile(sendHtml("admin-add-v2.html")));
-app.get("/admin-review", (req, res) => res.sendFile(sendHtml("admin-review-v2.html")));
-app.get("/admin-queue", (req, res) => res.sendFile(sendHtml("admin-queue-v2.html")));
-app.get("/admin-history", (req, res) => res.sendFile(sendHtml("admin-history-v2.html")));
 // หน้า legacy เลิกใช้แล้ว ให้ redirect ไป V2
 app.get("/edit-profile", (req, res) => res.sendFile(sendHtml("edit-profile.html")));
 app.get("/tech", (req, res) => res.sendFile(sendHtml("tech.html")));
@@ -26839,10 +26835,6 @@ app.get("/register", (req, res) => res.sendFile(sendHtml("register.html")));
 app.get("/track", (req, res) => res.sendFile(sendHtml("track.html")));
 app.get("/home", (req, res) => res.sendFile(sendHtml("index.html")));
 
-app.get("/admin-add-v2.html", (req, res) => res.sendFile(sendHtml("admin-add-v2.html")));
-app.get("/admin-review-v2.html", (req, res) => res.sendFile(sendHtml("admin-review-v2.html")));
-app.get("/admin-queue-v2.html", (req, res) => res.sendFile(sendHtml("admin-queue-v2.html")));
-app.get("/admin-history-v2.html", (req, res) => res.sendFile(sendHtml("admin-history-v2.html")));
 app.get("/edit-profile.html", (req, res) => res.sendFile(sendHtml("edit-profile.html")));
 app.get("/tech.html", (req, res) => res.sendFile(sendHtml("tech.html")));
 app.get("/register.html", (req, res) => res.sendFile(sendHtml("register.html")));

--- a/server/routes/pages/index.js
+++ b/server/routes/pages/index.js
@@ -13,6 +13,14 @@ module.exports = function createPageRoutes(deps = {}) {
   router.get("/admin-tech.html", (req, res) => res.redirect(302, "/admin-review-v2.html"));
   router.get("/add-job", (req, res) => res.redirect(302, "/admin-add-v2.html"));
   router.get("/add-job.html", (req, res) => res.redirect(302, "/admin-add-v2.html"));
+  router.get("/admin-add", (req, res) => res.sendFile(sendHtml("admin-add-v2.html")));
+  router.get("/admin-review", (req, res) => res.sendFile(sendHtml("admin-review-v2.html")));
+  router.get("/admin-queue", (req, res) => res.sendFile(sendHtml("admin-queue-v2.html")));
+  router.get("/admin-history", (req, res) => res.sendFile(sendHtml("admin-history-v2.html")));
+  router.get("/admin-add-v2.html", (req, res) => res.sendFile(sendHtml("admin-add-v2.html")));
+  router.get("/admin-review-v2.html", (req, res) => res.sendFile(sendHtml("admin-review-v2.html")));
+  router.get("/admin-queue-v2.html", (req, res) => res.sendFile(sendHtml("admin-queue-v2.html")));
+  router.get("/admin-history-v2.html", (req, res) => res.sendFile(sendHtml("admin-history-v2.html")));
 
   return router;
 };


### PR DESCRIPTION
## Summary

- Supersede the older PR #15 with a fresh branch from current `main`
- Extract the largest clearly safe remaining batch under the current production constraints: eight admin static page aliases
- Move only:
  - `GET /admin-add`
  - `GET /admin-review`
  - `GET /admin-queue`
  - `GET /admin-history`
  - `GET /admin-add-v2.html`
  - `GET /admin-review-v2.html`
  - `GET /admin-queue-v2.html`
  - `GET /admin-history-v2.html`
- Preserve exact `res.sendFile(sendHtml(...))` behavior
- Add `docs/PHASE3A_MAJOR_PAGE_ROUTE_EXTRACTION.md` with current-state audit, moved/skipped routes, checks, smoke checklist, rollback, and estimated line reduction

## Why only eight routes

The latest `main` audit found that these eight routes are the only remaining routes that are clearly safe to move now without crossing into technician/profile, public/customer, auth-adjacent, partner, or business-flow territory. Static-only routes like `/edit-profile*`, `/home`, and `/index.html` were intentionally left for separate review instead of padding this batch with weaker candidates.

## Safety

- Static GET page aliases only, no DB or request body usage
- Reuses existing `createPageRoutes({ sendHtml })` factory and mount location
- No new business logic added to `index.js`
- Did not touch `GET /promotions`, `POST /login`, `GET /`, `GET /tech`, `GET /tech.html`, `POST /service_zones/detect`, `/attendance/*`, `/api/maps/resolve`, public booking/availability/tracking routes, install quote routes, job/offer/close-job/photo/evidence routes, technician income/payout routes, accounting/tax/VAT, Partner Academy routes, auth/session core, or LINE login
- Did not change `sendHtml()` or frontend files
- Did not touch app.js, tech.html, sw.js, package.json, db.js, or migrations

## Verification

- Read `CWF_Technician_App_Master_Spec.md` first
- `node --check index.js`
- `node --check server/routes/pages/index.js`
- `node --check server/routes/serviceZones/index.js`
- `node --check server/routes/catalog/items.js`
- `node --check server/routes/system/index.js`
- `node --check server/routes/users/technicians.js`
- `node --check server/db/pool.js`

## Manual smoke checklist

- App starts
- All moved routes still return exactly as before
- `/login` still works
- `/login.html` still works
- `POST /login` still works
- `/` still works
- `/tech` and `/tech.html` still work
- All moved admin static pages still open
- Admin guard behavior still works
- `/service_zones` still works
- `POST /service_zones/detect` still works
- Technician job page has no regression
- Customer/public pages that were not moved still work
- No regression in booking, pricing, income, or close-job flows