### PR TITLE
Bust admin job edit script cache for AC parser fix

### DIFF
--- a/admin-job-view-v2.html
+++ b/admin-job-view-v2.html
@@ -30,6 +30,6 @@
   </div>
 
   <script src="/admin-v2-common.js?v=20260428_allpages_ui1"></script>
-  <script src="/admin-job-view-v2.js?v=20260508_edit_service_builder_v2"></script>
+  <script src="/admin-job-view-v2.js?v=20260617_ac_type_parser_fix"></script>
 </body>
 </html>

--- a/admin-job-view-v2.js
+++ b/admin-job-view-v2.js
@@ -15,6 +15,7 @@
 
 console.info('[admin-job-view] rework UI v3 loaded');
 console.info('[admin-job-edit] service builder v2 loaded');
+console.info('[admin-job-edit] ac type parser fix 20260617 loaded');
 
 function safe(t){ return (t||'').toString(); }
 function fmtDT(iso){


### PR DESCRIPTION
## Summary
- Confirms PR #41 is already merged into `main` via merge commit `c44615a823f7349fde1c529a0eab5daf3b6f8380`.
- Updates the Admin job detail page script query string so production browsers fetch a fresh `admin-job-view-v2.js`.
- Adds a visible console marker to verify the deployed JS file loaded.

## Changes
- `admin-job-view-v2.html`: `/admin-job-view-v2.js?v=20260508_edit_service_builder_v2` -> `/admin-job-view-v2.js?v=20260617_ac_type_parser_fix`
- `admin-job-view-v2.js`: adds `console.info('[admin-job-edit] ac type parser fix 20260617 loaded');`

## Scope
No parser logic changes. No backend, database, payout, auth, LINE webhook, or pricing changes.

## Tests
- `node --check admin-job-view-v2.js`
- `git diff --check`
- `git diff --name-only` confirms only:
  - `admin-job-view-v2.html`
  - `admin-job-view-v2.js`

## Cache Bust Version
`20260617_ac_type_parser_fix`