### PR TITLE
Fix AI Office payout summary and LINE selected-question context

### DIFF
--- a/admin-ai-office.html
+++ b/admin-ai-office.html
@@ -150,6 +150,12 @@
     .iconBtn.dislikeIcon{background:#fff1f2;color:#b42318;border-color:rgba(180,35,24,.16)}
     .lineBubble.ai.not-used{opacity:.72;background:#f8fafc;border-color:rgba(100,116,139,.25)}
     .lineBubble.ai.not-used .replyText{background:#f8fafc;color:#64748b}
+    .lineBubble.customer.jumpHighlight{animation:customerJumpFlash 1.4s ease}
+    @keyframes customerJumpFlash{0%,100%{box-shadow:0 8px 18px rgba(7,21,47,.07)}18%,72%{box-shadow:0 0 0 4px rgba(255,204,0,.72),0 14px 28px rgba(7,21,47,.16)}}
+    .aiDraftSource{display:flex;align-items:flex-start;justify-content:space-between;gap:8px;margin:8px 0 10px;padding:8px 10px;border-radius:14px;background:#f8fbff;border:1px solid rgba(21,88,214,.11);color:#475569;font-size:12px;font-weight:900;white-space:pre-wrap}
+    .miniJumpBtn{appearance:none;border:1px solid rgba(21,88,214,.18);background:#fff;color:#0d3d8d;width:30px;height:30px;min-width:30px;border-radius:999px;font-weight:1000;line-height:1}
+    .newCustomerContextBar{display:flex;align-items:center;gap:7px;flex-wrap:wrap;margin:0 0 10px;padding:8px 10px;border-radius:14px;background:#fff7ed;border:1px solid rgba(245,158,11,.28);color:#9a3412;font-size:12px;font-weight:950}
+    .newCustomerContextBar button{appearance:none;border:1px solid rgba(154,52,18,.18);background:#fff;color:#9a3412;border-radius:999px;min-height:28px;padding:0 9px;font-size:12px;font-weight:1000}
     .bubbleTitleRow{display:flex;align-items:center;justify-content:space-between;gap:8px;margin-bottom:8px}
     .bubbleTitleRow .bubbleTitle{margin:0}
 

--- a/admin-ai-office.js
+++ b/admin-ai-office.js
@@ -140,6 +140,8 @@
       customer_reply: String(draft.customer_reply || ""),
       customer_question: String(draft.customer_question || state.selectedCustomerQuestion || state.lastCustomerMessage || ""),
       customer_message_id: String(draft.customer_message_id || state.selectedCustomerMessageId || ""),
+      customer_message_received_at: String(draft.customer_message_received_at || ""),
+      explicit_selected: Boolean(draft.explicit_selected),
       admin_question: String(draft.admin_question || ""),
       created_at: new Date().toISOString(),
     });
@@ -147,8 +149,16 @@
     saveLineDraftMemory();
   }
 
+  function explicitSelectedCustomerQuestion() {
+    return clean(state.selectedCustomerQuestion || "");
+  }
+
+  function fallbackLatestCustomerQuestion() {
+    return clean(state.lastCustomerMessage || "");
+  }
+
   function selectedQuestionForLearning() {
-    return clean(state.selectedCustomerQuestion || state.lastCustomerMessage || "");
+    return clean(explicitSelectedCustomerQuestion() || fallbackLatestCustomerQuestion());
   }
 
   function latestInboundMessage() {
@@ -161,9 +171,20 @@
 
   function latestInboundTimeMs() {
     const m = latestInboundMessage();
+    const t = messageTimeMs(m);
+    return Number.isFinite(t) ? t : 0;
+  }
+
+  function messageTimeMs(m) {
     const raw = m?.received_at || m?.created_at || "";
     const t = raw ? new Date(raw).getTime() : 0;
     return Number.isFinite(t) ? t : 0;
+  }
+
+  function findCustomerMessageById(id) {
+    const sid = String(id || "");
+    if (!sid) return null;
+    return (state.selectedMessages || []).find((m, idx) => String(messageIdFor(m, `msg_${idx}`)) === sid) || null;
   }
 
   function excerpt(text, max = 120) {
@@ -546,6 +567,8 @@
         customer_reply: draft.customer_reply,
         customer_question: draft.customer_question,
         customer_message_id: draft.customer_message_id,
+        customer_message_received_at: draft.customer_message_received_at,
+        explicit_selected: draft.explicit_selected,
         created_at: draft.created_at,
         persisted: true,
         skip_persist: true,
@@ -613,18 +636,27 @@
   function renderAiBubble(draft) {
     const reply = clean(draft?.customer_reply || draft?.answer || "");
     const text = reply || "ยังไม่ได้ข้อความพร้อมส่งลูกค้า";
-    const sourceQuestion = clean(draft?.customer_question || selectedQuestionForLearning());
+    const explicitSelected = Object.prototype.hasOwnProperty.call(draft || {}, "explicit_selected")
+      ? Boolean(draft.explicit_selected)
+      : Boolean(explicitSelectedCustomerQuestion());
+    const sourceQuestion = clean(draft?.customer_question || (explicitSelected ? explicitSelectedCustomerQuestion() : fallbackLatestCustomerQuestion()));
     const latestInbound = latestInboundMessage();
-    const sourceMessageId = String(draft?.customer_message_id || (sourceQuestion && state.selectedCustomerMessageId) || (sourceQuestion ? messageIdFor(latestInbound) : "") || "");
-    const sourceLabel = sourceQuestion ? `ตอบจาก:\n“${excerpt(sourceQuestion)}”` : "ตอบจากข้อความล่าสุด";
+    const sourceMessageId = String(draft?.customer_message_id || (explicitSelected ? state.selectedCustomerMessageId : messageIdFor(latestInbound)) || "");
+    const sourceMsg = findCustomerMessageById(sourceMessageId) || (!explicitSelected ? latestInbound : null);
+    const sourceReceivedAt = String(draft?.customer_message_received_at || sourceMsg?.received_at || sourceMsg?.created_at || "");
+    const sourceLabel = explicitSelected && sourceQuestion ? `ตอบจาก:\n“${excerpt(sourceQuestion)}”` : "ตอบจากข้อความล่าสุด";
     const persisted = Boolean(draft?.persisted);
     const draftTime = draft?.created_at ? new Date(draft.created_at).getTime() : Date.now();
-    const hasNewerInbound = Boolean(persisted && latestInboundTimeMs() > draftTime);
+    const sourceTime = sourceReceivedAt ? new Date(sourceReceivedAt).getTime() : 0;
+    const latestTime = latestInboundTimeMs();
+    const hasNewerInbound = Boolean(latestTime && ((sourceTime && latestTime > sourceTime) || latestTime > draftTime));
     if (!draft?.skip_persist && state.selectedConversation?.id && reply) {
       addDraftToConversation(state.selectedConversation.id, {
         customer_reply: reply,
         customer_question: sourceQuestion,
         customer_message_id: sourceMessageId,
+        customer_message_received_at: sourceReceivedAt,
+        explicit_selected: explicitSelected,
         admin_question: draft?.admin_question || state.lastLineRetry || "",
       });
     }
@@ -633,7 +665,7 @@
         <article class="aiNaturalBubble">
           <div class="aiNaturalTop">
             <span class="aiNaturalLabel">AI แนะนำ</span>
-            ${sourceQuestion ? `<span class="aiNaturalSource">ตอบจากคำถามที่เลือก</span>` : `<span class="aiNaturalSource">${persisted ? "จากประวัติก่อนหน้า" : "พร้อมส่งลูกค้า"}</span>`}
+            ${explicitSelected ? `<span class="aiNaturalSource">ตอบจากคำถามที่เลือก</span>` : `<span class="aiNaturalSource">ตอบจากข้อความล่าสุด</span>`}
           </div>
           <div class="aiDraftSource" data-source-message-id="${esc(sourceMessageId)}">
             <span>${esc(sourceLabel)}</span>
@@ -641,7 +673,7 @@
           </div>
           ${hasNewerInbound ? `<div class="newCustomerContextBar">มีข้อความลูกค้าใหม่ <button type="button" data-use-latest-customer>ใช้ข้อความล่าสุด</button><button type="button" data-pick-customer-message>เลือกเอง</button></div>` : ""}
           <div class="replyDisplay" data-reply-display>${esc(text)}</div>
-          <textarea class="replyText" data-reply-text data-source-question="${esc(sourceQuestion)}" data-source-message-id="${esc(sourceMessageId)}">${esc(text)}</textarea>
+          <textarea class="replyText" data-reply-text data-source-question="${esc(sourceQuestion)}" data-source-message-id="${esc(sourceMessageId)}" data-explicit-selected="${explicitSelected ? "1" : "0"}">${esc(text)}</textarea>
           <div class="aiNaturalActions" aria-label="จัดการคำตอบ AI">
             <button class="iconBtn editIcon" type="button" data-edit-reply aria-label="แก้ไขข้อความ" title="แก้ไขข้อความ">✎</button>
             <button class="iconBtn copyIcon" type="button" data-copy-reply aria-label="คัดลอกข้อความนี้" title="คัดลอกข้อความนี้">⧉</button>
@@ -664,7 +696,11 @@
     const input = $("#lineAiQuestion");
     const question = clean(input.value);
     if (!conv?.id || !question) return;
-    const sourceQuestion = selectedQuestionForLearning();
+    const explicitQuestion = explicitSelectedCustomerQuestion();
+    const sourceQuestion = explicitQuestion || fallbackLatestCustomerQuestion();
+    const sourceMessage = explicitQuestion ? findCustomerMessageById(state.selectedCustomerMessageId) : latestInboundMessage();
+    const sourceMessageId = explicitQuestion ? (state.selectedCustomerMessageId || "") : messageIdFor(sourceMessage);
+    const sourceReceivedAt = String(sourceMessage?.received_at || sourceMessage?.created_at || "");
     state.lastLineRetry = question;
     const submitBtn = $("#lineAiForm .sendBtn");
     if (submitBtn) submitBtn.disabled = true;
@@ -679,19 +715,26 @@
         body: JSON.stringify({
           conversation_id: conv.id,
           admin_question: question,
-          selected_customer_question: sourceQuestion,
+          selected_customer_question: explicitQuestion ? sourceQuestion : "",
           prior_drafts: draftsForConversation(conv.id).slice(-6),
           use_shared_memory: true,
-          instruction: sourceQuestion ? `${question}\n\nต้องตอบเฉพาะคำถามลูกค้าที่แอดมินเลือกนี้เป็นหลัก: ${sourceQuestion}` : question,
+          instruction: explicitQuestion ? `${question}\n\nต้องตอบเฉพาะคำถามลูกค้าที่แอดมินเลือกนี้เป็นหลัก: ${sourceQuestion}` : question,
           agent: state.agent === "sales" ? "sales" : "admin"
         })
       });
       removeLatestLoadingBubble();
-      renderAiBubble({ ...(data.draft || { customer_reply: data.answer }), customer_question: sourceQuestion, customer_message_id: state.selectedCustomerMessageId || "", admin_question: question });
+      renderAiBubble({
+        ...(data.draft || { customer_reply: data.answer }),
+        customer_question: sourceQuestion,
+        customer_message_id: sourceMessageId,
+        customer_message_received_at: sourceReceivedAt,
+        explicit_selected: Boolean(explicitQuestion),
+        admin_question: question
+      });
       logSharedMemoryEvent("line_drafted", {
         source: "line_chat",
         conversation_id: conv.id,
-        selected_customer_question: sourceQuestion,
+        selected_customer_question: explicitQuestion ? sourceQuestion : "",
         customer_message: sourceQuestion,
         ai_reply: (data.draft?.customer_reply || data.answer || ""),
         action_status: "drafted",

--- a/admin-ai-office.js
+++ b/admin-ai-office.js
@@ -139,6 +139,7 @@
       id: `draft_${Date.now()}_${Math.random().toString(16).slice(2)}`,
       customer_reply: String(draft.customer_reply || ""),
       customer_question: String(draft.customer_question || state.selectedCustomerQuestion || state.lastCustomerMessage || ""),
+      customer_message_id: String(draft.customer_message_id || state.selectedCustomerMessageId || ""),
       admin_question: String(draft.admin_question || ""),
       created_at: new Date().toISOString(),
     });
@@ -148,6 +149,26 @@
 
   function selectedQuestionForLearning() {
     return clean(state.selectedCustomerQuestion || state.lastCustomerMessage || "");
+  }
+
+  function latestInboundMessage() {
+    return [...(state.selectedMessages || [])].reverse().find((m) => (m.direction || "inbound") === "inbound" && clean(messageText(m)));
+  }
+
+  function messageIdFor(m, fallback = "") {
+    return String(m?.id || m?.message_id || fallback || "");
+  }
+
+  function latestInboundTimeMs() {
+    const m = latestInboundMessage();
+    const raw = m?.received_at || m?.created_at || "";
+    const t = raw ? new Date(raw).getTime() : 0;
+    return Number.isFinite(t) ? t : 0;
+  }
+
+  function excerpt(text, max = 120) {
+    const s = clean(text);
+    return s.length > max ? `${s.slice(0, max - 1)}…` : s;
   }
 
   function saveHistory() {
@@ -524,6 +545,8 @@
       renderAiBubble({
         customer_reply: draft.customer_reply,
         customer_question: draft.customer_question,
+        customer_message_id: draft.customer_message_id,
+        created_at: draft.created_at,
         persisted: true,
         skip_persist: true,
       });
@@ -591,11 +614,17 @@
     const reply = clean(draft?.customer_reply || draft?.answer || "");
     const text = reply || "ยังไม่ได้ข้อความพร้อมส่งลูกค้า";
     const sourceQuestion = clean(draft?.customer_question || selectedQuestionForLearning());
+    const latestInbound = latestInboundMessage();
+    const sourceMessageId = String(draft?.customer_message_id || (sourceQuestion && state.selectedCustomerMessageId) || (sourceQuestion ? messageIdFor(latestInbound) : "") || "");
+    const sourceLabel = sourceQuestion ? `ตอบจาก:\n“${excerpt(sourceQuestion)}”` : "ตอบจากข้อความล่าสุด";
     const persisted = Boolean(draft?.persisted);
+    const draftTime = draft?.created_at ? new Date(draft.created_at).getTime() : Date.now();
+    const hasNewerInbound = Boolean(persisted && latestInboundTimeMs() > draftTime);
     if (!draft?.skip_persist && state.selectedConversation?.id && reply) {
       addDraftToConversation(state.selectedConversation.id, {
         customer_reply: reply,
         customer_question: sourceQuestion,
+        customer_message_id: sourceMessageId,
         admin_question: draft?.admin_question || state.lastLineRetry || "",
       });
     }
@@ -606,9 +635,13 @@
             <span class="aiNaturalLabel">AI แนะนำ</span>
             ${sourceQuestion ? `<span class="aiNaturalSource">ตอบจากคำถามที่เลือก</span>` : `<span class="aiNaturalSource">${persisted ? "จากประวัติก่อนหน้า" : "พร้อมส่งลูกค้า"}</span>`}
           </div>
-          ${sourceQuestion ? `<div class="aiDraftSource">อ้างอิง: ${esc(sourceQuestion)}</div>` : ""}
+          <div class="aiDraftSource" data-source-message-id="${esc(sourceMessageId)}">
+            <span>${esc(sourceLabel)}</span>
+            ${sourceMessageId ? `<button class="miniJumpBtn" type="button" data-jump-source-message="${esc(sourceMessageId)}" aria-label="ไปที่ข้อความลูกค้า" title="ไปที่ข้อความลูกค้า">↩</button>` : ""}
+          </div>
+          ${hasNewerInbound ? `<div class="newCustomerContextBar">มีข้อความลูกค้าใหม่ <button type="button" data-use-latest-customer>ใช้ข้อความล่าสุด</button><button type="button" data-pick-customer-message>เลือกเอง</button></div>` : ""}
           <div class="replyDisplay" data-reply-display>${esc(text)}</div>
-          <textarea class="replyText" data-reply-text data-source-question="${esc(sourceQuestion)}">${esc(text)}</textarea>
+          <textarea class="replyText" data-reply-text data-source-question="${esc(sourceQuestion)}" data-source-message-id="${esc(sourceMessageId)}">${esc(text)}</textarea>
           <div class="aiNaturalActions" aria-label="จัดการคำตอบ AI">
             <button class="iconBtn editIcon" type="button" data-edit-reply aria-label="แก้ไขข้อความ" title="แก้ไขข้อความ">✎</button>
             <button class="iconBtn copyIcon" type="button" data-copy-reply aria-label="คัดลอกข้อความนี้" title="คัดลอกข้อความนี้">⧉</button>
@@ -654,7 +687,7 @@
         })
       });
       removeLatestLoadingBubble();
-      renderAiBubble({ ...(data.draft || { customer_reply: data.answer }), customer_question: sourceQuestion, admin_question: question });
+      renderAiBubble({ ...(data.draft || { customer_reply: data.answer }), customer_question: sourceQuestion, customer_message_id: state.selectedCustomerMessageId || "", admin_question: question });
       logSharedMemoryEvent("line_drafted", {
         source: "line_chat",
         conversation_id: conv.id,
@@ -699,6 +732,25 @@
       syncReplyDisplay(card);
       button.textContent = "✎";
     }
+  }
+
+  function jumpToCustomerMessage(id) {
+    const target = $(`.lineBubble.customer[data-customer-message-id="${CSS.escape(String(id || ""))}"]`);
+    if (!target) return;
+    target.scrollIntoView({ behavior: "smooth", block: "center" });
+    target.classList.add("jumpHighlight");
+    setTimeout(() => target.classList.remove("jumpHighlight"), 1400);
+  }
+
+  function useLatestCustomerMessage() {
+    const latest = latestInboundMessage();
+    if (!latest) return;
+    setSelectedQuestion(messageText(latest), messageIdFor(latest));
+  }
+
+  function pickCustomerMessage() {
+    clearSelectedQuestion(true);
+    showToast("เลือกข้อความลูกค้าด้วยการกดค้างหรือดับเบิลคลิก");
   }
 
   async function copyReply(button) {
@@ -874,6 +926,9 @@
       if (e.target.closest("[data-open-memory]")) return openMemoryPanel();
       if (e.target.closest("[data-prefill-memory]")) return prefillMemoryFromChat();
       if (e.target.closest("[data-edit-reply]")) return toggleEditReply(e.target.closest("[data-edit-reply]"));
+      if (e.target.closest("[data-jump-source-message]")) return jumpToCustomerMessage(e.target.closest("[data-jump-source-message]").dataset.jumpSourceMessage);
+      if (e.target.closest("[data-use-latest-customer]")) return useLatestCustomerMessage();
+      if (e.target.closest("[data-pick-customer-message]")) return pickCustomerMessage();
       if (e.target.closest("[data-selected-question-add-reply]")) return prefillMemoryFromChat("");
       if (e.target.closest("[data-copy-reply]")) return copyReply(e.target.closest("[data-copy-reply]"));
       if (e.target.closest("[data-dislike-reply]")) return dislikeReply(e.target.closest("[data-dislike-reply]"));

--- a/index.js
+++ b/index.js
@@ -52,6 +52,9 @@ const createTechnicianBaseStatusReadOnlyRoutes = require("./server/routes/techni
 const createTechnicianCalendarReadOnlyRoutes = require("./server/routes/technicianCalendarReadOnly");
 const createTechnicianCountSummaryReadOnlyRoutes = require("./server/routes/technicianCountSummaryReadOnly");
 const createAdminAiOfficeReadOnlyRoutes = require("./server/routes/adminAiOfficeReadOnly");
+const createAdminAiOfficeSharedMemoryV27Routes = require("./server/routes/adminAiOfficeSharedMemoryV27");
+const createAdminAiOfficeLineDraftV27Routes = require("./server/routes/adminAiOfficeLineDraftV27");
+const createAdminAiOfficeSmartAssistantV28Routes = require("./server/routes/adminAiOfficeSmartAssistantV28");
 const { createLineWebhookRoutes, ensureLineInboxSchema } = require("./server/routes/lineWebhook");
 const {
   calculateTechnicianBaseStatus,
@@ -4372,7 +4375,17 @@ app.post('/api/logout', async (req, res) => {
   return res.json({ ok: true });
 });
 
-app.use(createAdminAiOfficeReadOnlyRoutes({ pool, requireAdminSession }));
+const aiOfficeAccountingDeps = {
+  buildPayoutTechSummaryRows: _buildPayoutTechSummaryRows,
+  accountingEnrichPayoutTechRows: _accountingEnrichPayoutTechRows,
+  getPayoutPeriod: _getPayoutPeriod,
+  money: _money,
+  paidStatus: _paidStatus,
+};
+app.use(createAdminAiOfficeSharedMemoryV27Routes({ pool, requireAdminSession })); // CWF AI Office shared memory
+app.use(createAdminAiOfficeLineDraftV27Routes({ pool, requireAdminSession })); // CWF AI Office selected-question LINE draft override
+app.use(createAdminAiOfficeSmartAssistantV28Routes({ pool, requireAdminSession, accounting: aiOfficeAccountingDeps })); // CWF AI Office deterministic payout + availability
+app.use(createAdminAiOfficeReadOnlyRoutes({ pool, requireAdminSession, accounting: aiOfficeAccountingDeps }));
 app.get("/admin/ai-office", aiOfficeNoCache, requireAdminSession, (req, res) => res.sendFile(sendHtml("admin-ai-office.html")));
 app.get("/admin/ai-office.html", aiOfficeNoCache, requireAdminSession, (req, res) => res.sendFile(sendHtml("admin-ai-office.html")));
 app.get("/admin-ai-office.html", aiOfficeNoCache, requireAdminSession, (req, res) => res.sendFile(sendHtml("admin-ai-office.html")));

--- a/server/routes/adminAiOfficeLineDraftV27.js
+++ b/server/routes/adminAiOfficeLineDraftV27.js
@@ -28,6 +28,16 @@ function inferSituation(text) {
   if (/ล้างแบบ|แบบไหน|พรีเมียม|ปกติ|แขวนคอยล์|ตัดล้าง/.test(s)) return "cleaning_package";
   return "general";
 }
+function isAdminCorrection(text) {
+  return /(ผิด|ไม่ใช่|ยังว่าง|อย่าบอกว่าคิวเต็ม|ตอบแบบนี้ไม่ดี|ควรตอบแบบนี้|มั่ว|งง)/i.test(String(text || ""));
+}
+function correctionSituation(text) {
+  const s = String(text || "").toLowerCase();
+  if (/(คิว|ว่าง|ช่าง|เวลา|เต็ม)/.test(s)) return "availability_logic";
+  if (/(รายได้ช่าง|ยอดช่าง|ต้องจ่ายช่าง|ยังไม่จ่ายช่าง|จ่ายช่าง|payout|commission|technician income)/i.test(s)) return "payout_logic";
+  if (/(ราคา|แพง|แบบไหนดี|โปร|ส่วนลด)/.test(s)) return "sales_reply_logic";
+  return "customer_reply_style";
+}
 function getAdminUser(req) {
   return cleanText(req.session?.user?.username || req.session?.user?.email || req.session?.username || req.user?.username || req.user?.email || "", 120);
 }
@@ -83,7 +93,8 @@ async function loadSharedMemoryForDraft(pool, { conversationId, selectedQuestion
          AND action_status <> 'disliked'
          AND event_type <> 'disliked'
          AND (final_admin_reply <> '' OR ai_reply <> '')
-       ORDER BY CASE WHEN action_status IN ('saved','copied','liked') THEN 0 ELSE 1 END,
+       ORDER BY CASE WHEN event_type='admin_correction' OR action_status='correction' THEN 0 ELSE 1 END,
+                CASE WHEN action_status IN ('saved','copied','liked') THEN 0 ELSE 1 END,
                 CASE WHEN source='reply_example' THEN 0 ELSE 1 END,
                 created_at DESC
        LIMIT 8
@@ -271,11 +282,29 @@ module.exports = function createAdminAiOfficeLineDraftV27Routes(deps = {}) {
       const messages = await loadMessages(pool, conversationId);
       if (!messages.length) return res.status(400).json({ ok:false, error:"ยังไม่มีข้อความในแชทนี้" });
 
-      const selectedQuestion = cleanText(req.body?.selected_customer_question, 2000)
-        || cleanText([...messages].reverse().find((m) => m.direction === "inbound" && m.message_text)?.message_text || conversation.last_message_text, 2000);
+      const selectedQuestionFromRequest = cleanText(req.body?.selected_customer_question, 2000);
+      const latestInbound = [...messages].reverse().find((m) => m.direction === "inbound" && m.message_text);
+      const latestCustomerMessage = cleanText(latestInbound?.message_text || conversation.last_message_text, 2000);
+      const selectedQuestion = selectedQuestionFromRequest || latestCustomerMessage;
+      const selectedQuestionUsed = Boolean(selectedQuestionFromRequest);
+      const draftSource = selectedQuestionUsed ? "selected_customer_question" : "latest_customer_message";
       const adminQuestion = cleanText(req.body?.admin_question || req.body?.instruction || "ควรตอบลูกค้ายังไง", 1200);
       const language = detectLanguage(selectedQuestion);
       const situationType = inferSituation(`${selectedQuestion}\n${adminQuestion}`);
+      if (isAdminCorrection(adminQuestion)) {
+        await logSharedDraftMemory(pool, req, {
+          source: "line_chat",
+          event_type: "admin_correction",
+          agent_key: "admin",
+          conversation_id: conversationId,
+          selected_customer_question: selectedQuestion,
+          customer_message: selectedQuestion,
+          final_admin_reply: adminQuestion,
+          action_status: "correction",
+          situation_type: correctionSituation(`${selectedQuestion}\n${adminQuestion}`),
+          metadata: { auto_detected: true },
+        });
+      }
       const examples = await loadExamples(pool, { situationType, language });
       const sharedMemory = await loadSharedMemoryForDraft(pool, { conversationId, selectedQuestion, situationType, language });
       const priorDrafts = Array.isArray(req.body?.prior_drafts) ? req.body.prior_drafts.slice(-5) : [];
@@ -293,7 +322,9 @@ module.exports = function createAdminAiOfficeLineDraftV27Routes(deps = {}) {
       ].join(" ");
 
       const prompt = [
-        "selected_customer_question:", selectedQuestion, "",
+        "draft_source:", draftSource, "",
+        "selected_customer_question_main:", selectedQuestion, "",
+        "latest_customer_message_context_only:", latestCustomerMessage, "",
         "admin_instruction:", adminQuestion, "",
         "conversation:",
         JSON.stringify({ display_name: conversation.display_name || "", messages: messages.map((m) => ({ direction:m.direction, text:m.message_text, at:m.received_at || m.created_at })).slice(-20) }, null, 2),
@@ -341,6 +372,9 @@ module.exports = function createAdminAiOfficeLineDraftV27Routes(deps = {}) {
         thai_translation: cleanText(parsed.thai_translation, 1000),
         selected_customer_question: selectedQuestion,
         situation_type: situationType,
+        selected_question_used: selectedQuestionUsed,
+        draft_source: draftSource,
+        latest_customer_message: latestCustomerMessage,
         used_reply_examples: examples.map((e) => ({ id:e.id, situation_type:e.situation_type, language:e.language, service_type:e.service_type })),
       };
       const saved = await saveDraft(pool, req, { conversation_id: conversationId, selected_customer_message: selectedQuestion, admin_instruction: adminQuestion, ai_draft: customerReply, metadata: { situation_type: situationType, language, used_example_ids: draft.used_reply_examples.map((e) => e.id) } }).catch(() => null);
@@ -357,7 +391,18 @@ module.exports = function createAdminAiOfficeLineDraftV27Routes(deps = {}) {
         situation_type: situationType,
         metadata: { saved_draft_id: saved?.id || null, used_example_ids: draft.used_reply_examples.map((e) => e.id) },
       });
-      return res.json({ ok:true, answer:customerReply, draft, used_reply_examples:draft.used_reply_examples, conversation, messages });
+      return res.json({
+        ok:true,
+        answer:customerReply,
+        draft,
+        used_reply_examples:draft.used_reply_examples,
+        conversation,
+        messages,
+        selected_question_used: selectedQuestionUsed,
+        selected_customer_question: selectedQuestion,
+        latest_customer_message: latestCustomerMessage,
+        draft_source: draftSource,
+      });
     } catch (e) {
       console.error("V27 /line-draft-reply error:", e);
       return res.status(e.status || 500).json({ ok:false, error:e.message || "ร่างข้อความจาก LINE ไม่สำเร็จ" });

--- a/server/routes/adminAiOfficeSharedMemoryV27.js
+++ b/server/routes/adminAiOfficeSharedMemoryV27.js
@@ -124,6 +124,7 @@ async function loadSharedMemoryContext(pool, body = {}) {
        AND action_status <> 'disliked'
        AND event_type <> 'disliked'
      ORDER BY
+       CASE WHEN event_type='admin_correction' OR action_status='correction' THEN 0 ELSE 1 END,
        CASE WHEN action_status IN ('saved','copied','liked') THEN 0 ELSE 1 END,
        CASE WHEN source='reply_example' THEN 0 ELSE 1 END,
        created_at DESC

--- a/server/routes/adminAiOfficeSmartAssistantV28.js
+++ b/server/routes/adminAiOfficeSmartAssistantV28.js
@@ -81,10 +81,145 @@ function isCorrectionQuestion(question) {
 }
 function correctionSituation(question) {
   const q = String(question || "").toLowerCase();
+  if (/(รายได้ช่าง|ยอดช่าง|ต้องจ่ายช่าง|ยังไม่จ่ายช่าง|จ่ายช่าง|payout|technician income|commission)/i.test(q)) return "payout_logic";
   if (/(คิว|ว่าง|ช่าง|เวลา|บ่าย|เช้า|เย็น|นัด|เต็ม)/.test(q)) return "availability_logic";
   if (/(ราคา|แพง|ส่วนลด|โปร)/.test(q)) return "sales_reply_logic";
   if (/(ลูกค้า|แชท|ตอบ|line|ไลน์)/.test(q)) return "customer_reply_style";
+  if (/(รายได้ช่าง|ยอดช่าง|ต้องจ่ายช่าง|ยังไม่จ่ายช่าง|จ่ายช่าง|payout|technician income|commission)/i.test(q)) return "payout_logic";
   return "admin_correction";
+}
+function isPayoutQuestion(question) {
+  return /(รายได้ช่าง|ยอดช่าง|ต้องจ่ายช่าง|ยังไม่จ่ายช่าง|จ่ายช่าง|payout|technician income|commission)/i.test(String(question || ""));
+}
+function currentBangkokPayoutId(date = new Date()) {
+  const parts = bangkokDateParts(date);
+  const type = parts.d <= 10 ? "10" : "25";
+  return `payout_${parts.y}-${pad(parts.m)}_${type}`;
+}
+function money(value) {
+  const n = Number(value || 0);
+  return Number.isFinite(n) ? Math.round((n + Number.EPSILON) * 100) / 100 : 0;
+}
+function payoutPeriodLabel(period = {}) {
+  const start = String(period.period_start || "").slice(0, 10);
+  const end = String(period.period_end || "").slice(0, 10);
+  if (!start && !end) return String(period.payout_id || "");
+  return `${start || "-"} ถึง ${end || "-"}`;
+}
+async function buildPayoutSummary({ accounting, payoutId }) {
+  const warnings = [];
+  if (!accounting?.buildPayoutTechSummaryRows) {
+    return {
+      ok: false,
+      error: "MISSING_ACCOUNTING_PAYOUT_SOURCE",
+      diagnostics: {
+        missing_dependency: "accounting.buildPayoutTechSummaryRows",
+        expected_source: "index.js _buildPayoutTechSummaryRows / server/routes/accountingReadOnly.js buildPayoutTechSummaryRows",
+      },
+      period: { date_from: "", date_to: "", label: "" },
+      totals: {},
+      technicians: [],
+      warnings: ["AI Office payout summary cannot read the accounting payout helper."],
+    };
+  }
+
+  const payload = await accounting.buildPayoutTechSummaryRows(payoutId);
+  const period = payload?.period || await accounting.getPayoutPeriod?.(payoutId);
+  if (!period) {
+    return {
+      ok: false,
+      error: "PAYOUT_PERIOD_NOT_FOUND",
+      diagnostics: { payout_id: payoutId, source: payload?.source || "none" },
+      period: { date_from: "", date_to: "", label: payoutId },
+      totals: {},
+      technicians: [],
+      warnings: [`No payout period or virtual payout bounds found for ${payoutId}.`],
+    };
+  }
+
+  let rows = payload?.techs || [];
+  if (accounting.accountingEnrichPayoutTechRows) {
+    rows = await accounting.accountingEnrichPayoutTechRows(payoutId, period, rows);
+  }
+  const technicians = rows.map((row) => {
+    const payable = money(row.net_amount);
+    const paid = money(row.paid_amount);
+    const unpaid = money(Math.max(0, payable - paid));
+    const paidStatus = String(row.paid_status || (accounting.paidStatus ? accounting.paidStatus(payable, paid) : "") || "").trim() || (paid >= payable && payable > 0 ? "paid" : paid > 0 ? "partial" : "unpaid");
+    const jobCount = Number(row.jobs_count || row.job_count || 0);
+    return {
+      technician_key: row.technician_username || "",
+      technician_name: row.technician_full_name || row.technician_username || "",
+      payable_total: payable,
+      paid_total: paid,
+      unpaid_total: paidStatus === "paid" ? 0 : unpaid,
+      partial_total: paidStatus === "partial" ? unpaid : 0,
+      cash_held_total: money(row.cash_held_amount),
+      cash_offset_total: money(Math.abs(Number(row.adj_total || 0)) || 0),
+      job_count: jobCount,
+      paid_job_count: paidStatus === "paid" ? jobCount : 0,
+      unpaid_job_count: paidStatus === "unpaid" ? jobCount : 0,
+      partial_job_count: paidStatus === "partial" ? jobCount : 0,
+      rows: [],
+      source: row.source || payload?.source || "",
+    };
+  });
+  const totals = technicians.reduce((acc, t) => {
+    acc.total_payable += t.payable_total;
+    acc.total_paid += t.paid_total;
+    acc.total_unpaid += t.unpaid_total;
+    acc.total_partial += t.partial_total;
+    acc.total_cash_held_by_technicians += t.cash_held_total;
+    acc.total_cash_offset += t.cash_offset_total;
+    return acc;
+  }, {
+    total_payable: 0,
+    total_paid: 0,
+    total_unpaid: 0,
+    total_partial: 0,
+    total_cash_held_by_technicians: 0,
+    total_cash_offset: 0,
+  });
+  Object.keys(totals).forEach((key) => { totals[key] = money(totals[key]); });
+  if (!technicians.length) warnings.push("ไม่พบรายช่างในงวดนี้จากแหล่ง accounting payout");
+  return {
+    ok: true,
+    payout_id: payoutId,
+    source: payload?.source || "accounting_payout_helper",
+    period: {
+      date_from: String(period.period_start || "").slice(0, 10),
+      date_to: String(period.period_end || "").slice(0, 10),
+      label: payoutPeriodLabel(period),
+    },
+    totals,
+    technicians,
+    warnings,
+  };
+}
+function formatPayoutAnswer(summary) {
+  if (!summary?.ok) {
+    const diagnostics = summary?.diagnostics ? JSON.stringify(summary.diagnostics) : summary?.error || "unknown";
+    return `ยังสรุปยอดช่างจากข้อมูลจริงไม่ได้ค่ะ\n\nสาเหตุ: ${summary?.error || "PAYOUT_SUMMARY_FAILED"}\nDiagnostics: ${diagnostics}`;
+  }
+  const lines = [
+    `สรุปยอดช่างงวด ${summary.period?.label || summary.payout_id || ""} ค่ะ`,
+    "",
+    `ยอดต้องจ่ายช่างรวม ${summary.totals.total_payable} บาท`,
+    `จ่ายแล้ว ${summary.totals.total_paid} บาท`,
+    `ยังไม่จ่าย ${summary.totals.total_unpaid} บาท`,
+  ];
+  if (summary.totals.total_cash_held_by_technicians) lines.push(`เงินสดที่ช่างถือไว้ ${summary.totals.total_cash_held_by_technicians} บาท`);
+  lines.push("", "แยกรายช่าง:");
+  for (const t of (summary.technicians || []).slice(0, 12)) {
+    lines.push(`- ${t.technician_name || t.technician_key}: ต้องจ่าย ${t.payable_total} / จ่ายแล้ว ${t.paid_total} / คงเหลือ ${t.unpaid_total} บาท (${t.job_count} งาน)`);
+  }
+  const follow = (summary.technicians || []).filter((t) => Number(t.unpaid_total || 0) > 0).slice(0, 8);
+  if (follow.length) {
+    lines.push("", "รายการที่ต้องตาม:");
+    follow.forEach((t) => lines.push(`- ${t.technician_name || t.technician_key} / คงเหลือ ${t.unpaid_total} บาท / ${t.unpaid_job_count || t.partial_job_count || t.job_count} งาน`));
+  }
+  if (summary.warnings?.length) lines.push("", `หมายเหตุ: ${summary.warnings.join(" | ")}`);
+  return lines.join("\n");
 }
 function normalizeTechName(value) {
   return String(value || "").toLowerCase().replace(/\s+/g, "").replace(/[^a-z0-9ก-๙]/g, "");
@@ -209,6 +344,30 @@ async function loadDayJobs(pool, isoDate) {
   `, [isoDate]);
   return (r.rows || []).filter((row) => !hasDoneOrCanceled(row));
 }
+async function loadActiveTechnicians(pool) {
+  try {
+    const r = await pool.query(`
+      SELECT DISTINCT username, COALESCE(NULLIF(full_name,''), username) AS full_name
+      FROM (
+        SELECT username, full_name
+          FROM public.users
+         WHERE role IN ('technician','tech','senior_technician','lead_technician')
+        UNION
+        SELECT username, full_name
+          FROM public.technician_profiles
+         WHERE username IS NOT NULL
+           AND COALESCE(partner_status,'active') NOT IN ('rejected','suspended','inactive')
+           AND COALESCE(accept_status,'ready') NOT IN ('paused','suspended')
+      ) t
+      WHERE username IS NOT NULL
+      ORDER BY username
+      LIMIT 180
+    `);
+    return r.rows || [];
+  } catch (_) {
+    return [];
+  }
+}
 
 function buildBusySlots(jobs) {
   const busyByTech = new Map();
@@ -280,16 +439,26 @@ function computeGaps(busySlots, constraint) {
     .map((g) => ({ ...g, start_display: formatMins(g.start), end_display: formatMins(g.end), minutes: g.end - g.start }));
 }
 
-function analyzeAvailability({ jobs, question }) {
+function analyzeAvailability({ jobs, question, activeTechnicians = [] }) {
   const dateInfo = parseTargetDate(question);
   const constraint = parseTimeConstraint(question);
   const requestedTech = extractRequestedTech(question);
   const requestedNorm = normalizeTechName(requestedTech);
+  const includeAllActive = /ช่างทั้งหมด/.test(String(question || "")) && !/เฉพาะช่างที่มีงานวันนี้/.test(String(question || ""));
+  const onlyWithJobsToday = /เฉพาะช่างที่มีงานวันนี้/.test(String(question || ""));
   const { busyByTech, all } = buildBusySlots(jobs);
+  if (includeAllActive) {
+    for (const tech of activeTechnicians || []) {
+      const name = cleanText(tech.full_name || tech.username, 120);
+      const key = normalizeTechName(tech.username || name);
+      if (key && !busyByTech.has(key)) busyByTech.set(key, { name, slots: [] });
+    }
+  }
   const techRows = Array.from(busyByTech.values()).filter((v) => v.name && v.name !== "ไม่ระบุช่าง");
+  const filteredTechRows = onlyWithJobsToday ? techRows.filter((v) => (v.slots || []).length > 0) : techRows;
   const targetTechs = requestedNorm
-    ? techRows.filter((v) => normalizeTechName(v.name).includes(requestedNorm.replace(/^ช่าง/, "")) || requestedNorm.includes(normalizeTechName(v.name)))
-    : techRows;
+    ? filteredTechRows.filter((v) => normalizeTechName(v.name).includes(requestedNorm.replace(/^ช่าง/, "")) || requestedNorm.includes(normalizeTechName(v.name)))
+    : filteredTechRows;
 
   const analyses = (targetTechs.length ? targetTechs : techRows).map((tech) => ({
     technician: tech.name,
@@ -319,6 +488,9 @@ function analyzeAvailability({ jobs, question }) {
     overall_available_slots: allGaps.map((g) => ({ start: g.start_display, end: g.end_display, minutes: g.minutes })),
     has_available_slot: hasAnySlot,
     confidence: jobs.some((j) => !Number(j.duration_min || 0)) ? "medium" : "high",
+    confidence_warning: jobs.some((j) => !Number(j.duration_min || 0)) ? "มีบางงานไม่มี duration_min ระบบจึงใช้เวลาประเมินตามประเภทงาน" : "",
+    include_all_active_technicians: includeAllActive,
+    only_technicians_with_jobs_today: onlyWithJobsToday,
     warning: "คำนวณจากงานในระบบและ buffer เดินทาง 30 นาที ถ้าจะรับงานจริงควรเช็กพื้นที่และจำนวนเครื่องก่อนยืนยันลูกค้า",
   };
 }
@@ -352,8 +524,27 @@ function answerAvailability(result) {
 module.exports = function createAdminAiOfficeSmartAssistantV28Routes(deps = {}) {
   const pool = deps.pool;
   const requireAdminSession = deps.requireAdminSession;
+  const accounting = deps.accounting || {};
   if (!pool || !requireAdminSession) throw new Error("createAdminAiOfficeSmartAssistantV28Routes requires pool and requireAdminSession");
   const router = express.Router();
+
+  router.get("/admin/ai-office/accounting/payout-summary", requireAdminSession, async (req, res) => {
+    try {
+      const payoutId = cleanText(req.query?.payout_id, 80) || currentBangkokPayoutId();
+      const summary = await buildPayoutSummary({ accounting, payoutId });
+      return res.status(summary.ok ? 200 : 500).json(summary);
+    } catch (e) {
+      return res.status(e.status || 500).json({
+        ok: false,
+        error: e.message || "PAYOUT_SUMMARY_FAILED",
+        diagnostics: { route: "/admin/ai-office/accounting/payout-summary", source: "accounting.buildPayoutTechSummaryRows" },
+        period: { date_from: "", date_to: "", label: "" },
+        totals: {},
+        technicians: [],
+        warnings: [String(e.message || e)],
+      });
+    }
+  });
 
   router.post("/admin/ai-office/ask", requireAdminSession, async (req, res, next) => {
     const question = cleanText(req.body?.question, 2000);
@@ -372,11 +563,36 @@ module.exports = function createAdminAiOfficeSmartAssistantV28Routes(deps = {}) 
         });
       }
 
+      if (isPayoutQuestion(question)) {
+        const payoutId = cleanText(req.body?.payout_id || req.query?.payout_id, 80) || currentBangkokPayoutId();
+        const summary = await buildPayoutSummary({ accounting, payoutId });
+        const answer = formatPayoutAnswer(summary);
+        await logMemory(pool, req, {
+          source: "accounting_payout_summary",
+          event_type: summary.ok ? "payout_answered" : "payout_diagnostic",
+          agent_key: cleanText(req.body?.agent || "admin", 40),
+          customer_message: question,
+          ai_reply: answer,
+          action_status: summary.ok ? "answered" : "diagnostic",
+          situation_type: "payout_logic",
+          tags: ["deterministic", "payout", "read_only"],
+          metadata: { payout_summary: summary },
+        });
+        return res.json({
+          ok: summary.ok,
+          answer,
+          payout_summary: summary,
+          agent: { key: req.body?.agent || "admin", name: "Admin AI", role: "deterministic accounting payout summary" },
+          context: { payout_summary: summary },
+        });
+      }
+
       if (!isAvailabilityQuestion(question)) return next();
 
       const dateInfo = parseTargetDate(question);
       const jobs = await loadDayJobs(pool, dateInfo.iso);
-      const result = analyzeAvailability({ jobs, question });
+      const activeTechnicians = /ช่างทั้งหมด/.test(question) ? await loadActiveTechnicians(pool) : [];
+      const result = analyzeAvailability({ jobs, question, activeTechnicians });
       const answer = answerAvailability(result);
 
       await logMemory(pool, req, {
@@ -408,7 +624,8 @@ module.exports = function createAdminAiOfficeSmartAssistantV28Routes(deps = {}) 
       const question = cleanText(req.body?.question || req.query?.question, 2000);
       const dateInfo = parseTargetDate(question);
       const jobs = await loadDayJobs(pool, dateInfo.iso);
-      const result = analyzeAvailability({ jobs, question });
+      const activeTechnicians = /ช่างทั้งหมด/.test(question) ? await loadActiveTechnicians(pool) : [];
+      const result = analyzeAvailability({ jobs, question, activeTechnicians });
       return res.json({ ok: true, result, answer: answerAvailability(result) });
     } catch (e) {
       return res.status(e.status || 500).json({ ok: false, error: e.message || "ANALYZE_AVAILABILITY_FAILED" });

--- a/server/routes/adminAiOfficeSmartAssistantV28.js
+++ b/server/routes/adminAiOfficeSmartAssistantV28.js
@@ -106,6 +106,28 @@ function payoutPeriodLabel(period = {}) {
   if (!start && !end) return String(period.payout_id || "");
   return `${start || "-"} ถึง ${end || "-"}`;
 }
+function normalizePayoutJobRow(row = {}) {
+  return {
+    job_id: row.job_id || row.jobId || null,
+    booking_code: row.booking_code || row.bookingCode || "",
+    finished_at: row.finished_at || row.finishedAt || null,
+    payable_amount: money(row.earn_amount ?? row.payable_amount ?? row.net_amount ?? row.amount ?? 0),
+    source: row.source || row.step_rule_key || "",
+    detail: row.detail_json || row.detail || row.metadata || null,
+  };
+}
+function payoutJobRowsForTech(row = {}, payload = {}) {
+  const direct = row.rows || row.jobs || row.lines || row.payout_lines || row.job_rows;
+  if (Array.isArray(direct) && direct.length) return direct.map(normalizePayoutJobRow);
+  const tech = String(row.technician_username || row.technician_key || "").trim();
+  const payloadLines = payload.lines || payload.rows || payload.job_rows || payload.payout_lines;
+  if (Array.isArray(payloadLines) && payloadLines.length) {
+    return payloadLines
+      .filter((line) => String(line.technician_username || line.technician_key || "").trim() === tech)
+      .map(normalizePayoutJobRow);
+  }
+  return [];
+}
 async function buildPayoutSummary({ accounting, payoutId }) {
   const warnings = [];
   if (!accounting?.buildPayoutTechSummaryRows) {
@@ -141,12 +163,15 @@ async function buildPayoutSummary({ accounting, payoutId }) {
   if (accounting.accountingEnrichPayoutTechRows) {
     rows = await accounting.accountingEnrichPayoutTechRows(payoutId, period, rows);
   }
+  let hasAnyJobRows = false;
   const technicians = rows.map((row) => {
     const payable = money(row.net_amount);
     const paid = money(row.paid_amount);
     const unpaid = money(Math.max(0, payable - paid));
     const paidStatus = String(row.paid_status || (accounting.paidStatus ? accounting.paidStatus(payable, paid) : "") || "").trim() || (paid >= payable && payable > 0 ? "paid" : paid > 0 ? "partial" : "unpaid");
     const jobCount = Number(row.jobs_count || row.job_count || 0);
+    const jobRows = payoutJobRowsForTech(row, payload);
+    if (jobRows.length) hasAnyJobRows = true;
     return {
       technician_key: row.technician_username || "",
       technician_name: row.technician_full_name || row.technician_username || "",
@@ -160,7 +185,7 @@ async function buildPayoutSummary({ accounting, payoutId }) {
       paid_job_count: paidStatus === "paid" ? jobCount : 0,
       unpaid_job_count: paidStatus === "unpaid" ? jobCount : 0,
       partial_job_count: paidStatus === "partial" ? jobCount : 0,
-      rows: [],
+      rows: jobRows,
       source: row.source || payload?.source || "",
     };
   });
@@ -182,6 +207,7 @@ async function buildPayoutSummary({ accounting, payoutId }) {
   });
   Object.keys(totals).forEach((key) => { totals[key] = money(totals[key]); });
   if (!technicians.length) warnings.push("ไม่พบรายช่างในงวดนี้จากแหล่ง accounting payout");
+  if (technicians.length && !hasAnyJobRows) warnings.push("ยังไม่มีรายละเอียดระดับงานจาก payout helper");
   return {
     ok: true,
     payout_id: payoutId,
@@ -579,7 +605,7 @@ module.exports = function createAdminAiOfficeSmartAssistantV28Routes(deps = {}) 
           metadata: { payout_summary: summary },
         });
         return res.json({
-          ok: summary.ok,
+          ok: true,
           answer,
           payout_summary: summary,
           agent: { key: req.body?.agent || "admin", name: "Admin AI", role: "deterministic accounting payout summary" },


### PR DESCRIPTION
Production-focused AI Office fix.

Scope:
- Add read-only AI Office payout summary route using existing accounting payout helpers.
- Route payout questions to deterministic payout summary/diagnostics instead of generic AI.
- Fix LINE draft selected_customer_question handling so explicit selections are respected and latest inbound is fallback only.
- Add compact AI reply source quote and newer-customer-message context cue.
- Preserve draft-only/read-only behavior; no LINE sending, no job/payment/payout mutations.

Checks run:
- node --check admin-ai-office.js
- node --check server/routes/adminAiOfficeSmartAssistantV28.js
- node --check server/routes/adminAiOfficeLineDraftV27.js
- node --check server/routes/adminAiOfficeSharedMemoryV27.js
- node --check index.js
- git diff --check
- payout diagnostic smoke test
