### PR TITLE
Phase 2F: Customer App v2 logo, cache fix, and tracking parity

### DIFF
--- a/customer-app/assets/customer-app.css
+++ b/customer-app/assets/customer-app.css
@@ -154,7 +154,24 @@ p { margin: 0; }
   font-size: 16px;
   letter-spacing: 0.02em;
   box-shadow: 0 8px 18px -6px rgba(255, 185, 56, 0.6), inset 0 1px 0 rgba(255,255,255,0.5);
+  overflow: hidden;
+  position: relative;
 }
+.brand-mark img {
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+  padding: 5px;
+  background: #fff;
+}
+.brand-mark span {
+  display: none;
+  position: absolute;
+  inset: 0;
+  place-items: center;
+}
+.brand-mark.is-fallback span { display: grid; }
+.brand-mark.is-fallback img { display: none; }
 
 .eyebrow {
   margin: 0 0 1px;
@@ -912,6 +929,8 @@ p { margin: 0; }
 }
 .timeline-item .dot.is-muted { background: var(--line-strong); border-color: var(--bg); }
 .timeline-item .dot.is-warning { background: var(--yellow); border-color: var(--soft-yellow); }
+.timeline-item .dot.is-current { background: var(--yellow); border-color: var(--soft-yellow); box-shadow: 0 0 0 6px rgba(255, 210, 59, 0.18); }
+.timeline-item .dot.is-pending { background: var(--line-strong); border-color: var(--bg); }
 .timeline-item:not(:last-child) .dot::after {
   content: "";
   position: absolute;
@@ -927,6 +946,13 @@ p { margin: 0; }
 /* ===================== Tracking ===================== */
 .lookup-card { border: 1.5px solid var(--soft-blue-2); }
 .tracking-result-card { display: flex; flex-direction: column; gap: 12px; }
+.tracking-topline {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  flex-wrap: wrap;
+}
 .tracking-code-pill {
   display: inline-flex;
   align-self: flex-start;
@@ -942,6 +968,97 @@ p { margin: 0; }
   box-shadow: 0 12px 24px -12px rgba(22, 89, 224, 0.8);
 }
 .tracking-code-pill::before { content: "#"; opacity: 0.7; }
+.tracking-extra-card {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 14px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-sm);
+  background: linear-gradient(180deg, #fff, var(--bg-2));
+}
+.section-head.compact { margin-bottom: 0; }
+.section-head.compact h2 { font-size: 16px; }
+.tracking-photo-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 8px;
+}
+.tracking-photo-grid a {
+  display: block;
+  aspect-ratio: 1;
+  border-radius: 14px;
+  overflow: hidden;
+  border: 1px solid var(--line);
+  background: var(--soft-blue);
+}
+.tracking-photo-grid img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+.receipt-card {
+  flex-direction: row;
+  align-items: center;
+  justify-content: space-between;
+}
+.receipt-card .secondary-btn { width: auto; white-space: nowrap; }
+.review-form-card form {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+.review-summary-card p,
+.warranty-card p { line-height: 1.65; }
+.preserve-lines { white-space: pre-wrap; }
+.tracking-tech-card {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+  padding: 14px;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--soft-blue-2);
+  background: #fff;
+}
+.tracking-tech-card.is-empty {
+  align-items: flex-start;
+  background: var(--soft-yellow);
+  border-color: rgba(255, 210, 59, 0.55);
+}
+.tech-avatar {
+  display: grid;
+  place-items: center;
+  flex: 0 0 52px;
+  width: 52px;
+  height: 52px;
+  border-radius: 999px;
+  overflow: hidden;
+  background: var(--grad-cta);
+  color: #fff;
+  font-weight: 900;
+}
+.tech-avatar img { width: 100%; height: 100%; object-fit: cover; display: block; }
+.tech-main {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  min-width: 0;
+}
+.team-strip {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-top: 4px;
+}
+.team-strip span {
+  padding: 4px 8px;
+  border-radius: var(--radius-pill);
+  background: var(--soft-blue);
+  color: var(--navy-2);
+  font-size: 12px;
+  font-weight: 800;
+}
 
 /* ===================== Profile ===================== */
 .guest-card { background: linear-gradient(180deg, #fff, var(--bg-2)); }

--- a/customer-app/assets/customer-app.js
+++ b/customer-app/assets/customer-app.js
@@ -5,6 +5,14 @@
 
   function init() {
     App.state.init();
+    const params = new URLSearchParams(window.location.search || "");
+    const trackingKey = String(params.get("q") || params.get("token") || "").trim();
+    if (trackingKey) {
+      App.state.updateDraft("tracking", { trackingCode: trackingKey });
+      if (!window.location.hash || App.state.readRouteFromHash() === "home") {
+        window.location.hash = "#tracking";
+      }
+    }
     App.router.register({
       home: App.ui.renderHome,
       booking: App.ui.renderBookingMode,

--- a/customer-app/index.html
+++ b/customer-app/index.html
@@ -4,13 +4,16 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>CWF Customer App V2</title>
-  <link rel="stylesheet" href="./assets/customer-app.css">
+  <link rel="stylesheet" href="./assets/customer-app.css?v=20260617_customer_app_v2_phase2f">
 </head>
 <body>
   <div class="app-shell" data-app-shell>
     <header class="app-header">
       <div class="brand-lockup">
-        <div class="brand-mark" aria-hidden="true">CWF</div>
+        <div class="brand-mark" aria-hidden="true">
+          <img src="/logo.png?v=20260617_customer_app_v2_phase2f" alt="" onerror="this.hidden=true;this.parentElement.classList.add('is-fallback')">
+          <span>CWF</span>
+        </div>
         <div>
           <p class="eyebrow">Coldwindflow</p>
           <h1>CWF Service</h1>
@@ -39,19 +42,19 @@
     </nav>
   </div>
 
-  <script src="./modules/state.js"></script>
-  <script src="./modules/utils.js"></script>
-  <script src="./modules/api.js"></script>
-  <script src="./modules/services.js"></script>
-  <script src="./modules/ui.js"></script>
-  <script src="./modules/auth.js"></script>
-  <script src="./modules/pricing.js"></script>
-  <script src="./modules/availability.js"></script>
-  <script src="./modules/bookingScheduled.js"></script>
-  <script src="./modules/bookingUrgent.js"></script>
-  <script src="./modules/tracking.js"></script>
-  <script src="./modules/profile.js"></script>
-  <script src="./modules/router.js"></script>
-  <script src="./assets/customer-app.js"></script>
+  <script src="./modules/state.js?v=20260617_customer_app_v2_phase2f"></script>
+  <script src="./modules/utils.js?v=20260617_customer_app_v2_phase2f"></script>
+  <script src="./modules/api.js?v=20260617_customer_app_v2_phase2f"></script>
+  <script src="./modules/services.js?v=20260617_customer_app_v2_phase2f"></script>
+  <script src="./modules/ui.js?v=20260617_customer_app_v2_phase2f"></script>
+  <script src="./modules/auth.js?v=20260617_customer_app_v2_phase2f"></script>
+  <script src="./modules/pricing.js?v=20260617_customer_app_v2_phase2f"></script>
+  <script src="./modules/availability.js?v=20260617_customer_app_v2_phase2f"></script>
+  <script src="./modules/bookingScheduled.js?v=20260617_customer_app_v2_phase2f"></script>
+  <script src="./modules/bookingUrgent.js?v=20260617_customer_app_v2_phase2f"></script>
+  <script src="./modules/tracking.js?v=20260617_customer_app_v2_phase2f"></script>
+  <script src="./modules/profile.js?v=20260617_customer_app_v2_phase2f"></script>
+  <script src="./modules/router.js?v=20260617_customer_app_v2_phase2f"></script>
+  <script src="./assets/customer-app.js?v=20260617_customer_app_v2_phase2f"></script>
 </body>
 </html>

--- a/customer-app/modules/tracking.js
+++ b/customer-app/modules/tracking.js
@@ -62,9 +62,11 @@
   }
 
   function mapUrl(data) {
-    const lat = Number(data.gps_latitude);
-    const lng = Number(data.gps_longitude);
-    if (Number.isFinite(lat) && Number.isFinite(lng)) {
+    const rawLat = clean(data.gps_latitude);
+    const rawLng = clean(data.gps_longitude);
+    const lat = Number(rawLat);
+    const lng = Number(rawLng);
+    if (rawLat && rawLng && Number.isFinite(lat) && Number.isFinite(lng)) {
       return `https://www.google.com/maps/dir/?api=1&destination=${encodeURIComponent(`${lat},${lng}`)}&travelmode=driving`;
     }
     const direct = clean(data.maps_url || data.map_url);
@@ -74,9 +76,22 @@
   }
 
   function receiptUrl(data) {
+    const fallback = isDone(data) && data.job_id ? `/docs/receipt/${encodeURIComponent(data.job_id)}` : "";
     const raw = clean(data.receipt_url);
-    if (raw) return imageUrl(raw);
-    return isDone(data) && data.job_id ? `/docs/receipt/${encodeURIComponent(data.job_id)}` : "";
+    if (!raw) return fallback;
+
+    const apiBase = clean(root.api.getApiBase()) || window.location.origin;
+    try {
+      const url = new URL(raw, apiBase);
+      const current = new URL(apiBase || window.location.origin, window.location.href);
+      const isLocalHost = url.hostname === "localhost" || url.hostname === "127.0.0.1" || url.hostname === "0.0.0.0";
+      if (isLocalHost || url.origin !== current.origin) {
+        return `${current.origin}${url.pathname}${url.search}`;
+      }
+      return `${url.pathname}${url.search}`;
+    } catch (_) {
+      return fallback || imageUrl(raw);
+    }
   }
 
   function photoList(data) {
@@ -367,9 +382,11 @@
       form.addEventListener("submit", async (event) => {
         event.preventDefault();
         const status = form.querySelector("[data-review-status]");
+        const submit = form.querySelector("button[type='submit']");
         const payload = Object.fromEntries(new FormData(form).entries());
         payload.rating = Number(payload.rating || 5);
         if (status) status.textContent = "กำลังส่งรีวิว...";
+        if (submit) submit.disabled = true;
         try {
           const response = await fetch(`${root.api.getApiBase()}/public/review`, {
             method: "POST",
@@ -382,8 +399,9 @@
           setTimeout(() => lookup(container), 500);
         } catch (error) {
           if (status) status.textContent = error.message || "ส่งรีวิวไม่สำเร็จ";
+          if (submit) submit.disabled = false;
         }
-      }, { once: true });
+      });
     }
   }
 

--- a/customer-app/modules/tracking.js
+++ b/customer-app/modules/tracking.js
@@ -4,6 +4,7 @@
   const root = window.CWFCustomerAppV2 = window.CWFCustomerAppV2 || {};
   const ADMIN_PHONE = "098-877-7321";
   const LINE_URL = "https://lin.ee/fG1Oq7y";
+  const WARRANTY_COPY = "รับประกันงานล้าง 30 วัน เฉพาะอาการที่เกี่ยวข้องกับการบริการ ไม่รวมอะไหล่เสีย ระบบรั่ว บอร์ด คอมเพรสเซอร์ ไฟตก หรือปัญหาจากตัวเครื่องเดิม";
 
   function esc(value) {
     return root.utils.escapeHtml(value == null ? "" : String(value));
@@ -39,10 +40,63 @@
     return value.startsWith("/") ? value : `/${value}`;
   }
 
+  function isDone(data) {
+    const status = clean(data.job_status);
+    return !!(clean(data.finished_at) || status.includes("เสร็จ"));
+  }
+
+  function techList(data) {
+    const list = [];
+    if (data.technician) list.push(data.technician);
+    if (Array.isArray(data.technician_team)) {
+      data.technician_team.forEach((tech) => {
+        const key = clean(tech && (tech.id || tech.username || tech.full_name || tech.phone));
+        if (tech && !list.some((x) => clean(x.id || x.username || x.full_name || x.phone) === key)) list.push(tech);
+      });
+    }
+    return list;
+  }
+
+  function hasAssignedTech(data) {
+    return techList(data).length > 0 || !!clean(data.assigned_at || data.accepted_at);
+  }
+
+  function mapUrl(data) {
+    const lat = Number(data.gps_latitude);
+    const lng = Number(data.gps_longitude);
+    if (Number.isFinite(lat) && Number.isFinite(lng)) {
+      return `https://www.google.com/maps/dir/?api=1&destination=${encodeURIComponent(`${lat},${lng}`)}&travelmode=driving`;
+    }
+    const direct = clean(data.maps_url || data.map_url);
+    if (direct) return direct;
+    const address = clean(data.address_text);
+    return address ? `https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(address)}` : "";
+  }
+
+  function receiptUrl(data) {
+    const raw = clean(data.receipt_url);
+    if (raw) return imageUrl(raw);
+    return isDone(data) && data.job_id ? `/docs/receipt/${encodeURIComponent(data.job_id)}` : "";
+  }
+
+  function photoList(data) {
+    return Array.isArray(data.photos)
+      ? data.photos.map((item) => {
+          if (typeof item === "string") return { url: imageUrl(item), label: "รูปงาน" };
+          return { url: imageUrl(item.public_url || item.url || item.photo_url || item.path), label: item.phase || item.label || "รูปงาน" };
+        }).filter((item) => item.url)
+      : [];
+  }
+
+  function timelineState(done, current) {
+    if (done) return "done";
+    return current ? "current" : "pending";
+  }
+
   function statusCopy(data, mode) {
     const status = clean(data.job_status);
-    const assigned = !!(data.technician || (Array.isArray(data.technician_team) && data.technician_team.length));
-    const done = status.includes("เสร็จ") || clean(data.finished_at);
+    const assigned = hasAssignedTech(data);
+    const done = isDone(data);
     const traveling = clean(data.travel_started_at);
     const started = clean(data.started_at) || clean(data.checkin_at);
     const noTech = status.includes("ไม่พบช่าง") || status.includes("ตีกลับ");
@@ -64,19 +118,13 @@
   }
 
   function renderTechnicianCard(data) {
-    const list = [];
-    if (data.technician) list.push(data.technician);
-    if (Array.isArray(data.technician_team)) {
-      data.technician_team.forEach((tech) => {
-        if (tech && !list.some((x) => clean(x.username) === clean(tech.username))) list.push(tech);
-      });
-    }
+    const list = techList(data);
     if (!list.length) {
       return `
         <div class="tracking-tech-card is-empty">
           <div>
-            <strong>ยังไม่ได้มอบหมายช่าง</strong>
-            <span class="muted">แอดมินกำลังตรวจสอบคิว หรือระบบกำลังรอช่างพาร์ทเนอร์รับงาน</span>
+            <strong>แอดมินกำลังช่วยจัดคิวให้</strong>
+            <span class="muted">ยังไม่มีช่างยืนยันงานนี้ หากเป็นคิวด่วน งานจะยืนยันเมื่อมีช่างรับหรือแอดมินยืนยันเท่านั้น</span>
           </div>
         </div>
       `;
@@ -88,11 +136,121 @@
         <div class="tech-avatar">${photo ? `<img src="${esc(photo)}" alt="">` : `<span>${esc(clean(primary.full_name || primary.username).slice(0, 1) || "C")}</span>`}</div>
         <div class="tech-main">
           <strong>${esc(primary.full_name || primary.username || "ช่าง CWF")}</strong>
-          <span class="muted">${esc(primary.grade || primary.rank_key || "ทีมบริการ CWF")}</span>
+          <span class="muted">${esc([primary.grade || primary.rank_key, primary.rating ? `คะแนน ${primary.rating}` : ""].filter(Boolean).join(" · ") || "ทีมบริการ CWF")}</span>
           ${primary.phone ? `<a class="mini-link" href="tel:${esc(primary.phone)}">โทรหาช่าง</a>` : ""}
           ${list.length > 1 ? `<div class="team-strip">${list.map((tech) => `<span>${esc(tech.full_name || tech.username || "ทีมช่าง")}</span>`).join("")}</div>` : ""}
         </div>
       </div>
+    `;
+  }
+
+  function renderPhotos(data) {
+    const photos = isDone(data) ? photoList(data) : [];
+    if (!photos.length) return "";
+    return `
+      <section class="tracking-extra-card">
+        <div class="section-head compact">
+          <span class="section-kicker">Photos</span>
+          <h2>รูปหลังจบงาน</h2>
+        </div>
+        <div class="tracking-photo-grid">
+          ${photos.map((photo) => `
+            <a href="${esc(photo.url)}" target="_blank" rel="noopener" aria-label="เปิดรูปงาน">
+              <img src="${esc(photo.url)}" alt="${esc(photo.label)}" loading="lazy">
+            </a>
+          `).join("")}
+        </div>
+      </section>
+    `;
+  }
+
+  function renderTechnicianNote(data) {
+    if (!isDone(data) || !clean(data.technician_note)) return "";
+    return `
+      <section class="tracking-extra-card">
+        <div class="section-head compact">
+          <span class="section-kicker">Note</span>
+          <h2>หมายเหตุจากช่าง</h2>
+        </div>
+        <p class="muted preserve-lines">${esc(data.technician_note)}</p>
+      </section>
+    `;
+  }
+
+  function renderReceipt(data) {
+    const url = receiptUrl(data);
+    if (!url) return "";
+    return `
+      <section class="tracking-extra-card receipt-card">
+        <div>
+          <strong>เอกสารหลังบริการ</strong>
+          <p class="muted">เปิดใบรับเงินหรือ E-slip จากข้อมูลเดิมของระบบ</p>
+        </div>
+        <a class="secondary-btn" href="${esc(url)}" target="_blank" rel="noopener">เปิด E-slip</a>
+      </section>
+    `;
+  }
+
+  function renderReview(data) {
+    if (!isDone(data)) return "";
+    const review = data.review || {};
+    if (review.already_reviewed) {
+      return `
+        <section class="tracking-extra-card review-summary-card">
+          <div class="section-head compact">
+            <span class="section-kicker">Review</span>
+            <h2>รีวิวของคุณ</h2>
+          </div>
+          <p><strong>${esc(review.rating || "-")} / 5</strong></p>
+          ${review.review_text ? `<p class="muted preserve-lines">${esc(review.review_text)}</p>` : ""}
+        </section>
+      `;
+    }
+    const key = data.booking_token || data.booking_code || "";
+    if (!key) return "";
+    return `
+      <section class="tracking-extra-card review-form-card">
+        <div class="section-head compact">
+          <span class="section-kicker">Review</span>
+          <h2>ให้คะแนนงานนี้</h2>
+        </div>
+        <form data-review-form>
+          <input type="hidden" name="q" value="${esc(key)}">
+          <label class="field">
+            <span>คะแนน</span>
+            <select class="input" name="rating">
+              <option value="5">5 - ดีมาก</option>
+              <option value="4">4 - ดี</option>
+              <option value="3">3 - พอใช้</option>
+              <option value="2">2 - ควรปรับปรุง</option>
+              <option value="1">1 - ไม่พอใจ</option>
+            </select>
+          </label>
+          <label class="field">
+            <span>รีวิว</span>
+            <textarea class="input" name="review_text" rows="3" placeholder="เขียนรีวิว (ถ้ามี)"></textarea>
+          </label>
+          <label class="field">
+            <span>ข้อเสนอแนะ / ร้องเรียน</span>
+            <textarea class="input" name="complaint_text" rows="2" placeholder="ส่งถึงทีม CWF (ถ้ามี)"></textarea>
+          </label>
+          <button class="primary-btn" type="submit">ส่งรีวิว</button>
+          <p class="muted" data-review-status></p>
+        </form>
+      </section>
+    `;
+  }
+
+  function renderWarranty(data) {
+    if (!isDone(data)) return "";
+    return `
+      <section class="tracking-extra-card warranty-card">
+        <div class="section-head compact">
+          <span class="section-kicker">Warranty</span>
+          <h2>เงื่อนไขรับประกัน</h2>
+        </div>
+        <p class="muted">${esc(WARRANTY_COPY)}</p>
+      </section>
     `;
   }
 
@@ -104,8 +262,8 @@
 
     const data = state.data || {};
     const mode = modeFromData(data);
-    const photos = Array.isArray(data.photos) ? data.photos : [];
-    const maps = clean(data.maps_url);
+    const photos = photoList(data);
+    const maps = mapUrl(data);
     const trackingKey = data.booking_token || data.booking_code || "";
     return `
       <div class="tracking-result-card">
@@ -125,16 +283,23 @@
           <div class="data-row"><strong>ระยะเวลา</strong><span class="muted">${data.duration_min ? `${Number(data.duration_min)} นาที` : "-"}</span></div>
           <div class="data-row"><strong>ที่อยู่</strong><span class="muted">${esc(data.address_text || "-")}</span></div>
           ${data.job_zone ? `<div class="data-row"><strong>พื้นที่</strong><span class="muted">${esc(data.job_zone)}</span></div>` : ""}
-          ${maps ? `<div class="data-row"><strong>แผนที่</strong><span><a class="mini-link" href="${esc(maps)}" target="_blank" rel="noopener">เปิดแผนที่</a></span></div>` : ""}
+          ${maps ? `<div class="data-row"><strong>แผนที่</strong><span><a class="mini-link" href="${esc(maps)}" target="_blank" rel="noopener">นำทางไปหน้างาน</a></span></div>` : ""}
           <div class="data-row"><strong>หลังจบงาน</strong><span class="muted">รูปงาน ${photos.length} รายการ ${data.receipt_url ? "และมีเอกสารหลังบริการ" : ""}</span></div>
         </div>
         ${renderTechnicianCard(data)}
         <div class="support-strip">
+          ${maps ? `<a class="secondary-btn" href="${esc(maps)}" target="_blank" rel="noopener">เปิดแผนที่</a>` : ""}
           <button class="secondary-btn" type="button" data-action="track-refresh">รีเฟรช</button>
           <a class="secondary-btn" href="tel:${ADMIN_PHONE}">โทรหา CWF</a>
           <a class="secondary-btn" href="${LINE_URL}" target="_blank" rel="noopener">LINE หา CWF</a>
+          ${mode === "urgent" && !hasAssignedTech(data) ? `<button class="secondary-btn" type="button" data-route="scheduled">เปลี่ยนเป็นจองล่วงหน้า</button>` : ""}
         </div>
         <p class="muted support-note">ต้องการแก้ไขเวลา เลื่อนนัด หรือยกเลิกงาน กรุณาติดต่อแอดมิน CWF</p>
+        ${renderTechnicianNote(data)}
+        ${renderPhotos(data)}
+        ${renderReceipt(data)}
+        ${renderReview(data)}
+        ${renderWarranty(data)}
       </div>
     `;
   }
@@ -142,18 +307,33 @@
   function renderTimeline() {
     const data = root.state.tracking.data || {};
     const mode = modeFromData(data);
-    const urgent = mode === "urgent";
-    return root.utils.timeline(urgent ? [
-      { title: "ส่งคำขอคิวด่วนแล้ว", copy: "กำลังรอช่างพาร์ทเนอร์กดรับงาน ยังไม่ถือว่ายืนยันงาน", kind: "" },
-      { title: "ช่างรับงานแล้ว", copy: "ยืนยันเมื่อมีช่างกดรับหรือแอดมินยืนยัน", kind: "muted" },
-      { title: "แอดมินช่วยตรวจสอบคิวด่วน", copy: "ใช้เมื่อไม่มีช่างรับในเวลาที่กำหนด", kind: "muted" },
-    ] : [
-      { title: "รับคำขอจองแล้ว", copy: "รอแอดมินตรวจสอบคิว", kind: "" },
-      { title: "ยืนยันคิวแล้ว", copy: "แอดมินมอบหมายทีมช่างแล้ว", kind: "muted" },
-      { title: "ช่างกำลังเดินทาง", copy: "แสดงเมื่อช่างเริ่มเดินทาง", kind: "muted" },
-      { title: "กำลังให้บริการ", copy: "แสดงเมื่อทีมเริ่มงาน", kind: "muted" },
-      { title: "งานเสร็จแล้ว", copy: "ดูรูปงานและข้อมูลหลังบริการ", kind: "muted" },
-    ]);
+    const assigned = hasAssignedTech(data);
+    const travel = !!clean(data.travel_started_at);
+    const checkin = !!clean(data.checkin_at);
+    const started = !!clean(data.started_at);
+    const done = isDone(data);
+    const steps = [
+      {
+        title: mode === "urgent" ? "ส่งคำขอคิวด่วนแล้ว" : "รับคำขอจองแล้ว",
+        copy: mode === "urgent" ? "ระบบรับคำขอแล้ว แต่ยังไม่ถือว่ายืนยันงานจนกว่าจะมีช่างรับหรือแอดมินยืนยัน" : "รอแอดมินตรวจสอบคิวและรายละเอียด",
+        ok: true,
+      },
+      {
+        title: mode === "urgent" ? "ช่างรับงาน / แอดมินยืนยัน" : "ยืนยันคิวและมอบหมายทีม",
+        copy: assigned ? "มีทีมดูแลงานนี้แล้ว" : "แอดมินกำลังช่วยจัดคิวให้",
+        ok: assigned,
+      },
+      { title: "ช่างกำลังเดินทาง", copy: data.travel_started_at ? root.utils.formatDateTime(data.travel_started_at) : "จะแสดงเมื่อช่างเริ่มเดินทาง", ok: travel },
+      { title: "ถึงหน้างาน", copy: data.checkin_at ? root.utils.formatDateTime(data.checkin_at) : "จะแสดงเมื่อทีมเช็กอิน", ok: checkin },
+      { title: "เริ่มให้บริการ", copy: data.started_at ? root.utils.formatDateTime(data.started_at) : "จะแสดงเมื่อทีมเริ่มงาน", ok: started },
+      { title: "งานเสร็จแล้ว", copy: data.finished_at ? root.utils.formatDateTime(data.finished_at) : "หลังจบงานจะแสดงรูป เอกสาร รีวิว และเงื่อนไขรับประกัน", ok: done },
+    ];
+    const firstPending = steps.findIndex((step) => !step.ok);
+    return root.utils.timeline(steps.map((step, index) => ({
+      title: step.title,
+      copy: step.copy,
+      kind: step.ok ? "" : timelineState(false, index === firstPending),
+    })));
   }
 
   async function lookup(container) {
@@ -182,6 +362,29 @@
   function bindResultActions(container) {
     const refresh = container.querySelector("[data-action='track-refresh']");
     if (refresh) refresh.addEventListener("click", () => lookup(container), { once: true });
+    const form = container.querySelector("[data-review-form]");
+    if (form) {
+      form.addEventListener("submit", async (event) => {
+        event.preventDefault();
+        const status = form.querySelector("[data-review-status]");
+        const payload = Object.fromEntries(new FormData(form).entries());
+        payload.rating = Number(payload.rating || 5);
+        if (status) status.textContent = "กำลังส่งรีวิว...";
+        try {
+          const response = await fetch(`${root.api.getApiBase()}/public/review`, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify(payload),
+          });
+          const data = await response.json().catch(() => ({}));
+          if (!response.ok) throw new Error(data.error || "ส่งรีวิวไม่สำเร็จ");
+          if (status) status.textContent = "ส่งรีวิวเรียบร้อย ขอบคุณครับ";
+          setTimeout(() => lookup(container), 500);
+        } catch (error) {
+          if (status) status.textContent = error.message || "ส่งรีวิวไม่สำเร็จ";
+        }
+      }, { once: true });
+    }
   }
 
   root.tracking = {
@@ -228,6 +431,9 @@
         root.state.updateDraft("tracking", { trackingCode: event.target.value });
       });
       bindResultActions(container);
+      if (code && root.state.tracking.status === "idle") {
+        setTimeout(() => lookup(container), 0);
+      }
     },
   };
 })();

--- a/sw.js
+++ b/sw.js
@@ -1,7 +1,7 @@
 // ✅ Phase 2: PWA เสถียร + บังคับอัปเดต cache
 // - เพิ่ม icons (192/512/maskable) ให้ Chrome “ติดตั้งเป็นแอพ” ได้จริง
 // - bump cache name เพื่อกันไฟล์ค้าง
-const CACHE_NAME = "cwf-cache-v121-ai-office-chat-ux-v17-20260608";
+const CACHE_NAME = "cwf-cache-v122-customer-app-v2-phase2f-20260617";
 
 const ASSETS = [
   "/",
@@ -93,6 +93,24 @@ self.addEventListener("fetch", (e) => {
   const isStaticExt = /\.(?:html|css|js|png|jpg|jpeg|webp|svg|ico|json)$/.test(pathname);
   const isAssetListed = ASSETS.includes(pathname) || (pathname === "/" && ASSETS.includes("/"));
   const shouldCache = isSameOrigin && (isStaticExt || isAssetListed || e.request.mode === "navigate");
+
+  const isCustomerAppV2 = pathname === "/customer-app" || pathname === "/customer-app/" || pathname.startsWith("/customer-app/");
+  if (isSameOrigin && isCustomerAppV2) {
+    e.respondWith(
+      fetch(e.request, { cache: "no-store" })
+        .then((resp) => {
+          if (e.request.mode === "navigate") {
+            const copy = resp.clone();
+            caches.open(CACHE_NAME).then((c) => c.put(e.request, copy));
+          }
+          return resp;
+        })
+        .catch(async () => {
+          return (await caches.match(e.request)) || (await caches.match("/customer-app/")) || Response.error();
+        })
+    );
+    return;
+  }
 
   // ถ้าไม่ควร cache → ปล่อยผ่าน network ตรง ๆ
   if (!shouldCache) return;


### PR DESCRIPTION
## Summary

- Adds cache-busting version query strings to Customer App v2 CSS/JS imports.
- Bumps the service worker cache name and bypasses stale caching for `/customer-app/` static assets.
- Replaces the text-only Customer App v2 header mark with the existing CWF company logo and safe fallback text.
- Improves Tracking v2 parity using existing public API behavior from old `track.html` without backend changes.

## Claude Premium Redesign Preservation

- Claude premium LINE/Google provider buttons are preserved.
- `auth.js` is unchanged in this PR.
- Required provider UI markers remain present: `LINE_ICON`, `GOOGLE_ICON`, `renderProviderButtons`, `provider-btn`, `prov-ico`, `prov-label`, `prov-soon`, `.line-btn`, and `.google-btn`.
- LINE green styling and Google white button styling remain intact.

## Untouched Legacy Files

- `track.html` is untouched.
- `customer.html` is untouched.

## Tracking Features Added From Old `track.html`

- Auto-route and auto-load tracking from `?q=` and `?token=`.
- Better status header using booking code, current status, appointment date/time, service summary, and address summary.
- Timeline based on assignment, travel, check-in, start, and finish fields.
- Technician/team card with photo/avatar, grade/rating where available, and phone button only when provided by the API.
- Google Maps navigation using GPS coordinates when present, with address fallback.
- Post-finish photo gallery from returned `photos`.
- Technician note after job finish when available.
- E-slip/receipt link using `receipt_url` or safe `/docs/receipt/:job_id` fallback after finish.
- Post-finish 1-5 star review form using existing `/public/review` contract, with submitted-review display when already reviewed.
- Warranty card using conservative 30-day cleaning warranty wording.
- Urgent fallback messaging avoids saying an urgent job is confirmed before technician/admin confirmation.

## Cache / Version Fix Details

- Adds `?v=20260617_customer_app_v2_phase2f` to Customer App v2 imports in `customer-app/index.html`.
- Bumps `CACHE_NAME` to `cwf-cache-v122-customer-app-v2-phase2f-20260617`.
- Adds service-worker network `no-store` handling for `/customer-app/` assets.
- Preserves the existing dynamic API/data cache safety behavior.

## Tests Run

- `node --check customer-app/modules/*.js`
- `node --check customer-app/assets/customer-app.js`
- `node --check sw.js`
- `git diff --check`

## Remaining Risks / Manual Browser Testing Needed

- Browser automation in this environment could not open localhost because the in-app browser blocked the local URL with `ERR_BLOCKED_BY_CLIENT`.
- Manual mobile browser verification is still needed at 360px, 390px, and 430px.
- Confirm LINE/Google premium buttons render with icons after service-worker/cache refresh.
- Confirm company logo renders in the Customer App v2 header.
- Confirm `?q=` and `?token=` auto-route to tracking and load the existing public tracking API.
- Confirm Tracking v2 urgent wording does not imply confirmation before admin/technician confirmation.