### PR TITLE
Phase 2H-2X: Admin multi-location lookup from job history

### DIFF
--- a/admin-add-v2.html
+++ b/admin-add-v2.html
@@ -30,6 +30,16 @@
     .line .grow{flex:1}
     .mini{font-size:12px}
     .muted2{color:rgba(15,23,42,0.72);font-size:13px}
+    .customer-location-candidates{display:none;margin-top:10px;border:1px solid rgba(11,75,179,0.16);background:#f8fbff;border-radius:16px;padding:10px}
+    .customer-location-candidates.show{display:block}
+    .customer-location-head{font-size:13px;font-weight:900;color:#0b1b3a;margin-bottom:8px}
+    .customer-location-warn{font-size:12px;color:#92400e;background:#fffbeb;border:1px solid rgba(245,158,11,0.26);border-radius:12px;padding:8px;margin-bottom:8px}
+    .customer-location-list{display:grid;gap:8px}
+    .customer-location-card{border:1px solid rgba(11,75,179,0.16);background:#fff;border-radius:14px;padding:10px;display:grid;gap:6px}
+    .customer-location-title{font-size:13px;font-weight:900;color:#0b1b3a}
+    .customer-location-address{font-size:13px;color:#334155;line-height:1.35;overflow-wrap:anywhere}
+    .customer-location-meta{font-size:12px;color:#64748b;display:flex;gap:6px;flex-wrap:wrap}
+    .customer-location-card button{justify-self:start;width:auto}
     .slot-grid{display:grid;grid-template-columns:repeat(4,1fr);gap:8px}
     @media (max-width:720px){.slot-grid{grid-template-columns:repeat(2,1fr)}}
     @media (max-width:420px){.slot-grid{grid-template-columns:repeat(2,1fr)}}
@@ -201,6 +211,7 @@
             <button id="btnUseLatestCustomerData" class="secondary" type="button" style="display:none;width:auto;">Use latest customer data</button>
             <div id="customer_lookup_hint" class="muted2 grow">กรอกเบอร์ลูกค้าเก่าแล้วออกจากช่องนี้ ระบบจะค้นหาข้อมูลล่าสุดให้ก่อน โดยยังไม่เติมค่าให้อัตโนมัติ</div>
           </div>
+          <div id="customer_location_candidates" class="customer-location-candidates"></div>
         </div>
       </div>
       <label style="margin-top:10px">ที่อยู่ *</label>

--- a/admin-add-v2.js
+++ b/admin-add-v2.js
@@ -142,13 +142,53 @@ function normalizePhoneLookupClient(phone){
   return String(phone || "").replace(/\D/g, "").trim();
 }
 
+function escapeHtml(value){
+  return String(value ?? "").replace(/[&<>"']/g, (ch) => ({
+    "&": "&amp;",
+    "<": "&lt;",
+    ">": "&gt;",
+    '"': "&quot;",
+    "'": "&#39;",
+  }[ch]));
+}
+
+function shortText(value, max = 96){
+  const s = String(value || "").trim().replace(/\s+/g, " ");
+  if (s.length <= max) return s;
+  return `${s.slice(0, max - 1)}…`;
+}
+
+function formatLookupDate(value){
+  const s = String(value || "").trim();
+  if (!s) return "";
+  const d = new Date(s);
+  if (Number.isNaN(d.getTime())) return s.slice(0, 16);
+  try {
+    return d.toLocaleString("th-TH", {
+      timeZone: "Asia/Bangkok",
+      year: "numeric",
+      month: "short",
+      day: "numeric",
+      hour: "2-digit",
+      minute: "2-digit",
+    });
+  } catch(e) {
+    return s.slice(0, 16);
+  }
+}
+
 function resetCustomerLookupUI(message){
   state.customer_lookup = { query: "", data: null };
   const btn = el("btnUseLatestCustomerData");
   const hint = el("customer_lookup_hint");
+  const candidatesBox = el("customer_location_candidates");
   if (el("customer_id")) el("customer_id").value = "";
   if (btn) btn.style.display = "none";
   if (hint) hint.textContent = message || "กรอกเบอร์ลูกค้าเก่าแล้วออกจากช่องนี้ ระบบจะค้นหาข้อมูลล่าสุดให้ก่อน โดยยังไม่เติมค่าให้อัตโนมัติ";
+  if (candidatesBox) {
+    candidatesBox.classList.remove("show");
+    candidatesBox.innerHTML = "";
+  }
 }
 
 async function loadServiceZones(){
@@ -203,13 +243,63 @@ async function detectAdminServiceZone(){
 function renderCustomerLookupUI(result){
   const btn = el("btnUseLatestCustomerData");
   const hint = el("customer_lookup_hint");
+  const candidatesBox = el("customer_location_candidates");
   if (!btn || !hint) return;
+  if (candidatesBox) {
+    candidatesBox.classList.remove("show");
+    candidatesBox.innerHTML = "";
+  }
   if (!result || !result.found) {
     btn.style.display = "none";
     hint.textContent = "ไม่พบข้อมูลลูกค้าเก่าจากเบอร์นี้ ยังสามารถกรอกข้อมูลใหม่ต่อได้ตามปกติ";
     return;
   }
+  const candidates = Array.isArray(result.location_candidates) ? result.location_candidates.filter(c => c && c.address_text) : [];
+  if (candidates.length > 1) {
+    btn.style.display = "none";
+    hint.textContent = `พบลูกค้าเก่า ${candidates.length} สถานที่ กรุณาเลือกสถานที่ให้ถูกต้อง`;
+    if (candidatesBox) {
+      candidatesBox.classList.add("show");
+      candidatesBox.innerHTML = `
+        <div class="customer-location-head">เลือกสถานที่จากประวัติงานเดิม</div>
+        <div class="customer-location-warn">ลูกค้าคนนี้มีหลายสถานที่ อย่าใช้ที่อยู่ล่าสุดโดยไม่ตรวจ</div>
+        <div class="customer-location-list">
+          ${candidates.map((c, index) => {
+            const meta = [
+              c.job_zone ? `โซน: ${c.job_zone}` : "",
+              c.last_seen_at ? `ล่าสุด: ${formatLookupDate(c.last_seen_at)}` : "",
+              c.job_count ? `ใช้แล้ว ${c.job_count} งาน` : "",
+              c.booking_code ? `ใบงาน: ${c.booking_code}` : "",
+            ].filter(Boolean);
+            return `
+              <div class="customer-location-card">
+                <div class="customer-location-title">${escapeHtml(c.label || (c.source === "customer_profiles" ? "ที่อยู่ในโปรไฟล์" : "สถานที่จากประวัติงาน"))}</div>
+                <div class="customer-location-address">${escapeHtml(shortText(c.address_text, 140))}</div>
+                ${meta.length ? `<div class="customer-location-meta">${meta.map(x => `<span>${escapeHtml(x)}</span>`).join("")}</div>` : ""}
+                <button class="secondary btn-mini" type="button" data-customer-location-index="${index}">ใช้สถานที่นี้</button>
+              </div>
+            `;
+          }).join("")}
+        </div>
+      `;
+    }
+    return;
+  }
   btn.style.display = "";
+  if (candidates.length === 1 && candidatesBox) {
+    const c = candidates[0];
+    const meta = [
+      c.job_zone ? `โซน: ${c.job_zone}` : "",
+      c.last_seen_at ? `ล่าสุด: ${formatLookupDate(c.last_seen_at)}` : "",
+      c.job_count && Number(c.job_count) > 1 ? `ใช้แล้ว ${c.job_count} งาน` : "",
+    ].filter(Boolean).join(" • ");
+    candidatesBox.classList.add("show");
+    candidatesBox.innerHTML = `
+      <div class="customer-location-head">${escapeHtml(c.label || "พบสถานที่จากข้อมูลลูกค้าเดิม")}</div>
+      <div class="customer-location-address">${escapeHtml(shortText(c.address_text, 140))}</div>
+      ${meta ? `<div class="customer-location-meta"><span>${escapeHtml(meta)}</span></div>` : ""}
+    `;
+  }
   if (result.source === "customer_profiles") {
     hint.textContent = 'พบข้อมูลจาก customer_profiles • กด "Use latest customer data" เพื่อเติมชื่อ/เบอร์/ที่อยู่/แผนที่ล่าสุด';
     return;
@@ -252,9 +342,38 @@ function applyLatestCustomerData(){
   if (el("customer_id")) el("customer_id").value = data.customer_id || "";
   if (data.address_text) el("address_text").value = data.address_text;
   if (data.maps_url) el("maps_url").value = data.maps_url;
+  if (data.job_zone && el("job_zone")) el("job_zone").value = data.job_zone;
   try { el("address_text").dispatchEvent(new Event("input", { bubbles: true })); } catch(e){}
   try { el("maps_url").dispatchEvent(new Event("input", { bubbles: true })); } catch(e){}
+  try { el("job_zone").dispatchEvent(new Event("input", { bubbles: true })); } catch(e){}
+  try { detectAdminServiceZone(); } catch(e){}
   showToast(data.source === "customer_profiles" ? "เติมข้อมูลจาก customer_profiles แล้ว" : "เติมข้อมูลจาก latest job แล้ว", "success");
+}
+
+function applyCustomerLocationCandidate(index){
+  const data = state.customer_lookup?.data;
+  const candidates = Array.isArray(data?.location_candidates) ? data.location_candidates : [];
+  const candidate = candidates[Number(index)];
+  if (!data || !candidate) {
+    showToast("ยังไม่มีสถานที่ลูกค้าที่พร้อมใช้", "error");
+    return;
+  }
+  const currentQuery = normalizePhoneLookupClient(el("customer_phone")?.value || "");
+  if (state.customer_lookup?.query && currentQuery !== state.customer_lookup.query) {
+    showToast("เบอร์โทรเปลี่ยนแล้ว กรุณาค้นหาข้อมูลลูกค้าอีกครั้ง", "error");
+    return;
+  }
+  if (candidate.customer_name || data.customer_name) el("customer_name").value = candidate.customer_name || data.customer_name || "";
+  if (candidate.customer_phone || data.customer_phone) el("customer_phone").value = candidate.customer_phone || data.customer_phone || "";
+  if (el("customer_id")) el("customer_id").value = candidate.customer_id || data.customer_id || "";
+  if (candidate.address_text) el("address_text").value = candidate.address_text;
+  if (candidate.maps_url) el("maps_url").value = candidate.maps_url;
+  if (candidate.job_zone && el("job_zone")) el("job_zone").value = candidate.job_zone;
+  try { el("address_text").dispatchEvent(new Event("input", { bubbles: true })); } catch(e){}
+  try { el("maps_url").dispatchEvent(new Event("input", { bubbles: true })); } catch(e){}
+  try { el("job_zone").dispatchEvent(new Event("input", { bubbles: true })); } catch(e){}
+  try { detectAdminServiceZone(); } catch(e){}
+  showToast("เลือกสถานที่ลูกค้าแล้ว", "success");
 }
 
 function maskPII(obj){
@@ -2874,6 +2993,11 @@ function wireEvents() {
     });
   } catch(e){}
   el("btnUseLatestCustomerData")?.addEventListener("click", applyLatestCustomerData);
+  el("customer_location_candidates")?.addEventListener("click", (ev) => {
+    const btn = ev.target?.closest?.("[data-customer-location-index]");
+    if (!btn) return;
+    applyCustomerLocationCandidate(btn.getAttribute("data-customer-location-index"));
+  });
   el("customer_phone")?.addEventListener("blur", lookupLatestCustomerDataByPhone);
   el("customer_phone")?.addEventListener("change", lookupLatestCustomerDataByPhone);
   el("customer_phone")?.addEventListener("input", () => {

--- a/server/customerLookup.js
+++ b/server/customerLookup.js
@@ -12,10 +12,107 @@ function buildPhoneLookupCandidates(phone) {
   return [...set].filter(Boolean);
 }
 
+function compactText(value) {
+  return String(value || "").trim().replace(/\s+/g, " ");
+}
+
+function normalizeLocationKey(addressText, mapsUrl) {
+  const address = compactText(addressText).toLowerCase();
+  const maps = compactText(mapsUrl).toLowerCase();
+  if (!address && !maps) return "";
+  return `${address}|${maps}`;
+}
+
+function buildProfileLocationCandidate(row) {
+  const addressText = compactText(row?.address_text);
+  const mapsUrl = compactText(row?.maps_url);
+  if (!addressText && !mapsUrl) return null;
+  return {
+    source: "customer_profiles",
+    label: "ที่อยู่ในโปรไฟล์",
+    customer_id: row.customer_id || null,
+    customer_name: row.customer_name || null,
+    customer_phone: row.customer_phone || null,
+    address_text: addressText || null,
+    maps_url: mapsUrl || null,
+    job_zone: null,
+    booking_code: null,
+    job_id: null,
+    job_count: 1,
+    last_seen_at: row.updated_at || null,
+    last_job_status: null,
+  };
+}
+
+function buildJobLocationCandidate(row) {
+  const addressText = compactText(row?.address_text);
+  const mapsUrl = compactText(row?.maps_url);
+  if (!addressText) return null;
+  return {
+    source: "jobs",
+    label: "เลือกสถานที่จากประวัติงานเดิม",
+    customer_id: null,
+    customer_name: row.customer_name || null,
+    customer_phone: row.customer_phone || null,
+    address_text: addressText,
+    maps_url: mapsUrl || null,
+    job_zone: row.job_zone || null,
+    booking_code: row.booking_code || null,
+    job_id: row.job_id || null,
+    job_count: Number(row.job_count || 0) || 1,
+    last_seen_at: row.last_seen_at || null,
+    last_job_status: row.last_job_status || null,
+  };
+}
+
+function addLocationCandidate(list, candidate, max = 8) {
+  if (!candidate || !candidate.address_text) return;
+  const key = normalizeLocationKey(candidate.address_text, candidate.maps_url);
+  if (!key) return;
+  const existingIndex = list.findIndex((item) => normalizeLocationKey(item.address_text, item.maps_url) === key);
+  if (existingIndex >= 0) {
+    const existing = list[existingIndex];
+    list[existingIndex] = {
+      ...existing,
+      customer_name: candidate.customer_name || existing.customer_name || null,
+      customer_phone: candidate.customer_phone || existing.customer_phone || null,
+      maps_url: candidate.maps_url || existing.maps_url || null,
+      job_zone: candidate.job_zone || existing.job_zone || null,
+      booking_code: candidate.booking_code || existing.booking_code || null,
+      job_id: candidate.job_id || existing.job_id || null,
+      job_count: Math.max(Number(existing.job_count || 0), Number(candidate.job_count || 0)) || null,
+      last_seen_at: candidate.last_seen_at || existing.last_seen_at || null,
+      last_job_status: candidate.last_job_status || existing.last_job_status || null,
+    };
+    return;
+  }
+  if (list.length < max) list.push(candidate);
+}
+
+function buildLookupResultFromDefault(defaultCandidate) {
+  if (!defaultCandidate) return { found: false, location_candidates: [] };
+  return {
+    found: true,
+    source: defaultCandidate.source || null,
+    customer_id: defaultCandidate.customer_id || null,
+    customer_name: defaultCandidate.customer_name || null,
+    customer_phone: defaultCandidate.customer_phone || null,
+    address_text: defaultCandidate.address_text || null,
+    maps_url: defaultCandidate.maps_url || null,
+    booking_code: defaultCandidate.booking_code || null,
+    job_id: defaultCandidate.job_id || null,
+  };
+}
+
 async function lookupCustomerByPhoneV2(db, phone) {
   const rawPhone = String(phone || "").trim();
   const candidates = buildPhoneLookupCandidates(rawPhone);
-  if (!candidates.length || normalizePhone(rawPhone).length < 8) return { found: false };
+  if (!candidates.length || normalizePhone(rawPhone).length < 8) {
+    return { found: false, location_candidates: [] };
+  }
+
+  let profileRow = null;
+  const locationCandidates = [];
 
   try {
     const profileR = await db.query(
@@ -25,7 +122,8 @@ async function lookupCustomerByPhoneV2(db, phone) {
         COALESCE(NULLIF(display_name, ''), NULLIF(phone, ''), 'ลูกค้าเดิม') AS customer_name,
         phone AS customer_phone,
         address AS address_text,
-        maps_url
+        maps_url,
+        updated_at
       FROM public.customer_profiles
       WHERE regexp_replace(COALESCE(phone, ''), '[^0-9]', '', 'g') = ANY($1::text[])
       ORDER BY updated_at DESC NULLS LAST
@@ -34,16 +132,8 @@ async function lookupCustomerByPhoneV2(db, phone) {
       [candidates]
     );
     if (profileR.rows.length) {
-      const row = profileR.rows[0];
-      return {
-        found: true,
-        source: "customer_profiles",
-        customer_id: row.customer_id || null,
-        customer_name: row.customer_name || null,
-        customer_phone: row.customer_phone || null,
-        address_text: row.address_text || null,
-        maps_url: row.maps_url || null,
-      };
+      profileRow = profileR.rows[0];
+      addLocationCandidate(locationCandidates, buildProfileLocationCandidate(profileRow));
     }
   } catch (e) {
     console.warn("[customer_lookup_by_phone_v2] customer_profiles lookup failed:", e.message);
@@ -52,39 +142,99 @@ async function lookupCustomerByPhoneV2(db, phone) {
   try {
     const jobR = await db.query(
       `
+      WITH recent_jobs AS (
+        SELECT
+          customer_name,
+          customer_phone,
+          address_text,
+          maps_url,
+          job_zone,
+          booking_code,
+          job_id,
+          status,
+          COALESCE(finished_at, appointment_datetime, created_at) AS seen_at
+        FROM public.jobs
+        WHERE regexp_replace(COALESCE(customer_phone, ''), '[^0-9]', '', 'g') = ANY($1::text[])
+          AND COALESCE(NULLIF(btrim(address_text), ''), '') <> ''
+        ORDER BY COALESCE(finished_at, appointment_datetime, created_at) DESC NULLS LAST, job_id DESC
+        LIMIT 80
+      ),
+      grouped AS (
+        SELECT
+          lower(regexp_replace(btrim(address_text), '\\s+', ' ', 'g')) AS address_key,
+          lower(regexp_replace(COALESCE(btrim(maps_url), ''), '\\s+', ' ', 'g')) AS maps_key,
+          COUNT(*) AS job_count,
+          MAX(seen_at) AS last_seen_at
+        FROM recent_jobs
+        GROUP BY 1, 2
+      ),
+      ranked AS (
+        SELECT
+          r.customer_name,
+          r.customer_phone,
+          r.address_text,
+          r.maps_url,
+          r.job_zone,
+          r.booking_code,
+          r.job_id,
+          g.job_count,
+          g.last_seen_at,
+          r.status AS last_job_status,
+          ROW_NUMBER() OVER (
+            PARTITION BY g.address_key, g.maps_key
+            ORDER BY r.seen_at DESC NULLS LAST, r.job_id DESC
+          ) AS rn
+        FROM grouped g
+        JOIN recent_jobs r
+          ON lower(regexp_replace(btrim(r.address_text), '\\s+', ' ', 'g')) = g.address_key
+         AND lower(regexp_replace(COALESCE(btrim(r.maps_url), ''), '\\s+', ' ', 'g')) = g.maps_key
+         AND r.seen_at IS NOT DISTINCT FROM g.last_seen_at
+      )
       SELECT
         customer_name,
         customer_phone,
         address_text,
         maps_url,
+        job_zone,
         booking_code,
-        job_id
-      FROM public.jobs
-      WHERE regexp_replace(COALESCE(customer_phone, ''), '[^0-9]', '', 'g') = ANY($1::text[])
-      ORDER BY COALESCE(finished_at, appointment_datetime, created_at) DESC NULLS LAST, job_id DESC
-      LIMIT 1
+        job_id,
+        job_count,
+        last_seen_at,
+        last_job_status
+      FROM ranked
+      WHERE rn = 1
+      ORDER BY last_seen_at DESC NULLS LAST, job_id DESC
+      LIMIT 8
       `,
       [candidates]
     );
-    if (jobR.rows.length) {
-      const row = jobR.rows[0];
-      return {
-        found: true,
-        source: "jobs",
-        customer_id: null,
-        customer_name: row.customer_name || null,
-        customer_phone: row.customer_phone || null,
-        address_text: row.address_text || null,
-        maps_url: row.maps_url || null,
-        booking_code: row.booking_code || null,
-        job_id: row.job_id || null,
-      };
+    for (const row of jobR.rows || []) {
+      addLocationCandidate(locationCandidates, buildJobLocationCandidate(row));
     }
   } catch (e) {
-    console.warn("[customer_lookup_by_phone_v2] jobs fallback lookup failed:", e.message);
+    console.warn("[customer_lookup_by_phone_v2] jobs location candidates lookup failed:", e.message);
   }
 
-  return { found: false };
+  const defaultCandidate = locationCandidates[0] || (profileRow ? {
+    source: "customer_profiles",
+    customer_id: profileRow.customer_id || null,
+    customer_name: profileRow.customer_name || null,
+    customer_phone: profileRow.customer_phone || null,
+    address_text: profileRow.address_text || null,
+    maps_url: profileRow.maps_url || null,
+  } : null);
+
+  const result = buildLookupResultFromDefault(defaultCandidate);
+  if (!result.found) return result;
+  if (profileRow) {
+    result.customer_id = result.customer_id || profileRow.customer_id || null;
+    result.customer_name = result.customer_name || profileRow.customer_name || null;
+    result.customer_phone = result.customer_phone || profileRow.customer_phone || null;
+  }
+  return {
+    ...result,
+    location_candidates: locationCandidates,
+  };
 }
 
 module.exports = {


### PR DESCRIPTION
## Summary

- Adds backward-compatible `location_candidates` to `/admin/customer_lookup_by_phone_v2` via `lookupCustomerByPhoneV2`.
- Lets Admin Add Job show multiple selectable address/location candidates from existing `customer_profiles` and `jobs` data.
- Keeps `/admin/book_v2` payload unchanged: selected candidates still fill the existing `customer_name`, `customer_phone`, `customer_id`, `address_text`, `maps_url`, and `job_zone` fields.

## Baseline

- Pulled latest GitHub `main` before work.
- Latest main commit inspected: `a516e81b3cc9dc3a02c4427cf5d32318f5574526`.
- No ZIP/local old files were used as source of truth.

## Changed Files

- `server/customerLookup.js`
- `admin-add-v2.js`
- `admin-add-v2.html`

## Backend Changes

- `lookupCustomerByPhoneV2(db, phone)` still returns existing top-level fields: `found`, `source`, `customer_id`, `customer_name`, `customer_phone`, `address_text`, `maps_url`, `booking_code`, and `job_id`.
- Adds `location_candidates: []` to the response.
- Includes profile address as a candidate when available.
- Queries recent matching `jobs` rows by normalized phone, groups/dedupes by normalized `address_text` + `maps_url`, orders job candidates by latest seen job, and limits candidates to 8.
- Candidate objects include source, label, customer/address/map fields, `job_zone`, `booking_code`, `job_id`, `job_count`, `last_seen_at`, and `last_job_status`.

## Admin UI Changes

- Adds a compact `customer_location_candidates` container under the existing lookup hint.
- If multiple candidates exist, hides the old latest-data button and requires the admin to select a location card.
- Candidate cards show label/source, address preview, zone, last seen date, job count, and a `ใช้สถานที่นี้` button.
- Clicking a candidate fills the existing customer/address/map/zone fields, dispatches input events, and triggers existing service-zone detection.
- Existing one-candidate lookup flow and `Use latest customer data` button remain available.
- Existing phone-change mismatch protection remains in place.

## Confirmations

- No DB migration.
- No database schema change.
- No production data changed.
- No new tables required.
- No customer app changes.
- No technician app changes.
- No payment/auth/receipt/tax/LINE changes.
- Booking price rules unchanged.
- `/admin/book_v2` payload unchanged.

## Tests Run

- `node --check server/customerLookup.js`
- `node --check admin-add-v2.js`
- `git diff --check`
- `git diff --name-only`
- `git diff --stat`

## Remaining Risks / Manual Testing

- Needs manual browser testing with real admin staging/production-safe data for:
  - phone with no past jobs
  - phone with one past address
  - phone with multiple past addresses
  - phone changed after lookup before candidate apply
  - saving `/admin/book_v2` after selecting a candidate
- Candidate grouping is based on normalized `address_text` + `maps_url`; very similar but not identical address wording may still appear as separate cards.

Do not merge until ChatGPT reviews.