### PR TITLE
Add final repo cleanup summary

### DIFF
--- a/docs/archive/REPO_CLEANUP_FINAL_SUMMARY_20260614.md
+++ b/docs/archive/REPO_CLEANUP_FINAL_SUMMARY_20260614.md
@@ -1,0 +1,79 @@
+# Repo Cleanup Final Summary
+
+Date: 2026-06-14  
+Mode: final post-cleanup verification only  
+Branch: `repo-cleanup-final-summary-20260614`  
+
+## Scope
+
+This summary records the final verification after the safe repo cleanup, AI Office asset audit, AI Office asset deduplication, route investigation, and approved removal of the retired AI Office cartoon/game visual asset system.
+
+No files were deleted in this final verification task. No runtime code was edited.
+
+## Cleanup PRs Completed
+
+| PR | Merge commit | Result |
+| --- | --- | --- |
+| #30 | Earlier cleanup merge | Safe root/docs cleanup and duplicate file cleanup |
+| #32 | Earlier audit merge | AI Office asset duplicate audit report |
+| #33 | `4f06666ab576a22fb2af366a3ad4ce0e60051dbe` | Removed 27 audited duplicate AI Office assets |
+| #34 | `10da0229b821169d986853e9cab8b146ec283a28` | Added repo diet phase 2 audit |
+| #35 | `db3117ce18ab35d585c14b9f154170483652b547` | Added AI Office connector route audit |
+| #36 | `9ac635daf2badd14bf039b96101c18a349eb07c5` | Removed retired AI Office visual asset pack |
+
+## Final Verification
+
+Latest `main` was pulled before this verification branch was created.
+
+| Check | Result |
+| --- | --- |
+| `assets/ai-office-final` local directory | Absent |
+| Local `npm start` smoke | Passed |
+| Local `/api/version` | HTTP 200 |
+| Local `/admin/ai-office` without session | HTTP 401 |
+| Local `/assets/ai-office-final/manifest.json` | HTTP 404 |
+| Production `/api/version` | HTTP 200 |
+| Production `/assets/ai-office-final/manifest.json` | HTTP 404 |
+| Production `/admin/ai-office` without session | HTTP 401 |
+| Local `main` status before summary branch | Clean |
+
+## Local Smoke Details
+
+The app was started with `npm start` on temporary local port `4318`.
+
+Observed:
+
+- Server stayed running.
+- `/api/version` returned HTTP 200.
+- `/admin/ai-office` returned HTTP 401 without an admin session.
+- `/assets/ai-office-final/manifest.json` returned HTTP 404.
+
+The temporary smoke process was stopped after verification.
+
+## Production Check Details
+
+Observed on `https://app.cwf-air.com`:
+
+- `/api/version` returned HTTP 200 with `{"ok":true,"version":"gps-v4",...}`.
+- `/assets/ai-office-final/manifest.json` returned HTTP 404.
+- `/admin/ai-office` returned HTTP 401 without an admin session.
+
+## Admin Visual Check
+
+The in-app browser did not have an active admin session.
+
+Navigating to `/admin/ai-office` redirected to `https://app.cwf-air.com/login.html`, showing the CWF login screen. Because no admin credentials/session were available in this environment, the authenticated visual check of the AI Office page was not completed in this task.
+
+## Current State
+
+- The retired AI Office cartoon/game visual pack is removed from current `main`.
+- Git history was not rewritten.
+- AI Office routes/pages remain present.
+- `server/routes/aiOfficeConnectorsProduction.js` remains present for now per product decision because it contains Google Ads OAuth/sync and LINE identity-link endpoints that are not fully superseded.
+- Historical docs remain under `docs/archive/`.
+
+## Remaining Follow-Up
+
+1. Use an admin session to visually confirm `/admin/ai-office` after deployment.
+2. Confirm `/admin/ai-office/diagnostics` behind admin auth.
+3. Consider a separate, explicitly approved Git history rewrite only if reducing historical repository clone size is required.


### PR DESCRIPTION
## Summary

Adds `docs/archive/REPO_CLEANUP_FINAL_SUMMARY_20260614.md` as the final post-cleanup verification record.

## Verification Recorded

- Pulled latest `main` before creating the summary branch
- Confirmed `assets/ai-office-final` does not exist locally
- Ran local `npm start` smoke on temporary port `4318`
- Confirmed local `/api/version` returned HTTP 200
- Confirmed local removed asset URL returned HTTP 404
- Confirmed local `/admin/ai-office` returned HTTP 401 without session
- Confirmed production `/api/version` returned HTTP 200
- Confirmed production removed asset URL returned HTTP 404
- Confirmed production `/admin/ai-office` returned HTTP 401 without session
- Browser check found no active admin session and redirected to login, so authenticated visual check remains follow-up

## Guardrails

- Summary-only PR
- No runtime code edits
- No deletions
- No Git history rewrite