### PR TITLE
Fix old customer lookup status column

### DIFF
--- a/server/customerLookup.js
+++ b/server/customerLookup.js
@@ -287,7 +287,7 @@ async function queryJobLocationRows(db, matchClause, params, lookupSource) {
           lower(regexp_replace(COALESCE(btrim(maps_url), ''), '\\s+', ' ', 'g'))
       ) AS job_count,
       COALESCE(finished_at, appointment_datetime, created_at) AS last_seen_at,
-      status AS last_job_status,
+      job_status AS last_job_status,
       $${sourceParam}::text AS lookup_source
     FROM public.jobs
     WHERE ${matchClause}


### PR DESCRIPTION
## Summary

- Fixes old-customer lookup candidate queries failing with `column "status" does not exist`.
- Replaces `status AS last_job_status` with `job_status AS last_job_status` in `server/customerLookup.js`.
- Does not change matching logic, debug output shape, normal response shape, or blank-address filtering.

## Column Check

I inspected current repo usage before changing the column:

- `index.js` reads and writes `public.jobs.job_status` throughout admin, technician, tracking, and operational flows.
- No safe current usage of `public.jobs.status` for job status was found.

So `job_status` is the confirmed production job status column.

## Changed File

- `server/customerLookup.js`

## Confirmations

- No DB schema change.
- No migrations created or changed.
- No frontend changes.
- No booking creation changes.
- No payment/auth/tax/receipt/customer app changes.
- No direct push to `main`.

## Tests Run

- `node --check server/customerLookup.js`
- `git diff --check`
- `git diff --name-only`
- `git diff --stat`

## Manual Test After Deploy

1. `/admin/customer_lookup_by_phone_v2?phone=0909906857&debug=1`
   - `candidate_query_errors` should be empty.
   - `candidate_rows_exact_count` should be greater than `0`.
2. `/admin/customer_lookup_by_phone_v2?phone=0909906857`
   - should return `found:true`.
   - should return at least one `location_candidates` item.

Do not merge until ChatGPT reviews.