### PR TITLE
refactor: extract technician count summary readonly routes

### DIFF
--- a/docs/INDEX_JS_SPLIT_PLAN.md
+++ b/docs/INDEX_JS_SPLIT_PLAN.md
@@ -362,6 +362,22 @@ Phase 1B status:
   - non-empty lines: `23,603` -> `23,430`
 - See `docs/PHASE3J_NEXT_SAFE_INDEX_REDUCTION.md` for candidate inventory, risk notes, tests, smoke checklist, and rollback plan.
 
+### Phase 3L: Technician Count Summary Read-Only Extraction
+
+- Extracted the two technician count summary endpoints into `server/routes/technicianCountSummaryReadOnly.js`.
+- Moved:
+  - `GET /tech/completed_count_summary`
+  - `GET /tech/rework_count_summary`
+- Preserved the existing identity fallback behavior:
+  - try `getAuthContext(req, res)` first
+  - allow `?username=` only after validating the username in `public.technician_profiles`
+- Kept all technician income routes and formulas in `index.js`.
+- Kept close-job, job mutation, booking, pricing, customer flow, and frontend files untouched.
+- `index.js` line counts changed:
+  - physical lines: `25,260` -> `25,149`
+  - non-empty lines: `23,430` -> `23,330`
+- See `docs/PHASE3L_TECHNICIAN_COUNT_SUMMARY_READONLY.md` for the route audit, dependencies, tests, smoke checklist, and rollback plan.
+
 ### Phase 2: Read-Only Technician Routes
 
 - Move read-only technician routes with no DB writes.

--- a/docs/PHASE3L_TECHNICIAN_COUNT_SUMMARY_READONLY.md
+++ b/docs/PHASE3L_TECHNICIAN_COUNT_SUMMARY_READONLY.md
@@ -1,0 +1,144 @@
+# Phase 3L: Technician Count Summary Read-Only Extraction
+
+## Summary
+
+Phase 3L extracted the two technician count summary endpoints from `index.js` into a dedicated read-only route module:
+
+- `GET /tech/completed_count_summary`
+- `GET /tech/rework_count_summary`
+
+The change is intentionally small because these routes sit directly above the technician income route block. The extraction keeps the technician income formula, close-job flow, job mutation routes, auth/session core, frontend files, booking, pricing, and customer flows untouched.
+
+## Audit Result
+
+Both candidate routes are GET-only and query-only:
+
+- No DB writes.
+- No status transition.
+- No payout or income calculation formula changes.
+- No close-job or job mutation behavior.
+- No frontend file changes.
+- Existing PWA/webview fallback through `?username` is preserved.
+
+Risk is **Medium** because the routes use technician identity fallback behavior:
+
+1. First try `getAuthContext(req, res)`.
+2. If the effective user is a technician, use `ctx.effective.username`.
+3. If no authenticated technician is available, allow `?username=` only after validating that username exists in `public.technician_profiles`.
+
+## New Module
+
+Target module:
+
+- `server/routes/technicianCountSummaryReadOnly.js`
+
+Factory:
+
+```js
+module.exports = function createTechnicianCountSummaryReadOnlyRoutes(deps = {}) {
+  // ...
+};
+```
+
+Dependencies are passed explicitly from `index.js`:
+
+- `pool`
+- `getAuthContext`
+- `isTechnicianRole`
+- `_bkkNow`
+- `_bkkYmd`
+- `_bangkokMidnightUTC`
+- `_sqlDonePredicate`
+
+## Mount Location
+
+The router is mounted at the original location immediately before:
+
+- `GET /tech/income_summary`
+
+This preserves route order and keeps the extracted summary routes outside the technician income route block.
+
+## Behavior Preserved
+
+`GET /tech/completed_count_summary` preserves:
+
+- SQL text and parameters.
+- Bangkok month boundary calculation.
+- `finished_at_distinct_jobs` source.
+- `401 { ok:false, error:'UNAUTHORIZED' }` when no session and no `?username`.
+- `403 { ok:false, error:'FORBIDDEN' }` when fallback username is not a technician profile.
+- `500 { ok:false, error:'COMPLETED_COUNT_SUMMARY_FAILED' }`.
+
+`GET /tech/rework_count_summary` preserves:
+
+- `technician_rework_cases` table existence check.
+- Missing-table fallback response:
+  - `{ ok:true, username, month, month_rework_cases:0, source:'technician_rework_cases_missing' }`
+- SQL text and parameters.
+- `technician_rework_cases_created_at` source.
+- `401`, `403`, and `500` error behavior.
+
+## Line Count
+
+Before Phase 3L:
+
+- `index.js` physical lines: `25,260`
+- `index.js` non-empty lines: `23,430`
+
+After Phase 3L:
+
+- `index.js` physical lines: `25,149`
+- `index.js` non-empty lines: `23,330`
+
+Reduction:
+
+- `111` physical lines
+- `100` non-empty lines
+
+## Routes Skipped
+
+Skipped:
+
+- `GET /tech/income_summary`
+- `GET /tech/income_today_month`
+- `GET /tech/income_next_period_estimate`
+- all other technician income routes
+
+Reason:
+
+- These routes touch technician income calculation/display behavior and are frozen unless a dedicated income-display extraction is requested.
+
+## Tests
+
+Required checks:
+
+- `node --check index.js`
+- `node --check server/routes/technicianCountSummaryReadOnly.js`
+- `node --check` on all existing route/helper modules
+- `git diff --check`
+- startup smoke with `node index.js` for 5 seconds
+
+## Manual Smoke Checklist
+
+- App starts.
+- `GET /tech/completed_count_summary` returns the same shape as before.
+- `GET /tech/rework_count_summary` returns the same shape as before.
+- Test normal cookie/session technician flow.
+- Test `?username=` fallback behavior.
+- Technician job page still loads.
+- Technician income page still loads.
+- Close-job flow is not regressed.
+- Booking/pricing/customer flow is not regressed.
+- `/login` and `POST /login` still work.
+- `/tech` and `/tech.html` still work.
+- `/service_zones` and `POST /service_zones/detect` still work.
+
+## Rollback Plan
+
+1. Remove the `createTechnicianCountSummaryReadOnlyRoutes` require from `index.js`.
+2. Remove the `app.use(createTechnicianCountSummaryReadOnlyRoutes(...))` mount from `index.js`.
+3. Restore the two inline handlers in `index.js` at the original location before `GET /tech/income_summary`.
+4. Delete `server/routes/technicianCountSummaryReadOnly.js`.
+5. Run `node --check index.js`.
+6. Run startup smoke.
+7. Smoke test both count summary endpoints with session and `?username`.

--- a/index.js
+++ b/index.js
@@ -46,6 +46,7 @@ const createAdminDeductionsReadOnlyRoutes = require("./server/routes/adminDeduct
 const createTechnicianBaseStatusDataHelpers = require("./server/helpers/technicianBaseStatusDataHelpers");
 const createTechnicianBaseStatusReadOnlyRoutes = require("./server/routes/technicianBaseStatusReadOnly");
 const createTechnicianCalendarReadOnlyRoutes = require("./server/routes/technicianCalendarReadOnly");
+const createTechnicianCountSummaryReadOnlyRoutes = require("./server/routes/technicianCountSummaryReadOnly");
 const {
   calculateTechnicianBaseStatus,
 } = require("./server/helpers/technicianBaseStatusScoring");
@@ -10317,127 +10318,15 @@ async function _buildTechnicianIncomeComputedJobs(tech, start, endEx) {
   }
 }
 
-// NOTE: some tech clients may lose cookie/session in PWA webview.
-// Fail-open by allowing ?username= for technicians only (validated against DB).
-app.get('/tech/completed_count_summary', async (req, res) => {
-  try {
-    let tech = '';
-    try {
-      const ctx = await getAuthContext(req, res);
-      if (ctx.ok && isTechnicianRole(ctx.effective?.role)) tech = String(ctx.effective.username || '').trim();
-    } catch (_) {}
-
-    if (!tech) {
-      const qUser = String(req.query.username || '').trim();
-      if (!qUser) return res.status(401).json({ ok:false, error:'UNAUTHORIZED' });
-      const vr = await pool.query(
-        `SELECT username FROM public.technician_profiles WHERE username=$1 LIMIT 1`,
-        [qUser]
-      );
-      if (!vr.rows || !vr.rows.length) return res.status(403).json({ ok:false, error:'FORBIDDEN' });
-      tech = qUser;
-    }
-
-    const nowBkk = _bkkNow();
-    const { y, m } = _bkkYmd(nowBkk);
-    const monthStart = _bangkokMidnightUTC(y, m, 1);
-    let ny = y, nm = m + 1;
-    if (nm > 12) { nm = 1; ny = y + 1; }
-    const nextMonthStart = _bangkokMidnightUTC(ny, nm, 1);
-    const month = `${y}-${String(m).padStart(2, '0')}`;
-    const donePred = _sqlDonePredicate('j');
-
-    const q = await pool.query(
-      `SELECT COUNT(DISTINCT j.job_id)::int AS month_completed_jobs
-         FROM public.jobs j
-        WHERE ${donePred}
-          AND j.finished_at IS NOT NULL
-          AND j.finished_at >= $1
-          AND j.finished_at < $2
-          AND j.canceled_at IS NULL
-          AND COALESCE(j.job_status,'') NOT ILIKE '%cancel%'
-          AND COALESCE(j.job_status,'') NOT ILIKE '%ยกเลิก%'
-          AND (
-            j.technician_username = $3
-            OR EXISTS (SELECT 1 FROM public.job_team_members tm WHERE tm.job_id=j.job_id AND tm.username=$3)
-            OR EXISTS (SELECT 1 FROM public.job_assignments a WHERE a.job_id=j.job_id AND a.technician_username=$3)
-          )`,
-      [monthStart.toISOString(), nextMonthStart.toISOString(), tech]
-    );
-
-    return res.json({
-      ok: true,
-      username: tech,
-      month,
-      month_completed_jobs: Number(q.rows?.[0]?.month_completed_jobs || 0),
-      source: 'finished_at_distinct_jobs',
-    });
-  } catch (e) {
-    console.error('GET /tech/completed_count_summary', e);
-    return res.status(500).json({ ok:false, error:'COMPLETED_COUNT_SUMMARY_FAILED' });
-  }
-});
-
-
-app.get('/tech/rework_count_summary', async (req, res) => {
-  try {
-    let tech = '';
-    try {
-      const ctx = await getAuthContext(req, res);
-      if (ctx.ok && isTechnicianRole(ctx.effective?.role)) tech = String(ctx.effective.username || '').trim();
-    } catch (_) {}
-
-    if (!tech) {
-      const qUser = String(req.query.username || '').trim();
-      if (!qUser) return res.status(401).json({ ok:false, error:'UNAUTHORIZED' });
-      const vr = await pool.query(
-        `SELECT username FROM public.technician_profiles WHERE username=$1 LIMIT 1`,
-        [qUser]
-      );
-      if (!vr.rows || !vr.rows.length) return res.status(403).json({ ok:false, error:'FORBIDDEN' });
-      tech = qUser;
-    }
-
-    const nowBkk = _bkkNow();
-    const { y, m } = _bkkYmd(nowBkk);
-    const monthStart = _bangkokMidnightUTC(y, m, 1);
-    let ny = y, nm = m + 1;
-    if (nm > 12) { nm = 1; ny = y + 1; }
-    const nextMonthStart = _bangkokMidnightUTC(ny, nm, 1);
-    const month = `${y}-${String(m).padStart(2, '0')}`;
-
-    const exists = await pool.query(`SELECT to_regclass('public.technician_rework_cases') AS tbl`);
-    if (!exists.rows?.[0]?.tbl) {
-      return res.json({ ok:true, username:tech, month, month_rework_cases:0, source:'technician_rework_cases_missing' });
-    }
-
-    const q = await pool.query(
-      `SELECT COUNT(DISTINCT rc.rework_case_id)::int AS month_rework_cases
-         FROM public.technician_rework_cases rc
-         LEFT JOIN public.jobs j ON j.job_id = rc.job_id
-        WHERE COALESCE(rc.created_at, rc.updated_at, NOW()) >= $1
-          AND COALESCE(rc.created_at, rc.updated_at, NOW()) < $2
-          AND (
-            rc.technician_username = $3
-            OR j.technician_username = $3
-            OR EXISTS (SELECT 1 FROM public.job_team_members tm WHERE tm.job_id=rc.job_id AND tm.username=$3)
-            OR EXISTS (SELECT 1 FROM public.job_assignments a WHERE a.job_id=rc.job_id AND a.technician_username=$3)
-          )`,
-      [monthStart.toISOString(), nextMonthStart.toISOString(), tech]
-    );
-
-    return res.json({
-      ok: true,
-      username: tech,
-      month,
-      month_rework_cases: Number(q.rows?.[0]?.month_rework_cases || 0),
-      source: 'technician_rework_cases_created_at',
-    });
-  } catch (e) {
-    console.error('GET /tech/rework_count_summary', e);
-    return res.status(500).json({ ok:false, error:'REWORK_COUNT_SUMMARY_FAILED' });
-  }
-});
+app.use(createTechnicianCountSummaryReadOnlyRoutes({
+  pool,
+  getAuthContext,
+  isTechnicianRole,
+  _bkkNow,
+  _bkkYmd,
+  _bangkokMidnightUTC,
+  _sqlDonePredicate,
+}));
 
 app.get('/tech/income_summary', requireTechnicianSession, async (req, res) => {
   try {

--- a/server/routes/technicianCountSummaryReadOnly.js
+++ b/server/routes/technicianCountSummaryReadOnly.js
@@ -1,0 +1,136 @@
+module.exports = function createTechnicianCountSummaryReadOnlyRoutes(deps = {}) {
+  const express = require("express");
+  const router = express.Router();
+
+  const pool = deps.pool;
+  const getAuthContext = deps.getAuthContext;
+  const isTechnicianRole = deps.isTechnicianRole;
+  const _bkkNow = deps._bkkNow;
+  const _bkkYmd = deps._bkkYmd;
+  const _bangkokMidnightUTC = deps._bangkokMidnightUTC;
+  const _sqlDonePredicate = deps._sqlDonePredicate;
+
+  // NOTE: some tech clients may lose cookie/session in PWA webview.
+  // Fail-open by allowing ?username= for technicians only (validated against DB).
+  router.get('/tech/completed_count_summary', async (req, res) => {
+    try {
+      let tech = '';
+      try {
+        const ctx = await getAuthContext(req, res);
+        if (ctx.ok && isTechnicianRole(ctx.effective?.role)) tech = String(ctx.effective.username || '').trim();
+      } catch (_) {}
+
+      if (!tech) {
+        const qUser = String(req.query.username || '').trim();
+        if (!qUser) return res.status(401).json({ ok:false, error:'UNAUTHORIZED' });
+        const vr = await pool.query(
+          `SELECT username FROM public.technician_profiles WHERE username=$1 LIMIT 1`,
+          [qUser]
+        );
+        if (!vr.rows || !vr.rows.length) return res.status(403).json({ ok:false, error:'FORBIDDEN' });
+        tech = qUser;
+      }
+
+      const nowBkk = _bkkNow();
+      const { y, m } = _bkkYmd(nowBkk);
+      const monthStart = _bangkokMidnightUTC(y, m, 1);
+      let ny = y, nm = m + 1;
+      if (nm > 12) { nm = 1; ny = y + 1; }
+      const nextMonthStart = _bangkokMidnightUTC(ny, nm, 1);
+      const month = `${y}-${String(m).padStart(2, '0')}`;
+      const donePred = _sqlDonePredicate('j');
+
+      const q = await pool.query(
+        `SELECT COUNT(DISTINCT j.job_id)::int AS month_completed_jobs
+           FROM public.jobs j
+          WHERE ${donePred}
+            AND j.finished_at IS NOT NULL
+            AND j.finished_at >= $1
+            AND j.finished_at < $2
+            AND j.canceled_at IS NULL
+            AND COALESCE(j.job_status,'') NOT ILIKE '%cancel%'
+            AND COALESCE(j.job_status,'') NOT ILIKE '%à¸¢à¸à¹€à¸¥à¸´à¸%'
+            AND (
+              j.technician_username = $3
+              OR EXISTS (SELECT 1 FROM public.job_team_members tm WHERE tm.job_id=j.job_id AND tm.username=$3)
+              OR EXISTS (SELECT 1 FROM public.job_assignments a WHERE a.job_id=j.job_id AND a.technician_username=$3)
+            )`,
+        [monthStart.toISOString(), nextMonthStart.toISOString(), tech]
+      );
+
+      return res.json({
+        ok: true,
+        username: tech,
+        month,
+        month_completed_jobs: Number(q.rows?.[0]?.month_completed_jobs || 0),
+        source: 'finished_at_distinct_jobs',
+      });
+    } catch (e) {
+      console.error('GET /tech/completed_count_summary', e);
+      return res.status(500).json({ ok:false, error:'COMPLETED_COUNT_SUMMARY_FAILED' });
+    }
+  });
+
+
+  router.get('/tech/rework_count_summary', async (req, res) => {
+    try {
+      let tech = '';
+      try {
+        const ctx = await getAuthContext(req, res);
+        if (ctx.ok && isTechnicianRole(ctx.effective?.role)) tech = String(ctx.effective.username || '').trim();
+      } catch (_) {}
+
+      if (!tech) {
+        const qUser = String(req.query.username || '').trim();
+        if (!qUser) return res.status(401).json({ ok:false, error:'UNAUTHORIZED' });
+        const vr = await pool.query(
+          `SELECT username FROM public.technician_profiles WHERE username=$1 LIMIT 1`,
+          [qUser]
+        );
+        if (!vr.rows || !vr.rows.length) return res.status(403).json({ ok:false, error:'FORBIDDEN' });
+        tech = qUser;
+      }
+
+      const nowBkk = _bkkNow();
+      const { y, m } = _bkkYmd(nowBkk);
+      const monthStart = _bangkokMidnightUTC(y, m, 1);
+      let ny = y, nm = m + 1;
+      if (nm > 12) { nm = 1; ny = y + 1; }
+      const nextMonthStart = _bangkokMidnightUTC(ny, nm, 1);
+      const month = `${y}-${String(m).padStart(2, '0')}`;
+
+      const exists = await pool.query(`SELECT to_regclass('public.technician_rework_cases') AS tbl`);
+      if (!exists.rows?.[0]?.tbl) {
+        return res.json({ ok:true, username:tech, month, month_rework_cases:0, source:'technician_rework_cases_missing' });
+      }
+
+      const q = await pool.query(
+        `SELECT COUNT(DISTINCT rc.rework_case_id)::int AS month_rework_cases
+           FROM public.technician_rework_cases rc
+           LEFT JOIN public.jobs j ON j.job_id = rc.job_id
+          WHERE COALESCE(rc.created_at, rc.updated_at, NOW()) >= $1
+            AND COALESCE(rc.created_at, rc.updated_at, NOW()) < $2
+            AND (
+              rc.technician_username = $3
+              OR j.technician_username = $3
+              OR EXISTS (SELECT 1 FROM public.job_team_members tm WHERE tm.job_id=rc.job_id AND tm.username=$3)
+              OR EXISTS (SELECT 1 FROM public.job_assignments a WHERE a.job_id=rc.job_id AND a.technician_username=$3)
+            )`,
+        [monthStart.toISOString(), nextMonthStart.toISOString(), tech]
+      );
+
+      return res.json({
+        ok: true,
+        username: tech,
+        month,
+        month_rework_cases: Number(q.rows?.[0]?.month_rework_cases || 0),
+        source: 'technician_rework_cases_created_at',
+      });
+    } catch (e) {
+      console.error('GET /tech/rework_count_summary', e);
+      return res.status(500).json({ ok:false, error:'REWORK_COUNT_SUMMARY_FAILED' });
+    }
+  });
+
+  return router;
+};


### PR DESCRIPTION
## Summary
- extract the two technician count summary read-only endpoints from `index.js`
- add `server/routes/technicianCountSummaryReadOnly.js` using the existing factory/dependency injection pattern
- keep technician income routes/formulas, close-job, job mutation, auth/session core, frontend files, booking, pricing, and customer flow untouched
- document Phase 3L audit, dependencies, smoke checklist, and rollback plan

## Routes moved
- `GET /tech/completed_count_summary`
- `GET /tech/rework_count_summary`

## Safety
- GET/read-only only
- no DB writes or state transitions
- preserves `getAuthContext(req, res)` technician identity behavior
- preserves `?username=` fallback after validation against `public.technician_profiles`
- preserves SQL, response shape, status/error bodies, and console logging
- keeps all technician income routes in `index.js`

## Line count
- `index.js` physical lines: `25,260` -> `25,149`
- `index.js` non-empty lines: `23,430` -> `23,330`

## Validation
- `node --check index.js`
- `node --check server/routes/technicianCountSummaryReadOnly.js`
- `node --check server/routes/technicianCalendarReadOnly.js`
- `node --check server/helpers/technicianBaseStatusScoring.js`
- `node --check server/helpers/technicianBaseStatusDataHelpers.js`
- `node --check server/routes/technicianBaseStatusReadOnly.js`
- `node --check server/routes/accountingReadOnly.js`
- `node --check server/routes/docs.js`
- `node --check server/helpers/adminReworkDeductionsHelpers.js`
- `node --check server/routes/adminDeductionsReadOnly.js`
- `node --check server/routes/adminReworkReadOnly.js`
- `node --check server/routes/pages/index.js`
- `node --check server/routes/serviceZones/index.js`
- `node --check server/routes/catalog/items.js`
- `node --check server/routes/system/index.js`
- `node --check server/routes/users/technicians.js`
- `node --check server/db/pool.js`
- `git diff --check`
- 5-second startup smoke with `node index.js`