### PR TITLE
refactor: batch extract static page routes

### DIFF
--- a/docs/INDEX_JS_SPLIT_PLAN.md
+++ b/docs/INDEX_JS_SPLIT_PLAN.md
@@ -213,6 +213,21 @@ Phase 1B status:
 - Skipped active sendFile/static pages, customer/track/register/quote pages, partner pages, `/`, `/tech`, `/tech.html`, `POST /login`, and all API/business routes.
 - Rollback: remove only the six Phase 2N handlers from `server/routes/pages/index.js`, restore the six original inline redirect handlers in `index.js`, then run syntax checks.
 
+### Phase 3A: Major Index Reduction
+
+- The page router is now split into domain-focused modules:
+  - `server/routes/pages/admin.js`
+  - `server/routes/pages/technician.js`
+  - `server/routes/pages/public.js`
+- Sixteen safe page routes moved out of `index.js` in one batch:
+  - 8 admin static page aliases
+  - 4 technician static page aliases
+  - 4 public neutral static aliases
+- `index.js` keeps only `app.use(createPageRoutes({ sendHtml }))` for these page routes.
+- `sendHtml()`, guard order, static middleware order, DB code, frontend files, and business routes were not changed.
+- Routes intentionally skipped include customer/track pages, install quote pages, partner pages, `/`, `POST /login`, protected admin pages, and all business/API routes.
+- Rollback: restore the 16 original inline handlers to `index.js`, remove the three new page submodules, and collapse `server/routes/pages/index.js` back to the prior single-file router.
+
 ### Phase 2: Read-Only Technician Routes
 
 - Move read-only technician routes with no DB writes.

--- a/docs/PHASE3A_MAJOR_INDEX_REDUCTION.md
+++ b/docs/PHASE3A_MAJOR_INDEX_REDUCTION.md
@@ -1,0 +1,134 @@
+# Phase 3A Major Index Reduction
+
+Date: 2026-05-16
+
+## Before / After
+
+- `index.js` before: 24,959 lines
+- `index.js` after: 24,943 lines
+- Reduction: 16 route lines
+- Route count moved in this batch: 16
+
+## Current Repo / PR Status
+
+- `main` was inspected at commit `dcabd7c8e704faf315e4958542d84323695a64be`.
+- PR #16 was open during planning and contained only the smaller 8-route admin page subset.
+- Decision: supersede PR #16 with this larger current-main batch instead of merging another small PR first.
+
+## Route Inventory Summary
+
+| Group | Current state | Decision |
+| --- | --- | --- |
+| Static/sendHtml page routes | Bottom page area plus a few protected static routes | Move safe unprotected subset |
+| Redirect-only routes | Existing page aliases and a few guarded aliases | Keep prior extracted routes; do not move guarded aliases |
+| Public/customer routes | `/public/*`, `/customer`, `/track`, install quote pages | Keep in place |
+| Admin routes | Large protected CRUD/business surface | Keep in place |
+| Technician routes | Jobs, income, readiness, profile, base status | Keep in place except static page aliases |
+| Income/payout routes | Many DB-backed routes | Keep in place |
+| Rework routes | Admin DB-backed routes | Keep in place |
+| Service zone routes | `GET /service_zones` extracted; detect remains inline | Keep detect inline |
+| Auth/session routes | LINE, login, logout, password/session | Keep in place |
+| Booking/availability routes | Public/admin DB-backed routes | Keep in place |
+| Accounting/tax routes | Protected accounting routes | Keep in place |
+| Utility/API routes | maps/docs/debug/etc. | Keep in place |
+
+## Routes Moved
+
+### Admin page aliases
+
+| Route | Old location | Behavior |
+| --- | --- | --- |
+| `GET /admin-add` | `index.js:26822` | `sendHtml("admin-add-v2.html")` |
+| `GET /admin-review` | `index.js:26823` | `sendHtml("admin-review-v2.html")` |
+| `GET /admin-queue` | `index.js:26824` | `sendHtml("admin-queue-v2.html")` |
+| `GET /admin-history` | `index.js:26825` | `sendHtml("admin-history-v2.html")` |
+| `GET /admin-add-v2.html` | `index.js:26842` | `sendHtml("admin-add-v2.html")` |
+| `GET /admin-review-v2.html` | `index.js:26843` | `sendHtml("admin-review-v2.html")` |
+| `GET /admin-queue-v2.html` | `index.js:26844` | `sendHtml("admin-queue-v2.html")` |
+| `GET /admin-history-v2.html` | `index.js:26845` | `sendHtml("admin-history-v2.html")` |
+
+### Technician page aliases
+
+| Route | Old location | Behavior |
+| --- | --- | --- |
+| `GET /edit-profile` | `index.js:26827` | `sendHtml("edit-profile.html")` |
+| `GET /tech` | `index.js:26828` | `sendHtml("tech.html")` |
+| `GET /edit-profile.html` | `index.js:26846` | `sendHtml("edit-profile.html")` |
+| `GET /tech.html` | `index.js:26847` | `sendHtml("tech.html")` |
+
+### Public neutral page aliases
+
+| Route | Old location | Behavior |
+| --- | --- | --- |
+| `GET /register` | `index.js:26838` | `sendHtml("register.html")` |
+| `GET /home` | `index.js:26840` | `sendHtml("index.html")` |
+| `GET /register.html` | `index.js:26848` | `sendHtml("register.html")` |
+| `GET /index.html` | `index.js:26853` | `sendHtml("index.html")` |
+
+## Modules Created / Updated
+
+- Updated `server/routes/pages/index.js`
+- Added `server/routes/pages/admin.js`
+- Added `server/routes/pages/technician.js`
+- Added `server/routes/pages/public.js`
+
+## Routes Skipped And Why
+
+- `GET /customer`, `GET /track`: customer/public flow surfaces; keep out of this batch.
+- `GET /install-quote`, `GET /install-quote.html`: pricing-adjacent.
+- Partner page routes: keep outside this project slice.
+- Protected admin static pages and base-status pages: contain auth middleware / guard sensitivity.
+- `/`, `POST /login`: explicit auth-entry surfaces.
+- `GET /promotions`, booking, availability, customer tracking APIs, technician income, payouts, close-job, evidence, accounting/tax/VAT: hard-frozen business systems.
+
+## Risk
+
+- Overall risk: Medium.
+- Reason: admin and technician page aliases are user-visible entry points, even though handlers are static-only.
+- Protections:
+  - exact route paths preserved
+  - exact `sendHtml(...)` targets preserved
+  - existing `app.use(createPageRoutes({ sendHtml }))` mount preserved
+  - no middleware order changes
+  - no frontend, DB, migration, or package changes
+
+## Tests Run
+
+```bash
+node --check index.js
+node --check server/routes/pages/index.js
+node --check server/routes/pages/admin.js
+node --check server/routes/pages/technician.js
+node --check server/routes/pages/public.js
+node --check server/routes/serviceZones/index.js
+node --check server/routes/catalog/items.js
+node --check server/routes/system/index.js
+node --check server/routes/users/technicians.js
+node --check server/db/pool.js
+```
+
+## Manual Smoke Checklist
+
+- App starts.
+- `/login` and `/login.html` still work.
+- `POST /login` still works.
+- `/` still works.
+- `/tech` and `/tech.html` still work.
+- All moved page routes still return exactly as before.
+- Admin pages that were moved still open.
+- Admin guard behavior still works.
+- `/service_zones` still works.
+- `POST /service_zones/detect` still works.
+- Technician job page still loads.
+- Technician history page still loads.
+- Technician income page still loads.
+- Customer/public pages that were not moved still work.
+- No regression in booking, pricing, income, or close-job flows.
+
+## Rollback Plan
+
+1. Restore the 16 original inline handlers in `index.js`.
+2. Remove `server/routes/pages/admin.js`, `server/routes/pages/technician.js`, and `server/routes/pages/public.js`.
+3. Revert `server/routes/pages/index.js` to the prior single-file router.
+4. Run the syntax checks above.
+5. Smoke test all moved routes plus login, technician, service zone, and admin page entry points.

--- a/index.js
+++ b/index.js
@@ -26819,13 +26819,7 @@ app.use(express.static(ROOT_DIR));
 // - ตัวอย่าง: /tech, /admin, /track, /customer
 app.use(createPageRoutes({ sendHtml }));
 // Admin landing: ใช้ V2 เป็นหลัก (หน้าเก่าเลิกใช้แล้ว)
-app.get("/admin-add", (req, res) => res.sendFile(sendHtml("admin-add-v2.html")));
-app.get("/admin-review", (req, res) => res.sendFile(sendHtml("admin-review-v2.html")));
-app.get("/admin-queue", (req, res) => res.sendFile(sendHtml("admin-queue-v2.html")));
-app.get("/admin-history", (req, res) => res.sendFile(sendHtml("admin-history-v2.html")));
 // หน้า legacy เลิกใช้แล้ว ให้ redirect ไป V2
-app.get("/edit-profile", (req, res) => res.sendFile(sendHtml("edit-profile.html")));
-app.get("/tech", (req, res) => res.sendFile(sendHtml("tech.html")));
 app.get("/customer", (req, res) => res.sendFile(sendHtml("customer.html")));
 app.get("/partner-apply", (req, res) => res.sendFile(sendHtml("partner-apply.html")));
 app.get("/partner-status", (req, res) => res.sendFile(sendHtml("partner-status.html")));
@@ -26835,22 +26829,12 @@ app.get("/partner-academy", (req, res) => res.sendFile(sendHtml("partner-academy
 app.get("/install-quote", (req, res) => res.sendFile(sendHtml("install-quote.html")));
 // Canonical path: keep short URL, redirect direct-file access
 app.get("/install-quote.html", (req, res) => res.redirect(302, "/install-quote"));
-app.get("/register", (req, res) => res.sendFile(sendHtml("register.html")));
 app.get("/track", (req, res) => res.sendFile(sendHtml("track.html")));
-app.get("/home", (req, res) => res.sendFile(sendHtml("index.html")));
 
-app.get("/admin-add-v2.html", (req, res) => res.sendFile(sendHtml("admin-add-v2.html")));
-app.get("/admin-review-v2.html", (req, res) => res.sendFile(sendHtml("admin-review-v2.html")));
-app.get("/admin-queue-v2.html", (req, res) => res.sendFile(sendHtml("admin-queue-v2.html")));
-app.get("/admin-history-v2.html", (req, res) => res.sendFile(sendHtml("admin-history-v2.html")));
-app.get("/edit-profile.html", (req, res) => res.sendFile(sendHtml("edit-profile.html")));
-app.get("/tech.html", (req, res) => res.sendFile(sendHtml("tech.html")));
-app.get("/register.html", (req, res) => res.sendFile(sendHtml("register.html")));
 app.get("/partner-apply.html", (req, res) => res.sendFile(sendHtml("partner-apply.html")));
 app.get("/partner-status.html", (req, res) => res.sendFile(sendHtml("partner-status.html")));
 app.get("/partner-agreement.html", (req, res) => res.sendFile(sendHtml("partner-agreement.html")));
 app.get("/partner-academy.html", (req, res) => res.sendFile(sendHtml("partner-academy.html")));
-app.get("/index.html", (req, res) => res.sendFile(sendHtml("index.html")));
 app.get("/", (req, res) => res.sendFile(sendHtml("login.html")));
 
 // =======================================

--- a/server/routes/pages/admin.js
+++ b/server/routes/pages/admin.js
@@ -1,0 +1,24 @@
+module.exports = function createAdminPageRoutes(deps = {}) {
+  const express = require("express");
+  const router = express.Router();
+  const sendHtml = deps.sendHtml;
+
+  router.get("/admin-legacy", (req, res) => res.redirect(302, "/admin-review-v2.html"));
+  router.get("/admin-legacy.html", (req, res) => res.redirect(302, "/admin-review-v2.html"));
+  router.get("/admin", (req, res) => res.redirect(302, "/admin-review-v2.html"));
+  router.get("/admin.html", (req, res) => res.redirect(302, "/admin-review-v2.html"));
+  router.get("/admin-tech", (req, res) => res.redirect(302, "/admin-review-v2.html"));
+  router.get("/admin-tech.html", (req, res) => res.redirect(302, "/admin-review-v2.html"));
+  router.get("/add-job", (req, res) => res.redirect(302, "/admin-add-v2.html"));
+  router.get("/add-job.html", (req, res) => res.redirect(302, "/admin-add-v2.html"));
+  router.get("/admin-add", (req, res) => res.sendFile(sendHtml("admin-add-v2.html")));
+  router.get("/admin-review", (req, res) => res.sendFile(sendHtml("admin-review-v2.html")));
+  router.get("/admin-queue", (req, res) => res.sendFile(sendHtml("admin-queue-v2.html")));
+  router.get("/admin-history", (req, res) => res.sendFile(sendHtml("admin-history-v2.html")));
+  router.get("/admin-add-v2.html", (req, res) => res.sendFile(sendHtml("admin-add-v2.html")));
+  router.get("/admin-review-v2.html", (req, res) => res.sendFile(sendHtml("admin-review-v2.html")));
+  router.get("/admin-queue-v2.html", (req, res) => res.sendFile(sendHtml("admin-queue-v2.html")));
+  router.get("/admin-history-v2.html", (req, res) => res.sendFile(sendHtml("admin-history-v2.html")));
+
+  return router;
+};

--- a/server/routes/pages/index.js
+++ b/server/routes/pages/index.js
@@ -1,18 +1,17 @@
 module.exports = function createPageRoutes(deps = {}) {
   const express = require("express");
   const router = express.Router();
+  const createAdminPageRoutes = require("./admin");
+  const createTechnicianPageRoutes = require("./technician");
+  const createPublicPageRoutes = require("./public");
   const sendHtml = deps.sendHtml;
 
   router.get("/login", (req, res) => res.sendFile(sendHtml("login.html")));
   router.get("/login.html", (req, res) => res.sendFile(sendHtml("login.html")));
-  router.get("/admin-legacy", (req, res) => res.redirect(302, "/admin-review-v2.html"));
-  router.get("/admin-legacy.html", (req, res) => res.redirect(302, "/admin-review-v2.html"));
-  router.get("/admin", (req, res) => res.redirect(302, "/admin-review-v2.html"));
-  router.get("/admin.html", (req, res) => res.redirect(302, "/admin-review-v2.html"));
-  router.get("/admin-tech", (req, res) => res.redirect(302, "/admin-review-v2.html"));
-  router.get("/admin-tech.html", (req, res) => res.redirect(302, "/admin-review-v2.html"));
-  router.get("/add-job", (req, res) => res.redirect(302, "/admin-add-v2.html"));
-  router.get("/add-job.html", (req, res) => res.redirect(302, "/admin-add-v2.html"));
+
+  router.use(createAdminPageRoutes({ sendHtml }));
+  router.use(createTechnicianPageRoutes({ sendHtml }));
+  router.use(createPublicPageRoutes({ sendHtml }));
 
   return router;
 };

--- a/server/routes/pages/public.js
+++ b/server/routes/pages/public.js
@@ -1,0 +1,12 @@
+module.exports = function createPublicPageRoutes(deps = {}) {
+  const express = require("express");
+  const router = express.Router();
+  const sendHtml = deps.sendHtml;
+
+  router.get("/register", (req, res) => res.sendFile(sendHtml("register.html")));
+  router.get("/home", (req, res) => res.sendFile(sendHtml("index.html")));
+  router.get("/register.html", (req, res) => res.sendFile(sendHtml("register.html")));
+  router.get("/index.html", (req, res) => res.sendFile(sendHtml("index.html")));
+
+  return router;
+};

--- a/server/routes/pages/technician.js
+++ b/server/routes/pages/technician.js
@@ -1,0 +1,12 @@
+module.exports = function createTechnicianPageRoutes(deps = {}) {
+  const express = require("express");
+  const router = express.Router();
+  const sendHtml = deps.sendHtml;
+
+  router.get("/edit-profile", (req, res) => res.sendFile(sendHtml("edit-profile.html")));
+  router.get("/tech", (req, res) => res.sendFile(sendHtml("tech.html")));
+  router.get("/edit-profile.html", (req, res) => res.sendFile(sendHtml("edit-profile.html")));
+  router.get("/tech.html", (req, res) => res.sendFile(sendHtml("tech.html")));
+
+  return router;
+};


### PR DESCRIPTION
## Summary

- Supersede the smaller PR #16 with one larger current-main page-layer batch
- Move 16 safe static page routes out of `index.js`
- Split page routing into domain modules:
  - `server/routes/pages/admin.js`
  - `server/routes/pages/technician.js`
  - `server/routes/pages/public.js`
- Keep `index.js` as route wiring via `app.use(createPageRoutes({ sendHtml }))`

## Routes moved

### Admin static aliases
- `GET /admin-add`
- `GET /admin-review`
- `GET /admin-queue`
- `GET /admin-history`
- `GET /admin-add-v2.html`
- `GET /admin-review-v2.html`
- `GET /admin-queue-v2.html`
- `GET /admin-history-v2.html`

### Technician static aliases
- `GET /edit-profile`
- `GET /tech`
- `GET /edit-profile.html`
- `GET /tech.html`

### Public neutral aliases
- `GET /register`
- `GET /home`
- `GET /register.html`
- `GET /index.html`

## Safety

- Static `GET` routes only; all keep exact `res.sendFile(sendHtml(...))` behavior
- No DB, writes, request body, shared cache, or business logic moved
- No change to `sendHtml()`, guard order, static middleware order, or page targets
- Did not touch pricing/promotion, booking/availability, customer tracking APIs, auth/session core, LINE login, technician income, payout, close-job, evidence upload, accounting/tax/VAT, package.json, migrations, or frontend files

## Before / after

- `index.js` before: 24,959 lines
- `index.js` after: 24,943 lines
- Net reduction: 16 route lines

## Verification

- Read `CWF_Technician_App_Master_Spec.md` first
- `node --check index.js`
- `node --check server/routes/pages/index.js`
- `node --check server/routes/pages/admin.js`
- `node --check server/routes/pages/technician.js`
- `node --check server/routes/pages/public.js`
- `node --check server/routes/serviceZones/index.js`
- `node --check server/routes/catalog/items.js`
- `node --check server/routes/system/index.js`
- `node --check server/routes/users/technicians.js`
- `node --check server/db/pool.js`
- No `npm test` or `npm run build` script exists in `package.json`

## Manual smoke checklist

- App starts
- `/login`, `/login.html`, and `POST /login` still work
- `/`, `/tech`, and `/tech.html` still work
- All moved page routes still return exactly as before
- Relevant admin pages still open
- Admin guard behavior still works
- `/service_zones` still works
- `POST /service_zones/detect` still works
- Technician job page still loads
- Technician history page still loads
- Technician income page still loads
- Customer/public pages that were not moved still work
- No regression in booking, pricing, income, or close-job flows

## Rollback

1. Restore the 16 original inline handlers in `index.js`
2. Remove `server/routes/pages/admin.js`, `server/routes/pages/technician.js`, and `server/routes/pages/public.js`
3. Revert `server/routes/pages/index.js` to the prior single-file router
4. Re-run syntax checks and smoke tests