### PR TITLE
Fix admin edit stale team snapshot

### DIFF
--- a/admin-job-view-v2.js
+++ b/admin-job-view-v2.js
@@ -71,7 +71,7 @@ function buildAdminEditTeamSnapshot(primaryUsername, members){
   const primary = String(primaryUsername||'').trim() || null;
   let list = (Array.isArray(members) ? members : []).map(x=>String(x||'').trim()).filter(Boolean);
   if (primary && !list.includes(primary)) list.unshift(primary);
-  list = Array.from(new Set(list));
+  list = Array.from(new Set(list)).sort((a,b)=>a.localeCompare(b));
   return {
     primary_username: primary && list.includes(primary) ? primary : (list[0] || null),
     members: list,
@@ -1497,7 +1497,7 @@ async function loadJob(){
           if (!Array.isArray(desired)) desired = [];
           desired = desired.map(x=>String(x||'').trim()).filter(Boolean);
           if (primaryU && !desired.includes(primaryU)) desired.unshift(primaryU);
-          desired = Array.from(new Set(desired));
+          desired = buildAdminEditTeamSnapshot(primaryU, desired).members;
 
           // Save everything through one orchestrated backend call.
           // Rationale: avoid the old 3-step save flow that could leave header/items/team out of sync.

--- a/index.js
+++ b/index.js
@@ -15714,7 +15714,7 @@ function normalizeAdminEditTeamSnapshot(payload) {
   let members = Array.isArray(body.members) ? body.members : [];
   members = members.map((x) => String(x || '').trim()).filter(Boolean);
   if (rawPrimary && !members.includes(rawPrimary)) members.unshift(rawPrimary);
-  members = [...new Set(members)];
+  members = [...new Set(members)].sort((a, b) => a.localeCompare(b));
   const primary_username = rawPrimary && members.includes(rawPrimary) ? rawPrimary : (members[0] || null);
   return { primary_username, members };
 }


### PR DESCRIPTION
## Root cause
Admin edit stale-team protection compared team snapshots with `JSON.stringify()`, but the `members` array order could differ between frontend/UI and backend/DB ordering even when the actual team had not changed. That could trigger a false `STALE_TEAM` conflict when saving unrelated job edits.

## What changed
- Canonicalize the admin edit team snapshot on the frontend by sorting unique trimmed members.
- Canonicalize the backend team snapshot with the same deterministic sorted-member rule before stale comparison and save.
- Keep the rule that `primary_username` must be present in `members`.
- Preserve stale-team guard behavior for real concurrent team changes.

## Scope
Only changed:
- `admin-job-view-v2.js`
- `index.js`

No payment, payout, auth, database/schema, or LINE webhook changes.

## Checks run
- `git status`
- `git diff -- admin-job-view-v2.js index.js`
- `git diff --check -- admin-job-view-v2.js index.js`
- `node --check admin-job-view-v2.js`
- `node --check index.js`

## Review note
Please verify the diff before merge/deploy, especially the 2-tab stale guard case: if one tab changes the team for real, another tab with an older snapshot should still receive `STALE_TEAM`.