### PR TITLE
Phase 2H-2: Additive multi-location DB migration draft

### DIFF
--- a/docs/CUSTOMER_APP_V2_PHASE2H_DB_MIGRATION_NOTES.md
+++ b/docs/CUSTOMER_APP_V2_PHASE2H_DB_MIGRATION_NOTES.md
@@ -1,0 +1,94 @@
+# Customer App V2 Phase 2H-2 DB Migration Notes
+
+Date: 2026-06-17
+Baseline main SHA inspected: `d347b5458fa6b4cd6be2d1ba5fdda16fc90e18ce`
+
+## Scope
+
+This phase drafts the additive database schema for customer multi-location support only.
+
+Changed files:
+
+- `migrations/20260617_phase2h_customer_locations.sql`
+- `docs/CUSTOMER_APP_V2_PHASE2H_DB_MIGRATION_NOTES.md`
+
+No runtime code was changed. No backend route, frontend UI, admin UI, auth/OAuth/LINE, payment, tax, receipt, booking, tracking, or production data behavior is changed by this PR.
+
+## Migration Summary
+
+The migration creates:
+
+- `public.customer_locations`
+- `public.customer_location_units`
+
+The migration adds nullable fields to `public.jobs`:
+
+- `location_id`
+- location label/place/building/access/site contact snapshot columns
+- optional `address_snapshot JSONB`
+
+The migration also adds safe indexes and a nullable `jobs.location_id` foreign key to `customer_locations(location_id)` with `ON DELETE SET NULL`.
+
+## Additive / Backward-compatible Design
+
+Existing production behavior remains based on current job snapshot fields:
+
+- `jobs.address_text`
+- `jobs.maps_url`
+- `jobs.job_zone`
+- `jobs.gps_latitude`
+- `jobs.gps_longitude`
+
+The migration does not replace or rewrite any of those fields. No API uses `location_id` until Phase 2H-3. No UI uses saved locations until Phase 2H-4.
+
+## Backfill Policy
+
+No automatic backfill is included.
+
+The migration contains commented audit queries only, clearly marked:
+
+- `DO NOT RUN AUTOMATICALLY IN PRODUCTION`
+- `Manual review required`
+
+Any future backfill from `customer_profiles` or `jobs` should be reviewed, staged, and run separately after owner approval.
+
+## Rollback Summary
+
+Rollback should be reviewed before use. The migration includes a commented rollback outline:
+
+1. Drop new indexes.
+2. Drop `jobs.location_id` foreign key.
+3. Drop new nullable `jobs` location/snapshot columns.
+4. Drop `customer_location_units`.
+5. Drop `customer_locations`.
+
+Because the schema is additive and current runtime code does not use these columns/tables yet, rollback should not affect current booking, tracking, dispatch, receipt, or admin behavior if no later phase has started using the new schema.
+
+## Production Deployment Warning
+
+Before applying to production:
+
+- Backup the database.
+- Test the migration on staging or a Render preview database.
+- Inspect lock risk for `ALTER TABLE public.jobs`.
+- Confirm the production PostgreSQL version supports all used `IF NOT EXISTS` patterns.
+- Do not run the commented audit/backfill queries automatically.
+
+## Remaining Risks
+
+- `ALTER TABLE public.jobs ADD COLUMN` and foreign key creation can take locks. Test on a copy of production-sized data first.
+- Partial unique default-location indexes enforce one active default by `customer_sub` or guest phone key. Existing data is not backfilled in this phase, so this should not conflict at apply time.
+- Future APIs must explicitly decide precedence when both `location_id` and manual address fields are sent.
+- Future AI/admin flows must not infer "same as before" when multiple active locations exist.
+
+## Recommended Next Phase
+
+Phase 2H-3 should implement backend APIs behind a conservative rollout plan:
+
+- `GET /public/locations`
+- `POST /public/locations`
+- `PATCH /public/locations/:id`
+- archive/delete endpoint
+- unit list/create endpoints
+- backward-compatible `/public/book` support for `location_id`
+- admin/customer lookup responses that return multiple locations instead of one silent latest address

--- a/docs/CUSTOMER_APP_V2_PHASE2H_DB_MIGRATION_NOTES.md
+++ b/docs/CUSTOMER_APP_V2_PHASE2H_DB_MIGRATION_NOTES.md
@@ -71,12 +71,16 @@ Before applying to production:
 - Backup the database.
 - Test the migration on staging or a Render preview database.
 - Inspect lock risk for `ALTER TABLE public.jobs`.
+- Treat the `public.jobs` index/FK work as the only lock-sensitive part of this draft.
+- Create `idx_jobs_location_id` with `CREATE INDEX CONCURRENTLY` outside a transaction, or schedule a manual maintenance window if the migration runner cannot run non-transactional statements.
+- The `jobs.location_id` foreign key is added as `NOT VALID` first; validate it later during a maintenance window with `ALTER TABLE public.jobs VALIDATE CONSTRAINT jobs_location_id_customer_locations_fk`.
 - Confirm the production PostgreSQL version supports all used `IF NOT EXISTS` patterns.
 - Do not run the commented audit/backfill queries automatically.
 
 ## Remaining Risks
 
 - `ALTER TABLE public.jobs ADD COLUMN` and foreign key creation can take locks. Test on a copy of production-sized data first.
+- `public.jobs` FK validation and `jobs(location_id)` index creation must be planned separately for production-scale data.
 - Partial unique default-location indexes enforce one active default by `customer_sub` or guest phone key. Existing data is not backfilled in this phase, so this should not conflict at apply time.
 - Future APIs must explicitly decide precedence when both `location_id` and manual address fields are sent.
 - Future AI/admin flows must not infer "same as before" when multiple active locations exist.

--- a/migrations/20260617_phase2h_customer_locations.sql
+++ b/migrations/20260617_phase2h_customer_locations.sql
@@ -1,0 +1,204 @@
+-- Phase 2H-2: Customer multi-location address book schema draft
+-- Repo: coldwindflow/cwf-services-system
+--
+-- Purpose:
+--   Add an additive, backward-compatible schema foundation for customers with
+--   multiple homes/condos/offices/branches.
+--
+-- Production safety:
+--   - Do not run against production until reviewed and approved.
+--   - Take a database backup before applying.
+--   - Test on staging / preview DB first.
+--   - Inspect lock risk for ALTER TABLE public.jobs before production apply.
+--   - No automatic data backfill is included in this migration.
+--
+-- Current behavior remains unchanged:
+--   Existing booking/tracking/dispatch/receipt flows continue using
+--   jobs.address_text, jobs.maps_url, jobs.job_zone, jobs.gps_latitude,
+--   and jobs.gps_longitude as operational job snapshots.
+
+CREATE TABLE IF NOT EXISTS public.customer_locations (
+  location_id BIGSERIAL PRIMARY KEY,
+  customer_sub TEXT NULL,
+  customer_phone TEXT NULL,
+  customer_phone_norm TEXT NULL,
+  label TEXT NOT NULL,
+  place_type TEXT NULL,
+  address_text TEXT NOT NULL,
+  maps_url TEXT NULL,
+  gps_latitude NUMERIC(10,7) NULL,
+  gps_longitude NUMERIC(10,7) NULL,
+  job_zone TEXT NULL,
+  service_zone_code TEXT NULL,
+  building_name TEXT NULL,
+  tower TEXT NULL,
+  floor_no TEXT NULL,
+  room_no TEXT NULL,
+  parking_note TEXT NULL,
+  access_note TEXT NULL,
+  juristic_time_note TEXT NULL,
+  site_contact_name TEXT NULL,
+  site_contact_phone TEXT NULL,
+  is_default BOOLEAN NOT NULL DEFAULT FALSE,
+  is_active BOOLEAN NOT NULL DEFAULT TRUE,
+  archived_at TIMESTAMPTZ NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  CONSTRAINT customer_locations_label_not_blank CHECK (length(btrim(label)) > 0),
+  CONSTRAINT customer_locations_address_not_blank CHECK (length(btrim(address_text)) > 0),
+  CONSTRAINT customer_locations_lat_range CHECK (gps_latitude IS NULL OR (gps_latitude >= -90 AND gps_latitude <= 90)),
+  CONSTRAINT customer_locations_lng_range CHECK (gps_longitude IS NULL OR (gps_longitude >= -180 AND gps_longitude <= 180))
+);
+
+CREATE TABLE IF NOT EXISTS public.customer_location_units (
+  unit_id BIGSERIAL PRIMARY KEY,
+  location_id BIGINT NOT NULL REFERENCES public.customer_locations(location_id) ON DELETE RESTRICT,
+  unit_label TEXT NULL,
+  room_label TEXT NULL,
+  ac_type TEXT NULL,
+  btu INTEGER NULL,
+  brand TEXT NULL,
+  model TEXT NULL,
+  serial_no TEXT NULL,
+  install_position TEXT NULL,
+  last_service_job_id BIGINT NULL,
+  last_service_at TIMESTAMPTZ NULL,
+  notes TEXT NULL,
+  is_active BOOLEAN NOT NULL DEFAULT TRUE,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  CONSTRAINT customer_location_units_btu_positive CHECK (btu IS NULL OR btu > 0)
+);
+
+ALTER TABLE public.jobs ADD COLUMN IF NOT EXISTS location_id BIGINT NULL;
+ALTER TABLE public.jobs ADD COLUMN IF NOT EXISTS location_label_snapshot TEXT NULL;
+ALTER TABLE public.jobs ADD COLUMN IF NOT EXISTS place_type_snapshot TEXT NULL;
+ALTER TABLE public.jobs ADD COLUMN IF NOT EXISTS building_name_snapshot TEXT NULL;
+ALTER TABLE public.jobs ADD COLUMN IF NOT EXISTS tower_snapshot TEXT NULL;
+ALTER TABLE public.jobs ADD COLUMN IF NOT EXISTS floor_snapshot TEXT NULL;
+ALTER TABLE public.jobs ADD COLUMN IF NOT EXISTS room_snapshot TEXT NULL;
+ALTER TABLE public.jobs ADD COLUMN IF NOT EXISTS parking_note_snapshot TEXT NULL;
+ALTER TABLE public.jobs ADD COLUMN IF NOT EXISTS access_note_snapshot TEXT NULL;
+ALTER TABLE public.jobs ADD COLUMN IF NOT EXISTS juristic_time_note_snapshot TEXT NULL;
+ALTER TABLE public.jobs ADD COLUMN IF NOT EXISTS site_contact_name_snapshot TEXT NULL;
+ALTER TABLE public.jobs ADD COLUMN IF NOT EXISTS site_contact_phone_snapshot TEXT NULL;
+ALTER TABLE public.jobs ADD COLUMN IF NOT EXISTS address_snapshot JSONB NULL;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conname = 'jobs_location_id_customer_locations_fk'
+      AND conrelid = 'public.jobs'::regclass
+  ) THEN
+    ALTER TABLE public.jobs
+      ADD CONSTRAINT jobs_location_id_customer_locations_fk
+      FOREIGN KEY (location_id)
+      REFERENCES public.customer_locations(location_id)
+      ON DELETE SET NULL;
+  END IF;
+END $$;
+
+CREATE INDEX IF NOT EXISTS idx_customer_locations_customer_sub
+  ON public.customer_locations(customer_sub)
+  WHERE customer_sub IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_customer_locations_customer_phone_norm
+  ON public.customer_locations(customer_phone_norm)
+  WHERE customer_phone_norm IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_customer_locations_is_active
+  ON public.customer_locations(is_active);
+
+CREATE INDEX IF NOT EXISTS idx_customer_locations_job_zone
+  ON public.customer_locations(job_zone);
+
+CREATE INDEX IF NOT EXISTS idx_customer_location_units_location_id
+  ON public.customer_location_units(location_id);
+
+CREATE INDEX IF NOT EXISTS idx_jobs_location_id
+  ON public.jobs(location_id);
+
+CREATE UNIQUE INDEX IF NOT EXISTS ux_customer_locations_default_by_sub
+  ON public.customer_locations(customer_sub)
+  WHERE is_active = TRUE
+    AND is_default = TRUE
+    AND customer_sub IS NOT NULL;
+
+CREATE UNIQUE INDEX IF NOT EXISTS ux_customer_locations_default_by_phone_guest
+  ON public.customer_locations(customer_phone_norm)
+  WHERE is_active = TRUE
+    AND is_default = TRUE
+    AND customer_sub IS NULL
+    AND customer_phone_norm IS NOT NULL;
+
+COMMENT ON TABLE public.customer_locations IS
+  'Phase 2H additive saved customer service locations. Runtime APIs do not use this table until Phase 2H-3.';
+COMMENT ON TABLE public.customer_location_units IS
+  'Phase 2H additive AC/unit inventory per customer location. Runtime APIs do not use this table until Phase 2H-3/2H-4.';
+COMMENT ON COLUMN public.jobs.location_id IS
+  'Nullable reference to saved customer location. Existing job address/map/zone/GPS fields remain operational snapshots.';
+COMMENT ON COLUMN public.jobs.address_snapshot IS
+  'Optional immutable JSON snapshot of selected saved location details at booking time.';
+
+-- ---------------------------------------------------------------------------
+-- Manual audit/backfill ideas only.
+-- DO NOT RUN AUTOMATICALLY IN PRODUCTION.
+-- Manual review required before any insert/update of production data.
+-- ---------------------------------------------------------------------------
+
+-- Example: inspect candidate saved profile locations by phone/sub.
+-- SELECT
+--   sub AS customer_sub,
+--   phone AS customer_phone,
+--   regexp_replace(COALESCE(phone, ''), '[^0-9]', '', 'g') AS customer_phone_norm,
+--   address,
+--   maps_url,
+--   updated_at
+-- FROM public.customer_profiles
+-- WHERE COALESCE(address, '') <> ''
+-- ORDER BY updated_at DESC NULLS LAST;
+
+-- Example: inspect recent distinct job address candidates by customer phone.
+-- SELECT
+--   regexp_replace(COALESCE(customer_phone, ''), '[^0-9]', '', 'g') AS customer_phone_norm,
+--   customer_name,
+--   address_text,
+--   maps_url,
+--   job_zone,
+--   COUNT(*) AS job_count,
+--   MAX(COALESCE(finished_at, appointment_datetime, created_at)) AS last_seen_at
+-- FROM public.jobs
+-- WHERE COALESCE(customer_phone, '') <> ''
+--   AND COALESCE(address_text, '') <> ''
+-- GROUP BY 1, 2, 3, 4, 5
+-- ORDER BY last_seen_at DESC NULLS LAST;
+
+-- ---------------------------------------------------------------------------
+-- Rollback outline (review before use):
+--   DROP INDEX IF EXISTS ux_customer_locations_default_by_phone_guest;
+--   DROP INDEX IF EXISTS ux_customer_locations_default_by_sub;
+--   DROP INDEX IF EXISTS idx_jobs_location_id;
+--   DROP INDEX IF EXISTS idx_customer_location_units_location_id;
+--   DROP INDEX IF EXISTS idx_customer_locations_job_zone;
+--   DROP INDEX IF EXISTS idx_customer_locations_is_active;
+--   DROP INDEX IF EXISTS idx_customer_locations_customer_phone_norm;
+--   DROP INDEX IF EXISTS idx_customer_locations_customer_sub;
+--   ALTER TABLE public.jobs DROP CONSTRAINT IF EXISTS jobs_location_id_customer_locations_fk;
+--   ALTER TABLE public.jobs DROP COLUMN IF EXISTS address_snapshot;
+--   ALTER TABLE public.jobs DROP COLUMN IF EXISTS site_contact_phone_snapshot;
+--   ALTER TABLE public.jobs DROP COLUMN IF EXISTS site_contact_name_snapshot;
+--   ALTER TABLE public.jobs DROP COLUMN IF EXISTS juristic_time_note_snapshot;
+--   ALTER TABLE public.jobs DROP COLUMN IF EXISTS access_note_snapshot;
+--   ALTER TABLE public.jobs DROP COLUMN IF EXISTS parking_note_snapshot;
+--   ALTER TABLE public.jobs DROP COLUMN IF EXISTS room_snapshot;
+--   ALTER TABLE public.jobs DROP COLUMN IF EXISTS floor_snapshot;
+--   ALTER TABLE public.jobs DROP COLUMN IF EXISTS tower_snapshot;
+--   ALTER TABLE public.jobs DROP COLUMN IF EXISTS building_name_snapshot;
+--   ALTER TABLE public.jobs DROP COLUMN IF EXISTS place_type_snapshot;
+--   ALTER TABLE public.jobs DROP COLUMN IF EXISTS location_label_snapshot;
+--   ALTER TABLE public.jobs DROP COLUMN IF EXISTS location_id;
+--   DROP TABLE IF EXISTS public.customer_location_units;
+--   DROP TABLE IF EXISTS public.customer_locations;
+-- ---------------------------------------------------------------------------

--- a/migrations/20260617_phase2h_customer_locations.sql
+++ b/migrations/20260617_phase2h_customer_locations.sql
@@ -96,9 +96,13 @@ BEGIN
       ADD CONSTRAINT jobs_location_id_customer_locations_fk
       FOREIGN KEY (location_id)
       REFERENCES public.customer_locations(location_id)
-      ON DELETE SET NULL;
+      ON DELETE SET NULL
+      NOT VALID;
   END IF;
 END $$;
+
+-- Later maintenance-window validation after production apply:
+-- ALTER TABLE public.jobs VALIDATE CONSTRAINT jobs_location_id_customer_locations_fk;
 
 CREATE INDEX IF NOT EXISTS idx_customer_locations_customer_sub
   ON public.customer_locations(customer_sub)
@@ -117,8 +121,14 @@ CREATE INDEX IF NOT EXISTS idx_customer_locations_job_zone
 CREATE INDEX IF NOT EXISTS idx_customer_location_units_location_id
   ON public.customer_location_units(location_id);
 
-CREATE INDEX IF NOT EXISTS idx_jobs_location_id
-  ON public.jobs(location_id);
+-- Production lock-sensitive index:
+-- If this migration is run by a tool that wraps statements in a transaction,
+-- do not put CREATE INDEX CONCURRENTLY in this file. Create this index manually
+-- outside a transaction after the nullable jobs.location_id column exists.
+--
+-- Recommended production step:
+-- CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_jobs_location_id
+--   ON public.jobs(location_id);
 
 CREATE UNIQUE INDEX IF NOT EXISTS ux_customer_locations_default_by_sub
   ON public.customer_locations(customer_sub)
@@ -179,7 +189,7 @@ COMMENT ON COLUMN public.jobs.address_snapshot IS
 -- Rollback outline (review before use):
 --   DROP INDEX IF EXISTS ux_customer_locations_default_by_phone_guest;
 --   DROP INDEX IF EXISTS ux_customer_locations_default_by_sub;
---   DROP INDEX IF EXISTS idx_jobs_location_id;
+--   DROP INDEX CONCURRENTLY IF EXISTS idx_jobs_location_id; -- run outside transaction
 --   DROP INDEX IF EXISTS idx_customer_location_units_location_id;
 --   DROP INDEX IF EXISTS idx_customer_locations_job_zone;
 --   DROP INDEX IF EXISTS idx_customer_locations_is_active;


### PR DESCRIPTION
## Summary

- Adds an additive SQL migration draft for customer multi-location support.
- Adds a short DB migration note covering rollout, rollback, phase boundaries, and production warnings.
- No runtime application behavior changes are included in this PR.

## Baseline

- Pulled latest GitHub `main` before work.
- Latest main commit inspected: `d347b5458fa6b4cd6be2d1ba5fdda16fc90e18ce`.
- No ZIP/local old files were used as source of truth.

## Changed Files

- `migrations/20260617_phase2h_customer_locations.sql`
- `docs/CUSTOMER_APP_V2_PHASE2H_DB_MIGRATION_NOTES.md`

## Runtime / Production Confirmation

- No production code changed.
- No backend route changed.
- No frontend UI changed.
- No admin UI changed.
- No auth/OAuth/LINE/payment/tax/receipt logic changed.
- No production DB migration was run.
- No automatic production data backfill is included.

## Migration Summary

The migration draft creates:

- `public.customer_locations`
- `public.customer_location_units`

It adds nullable fields to `public.jobs` using `ALTER TABLE ... ADD COLUMN IF NOT EXISTS`, including:

- `location_id`
- location label/place/building/access/site-contact snapshot columns
- optional `address_snapshot JSONB`

It adds safe indexes and a nullable `jobs.location_id` foreign key to `customer_locations(location_id)` with `ON DELETE SET NULL`.

Existing production address fields remain the operational truth:

- `jobs.address_text`
- `jobs.maps_url`
- `jobs.job_zone`
- `jobs.gps_latitude`
- `jobs.gps_longitude`

## Backfill Policy

- No automatic backfill is performed.
- The migration only includes commented audit/backfill examples marked `DO NOT RUN AUTOMATICALLY IN PRODUCTION` and `manual review required`.

## Rollback Summary

The migration file includes a commented rollback outline:

1. Drop new indexes.
2. Drop the `jobs.location_id` foreign key.
3. Drop new nullable `jobs` location/snapshot columns.
4. Drop `customer_location_units`.
5. Drop `customer_locations`.

Because current runtime code does not use the new tables/columns, rollback should not affect current booking, tracking, dispatch, receipt, or admin behavior if no later phase has started using them.

## Remaining Risks

- `ALTER TABLE public.jobs` and FK creation may take locks; test on staging/preview DB first.
- Production DB backup is required before applying.
- Confirm production PostgreSQL compatibility with used `IF NOT EXISTS` patterns before deploy.
- Future APIs must define precedence when both `location_id` and manual address fields are sent.
- Future admin/AI flows must require disambiguation when multiple active locations exist.

## Validation

- `git diff --cached --name-only`
- `git diff --cached --stat`
- `git diff --cached --check`

Note: The files were new/untracked before staging, so staged diff validation was used to inspect the actual PR content.

## Recommended Next Phase

Phase 2H-3: backend API proposal/implementation for saved customer locations, including:

- `GET /public/locations`
- `POST /public/locations`
- `PATCH /public/locations/:id`
- archive/delete endpoint
- unit list/create endpoints
- backward-compatible `/public/book` support for `location_id`
- admin/customer lookup responses that return multiple locations instead of one silent latest address

Do not merge until ChatGPT reviews.