### PR TITLE
Diagnose old customer phone lookup misses

### DIFF
--- a/index.js
+++ b/index.js
@@ -14717,9 +14717,11 @@ async function handleInternalBookFromAi(req, res) {
 app.get("/admin/customer_lookup_by_phone_v2", requireAdminSoft, async (req, res) => {
   try {
     const rawPhone = String(req.query.phone || "").trim();
-    return res.json(await customerLookupHelpers.lookupCustomerByPhoneV2(pool, rawPhone));
+    const debug = String(req.query.debug || "") === "1";
+    return res.json(await customerLookupHelpers.lookupCustomerByPhoneV2(pool, rawPhone, { debug }));
   } catch (e) {
     console.error("GET /admin/customer_lookup_by_phone_v2", e);
+    if (String(req.query.debug || "") === "1") return res.json({ found: false, location_candidates: [], debug: { error: "LOOKUP_FAILED" } });
     return res.json({ found: false });
   }
 });

--- a/server/customerLookup.js
+++ b/server/customerLookup.js
@@ -111,6 +111,138 @@ function buildLookupResultFromDefault(defaultCandidate) {
   };
 }
 
+function buildJobMatchClauses({ candidates, digits }) {
+  const last9 = digits.length >= 9 ? digits.slice(-9) : "";
+  return [
+    {
+      key: "jobs_phone_exact",
+      enabled: candidates.length > 0,
+      clause: "regexp_replace(COALESCE(customer_phone, ''), '[^0-9]', '', 'g') = ANY($1::text[])",
+      params: [candidates],
+    },
+    {
+      key: "jobs_phone_last9",
+      enabled: digits.length >= 9,
+      clause: "right(regexp_replace(COALESCE(customer_phone, ''), '[^0-9]', '', 'g'), 9) = $1",
+      params: [last9],
+    },
+    {
+      key: "jobs_note_phone",
+      enabled: digits.length >= 9 && digits.length <= 10,
+      clause: "regexp_replace(COALESCE(customer_note, ''), '[^0-9]', '', 'g') LIKE '%' || $1 || '%'",
+      params: [digits],
+    },
+    {
+      key: "jobs_note_last9",
+      enabled: digits.length >= 9,
+      clause: "regexp_replace(COALESCE(customer_note, ''), '[^0-9]', '', 'g') LIKE '%' || $1 || '%'",
+      params: [last9],
+    },
+    {
+      key: "jobs_address_phone",
+      enabled: digits.length >= 9 && digits.length <= 10,
+      clause: "regexp_replace(COALESCE(address_text, ''), '[^0-9]', '', 'g') LIKE '%' || $1 || '%'",
+      params: [digits],
+    },
+    {
+      key: "jobs_address_last9",
+      enabled: digits.length >= 9,
+      clause: "regexp_replace(COALESCE(address_text, ''), '[^0-9]', '', 'g') LIKE '%' || $1 || '%'",
+      params: [last9],
+    },
+  ];
+}
+
+async function countRows(db, sql, params) {
+  const r = await db.query(sql, params);
+  return Number(r.rows?.[0]?.count || 0) || 0;
+}
+
+async function buildLookupDebug(db, { digits, candidates }) {
+  const clauses = buildJobMatchClauses({ candidates, digits });
+  const debug = {
+    lookup_debug_version: "admin_phone_lookup_debug_v1",
+    input_digits: digits,
+    lookup_candidates_generated: candidates,
+    fallback_enabled: digits.length >= 9,
+    exact_customer_profiles_count: 0,
+    exact_jobs_customer_phone_count: 0,
+    jobs_customer_phone_last9_count: 0,
+    jobs_customer_note_contains_full_digits_count: 0,
+    jobs_customer_note_contains_last9_count: 0,
+    jobs_address_text_contains_full_digits_count: 0,
+    jobs_address_text_contains_last9_count: 0,
+    matching_jobs_blank_address_text_count: 0,
+    newest_matching_job_id: null,
+    newest_matching_booking_code: null,
+  };
+
+  debug.exact_customer_profiles_count = await countRows(
+    db,
+    `
+    SELECT COUNT(*)::int AS count
+    FROM public.customer_profiles
+    WHERE regexp_replace(COALESCE(phone, ''), '[^0-9]', '', 'g') = ANY($1::text[])
+    `,
+    [candidates]
+  );
+
+  const countByKey = {
+    jobs_phone_exact: "exact_jobs_customer_phone_count",
+    jobs_phone_last9: "jobs_customer_phone_last9_count",
+    jobs_note_phone: "jobs_customer_note_contains_full_digits_count",
+    jobs_note_last9: "jobs_customer_note_contains_last9_count",
+    jobs_address_phone: "jobs_address_text_contains_full_digits_count",
+    jobs_address_last9: "jobs_address_text_contains_last9_count",
+  };
+
+  for (const item of clauses) {
+    if (!item.enabled) continue;
+    debug[countByKey[item.key]] = await countRows(
+      db,
+      `SELECT COUNT(*)::int AS count FROM public.jobs WHERE ${item.clause}`,
+      item.params
+    );
+  }
+
+  const enabled = clauses.filter((item) => item.enabled);
+  if (enabled.length) {
+    const parts = [];
+    const params = [];
+    for (const item of enabled) {
+      const offsetClause = item.clause.replace(/\$(\d+)/g, (_, n) => `$${params.length + Number(n)}`);
+      parts.push(`(${offsetClause})`);
+      params.push(...item.params);
+    }
+    const whereAny = parts.join(" OR ");
+    const blankR = await db.query(
+      `
+      SELECT COUNT(*)::int AS count
+      FROM public.jobs
+      WHERE (${whereAny})
+        AND COALESCE(NULLIF(btrim(address_text), ''), '') = ''
+      `,
+      params
+    );
+    debug.matching_jobs_blank_address_text_count = Number(blankR.rows?.[0]?.count || 0) || 0;
+
+    const newestR = await db.query(
+      `
+      SELECT job_id, booking_code
+      FROM public.jobs
+      WHERE ${whereAny}
+      ORDER BY COALESCE(finished_at, appointment_datetime, created_at) DESC NULLS LAST, job_id DESC
+      LIMIT 1
+      `,
+      params
+    );
+    debug.newest_matching_job_id = newestR.rows?.[0]?.job_id || null;
+    debug.newest_matching_booking_code = newestR.rows?.[0]?.booking_code || null;
+  }
+
+  return debug;
+}
+
 async function queryJobLocationRows(db, matchClause, params, lookupSource) {
   const sourceParam = params.length + 1;
   const jobR = await db.query(
@@ -196,17 +328,36 @@ function addJobRows(locationCandidates, rows) {
   return usableCount;
 }
 
-async function lookupCustomerByPhoneV2(db, phone) {
+async function lookupCustomerByPhoneV2(db, phone, options = {}) {
   const rawPhone = String(phone || "").trim();
   const digits = normalizePhone(rawPhone);
   const candidates = buildPhoneLookupCandidates(rawPhone);
   if (!candidates.length || digits.length < 8) {
-    return { found: false, location_candidates: [] };
+    const result = { found: false, location_candidates: [] };
+    if (options.debug) {
+      result.debug = {
+        input_digits: digits,
+        lookup_candidates_generated: candidates,
+        fallback_enabled: false,
+        reason: digits.length < 8 ? "INPUT_UNDER_8_DIGITS" : "NO_LOOKUP_CANDIDATES",
+      };
+    }
+    return result;
   }
 
   let profileRow = null;
   const locationCandidates = [];
   let jobCandidateCount = 0;
+  let debug = null;
+
+  if (options.debug) {
+    try {
+      debug = await buildLookupDebug(db, { digits, candidates });
+    } catch (e) {
+      console.warn("[customer_lookup_by_phone_v2] debug lookup failed:", e.message);
+      debug = { input_digits: digits, lookup_candidates_generated: candidates, error: "DEBUG_LOOKUP_FAILED" };
+    }
+  }
 
   try {
     const profileR = await db.query(
@@ -273,6 +424,20 @@ async function lookupCustomerByPhoneV2(db, phone) {
     }
   }
 
+  if (jobCandidateCount === 0 && digits.length >= 9) {
+    try {
+      const rows = await queryJobLocationRows(
+        db,
+        "regexp_replace(COALESCE(customer_note, ''), '[^0-9]', '', 'g') LIKE '%' || $1 || '%'",
+        [digits.slice(-9)],
+        "jobs_note_phone"
+      );
+      jobCandidateCount += addJobRows(locationCandidates, rows);
+    } catch (e) {
+      console.warn("[customer_lookup_by_phone_v2] jobs note last9 fallback lookup failed:", e.message);
+    }
+  }
+
   if (jobCandidateCount === 0 && digits.length >= 9 && digits.length <= 10) {
     try {
       const rows = await queryJobLocationRows(
@@ -287,6 +452,20 @@ async function lookupCustomerByPhoneV2(db, phone) {
     }
   }
 
+  if (jobCandidateCount === 0 && digits.length >= 9) {
+    try {
+      const rows = await queryJobLocationRows(
+        db,
+        "regexp_replace(COALESCE(address_text, ''), '[^0-9]', '', 'g') LIKE '%' || $1 || '%'",
+        [digits.slice(-9)],
+        "jobs_address_phone"
+      );
+      jobCandidateCount += addJobRows(locationCandidates, rows);
+    } catch (e) {
+      console.warn("[customer_lookup_by_phone_v2] jobs address last9 fallback lookup failed:", e.message);
+    }
+  }
+
   const defaultCandidate = locationCandidates[0] || (profileRow ? {
     source: "customer_profiles",
     customer_id: profileRow.customer_id || null,
@@ -297,16 +476,21 @@ async function lookupCustomerByPhoneV2(db, phone) {
   } : null);
 
   const result = buildLookupResultFromDefault(defaultCandidate);
-  if (!result.found) return result;
+  if (!result.found) {
+    if (debug) result.debug = debug;
+    return result;
+  }
   if (profileRow) {
     result.customer_id = result.customer_id || profileRow.customer_id || null;
     result.customer_name = result.customer_name || profileRow.customer_name || null;
     result.customer_phone = result.customer_phone || profileRow.customer_phone || null;
   }
-  return {
+  const response = {
     ...result,
     location_candidates: locationCandidates,
   };
+  if (debug) response.debug = debug;
+  return response;
 }
 
 module.exports = {


### PR DESCRIPTION
## Summary

- Adds admin-only diagnostic output for `/admin/customer_lookup_by_phone_v2?debug=1` so we can see why a real old phone still returns `found:false`.
- Keeps normal `/admin/customer_lookup_by_phone_v2?phone=...` response backward-compatible unless `debug=1` is present.
- Adds last-9 fallback search inside `jobs.customer_note` and `jobs.address_text` for input with at least 9 digits.

## Changed Files

- `server/customerLookup.js`
- `index.js` route wrapper for `/admin/customer_lookup_by_phone_v2` only, to pass `debug=1` into the helper.

## Debug Output

When `debug=1`, the response includes safe aggregate diagnostics only:

- `lookup_debug_version`
- input digits
- lookup candidates generated
- exact `customer_profiles` count
- exact `jobs.customer_phone` count
- `jobs.customer_phone` last9 count
- `jobs.customer_note` full digits count
- `jobs.customer_note` last9 count
- `jobs.address_text` full digits count
- `jobs.address_text` last9 count
- count of matching jobs with blank `address_text`
- newest matching `job_id` / `booking_code`

No customer name, phone, address, note text, or private row payload is returned in debug data.

## Fallback Strategy

Normal lookup order remains conservative:

1. exact normalized `customer_profiles.phone`
2. exact normalized `jobs.customer_phone`
3. last 9 digits of normalized `jobs.customer_phone`, only for 9+ digit input
4. full input digits inside `jobs.customer_note`, only for 9-10 digit input
5. last 9 digits inside `jobs.customer_note`, only for 9+ digit input
6. full input digits inside `jobs.address_text`, only for 9-10 digit input
7. last 9 digits inside `jobs.address_text`, only for 9+ digit input

Short inputs under 9 digits do not run fallback searches.

## Address Column Note

Existing docs and runtime use `jobs.address_text` as the operational job address snapshot. I did not introduce or use any guessed alternative address column. Normal mode still does not return candidates with blank `address_text`; debug reveals if matching jobs exist but are blank-address rows.

## Confirmations

- No DB schema change.
- No migrations created or changed.
- No payment/auth/tax/receipt/customer app changes.
- No booking creation changes.
- No direct push to `main`.

## Tests Run

- `node --check server/customerLookup.js`
- `node --check index.js`
- `git diff --check`
- `git diff --name-only`
- `git diff --stat`

## Manual Test Needed

1. Open `/admin/customer_lookup_by_phone_v2?phone=0909906857&debug=1` and inspect which count tier is nonzero or whether matches have blank `address_text`.
2. Open `/admin/customer_lookup_by_phone_v2?phone=0909906857` and confirm normal response shape remains backward-compatible.
3. Confirm short phone input under 9 digits does not run fallback search.
4. If debug shows matches only in blank-address jobs, decide separately whether any approved fallback address source should be used.

Do not merge until ChatGPT reviews.