### PR TITLE
refactor: prep admin rework deductions extraction

### DIFF
--- a/docs/INDEX_JS_SPLIT_PLAN.md
+++ b/docs/INDEX_JS_SPLIT_PLAN.md
@@ -213,6 +213,23 @@ Phase 1B status:
 - Skipped active sendFile/static pages, customer/track/register/quote pages, partner pages, `/`, `/tech`, `/tech.html`, `POST /login`, and all API/business routes.
 - Rollback: remove only the six Phase 2N handlers from `server/routes/pages/index.js`, restore the six original inline redirect handlers in `index.js`, then run syntax checks.
 
+### Phase 3B: Prep Admin Rework / Deductions Extraction
+
+- The mixed deductions/rework block has been split conservatively instead of moving mutations.
+- Extracted:
+  - shared schema-aware helper factory: `server/helpers/adminReworkDeductionsHelpers.js`
+  - read-only deductions routes: `server/routes/adminDeductionsReadOnly.js`
+    - `GET /admin/deductions`
+    - `GET /admin/deductions/summary`
+    - `GET /admin/deductions/audit`
+  - read-only rework routes: `server/routes/adminReworkReadOnly.js`
+    - `GET /admin/rework_cases`
+    - `GET /admin/rework_cases/:id`
+- Write routes, approval/reject/void transitions, rework creation, and rework resolution remain inline in `index.js`.
+- Estimated `index.js` reduction for this prep pass: about 288 net lines.
+- Remaining deductions lookup/detail routes stay inline for a later pass after this seam is verified in production.
+- Rollback: restore the original helper block plus five extracted GET handlers in `index.js`, remove the new helper/router modules, then run syntax checks and smoke tests.
+
 ### Phase 2: Read-Only Technician Routes
 
 - Move read-only technician routes with no DB writes.

--- a/docs/PHASE3B_PREP_ADMIN_REWORK_DEDUCTIONS_EXTRACTION.md
+++ b/docs/PHASE3B_PREP_ADMIN_REWORK_DEDUCTIONS_EXTRACTION.md
@@ -1,0 +1,122 @@
+# Phase 3B Prep Admin Rework Deductions Extraction
+
+Date: 2026-05-16
+
+## Scope
+
+Prepare the mixed admin deductions/rework area for future large extraction without moving business mutations.
+
+## Block Inventory
+
+| Category | Items |
+| --- | --- |
+| Read-only GET routes | `/admin/deductions`, `/admin/deductions/summary`, `/admin/deductions/audit`, `/admin/deductions/technician_search`, `/admin/deductions/job_search`, `/admin/deductions/warranty_jobs`, `/admin/deductions/suggestions`, `/admin/deductions/:id`, `/admin/rework_cases`, `/admin/rework_cases/:id` |
+| Write routes | `POST /admin/deductions`, `PATCH /admin/deductions/:id`, deduction submit/approve/reject/void POST routes, `POST /admin/jobs/:job_id/rework_case`, `POST /admin/rework_cases/:id/resolve` |
+| Pure helpers | `dHas`, `dCol`, `dTextCol`, `dSearchParts` |
+| DB query helpers | `getDeductionTableMeta`, deduction table metadata cache |
+| State transition helpers | `transitionDeductionCase` |
+| Must stay for now | all write routes, approval/release/finalize paths, rework creation/resolution, payout/payment mutations |
+
+## Selected Safe Subset
+
+Moved in this prep pass:
+
+- `server/helpers/adminReworkDeductionsHelpers.js`
+  - `getDeductionTableMeta`
+  - `dHas`
+  - `dCol`
+  - `dTextCol`
+  - `dSearchParts`
+- `server/routes/adminDeductionsReadOnly.js`
+  - `GET /admin/deductions`
+  - `GET /admin/deductions/summary`
+  - `GET /admin/deductions/audit`
+- `server/routes/adminReworkReadOnly.js`
+  - `GET /admin/rework_cases`
+  - `GET /admin/rework_cases/:id`
+
+These routes are read-only, preserve the same SQL and response shapes, and keep the same `requireAdminSession` middleware through dependency injection.
+
+## Skipped Risky Subset
+
+- All POST/PATCH mutation routes
+- `transitionDeductionCase`
+- deduction approval/reject/void flows
+- rework creation and resolve flows
+- technician income formula / payout / accounting / close-job flows
+
+The remaining deductions lookup/detail routes are intentionally left inline for now because they share a denser adjacent surface with route-specific search/detail logic. The new helper seam lets a later pass move them with less risk after this first extraction is validated.
+
+## Before / After
+
+- `index.js` before: 24,959 lines
+- `index.js` after: 24,671 lines
+- Net reduction: 288 lines
+- Moved route count: 5
+- Moved helper count: 5
+
+## Files Changed
+
+- `index.js`
+- `server/helpers/adminReworkDeductionsHelpers.js`
+- `server/routes/adminDeductionsReadOnly.js`
+- `server/routes/adminReworkReadOnly.js`
+- `docs/INDEX_JS_SPLIT_PLAN.md`
+- `docs/PHASE3B_PREP_ADMIN_REWORK_DEDUCTIONS_EXTRACTION.md`
+
+## Risk
+
+- Overall risk: Medium.
+- Why acceptable:
+  - moved routes are GET-only and read-only
+  - SQL, response shapes, status codes, logging, and auth middleware are preserved
+  - mutation routes remain untouched
+- Why not low:
+  - `GET /admin/rework_cases/:id` is a large schema-aware read path that fans out across multiple tables
+
+## Tests Run
+
+```bash
+node --check index.js
+node --check server/helpers/adminReworkDeductionsHelpers.js
+node --check server/routes/adminDeductionsReadOnly.js
+node --check server/routes/adminReworkReadOnly.js
+node --check server/routes/pages/index.js
+node --check server/routes/serviceZones/index.js
+node --check server/routes/catalog/items.js
+node --check server/routes/system/index.js
+node --check server/routes/users/technicians.js
+node --check server/db/pool.js
+```
+
+## Manual Smoke Checklist
+
+- App starts.
+- Admin rework/deductions read-only pages/API still return the same data.
+- `GET /admin/deductions` returns the same list shape.
+- `GET /admin/deductions/summary` returns the same summary shape.
+- `GET /admin/deductions/audit` returns the same audit shape.
+- `GET /admin/rework_cases` returns the same list shape.
+- `GET /admin/rework_cases/:id` returns the same detail shape.
+- No regression in deduction write actions.
+- No regression in rework state transitions.
+- Technician job page still loads.
+- Technician income page still loads.
+- Close-job flow is not touched.
+- Booking, pricing, and customer flow are not touched.
+
+## Rollback Plan
+
+1. Restore the original schema helper block in `index.js`.
+2. Restore the original inline handlers for:
+   - `GET /admin/deductions`
+   - `GET /admin/deductions/summary`
+   - `GET /admin/deductions/audit`
+   - `GET /admin/rework_cases`
+   - `GET /admin/rework_cases/:id`
+3. Remove:
+   - `server/helpers/adminReworkDeductionsHelpers.js`
+   - `server/routes/adminDeductionsReadOnly.js`
+   - `server/routes/adminReworkReadOnly.js`
+4. Remove the helper/router imports and route mount from `index.js`.
+5. Run the syntax checks above and smoke test read-only rework plus existing deduction/rework mutation flows.

--- a/index.js
+++ b/index.js
@@ -37,6 +37,9 @@ const createTechnicianDirectoryRoutes = require("./server/routes/users/technicia
 const createCatalogItemRoutes = require("./server/routes/catalog/items");
 const createServiceZoneRoutes = require("./server/routes/serviceZones");
 const createPageRoutes = require("./server/routes/pages");
+const createAdminReworkDeductionsHelpers = require("./server/helpers/adminReworkDeductionsHelpers");
+const createAdminReworkReadOnlyRoutes = require("./server/routes/adminReworkReadOnly");
+const createAdminDeductionsReadOnlyRoutes = require("./server/routes/adminDeductionsReadOnly");
 
 // =======================================
 // 🔔 Web Push Notifications (optional / fail-open)
@@ -15267,102 +15270,12 @@ app.get('/admin/job_v2', requireAdminSoft, (req, res) => {
   return res.redirect(302, `/admin/job_v2/${encodeURIComponent(id)}`);
 });
 
-app.get('/admin/deductions', requireAdminSession, async (req, res) => {
-  try {
-    const limit = Math.min(200, Math.max(1, Number(req.query.limit || 100)));
-    const { where, params } = deductionListFilters(req.query || {});
-    const sqlWhere = where.length ? `WHERE ${where.join(' AND ')}` : '';
-    const r = await pool.query(
-      `SELECT * FROM public.technician_deduction_cases ${sqlWhere}
-       ORDER BY created_at DESC, case_id DESC LIMIT ${limit}`,
-      params
-    );
-    return res.json({ ok: true, rows: r.rows, message: PAYOUT_DEDUCTION_WARNING });
-  } catch (e) {
-    console.error('GET /admin/deductions', e);
-    return res.status(500).json({ ok: false, error: 'โหลดเคสหักเงินไม่สำเร็จ' });
-  }
-});
-
-app.get('/admin/deductions/summary', requireAdminSession, async (_req, res) => {
-  try {
-    const q = await pool.query(`
-      WITH totals AS (
-        SELECT
-          COUNT(*) FILTER (WHERE status='pending_approval')::int AS pending_count,
-          COALESCE(SUM(amount) FILTER (WHERE status='pending_approval'),0)::numeric AS pending_amount,
-          COALESCE(SUM(amount) FILTER (WHERE status='approved'),0)::numeric AS approved_amount,
-          COUNT(*) FILTER (WHERE severity IN ('high','critical') AND status NOT IN ('rejected','voided'))::int AS high_critical_count
-        FROM public.technician_deduction_cases
-      ),
-      open_rework AS (
-        SELECT COUNT(*)::int AS open_rework_count
-        FROM public.technician_rework_cases
-        WHERE status IN ('open','in_progress')
-      ),
-      warranty_jobs AS (
-        SELECT COUNT(*)::int AS warranty_jobs_count
-        FROM public.jobs j
-        WHERE COALESCE(j.warranty_end_at, CASE WHEN j.finished_at IS NOT NULL THEN j.finished_at + INTERVAL '30 days' ELSE NULL END) IS NOT NULL
-          AND COALESCE(j.warranty_end_at, CASE WHEN j.finished_at IS NOT NULL THEN j.finished_at + INTERVAL '30 days' ELSE NULL END) >= NOW()
-          AND COALESCE(j.canceled_at, NULL) IS NULL
-          AND COALESCE(j.job_status,'') NOT ILIKE '%ยกเลิก%'
-          AND COALESCE(j.job_status,'') NOT ILIKE '%cancel%'
-      ),
-      failed_rework AS (
-        SELECT COUNT(*)::int AS unresolved_failed_rework_count
-        FROM public.technician_rework_cases
-        WHERE status <> 'voided'
-          AND (resolution='failed' OR revisit_result ILIKE '%fail%' OR revisit_result ILIKE '%ไม่สำเร็จ%')
-      ),
-      suggestions AS (
-        SELECT (
-          (SELECT COUNT(*) FROM public.jobs j
-             WHERE j.appointment_datetime IS NOT NULL
-               AND COALESCE(j.checkin_at, j.started_at) IS NOT NULL
-               AND COALESCE(j.checkin_at, j.started_at) > j.appointment_datetime + INTERVAL '15 minutes'
-               AND NOT EXISTS (
-                 SELECT 1 FROM public.technician_deduction_cases dc
-                  WHERE dc.job_id=j.job_id
-                    AND dc.technician_username=COALESCE(NULLIF(j.technician_username,''), j.technician_username)
-                    AND dc.deduction_type='late_arrival'
-                    AND dc.status NOT IN ('rejected','voided')
-               )
-          ) +
-          (SELECT COUNT(*) FROM public.technician_rework_cases rc
-             WHERE rc.status <> 'voided'
-               AND NOT EXISTS (
-                 SELECT 1 FROM public.technician_deduction_cases dc
-                  WHERE dc.job_id=rc.job_id
-                    AND dc.technician_username=rc.technician_username
-                    AND dc.deduction_type IN ('warranty_rework_minor','warranty_rework_major','rework_failed')
-                    AND dc.status NOT IN ('rejected','voided')
-               )
-          )
-        )::int AS suggestions_count
-      )
-      SELECT * FROM totals, open_rework, warranty_jobs, failed_rework, suggestions
-    `);
-    const top = await pool.query(`
-      SELECT technician_username, COUNT(*)::int AS case_count, COALESCE(SUM(amount),0)::numeric AS amount
-        FROM public.technician_deduction_cases
-       WHERE status NOT IN ('rejected','voided')
-       GROUP BY technician_username
-       ORDER BY case_count DESC, amount DESC
-       LIMIT 5
-    `);
-    const recent = await pool.query(`
-      SELECT case_id, case_code, technician_username, job_id, deduction_type, amount, status, severity, created_at
-        FROM public.technician_deduction_cases
-       ORDER BY created_at DESC, case_id DESC
-       LIMIT 8
-    `);
-    return res.json({ ok: true, ...(q.rows[0] || {}), top_technicians_by_cases: top.rows, recent_cases: recent.rows, message: PAYOUT_DEDUCTION_WARNING });
-  } catch (e) {
-    console.error('GET /admin/deductions/summary', e);
-    return res.status(500).json({ ok: false, error: 'โหลดสรุปเคสไม่สำเร็จ' });
-  }
-});
+app.use(createAdminDeductionsReadOnlyRoutes({
+  pool,
+  requireAdminSession,
+  deductionListFilters,
+  PAYOUT_DEDUCTION_WARNING,
+}));
 
 app.post('/admin/deductions', requireAdminSession, async (req, res) => {
   const b = req.body || {};
@@ -15406,60 +15319,16 @@ app.post('/admin/deductions', requireAdminSession, async (req, res) => {
   }
 });
 
-app.get('/admin/deductions/audit', requireAdminSession, async (req, res) => {
-  try {
-    const limit = Math.min(200, Math.max(1, Number(req.query.limit || 100)));
-    const where = [];
-    const params = [];
-    let p = 1;
-    const add = (sql, val) => { params.push(val); where.push(sql.replace('?', `$${p++}`)); };
-    if (req.query.entity_type) add('entity_type=?', String(req.query.entity_type).trim());
-    if (req.query.entity_id) add('entity_id=?', String(req.query.entity_id).trim());
-    if (req.query.actor_username) add('actor_username=?', String(req.query.actor_username).trim());
-    if (req.query.from) add('created_at >= ?::timestamptz', `${String(req.query.from).slice(0,10)} 00:00:00+07:00`);
-    if (req.query.to) add('created_at <= ?::timestamptz', `${String(req.query.to).slice(0,10)} 23:59:59+07:00`);
-    const sqlWhere = where.length ? `WHERE ${where.join(' AND ')}` : '';
-    const r = await pool.query(`SELECT * FROM public.technician_deduction_audit_logs ${sqlWhere} ORDER BY created_at DESC, audit_id DESC LIMIT ${limit}`, params);
-    return res.json({ ok: true, rows: r.rows });
-  } catch (e) {
-    console.error('GET /admin/deductions/audit', e);
-    return res.status(500).json({ ok: false, error: 'โหลด audit ไม่สำเร็จ' });
-  }
-});
-
-
-
 // Schema-aware helpers for deduction/rework usability routes.
 // These keep the Admin "หักเงินและงานแก้ไข" page usable even when older production DBs
 // have slightly different optional columns.
-const __deductionTableMetaCache = new Map();
-async function getDeductionTableMeta(tableName) {
-  const safe = String(tableName || '').trim();
-  if (!/^[a-zA-Z0-9_]+$/.test(safe)) return { exists: false, cols: new Set() };
-  const cached = __deductionTableMetaCache.get(safe);
-  if (cached && Date.now() - cached.ts < 5 * 60 * 1000) return cached.value;
-  try {
-    const [existsR, colsR] = await Promise.all([
-      pool.query(`SELECT to_regclass($1) AS reg`, [`public.${safe}`]),
-      pool.query(`SELECT column_name FROM information_schema.columns WHERE table_schema='public' AND table_name=$1`, [safe]),
-    ]);
-    const value = {
-      exists: !!(existsR.rows && existsR.rows[0] && existsR.rows[0].reg),
-      cols: new Set((colsR.rows || []).map(r => String(r.column_name))),
-    };
-    __deductionTableMetaCache.set(safe, { ts: Date.now(), value });
-    return value;
-  } catch (e) {
-    console.error('getDeductionTableMeta failed', safe, e);
-    return { exists: false, cols: new Set() };
-  }
-}
-function dHas(meta, col) { return !!(meta && meta.cols && meta.cols.has(col)); }
-function dCol(alias, meta, col, fallbackSql) { return dHas(meta, col) ? `${alias}.${col}` : fallbackSql; }
-function dTextCol(alias, meta, col, fallbackSql="''::text") { return dHas(meta, col) ? `COALESCE(${alias}.${col}::text,'')` : fallbackSql; }
-function dSearchParts(alias, meta, cols, paramRef) {
-  return cols.filter(c => dHas(meta, c)).map(c => `COALESCE(${alias}.${c}::text,'') ILIKE ${paramRef}`);
-}
+const {
+  getDeductionTableMeta,
+  dHas,
+  dCol,
+  dTextCol,
+  dSearchParts,
+} = createAdminReworkDeductionsHelpers({ pool });
 
 app.get('/admin/deductions/technician_search', requireAdminSession, async (req, res) => {
   try {
@@ -16013,182 +15882,13 @@ app.post('/admin/jobs/:job_id/rework_case', requireAdminSession, async (req, res
   }
 });
 
-app.get('/admin/rework_cases', requireAdminSession, async (req, res) => {
-  try {
-    const limit = Math.min(200, Math.max(1, Number(req.query.limit || 100)));
-    const where = [];
-    const params = [];
-    let p = 1;
-    const add = (sql, val) => { params.push(val); where.push(sql.replace('?', `$${p++}`)); };
-    if (req.query.status) add('status=?', String(req.query.status).trim());
-    if (req.query.technician_username) add('technician_username=?', String(req.query.technician_username).trim());
-    if (req.query.job_id) add('job_id=?', Number(req.query.job_id));
-    if (req.query.reason_type) add('reason_type=?', String(req.query.reason_type).trim());
-    if (req.query.from) add('created_at >= ?::timestamptz', `${String(req.query.from).slice(0,10)} 00:00:00+07:00`);
-    if (req.query.to) add('created_at <= ?::timestamptz', `${String(req.query.to).slice(0,10)} 23:59:59+07:00`);
-    const sqlWhere = where.length ? `WHERE ${where.join(' AND ')}` : '';
-    const r = await pool.query(`SELECT * FROM public.technician_rework_cases ${sqlWhere} ORDER BY created_at DESC, rework_case_id DESC LIMIT ${limit}`, params);
-    return res.json({ ok: true, rows: r.rows });
-  } catch (e) {
-    console.error('GET /admin/rework_cases', e);
-    return res.status(500).json({ ok: false, error: 'โหลดเคสงานแก้ไขไม่สำเร็จ' });
-  }
-});
-
-app.get('/admin/rework_cases/:id', requireAdminSession, async (req, res) => {
-  const id = Number(req.params.id);
-  if (!Number.isFinite(id) || id <= 0) return res.status(400).json({ ok: false, error: 'rework_case_id ไม่ถูกต้อง' });
-  try {
-    const rr = await pool.query(`SELECT * FROM public.technician_rework_cases WHERE rework_case_id=$1`, [id]);
-    if (!rr.rows.length) return res.status(404).json({ ok: false, error: 'ไม่พบเคสงานแก้ไข' });
-    const row = rr.rows[0];
-
-    const jobsMeta = await getDeductionTableMeta('jobs');
-    const jobSelect = [
-      'j.job_id',
-      dHas(jobsMeta, 'booking_code') ? 'j.booking_code' : 'j.job_id::text AS booking_code',
-      dHas(jobsMeta, 'customer_name') ? 'j.customer_name' : "NULL::text AS customer_name",
-      dHas(jobsMeta, 'customer_phone') ? 'j.customer_phone' : "NULL::text AS customer_phone",
-      dHas(jobsMeta, 'job_type') ? 'j.job_type' : "NULL::text AS job_type",
-      dHas(jobsMeta, 'job_status') ? 'j.job_status' : "NULL::text AS job_status",
-      dHas(jobsMeta, 'appointment_datetime') ? 'j.appointment_datetime' : "NULL::timestamptz AS appointment_datetime",
-      dHas(jobsMeta, 'technician_username') ? 'j.technician_username' : "NULL::text AS technician_username",
-      dHas(jobsMeta, 'warranty_end_at') ? 'j.warranty_end_at' : "NULL::timestamptz AS warranty_end_at",
-      dHas(jobsMeta, 'return_reason') ? 'j.return_reason' : "NULL::text AS return_reason",
-      dHas(jobsMeta, 'returned_at') ? 'j.returned_at' : "NULL::timestamptz AS returned_at",
-      dHas(jobsMeta, 'travel_started_at') ? 'j.travel_started_at' : "NULL::timestamptz AS travel_started_at",
-      dHas(jobsMeta, 'checkin_at') ? 'j.checkin_at' : "NULL::timestamptz AS checkin_at",
-      dHas(jobsMeta, 'started_at') ? 'j.started_at' : "NULL::timestamptz AS started_at",
-      dHas(jobsMeta, 'finished_at') ? 'j.finished_at' : "NULL::timestamptz AS finished_at",
-      dHas(jobsMeta, 'revisit_result') ? 'j.revisit_result' : "NULL::text AS revisit_result",
-      dHas(jobsMeta, 'revisit_note') ? 'j.revisit_note' : "NULL::text AS revisit_note",
-      dHas(jobsMeta, 'evidence_json') ? 'j.evidence_json' : "NULL::jsonb AS evidence_json",
-      dHas(jobsMeta, 'before_photos') ? 'j.before_photos' : "NULL::jsonb AS before_photos",
-      dHas(jobsMeta, 'after_photos') ? 'j.after_photos' : "NULL::jsonb AS after_photos",
-      dHas(jobsMeta, 'revisit_evidence_json') ? 'j.revisit_evidence_json' : "NULL::jsonb AS revisit_evidence_json"
-    ];
-    const jr = await pool.query(`SELECT ${jobSelect.join(', ')} FROM public.jobs j WHERE j.job_id=$1`, [row.job_id]);
-    const job = jr.rows[0] || null;
-
-    let technician = null;
-    try {
-      const usersMeta = await getDeductionTableMeta('users');
-      const profMeta = await getDeductionTableMeta('technician_profiles');
-      const techUsername = row.technician_username || job?.technician_username || '';
-      if (techUsername && (usersMeta.exists || profMeta.exists)) {
-        const displayName = `COALESCE(NULLIF(${dTextCol('p', profMeta, 'full_name')},''), NULLIF(${dTextCol('p', profMeta, 'name')},''), NULLIF(${dTextCol('u', usersMeta, 'full_name')},''), NULLIF(${dTextCol('u', usersMeta, 'name')},''), $1)`;
-        const phone = `COALESCE(NULLIF(${dTextCol('p', profMeta, 'phone')},''), NULLIF(${dTextCol('u', usersMeta, 'phone')},''), '')`;
-        let techSql;
-        if (usersMeta.exists && profMeta.exists && dHas(usersMeta, 'username') && dHas(profMeta, 'username')) {
-          techSql = `SELECT $1::text AS technician_username, ${displayName} AS display_name, ${phone} AS phone FROM public.users u FULL OUTER JOIN public.technician_profiles p ON p.username=u.username WHERE COALESCE(p.username,u.username)=$1 LIMIT 1`;
-        } else if (profMeta.exists && dHas(profMeta, 'username')) {
-          techSql = `SELECT p.username AS technician_username, ${displayName} AS display_name, ${phone} AS phone FROM public.technician_profiles p LEFT JOIN public.users u ON false WHERE p.username=$1 LIMIT 1`;
-        } else if (usersMeta.exists && dHas(usersMeta, 'username')) {
-          techSql = `SELECT u.username AS technician_username, ${displayName} AS display_name, ${phone} AS phone FROM public.users u LEFT JOIN public.technician_profiles p ON false WHERE u.username=$1 LIMIT 1`;
-        }
-        if (techSql) {
-          const tr = await pool.query(techSql, [techUsername]);
-          technician = tr.rows[0] || { technician_username: techUsername };
-        }
-      }
-    } catch (e) {
-      try { console.warn('[rework detail] technician lookup skipped:', e.message); } catch {}
-    }
-
-    let deduction = null;
-    if (row.linked_deduction_case_id) {
-      const dr = await pool.query(`SELECT * FROM public.technician_deduction_cases WHERE case_id=$1`, [row.linked_deduction_case_id]);
-      deduction = dr.rows[0] || null;
-    }
-    const audit = await pool.query(
-      `SELECT * FROM public.technician_deduction_audit_logs
-       WHERE (entity_type='rework_case' AND entity_id=$1)
-          OR (entity_type='deduction_case' AND entity_id=$2)
-       ORDER BY created_at DESC, audit_id DESC`,
-      [String(id), row.linked_deduction_case_id ? String(row.linked_deduction_case_id) : '__none__']
-    );
-
-    let job_updates = [];
-    try {
-      const updatesMeta = await getDeductionTableMeta('job_updates_v2');
-      if (updatesMeta.exists && dHas(updatesMeta, 'job_id')) {
-        const updateIdExpr = dHas(updatesMeta, 'update_id') ? 'update_id' : 'NULL::bigint AS update_id';
-        const actorExpr = dHas(updatesMeta, 'actor_username') ? 'actor_username' : "NULL::text AS actor_username";
-        const roleExpr = dHas(updatesMeta, 'actor_role') ? 'actor_role' : "NULL::text AS actor_role";
-        const actionExpr = dHas(updatesMeta, 'action') ? 'action' : "NULL::text AS action";
-        const msgExpr = dHas(updatesMeta, 'message') ? 'message' : "NULL::text AS message";
-        const payloadExpr = dHas(updatesMeta, 'payload_json') ? 'payload_json' : "NULL::jsonb AS payload_json";
-        const createdExpr = dHas(updatesMeta, 'created_at') ? 'created_at' : 'NOW() AS created_at';
-        const ur = await pool.query(
-          `SELECT ${updateIdExpr}, ${actorExpr}, ${roleExpr}, ${actionExpr}, ${msgExpr}, ${payloadExpr}, ${createdExpr}
-             FROM public.job_updates_v2
-            WHERE job_id=$1
-              AND (
-                COALESCE(action::text,'') ILIKE '%rework%'
-                OR COALESCE(action::text,'') ILIKE '%revisit%'
-                OR COALESCE(action::text,'') ILIKE '%return%'
-                OR COALESCE(message::text,'') ILIKE '%แก้%'
-                OR COALESCE(message::text,'') ILIKE '%ประกัน%'
-              )
-            ORDER BY created_at DESC
-            LIMIT 50`,
-          [row.job_id]
-        );
-        job_updates = ur.rows || [];
-      }
-    } catch (e) {
-      try { console.warn('[rework detail] job update lookup skipped:', e.message); } catch {}
-    }
-
-    let job_photos = [];
-    try {
-      const photosMeta = await getDeductionTableMeta('job_photos');
-      if (photosMeta.exists && dHas(photosMeta, 'job_id')) {
-        const photoSelect = [
-          dHas(photosMeta, 'photo_id') ? 'photo_id' : 'NULL::bigint AS photo_id',
-          dHas(photosMeta, 'photo_url') ? 'photo_url' : (dHas(photosMeta, 'url') ? 'url AS photo_url' : (dHas(photosMeta, 'secure_url') ? 'secure_url AS photo_url' : "NULL::text AS photo_url")),
-          dHas(photosMeta, 'type') ? 'type' : (dHas(photosMeta, 'photo_type') ? 'photo_type AS type' : "NULL::text AS type"),
-          dHas(photosMeta, 'created_at') ? 'created_at' : 'NOW() AS created_at'
-        ];
-        const pr = await pool.query(`SELECT ${photoSelect.join(', ')} FROM public.job_photos WHERE job_id=$1 ORDER BY created_at DESC LIMIT 80`, [row.job_id]);
-        job_photos = pr.rows || [];
-      }
-    } catch (e) {
-      try { console.warn('[rework detail] job photo lookup skipped:', e.message); } catch {}
-    }
-
-    const evidence_sources = {
-      rework_evidence_json: row.evidence_json || [],
-      job_evidence_json: job?.evidence_json || null,
-      before_photos: job?.before_photos || null,
-      after_photos: job?.after_photos || null,
-      revisit_evidence_json: job?.revisit_evidence_json || null,
-      job_photos
-    };
-    const verification = {
-      revisit_result: row.revisit_result || job?.revisit_result || null,
-      revisit_note: row.revisit_note || job?.revisit_note || null,
-      timeline: {
-        returned_at: job?.returned_at || null,
-        travel_started_at: job?.travel_started_at || null,
-        checkin_at: job?.checkin_at || null,
-        started_at: job?.started_at || null,
-        finished_at: job?.finished_at || null,
-        resolved_at: row.resolved_at || null
-      },
-      has_evidence: !!(
-        (Array.isArray(row.evidence_json) && row.evidence_json.length) ||
-        job?.evidence_json || job?.before_photos || job?.after_photos || job?.revisit_evidence_json ||
-        (Array.isArray(job_photos) && job_photos.length)
-      )
-    };
-
-    return res.json({ ok: true, row, job, technician, linked_deduction_case: deduction, audit_logs: audit.rows, job_updates, job_photos, evidence_sources, verification });
-  } catch (e) {
-    console.error('GET /admin/rework_cases/:id', e);
-    return res.status(500).json({ ok: false, error: 'โหลดรายละเอียดเคสงานแก้ไขไม่สำเร็จ', detail: process.env.NODE_ENV === 'production' ? undefined : e.message });
-  }
-});
+app.use(createAdminReworkReadOnlyRoutes({
+  pool,
+  requireAdminSession,
+  getDeductionTableMeta,
+  dHas,
+  dTextCol,
+}));
 
 app.post('/admin/rework_cases/:id/resolve', requireAdminSession, async (req, res) => {
   const id = Number(req.params.id);

--- a/server/helpers/adminReworkDeductionsHelpers.js
+++ b/server/helpers/adminReworkDeductionsHelpers.js
@@ -1,0 +1,41 @@
+module.exports = function createAdminReworkDeductionsHelpers(deps = {}) {
+  const pool = deps.pool;
+  const deductionTableMetaCache = new Map();
+
+  async function getDeductionTableMeta(tableName) {
+    const safe = String(tableName || '').trim();
+    if (!/^[a-zA-Z0-9_]+$/.test(safe)) return { exists: false, cols: new Set() };
+    const cached = deductionTableMetaCache.get(safe);
+    if (cached && Date.now() - cached.ts < 5 * 60 * 1000) return cached.value;
+    try {
+      const [existsR, colsR] = await Promise.all([
+        pool.query(`SELECT to_regclass($1) AS reg`, [`public.${safe}`]),
+        pool.query(`SELECT column_name FROM information_schema.columns WHERE table_schema='public' AND table_name=$1`, [safe]),
+      ]);
+      const value = {
+        exists: !!(existsR.rows && existsR.rows[0] && existsR.rows[0].reg),
+        cols: new Set((colsR.rows || []).map(r => String(r.column_name))),
+      };
+      deductionTableMetaCache.set(safe, { ts: Date.now(), value });
+      return value;
+    } catch (e) {
+      console.error('getDeductionTableMeta failed', safe, e);
+      return { exists: false, cols: new Set() };
+    }
+  }
+
+  function dHas(meta, col) { return !!(meta && meta.cols && meta.cols.has(col)); }
+  function dCol(alias, meta, col, fallbackSql) { return dHas(meta, col) ? `${alias}.${col}` : fallbackSql; }
+  function dTextCol(alias, meta, col, fallbackSql="''::text") { return dHas(meta, col) ? `COALESCE(${alias}.${col}::text,'')` : fallbackSql; }
+  function dSearchParts(alias, meta, cols, paramRef) {
+    return cols.filter(c => dHas(meta, c)).map(c => `COALESCE(${alias}.${c}::text,'') ILIKE ${paramRef}`);
+  }
+
+  return {
+    getDeductionTableMeta,
+    dHas,
+    dCol,
+    dTextCol,
+    dSearchParts,
+  };
+};

--- a/server/routes/adminDeductionsReadOnly.js
+++ b/server/routes/adminDeductionsReadOnly.js
@@ -1,0 +1,130 @@
+module.exports = function createAdminDeductionsReadOnlyRoutes(deps = {}) {
+  const express = require("express");
+  const router = express.Router();
+  const {
+    pool,
+    requireAdminSession,
+    deductionListFilters,
+    PAYOUT_DEDUCTION_WARNING,
+  } = deps;
+
+  router.get('/admin/deductions', requireAdminSession, async (req, res) => {
+    try {
+      const limit = Math.min(200, Math.max(1, Number(req.query.limit || 100)));
+      const { where, params } = deductionListFilters(req.query || {});
+      const sqlWhere = where.length ? `WHERE ${where.join(' AND ')}` : '';
+      const r = await pool.query(
+        `SELECT * FROM public.technician_deduction_cases ${sqlWhere}
+         ORDER BY created_at DESC, case_id DESC LIMIT ${limit}`,
+        params
+      );
+      return res.json({ ok: true, rows: r.rows, message: PAYOUT_DEDUCTION_WARNING });
+    } catch (e) {
+      console.error('GET /admin/deductions', e);
+      return res.status(500).json({ ok: false, error: 'โหลดเคสหักเงินไม่สำเร็จ' });
+    }
+  });
+
+  router.get('/admin/deductions/summary', requireAdminSession, async (_req, res) => {
+    try {
+      const q = await pool.query(`
+        WITH totals AS (
+          SELECT
+            COUNT(*) FILTER (WHERE status='pending_approval')::int AS pending_count,
+            COALESCE(SUM(amount) FILTER (WHERE status='pending_approval'),0)::numeric AS pending_amount,
+            COALESCE(SUM(amount) FILTER (WHERE status='approved'),0)::numeric AS approved_amount,
+            COUNT(*) FILTER (WHERE severity IN ('high','critical') AND status NOT IN ('rejected','voided'))::int AS high_critical_count
+          FROM public.technician_deduction_cases
+        ),
+        open_rework AS (
+          SELECT COUNT(*)::int AS open_rework_count
+          FROM public.technician_rework_cases
+          WHERE status IN ('open','in_progress')
+        ),
+        warranty_jobs AS (
+          SELECT COUNT(*)::int AS warranty_jobs_count
+          FROM public.jobs j
+          WHERE COALESCE(j.warranty_end_at, CASE WHEN j.finished_at IS NOT NULL THEN j.finished_at + INTERVAL '30 days' ELSE NULL END) IS NOT NULL
+            AND COALESCE(j.warranty_end_at, CASE WHEN j.finished_at IS NOT NULL THEN j.finished_at + INTERVAL '30 days' ELSE NULL END) >= NOW()
+            AND COALESCE(j.canceled_at, NULL) IS NULL
+            AND COALESCE(j.job_status,'') NOT ILIKE '%ยกเลิก%'
+            AND COALESCE(j.job_status,'') NOT ILIKE '%cancel%'
+        ),
+        failed_rework AS (
+          SELECT COUNT(*)::int AS unresolved_failed_rework_count
+          FROM public.technician_rework_cases
+          WHERE status <> 'voided'
+            AND (resolution='failed' OR revisit_result ILIKE '%fail%' OR revisit_result ILIKE '%ไม่สำเร็จ%')
+        ),
+        suggestions AS (
+          SELECT (
+            (SELECT COUNT(*) FROM public.jobs j
+               WHERE j.appointment_datetime IS NOT NULL
+                 AND COALESCE(j.checkin_at, j.started_at) IS NOT NULL
+                 AND COALESCE(j.checkin_at, j.started_at) > j.appointment_datetime + INTERVAL '15 minutes'
+                 AND NOT EXISTS (
+                   SELECT 1 FROM public.technician_deduction_cases dc
+                    WHERE dc.job_id=j.job_id
+                      AND dc.technician_username=COALESCE(NULLIF(j.technician_username,''), j.technician_username)
+                      AND dc.deduction_type='late_arrival'
+                      AND dc.status NOT IN ('rejected','voided')
+                 )
+            ) +
+            (SELECT COUNT(*) FROM public.technician_rework_cases rc
+               WHERE rc.status <> 'voided'
+                 AND NOT EXISTS (
+                   SELECT 1 FROM public.technician_deduction_cases dc
+                    WHERE dc.job_id=rc.job_id
+                      AND dc.technician_username=rc.technician_username
+                      AND dc.deduction_type IN ('warranty_rework_minor','warranty_rework_major','rework_failed')
+                      AND dc.status NOT IN ('rejected','voided')
+                 )
+            )
+          )::int AS suggestions_count
+        )
+        SELECT * FROM totals, open_rework, warranty_jobs, failed_rework, suggestions
+      `);
+      const top = await pool.query(`
+        SELECT technician_username, COUNT(*)::int AS case_count, COALESCE(SUM(amount),0)::numeric AS amount
+          FROM public.technician_deduction_cases
+         WHERE status NOT IN ('rejected','voided')
+         GROUP BY technician_username
+         ORDER BY case_count DESC, amount DESC
+         LIMIT 5
+      `);
+      const recent = await pool.query(`
+        SELECT case_id, case_code, technician_username, job_id, deduction_type, amount, status, severity, created_at
+          FROM public.technician_deduction_cases
+         ORDER BY created_at DESC, case_id DESC
+         LIMIT 8
+      `);
+      return res.json({ ok: true, ...(q.rows[0] || {}), top_technicians_by_cases: top.rows, recent_cases: recent.rows, message: PAYOUT_DEDUCTION_WARNING });
+    } catch (e) {
+      console.error('GET /admin/deductions/summary', e);
+      return res.status(500).json({ ok: false, error: 'โหลดสรุปเคสไม่สำเร็จ' });
+    }
+  });
+
+  router.get('/admin/deductions/audit', requireAdminSession, async (req, res) => {
+    try {
+      const limit = Math.min(200, Math.max(1, Number(req.query.limit || 100)));
+      const where = [];
+      const params = [];
+      let p = 1;
+      const add = (sql, val) => { params.push(val); where.push(sql.replace('?', `$${p++}`)); };
+      if (req.query.entity_type) add('entity_type=?', String(req.query.entity_type).trim());
+      if (req.query.entity_id) add('entity_id=?', String(req.query.entity_id).trim());
+      if (req.query.actor_username) add('actor_username=?', String(req.query.actor_username).trim());
+      if (req.query.from) add('created_at >= ?::timestamptz', `${String(req.query.from).slice(0,10)} 00:00:00+07:00`);
+      if (req.query.to) add('created_at <= ?::timestamptz', `${String(req.query.to).slice(0,10)} 23:59:59+07:00`);
+      const sqlWhere = where.length ? `WHERE ${where.join(' AND ')}` : '';
+      const r = await pool.query(`SELECT * FROM public.technician_deduction_audit_logs ${sqlWhere} ORDER BY created_at DESC, audit_id DESC LIMIT ${limit}`, params);
+      return res.json({ ok: true, rows: r.rows });
+    } catch (e) {
+      console.error('GET /admin/deductions/audit', e);
+      return res.status(500).json({ ok: false, error: 'โหลด audit ไม่สำเร็จ' });
+    }
+  });
+
+  return router;
+};

--- a/server/routes/adminReworkReadOnly.js
+++ b/server/routes/adminReworkReadOnly.js
@@ -1,0 +1,190 @@
+module.exports = function createAdminReworkReadOnlyRoutes(deps = {}) {
+  const express = require("express");
+  const router = express.Router();
+  const {
+    pool,
+    requireAdminSession,
+    getDeductionTableMeta,
+    dHas,
+    dTextCol,
+  } = deps;
+
+  router.get('/admin/rework_cases', requireAdminSession, async (req, res) => {
+    try {
+      const limit = Math.min(200, Math.max(1, Number(req.query.limit || 100)));
+      const where = [];
+      const params = [];
+      let p = 1;
+      const add = (sql, val) => { params.push(val); where.push(sql.replace('?', `$${p++}`)); };
+      if (req.query.status) add('status=?', String(req.query.status).trim());
+      if (req.query.technician_username) add('technician_username=?', String(req.query.technician_username).trim());
+      if (req.query.job_id) add('job_id=?', Number(req.query.job_id));
+      if (req.query.reason_type) add('reason_type=?', String(req.query.reason_type).trim());
+      if (req.query.from) add('created_at >= ?::timestamptz', `${String(req.query.from).slice(0,10)} 00:00:00+07:00`);
+      if (req.query.to) add('created_at <= ?::timestamptz', `${String(req.query.to).slice(0,10)} 23:59:59+07:00`);
+      const sqlWhere = where.length ? `WHERE ${where.join(' AND ')}` : '';
+      const r = await pool.query(`SELECT * FROM public.technician_rework_cases ${sqlWhere} ORDER BY created_at DESC, rework_case_id DESC LIMIT ${limit}`, params);
+      return res.json({ ok: true, rows: r.rows });
+    } catch (e) {
+      console.error('GET /admin/rework_cases', e);
+      return res.status(500).json({ ok: false, error: 'โหลดเคสงานแก้ไขไม่สำเร็จ' });
+    }
+  });
+
+  router.get('/admin/rework_cases/:id', requireAdminSession, async (req, res) => {
+    const id = Number(req.params.id);
+    if (!Number.isFinite(id) || id <= 0) return res.status(400).json({ ok: false, error: 'rework_case_id ไม่ถูกต้อง' });
+    try {
+      const rr = await pool.query(`SELECT * FROM public.technician_rework_cases WHERE rework_case_id=$1`, [id]);
+      if (!rr.rows.length) return res.status(404).json({ ok: false, error: 'ไม่พบเคสงานแก้ไข' });
+      const row = rr.rows[0];
+
+      const jobsMeta = await getDeductionTableMeta('jobs');
+      const jobSelect = [
+        'j.job_id',
+        dHas(jobsMeta, 'booking_code') ? 'j.booking_code' : 'j.job_id::text AS booking_code',
+        dHas(jobsMeta, 'customer_name') ? 'j.customer_name' : "NULL::text AS customer_name",
+        dHas(jobsMeta, 'customer_phone') ? 'j.customer_phone' : "NULL::text AS customer_phone",
+        dHas(jobsMeta, 'job_type') ? 'j.job_type' : "NULL::text AS job_type",
+        dHas(jobsMeta, 'job_status') ? 'j.job_status' : "NULL::text AS job_status",
+        dHas(jobsMeta, 'appointment_datetime') ? 'j.appointment_datetime' : "NULL::timestamptz AS appointment_datetime",
+        dHas(jobsMeta, 'technician_username') ? 'j.technician_username' : "NULL::text AS technician_username",
+        dHas(jobsMeta, 'warranty_end_at') ? 'j.warranty_end_at' : "NULL::timestamptz AS warranty_end_at",
+        dHas(jobsMeta, 'return_reason') ? 'j.return_reason' : "NULL::text AS return_reason",
+        dHas(jobsMeta, 'returned_at') ? 'j.returned_at' : "NULL::timestamptz AS returned_at",
+        dHas(jobsMeta, 'travel_started_at') ? 'j.travel_started_at' : "NULL::timestamptz AS travel_started_at",
+        dHas(jobsMeta, 'checkin_at') ? 'j.checkin_at' : "NULL::timestamptz AS checkin_at",
+        dHas(jobsMeta, 'started_at') ? 'j.started_at' : "NULL::timestamptz AS started_at",
+        dHas(jobsMeta, 'finished_at') ? 'j.finished_at' : "NULL::timestamptz AS finished_at",
+        dHas(jobsMeta, 'revisit_result') ? 'j.revisit_result' : "NULL::text AS revisit_result",
+        dHas(jobsMeta, 'revisit_note') ? 'j.revisit_note' : "NULL::text AS revisit_note",
+        dHas(jobsMeta, 'evidence_json') ? 'j.evidence_json' : "NULL::jsonb AS evidence_json",
+        dHas(jobsMeta, 'before_photos') ? 'j.before_photos' : "NULL::jsonb AS before_photos",
+        dHas(jobsMeta, 'after_photos') ? 'j.after_photos' : "NULL::jsonb AS after_photos",
+        dHas(jobsMeta, 'revisit_evidence_json') ? 'j.revisit_evidence_json' : "NULL::jsonb AS revisit_evidence_json"
+      ];
+      const jr = await pool.query(`SELECT ${jobSelect.join(', ')} FROM public.jobs j WHERE j.job_id=$1`, [row.job_id]);
+      const job = jr.rows[0] || null;
+
+      let technician = null;
+      try {
+        const usersMeta = await getDeductionTableMeta('users');
+        const profMeta = await getDeductionTableMeta('technician_profiles');
+        const techUsername = row.technician_username || job?.technician_username || '';
+        if (techUsername && (usersMeta.exists || profMeta.exists)) {
+          const displayName = `COALESCE(NULLIF(${dTextCol('p', profMeta, 'full_name')},''), NULLIF(${dTextCol('p', profMeta, 'name')},''), NULLIF(${dTextCol('u', usersMeta, 'full_name')},''), NULLIF(${dTextCol('u', usersMeta, 'name')},''), $1)`;
+          const phone = `COALESCE(NULLIF(${dTextCol('p', profMeta, 'phone')},''), NULLIF(${dTextCol('u', usersMeta, 'phone')},''), '')`;
+          let techSql;
+          if (usersMeta.exists && profMeta.exists && dHas(usersMeta, 'username') && dHas(profMeta, 'username')) {
+            techSql = `SELECT $1::text AS technician_username, ${displayName} AS display_name, ${phone} AS phone FROM public.users u FULL OUTER JOIN public.technician_profiles p ON p.username=u.username WHERE COALESCE(p.username,u.username)=$1 LIMIT 1`;
+          } else if (profMeta.exists && dHas(profMeta, 'username')) {
+            techSql = `SELECT p.username AS technician_username, ${displayName} AS display_name, ${phone} AS phone FROM public.technician_profiles p LEFT JOIN public.users u ON false WHERE p.username=$1 LIMIT 1`;
+          } else if (usersMeta.exists && dHas(usersMeta, 'username')) {
+            techSql = `SELECT u.username AS technician_username, ${displayName} AS display_name, ${phone} AS phone FROM public.users u LEFT JOIN public.technician_profiles p ON false WHERE u.username=$1 LIMIT 1`;
+          }
+          if (techSql) {
+            const tr = await pool.query(techSql, [techUsername]);
+            technician = tr.rows[0] || { technician_username: techUsername };
+          }
+        }
+      } catch (e) {
+        try { console.warn('[rework detail] technician lookup skipped:', e.message); } catch {}
+      }
+
+      let deduction = null;
+      if (row.linked_deduction_case_id) {
+        const dr = await pool.query(`SELECT * FROM public.technician_deduction_cases WHERE case_id=$1`, [row.linked_deduction_case_id]);
+        deduction = dr.rows[0] || null;
+      }
+      const audit = await pool.query(
+        `SELECT * FROM public.technician_deduction_audit_logs
+         WHERE (entity_type='rework_case' AND entity_id=$1)
+            OR (entity_type='deduction_case' AND entity_id=$2)
+         ORDER BY created_at DESC, audit_id DESC`,
+        [String(id), row.linked_deduction_case_id ? String(row.linked_deduction_case_id) : '__none__']
+      );
+
+      let job_updates = [];
+      try {
+        const updatesMeta = await getDeductionTableMeta('job_updates_v2');
+        if (updatesMeta.exists && dHas(updatesMeta, 'job_id')) {
+          const updateIdExpr = dHas(updatesMeta, 'update_id') ? 'update_id' : 'NULL::bigint AS update_id';
+          const actorExpr = dHas(updatesMeta, 'actor_username') ? 'actor_username' : "NULL::text AS actor_username";
+          const roleExpr = dHas(updatesMeta, 'actor_role') ? 'actor_role' : "NULL::text AS actor_role";
+          const actionExpr = dHas(updatesMeta, 'action') ? 'action' : "NULL::text AS action";
+          const msgExpr = dHas(updatesMeta, 'message') ? 'message' : "NULL::text AS message";
+          const payloadExpr = dHas(updatesMeta, 'payload_json') ? 'payload_json' : "NULL::jsonb AS payload_json";
+          const createdExpr = dHas(updatesMeta, 'created_at') ? 'created_at' : 'NOW() AS created_at';
+          const ur = await pool.query(
+            `SELECT ${updateIdExpr}, ${actorExpr}, ${roleExpr}, ${actionExpr}, ${msgExpr}, ${payloadExpr}, ${createdExpr}
+               FROM public.job_updates_v2
+              WHERE job_id=$1
+                AND (
+                  COALESCE(action::text,'') ILIKE '%rework%'
+                  OR COALESCE(action::text,'') ILIKE '%revisit%'
+                  OR COALESCE(action::text,'') ILIKE '%return%'
+                  OR COALESCE(message::text,'') ILIKE '%แก้%'
+                  OR COALESCE(message::text,'') ILIKE '%ประกัน%'
+                )
+              ORDER BY created_at DESC
+              LIMIT 50`,
+            [row.job_id]
+          );
+          job_updates = ur.rows || [];
+        }
+      } catch (e) {
+        try { console.warn('[rework detail] job update lookup skipped:', e.message); } catch {}
+      }
+
+      let job_photos = [];
+      try {
+        const photosMeta = await getDeductionTableMeta('job_photos');
+        if (photosMeta.exists && dHas(photosMeta, 'job_id')) {
+          const photoSelect = [
+            dHas(photosMeta, 'photo_id') ? 'photo_id' : 'NULL::bigint AS photo_id',
+            dHas(photosMeta, 'photo_url') ? 'photo_url' : (dHas(photosMeta, 'url') ? 'url AS photo_url' : (dHas(photosMeta, 'secure_url') ? 'secure_url AS photo_url' : "NULL::text AS photo_url")),
+            dHas(photosMeta, 'type') ? 'type' : (dHas(photosMeta, 'photo_type') ? 'photo_type AS type' : "NULL::text AS type"),
+            dHas(photosMeta, 'created_at') ? 'created_at' : 'NOW() AS created_at'
+          ];
+          const pr = await pool.query(`SELECT ${photoSelect.join(', ')} FROM public.job_photos WHERE job_id=$1 ORDER BY created_at DESC LIMIT 80`, [row.job_id]);
+          job_photos = pr.rows || [];
+        }
+      } catch (e) {
+        try { console.warn('[rework detail] job photo lookup skipped:', e.message); } catch {}
+      }
+
+      const evidence_sources = {
+        rework_evidence_json: row.evidence_json || [],
+        job_evidence_json: job?.evidence_json || null,
+        before_photos: job?.before_photos || null,
+        after_photos: job?.after_photos || null,
+        revisit_evidence_json: job?.revisit_evidence_json || null,
+        job_photos
+      };
+      const verification = {
+        revisit_result: row.revisit_result || job?.revisit_result || null,
+        revisit_note: row.revisit_note || job?.revisit_note || null,
+        timeline: {
+          returned_at: job?.returned_at || null,
+          travel_started_at: job?.travel_started_at || null,
+          checkin_at: job?.checkin_at || null,
+          started_at: job?.started_at || null,
+          finished_at: job?.finished_at || null,
+          resolved_at: row.resolved_at || null
+        },
+        has_evidence: !!(
+          (Array.isArray(row.evidence_json) && row.evidence_json.length) ||
+          job?.evidence_json || job?.before_photos || job?.after_photos || job?.revisit_evidence_json ||
+          (Array.isArray(job_photos) && job_photos.length)
+        )
+      };
+
+      return res.json({ ok: true, row, job, technician, linked_deduction_case: deduction, audit_logs: audit.rows, job_updates, job_photos, evidence_sources, verification });
+    } catch (e) {
+      console.error('GET /admin/rework_cases/:id', e);
+      return res.status(500).json({ ok: false, error: 'โหลดรายละเอียดเคสงานแก้ไขไม่สำเร็จ', detail: process.env.NODE_ENV === 'production' ? undefined : e.message });
+    }
+  });
+
+  return router;
+};


### PR DESCRIPTION
## Summary
- extract shared admin rework/deduction schema helpers into a dedicated helper factory
- extract read-only admin deduction list/summary/audit routes into `server/routes/adminDeductionsReadOnly.js`
- extract read-only admin rework list/detail routes into `server/routes/adminReworkReadOnly.js`
- document the Phase 3B prep scope, skipped mutation paths, tests, and rollback plan

## Scope preserved
- no write/state-transition routes moved
- no deduction approval/reject/void flows moved
- no rework create/resolve flows moved
- no technician income, close-job, booking, pricing, customer flow, frontend, DB schema, or migration changes

## Validation
- `node --check index.js`
- `node --check server/helpers/adminReworkDeductionsHelpers.js`
- `node --check server/routes/adminDeductionsReadOnly.js`
- `node --check server/routes/adminReworkReadOnly.js`
- `node --check server/routes/pages/index.js`
- `node --check server/routes/serviceZones/index.js`
- `node --check server/routes/catalog/items.js`
- `node --check server/routes/system/index.js`
- `node --check server/routes/users/technicians.js`
- `node --check server/db/pool.js`

## Notes
- `index.js` line count reduced from 24,959 to 24,671 (net -288)
- PR intentionally leaves mutation routes inline for a later, separately reviewed phase