### PR TITLE
Customer App AC Health Passport Phase A

### DIFF
--- a/customer-app/assets/customer-app.css
+++ b/customer-app/assets/customer-app.css
@@ -998,6 +998,221 @@ p { margin: 0; }
   object-fit: cover;
   display: block;
 }
+.passport-shell {
+  position: relative;
+  overflow: hidden;
+  border: 1px solid rgba(11, 75, 179, 0.16);
+  border-radius: 24px;
+  background:
+    radial-gradient(120% 120% at 100% -10%, rgba(255, 210, 59, 0.28), transparent 48%),
+    linear-gradient(180deg, #ffffff 0%, #f5f9ff 100%);
+  box-shadow: 0 22px 50px -34px rgba(6, 24, 47, 0.55);
+}
+.passport-hero {
+  padding: 18px;
+  color: #fff;
+  background:
+    radial-gradient(110% 130% at 94% 0%, rgba(255, 210, 59, 0.42), transparent 52%),
+    linear-gradient(135deg, #06182f 0%, #0a2a57 48%, #0b4bb3 100%);
+}
+.passport-kicker {
+  display: inline-flex;
+  align-items: center;
+  width: max-content;
+  padding: 6px 10px;
+  border-radius: var(--radius-pill);
+  background: rgba(255, 255, 255, 0.14);
+  color: #ffe68a;
+  font-size: 11px;
+  font-weight: 900;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+.passport-hero h2 {
+  margin: 10px 0 4px;
+  color: #fff;
+  font-size: 26px;
+  line-height: 1.05;
+}
+.passport-hero p {
+  margin: 0;
+  color: rgba(255, 255, 255, 0.88);
+  font-weight: 750;
+  line-height: 1.45;
+}
+.passport-grid {
+  display: grid;
+  gap: 10px;
+  padding: 12px;
+}
+.passport-card {
+  min-width: 0;
+  padding: 14px;
+  border: 1px solid rgba(11, 75, 179, 0.12);
+  border-radius: 18px;
+  background: rgba(255, 255, 255, 0.92);
+  box-shadow: 0 12px 30px -24px rgba(6, 24, 47, 0.42);
+}
+.passport-card-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 10px;
+  margin-bottom: 10px;
+}
+.passport-card-head span {
+  color: var(--muted);
+  font-size: 11px;
+  font-weight: 900;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+.passport-card-head strong {
+  color: #0a2a57;
+  font-size: 14px;
+  font-weight: 950;
+  text-align: right;
+}
+.passport-card h3 {
+  margin: 10px 0 5px;
+  color: var(--ink);
+  font-size: 17px;
+  line-height: 1.22;
+}
+.passport-card p,
+.passport-card small {
+  display: block;
+  margin: 0;
+  color: var(--muted);
+  font-weight: 750;
+  line-height: 1.5;
+}
+.passport-lead {
+  margin-bottom: 12px !important;
+  color: #0a2a57 !important;
+  font-weight: 900 !important;
+}
+.passport-data {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 8px;
+}
+.passport-data div {
+  min-width: 0;
+  padding: 10px;
+  border: 1px solid rgba(11, 75, 179, 0.1);
+  border-radius: 14px;
+  background: #f8fbff;
+}
+.passport-data b,
+.passport-warranty-lists b {
+  display: block;
+  margin-bottom: 4px;
+  color: #0b4bb3;
+  font-size: 11px;
+  font-weight: 950;
+  text-transform: uppercase;
+}
+.passport-data span {
+  display: block;
+  color: var(--ink);
+  font-size: 13px;
+  font-weight: 850;
+  line-height: 1.35;
+  overflow-wrap: anywhere;
+}
+.passport-note {
+  margin-top: 10px;
+  padding: 11px;
+  border-left: 4px solid var(--yellow);
+  border-radius: 14px;
+  background: #fffbea;
+}
+.passport-note b {
+  color: #7a5a00;
+  font-size: 12px;
+  font-weight: 950;
+}
+.passport-note p {
+  margin-top: 5px;
+  white-space: pre-wrap;
+}
+.passport-health-bar {
+  height: 12px;
+  overflow: hidden;
+  border-radius: var(--radius-pill);
+  background: #dbe7f7;
+}
+.passport-health-bar span {
+  display: block;
+  height: 100%;
+  min-width: 8px;
+  border-radius: inherit;
+  background: linear-gradient(90deg, #0b4bb3, #19b36b);
+}
+.passport-health-bar.is-watch span { background: linear-gradient(90deg, #ffcc00, #ff9f1c); }
+.passport-health-bar.is-alert span { background: linear-gradient(90deg, #f97316, #dc2626); }
+.passport-health-bar.is-unknown span { background: #94a3b8; }
+.passport-muted-card {
+  background: linear-gradient(180deg, #f8fbff, #ffffff);
+}
+.passport-warranty-card {
+  background: linear-gradient(180deg, #fffdf0, #ffffff);
+}
+.passport-warranty-lists {
+  display: grid;
+  gap: 8px;
+  margin-top: 12px;
+}
+.passport-warranty-lists div {
+  display: grid;
+  gap: 5px;
+  padding: 10px;
+  border-radius: 14px;
+  background: rgba(255, 255, 255, 0.74);
+  border: 1px solid rgba(11, 75, 179, 0.1);
+}
+.passport-warranty-lists span {
+  color: var(--muted);
+  font-size: 12px;
+  font-weight: 750;
+  line-height: 1.35;
+}
+.passport-recommend-card {
+  border-color: rgba(255, 210, 59, 0.52);
+  background: linear-gradient(135deg, #fffbea 0%, #ffffff 62%);
+}
+.passport-photo-card {
+  background: linear-gradient(180deg, #eef6ff, #ffffff);
+}
+@media (min-width: 720px) {
+  .passport-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+  .passport-summary-card,
+  .passport-warranty-card,
+  .passport-recommend-card {
+    grid-column: 1 / -1;
+  }
+  .passport-warranty-lists {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+@media (max-width: 420px) {
+  .passport-hero,
+  .passport-card {
+    padding: 13px;
+  }
+  .passport-hero h2 {
+    font-size: 23px;
+  }
+  .passport-data {
+    grid-template-columns: 1fr;
+  }
+  .passport-card-head {
+    align-items: flex-start;
+  }
+}
 .receipt-card {
   flex-direction: row;
   align-items: center;

--- a/customer-app/modules/tracking.js
+++ b/customer-app/modules/tracking.js
@@ -103,6 +103,133 @@
       : [];
   }
 
+  function parseDate(value) {
+    const raw = clean(value);
+    if (!raw) return null;
+    const date = new Date(raw);
+    return Number.isFinite(date.getTime()) ? date : null;
+  }
+
+  function serviceDate(data) {
+    return parseDate(data.finished_at || data.completed_at || data.closed_at || data.appointment_datetime);
+  }
+
+  function monthsSince(date) {
+    if (!date) return null;
+    const days = Math.max(0, (Date.now() - date.getTime()) / 86400000);
+    return days / 30.4375;
+  }
+
+  function serviceProfile(data) {
+    const text = clean([data.job_type, data.service_summary, data.items_text].filter(Boolean).join(" ")).toLowerCase();
+    if (/full|heavy|disassembly|overhaul|ถอด|ตัดล้างใหญ่|ล้างใหญ่/.test(text)) {
+      return { kind: "heavy", label: "ตัดล้างใหญ่", coilMonths: 10, nextText: "8-12 เดือน" };
+    }
+    if (/hang|deep|แขวนคอยล์|ล้างลึก|deep clean/.test(text)) {
+      return { kind: "deep", label: "แขวนคอยล์ / ล้างลึก", coilMonths: 7, nextText: "6-8 เดือน" };
+    }
+    if (/premium|พรีเมียม/.test(text)) {
+      return { kind: "premium", label: "ล้างพรีเมียม", coilMonths: 6, nextText: "5-6 เดือน" };
+    }
+    if (/ล้าง|clean|wash/.test(text)) {
+      return { kind: "clean", label: "ล้างปกติ", coilMonths: 5, nextText: "4-6 เดือน" };
+    }
+    return { kind: "general", label: serviceSummary(data), coilMonths: 6, nextText: "ประมาณ 6 เดือน" };
+  }
+
+  function healthScore(months, alertMonths) {
+    if (months == null || !Number.isFinite(months)) return null;
+    const score = 100 - (months / Math.max(1, alertMonths)) * 80;
+    return Math.max(0, Math.min(100, Math.round(score)));
+  }
+
+  function coilLabel(score) {
+    if (score == null) return "รอข้อมูลงานเสร็จ";
+    if (score >= 90) return "สะอาดมาก";
+    if (score >= 70) return "ยังดี";
+    if (score >= 45) return "เริ่มมีฝุ่นสะสม";
+    if (score >= 20) return "ควรล้างเร็ว ๆ นี้";
+    return "เกินรอบแนะนำ";
+  }
+
+  function drainLabel(score) {
+    if (score == null) return "รอข้อมูลงานเสร็จ";
+    if (score >= 85) return "ระบายดี";
+    if (score >= 65) return "ยังปกติ";
+    if (score >= 35) return "เริ่มควรตรวจ";
+    return "เสี่ยงตัน / ควรล้าง";
+  }
+
+  function healthTone(score) {
+    if (score == null) return "unknown";
+    if (score >= 70) return "good";
+    if (score >= 45) return "watch";
+    return "alert";
+  }
+
+  function hasDrainRisk(data) {
+    const text = clean([data.job_type, data.technician_note, data.customer_note, data.job_status].filter(Boolean).join(" "));
+    return /น้ำหยด|ท่อตัน|ถาดตัน|น้ำทิ้ง|ระบายช้า/i.test(text);
+  }
+
+  function warrantyInfo(data, date) {
+    const profile = serviceProfile(data);
+    const isCleaning = profile.kind !== "general" || /ล้าง|clean|wash/i.test(clean(data.job_type));
+    if (!isDone(data) || !date || !isCleaning) return null;
+    const end = new Date(date.getTime());
+    end.setDate(end.getDate() + 30);
+    const days = Math.ceil((end.getTime() - Date.now()) / 86400000);
+    return {
+      end,
+      daysLeft: Math.max(0, days),
+      active: days >= 0,
+    };
+  }
+
+  function recommendation(data, coil, drain, profile, done) {
+    if (!done) {
+      return {
+        title: "ครั้งต่อไปแนะนำ: จะแสดงคำแนะนำหลังงานเสร็จสิ้น",
+        reason: "ระบบจะประเมินจากวันที่ปิดงาน ประเภทบริการ และหมายเหตุจากช่างเมื่อมีข้อมูลจริง",
+      };
+    }
+    if (hasDrainRisk(data) || (drain != null && drain < 45)) {
+      return {
+        title: "ครั้งต่อไปแนะนำ: ตรวจเช็คระบบ",
+        reason: "ควรตรวจระบบน้ำทิ้งเร็วกว่าปกติจากประวัติงานและรอบเวลาหลังบริการ",
+      };
+    }
+    if (coil != null && coil < 30) {
+      return {
+        title: profile.kind === "heavy" ? "ครั้งต่อไปแนะนำ: ตัดล้างใหญ่" : "ครั้งต่อไปแนะนำ: แขวนคอยล์",
+        reason: "คะแนนความสะอาดโดยประมาณต่ำกว่ารอบดูแลที่แนะนำ",
+      };
+    }
+    if (profile.kind === "premium" || profile.kind === "deep" || profile.kind === "heavy") {
+      return {
+        title: `ครั้งต่อไปแนะนำ: ${profile.label} ใน ${profile.nextText}`,
+        reason: "งานล่าสุดเป็นแพ็กเกจดูแลละเอียด จึงใช้รอบแนะนำที่ยาวกว่างานล้างปกติ",
+      };
+    }
+    return {
+      title: `ครั้งต่อไปแนะนำ: ${profile.kind === "clean" ? "ล้างปกติ" : "ล้างพรีเมียม"} ใน ${profile.nextText}`,
+      reason: "ประเมินจากประเภทบริการล่าสุดและเวลาหลังจบงาน",
+    };
+  }
+
+  function phaseCount(photos, phase) {
+    return photos.filter((photo) => clean(photo.phase || photo.label).toLowerCase() === phase).length;
+  }
+
+  function renderHealthBar(score) {
+    const value = score == null ? 0 : score;
+    return `
+      <div class="passport-health-bar is-${healthTone(score)}" aria-hidden="true">
+        <span style="width:${value}%"></span>
+      </div>
+    `;
+  }
+
   function timelineState(done, current) {
     if (done) return "done";
     return current ? "current" : "pending";
@@ -130,6 +257,138 @@
     if (traveling) return "ช่างกำลังเดินทาง";
     if (assigned || status.includes("รอดำเนินการ")) return "ยืนยันคิวแล้ว";
     return "รับคำขอจองแล้ว รอแอดมินตรวจสอบคิว";
+  }
+
+  function renderPassport(data) {
+    const done = isDone(data);
+    const date = serviceDate(data);
+    const months = done ? monthsSince(date) : null;
+    const profile = serviceProfile(data);
+    const coilScore = done ? healthScore(months, profile.coilMonths) : null;
+    const drainAlertMonths = hasDrainRisk(data) ? 4 : 6;
+    const drainScore = done ? healthScore(months, drainAlertMonths) : null;
+    const warranty = warrantyInfo(data, date);
+    const photos = photoList(data);
+    const beforeCount = phaseCount(photos, "before");
+    const afterCount = phaseCount(photos, "after");
+    const next = recommendation(data, coilScore, drainScore, profile, done);
+    const completionText = done ? "งานเสร็จสิ้นแล้ว" : "รอข้อมูลงานเสร็จสิ้น";
+    const serviceDateText = date ? root.utils.formatDateTime(date.toISOString()) : "-";
+    const warrantyStatus = warranty
+      ? (warranty.active ? "อยู่ในประกันงานล้าง" : "หมดประกันงานล้างแล้ว")
+      : "แสดงเงื่อนไขประกันงานล้างตามข้อมูลที่มี";
+    const warrantyMeta = warranty
+      ? `${warranty.active ? `เหลือ ${warranty.daysLeft} วัน` : "ครบ 30 วันแล้ว"} · สิ้นสุด ${root.utils.formatDateTime(warranty.end.toISOString())}`
+      : "ยังไม่มีวันที่ครบถ้วนพอสำหรับนับถอยหลัง";
+
+    return `
+      <section class="passport-shell">
+        <div class="passport-hero">
+          <span class="passport-kicker">AC Health Passport</span>
+          <h2>CWF AC Health Passport</h2>
+          <p>สมุดสุขภาพแอร์จากงานบริการ Coldwindflow</p>
+        </div>
+        <div class="passport-grid">
+          <article class="passport-card passport-summary-card">
+            <div class="passport-card-head">
+              <span>รายงานล่าสุด</span>
+              <strong>${esc(completionText)}</strong>
+            </div>
+            <p class="passport-lead">รายงานสุขภาพแอร์จากงานบริการล่าสุด</p>
+            <div class="passport-data">
+              <div><b>Booking</b><span>${esc(data.booking_code || "-")}</span></div>
+              <div><b>สถานะ</b><span>${esc(data.job_status || "-")}</span></div>
+              <div><b>บริการ</b><span>${esc(serviceSummary(data))}</span></div>
+              <div><b>วันที่บริการ</b><span>${esc(serviceDateText)}</span></div>
+            </div>
+            ${done && clean(data.technician_note) ? `<div class="passport-note"><b>หมายเหตุจากช่าง</b><p>${esc(data.technician_note)}</p></div>` : ""}
+          </article>
+
+          <article class="passport-card">
+            <div class="passport-card-head">
+              <span>Coil Cleanliness</span>
+              <strong>${coilScore == null ? "-" : `${coilScore}%`}</strong>
+            </div>
+            ${renderHealthBar(coilScore)}
+            <h3>${esc(coilLabel(coilScore))}</h3>
+            <p>ประเมินจากวันที่ล้างล่าสุด</p>
+            <small>รอบแนะนำสำหรับ ${esc(profile.label)}: ${esc(profile.nextText)}</small>
+          </article>
+
+          <article class="passport-card">
+            <div class="passport-card-head">
+              <span>Drain Health</span>
+              <strong>${drainScore == null ? "-" : `${drainScore}%`}</strong>
+            </div>
+            ${renderHealthBar(drainScore)}
+            <h3>${esc(drainLabel(drainScore))}</h3>
+            <p>ประเมินจากวันที่ล้างล่าสุดและประวัติงาน</p>
+            <small>${hasDrainRisk(data) ? "พบสัญญาณเกี่ยวกับระบบน้ำทิ้งในประวัติงาน จึงแนะนำตรวจเร็วขึ้น" : "ยังไม่พบสัญญาณเสี่ยงจากข้อมูลที่เปิดให้ลูกค้าเห็น"}</small>
+          </article>
+
+          <article class="passport-card passport-muted-card">
+            <div class="passport-card-head">
+              <span>Refrigerant / PSI</span>
+              <strong>ไม่มีค่าวัด</strong>
+            </div>
+            <h3>สถานะน้ำยา: ยังไม่มีข้อมูลวัดจริง</h3>
+            <p>ค่า PSI จะแสดงเมื่อช่างบันทึกค่าที่วัดจริง</p>
+            <small>ค่าแรงดันต้องดูร่วมกับชนิดน้ำยา อุณหภูมิ กระแสไฟ รุ่นเครื่อง และสภาพหน้างาน</small>
+          </article>
+
+          <article class="passport-card passport-muted-card">
+            <div class="passport-card-head">
+              <span>Temperature</span>
+              <strong>ไม่มีค่าวัด</strong>
+            </div>
+            <h3>สถานะอุณหภูมิ: ยังไม่มีข้อมูลวัดจริง</h3>
+            <p>ระบบจะแสดงลมส่ง / ลมกลับ เมื่อมีการบันทึกค่าจากช่าง</p>
+            <small>ยังไม่มี delta T เพราะระบบยังไม่ได้รับค่าที่วัดจริง</small>
+          </article>
+
+          <article class="passport-card passport-warranty-card">
+            <div class="passport-card-head">
+              <span>Warranty</span>
+              <strong>${esc(warrantyStatus)}</strong>
+            </div>
+            <p>${esc(warrantyMeta)}</p>
+            <div class="passport-warranty-lists">
+              <div>
+                <b>ครอบคลุม</b>
+                <span>อาการที่เกี่ยวข้องกับงานล้าง</span>
+                <span>ประกอบไม่เรียบร้อย</span>
+                <span>น้ำหยดจากจุดที่เกี่ยวข้องกับงานล้าง</span>
+              </div>
+              <div>
+                <b>ไม่ครอบคลุม</b>
+                <span>น้ำยารั่ว บอร์ดเสีย คอมเพรสเซอร์เสีย</span>
+                <span>ท่อหรือระบบเดิมเสีย ไฟตก หนู แมลง</span>
+                <span>งานจากช่างอื่น หรืออาการใหม่ที่ไม่เกี่ยวกับงานล้าง</span>
+              </div>
+            </div>
+          </article>
+
+          <article class="passport-card passport-recommend-card">
+            <div class="passport-card-head">
+              <span>Next Service</span>
+              <strong>คำแนะนำ</strong>
+            </div>
+            <h3>${esc(next.title)}</h3>
+            <p>${esc(next.reason)}</p>
+          </article>
+
+          <article class="passport-card passport-photo-card">
+            <div class="passport-card-head">
+              <span>Job Photos</span>
+              <strong>${photos.length} รูป</strong>
+            </div>
+            <h3>รูปงานรวมของใบงานนี้</h3>
+            <p>ก่อนทำ ${beforeCount} รูป · หลังทำ ${afterCount} รูป · รวม ${photos.length} รูป</p>
+            <small>ยังไม่มีข้อมูลแยกรายเครื่องในระบบ จึงไม่แสดงเป็นรูปประจำเครื่อง</small>
+          </article>
+        </div>
+      </section>
+    `;
   }
 
   function renderTechnicianCard(data) {
@@ -310,6 +569,7 @@
           ${mode === "urgent" && !hasAssignedTech(data) ? `<button class="secondary-btn" type="button" data-route="scheduled">เปลี่ยนเป็นจองล่วงหน้า</button>` : ""}
         </div>
         <p class="muted support-note">ต้องการแก้ไขเวลา เลื่อนนัด หรือยกเลิกงาน กรุณาติดต่อแอดมิน CWF</p>
+        ${renderPassport(data)}
         ${renderTechnicianNote(data)}
         ${renderPhotos(data)}
         ${renderReceipt(data)}

--- a/customer-app/modules/tracking.js
+++ b/customer-app/modules/tracking.js
@@ -111,7 +111,11 @@
   }
 
   function serviceDate(data) {
-    return parseDate(data.finished_at || data.completed_at || data.closed_at || data.appointment_datetime);
+    return completionDate(data) || parseDate(data.appointment_datetime);
+  }
+
+  function completionDate(data) {
+    return parseDate(data.finished_at || data.completed_at || data.closed_at);
   }
 
   function monthsSince(date) {
@@ -262,12 +266,14 @@
   function renderPassport(data) {
     const done = isDone(data);
     const date = serviceDate(data);
+    const completedAt = completionDate(data);
+    const usesAppointmentEstimate = done && !completedAt && !!date;
     const months = done ? monthsSince(date) : null;
     const profile = serviceProfile(data);
     const coilScore = done ? healthScore(months, profile.coilMonths) : null;
     const drainAlertMonths = hasDrainRisk(data) ? 4 : 6;
     const drainScore = done ? healthScore(months, drainAlertMonths) : null;
-    const warranty = warrantyInfo(data, date);
+    const warranty = warrantyInfo(data, completedAt);
     const photos = photoList(data);
     const beforeCount = phaseCount(photos, "before");
     const afterCount = phaseCount(photos, "after");
@@ -279,7 +285,13 @@
       : "แสดงเงื่อนไขประกันงานล้างตามข้อมูลที่มี";
     const warrantyMeta = warranty
       ? `${warranty.active ? `เหลือ ${warranty.daysLeft} วัน` : "ครบ 30 วันแล้ว"} · สิ้นสุด ${root.utils.formatDateTime(warranty.end.toISOString())}`
-      : "ยังไม่มีวันที่ครบถ้วนพอสำหรับนับถอยหลัง";
+      : "ยังไม่มีวันที่ปิดงานที่ชัดเจนสำหรับนับประกัน";
+    const healthEstimateText = usesAppointmentEstimate
+      ? "ประเมินจากวันนัดหมาย เนื่องจากยังไม่มีวันที่ปิดงาน"
+      : "ประเมินจากวันที่ล้างล่าสุด";
+    const drainEstimateText = usesAppointmentEstimate
+      ? "ประเมินจากวันนัดหมาย เนื่องจากยังไม่มีวันที่ปิดงาน"
+      : "ประเมินจากวันที่ล้างล่าสุดและประวัติงาน";
 
     return `
       <section class="passport-shell">
@@ -311,7 +323,7 @@
             </div>
             ${renderHealthBar(coilScore)}
             <h3>${esc(coilLabel(coilScore))}</h3>
-            <p>ประเมินจากวันที่ล้างล่าสุด</p>
+            <p>${esc(healthEstimateText)}</p>
             <small>รอบแนะนำสำหรับ ${esc(profile.label)}: ${esc(profile.nextText)}</small>
           </article>
 
@@ -322,7 +334,7 @@
             </div>
             ${renderHealthBar(drainScore)}
             <h3>${esc(drainLabel(drainScore))}</h3>
-            <p>ประเมินจากวันที่ล้างล่าสุดและประวัติงาน</p>
+            <p>${esc(drainEstimateText)}</p>
             <small>${hasDrainRisk(data) ? "พบสัญญาณเกี่ยวกับระบบน้ำทิ้งในประวัติงาน จึงแนะนำตรวจเร็วขึ้น" : "ยังไม่พบสัญญาณเสี่ยงจากข้อมูลที่เปิดให้ลูกค้าเห็น"}</small>
           </article>
 


### PR DESCRIPTION
## Summary
- Adds a premium `CWF AC Health Passport` section to Customer App V2 tracking results.
- Uses only the existing public tracking payload and keeps all data job-level in Phase A.
- Adds time-based coil cleanliness and drain health estimates, warranty status/countdown for completed cleaning jobs, measurement-unavailable cards for PSI and temperature, next-service recommendation, and job-level photo summary.
- Adds scoped mobile-first CSS for the Passport cards and health bars.

## Honesty / data constraints
- No backend or `/public/track` changes were made.
- No per-machine data is claimed because the current public payload does not expose units or unit-linked photos.
- PSI/refrigerant and supply/return temperature are not invented. The UI says measured data is unavailable until real technician-entered values exist.
- Photos are labeled as mixed job-level photos for the current booking.

## Changed files
- `customer-app/modules/tracking.js`
- `customer-app/assets/customer-app.css`

## Validation
- `node --check customer-app/modules/tracking.js`
- `git diff --check`
- `git diff --name-only`
- `git diff --stat`

## Manual visual checks
- Not run in browser in this workspace because no completed live/staging tracking token was provided.
- Needs manual review on `/customer-app/` with a completed job tracking code at mobile widths 360 / 390 / 430px.

## Confirmations
- Frontend-only Customer App change.
- No backend, DB schema, migrations, `/public/track`, booking creation, payment/auth/tax/receipt logic, or technician app changes.
- Do not merge until ChatGPT reviews.