### PR TITLE
Fix admin edit AC type parsing

### DIFF
--- a/admin-job-view-v2.js
+++ b/admin-job-view-v2.js
@@ -980,16 +980,23 @@ async function loadJob(){
       }
       return `ล้างแอร์${STD_AC_PAYLOAD[ac] || 'สี่ทิศทาง'} • ${btuText} • ${qty} เครื่อง`;
     };
+    const detectAcTypeKeyFromServiceName = (name) => {
+      const s = String(name || '').toLowerCase();
+      if (!s.trim()) return null;
+      const hasWallCoil = s.includes('แขวนคอย') || s.includes('coil');
+      if (s.includes('สี่ทิศ') || s.includes('cassette') || s.includes('four')) return 'fourway';
+      if (s.includes('เปลือย') || s.includes('ใต้ฝ้า') || s.includes('ฝังฝ้า') || s.includes('ceiling') || s.includes('concealed')) return 'ceiling';
+      if ((s.includes('แขวน') || s.includes('ตั้งพื้น') || s.includes('floor') || s.includes('hanging')) && !hasWallCoil) return 'hanging';
+      if (s.includes('ผนัง') || s.includes('wall') || hasWallCoil) return 'wall';
+      return null;
+    };
     const parseStandardItemName = (name) => {
       const raw = String(name || '');
       const s = raw.toLowerCase();
       if (!s.trim()) return null;
       const job_type_key = s.includes('ติดตั้ง') ? 'install' : (s.includes('ซ่อม') ? 'repair' : 'wash');
       const hasWallCoil = s.includes('แขวนคอย') || s.includes('coil');
-      const ac = s.includes('สี่ทิศ') || s.includes('cassette') || s.includes('four') ? 'fourway'
-        : (s.includes('ผนัง') || s.includes('wall') || hasWallCoil || s.includes('ล้างแอร์') ? 'wall'
-        : ((s.includes('แขวน') || s.includes('ตั้งพื้น') || s.includes('floor')) && !hasWallCoil ? 'hanging'
-        : (s.includes('เปลือย') || s.includes('ใต้ฝ้า') || s.includes('ceiling') || s.includes('concealed') ? 'ceiling' : 'wall')));
+      const ac = detectAcTypeKeyFromServiceName(raw) || 'wall';
       const wash = ac !== 'wall' ? 'none'
         : (s.includes('พรีเมียม') || s.includes('พรีเมี่ยม') || s.includes('premium') ? 'premium'
         : (s.includes('แขวนคอย') || s.includes('coil') ? 'coil'


### PR DESCRIPTION
## Summary
- Fixes the Admin v2 edit parser so opening an existing service item no longer treats any `ล้างแอร์...` line as wall AC by default.
- Adds explicit AC type detection order in `admin-job-view-v2.js`: fourway, ceiling/concealed, hanging/floor, wall/wall-coil, then fallback wall only when no specific type exists.
- Leaves pricing, payout, auth, database schema, and production data untouched.

## Root Cause
`parseStandardItemName(name)` in `admin-job-view-v2.js` checked generic `s.includes('ล้างแอร์')` as a reason to return `ac_type_key: 'wall'` before checking `เปลือย`, `ใต้ฝ้า`, or hanging/floor cases. The admin edit screen then rebuilt `item_name`, `ac_type`, `wash_variant`, `btu`, and `machine_count` from that parsed editor state, so saving could overwrite correct `job_items` as wall AC.

## Smoke Test Results
All seven requested parser cases now pass:
- `ล้างแอร์เปลือยใต้ฝ้า` => `ceiling / none`
- `ล้างแอร์ผนัง + ล้างแขวนคอยล์` => `wall / coil`
- `ล้างแอร์ผนัง + ล้างธรรมดา` => `wall / normal`
- `ล้างแอร์สี่ทิศทาง` => `fourway / none`
- `ล้างแอร์แขวน` => `hanging / none`
- `ซ่อมแอร์เปลือยใต้ฝ้า` => `ceiling / none`
- `ติดตั้งแอร์เปลือยใต้ฝ้า` => `ceiling / none`

Checked related backend helpers: `server/technicianIncome.js` and `server/normalizers.js` already preserve these AC types for the same patterns, so no backend change was made.

## Tests
- `node --check admin-job-view-v2.js`
- `node --check index.js`
- `node --check server/technicianIncome.js`
- `git diff --check`
- Local Node smoke tests against the edited parser and technician income helper

## Risk / Rollback
Low-risk frontend parser-only change. Roll back by reverting this commit if the admin edit service parser shows unexpected behavior. Existing production rows that were already overwritten require a separate approved data repair; this PR does not modify production data.