### PR TITLE
Fix stale LINE AI accounting prefill on normal add job page

### DIFF
--- a/admin-add-ai-intake-prefill.js
+++ b/admin-add-ai-intake-prefill.js
@@ -7,7 +7,7 @@
   function clean(v){ return String(v == null ? "" : v).replace(/\s+/g, " ").trim(); }
   function byId(id){ return document.getElementById(id); }
   function toast(msg, type){ try { if (typeof showToast === "function") showToast(msg, type || "info"); } catch(_){} }
-  function clearPendingIntakeStorage(){ try { localStorage.removeItem("cwf_line_ai_intake_pending_id"); localStorage.removeItem("cwf_line_ai_intake_pending_payload"); } catch(_){} }
+  function clearPendingIntakeStorage(){ try { localStorage.removeItem("cwf_line_ai_intake_pending_id"); localStorage.removeItem("cwf_line_ai_intake_pending_payload"); localStorage.removeItem("cwf_accounting_quote_prefill"); } catch(_){} }
   function isIntentionalLineAiFlow(p){ return p && p.get("source") === "line_ai"; }
   function api(url, options){
     if (typeof apiFetch === "function") return apiFetch(url, options || {});

--- a/admin-add-v2.js
+++ b/admin-add-v2.js
@@ -3244,6 +3244,16 @@ document.addEventListener("DOMContentLoaded", init);
 // =============================================================
 (function initAccountingQuotePrefill(){
   function safeSet(id, value){ try{ const x = document.getElementById(id); if(x && value != null && String(value) !== ''){ x.value = value; x.dispatchEvent(new Event('input', { bubbles:true })); x.dispatchEvent(new Event('change', { bubbles:true })); } }catch(_){} }
+  function quoteParams(){ return new URLSearchParams(window.location.search || ''); }
+  function isIntentionalLineAiFlow(p){ return p.get('source') === 'line_ai' && !!p.get('ai_intake_id'); }
+  function isExplicitAccountingFlow(p){ return p.get('source') === 'accounting_quotation' || !!p.get('from_quote') || !!p.get('accounting_quote_id'); }
+  function isLineAiDerivedQuote(data){
+    const doc = String(data?.document_no || '').trim().toUpperCase();
+    const note = String(data?.customer_note || '').trim();
+    const desc = Array.isArray(data?.service_lines) ? data.service_lines.map(x => String(x?.description || '')).join(' ') : '';
+    return doc.startsWith('LINE-AI-') || /LINE AI/i.test(`${note} ${desc}`);
+  }
+  function clearQuotePrefill(){ try { localStorage.removeItem('cwf_accounting_quote_prefill'); } catch(_) {} }
   function normalizeLine(x){
     const jobRaw = String(x?.job_type || 'ล้าง').replace('ล้างแอร์','ล้าง');
     const acRaw = String(x?.ac_type || 'ผนัง').replace('แอร์ผนัง','ผนัง');
@@ -3265,7 +3275,19 @@ document.addEventListener("DOMContentLoaded", init);
     let data = null;
     try { data = JSON.parse(raw); } catch(_) { return; }
     if(!data || data.source !== 'accounting_quotation') return;
-    try { localStorage.removeItem('cwf_accounting_quote_prefill'); } catch(_) {}
+    const p = quoteParams();
+    const lineAiFlow = isIntentionalLineAiFlow(p);
+    const accountingFlow = isExplicitAccountingFlow(p);
+    const lineAiDerived = isLineAiDerivedQuote(data);
+    if (lineAiDerived && !lineAiFlow) {
+      clearQuotePrefill();
+      return;
+    }
+    if (!lineAiFlow && !accountingFlow) {
+      clearQuotePrefill();
+      return;
+    }
+    clearQuotePrefill();
     safeSet('customer_name', data.customer_name || '');
     safeSet('customer_phone', data.customer_phone || '');
     safeSet('address_text', data.address_text || '');


### PR DESCRIPTION
## Root Cause

PR #49 stopped stale `cwf_line_ai_intake_pending_id` from auto-starting LINE AI prefill, but LINE AI review also writes `cwf_accounting_quote_prefill`. Because `admin-add-v2.js` accepted any stored `source: "accounting_quotation"` payload, a stale LINE-AI-derived quote payload could still prefill the normal Add Job page.

## Changed Files

- `admin-add-ai-intake-prefill.js`
- `admin-add-v2.js`

## Summary

- Normal Add Job page cleanup now removes:
  - `cwf_line_ai_intake_pending_id`
  - `cwf_line_ai_intake_pending_payload`
  - `cwf_accounting_quote_prefill`
- `admin-add-v2.js` now gates accounting quote prefill:
  - allows intentional LINE AI flow only with `source=line_ai&ai_intake_id=<id>`
  - allows real accounting quotation flow with explicit accounting URL context such as `from_quote`, `source=accounting_quotation`, or `accounting_quote_id`
  - clears LINE-AI-derived quote payloads, including `document_no` beginning `LINE-AI-`, on normal Add Job page
- Keeps intentional LINE AI prefill working.
- Keeps real accounting quotation flow from `admin-accounting-v2.js` working.

## Confirmations

- Frontend-only fix.
- No DB changes.
- No migrations changed.
- No backend routes changed.
- No payment/auth/tax/receipt/customer app changes.
- `/admin/book_v2` unchanged.
- No direct push to `main`.

## Tests Run

- `node --check admin-add-ai-intake-prefill.js`
- `node --check admin-add-v2.js`
- `git diff --check`
- `git diff --name-only`
- `git diff --stat`

## Manual Test Needed

1. Normal `/admin-add-v2.html`: no LINE AI banner, no LINE AI chat text in address, no stale map.
2. Normal add page after old LINE AI flow: stale LINE AI storage is cleared.
3. Intentional `/admin-add-v2.html?source=line_ai&ai_intake_id=123`: prefill still works.
4. Real accounting quotation flow from `admin-accounting-v2.js`: quote prefill still works through explicit `from_quote` URL.

Do not merge until ChatGPT reviews.