### PR TITLE
refactor: prep technician base status readonly seam

### DIFF
--- a/docs/INDEX_JS_SPLIT_PLAN.md
+++ b/docs/INDEX_JS_SPLIT_PLAN.md
@@ -284,6 +284,41 @@ Phase 1B status:
 - `index.js` line count reduced from `24,019` to `23,716` lines.
 - Rollback: remove the accounting read-only import/mount, restore the six inline GET handlers, delete `server/routes/accountingReadOnly.js`, then run syntax checks and smoke-test all six routes.
 
+### Phase 3F: Audit for the Next Large Safe Block
+
+- Audited the next large `index.js` candidates after the accounting read-only extraction.
+- No runtime extraction was opened because every candidate large enough to remove at least `200` lines still crossed a forbidden seam:
+  - admin dashboard v2 has hidden side effects inside a GET path
+  - payout views remain coupled to payout mutation/finalization logic
+  - technician work-calendar/readiness mixes read paths with write helpers and upsert behavior
+  - technician base-status has a pure-helper subset, but the safe subset is still below the phase size threshold
+  - remaining accounting-adjacent routes are tied to schema ensure, auto-create, audit writes, or tax/document flows
+- See `docs/PHASE3F_NEXT_SAFE_INDEX_REDUCTION.md` for the full candidate inventory and skip rationale.
+- Runtime code changed in Phase 3F: none.
+- Future backend extraction PRs must include a startup smoke check in addition to syntax checks.
+
+### Phase 3G: Technician Base Status Prep Seam
+
+- Extracted the read-only technician base-status seam while keeping POST/write behavior frozen in `index.js`.
+- New helper module:
+  - `server/helpers/technicianBaseStatusDataHelpers.js`
+- New read-only route module:
+  - `server/routes/technicianBaseStatusReadOnly.js`
+- Moved read-only routes:
+  - `GET /admin/api/team-status`
+  - `GET /admin/api/technicians/:username/base-status`
+  - `GET /admin/api/technicians/:username/status`
+  - `GET /tech/api/base-status`
+- Kept in place:
+  - `POST /admin/api/technicians/:username/base-status`
+  - `POST /tech/api/base-status`
+  - pure scoring helpers shared by the retained write routes
+- This prep phase intentionally reduces less than the normal target because it creates the safe dependency seam needed before any later POST/write extraction.
+- `index.js` line counts changed:
+  - physical lines: `25,567` -> `25,468`
+  - non-empty lines: `23,717` -> `23,623`
+- See `docs/PHASE3G_TECHNICIAN_BASE_STATUS_PREP.md` for the full route inventory, rationale, checklist, and rollback plan.
+
 ### Phase 2: Read-Only Technician Routes
 
 - Move read-only technician routes with no DB writes.
@@ -339,4 +374,5 @@ Before extracting any route:
 - Identify frontend callers and expected response shape.
 - Add or update a focused test/checklist.
 - Run `node --check index.js` and `node --check` on every changed JS file.
+- Run a runtime startup smoke such as `timeout 5s node index.js` (or equivalent) and verify no boot-time `ReferenceError`, missing import, or undefined route factory occurs before timeout.
 - Run manual smoke tests for the relevant user flow.

--- a/docs/PHASE3F_NEXT_SAFE_INDEX_REDUCTION.md
+++ b/docs/PHASE3F_NEXT_SAFE_INDEX_REDUCTION.md
@@ -1,0 +1,117 @@
+# Phase 3F: Next Safe index.js Reduction Audit
+
+## Current State
+
+- Current `main` head checked for this audit: `072bc38157d4ea3b4798648028e1edb96f2dc15b`
+- Current `index.js` line count: `25,567`
+- Phase 3F goal: find one production-safe extraction block worth at least `200` lines.
+- Result: no candidate met both the size target and the requested safety gates, so Phase 3F stops at audit only.
+
+## Top Candidates Reviewed
+
+| Candidate | Approx area | Estimated removable lines | Risk | Decision |
+| --- | --- | ---: | --- | --- |
+| Admin dashboard v2 | `index.js:4371-4747` | `370+` | High | Skip: the GET handler also expires technician accept statuses and recomputes live technician cost through payout helpers |
+| Admin payout read views | `index.js:7805-8016` | `200+` | High | Skip: the surrounding payout block is coupled to payout generation/finalization helpers and contains period auto-create behavior |
+| Technician work calendar + readiness | `index.js:19821-20449` | `600+` | High | Skip: read routes share helpers with writes, and `ensureDailyReadinessRow()` inserts/updates rows |
+| Technician base-status block | `index.js:20935-21235` | `300+` total, but safe helper-only subset is below `200` | High for the full block / Low for helper-only seam | Skip for now: the full block mixes GET and POST routes; the safe pure-helper subset is too small for the Phase 3F threshold |
+| Remaining accounting-adjacent block | `index.js:22305-23352` | `200+` | High | Skip: remaining GET routes are tied to schema ensure, payout auto-create, report audit logging, or tax/withholding/document flows |
+
+## Why No Runtime Extraction Was Opened
+
+The remaining blocks large enough to reduce `index.js` meaningfully all violate at least one Phase 3F safety gate:
+
+- hidden writes inside GET flows
+- direct coupling to payout mutation/finalization
+- shared helpers used by both read and write routes
+- tax/withholding/document behavior outside the allowed scope
+- technician state flows that are not yet split into a read-only seam
+
+The only clearly safe subset identified in this pass is the pure helper portion of technician base-status calculation, but it is below the requested `200` line threshold and would repeat the small-PR pattern the project is explicitly trying to leave behind.
+
+## Candidate-Specific Notes
+
+### 1. Admin Dashboard v2
+
+- Includes `GET /admin/dashboard_v2`
+- Dependencies include `_buildPayoutLinesForJob`, `_sqlDonePredicate`, `_accounting*` helpers, and `expireTechnicianAcceptStatuses(pool)`
+- Not safe for Phase 3F because the route is not a pure read path despite being a GET endpoint
+
+### 2. Admin Payout Read Views
+
+- Includes admin/super payout list and detail GET routes
+- Surrounding block is interleaved with generation, reconciliation, lock, pay, delete, and adjustment actions
+- Not safe while payout mutation/finalization remains explicitly frozen
+
+### 3. Technician Work Calendar + Daily Readiness
+
+- Includes work-calendar/readiness GET routes plus shared helpers
+- Read helpers are coupled to:
+  - `upsertCalendarDay(...)`
+  - `ensureDailyReadinessRow(...)`
+  - route-level writes in adjacent `PUT`/`POST` handlers
+- `ensureDailyReadinessRow(...)` performs `INSERT ... ON CONFLICT DO UPDATE`
+- Not safe until a deliberate read-only seam is designed
+
+### 4. Technician Base Status
+
+- Full block includes both GET and POST routes plus shared calculation helpers
+- Pure helpers such as `calculateTechnicianBaseStatus()` and `buildTechnicianCharacterPrompt()` are moveable in principle
+- However, moving only the helper seam would remove less than `200` lines from `index.js`, so it does not satisfy the current phase objective
+
+### 5. Remaining Accounting-Adjacent Routes
+
+- Explicitly skipped:
+  - `GET /admin/accounting/settings`
+  - `GET /admin/accounting/payouts`
+  - report CSV export
+  - tax profile / withholding certificate / document print routes
+- Reasons include schema ensure, auto-create behavior, audit writes, and tax/document scope restrictions
+
+## Runtime Scope
+
+- Runtime code changed in Phase 3F: **none**
+- New route modules created: **none**
+- Existing route modules changed: **none**
+- This phase is documentation/audit only.
+
+## Recommended Next Step
+
+Before the next runtime extraction, first create a dedicated prep/audit phase for one of these seams:
+
+1. **Technician base-status helper seam**
+   - Extract only pure functions into a helper module
+   - Keep all GET/POST routes in place initially
+   - Use it as groundwork for a later larger route move
+2. **Technician work-calendar read/write separation**
+   - Map which helpers are truly pure/read-only
+   - Identify whether GET routes can be separated without carrying `ensureDailyReadinessRow()` side effects
+
+Neither should be moved blindly in the same PR without a fresh focused audit.
+
+## Required Verification for Future Backend Refactors
+
+Syntax checks alone are not sufficient. Every future backend extraction PR must include:
+
+- `node --check` on all changed runtime files
+- runtime startup smoke, such as `timeout 5s node index.js` or an equivalent 5-second boot check
+- confirmation that all new route factory imports are present and names match their exports exactly
+
+## Manual Smoke Checklist for Future Selected Block
+
+- App starts.
+- Every moved route/function behaves exactly as before.
+- Accounting read-only routes from Phase 3E still work.
+- Docs routes from Phase 3D still work.
+- Admin deductions/rework routes from Phases 3B and 3C still work.
+- Technician job page still loads.
+- Technician income page still loads.
+- Close-job flow is not regressed.
+- Booking/pricing/customer flow is not regressed.
+- `/login` and `POST /login` still work.
+- `/tech` and `/tech.html` still work.
+- `/service_zones` and `POST /service_zones/detect` still work.
+
+## Rollback Plan
+
+No runtime code changed in Phase 3F, so no rollback is required for this audit-only phase.

--- a/docs/PHASE3G_TECHNICIAN_BASE_STATUS_PREP.md
+++ b/docs/PHASE3G_TECHNICIAN_BASE_STATUS_PREP.md
@@ -1,0 +1,157 @@
+# Phase 3G: Technician Base Status Prep
+
+## Current State
+
+- Baseline head: `072bc38157d4ea3b4798648028e1edb96f2dc15b`
+- `index.js` before Phase 3G:
+  - physical lines: `25,567`
+  - non-empty lines: `23,717`
+- Goal: create a safe seam inside the mixed technician base-status block without touching write routes or changing technician identity/auth behavior.
+
+## Block Inventory
+
+### Pure Helper Functions Kept In Place For Now
+
+- `clamp100`
+- `avgNums`
+- `score100`
+- `pickEvidence`
+- `selectedCaps`
+- `rankFromAverage`
+- `expSkill`
+- `optionScore`
+- `capLabels`
+- `calculateTechnicianBaseStatus`
+- `buildTechnicianCharacterPrompt`
+
+These remain in `index.js` because they are shared by the write routes still frozen for now.
+
+### Read-Only Data Helpers Moved
+
+- `getTechnicianForStatus`
+- `getLatestBaseStatus`
+
+New location:
+
+- `server/helpers/technicianBaseStatusDataHelpers.js`
+
+These helpers only read from the database and now form an explicit dependency seam that can be reused by both the retained write routes and the extracted read-only routes.
+
+### GET Read-Only Routes Moved
+
+- `GET /admin/api/team-status`
+- `GET /admin/api/technicians/:username/base-status`
+- `GET /admin/api/technicians/:username/status`
+- `GET /tech/api/base-status`
+
+New location:
+
+- `server/routes/technicianBaseStatusReadOnly.js`
+
+Mount location:
+
+- `index.js` mounts `createTechnicianBaseStatusReadOnlyRoutes({...})` immediately after the existing team-status page aliases and before the retained write routes.
+
+### Routes Kept In `index.js`
+
+- `POST /admin/api/technicians/:username/base-status`
+- `POST /tech/api/base-status`
+- `GET /admin/team-status`
+- `GET /admin/team-status.html`
+- `GET /admin-team-status.html`
+- `GET /tech/base-status`
+- `GET /tech/base-status.html`
+
+These stay in place because the POST routes write assessments, and the page aliases are not needed to create the read-only seam.
+
+## Why This Prep Seam Matters
+
+This phase reduces less than the normal target:
+
+- physical reduction: `99` lines
+- non-empty reduction: `94` lines
+
+That is intentionally smaller than the usual threshold, but it is still useful rather than cosmetic:
+
+1. It separates the read-only API surface from the POST/write surface.
+2. It moves the shared read-only database helpers behind an explicit dependency seam.
+3. It makes a later extraction of the remaining POST routes easier to review because the future diff can focus on write behavior only.
+4. It avoids moving the pure scoring helpers prematurely while they are still shared by the retained write routes.
+
+## Behavior Preservation
+
+- Route paths unchanged
+- Middleware unchanged
+- SQL unchanged
+- Response shapes unchanged
+- Status codes unchanged
+- Error bodies unchanged
+- `req.auth` / `req.effective` identity source unchanged
+- No frontend, booking, pricing, close-job, readiness, or work-calendar code changed
+
+## Before / After
+
+- Before:
+  - physical lines: `25,567`
+  - non-empty lines: `23,717`
+- After:
+  - physical lines: `25,468`
+  - non-empty lines: `23,623`
+
+## Risk
+
+- Overall risk: Medium-Low
+- Why:
+  - only GET read-only routes moved
+  - database helpers are read-only
+  - existing POST/write flows remain in place
+  - the main review point is confirming the new factory import/mount and response parity
+
+## Tests Run
+
+- `node --check index.js`
+- `node --check server/helpers/technicianBaseStatusDataHelpers.js`
+- `node --check server/routes/technicianBaseStatusReadOnly.js`
+- `node --check server/routes/accountingReadOnly.js`
+- `node --check server/routes/docs.js`
+- `node --check server/helpers/adminReworkDeductionsHelpers.js`
+- `node --check server/routes/adminDeductionsReadOnly.js`
+- `node --check server/routes/adminReworkReadOnly.js`
+- `node --check server/routes/pages/index.js`
+- `node --check server/routes/serviceZones/index.js`
+- `node --check server/routes/catalog/items.js`
+- `node --check server/routes/system/index.js`
+- `node --check server/routes/users/technicians.js`
+- `node --check server/db/pool.js`
+- `git diff --check`
+- runtime startup smoke with 5-second `node index.js` boot window
+
+## Manual Smoke Checklist
+
+- App starts.
+- `/tech` and `/tech.html` still load.
+- `GET /admin/api/team-status` returns the same payload.
+- `GET /admin/api/technicians/:username/base-status` returns the same payload.
+- `GET /admin/api/technicians/:username/status` returns the same payload.
+- `GET /tech/api/base-status` returns the same payload.
+- `POST /admin/api/technicians/:username/base-status` still writes the same way.
+- `POST /tech/api/base-status` still writes the same way.
+- Readiness behavior does not change.
+- Work-calendar behavior does not change.
+- Technician job page still loads.
+- Technician income page still loads.
+- Close-job flow is not regressed.
+- Booking/pricing/customer flow is not regressed.
+- `/login` and `POST /login` still work.
+- `/service_zones` and `POST /service_zones/detect` still work.
+
+## Rollback Plan
+
+1. Remove the `createTechnicianBaseStatusDataHelpers` and `createTechnicianBaseStatusReadOnlyRoutes` imports from `index.js`.
+2. Restore `getTechnicianForStatus` and `getLatestBaseStatus` inline in `index.js`.
+3. Restore the four original inline GET handlers at their previous locations.
+4. Remove the read-only router mount.
+5. Delete:
+   - `server/helpers/technicianBaseStatusDataHelpers.js`
+   - `server/routes/technicianBaseStatusReadOnly.js`
+6. Run syntax checks, startup smoke, and the base-status manual smoke checklist.

--- a/index.js
+++ b/index.js
@@ -42,6 +42,8 @@ const createAccountingReadOnlyRoutes = require("./server/routes/accountingReadOn
 const createAdminReworkDeductionsHelpers = require("./server/helpers/adminReworkDeductionsHelpers");
 const createAdminReworkReadOnlyRoutes = require("./server/routes/adminReworkReadOnly");
 const createAdminDeductionsReadOnlyRoutes = require("./server/routes/adminDeductionsReadOnly");
+const createTechnicianBaseStatusDataHelpers = require("./server/helpers/technicianBaseStatusDataHelpers");
+const createTechnicianBaseStatusReadOnlyRoutes = require("./server/routes/technicianBaseStatusReadOnly");
 
 // =======================================
 // 🔔 Web Push Notifications (optional / fail-open)
@@ -21037,94 +21039,21 @@ function buildTechnicianCharacterPrompt({ technician = {}, stats = {}, level, ra
   return `Create a premium 9:16 RPG-style Thai character status card for Coldwindflow Air Services. Use the technician profile photo as identity reference only, not for judging ability. Character name: ${name}. Class/Role: ${role}. Level: ${level}. Rank: ${rank}. Use navy blue, electric blue, white, and yellow CWF branding. Include stats: SKILL ${stats.SKILL}, END ${stats.END}, WIS ${stats.WIS}, INT ${stats.INT}, DISC ${stats.DISC}, SERVICE ${stats.SERVICE}, COMM ${stats.COMM}, TEAM ${stats.TEAM}, TRUST ${stats.TRUST}, GROWTH ${stats.GROWTH}. Passive skills/strengths: ${strengths.join(', ')}. Upgrade points: ${dev.join(', ')}. Risk warnings: ${restricted.join(', ')}. Add Thai footer: "Base Status ก่อนเริ่มงาน / คะแนนจริงต้องปรับด้วยผลงานจริง". Make it look like a premium game status screen, clean readable Thai typography, stat bars, badges, and Coldwindflow technician theme.`;
 }
 
-async function getTechnicianForStatus(username) {
-  const r = await pool.query(
-    `SELECT u.username, u.role, COALESCE(p.full_name, u.full_name, u.username) AS full_name,
-            p.technician_code, p.position, p.photo_path, p.phone,
-            COALESCE(p.employment_type,'company') AS employment_type,
-            p.rating, p.grade, p.done_count
-     FROM public.users u
-     LEFT JOIN public.technician_profiles p ON p.username=u.username
-     WHERE u.username=$1 AND u.role='technician'
-     LIMIT 1`,
-    [username]
-  );
-  return (r.rows || [])[0] || null;
-}
-
-async function getLatestBaseStatus(username, opts = {}) {
-  const values = [username];
-  let where = `technician_username=$1`;
-  if (opts.review_status) {
-    values.push(String(opts.review_status));
-    where += ` AND COALESCE(review_status,'verified')=$${values.length}`;
-  }
-  const r = await pool.query(
-    `SELECT * FROM public.technician_base_status_assessments
-     WHERE ${where}
-     ORDER BY created_at DESC
-     LIMIT 1`,
-    values
-  );
-  return (r.rows || [])[0] || null;
-}
+const {
+  getTechnicianForStatus,
+  getLatestBaseStatus,
+} = createTechnicianBaseStatusDataHelpers({ pool });
 
 app.get('/admin/team-status', requireAdminSession, (req, res) => res.sendFile(sendHtml('admin-team-status.html')));
 app.get('/admin/team-status.html', requireAdminSession, (req, res) => res.redirect(302, '/admin/team-status'));
 app.get('/admin-team-status.html', requireAdminSession, (req, res) => res.sendFile(sendHtml('admin-team-status.html')));
-
-app.get('/admin/api/team-status', requireAdminSession, async (req, res) => {
-  try {
-    const techs = await pool.query(
-      `SELECT u.username, COALESCE(p.full_name, u.full_name, u.username) AS full_name,
-              p.photo_path, p.phone, p.technician_code, COALESCE(p.employment_type,'company') AS employment_type,
-              p.rating, p.grade, p.done_count
-       FROM public.users u
-       LEFT JOIN public.technician_profiles p ON p.username=u.username
-       WHERE u.role='technician'
-       ORDER BY COALESCE(p.full_name, u.username) ASC`
-    );
-    const latest = await pool.query(
-      `SELECT DISTINCT ON (technician_username)
-          id, technician_username, level, rank, stats_json, suitable_jobs_json, restricted_jobs_json,
-          strengths_json, risk_points_json, development_plan_json, generated_prompt,
-          COALESCE(assessment_source,'admin') AS assessment_source,
-          COALESCE(review_status,'verified') AS review_status,
-          assessed_by, reviewed_by, reviewed_at, created_at
-       FROM public.technician_base_status_assessments
-       ORDER BY technician_username, created_at DESC`
-    );
-    const pending = await pool.query(
-      `SELECT DISTINCT ON (technician_username)
-          id, technician_username, level, rank, created_at,
-          COALESCE(assessment_source,'self') AS assessment_source,
-          COALESCE(review_status,'pending_review') AS review_status
-       FROM public.technician_base_status_assessments
-       WHERE COALESCE(review_status,'verified')='pending_review'
-       ORDER BY technician_username, created_at DESC`
-    );
-    const map = new Map((latest.rows || []).map(r => [String(r.technician_username), r]));
-    const pendingMap = new Map((pending.rows || []).map(r => [String(r.technician_username), r]));
-    const people = (techs.rows || []).map(t => ({ ...t, latest_status: map.get(String(t.username)) || null, pending_status: pendingMap.get(String(t.username)) || null }));
-    return res.json({ ok: true, people });
-  } catch (e) {
-    console.error('GET team-status error:', e);
-    return res.status(500).json({ error: 'โหลด Team Status ไม่สำเร็จ' });
-  }
-});
-
-app.get('/admin/api/technicians/:username/base-status', requireAdminSession, async (req, res) => {
-  try {
-    const username = String(req.params.username || '').trim();
-    const technician = await getTechnicianForStatus(username);
-    if (!technician) return res.status(404).json({ error: 'ไม่พบช่าง' });
-    const latest = await getLatestBaseStatus(username);
-    return res.json({ ok: true, technician, latest });
-  } catch (e) {
-    console.error('GET base-status error:', e);
-    return res.status(500).json({ error: 'โหลด Base Status ไม่สำเร็จ' });
-  }
-});
+app.use(createTechnicianBaseStatusReadOnlyRoutes({
+  pool,
+  requireAdminSession,
+  requireTechnicianSession,
+  getTechnicianForStatus,
+  getLatestBaseStatus,
+}));
 
 app.post('/admin/api/technicians/:username/base-status', requireAdminSession, async (req, res) => {
   try {
@@ -21162,39 +21091,11 @@ app.post('/admin/api/technicians/:username/base-status', requireAdminSession, as
   }
 });
 
-app.get('/admin/api/technicians/:username/status', requireAdminSession, async (req, res) => {
-  try {
-    const username = String(req.params.username || '').trim();
-    const technician = await getTechnicianForStatus(username);
-    if (!technician) return res.status(404).json({ error: 'ไม่พบช่าง' });
-    const latest = await getLatestBaseStatus(username);
-    return res.json({ ok: true, technician, latest, future_work_adjustment: ['Completed jobs','On-time check-in','Status update completeness','Before/after photos','Customer reviews','Complaints','Rework','Admin override notes'] });
-  } catch (e) {
-    console.error('GET tech status error:', e);
-    return res.status(500).json({ error: 'โหลด Status ไม่สำเร็จ' });
-  }
-});
-
 // Technician Self Assessment entrypoint (Phase 1.1)
 // - ช่างทำแบบประเมินเองได้จากเมนูช่าง
 // - บันทึกเป็น pending_review เพื่อให้ Admin/Super Admin ตรวจต่อ ไม่ใช่คะแนน official อัตโนมัติ
 app.get('/tech/base-status', requireTechnicianSession, (req, res) => res.sendFile(sendHtml('tech-base-status.html')));
 app.get('/tech/base-status.html', requireTechnicianSession, (req, res) => res.redirect(302, '/tech/base-status'));
-
-app.get('/tech/api/base-status', requireTechnicianSession, async (req, res) => {
-  try {
-    const username = String(req.auth?.username || req.effective?.username || '').trim();
-    const technician = await getTechnicianForStatus(username);
-    if (!technician) return res.status(404).json({ error: 'ไม่พบข้อมูลช่างของคุณ' });
-    const latest = await getLatestBaseStatus(username);
-    const latest_self = await getLatestBaseStatus(username, { review_status: 'pending_review' });
-    const latest_verified = await getLatestBaseStatus(username, { review_status: 'verified' });
-    return res.json({ ok: true, technician, latest, latest_self, latest_verified });
-  } catch (e) {
-    console.error('GET tech self base-status error:', e);
-    return res.status(500).json({ error: 'โหลดแบบประเมินของช่างไม่สำเร็จ' });
-  }
-});
 
 app.post('/tech/api/base-status', requireTechnicianSession, async (req, res) => {
   try {

--- a/server/helpers/technicianBaseStatusDataHelpers.js
+++ b/server/helpers/technicianBaseStatusDataHelpers.js
@@ -1,0 +1,40 @@
+module.exports = function createTechnicianBaseStatusDataHelpers(deps = {}) {
+  const pool = deps.pool;
+
+  async function getTechnicianForStatus(username) {
+    const r = await pool.query(
+      `SELECT u.username, u.role, COALESCE(p.full_name, u.full_name, u.username) AS full_name,
+              p.technician_code, p.position, p.photo_path, p.phone,
+              COALESCE(p.employment_type,'company') AS employment_type,
+              p.rating, p.grade, p.done_count
+       FROM public.users u
+       LEFT JOIN public.technician_profiles p ON p.username=u.username
+       WHERE u.username=$1 AND u.role='technician'
+       LIMIT 1`,
+      [username]
+    );
+    return (r.rows || [])[0] || null;
+  }
+
+  async function getLatestBaseStatus(username, opts = {}) {
+    const values = [username];
+    let where = `technician_username=$1`;
+    if (opts.review_status) {
+      values.push(String(opts.review_status));
+      where += ` AND COALESCE(review_status,'verified')=$${values.length}`;
+    }
+    const r = await pool.query(
+      `SELECT * FROM public.technician_base_status_assessments
+       WHERE ${where}
+       ORDER BY created_at DESC
+       LIMIT 1`,
+      values
+    );
+    return (r.rows || [])[0] || null;
+  }
+
+  return {
+    getTechnicianForStatus,
+    getLatestBaseStatus,
+  };
+};

--- a/server/routes/technicianBaseStatusReadOnly.js
+++ b/server/routes/technicianBaseStatusReadOnly.js
@@ -1,0 +1,93 @@
+module.exports = function createTechnicianBaseStatusReadOnlyRoutes(deps = {}) {
+  const express = require("express");
+  const router = express.Router();
+
+  const pool = deps.pool;
+  const requireAdminSession = deps.requireAdminSession;
+  const requireTechnicianSession = deps.requireTechnicianSession;
+  const getTechnicianForStatus = deps.getTechnicianForStatus;
+  const getLatestBaseStatus = deps.getLatestBaseStatus;
+
+  router.get('/admin/api/team-status', requireAdminSession, async (req, res) => {
+    try {
+      const techs = await pool.query(
+        `SELECT u.username, COALESCE(p.full_name, u.full_name, u.username) AS full_name,
+                p.photo_path, p.phone, p.technician_code, COALESCE(p.employment_type,'company') AS employment_type,
+                p.rating, p.grade, p.done_count
+         FROM public.users u
+         LEFT JOIN public.technician_profiles p ON p.username=u.username
+         WHERE u.role='technician'
+         ORDER BY COALESCE(p.full_name, u.username) ASC`
+      );
+      const latest = await pool.query(
+        `SELECT DISTINCT ON (technician_username)
+            id, technician_username, level, rank, stats_json, suitable_jobs_json, restricted_jobs_json,
+            strengths_json, risk_points_json, development_plan_json, generated_prompt,
+            COALESCE(assessment_source,'admin') AS assessment_source,
+            COALESCE(review_status,'verified') AS review_status,
+            assessed_by, reviewed_by, reviewed_at, created_at
+         FROM public.technician_base_status_assessments
+         ORDER BY technician_username, created_at DESC`
+      );
+      const pending = await pool.query(
+        `SELECT DISTINCT ON (technician_username)
+            id, technician_username, level, rank, created_at,
+            COALESCE(assessment_source,'self') AS assessment_source,
+            COALESCE(review_status,'pending_review') AS review_status
+         FROM public.technician_base_status_assessments
+         WHERE COALESCE(review_status,'verified')='pending_review'
+         ORDER BY technician_username, created_at DESC`
+      );
+      const map = new Map((latest.rows || []).map(r => [String(r.technician_username), r]));
+      const pendingMap = new Map((pending.rows || []).map(r => [String(r.technician_username), r]));
+      const people = (techs.rows || []).map(t => ({ ...t, latest_status: map.get(String(t.username)) || null, pending_status: pendingMap.get(String(t.username)) || null }));
+      return res.json({ ok: true, people });
+    } catch (e) {
+      console.error('GET team-status error:', e);
+      return res.status(500).json({ error: 'โหลด Team Status ไม่สำเร็จ' });
+    }
+  });
+
+  router.get('/admin/api/technicians/:username/base-status', requireAdminSession, async (req, res) => {
+    try {
+      const username = String(req.params.username || '').trim();
+      const technician = await getTechnicianForStatus(username);
+      if (!technician) return res.status(404).json({ error: 'ไม่พบช่าง' });
+      const latest = await getLatestBaseStatus(username);
+      return res.json({ ok: true, technician, latest });
+    } catch (e) {
+      console.error('GET base-status error:', e);
+      return res.status(500).json({ error: 'โหลด Base Status ไม่สำเร็จ' });
+    }
+  });
+
+  router.get('/admin/api/technicians/:username/status', requireAdminSession, async (req, res) => {
+    try {
+      const username = String(req.params.username || '').trim();
+      const technician = await getTechnicianForStatus(username);
+      if (!technician) return res.status(404).json({ error: 'ไม่พบช่าง' });
+      const latest = await getLatestBaseStatus(username);
+      return res.json({ ok: true, technician, latest, future_work_adjustment: ['Completed jobs','On-time check-in','Status update completeness','Before/after photos','Customer reviews','Complaints','Rework','Admin override notes'] });
+    } catch (e) {
+      console.error('GET tech status error:', e);
+      return res.status(500).json({ error: 'โหลด Status ไม่สำเร็จ' });
+    }
+  });
+
+  router.get('/tech/api/base-status', requireTechnicianSession, async (req, res) => {
+    try {
+      const username = String(req.auth?.username || req.effective?.username || '').trim();
+      const technician = await getTechnicianForStatus(username);
+      if (!technician) return res.status(404).json({ error: 'ไม่พบข้อมูลช่างของคุณ' });
+      const latest = await getLatestBaseStatus(username);
+      const latest_self = await getLatestBaseStatus(username, { review_status: 'pending_review' });
+      const latest_verified = await getLatestBaseStatus(username, { review_status: 'verified' });
+      return res.json({ ok: true, technician, latest, latest_self, latest_verified });
+    } catch (e) {
+      console.error('GET tech self base-status error:', e);
+      return res.status(500).json({ error: 'โหลดแบบประเมินของช่างไม่สำเร็จ' });
+    }
+  });
+
+  return router;
+};


### PR DESCRIPTION
## Summary
- extract the read-only technician base-status seam into `server/routes/technicianBaseStatusReadOnly.js`
- move query-only base-status data helpers into `server/helpers/technicianBaseStatusDataHelpers.js`
- document the Phase 3F audit outcome and Phase 3G prep rationale

## Scope
Moved read-only routes only:
- `GET /admin/api/team-status`
- `GET /admin/api/technicians/:username/base-status`
- `GET /admin/api/technicians/:username/status`
- `GET /tech/api/base-status`

Kept write routes in `index.js`:
- `POST /admin/api/technicians/:username/base-status`
- `POST /tech/api/base-status`

## Verification
- `node --check index.js`
- `node --check server/helpers/technicianBaseStatusDataHelpers.js`
- `node --check server/routes/technicianBaseStatusReadOnly.js`
- prior extracted route/module syntax checks
- `git diff --check`
- startup smoke: 5-second `node index.js` boot window passed without ReferenceError or undefined route factory

## Notes
This is intentionally a prep seam rather than a broad move. It reduces `index.js` from 25,567 to 25,468 physical lines and from 23,717 to 23,623 non-empty lines while separating the GET-only surface from the retained POST/write paths for safer follow-up work.