### PR TITLE
Add AI Office Brain Manager

### DIFF
--- a/admin-ai-office.html
+++ b/admin-ai-office.html
@@ -502,6 +502,50 @@
           <button class="whiteBtn" type="button" id="memoryReload">โหลดคลังคำตอบ</button>
         </div>
       </form>
+      <form class="memoryForm" id="brainImportForm" style="margin-top:12px">
+        <label>สมอง AI
+          <input id="brainFile" type="file" accept=".json,.jsonl,.csv,application/json,text/csv">
+        </label>
+        <label>โหมดบันทึก
+          <select id="brainCommitMode"><option value="append">append</option><option value="replace_same_source">replace_same_source</option></select>
+        </label>
+        <label>source
+          <input id="brainSource" placeholder="manual_import">
+        </label>
+        <div class="wide bubbleActions">
+          <button class="whiteBtn" type="submit">Preview import</button>
+          <button class="blueBtn" type="button" id="brainCommit" disabled>Commit import</button>
+          <button class="whiteBtn" type="button" id="brainExport">Export brain</button>
+        </div>
+        <div class="wide" id="brainWarnings"></div>
+        <div class="memoryList wide" id="brainPreview"></div>
+      </form>
+      <form class="memoryForm" id="brainSearchForm" style="margin-top:12px">
+        <label class="wide">ค้นหาสมอง AI
+          <input id="brainSearch" placeholder="price, warranty, objection">
+        </label>
+        <label>item_type
+          <select id="brainTypeFilter">
+            <option value="">all</option>
+            <option value="service_fact">service_fact</option>
+            <option value="pricing_rule">pricing_rule</option>
+            <option value="sales_playbook">sales_playbook</option>
+            <option value="objection_handler">objection_handler</option>
+            <option value="approved_reply">approved_reply</option>
+            <option value="bad_reply_pattern">bad_reply_pattern</option>
+            <option value="admin_correction">admin_correction</option>
+            <option value="policy_rule">policy_rule</option>
+            <option value="workflow_rule">workflow_rule</option>
+            <option value="technician_rule">technician_rule</option>
+            <option value="customer_stage_rule">customer_stage_rule</option>
+          </select>
+        </label>
+        <label>agent_key
+          <select id="brainAgentFilter"><option value="">all</option><option value="all">all</option><option value="admin">admin</option><option value="sales">sales</option><option value="ops">ops</option><option value="line">line</option></select>
+        </label>
+        <div class="wide"><button class="whiteBtn" type="submit">ค้นหา</button></div>
+      </form>
+      <div class="memoryList" id="brainList"></div>
       <div class="memoryList" id="memoryList"></div>
     </div>
   </section>

--- a/admin-ai-office.html
+++ b/admin-ai-office.html
@@ -150,6 +150,12 @@
     .iconBtn.dislikeIcon{background:#fff1f2;color:#b42318;border-color:rgba(180,35,24,.16)}
     .lineBubble.ai.not-used{opacity:.72;background:#f8fafc;border-color:rgba(100,116,139,.25)}
     .lineBubble.ai.not-used .replyText{background:#f8fafc;color:#64748b}
+    .lineBubble.customer.jumpHighlight{animation:customerJumpFlash 1.4s ease}
+    @keyframes customerJumpFlash{0%,100%{box-shadow:0 8px 18px rgba(7,21,47,.07)}18%,72%{box-shadow:0 0 0 4px rgba(255,204,0,.72),0 14px 28px rgba(7,21,47,.16)}}
+    .aiDraftSource{display:flex;align-items:flex-start;justify-content:space-between;gap:8px;margin:8px 0 10px;padding:8px 10px;border-radius:14px;background:#f8fbff;border:1px solid rgba(21,88,214,.11);color:#475569;font-size:12px;font-weight:900;white-space:pre-wrap}
+    .miniJumpBtn{appearance:none;border:1px solid rgba(21,88,214,.18);background:#fff;color:#0d3d8d;width:30px;height:30px;min-width:30px;border-radius:999px;font-weight:1000;line-height:1}
+    .newCustomerContextBar{display:flex;align-items:center;gap:7px;flex-wrap:wrap;margin:0 0 10px;padding:8px 10px;border-radius:14px;background:#fff7ed;border:1px solid rgba(245,158,11,.28);color:#9a3412;font-size:12px;font-weight:950}
+    .newCustomerContextBar button{appearance:none;border:1px solid rgba(154,52,18,.18);background:#fff;color:#9a3412;border-radius:999px;min-height:28px;padding:0 9px;font-size:12px;font-weight:1000}
     .bubbleTitleRow{display:flex;align-items:center;justify-content:space-between;gap:8px;margin-bottom:8px}
     .bubbleTitleRow .bubbleTitle{margin:0}
 

--- a/admin-ai-office.js
+++ b/admin-ai-office.js
@@ -117,6 +117,7 @@
     lastAgentRetry: null,
     lastLineRetry: null,
     agentHistory: JSON.parse(localStorage.getItem("cwfAiOfficeAgentHistoryV28") || "{}"),
+    brainPreviewItems: [],
   };
 
 
@@ -861,6 +862,7 @@
     if (prefill.situation_type) $("#memSituation").value = prefill.situation_type;
     if (prefill.language) $("#memLanguage").value = prefill.language;
     loadMemoryExamples();
+    loadBrainItems();
   }
 
   function closeMemoryPanel() {
@@ -945,6 +947,115 @@
   }
 
 
+  function renderBrainPreview(data = {}) {
+    const box = $("#brainPreview");
+    const warnings = $("#brainWarnings");
+    state.brainPreviewItems = data.preview_items || [];
+    if ($("#brainCommit")) $("#brainCommit").disabled = !state.brainPreviewItems.length;
+    if (warnings) {
+      const warn = data.warnings || [];
+      warnings.innerHTML = warn.length ? `<div class="memoryItem"><b>Warnings</b><p>${esc(warn.join("\n"))}</p></div>` : "";
+    }
+    if (!box) return;
+    if (!state.brainPreviewItems.length) {
+      box.innerHTML = `<div class="emptyState">No valid brain items to import</div>`;
+      return;
+    }
+    box.innerHTML = state.brainPreviewItems.slice(0, 20).map((item) => `
+      <article class="memoryItem">
+        <b>${esc(item.item_type)} · ${esc(item.agent_key || "all")} · ${esc(item.intent || "general")}</b>
+        <p><strong>${esc(item.title || "(no title)")}</strong></p>
+        <p>${esc(item.content || "")}</p>
+        ${item.warnings?.length ? `<p><strong>Warnings:</strong> ${esc(item.warnings.join(", "))}</p>` : ""}
+      </article>
+    `).join("");
+  }
+
+  async function previewBrainImport(e) {
+    e.preventDefault();
+    const file = $("#brainFile")?.files?.[0];
+    if (!file) return alert("Please choose a JSON, JSONL, or CSV brain file");
+    const form = new FormData();
+    form.append("file", file);
+    form.append("source", $("#brainSource")?.value || "manual_import");
+    try {
+      const res = await fetch("/admin/ai-office/brain/import-preview", { method:"POST", body:form });
+      const data = await res.json();
+      if (!res.ok || data.ok === false) throw new Error(data.error || "IMPORT_PREVIEW_FAILED");
+      renderBrainPreview(data);
+      showToast(`Preview ${data.valid_count || 0} valid / ${data.invalid_count || 0} rejected`);
+    } catch (err) {
+      alert(`Preview failed: ${err.message}`);
+    }
+  }
+
+  async function commitBrainImport() {
+    if (!state.brainPreviewItems.length) return;
+    try {
+      const data = await api("/admin/ai-office/brain/import-commit", {
+        method:"POST",
+        body:JSON.stringify({
+          mode: $("#brainCommitMode")?.value || "append",
+          source: $("#brainSource")?.value || "manual_import",
+          items: state.brainPreviewItems,
+        })
+      });
+      renderBrainPreview({ preview_items: [], warnings: [] });
+      await loadBrainItems();
+      showToast(`Imported ${data.saved_count || 0} brain items`);
+    } catch (err) {
+      alert(`Commit failed: ${err.message}`);
+    }
+  }
+
+  function exportBrain() {
+    window.location.href = "/admin/ai-office/brain/export?format=json";
+  }
+
+  async function loadBrainItems(e) {
+    if (e?.preventDefault) e.preventDefault();
+    const box = $("#brainList");
+    if (!box) return;
+    box.innerHTML = `<div class="emptyState">Loading AI brain...</div>`;
+    const qs = new URLSearchParams();
+    const q = clean($("#brainSearch")?.value || "");
+    const itemType = $("#brainTypeFilter")?.value || "";
+    const agentKey = $("#brainAgentFilter")?.value || "";
+    if (q) qs.set("q", q);
+    if (itemType) qs.set("item_type", itemType);
+    if (agentKey) qs.set("agent_key", agentKey);
+    qs.set("active", "true");
+    try {
+      const data = await api(`/admin/ai-office/brain/items?${qs.toString()}`);
+      const items = data.items || [];
+      if (!items.length) {
+        box.innerHTML = `<div class="emptyState">No active AI brain items found</div>`;
+        return;
+      }
+      box.innerHTML = items.map((item) => `
+        <article class="memoryItem" data-brain-id="${esc(item.id)}">
+          <b>${esc(item.item_type)} · ${esc(item.agent_key || "all")} · P${esc(item.priority || "")}</b>
+          <p><strong>${esc(item.title || "(no title)")}</strong></p>
+          <p>${esc(item.content || "")}</p>
+          <div class="bubbleActions"><button class="dangerBtn" type="button" data-disable-brain="${esc(item.id)}">Disable</button></div>
+        </article>
+      `).join("");
+    } catch (err) {
+      box.innerHTML = `<div class="emptyState">Load failed: ${esc(err.message)}</div>`;
+    }
+  }
+
+  async function disableBrainItem(id) {
+    if (!id) return;
+    try {
+      await api(`/admin/ai-office/brain/items/${id}/disable`, { method:"PATCH", body:"{}" });
+      await loadBrainItems();
+      showToast("Brain item disabled");
+    } catch (err) {
+      alert(`Disable failed: ${err.message}`);
+    }
+  }
+
   function handleComposerKeydown(formSelector) {
     return (e) => {
       if (e.key === "Enter" && !e.shiftKey) {
@@ -967,6 +1078,7 @@
       if (e.target.closest("[data-retry-agent]")) return submitAgentQuestion(null, state.lastAgentRetry || "");
       if (e.target.closest("[data-back-list]")) return showInboxList();
       if (e.target.closest("[data-open-memory]")) return openMemoryPanel();
+      if (e.target.closest("[data-disable-brain]")) return disableBrainItem(e.target.closest("[data-disable-brain]").dataset.disableBrain);
       if (e.target.closest("[data-prefill-memory]")) return prefillMemoryFromChat();
       if (e.target.closest("[data-edit-reply]")) return toggleEditReply(e.target.closest("[data-edit-reply]"));
       if (e.target.closest("[data-jump-source-message]")) return jumpToCustomerMessage(e.target.closest("[data-jump-source-message]").dataset.jumpSourceMessage);
@@ -997,6 +1109,10 @@
     $("#memoryForm")?.addEventListener("submit", saveMemoryExample);
     $("#memoryClose")?.addEventListener("click", closeMemoryPanel);
     $("#memoryReload")?.addEventListener("click", loadMemoryExamples);
+    $("#brainImportForm")?.addEventListener("submit", previewBrainImport);
+    $("#brainCommit")?.addEventListener("click", commitBrainImport);
+    $("#brainExport")?.addEventListener("click", exportBrain);
+    $("#brainSearchForm")?.addEventListener("submit", loadBrainItems);
     $$("textarea").forEach((ta) => ta.addEventListener("input", () => autoGrow(ta)));
   }
 

--- a/admin-ai-office.js
+++ b/admin-ai-office.js
@@ -140,6 +140,8 @@
       customer_reply: String(draft.customer_reply || ""),
       customer_question: String(draft.customer_question || state.selectedCustomerQuestion || state.lastCustomerMessage || ""),
       customer_message_id: String(draft.customer_message_id || state.selectedCustomerMessageId || ""),
+      customer_message_received_at: String(draft.customer_message_received_at || ""),
+      explicit_selected: Boolean(draft.explicit_selected),
       admin_question: String(draft.admin_question || ""),
       created_at: new Date().toISOString(),
     });
@@ -147,8 +149,16 @@
     saveLineDraftMemory();
   }
 
+  function explicitSelectedCustomerQuestion() {
+    return clean(state.selectedCustomerQuestion || "");
+  }
+
+  function fallbackLatestCustomerQuestion() {
+    return clean(state.lastCustomerMessage || "");
+  }
+
   function selectedQuestionForLearning() {
-    return clean(state.selectedCustomerQuestion || state.lastCustomerMessage || "");
+    return clean(explicitSelectedCustomerQuestion() || fallbackLatestCustomerQuestion());
   }
 
   function latestInboundMessage() {
@@ -161,9 +171,20 @@
 
   function latestInboundTimeMs() {
     const m = latestInboundMessage();
+    const t = messageTimeMs(m);
+    return Number.isFinite(t) ? t : 0;
+  }
+
+  function messageTimeMs(m) {
     const raw = m?.received_at || m?.created_at || "";
     const t = raw ? new Date(raw).getTime() : 0;
     return Number.isFinite(t) ? t : 0;
+  }
+
+  function findCustomerMessageById(id) {
+    const sid = String(id || "");
+    if (!sid) return null;
+    return (state.selectedMessages || []).find((m, idx) => String(messageIdFor(m, `msg_${idx}`)) === sid) || null;
   }
 
   function excerpt(text, max = 120) {
@@ -546,6 +567,8 @@
         customer_reply: draft.customer_reply,
         customer_question: draft.customer_question,
         customer_message_id: draft.customer_message_id,
+        customer_message_received_at: draft.customer_message_received_at,
+        explicit_selected: draft.explicit_selected,
         created_at: draft.created_at,
         persisted: true,
         skip_persist: true,
@@ -613,18 +636,27 @@
   function renderAiBubble(draft) {
     const reply = clean(draft?.customer_reply || draft?.answer || "");
     const text = reply || "ยังไม่ได้ข้อความพร้อมส่งลูกค้า";
-    const sourceQuestion = clean(draft?.customer_question || selectedQuestionForLearning());
+    const explicitSelected = Object.prototype.hasOwnProperty.call(draft || {}, "explicit_selected")
+      ? Boolean(draft.explicit_selected)
+      : Boolean(explicitSelectedCustomerQuestion());
+    const sourceQuestion = clean(draft?.customer_question || (explicitSelected ? explicitSelectedCustomerQuestion() : fallbackLatestCustomerQuestion()));
     const latestInbound = latestInboundMessage();
-    const sourceMessageId = String(draft?.customer_message_id || (sourceQuestion && state.selectedCustomerMessageId) || (sourceQuestion ? messageIdFor(latestInbound) : "") || "");
-    const sourceLabel = sourceQuestion ? `ตอบจาก:\n“${excerpt(sourceQuestion)}”` : "ตอบจากข้อความล่าสุด";
+    const sourceMessageId = String(draft?.customer_message_id || (explicitSelected ? state.selectedCustomerMessageId : messageIdFor(latestInbound)) || "");
+    const sourceMsg = findCustomerMessageById(sourceMessageId) || (!explicitSelected ? latestInbound : null);
+    const sourceReceivedAt = String(draft?.customer_message_received_at || sourceMsg?.received_at || sourceMsg?.created_at || "");
+    const sourceLabel = explicitSelected && sourceQuestion ? `ตอบจาก:\n“${excerpt(sourceQuestion)}”` : "ตอบจากข้อความล่าสุด";
     const persisted = Boolean(draft?.persisted);
     const draftTime = draft?.created_at ? new Date(draft.created_at).getTime() : Date.now();
-    const hasNewerInbound = Boolean(persisted && latestInboundTimeMs() > draftTime);
+    const sourceTime = sourceReceivedAt ? new Date(sourceReceivedAt).getTime() : 0;
+    const latestTime = latestInboundTimeMs();
+    const hasNewerInbound = Boolean(latestTime && ((sourceTime && latestTime > sourceTime) || latestTime > draftTime));
     if (!draft?.skip_persist && state.selectedConversation?.id && reply) {
       addDraftToConversation(state.selectedConversation.id, {
         customer_reply: reply,
         customer_question: sourceQuestion,
         customer_message_id: sourceMessageId,
+        customer_message_received_at: sourceReceivedAt,
+        explicit_selected: explicitSelected,
         admin_question: draft?.admin_question || state.lastLineRetry || "",
       });
     }
@@ -633,7 +665,7 @@
         <article class="aiNaturalBubble">
           <div class="aiNaturalTop">
             <span class="aiNaturalLabel">AI แนะนำ</span>
-            ${sourceQuestion ? `<span class="aiNaturalSource">ตอบจากคำถามที่เลือก</span>` : `<span class="aiNaturalSource">${persisted ? "จากประวัติก่อนหน้า" : "พร้อมส่งลูกค้า"}</span>`}
+            ${explicitSelected ? `<span class="aiNaturalSource">ตอบจากคำถามที่เลือก</span>` : `<span class="aiNaturalSource">ตอบจากข้อความล่าสุด</span>`}
           </div>
           <div class="aiDraftSource" data-source-message-id="${esc(sourceMessageId)}">
             <span>${esc(sourceLabel)}</span>
@@ -641,7 +673,7 @@
           </div>
           ${hasNewerInbound ? `<div class="newCustomerContextBar">มีข้อความลูกค้าใหม่ <button type="button" data-use-latest-customer>ใช้ข้อความล่าสุด</button><button type="button" data-pick-customer-message>เลือกเอง</button></div>` : ""}
           <div class="replyDisplay" data-reply-display>${esc(text)}</div>
-          <textarea class="replyText" data-reply-text data-source-question="${esc(sourceQuestion)}" data-source-message-id="${esc(sourceMessageId)}">${esc(text)}</textarea>
+          <textarea class="replyText" data-reply-text data-source-question="${esc(sourceQuestion)}" data-source-message-id="${esc(sourceMessageId)}" data-explicit-selected="${explicitSelected ? "1" : "0"}">${esc(text)}</textarea>
           <div class="aiNaturalActions" aria-label="จัดการคำตอบ AI">
             <button class="iconBtn editIcon" type="button" data-edit-reply aria-label="แก้ไขข้อความ" title="แก้ไขข้อความ">✎</button>
             <button class="iconBtn copyIcon" type="button" data-copy-reply aria-label="คัดลอกข้อความนี้" title="คัดลอกข้อความนี้">⧉</button>
@@ -664,7 +696,11 @@
     const input = $("#lineAiQuestion");
     const question = clean(input.value);
     if (!conv?.id || !question) return;
-    const sourceQuestion = selectedQuestionForLearning();
+    const explicitQuestion = explicitSelectedCustomerQuestion();
+    const sourceQuestion = explicitQuestion || fallbackLatestCustomerQuestion();
+    const sourceMessage = explicitQuestion ? findCustomerMessageById(state.selectedCustomerMessageId) : latestInboundMessage();
+    const sourceMessageId = explicitQuestion ? (state.selectedCustomerMessageId || "") : messageIdFor(sourceMessage);
+    const sourceReceivedAt = String(sourceMessage?.received_at || sourceMessage?.created_at || "");
     state.lastLineRetry = question;
     const submitBtn = $("#lineAiForm .sendBtn");
     if (submitBtn) submitBtn.disabled = true;
@@ -679,19 +715,26 @@
         body: JSON.stringify({
           conversation_id: conv.id,
           admin_question: question,
-          selected_customer_question: sourceQuestion,
+          selected_customer_question: explicitQuestion ? sourceQuestion : "",
           prior_drafts: draftsForConversation(conv.id).slice(-6),
           use_shared_memory: true,
-          instruction: sourceQuestion ? `${question}\n\nต้องตอบเฉพาะคำถามลูกค้าที่แอดมินเลือกนี้เป็นหลัก: ${sourceQuestion}` : question,
+          instruction: explicitQuestion ? `${question}\n\nต้องตอบเฉพาะคำถามลูกค้าที่แอดมินเลือกนี้เป็นหลัก: ${sourceQuestion}` : question,
           agent: state.agent === "sales" ? "sales" : "admin"
         })
       });
       removeLatestLoadingBubble();
-      renderAiBubble({ ...(data.draft || { customer_reply: data.answer }), customer_question: sourceQuestion, customer_message_id: state.selectedCustomerMessageId || "", admin_question: question });
+      renderAiBubble({
+        ...(data.draft || { customer_reply: data.answer }),
+        customer_question: sourceQuestion,
+        customer_message_id: sourceMessageId,
+        customer_message_received_at: sourceReceivedAt,
+        explicit_selected: Boolean(explicitQuestion),
+        admin_question: question
+      });
       logSharedMemoryEvent("line_drafted", {
         source: "line_chat",
         conversation_id: conv.id,
-        selected_customer_question: sourceQuestion,
+        selected_customer_question: explicitQuestion ? sourceQuestion : "",
         customer_message: sourceQuestion,
         ai_reply: (data.draft?.customer_reply || data.answer || ""),
         action_status: "drafted",

--- a/admin-ai-office.js
+++ b/admin-ai-office.js
@@ -139,6 +139,7 @@
       id: `draft_${Date.now()}_${Math.random().toString(16).slice(2)}`,
       customer_reply: String(draft.customer_reply || ""),
       customer_question: String(draft.customer_question || state.selectedCustomerQuestion || state.lastCustomerMessage || ""),
+      customer_message_id: String(draft.customer_message_id || state.selectedCustomerMessageId || ""),
       admin_question: String(draft.admin_question || ""),
       created_at: new Date().toISOString(),
     });
@@ -148,6 +149,26 @@
 
   function selectedQuestionForLearning() {
     return clean(state.selectedCustomerQuestion || state.lastCustomerMessage || "");
+  }
+
+  function latestInboundMessage() {
+    return [...(state.selectedMessages || [])].reverse().find((m) => (m.direction || "inbound") === "inbound" && clean(messageText(m)));
+  }
+
+  function messageIdFor(m, fallback = "") {
+    return String(m?.id || m?.message_id || fallback || "");
+  }
+
+  function latestInboundTimeMs() {
+    const m = latestInboundMessage();
+    const raw = m?.received_at || m?.created_at || "";
+    const t = raw ? new Date(raw).getTime() : 0;
+    return Number.isFinite(t) ? t : 0;
+  }
+
+  function excerpt(text, max = 120) {
+    const s = clean(text);
+    return s.length > max ? `${s.slice(0, max - 1)}…` : s;
   }
 
   function saveHistory() {
@@ -524,6 +545,8 @@
       renderAiBubble({
         customer_reply: draft.customer_reply,
         customer_question: draft.customer_question,
+        customer_message_id: draft.customer_message_id,
+        created_at: draft.created_at,
         persisted: true,
         skip_persist: true,
       });
@@ -591,11 +614,17 @@
     const reply = clean(draft?.customer_reply || draft?.answer || "");
     const text = reply || "ยังไม่ได้ข้อความพร้อมส่งลูกค้า";
     const sourceQuestion = clean(draft?.customer_question || selectedQuestionForLearning());
+    const latestInbound = latestInboundMessage();
+    const sourceMessageId = String(draft?.customer_message_id || (sourceQuestion && state.selectedCustomerMessageId) || (sourceQuestion ? messageIdFor(latestInbound) : "") || "");
+    const sourceLabel = sourceQuestion ? `ตอบจาก:\n“${excerpt(sourceQuestion)}”` : "ตอบจากข้อความล่าสุด";
     const persisted = Boolean(draft?.persisted);
+    const draftTime = draft?.created_at ? new Date(draft.created_at).getTime() : Date.now();
+    const hasNewerInbound = Boolean(persisted && latestInboundTimeMs() > draftTime);
     if (!draft?.skip_persist && state.selectedConversation?.id && reply) {
       addDraftToConversation(state.selectedConversation.id, {
         customer_reply: reply,
         customer_question: sourceQuestion,
+        customer_message_id: sourceMessageId,
         admin_question: draft?.admin_question || state.lastLineRetry || "",
       });
     }
@@ -606,9 +635,13 @@
             <span class="aiNaturalLabel">AI แนะนำ</span>
             ${sourceQuestion ? `<span class="aiNaturalSource">ตอบจากคำถามที่เลือก</span>` : `<span class="aiNaturalSource">${persisted ? "จากประวัติก่อนหน้า" : "พร้อมส่งลูกค้า"}</span>`}
           </div>
-          ${sourceQuestion ? `<div class="aiDraftSource">อ้างอิง: ${esc(sourceQuestion)}</div>` : ""}
+          <div class="aiDraftSource" data-source-message-id="${esc(sourceMessageId)}">
+            <span>${esc(sourceLabel)}</span>
+            ${sourceMessageId ? `<button class="miniJumpBtn" type="button" data-jump-source-message="${esc(sourceMessageId)}" aria-label="ไปที่ข้อความลูกค้า" title="ไปที่ข้อความลูกค้า">↩</button>` : ""}
+          </div>
+          ${hasNewerInbound ? `<div class="newCustomerContextBar">มีข้อความลูกค้าใหม่ <button type="button" data-use-latest-customer>ใช้ข้อความล่าสุด</button><button type="button" data-pick-customer-message>เลือกเอง</button></div>` : ""}
           <div class="replyDisplay" data-reply-display>${esc(text)}</div>
-          <textarea class="replyText" data-reply-text data-source-question="${esc(sourceQuestion)}">${esc(text)}</textarea>
+          <textarea class="replyText" data-reply-text data-source-question="${esc(sourceQuestion)}" data-source-message-id="${esc(sourceMessageId)}">${esc(text)}</textarea>
           <div class="aiNaturalActions" aria-label="จัดการคำตอบ AI">
             <button class="iconBtn editIcon" type="button" data-edit-reply aria-label="แก้ไขข้อความ" title="แก้ไขข้อความ">✎</button>
             <button class="iconBtn copyIcon" type="button" data-copy-reply aria-label="คัดลอกข้อความนี้" title="คัดลอกข้อความนี้">⧉</button>
@@ -654,7 +687,7 @@
         })
       });
       removeLatestLoadingBubble();
-      renderAiBubble({ ...(data.draft || { customer_reply: data.answer }), customer_question: sourceQuestion, admin_question: question });
+      renderAiBubble({ ...(data.draft || { customer_reply: data.answer }), customer_question: sourceQuestion, customer_message_id: state.selectedCustomerMessageId || "", admin_question: question });
       logSharedMemoryEvent("line_drafted", {
         source: "line_chat",
         conversation_id: conv.id,
@@ -699,6 +732,25 @@
       syncReplyDisplay(card);
       button.textContent = "✎";
     }
+  }
+
+  function jumpToCustomerMessage(id) {
+    const target = $(`.lineBubble.customer[data-customer-message-id="${CSS.escape(String(id || ""))}"]`);
+    if (!target) return;
+    target.scrollIntoView({ behavior: "smooth", block: "center" });
+    target.classList.add("jumpHighlight");
+    setTimeout(() => target.classList.remove("jumpHighlight"), 1400);
+  }
+
+  function useLatestCustomerMessage() {
+    const latest = latestInboundMessage();
+    if (!latest) return;
+    setSelectedQuestion(messageText(latest), messageIdFor(latest));
+  }
+
+  function pickCustomerMessage() {
+    clearSelectedQuestion(true);
+    showToast("เลือกข้อความลูกค้าด้วยการกดค้างหรือดับเบิลคลิก");
   }
 
   async function copyReply(button) {
@@ -874,6 +926,9 @@
       if (e.target.closest("[data-open-memory]")) return openMemoryPanel();
       if (e.target.closest("[data-prefill-memory]")) return prefillMemoryFromChat();
       if (e.target.closest("[data-edit-reply]")) return toggleEditReply(e.target.closest("[data-edit-reply]"));
+      if (e.target.closest("[data-jump-source-message]")) return jumpToCustomerMessage(e.target.closest("[data-jump-source-message]").dataset.jumpSourceMessage);
+      if (e.target.closest("[data-use-latest-customer]")) return useLatestCustomerMessage();
+      if (e.target.closest("[data-pick-customer-message]")) return pickCustomerMessage();
       if (e.target.closest("[data-selected-question-add-reply]")) return prefillMemoryFromChat("");
       if (e.target.closest("[data-copy-reply]")) return copyReply(e.target.closest("[data-copy-reply]"));
       if (e.target.closest("[data-dislike-reply]")) return dislikeReply(e.target.closest("[data-dislike-reply]"));

--- a/index.js
+++ b/index.js
@@ -52,6 +52,9 @@ const createTechnicianBaseStatusReadOnlyRoutes = require("./server/routes/techni
 const createTechnicianCalendarReadOnlyRoutes = require("./server/routes/technicianCalendarReadOnly");
 const createTechnicianCountSummaryReadOnlyRoutes = require("./server/routes/technicianCountSummaryReadOnly");
 const createAdminAiOfficeReadOnlyRoutes = require("./server/routes/adminAiOfficeReadOnly");
+const createAdminAiOfficeSharedMemoryV27Routes = require("./server/routes/adminAiOfficeSharedMemoryV27");
+const createAdminAiOfficeLineDraftV27Routes = require("./server/routes/adminAiOfficeLineDraftV27");
+const createAdminAiOfficeSmartAssistantV28Routes = require("./server/routes/adminAiOfficeSmartAssistantV28");
 const { createLineWebhookRoutes, ensureLineInboxSchema } = require("./server/routes/lineWebhook");
 const {
   calculateTechnicianBaseStatus,
@@ -4372,7 +4375,17 @@ app.post('/api/logout', async (req, res) => {
   return res.json({ ok: true });
 });
 
-app.use(createAdminAiOfficeReadOnlyRoutes({ pool, requireAdminSession }));
+const aiOfficeAccountingDeps = {
+  buildPayoutTechSummaryRows: _buildPayoutTechSummaryRows,
+  accountingEnrichPayoutTechRows: _accountingEnrichPayoutTechRows,
+  getPayoutPeriod: _getPayoutPeriod,
+  money: _money,
+  paidStatus: _paidStatus,
+};
+app.use(createAdminAiOfficeSharedMemoryV27Routes({ pool, requireAdminSession })); // CWF AI Office shared memory
+app.use(createAdminAiOfficeLineDraftV27Routes({ pool, requireAdminSession })); // CWF AI Office selected-question LINE draft override
+app.use(createAdminAiOfficeSmartAssistantV28Routes({ pool, requireAdminSession, accounting: aiOfficeAccountingDeps })); // CWF AI Office deterministic payout + availability
+app.use(createAdminAiOfficeReadOnlyRoutes({ pool, requireAdminSession, accounting: aiOfficeAccountingDeps }));
 app.get("/admin/ai-office", aiOfficeNoCache, requireAdminSession, (req, res) => res.sendFile(sendHtml("admin-ai-office.html")));
 app.get("/admin/ai-office.html", aiOfficeNoCache, requireAdminSession, (req, res) => res.sendFile(sendHtml("admin-ai-office.html")));
 app.get("/admin-ai-office.html", aiOfficeNoCache, requireAdminSession, (req, res) => res.sendFile(sendHtml("admin-ai-office.html")));

--- a/index.js
+++ b/index.js
@@ -55,6 +55,7 @@ const createAdminAiOfficeReadOnlyRoutes = require("./server/routes/adminAiOffice
 const createAdminAiOfficeSharedMemoryV27Routes = require("./server/routes/adminAiOfficeSharedMemoryV27");
 const createAdminAiOfficeLineDraftV27Routes = require("./server/routes/adminAiOfficeLineDraftV27");
 const createAdminAiOfficeSmartAssistantV28Routes = require("./server/routes/adminAiOfficeSmartAssistantV28");
+const createAdminAiOfficeBrainManagerRoutes = require("./server/routes/adminAiOfficeBrainManager");
 const { createLineWebhookRoutes, ensureLineInboxSchema } = require("./server/routes/lineWebhook");
 const {
   calculateTechnicianBaseStatus,
@@ -4386,6 +4387,7 @@ app.use(createAdminAiOfficeSharedMemoryV27Routes({ pool, requireAdminSession }))
 app.use(createAdminAiOfficeLineDraftV27Routes({ pool, requireAdminSession })); // CWF AI Office selected-question LINE draft override
 app.use(createAdminAiOfficeSmartAssistantV28Routes({ pool, requireAdminSession, accounting: aiOfficeAccountingDeps })); // CWF AI Office deterministic payout + availability
 app.use(createAdminAiOfficeReadOnlyRoutes({ pool, requireAdminSession, accounting: aiOfficeAccountingDeps }));
+app.use(createAdminAiOfficeBrainManagerRoutes({ pool, requireAdminSession })); // CWF AI Office Brain Manager
 app.get("/admin/ai-office", aiOfficeNoCache, requireAdminSession, (req, res) => res.sendFile(sendHtml("admin-ai-office.html")));
 app.get("/admin/ai-office.html", aiOfficeNoCache, requireAdminSession, (req, res) => res.sendFile(sendHtml("admin-ai-office.html")));
 app.get("/admin-ai-office.html", aiOfficeNoCache, requireAdminSession, (req, res) => res.sendFile(sendHtml("admin-ai-office.html")));

--- a/migrations/20260608_ai_office_brain_items.sql
+++ b/migrations/20260608_ai_office_brain_items.sql
@@ -1,0 +1,39 @@
+CREATE TABLE IF NOT EXISTS public.ai_brain_items (
+  id BIGSERIAL PRIMARY KEY,
+  item_type TEXT NOT NULL,
+  title TEXT NOT NULL DEFAULT '',
+  content TEXT NOT NULL,
+  intent TEXT NOT NULL DEFAULT '',
+  service_type TEXT NOT NULL DEFAULT '',
+  customer_stage TEXT NOT NULL DEFAULT '',
+  agent_key TEXT NOT NULL DEFAULT 'all',
+  language TEXT NOT NULL DEFAULT 'th',
+  priority INTEGER NOT NULL DEFAULT 50,
+  confidence INTEGER NOT NULL DEFAULT 80,
+  tags JSONB NOT NULL DEFAULT '[]'::jsonb,
+  source TEXT NOT NULL DEFAULT 'manual',
+  is_active BOOLEAN NOT NULL DEFAULT true,
+  metadata JSONB NOT NULL DEFAULT '{}'::jsonb,
+  created_by TEXT NOT NULL DEFAULT '',
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  CONSTRAINT ai_brain_items_item_type_check CHECK (item_type IN (
+    'service_fact',
+    'pricing_rule',
+    'sales_playbook',
+    'objection_handler',
+    'approved_reply',
+    'bad_reply_pattern',
+    'admin_correction',
+    'policy_rule',
+    'workflow_rule',
+    'technician_rule',
+    'customer_stage_rule'
+  ))
+);
+
+CREATE INDEX IF NOT EXISTS idx_ai_brain_items_active_lookup
+  ON public.ai_brain_items(is_active, agent_key, item_type, intent, service_type, customer_stage, priority DESC, updated_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_ai_brain_items_source_active
+  ON public.ai_brain_items(source, is_active, updated_at DESC);

--- a/server/routes/adminAiOfficeBrainManager.js
+++ b/server/routes/adminAiOfficeBrainManager.js
@@ -1,0 +1,481 @@
+const express = require("express");
+const multer = require("multer");
+
+const upload = multer({ storage: multer.memoryStorage(), limits: { fileSize: 1024 * 1024 } });
+
+const ALLOWED_ITEM_TYPES = new Set([
+  "service_fact",
+  "pricing_rule",
+  "sales_playbook",
+  "objection_handler",
+  "approved_reply",
+  "bad_reply_pattern",
+  "admin_correction",
+  "policy_rule",
+  "workflow_rule",
+  "technician_rule",
+  "customer_stage_rule",
+]);
+
+const EDITABLE_FIELDS = [
+  "item_type",
+  "title",
+  "content",
+  "intent",
+  "service_type",
+  "customer_stage",
+  "agent_key",
+  "language",
+  "priority",
+  "confidence",
+  "tags",
+  "source",
+  "is_active",
+  "metadata",
+];
+
+function cleanText(value, max = 4000) {
+  return String(value || "").replace(/\s+/g, " ").trim().slice(0, max);
+}
+
+function clampInt(value, def, min = 1, max = 100) {
+  const n = Number(value);
+  if (!Number.isFinite(n)) return def;
+  return Math.max(min, Math.min(max, Math.round(n)));
+}
+
+function normalizeTags(value) {
+  if (Array.isArray(value)) return value.map((x) => cleanText(x, 80)).filter(Boolean).slice(0, 30);
+  return String(value || "")
+    .split(/[|,]/)
+    .map((x) => cleanText(x, 80))
+    .filter(Boolean)
+    .slice(0, 30);
+}
+
+function normalizeJsonObject(value) {
+  if (value && typeof value === "object" && !Array.isArray(value)) return value;
+  if (typeof value === "string" && value.trim()) {
+    try {
+      const parsed = JSON.parse(value);
+      if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) return parsed;
+    } catch (_) {}
+  }
+  return {};
+}
+
+function hasPrivateCustomerData(value) {
+  const text = String(value || "");
+  const digits = text.replace(/\D/g, "");
+  const hasPhone = /(?:\+?66|0)\s*[-.]?\s*\d{1,2}\s*[-.]?\s*\d{3,4}\s*[-.]?\s*\d{3,4}/.test(text) || digits.length >= 9;
+  const hasAddress = /(บ้านเลขที่|หมู่บ้าน|ซอย|ถนน|แขวง|เขต|ตำบล|อำเภอ|จังหวัด|รหัสไปรษณีย์|address|house\s*no\.?)/i.test(text);
+  const hasSensitive = /(บัตรประชาชน|เลขบัญชี|บัญชีธนาคาร|password|otp|token|secret)/i.test(text);
+  return hasPhone || hasAddress || hasSensitive;
+}
+
+function getAdminUser(req) {
+  return cleanText(req.session?.user?.username || req.session?.user?.email || req.session?.username || req.user?.username || req.user?.email || "", 120);
+}
+
+async function ensureAiBrainSchema(pool) {
+  await pool.query(`
+    CREATE TABLE IF NOT EXISTS public.ai_brain_items (
+      id BIGSERIAL PRIMARY KEY,
+      item_type TEXT NOT NULL,
+      title TEXT NOT NULL DEFAULT '',
+      content TEXT NOT NULL,
+      intent TEXT NOT NULL DEFAULT '',
+      service_type TEXT NOT NULL DEFAULT '',
+      customer_stage TEXT NOT NULL DEFAULT '',
+      agent_key TEXT NOT NULL DEFAULT 'all',
+      language TEXT NOT NULL DEFAULT 'th',
+      priority INTEGER NOT NULL DEFAULT 50,
+      confidence INTEGER NOT NULL DEFAULT 80,
+      tags JSONB NOT NULL DEFAULT '[]'::jsonb,
+      source TEXT NOT NULL DEFAULT 'manual',
+      is_active BOOLEAN NOT NULL DEFAULT true,
+      metadata JSONB NOT NULL DEFAULT '{}'::jsonb,
+      created_by TEXT NOT NULL DEFAULT '',
+      created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      CONSTRAINT ai_brain_items_item_type_check CHECK (item_type IN (
+        'service_fact','pricing_rule','sales_playbook','objection_handler','approved_reply',
+        'bad_reply_pattern','admin_correction','policy_rule','workflow_rule','technician_rule','customer_stage_rule'
+      ))
+    )
+  `);
+  await pool.query(`CREATE INDEX IF NOT EXISTS idx_ai_brain_items_active_lookup ON public.ai_brain_items(is_active, agent_key, item_type, intent, service_type, customer_stage, priority DESC, updated_at DESC)`);
+  await pool.query(`CREATE INDEX IF NOT EXISTS idx_ai_brain_items_source_active ON public.ai_brain_items(source, is_active, updated_at DESC)`);
+  await seedAiBrainIfEmpty(pool);
+}
+
+async function seedAiBrainIfEmpty(pool) {
+  const r = await pool.query("SELECT COUNT(*)::int AS count FROM public.ai_brain_items");
+  if (Number(r.rows?.[0]?.count || 0) > 0) return;
+  const seed = [
+    {
+      item_type: "service_fact",
+      title: "Coldwindflow public contact",
+      content: "Coldwindflow Air Services provides air cleaning, air repair, air installation, and air inspection. Public LINE OA is @cwfair and public phone is 098-877-7321.",
+      agent_key: "all",
+      tags: ["cwf", "public_contact"],
+    },
+    {
+      item_type: "pricing_rule",
+      title: "Rainy season air cleaning promotion",
+      content: "Rainy season promo: wall AC <= 12,000 BTU normal 550, premium 790, hanging coil 1290, deep clean 1850. Wall AC >= 18,000 BTU normal 690, premium 990, hanging coil 1550, deep clean 2150. Check fee 700. Cassette 1500. Suspended/concealed 1200.",
+      intent: "price_question",
+      service_type: "air_cleaning",
+      agent_key: "sales",
+      priority: 90,
+      confidence: 90,
+      tags: ["pricing", "promotion", "air_cleaning"],
+    },
+    {
+      item_type: "policy_rule",
+      title: "Cleaning warranty",
+      content: "Cleaning warranty is 30 days for symptoms caused by the cleaning service. For repair, leak, or uncertain price cases, the technician must inspect before final quote.",
+      intent: "warranty",
+      agent_key: "all",
+      priority: 85,
+      confidence: 90,
+      tags: ["warranty", "policy"],
+    },
+  ];
+  for (const item of seed) {
+    await pool.query(`
+      INSERT INTO public.ai_brain_items(item_type,title,content,intent,service_type,customer_stage,agent_key,language,priority,confidence,tags,source,is_active,metadata,created_by)
+      VALUES($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11::jsonb,'internal_seed',true,$12::jsonb,'system')
+    `, [
+      item.item_type,
+      item.title,
+      item.content,
+      item.intent || "",
+      item.service_type || "",
+      item.customer_stage || "",
+      item.agent_key || "all",
+      item.language || "th",
+      item.priority || 50,
+      item.confidence || 80,
+      JSON.stringify(item.tags || []),
+      JSON.stringify({ seed: "cwf-ai-brain-v1" }),
+    ]);
+  }
+}
+
+function validateBrainItem(input = {}, rowNumber = 1) {
+  const warnings = [];
+  const errors = [];
+  const item = {
+    item_type: cleanText(input.item_type, 80),
+    title: cleanText(input.title, 240),
+    content: cleanText(input.content, 8000),
+    intent: cleanText(input.intent, 120),
+    service_type: cleanText(input.service_type, 120),
+    customer_stage: cleanText(input.customer_stage, 120),
+    agent_key: cleanText(input.agent_key || "all", 40) || "all",
+    language: cleanText(input.language || "th", 20) || "th",
+    priority: clampInt(input.priority, 50),
+    confidence: clampInt(input.confidence, 80),
+    tags: normalizeTags(input.tags),
+    source: cleanText(input.source || "manual", 120) || "manual",
+    is_active: input.is_active === undefined ? true : input.is_active !== false && input.is_active !== "false",
+    metadata: normalizeJsonObject(input.metadata),
+  };
+  if (!item.item_type) errors.push("item_type required");
+  else if (!ALLOWED_ITEM_TYPES.has(item.item_type)) errors.push(`unknown item_type: ${item.item_type}`);
+  if (!item.content) errors.push("content required");
+  if (!item.title) warnings.push("title is recommended");
+  if (String(input.content || "").length > 8000) warnings.push("content truncated to 8000 characters");
+  if (hasPrivateCustomerData(`${item.title}\n${item.content}`)) warnings.push("possible private customer data detected");
+  return { row_number: rowNumber, ok: errors.length === 0, item, warnings, errors };
+}
+
+function parseCsv(text) {
+  const rows = [];
+  let row = [];
+  let cell = "";
+  let quoted = false;
+  for (let i = 0; i < text.length; i += 1) {
+    const ch = text[i];
+    const next = text[i + 1];
+    if (quoted && ch === '"' && next === '"') {
+      cell += '"';
+      i += 1;
+    } else if (ch === '"') {
+      quoted = !quoted;
+    } else if (!quoted && ch === ",") {
+      row.push(cell);
+      cell = "";
+    } else if (!quoted && (ch === "\n" || ch === "\r")) {
+      if (ch === "\r" && next === "\n") i += 1;
+      row.push(cell);
+      if (row.some((v) => String(v).trim())) rows.push(row);
+      row = [];
+      cell = "";
+    } else {
+      cell += ch;
+    }
+  }
+  row.push(cell);
+  if (row.some((v) => String(v).trim())) rows.push(row);
+  if (!rows.length) return [];
+  const headers = rows.shift().map((h) => cleanText(h, 80));
+  return rows.map((values) => {
+    const obj = {};
+    headers.forEach((h, idx) => { obj[h] = values[idx] || ""; });
+    return obj;
+  });
+}
+
+function parseImportPayload(req) {
+  const fileText = req.file?.buffer ? req.file.buffer.toString("utf8") : "";
+  if (Array.isArray(req.body?.items)) return req.body.items;
+  if (req.body?.version && Array.isArray(req.body?.items)) return req.body.items;
+  const raw = fileText || String(req.body?.brain_text || req.body?.content || req.body?.data || "").trim();
+  if (!raw) return [];
+  const fileName = String(req.file?.originalname || "").toLowerCase();
+  const format = cleanText(req.body?.format, 20).toLowerCase();
+  if (format === "csv" || fileName.endsWith(".csv")) return parseCsv(raw);
+  if (format === "jsonl" || fileName.endsWith(".jsonl")) {
+    return raw.split(/\r?\n/).map((line) => line.trim()).filter(Boolean).map((line) => JSON.parse(line));
+  }
+  const parsed = JSON.parse(raw);
+  if (Array.isArray(parsed)) return parsed;
+  if (Array.isArray(parsed.items)) return parsed.items;
+  return [];
+}
+
+async function listBrainItems(pool, filters = {}) {
+  await ensureAiBrainSchema(pool);
+  const params = [];
+  const clauses = ["1=1"];
+  const add = (value, sql) => {
+    if (value === undefined || value === null || String(value).trim() === "") return;
+    params.push(value);
+    clauses.push(sql(params.length));
+  };
+  add(cleanText(filters.item_type, 80), (i) => `item_type = $${i}`);
+  add(cleanText(filters.agent_key, 40), (i) => `(agent_key = $${i} OR agent_key = 'all')`);
+  add(cleanText(filters.service_type, 120), (i) => `service_type = $${i}`);
+  add(cleanText(filters.intent, 120), (i) => `intent = $${i}`);
+  add(cleanText(filters.customer_stage, 120), (i) => `customer_stage = $${i}`);
+  if (String(filters.active || "").trim() !== "") {
+    params.push(String(filters.active) !== "false");
+    clauses.push(`is_active = $${params.length}`);
+  }
+  const q = cleanText(filters.q, 200);
+  if (q) {
+    params.push(`%${q}%`);
+    const i = params.length;
+    clauses.push(`(title ILIKE $${i} OR content ILIKE $${i} OR intent ILIKE $${i} OR service_type ILIKE $${i} OR tags::text ILIKE $${i})`);
+  }
+  params.push(Math.max(1, Math.min(Number(filters.limit || 120), 10000)));
+  const r = await pool.query(`
+    SELECT id,item_type,title,content,intent,service_type,customer_stage,agent_key,language,
+           priority,confidence,tags,source,is_active,metadata,created_by,created_at,updated_at
+      FROM public.ai_brain_items
+     WHERE ${clauses.join(" AND ")}
+     ORDER BY is_active DESC, priority DESC, updated_at DESC, id DESC
+     LIMIT $${params.length}
+  `, params);
+  return r.rows || [];
+}
+
+async function loadAiBrainContext(pool, opts = {}) {
+  await ensureAiBrainSchema(pool);
+  const query = cleanText(opts.query, 500);
+  const params = [
+    cleanText(opts.intent, 120),
+    cleanText(opts.service_type, 120),
+    cleanText(opts.customer_stage, 120),
+    cleanText(opts.agent_key || "all", 40) || "all",
+    cleanText(opts.language || "th", 20) || "th",
+    query ? `%${query.slice(0, 160)}%` : "",
+    Math.max(1, Math.min(Number(opts.limit || 8), 30)),
+  ];
+  const r = await pool.query(`
+    SELECT id,item_type,title,content,intent,service_type,customer_stage,agent_key,language,
+           priority,confidence,tags,source,updated_at
+      FROM public.ai_brain_items
+     WHERE is_active = true
+       AND ($5 = '' OR language = $5 OR language = 'th' OR language = 'unknown')
+       AND ($4 = '' OR agent_key = $4 OR agent_key = 'all')
+     ORDER BY
+       CASE WHEN $1 <> '' AND intent = $1 THEN 0 ELSE 1 END,
+       CASE WHEN $2 <> '' AND service_type = $2 THEN 0 ELSE 1 END,
+       CASE WHEN $3 <> '' AND customer_stage = $3 THEN 0 ELSE 1 END,
+       CASE WHEN agent_key = $4 THEN 0 WHEN agent_key = 'all' THEN 1 ELSE 2 END,
+       CASE item_type
+         WHEN 'policy_rule' THEN 0
+         WHEN 'admin_correction' THEN 1
+         WHEN 'bad_reply_pattern' THEN 2
+         WHEN 'pricing_rule' THEN 3
+         WHEN 'sales_playbook' THEN 4
+         WHEN 'objection_handler' THEN 5
+         WHEN 'approved_reply' THEN 6
+         WHEN 'service_fact' THEN 7
+         ELSE 8
+       END,
+       priority DESC,
+       updated_at DESC,
+       CASE WHEN $6 <> '' AND (title ILIKE $6 OR content ILIKE $6 OR tags::text ILIKE $6) THEN 0 ELSE 1 END
+     LIMIT $7
+  `, params);
+  return {
+    query,
+    agent_key: params[3],
+    intent: params[0],
+    service_type: params[1],
+    customer_stage: params[2],
+    language: params[4],
+    items: r.rows || [],
+  };
+}
+
+module.exports = function createAdminAiOfficeBrainManagerRoutes(deps = {}) {
+  const pool = deps.pool;
+  const requireAdminSession = deps.requireAdminSession;
+  if (!pool || !requireAdminSession) throw new Error("createAdminAiOfficeBrainManagerRoutes requires pool and requireAdminSession");
+  const router = express.Router();
+
+  router.get("/admin/ai-office/brain/items", requireAdminSession, async (req, res) => {
+    try {
+      const items = await listBrainItems(pool, req.query || {});
+      return res.json({ ok: true, items });
+    } catch (e) {
+      return res.status(e.status || 500).json({ ok: false, error: e.message || "LOAD_AI_BRAIN_FAILED" });
+    }
+  });
+
+  router.post("/admin/ai-office/brain/import-preview", requireAdminSession, upload.single("file"), async (req, res) => {
+    try {
+      const rows = parseImportPayload(req);
+      const checked = rows.map((row, idx) => validateBrainItem(row, idx + 1));
+      const previewItems = checked.filter((x) => x.ok).map((x) => ({ ...x.item, row_number: x.row_number, warnings: x.warnings }));
+      const rejectedItems = checked.filter((x) => !x.ok).map((x) => ({ row_number: x.row_number, item: x.item, errors: x.errors, warnings: x.warnings }));
+      const warnings = checked.flatMap((x) => x.warnings.map((w) => `row ${x.row_number}: ${w}`));
+      return res.json({
+        ok: true,
+        total_rows: rows.length,
+        valid_count: previewItems.length,
+        invalid_count: rejectedItems.length,
+        warnings,
+        preview_items: previewItems,
+        rejected_items: rejectedItems,
+      });
+    } catch (e) {
+      return res.status(400).json({ ok: false, error: e.message || "IMPORT_PREVIEW_FAILED", total_rows: 0, valid_count: 0, invalid_count: 0, warnings: [], preview_items: [], rejected_items: [] });
+    }
+  });
+
+  router.post("/admin/ai-office/brain/import-commit", requireAdminSession, async (req, res) => {
+    const client = await pool.connect();
+    try {
+      await ensureAiBrainSchema(pool);
+      const mode = cleanText(req.body?.mode || "append", 40);
+      const source = cleanText(req.body?.source || "manual_import", 120) || "manual_import";
+      const rows = Array.isArray(req.body?.items) ? req.body.items : Array.isArray(req.body?.preview_items) ? req.body.preview_items : [];
+      const checked = rows.map((row, idx) => validateBrainItem({ ...row, source: row.source || source }, idx + 1)).filter((x) => x.ok);
+      await client.query("BEGIN");
+      if (mode === "replace_same_source") {
+        await client.query("UPDATE public.ai_brain_items SET is_active=false, updated_at=NOW() WHERE source=$1 AND is_active=true", [source]);
+      }
+      const saved = [];
+      for (const x of checked) {
+        const item = { ...x.item, source };
+        const r = await client.query(`
+          INSERT INTO public.ai_brain_items(item_type,title,content,intent,service_type,customer_stage,agent_key,language,priority,confidence,tags,source,is_active,metadata,created_by)
+          VALUES($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11::jsonb,$12,$13,$14::jsonb,$15)
+          RETURNING *
+        `, [
+          item.item_type,
+          item.title,
+          item.content,
+          item.intent,
+          item.service_type,
+          item.customer_stage,
+          item.agent_key,
+          item.language,
+          item.priority,
+          item.confidence,
+          JSON.stringify(item.tags),
+          item.source,
+          item.is_active,
+          JSON.stringify(item.metadata),
+          getAdminUser(req),
+        ]);
+        saved.push(r.rows[0]);
+      }
+      await client.query("COMMIT");
+      return res.json({ ok: true, saved_count: saved.length, items: saved });
+    } catch (e) {
+      await client.query("ROLLBACK").catch(() => {});
+      return res.status(e.status || 500).json({ ok: false, error: e.message || "IMPORT_COMMIT_FAILED" });
+    } finally {
+      client.release();
+    }
+  });
+
+  router.get("/admin/ai-office/brain/export", requireAdminSession, async (req, res) => {
+    try {
+      const items = await listBrainItems(pool, { ...(req.query || {}), active: "true", limit: 10000 });
+      const payload = {
+        version: "cwf-ai-brain-v1",
+        exported_at: new Date().toISOString(),
+        business: "Coldwindflow Air Services",
+        items: items.map(({ id, created_at, updated_at, created_by, ...item }) => item),
+      };
+      res.setHeader("Content-Type", "application/json; charset=utf-8");
+      res.setHeader("Content-Disposition", `attachment; filename="cwf-ai-brain-${new Date().toISOString().slice(0, 10)}.json"`);
+      return res.send(JSON.stringify(payload, null, 2));
+    } catch (e) {
+      return res.status(e.status || 500).json({ ok: false, error: e.message || "EXPORT_AI_BRAIN_FAILED" });
+    }
+  });
+
+  router.patch("/admin/ai-office/brain/items/:id", requireAdminSession, async (req, res) => {
+    try {
+      await ensureAiBrainSchema(pool);
+      const id = Number(req.params.id || 0);
+      const existing = await pool.query("SELECT * FROM public.ai_brain_items WHERE id=$1 LIMIT 1", [id]);
+      if (!existing.rows?.[0]) return res.status(404).json({ ok: false, error: "AI_BRAIN_ITEM_NOT_FOUND" });
+      const input = {};
+      EDITABLE_FIELDS.forEach((field) => {
+        if (Object.prototype.hasOwnProperty.call(req.body || {}, field)) input[field] = req.body[field];
+      });
+      const checked = validateBrainItem({ ...existing.rows[0], ...input }, 1);
+      if (!checked.ok) return res.status(400).json({ ok: false, errors: checked.errors, warnings: checked.warnings });
+      const item = checked.item;
+      const r = await pool.query(`
+        UPDATE public.ai_brain_items
+           SET item_type=$2,title=$3,content=$4,intent=$5,service_type=$6,customer_stage=$7,
+               agent_key=$8,language=$9,priority=$10,confidence=$11,tags=$12::jsonb,
+               source=$13,is_active=$14,metadata=$15::jsonb,updated_at=NOW()
+         WHERE id=$1
+         RETURNING *
+      `, [id, item.item_type, item.title, item.content, item.intent, item.service_type, item.customer_stage, item.agent_key, item.language, item.priority, item.confidence, JSON.stringify(item.tags), item.source, item.is_active, JSON.stringify(item.metadata)]);
+      return res.json({ ok: true, item: r.rows[0], warnings: checked.warnings });
+    } catch (e) {
+      return res.status(e.status || 500).json({ ok: false, error: e.message || "UPDATE_AI_BRAIN_ITEM_FAILED" });
+    }
+  });
+
+  router.patch("/admin/ai-office/brain/items/:id/disable", requireAdminSession, async (req, res) => {
+    try {
+      await ensureAiBrainSchema(pool);
+      const r = await pool.query("UPDATE public.ai_brain_items SET is_active=false, updated_at=NOW() WHERE id=$1 RETURNING *", [Number(req.params.id || 0)]);
+      if (!r.rows?.[0]) return res.status(404).json({ ok: false, error: "AI_BRAIN_ITEM_NOT_FOUND" });
+      return res.json({ ok: true, item: r.rows[0] });
+    } catch (e) {
+      return res.status(e.status || 500).json({ ok: false, error: e.message || "DISABLE_AI_BRAIN_ITEM_FAILED" });
+    }
+  });
+
+  return router;
+};
+
+module.exports.ensureAiBrainSchema = ensureAiBrainSchema;
+module.exports.loadAiBrainContext = loadAiBrainContext;
+module.exports.validateBrainItem = validateBrainItem;
+module.exports.parseCsv = parseCsv;

--- a/server/routes/adminAiOfficeLineDraftV27.js
+++ b/server/routes/adminAiOfficeLineDraftV27.js
@@ -1,10 +1,16 @@
 const express = require("express");
 const https = require("https");
+const { loadAiBrainContext } = require("./adminAiOfficeBrainManager");
 
 const DEFAULT_MODEL = "gpt-4.1-mini";
 
 function cleanText(value, max = 4000) {
   return String(value || "").replace(/\s+/g, " ").trim().slice(0, max);
+}
+function clampConfidence(value) {
+  const n = Number(value);
+  if (!Number.isFinite(n)) return 80;
+  return Math.max(0, Math.min(100, Math.round(n)));
 }
 function hasThai(value) {
   return /[\u0E00-\u0E7F]/.test(String(value || ""));
@@ -37,6 +43,37 @@ function correctionSituation(text) {
   if (/(รายได้ช่าง|ยอดช่าง|ต้องจ่ายช่าง|ยังไม่จ่ายช่าง|จ่ายช่าง|payout|commission|technician income)/i.test(s)) return "payout_logic";
   if (/(ราคา|แพง|แบบไหนดี|โปร|ส่วนลด)/.test(s)) return "sales_reply_logic";
   return "customer_reply_style";
+}
+function detectLineIntent(text) {
+  const s = String(text || "").toLowerCase();
+  if (/(คืนเงิน|ฟ้อง|ร้องเรียน|เคลม|ไม่พอใจ|complaint|refund|legal)/i.test(s)) return "complaint";
+  if (/(แพง|ลด|ส่วนลด|ทำไมราคา|price objection|expensive)/i.test(s)) return "price_objection";
+  if (/(ราคา|เท่าไหร่|กี่บาท|price|cost)/i.test(s)) return "price_question";
+  if (/(แพ็กเกจ|แบบไหนดี|ล้างแบบ|premium|normal|deep clean)/i.test(s)) return "package_recommendation";
+  if (/(นัด|จอง|คิว|ว่าง|วันไหน|เวลา|booking)/i.test(s)) return "booking_request";
+  if (/(พื้นที่|ไปถึง|เขต|อำเภอ|จังหวัด|service area)/i.test(s)) return "service_area";
+  if (/(ประกัน|รับประกัน|warranty)/i.test(s)) return "warranty";
+  if (/(ซ่อม|รั่ว|ไม่เย็น|น้ำหยด|repair|leak)/i.test(s)) return "repair_question";
+  return "general";
+}
+function detectCustomerStage(text, intent) {
+  const s = String(text || "").toLowerCase();
+  if (intent === "complaint") return "complaint";
+  if (/(ยืนยัน|ตกลง|จองเลย|พร้อมนัด|confirmed)/i.test(s)) return "booking_ready";
+  if (/(ที่อยู่|โลเคชั่น|location|address)/i.test(s)) return "waiting_address";
+  if (/(หลังล้าง|หลังบริการ|เรียบร้อย|after service)/i.test(s)) return "after_service";
+  if (/(แพง|เทียบ|เจ้าอื่น|ขอดูก่อน|comparing)/i.test(s)) return "comparing";
+  if (intent === "price_question" || intent === "price_objection" || intent === "package_recommendation") return "asking_price";
+  return "new_lead";
+}
+function riskMetadata(text, intent) {
+  const s = String(text || "").toLowerCase();
+  const red = /(ฟ้อง|ทนาย|ร้องเรียน|คืนเงิน|refund|legal)/i.test(s);
+  const yellow = red || /(เคลม|ไม่พอใจ|เสียหาย|รั่ว|ซ่อม|complaint|repair|leak)/i.test(s);
+  return {
+    risk_level: red ? "red" : yellow ? "yellow" : "green",
+    needs_admin_review: red || intent === "complaint",
+  };
 }
 function getAdminUser(req) {
   return cleanText(req.session?.user?.username || req.session?.user?.email || req.session?.username || req.user?.username || req.user?.email || "", 120);
@@ -291,6 +328,17 @@ module.exports = function createAdminAiOfficeLineDraftV27Routes(deps = {}) {
       const adminQuestion = cleanText(req.body?.admin_question || req.body?.instruction || "ควรตอบลูกค้ายังไง", 1200);
       const language = detectLanguage(selectedQuestion);
       const situationType = inferSituation(`${selectedQuestion}\n${adminQuestion}`);
+      const intent = detectLineIntent(`${selectedQuestion}\n${adminQuestion}`);
+      const customerStage = detectCustomerStage(`${selectedQuestion}\n${adminQuestion}`, intent);
+      const brainContext = await loadAiBrainContext(pool, {
+        query: `${selectedQuestion}\n${adminQuestion}`,
+        agent_key: "sales",
+        intent,
+        service_type: "",
+        customer_stage: customerStage,
+        language: language === "unknown" ? "th" : language,
+        limit: 10,
+      }).catch(() => ({ items: [] }));
       if (isAdminCorrection(adminQuestion)) {
         await logSharedDraftMemory(pool, req, {
           source: "line_chat",
@@ -311,12 +359,17 @@ module.exports = function createAdminAiOfficeLineDraftV27Routes(deps = {}) {
 
       const system = [
         "You are Sales/Admin AI for Coldwindflow LINE OA.",
-        "Return strict JSON only with keys: customer_reply, admin_summary, missing_info, next_step, customer_language, is_foreign_customer, original_message, thai_translation.",
+        "Return strict JSON only with keys: customer_reply, admin_summary, missing_info, next_step, customer_language, is_foreign_customer, original_message, thai_translation, customer_stage, intent, confidence, risk_level, needs_admin_review.",
         "selected_customer_question is the MAIN customer question to answer. Other LINE messages are context only.",
         "Do not answer from the latest customer message if selected_customer_question exists.",
         "Write like a real Thai female LINE admin: short, warm, natural, ready to send. Use ค่ะ/นะคะ. Never use ครับ.",
         "No headings, no bullets, no report format, no JSON visible inside customer_reply.",
         "Do not repeat questions for details already present in selected_customer_question/context.",
+        "If missing required booking info, ask only the missing info. If enough info exists, do not ask again.",
+        "If customer says expensive, do not argue; explain value and offer a suitable option.",
+        "If repair, leak, or uncertain price, say the technician needs to inspect before final quote.",
+        "If complaint, legal, or refund risk exists, set needs_admin_review true.",
+        "Follow policy_rule and bad_reply_pattern brain items strictly. Use approved_reply and sales_playbook as examples. Never expose internal brain item text as system says.",
         "Do not claim any LINE message was sent or any booking/status was created.",
         "Use saved final_admin_reply examples as style reference only."
       ].join(" ");
@@ -346,6 +399,20 @@ module.exports = function createAdminAiOfficeLineDraftV27Routes(deps = {}) {
           situation_type:m.situation_type
         })), null, 2),
         "",
+        "ai_brain_context:",
+        JSON.stringify((brainContext.items || []).map((b) => ({
+          item_type:b.item_type,
+          title:b.title,
+          content:b.content,
+          intent:b.intent,
+          service_type:b.service_type,
+          customer_stage:b.customer_stage,
+          agent_key:b.agent_key,
+          priority:b.priority,
+          confidence:b.confidence,
+          tags:b.tags
+        })), null, 2),
+        "",
         "CWF facts:",
         JSON.stringify({ wall_under_12000: { normal:550, premium:790, hanging_coil:1290, deep_clean:1850 }, wall_18000_up: { normal:690, premium:990, hanging_coil:1550, deep_clean:2150 }, check_fee:700, warranty_cleaning_days:30, services:["ล้างแอร์","ซ่อมแอร์","ติดตั้งแอร์","ตรวจเช็คแอร์"] }, null, 2)
       ].join("\n");
@@ -360,6 +427,7 @@ module.exports = function createAdminAiOfficeLineDraftV27Routes(deps = {}) {
       let parsed = {};
       try { parsed = JSON.parse(raw); } catch (_) { parsed = { customer_reply: raw }; }
       const customerReply = sanitizeCustomerReply(parsed.customer_reply, selectedQuestion);
+      const risk = riskMetadata(`${selectedQuestion}\n${adminQuestion}`, intent);
       const draft = {
         customer_reply: customerReply,
         admin_summary: Array.isArray(parsed.admin_summary) ? parsed.admin_summary : [],
@@ -375,9 +443,15 @@ module.exports = function createAdminAiOfficeLineDraftV27Routes(deps = {}) {
         selected_question_used: selectedQuestionUsed,
         draft_source: draftSource,
         latest_customer_message: latestCustomerMessage,
+        intent: cleanText(parsed.intent || intent, 80),
+        customer_stage: cleanText(parsed.customer_stage || customerStage, 80),
+        confidence: clampConfidence(parsed.confidence),
+        risk_level: ["green", "yellow", "red"].includes(parsed.risk_level) ? parsed.risk_level : risk.risk_level,
+        needs_admin_review: Boolean(parsed.needs_admin_review || risk.needs_admin_review),
+        used_ai_brain_items: (brainContext.items || []).map((b) => ({ id:b.id, item_type:b.item_type, title:b.title, intent:b.intent, agent_key:b.agent_key })),
         used_reply_examples: examples.map((e) => ({ id:e.id, situation_type:e.situation_type, language:e.language, service_type:e.service_type })),
       };
-      const saved = await saveDraft(pool, req, { conversation_id: conversationId, selected_customer_message: selectedQuestion, admin_instruction: adminQuestion, ai_draft: customerReply, metadata: { situation_type: situationType, language, used_example_ids: draft.used_reply_examples.map((e) => e.id) } }).catch(() => null);
+      const saved = await saveDraft(pool, req, { conversation_id: conversationId, selected_customer_message: selectedQuestion, admin_instruction: adminQuestion, ai_draft: customerReply, metadata: { situation_type: situationType, language, intent: draft.intent, customer_stage: draft.customer_stage, risk_level: draft.risk_level, needs_admin_review: draft.needs_admin_review, used_example_ids: draft.used_reply_examples.map((e) => e.id), used_ai_brain_item_ids: draft.used_ai_brain_items.map((e) => e.id) } }).catch(() => null);
       if (saved) draft.saved_draft_id = saved.id;
       await logSharedDraftMemory(pool, req, {
         source: "line_chat",
@@ -389,7 +463,7 @@ module.exports = function createAdminAiOfficeLineDraftV27Routes(deps = {}) {
         ai_reply: customerReply,
         action_status: "drafted",
         situation_type: situationType,
-        metadata: { saved_draft_id: saved?.id || null, used_example_ids: draft.used_reply_examples.map((e) => e.id) },
+        metadata: { saved_draft_id: saved?.id || null, intent: draft.intent, customer_stage: draft.customer_stage, risk_level: draft.risk_level, needs_admin_review: draft.needs_admin_review, used_example_ids: draft.used_reply_examples.map((e) => e.id), used_ai_brain_item_ids: draft.used_ai_brain_items.map((e) => e.id) },
       });
       return res.json({
         ok:true,
@@ -402,6 +476,11 @@ module.exports = function createAdminAiOfficeLineDraftV27Routes(deps = {}) {
         selected_customer_question: selectedQuestion,
         latest_customer_message: latestCustomerMessage,
         draft_source: draftSource,
+        intent: draft.intent,
+        customer_stage: draft.customer_stage,
+        confidence: draft.confidence,
+        risk_level: draft.risk_level,
+        needs_admin_review: draft.needs_admin_review,
       });
     } catch (e) {
       console.error("V27 /line-draft-reply error:", e);

--- a/server/routes/adminAiOfficeLineDraftV27.js
+++ b/server/routes/adminAiOfficeLineDraftV27.js
@@ -28,6 +28,16 @@ function inferSituation(text) {
   if (/ล้างแบบ|แบบไหน|พรีเมียม|ปกติ|แขวนคอยล์|ตัดล้าง/.test(s)) return "cleaning_package";
   return "general";
 }
+function isAdminCorrection(text) {
+  return /(ผิด|ไม่ใช่|ยังว่าง|อย่าบอกว่าคิวเต็ม|ตอบแบบนี้ไม่ดี|ควรตอบแบบนี้|มั่ว|งง)/i.test(String(text || ""));
+}
+function correctionSituation(text) {
+  const s = String(text || "").toLowerCase();
+  if (/(คิว|ว่าง|ช่าง|เวลา|เต็ม)/.test(s)) return "availability_logic";
+  if (/(รายได้ช่าง|ยอดช่าง|ต้องจ่ายช่าง|ยังไม่จ่ายช่าง|จ่ายช่าง|payout|commission|technician income)/i.test(s)) return "payout_logic";
+  if (/(ราคา|แพง|แบบไหนดี|โปร|ส่วนลด)/.test(s)) return "sales_reply_logic";
+  return "customer_reply_style";
+}
 function getAdminUser(req) {
   return cleanText(req.session?.user?.username || req.session?.user?.email || req.session?.username || req.user?.username || req.user?.email || "", 120);
 }
@@ -83,7 +93,8 @@ async function loadSharedMemoryForDraft(pool, { conversationId, selectedQuestion
          AND action_status <> 'disliked'
          AND event_type <> 'disliked'
          AND (final_admin_reply <> '' OR ai_reply <> '')
-       ORDER BY CASE WHEN action_status IN ('saved','copied','liked') THEN 0 ELSE 1 END,
+       ORDER BY CASE WHEN event_type='admin_correction' OR action_status='correction' THEN 0 ELSE 1 END,
+                CASE WHEN action_status IN ('saved','copied','liked') THEN 0 ELSE 1 END,
                 CASE WHEN source='reply_example' THEN 0 ELSE 1 END,
                 created_at DESC
        LIMIT 8
@@ -271,11 +282,29 @@ module.exports = function createAdminAiOfficeLineDraftV27Routes(deps = {}) {
       const messages = await loadMessages(pool, conversationId);
       if (!messages.length) return res.status(400).json({ ok:false, error:"ยังไม่มีข้อความในแชทนี้" });
 
-      const selectedQuestion = cleanText(req.body?.selected_customer_question, 2000)
-        || cleanText([...messages].reverse().find((m) => m.direction === "inbound" && m.message_text)?.message_text || conversation.last_message_text, 2000);
+      const selectedQuestionFromRequest = cleanText(req.body?.selected_customer_question, 2000);
+      const latestInbound = [...messages].reverse().find((m) => m.direction === "inbound" && m.message_text);
+      const latestCustomerMessage = cleanText(latestInbound?.message_text || conversation.last_message_text, 2000);
+      const selectedQuestion = selectedQuestionFromRequest || latestCustomerMessage;
+      const selectedQuestionUsed = Boolean(selectedQuestionFromRequest);
+      const draftSource = selectedQuestionUsed ? "selected_customer_question" : "latest_customer_message";
       const adminQuestion = cleanText(req.body?.admin_question || req.body?.instruction || "ควรตอบลูกค้ายังไง", 1200);
       const language = detectLanguage(selectedQuestion);
       const situationType = inferSituation(`${selectedQuestion}\n${adminQuestion}`);
+      if (isAdminCorrection(adminQuestion)) {
+        await logSharedDraftMemory(pool, req, {
+          source: "line_chat",
+          event_type: "admin_correction",
+          agent_key: "admin",
+          conversation_id: conversationId,
+          selected_customer_question: selectedQuestion,
+          customer_message: selectedQuestion,
+          final_admin_reply: adminQuestion,
+          action_status: "correction",
+          situation_type: correctionSituation(`${selectedQuestion}\n${adminQuestion}`),
+          metadata: { auto_detected: true },
+        });
+      }
       const examples = await loadExamples(pool, { situationType, language });
       const sharedMemory = await loadSharedMemoryForDraft(pool, { conversationId, selectedQuestion, situationType, language });
       const priorDrafts = Array.isArray(req.body?.prior_drafts) ? req.body.prior_drafts.slice(-5) : [];
@@ -293,7 +322,9 @@ module.exports = function createAdminAiOfficeLineDraftV27Routes(deps = {}) {
       ].join(" ");
 
       const prompt = [
-        "selected_customer_question:", selectedQuestion, "",
+        "draft_source:", draftSource, "",
+        "selected_customer_question_main:", selectedQuestion, "",
+        "latest_customer_message_context_only:", latestCustomerMessage, "",
         "admin_instruction:", adminQuestion, "",
         "conversation:",
         JSON.stringify({ display_name: conversation.display_name || "", messages: messages.map((m) => ({ direction:m.direction, text:m.message_text, at:m.received_at || m.created_at })).slice(-20) }, null, 2),
@@ -341,6 +372,9 @@ module.exports = function createAdminAiOfficeLineDraftV27Routes(deps = {}) {
         thai_translation: cleanText(parsed.thai_translation, 1000),
         selected_customer_question: selectedQuestion,
         situation_type: situationType,
+        selected_question_used: selectedQuestionUsed,
+        draft_source: draftSource,
+        latest_customer_message: latestCustomerMessage,
         used_reply_examples: examples.map((e) => ({ id:e.id, situation_type:e.situation_type, language:e.language, service_type:e.service_type })),
       };
       const saved = await saveDraft(pool, req, { conversation_id: conversationId, selected_customer_message: selectedQuestion, admin_instruction: adminQuestion, ai_draft: customerReply, metadata: { situation_type: situationType, language, used_example_ids: draft.used_reply_examples.map((e) => e.id) } }).catch(() => null);
@@ -357,7 +391,18 @@ module.exports = function createAdminAiOfficeLineDraftV27Routes(deps = {}) {
         situation_type: situationType,
         metadata: { saved_draft_id: saved?.id || null, used_example_ids: draft.used_reply_examples.map((e) => e.id) },
       });
-      return res.json({ ok:true, answer:customerReply, draft, used_reply_examples:draft.used_reply_examples, conversation, messages });
+      return res.json({
+        ok:true,
+        answer:customerReply,
+        draft,
+        used_reply_examples:draft.used_reply_examples,
+        conversation,
+        messages,
+        selected_question_used: selectedQuestionUsed,
+        selected_customer_question: selectedQuestion,
+        latest_customer_message: latestCustomerMessage,
+        draft_source: draftSource,
+      });
     } catch (e) {
       console.error("V27 /line-draft-reply error:", e);
       return res.status(e.status || 500).json({ ok:false, error:e.message || "ร่างข้อความจาก LINE ไม่สำเร็จ" });

--- a/server/routes/adminAiOfficeReadOnly.js
+++ b/server/routes/adminAiOfficeReadOnly.js
@@ -31,6 +31,7 @@ const {
   detectPriorityFlags,
   extractCustomerContextFromMessages,
 } = require("../cwfAiKnowledge");
+const { loadAiBrainContext } = require("./adminAiOfficeBrainManager");
 
 const AI_OFFICE_DEFAULT_MODEL = "gpt-4.1-mini";
 const AI_OFFICE_JOB_LIMIT = 80;
@@ -340,11 +341,36 @@ function getLineAgent(agentKey) {
   return AI_OFFICE_AGENTS.admin;
 }
 
+function detectBrainIntent(text) {
+  const s = String(text || "").toLowerCase();
+  if (/(คืนเงิน|ฟ้อง|ร้องเรียน|เคลม|ไม่พอใจ|complaint|refund|legal)/i.test(s)) return "complaint";
+  if (/(แพง|ลด|ส่วนลด|ทำไมราคา|price objection|expensive)/i.test(s)) return "price_objection";
+  if (/(ราคา|เท่าไหร่|กี่บาท|price|cost)/i.test(s)) return "price_question";
+  if (/(แพ็กเกจ|แบบไหนดี|ล้างแบบ|premium|normal|deep clean)/i.test(s)) return "package_recommendation";
+  if (/(นัด|จอง|คิว|ว่าง|วันไหน|เวลา|booking)/i.test(s)) return "booking_request";
+  if (/(พื้นที่|ไปถึง|เขต|อำเภอ|จังหวัด|service area)/i.test(s)) return "service_area";
+  if (/(ประกัน|รับประกัน|warranty)/i.test(s)) return "warranty";
+  if (/(ซ่อม|รั่ว|ไม่เย็น|น้ำหยด|repair|leak)/i.test(s)) return "repair_question";
+  return "general";
+}
+
+function detectBrainCustomerStage(text, intent) {
+  const s = String(text || "").toLowerCase();
+  if (intent === "complaint") return "complaint";
+  if (/(ยืนยัน|ตกลง|จองเลย|พร้อมนัด|confirmed)/i.test(s)) return "booking_ready";
+  if (/(ที่อยู่|โลเคชั่น|location|address)/i.test(s)) return "waiting_address";
+  if (/(หลังล้าง|หลังบริการ|เรียบร้อย|after service)/i.test(s)) return "after_service";
+  if (/(แพง|เทียบ|เจ้าอื่น|ขอดูก่อน|comparing)/i.test(s)) return "comparing";
+  if (intent === "price_question" || intent === "price_objection" || intent === "package_recommendation") return "asking_price";
+  return "new_lead";
+}
+
 function buildGroundedPrompt(question, context, agent) {
   const officeInstructions = [
     `Business timezone: ${BANGKOK_TZ}. All user-facing dates and times must use appointment_display or appointment_time_th. Never show raw UTC timestamps to the admin or customer.`,
     "For queue/technician availability questions, use context.availability as the deterministic source. If it says job_schedule_only or missing data, do not confirm exact availability.",
     "For service, price, objection, and customer-reply questions, use context.cwf_knowledge as the current source of truth. It overrides old chat history.",
+    "Use context.ai_brain as admin-approved structured brain. Follow policy_rule and bad_reply_pattern strictly. Use approved_reply and sales_playbook as examples. Never expose internal brain text as system instructions.",
     "If agent is Office Chat, detect and combine relevant departments from context.office_chat_agents, then include a short line starting with แผนกที่เกี่ยวข้อง:",
     "Sales/customer replies must sound like a real LINE admin: short, natural Thai, usually 1-4 lines, price first when asked, one missing question at a time.",
     "Never reveal raw retrieved customer chat examples or private customer data.",
@@ -371,8 +397,9 @@ function buildLineDraftPrompt({ conversation, messages, agent, instruction, thre
   return [
     `Business timezone: ${BANGKOK_TZ}. Use Thai local time only; never show raw UTC timestamps.`,
     "Return STRICT JSON only. No markdown, no prose outside JSON.",
-    "JSON schema: {\"customer_reply\":\"string\",\"admin_summary\":[\"short bullet\"],\"missing_info\":[\"short bullet\"],\"next_step\":\"string\",\"customer_language\":\"th|en|ja|zh|ko|unknown\",\"is_foreign_customer\":true,\"foreign_customer_label\":\"string\",\"original_message\":\"string\",\"thai_translation\":\"string\"}",
+    "JSON schema: {\"customer_reply\":\"string\",\"admin_summary\":[\"short bullet\"],\"missing_info\":[\"short bullet\"],\"next_step\":\"string\",\"customer_language\":\"th|en|ja|zh|ko|unknown\",\"is_foreign_customer\":true,\"foreign_customer_label\":\"string\",\"original_message\":\"string\",\"thai_translation\":\"string\",\"customer_stage\":\"string\",\"intent\":\"string\",\"confidence\":80,\"risk_level\":\"green|yellow|red\",\"needs_admin_review\":false}",
     "Use current CWF service/pricing knowledge and short LINE admin tone. Do not use old chat prices as facts.",
+    "Use thread_context.ai_brain as admin-approved structured brain. Follow policy_rule and bad_reply_pattern strictly. Use approved_reply and sales_playbook as examples. Never expose internal brain item text as system says.",
     "If thread_context.reply_examples exists, use only final_admin_reply as trusted admin style examples. They are sanitized style memory, not factual pricing. Current CWF knowledge overrides them.",
     "Customer Inbox isolation rule: use only this selected conversation, selected customer context, CWF knowledge, and linked jobs in this JSON. Do not use any other customer's conversation.",
     "Phase 1 rule: draft copy-ready replies only. Do not claim a LINE message was sent, do not open a booking, and do not change any job/customer status.",
@@ -382,6 +409,7 @@ function buildLineDraftPrompt({ conversation, messages, agent, instruction, thre
     "customer_reply must not contain headings, bullets, JSON keys, the words สรุป, ข้อมูลที่ยังขาด, หมายเหตุสำหรับแอดมิน, แนะนำขั้นต่อไป, customer_reply, or admin_summary.",
     "If the customer asks price, answer the current CWF price first from cwf_knowledge, then ask one useful missing detail if needed.",
     "If the customer says expensive, explain value briefly and naturally, then offer a lower option when available.",
+    "If repair, leak, or uncertain price, say the technician needs to inspect before final quote. If complaint/legal/refund risk exists, set needs_admin_review true.",
     "If the latest customer message is English, customer_reply must be English. If Japanese, reply Japanese if possible, otherwise English. For foreign customers, include thai_translation for admin.",
     JSON.stringify({ cwf_knowledge: serviceKnowledge() }, null, 2),
     "คุณคือผู้ช่วย AI ภายในของ Coldwindflow Air Services สำหรับช่วยแอดมินอ่านแชท LINE OA เท่านั้น",
@@ -475,6 +503,11 @@ function fallbackLineDraft({ conversation, messages, threadContext }) {
     foreign_customer_label: isForeign ? foreignCustomerLabel(conversation) : "",
     original_message: original,
     thai_translation: latest.thai_translation || "",
+    customer_stage: detectBrainCustomerStage(original, detectBrainIntent(original)),
+    intent: detectBrainIntent(original),
+    confidence: 70,
+    risk_level: detectBrainIntent(original) === "complaint" ? "red" : "green",
+    needs_admin_review: detectBrainIntent(original) === "complaint",
   };
 }
 
@@ -490,6 +523,11 @@ function normalizeLineDraftPayload(payload, fallback) {
     foreign_customer_label: cleanText(payload?.foreign_customer_label, 200) || fallback.foreign_customer_label,
     original_message: cleanText(payload?.original_message, 1000) || fallback.original_message,
     thai_translation: cleanText(payload?.thai_translation, 1000) || fallback.thai_translation,
+    customer_stage: cleanText(payload?.customer_stage, 80) || fallback.customer_stage,
+    intent: cleanText(payload?.intent, 80) || fallback.intent,
+    confidence: Number.isFinite(Number(payload?.confidence)) ? Math.max(0, Math.min(100, Math.round(Number(payload.confidence)))) : fallback.confidence,
+    risk_level: ["green", "yellow", "red"].includes(payload?.risk_level) ? payload.risk_level : fallback.risk_level,
+    needs_admin_review: Boolean(payload?.needs_admin_review ?? fallback.needs_admin_review),
   };
   return out;
 }
@@ -537,8 +575,13 @@ function lineDraftResponseFormat() {
           foreign_customer_label: { type: "string" },
           original_message: { type: "string" },
           thai_translation: { type: "string" },
+          customer_stage: { type: "string" },
+          intent: { type: "string" },
+          confidence: { type: "number" },
+          risk_level: { type: "string", enum: ["green", "yellow", "red"] },
+          needs_admin_review: { type: "boolean" },
         },
-        required: ["customer_reply", "admin_summary", "missing_info", "next_step", "customer_language", "is_foreign_customer", "foreign_customer_label", "original_message", "thai_translation"],
+        required: ["customer_reply", "admin_summary", "missing_info", "next_step", "customer_language", "is_foreign_customer", "foreign_customer_label", "original_message", "thai_translation", "customer_stage", "intent", "confidence", "risk_level", "needs_admin_review"],
       },
     },
   };
@@ -1335,7 +1378,18 @@ module.exports = function createAdminAiOfficeReadOnlyRoutes(deps = {}) {
       const latest = latestCustomerMessage(messages);
       const latestText = cleanText(latest.message_text_for_admin || latest.message_text || conversation.last_message_text, 1200);
       const situationType = detectCustomerIntent(`${latestText}\n${instruction}`);
+      const brainIntent = detectBrainIntent(`${latestText}\n${instruction}`);
+      const brainCustomerStage = detectBrainCustomerStage(`${latestText}\n${instruction}`, brainIntent);
       const customerLanguage = detectCustomerLanguage(latestText);
+      threadContext.ai_brain = await loadAiBrainContext(pool, {
+        query: `${latestText}\n${instruction}`,
+        agent_key: "sales",
+        intent: brainIntent,
+        service_type: "",
+        customer_stage: brainCustomerStage,
+        language: customerLanguage || "th",
+        limit: 10,
+      }).catch(() => ({ items: [] }));
       const replyExamples = await loadMatchingReplyExamples(pool, {
         situation_type: situationType,
         language: customerLanguage,
@@ -1371,6 +1425,9 @@ module.exports = function createAdminAiOfficeReadOnlyRoutes(deps = {}) {
         rawAnswer = await callOpenAI({ apiKey, model, system: lineSystem, prompt: linePrompt });
       }
       const draft = parseLineDraftAnswer(rawAnswer, fallbackLineDraft({ conversation, messages, threadContext }));
+      draft.intent = draft.intent || brainIntent;
+      draft.customer_stage = draft.customer_stage || brainCustomerStage;
+      draft.used_ai_brain_items = (threadContext.ai_brain?.items || []).map((item) => ({ id: item.id, item_type: item.item_type, title: item.title, intent: item.intent, agent_key: item.agent_key }));
       const usedReplyExamples = threadContext.reply_examples.map((example) => ({
         id: example.id,
         situation_type: example.situation_type,
@@ -1419,6 +1476,17 @@ module.exports = function createAdminAiOfficeReadOnlyRoutes(deps = {}) {
         generated_at_display: formatThaiDateTime(new Date()),
         cwf_knowledge: serviceKnowledge(),
       };
+      const brainIntent = detectBrainIntent(question);
+      const brainCustomerStage = detectBrainCustomerStage(question, brainIntent);
+      context.ai_brain = await loadAiBrainContext(pool, {
+        query: question,
+        agent_key: cleanText(req.body?.agent || "admin", 40),
+        intent: brainIntent,
+        service_type: "",
+        customer_stage: brainCustomerStage,
+        language: "th",
+        limit: 10,
+      }).catch(() => ({ items: [] }));
       for (const bucket of buckets) {
         context.buckets[bucket] = await loadJobs(pool, bucket);
       }

--- a/server/routes/adminAiOfficeSharedMemoryV27.js
+++ b/server/routes/adminAiOfficeSharedMemoryV27.js
@@ -124,6 +124,7 @@ async function loadSharedMemoryContext(pool, body = {}) {
        AND action_status <> 'disliked'
        AND event_type <> 'disliked'
      ORDER BY
+       CASE WHEN event_type='admin_correction' OR action_status='correction' THEN 0 ELSE 1 END,
        CASE WHEN action_status IN ('saved','copied','liked') THEN 0 ELSE 1 END,
        CASE WHEN source='reply_example' THEN 0 ELSE 1 END,
        created_at DESC

--- a/server/routes/adminAiOfficeSmartAssistantV28.js
+++ b/server/routes/adminAiOfficeSmartAssistantV28.js
@@ -1,4 +1,5 @@
 const express = require("express");
+const { loadAiBrainContext } = require("./adminAiOfficeBrainManager");
 
 const BANGKOK_TZ = "Asia/Bangkok";
 const DEFAULT_WORK_START = "09:00";
@@ -592,6 +593,7 @@ module.exports = function createAdminAiOfficeSmartAssistantV28Routes(deps = {}) 
       if (isPayoutQuestion(question)) {
         const payoutId = cleanText(req.body?.payout_id || req.query?.payout_id, 80) || currentBangkokPayoutId();
         const summary = await buildPayoutSummary({ accounting, payoutId });
+        const brain = await loadAiBrainContext(pool, { query: question, agent_key: cleanText(req.body?.agent || "admin", 40), intent: "payout_logic", service_type: "", customer_stage: "", language: "th", limit: 6 }).catch(() => ({ items: [] }));
         const answer = formatPayoutAnswer(summary);
         await logMemory(pool, req, {
           source: "accounting_payout_summary",
@@ -602,14 +604,14 @@ module.exports = function createAdminAiOfficeSmartAssistantV28Routes(deps = {}) 
           action_status: summary.ok ? "answered" : "diagnostic",
           situation_type: "payout_logic",
           tags: ["deterministic", "payout", "read_only"],
-          metadata: { payout_summary: summary },
+          metadata: { payout_summary: summary, used_ai_brain_item_ids: (brain.items || []).map((b) => b.id) },
         });
         return res.json({
           ok: true,
           answer,
           payout_summary: summary,
           agent: { key: req.body?.agent || "admin", name: "Admin AI", role: "deterministic accounting payout summary" },
-          context: { payout_summary: summary },
+          context: { payout_summary: summary, ai_brain: brain },
         });
       }
 
@@ -619,6 +621,7 @@ module.exports = function createAdminAiOfficeSmartAssistantV28Routes(deps = {}) 
       const jobs = await loadDayJobs(pool, dateInfo.iso);
       const activeTechnicians = /ช่างทั้งหมด/.test(question) ? await loadActiveTechnicians(pool) : [];
       const result = analyzeAvailability({ jobs, question, activeTechnicians });
+      const brain = await loadAiBrainContext(pool, { query: question, agent_key: cleanText(req.body?.agent || "ops", 40), intent: "booking_request", service_type: "", customer_stage: "", language: "th", limit: 6 }).catch(() => ({ items: [] }));
       const answer = answerAvailability(result);
 
       await logMemory(pool, req, {
@@ -630,14 +633,14 @@ module.exports = function createAdminAiOfficeSmartAssistantV28Routes(deps = {}) 
         action_status: "answered",
         situation_type: "availability_logic",
         tags: ["deterministic", "availability", "v28"],
-        metadata: { availability_result: result },
+        metadata: { availability_result: result, used_ai_brain_item_ids: (brain.items || []).map((b) => b.id) },
       });
 
       return res.json({
         ok: true,
         answer,
         agent: { key: req.body?.agent || "admin", name: "Admin AI", role: "deterministic availability engine" },
-        context: { availability_result: result },
+        context: { availability_result: result, ai_brain: brain },
       });
     } catch (e) {
       console.error("V28 /admin/ai-office/ask availability error:", e);

--- a/server/routes/adminAiOfficeSmartAssistantV28.js
+++ b/server/routes/adminAiOfficeSmartAssistantV28.js
@@ -81,10 +81,145 @@ function isCorrectionQuestion(question) {
 }
 function correctionSituation(question) {
   const q = String(question || "").toLowerCase();
+  if (/(รายได้ช่าง|ยอดช่าง|ต้องจ่ายช่าง|ยังไม่จ่ายช่าง|จ่ายช่าง|payout|technician income|commission)/i.test(q)) return "payout_logic";
   if (/(คิว|ว่าง|ช่าง|เวลา|บ่าย|เช้า|เย็น|นัด|เต็ม)/.test(q)) return "availability_logic";
   if (/(ราคา|แพง|ส่วนลด|โปร)/.test(q)) return "sales_reply_logic";
   if (/(ลูกค้า|แชท|ตอบ|line|ไลน์)/.test(q)) return "customer_reply_style";
+  if (/(รายได้ช่าง|ยอดช่าง|ต้องจ่ายช่าง|ยังไม่จ่ายช่าง|จ่ายช่าง|payout|technician income|commission)/i.test(q)) return "payout_logic";
   return "admin_correction";
+}
+function isPayoutQuestion(question) {
+  return /(รายได้ช่าง|ยอดช่าง|ต้องจ่ายช่าง|ยังไม่จ่ายช่าง|จ่ายช่าง|payout|technician income|commission)/i.test(String(question || ""));
+}
+function currentBangkokPayoutId(date = new Date()) {
+  const parts = bangkokDateParts(date);
+  const type = parts.d <= 10 ? "10" : "25";
+  return `payout_${parts.y}-${pad(parts.m)}_${type}`;
+}
+function money(value) {
+  const n = Number(value || 0);
+  return Number.isFinite(n) ? Math.round((n + Number.EPSILON) * 100) / 100 : 0;
+}
+function payoutPeriodLabel(period = {}) {
+  const start = String(period.period_start || "").slice(0, 10);
+  const end = String(period.period_end || "").slice(0, 10);
+  if (!start && !end) return String(period.payout_id || "");
+  return `${start || "-"} ถึง ${end || "-"}`;
+}
+async function buildPayoutSummary({ accounting, payoutId }) {
+  const warnings = [];
+  if (!accounting?.buildPayoutTechSummaryRows) {
+    return {
+      ok: false,
+      error: "MISSING_ACCOUNTING_PAYOUT_SOURCE",
+      diagnostics: {
+        missing_dependency: "accounting.buildPayoutTechSummaryRows",
+        expected_source: "index.js _buildPayoutTechSummaryRows / server/routes/accountingReadOnly.js buildPayoutTechSummaryRows",
+      },
+      period: { date_from: "", date_to: "", label: "" },
+      totals: {},
+      technicians: [],
+      warnings: ["AI Office payout summary cannot read the accounting payout helper."],
+    };
+  }
+
+  const payload = await accounting.buildPayoutTechSummaryRows(payoutId);
+  const period = payload?.period || await accounting.getPayoutPeriod?.(payoutId);
+  if (!period) {
+    return {
+      ok: false,
+      error: "PAYOUT_PERIOD_NOT_FOUND",
+      diagnostics: { payout_id: payoutId, source: payload?.source || "none" },
+      period: { date_from: "", date_to: "", label: payoutId },
+      totals: {},
+      technicians: [],
+      warnings: [`No payout period or virtual payout bounds found for ${payoutId}.`],
+    };
+  }
+
+  let rows = payload?.techs || [];
+  if (accounting.accountingEnrichPayoutTechRows) {
+    rows = await accounting.accountingEnrichPayoutTechRows(payoutId, period, rows);
+  }
+  const technicians = rows.map((row) => {
+    const payable = money(row.net_amount);
+    const paid = money(row.paid_amount);
+    const unpaid = money(Math.max(0, payable - paid));
+    const paidStatus = String(row.paid_status || (accounting.paidStatus ? accounting.paidStatus(payable, paid) : "") || "").trim() || (paid >= payable && payable > 0 ? "paid" : paid > 0 ? "partial" : "unpaid");
+    const jobCount = Number(row.jobs_count || row.job_count || 0);
+    return {
+      technician_key: row.technician_username || "",
+      technician_name: row.technician_full_name || row.technician_username || "",
+      payable_total: payable,
+      paid_total: paid,
+      unpaid_total: paidStatus === "paid" ? 0 : unpaid,
+      partial_total: paidStatus === "partial" ? unpaid : 0,
+      cash_held_total: money(row.cash_held_amount),
+      cash_offset_total: money(Math.abs(Number(row.adj_total || 0)) || 0),
+      job_count: jobCount,
+      paid_job_count: paidStatus === "paid" ? jobCount : 0,
+      unpaid_job_count: paidStatus === "unpaid" ? jobCount : 0,
+      partial_job_count: paidStatus === "partial" ? jobCount : 0,
+      rows: [],
+      source: row.source || payload?.source || "",
+    };
+  });
+  const totals = technicians.reduce((acc, t) => {
+    acc.total_payable += t.payable_total;
+    acc.total_paid += t.paid_total;
+    acc.total_unpaid += t.unpaid_total;
+    acc.total_partial += t.partial_total;
+    acc.total_cash_held_by_technicians += t.cash_held_total;
+    acc.total_cash_offset += t.cash_offset_total;
+    return acc;
+  }, {
+    total_payable: 0,
+    total_paid: 0,
+    total_unpaid: 0,
+    total_partial: 0,
+    total_cash_held_by_technicians: 0,
+    total_cash_offset: 0,
+  });
+  Object.keys(totals).forEach((key) => { totals[key] = money(totals[key]); });
+  if (!technicians.length) warnings.push("ไม่พบรายช่างในงวดนี้จากแหล่ง accounting payout");
+  return {
+    ok: true,
+    payout_id: payoutId,
+    source: payload?.source || "accounting_payout_helper",
+    period: {
+      date_from: String(period.period_start || "").slice(0, 10),
+      date_to: String(period.period_end || "").slice(0, 10),
+      label: payoutPeriodLabel(period),
+    },
+    totals,
+    technicians,
+    warnings,
+  };
+}
+function formatPayoutAnswer(summary) {
+  if (!summary?.ok) {
+    const diagnostics = summary?.diagnostics ? JSON.stringify(summary.diagnostics) : summary?.error || "unknown";
+    return `ยังสรุปยอดช่างจากข้อมูลจริงไม่ได้ค่ะ\n\nสาเหตุ: ${summary?.error || "PAYOUT_SUMMARY_FAILED"}\nDiagnostics: ${diagnostics}`;
+  }
+  const lines = [
+    `สรุปยอดช่างงวด ${summary.period?.label || summary.payout_id || ""} ค่ะ`,
+    "",
+    `ยอดต้องจ่ายช่างรวม ${summary.totals.total_payable} บาท`,
+    `จ่ายแล้ว ${summary.totals.total_paid} บาท`,
+    `ยังไม่จ่าย ${summary.totals.total_unpaid} บาท`,
+  ];
+  if (summary.totals.total_cash_held_by_technicians) lines.push(`เงินสดที่ช่างถือไว้ ${summary.totals.total_cash_held_by_technicians} บาท`);
+  lines.push("", "แยกรายช่าง:");
+  for (const t of (summary.technicians || []).slice(0, 12)) {
+    lines.push(`- ${t.technician_name || t.technician_key}: ต้องจ่าย ${t.payable_total} / จ่ายแล้ว ${t.paid_total} / คงเหลือ ${t.unpaid_total} บาท (${t.job_count} งาน)`);
+  }
+  const follow = (summary.technicians || []).filter((t) => Number(t.unpaid_total || 0) > 0).slice(0, 8);
+  if (follow.length) {
+    lines.push("", "รายการที่ต้องตาม:");
+    follow.forEach((t) => lines.push(`- ${t.technician_name || t.technician_key} / คงเหลือ ${t.unpaid_total} บาท / ${t.unpaid_job_count || t.partial_job_count || t.job_count} งาน`));
+  }
+  if (summary.warnings?.length) lines.push("", `หมายเหตุ: ${summary.warnings.join(" | ")}`);
+  return lines.join("\n");
 }
 function normalizeTechName(value) {
   return String(value || "").toLowerCase().replace(/\s+/g, "").replace(/[^a-z0-9ก-๙]/g, "");
@@ -209,6 +344,30 @@ async function loadDayJobs(pool, isoDate) {
   `, [isoDate]);
   return (r.rows || []).filter((row) => !hasDoneOrCanceled(row));
 }
+async function loadActiveTechnicians(pool) {
+  try {
+    const r = await pool.query(`
+      SELECT DISTINCT username, COALESCE(NULLIF(full_name,''), username) AS full_name
+      FROM (
+        SELECT username, full_name
+          FROM public.users
+         WHERE role IN ('technician','tech','senior_technician','lead_technician')
+        UNION
+        SELECT username, full_name
+          FROM public.technician_profiles
+         WHERE username IS NOT NULL
+           AND COALESCE(partner_status,'active') NOT IN ('rejected','suspended','inactive')
+           AND COALESCE(accept_status,'ready') NOT IN ('paused','suspended')
+      ) t
+      WHERE username IS NOT NULL
+      ORDER BY username
+      LIMIT 180
+    `);
+    return r.rows || [];
+  } catch (_) {
+    return [];
+  }
+}
 
 function buildBusySlots(jobs) {
   const busyByTech = new Map();
@@ -280,16 +439,26 @@ function computeGaps(busySlots, constraint) {
     .map((g) => ({ ...g, start_display: formatMins(g.start), end_display: formatMins(g.end), minutes: g.end - g.start }));
 }
 
-function analyzeAvailability({ jobs, question }) {
+function analyzeAvailability({ jobs, question, activeTechnicians = [] }) {
   const dateInfo = parseTargetDate(question);
   const constraint = parseTimeConstraint(question);
   const requestedTech = extractRequestedTech(question);
   const requestedNorm = normalizeTechName(requestedTech);
+  const includeAllActive = /ช่างทั้งหมด/.test(String(question || "")) && !/เฉพาะช่างที่มีงานวันนี้/.test(String(question || ""));
+  const onlyWithJobsToday = /เฉพาะช่างที่มีงานวันนี้/.test(String(question || ""));
   const { busyByTech, all } = buildBusySlots(jobs);
+  if (includeAllActive) {
+    for (const tech of activeTechnicians || []) {
+      const name = cleanText(tech.full_name || tech.username, 120);
+      const key = normalizeTechName(tech.username || name);
+      if (key && !busyByTech.has(key)) busyByTech.set(key, { name, slots: [] });
+    }
+  }
   const techRows = Array.from(busyByTech.values()).filter((v) => v.name && v.name !== "ไม่ระบุช่าง");
+  const filteredTechRows = onlyWithJobsToday ? techRows.filter((v) => (v.slots || []).length > 0) : techRows;
   const targetTechs = requestedNorm
-    ? techRows.filter((v) => normalizeTechName(v.name).includes(requestedNorm.replace(/^ช่าง/, "")) || requestedNorm.includes(normalizeTechName(v.name)))
-    : techRows;
+    ? filteredTechRows.filter((v) => normalizeTechName(v.name).includes(requestedNorm.replace(/^ช่าง/, "")) || requestedNorm.includes(normalizeTechName(v.name)))
+    : filteredTechRows;
 
   const analyses = (targetTechs.length ? targetTechs : techRows).map((tech) => ({
     technician: tech.name,
@@ -319,6 +488,9 @@ function analyzeAvailability({ jobs, question }) {
     overall_available_slots: allGaps.map((g) => ({ start: g.start_display, end: g.end_display, minutes: g.minutes })),
     has_available_slot: hasAnySlot,
     confidence: jobs.some((j) => !Number(j.duration_min || 0)) ? "medium" : "high",
+    confidence_warning: jobs.some((j) => !Number(j.duration_min || 0)) ? "มีบางงานไม่มี duration_min ระบบจึงใช้เวลาประเมินตามประเภทงาน" : "",
+    include_all_active_technicians: includeAllActive,
+    only_technicians_with_jobs_today: onlyWithJobsToday,
     warning: "คำนวณจากงานในระบบและ buffer เดินทาง 30 นาที ถ้าจะรับงานจริงควรเช็กพื้นที่และจำนวนเครื่องก่อนยืนยันลูกค้า",
   };
 }
@@ -352,8 +524,27 @@ function answerAvailability(result) {
 module.exports = function createAdminAiOfficeSmartAssistantV28Routes(deps = {}) {
   const pool = deps.pool;
   const requireAdminSession = deps.requireAdminSession;
+  const accounting = deps.accounting || {};
   if (!pool || !requireAdminSession) throw new Error("createAdminAiOfficeSmartAssistantV28Routes requires pool and requireAdminSession");
   const router = express.Router();
+
+  router.get("/admin/ai-office/accounting/payout-summary", requireAdminSession, async (req, res) => {
+    try {
+      const payoutId = cleanText(req.query?.payout_id, 80) || currentBangkokPayoutId();
+      const summary = await buildPayoutSummary({ accounting, payoutId });
+      return res.status(summary.ok ? 200 : 500).json(summary);
+    } catch (e) {
+      return res.status(e.status || 500).json({
+        ok: false,
+        error: e.message || "PAYOUT_SUMMARY_FAILED",
+        diagnostics: { route: "/admin/ai-office/accounting/payout-summary", source: "accounting.buildPayoutTechSummaryRows" },
+        period: { date_from: "", date_to: "", label: "" },
+        totals: {},
+        technicians: [],
+        warnings: [String(e.message || e)],
+      });
+    }
+  });
 
   router.post("/admin/ai-office/ask", requireAdminSession, async (req, res, next) => {
     const question = cleanText(req.body?.question, 2000);
@@ -372,11 +563,36 @@ module.exports = function createAdminAiOfficeSmartAssistantV28Routes(deps = {}) 
         });
       }
 
+      if (isPayoutQuestion(question)) {
+        const payoutId = cleanText(req.body?.payout_id || req.query?.payout_id, 80) || currentBangkokPayoutId();
+        const summary = await buildPayoutSummary({ accounting, payoutId });
+        const answer = formatPayoutAnswer(summary);
+        await logMemory(pool, req, {
+          source: "accounting_payout_summary",
+          event_type: summary.ok ? "payout_answered" : "payout_diagnostic",
+          agent_key: cleanText(req.body?.agent || "admin", 40),
+          customer_message: question,
+          ai_reply: answer,
+          action_status: summary.ok ? "answered" : "diagnostic",
+          situation_type: "payout_logic",
+          tags: ["deterministic", "payout", "read_only"],
+          metadata: { payout_summary: summary },
+        });
+        return res.json({
+          ok: summary.ok,
+          answer,
+          payout_summary: summary,
+          agent: { key: req.body?.agent || "admin", name: "Admin AI", role: "deterministic accounting payout summary" },
+          context: { payout_summary: summary },
+        });
+      }
+
       if (!isAvailabilityQuestion(question)) return next();
 
       const dateInfo = parseTargetDate(question);
       const jobs = await loadDayJobs(pool, dateInfo.iso);
-      const result = analyzeAvailability({ jobs, question });
+      const activeTechnicians = /ช่างทั้งหมด/.test(question) ? await loadActiveTechnicians(pool) : [];
+      const result = analyzeAvailability({ jobs, question, activeTechnicians });
       const answer = answerAvailability(result);
 
       await logMemory(pool, req, {
@@ -408,7 +624,8 @@ module.exports = function createAdminAiOfficeSmartAssistantV28Routes(deps = {}) 
       const question = cleanText(req.body?.question || req.query?.question, 2000);
       const dateInfo = parseTargetDate(question);
       const jobs = await loadDayJobs(pool, dateInfo.iso);
-      const result = analyzeAvailability({ jobs, question });
+      const activeTechnicians = /ช่างทั้งหมด/.test(question) ? await loadActiveTechnicians(pool) : [];
+      const result = analyzeAvailability({ jobs, question, activeTechnicians });
       return res.json({ ok: true, result, answer: answerAvailability(result) });
     } catch (e) {
       return res.status(e.status || 500).json({ ok: false, error: e.message || "ANALYZE_AVAILABILITY_FAILED" });

--- a/server/routes/adminAiOfficeSmartAssistantV28.js
+++ b/server/routes/adminAiOfficeSmartAssistantV28.js
@@ -106,6 +106,28 @@ function payoutPeriodLabel(period = {}) {
   if (!start && !end) return String(period.payout_id || "");
   return `${start || "-"} ถึง ${end || "-"}`;
 }
+function normalizePayoutJobRow(row = {}) {
+  return {
+    job_id: row.job_id || row.jobId || null,
+    booking_code: row.booking_code || row.bookingCode || "",
+    finished_at: row.finished_at || row.finishedAt || null,
+    payable_amount: money(row.earn_amount ?? row.payable_amount ?? row.net_amount ?? row.amount ?? 0),
+    source: row.source || row.step_rule_key || "",
+    detail: row.detail_json || row.detail || row.metadata || null,
+  };
+}
+function payoutJobRowsForTech(row = {}, payload = {}) {
+  const direct = row.rows || row.jobs || row.lines || row.payout_lines || row.job_rows;
+  if (Array.isArray(direct) && direct.length) return direct.map(normalizePayoutJobRow);
+  const tech = String(row.technician_username || row.technician_key || "").trim();
+  const payloadLines = payload.lines || payload.rows || payload.job_rows || payload.payout_lines;
+  if (Array.isArray(payloadLines) && payloadLines.length) {
+    return payloadLines
+      .filter((line) => String(line.technician_username || line.technician_key || "").trim() === tech)
+      .map(normalizePayoutJobRow);
+  }
+  return [];
+}
 async function buildPayoutSummary({ accounting, payoutId }) {
   const warnings = [];
   if (!accounting?.buildPayoutTechSummaryRows) {
@@ -141,12 +163,15 @@ async function buildPayoutSummary({ accounting, payoutId }) {
   if (accounting.accountingEnrichPayoutTechRows) {
     rows = await accounting.accountingEnrichPayoutTechRows(payoutId, period, rows);
   }
+  let hasAnyJobRows = false;
   const technicians = rows.map((row) => {
     const payable = money(row.net_amount);
     const paid = money(row.paid_amount);
     const unpaid = money(Math.max(0, payable - paid));
     const paidStatus = String(row.paid_status || (accounting.paidStatus ? accounting.paidStatus(payable, paid) : "") || "").trim() || (paid >= payable && payable > 0 ? "paid" : paid > 0 ? "partial" : "unpaid");
     const jobCount = Number(row.jobs_count || row.job_count || 0);
+    const jobRows = payoutJobRowsForTech(row, payload);
+    if (jobRows.length) hasAnyJobRows = true;
     return {
       technician_key: row.technician_username || "",
       technician_name: row.technician_full_name || row.technician_username || "",
@@ -160,7 +185,7 @@ async function buildPayoutSummary({ accounting, payoutId }) {
       paid_job_count: paidStatus === "paid" ? jobCount : 0,
       unpaid_job_count: paidStatus === "unpaid" ? jobCount : 0,
       partial_job_count: paidStatus === "partial" ? jobCount : 0,
-      rows: [],
+      rows: jobRows,
       source: row.source || payload?.source || "",
     };
   });
@@ -182,6 +207,7 @@ async function buildPayoutSummary({ accounting, payoutId }) {
   });
   Object.keys(totals).forEach((key) => { totals[key] = money(totals[key]); });
   if (!technicians.length) warnings.push("ไม่พบรายช่างในงวดนี้จากแหล่ง accounting payout");
+  if (technicians.length && !hasAnyJobRows) warnings.push("ยังไม่มีรายละเอียดระดับงานจาก payout helper");
   return {
     ok: true,
     payout_id: payoutId,
@@ -579,7 +605,7 @@ module.exports = function createAdminAiOfficeSmartAssistantV28Routes(deps = {}) 
           metadata: { payout_summary: summary },
         });
         return res.json({
-          ok: summary.ok,
+          ok: true,
           answer,
           payout_summary: summary,
           agent: { key: req.body?.agent || "admin", name: "Admin AI", role: "deterministic accounting payout summary" },


### PR DESCRIPTION
## Summary
- Add protected AI Office Brain Manager routes for brain item list, import preview, import commit, export, update, and soft disable.
- Add additive `ai_brain_items` migration and runtime schema guard with safe internal seed only when the table is empty.
- Feed active brain context into Admin/Sales/Ops AI ask flows and LINE draft replies while keeping AI Office read-only/draft-only for production data.
- Add compact Brain Manager controls inside the existing AI Office memory panel for upload, preview, commit, export, search/filter, and disable.

## Safety
- No LINE auto-send behavior added.
- No jobs, payments, payouts, or customer records are mutated.
- Import preview does not save data; commit only writes `ai_brain_items`.
- Potential private customer data is surfaced as import warnings.

## Checks
- `node --check admin-ai-office.js`
- `node --check server/routes/adminAiOfficeReadOnly.js`
- `node --check server/routes/adminAiOfficeLineDraftV27.js`
- `node --check server/routes/adminAiOfficeSharedMemoryV27.js`
- `node --check server/routes/adminAiOfficeSmartAssistantV28.js`
- `node --check server/routes/adminAiOfficeBrainManager.js`
- `node --check index.js`
- `git diff --cached --check`
- Brain import/export smoke test with fake pool: valid preview, invalid item_type rejection, commit, search, export, soft disable