### PR TITLE
Customer App AC Health Passport Phase B Units

### DIFF
--- a/customer-app/assets/customer-app.css
+++ b/customer-app/assets/customer-app.css
@@ -1185,6 +1185,88 @@ p { margin: 0; }
 .passport-photo-card {
   background: linear-gradient(180deg, #eef6ff, #ffffff);
 }
+.passport-units-card {
+  grid-column: 1 / -1;
+  background: linear-gradient(180deg, #ffffff, #eef6ff);
+}
+.passport-unit-list {
+  display: grid;
+  gap: 10px;
+  margin-top: 12px;
+}
+.passport-unit-card {
+  display: grid;
+  gap: 10px;
+  padding: 12px;
+  border: 1px solid rgba(11, 75, 179, 0.12);
+  border-radius: 16px;
+  background: rgba(255, 255, 255, 0.86);
+}
+.passport-unit-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 10px;
+}
+.passport-unit-head b {
+  display: block;
+  color: #0a2a57;
+  font-size: 16px;
+  font-weight: 950;
+  line-height: 1.25;
+}
+.passport-unit-head span,
+.passport-unit-head small {
+  display: block;
+  color: var(--muted);
+  font-size: 12px;
+  font-weight: 800;
+  line-height: 1.35;
+}
+.passport-unit-head small {
+  flex: 0 0 auto;
+  padding: 5px 8px;
+  border-radius: var(--radius-pill);
+  background: #fffbea;
+  color: #7a5a00;
+}
+.passport-unit-stats {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 7px;
+}
+.passport-unit-stats span {
+  padding: 8px;
+  border-radius: 12px;
+  background: #f8fbff;
+  color: var(--muted);
+  font-size: 12px;
+  font-weight: 850;
+  text-align: center;
+}
+.passport-unit-stats b {
+  color: #0b4bb3;
+  font-size: 15px;
+}
+.passport-unit-photos {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 7px;
+}
+.passport-unit-photos a {
+  display: block;
+  overflow: hidden;
+  aspect-ratio: 1;
+  border: 1px solid rgba(11, 75, 179, 0.12);
+  border-radius: 13px;
+  background: var(--soft-blue);
+}
+.passport-unit-photos img {
+  display: block;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
 @media (min-width: 720px) {
   .passport-grid {
     grid-template-columns: repeat(2, minmax(0, 1fr));
@@ -1195,6 +1277,9 @@ p { margin: 0; }
     grid-column: 1 / -1;
   }
   .passport-warranty-lists {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+  .passport-unit-list {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 }
@@ -1211,6 +1296,12 @@ p { margin: 0; }
   }
   .passport-card-head {
     align-items: flex-start;
+  }
+  .passport-unit-stats {
+    grid-template-columns: 1fr;
+  }
+  .passport-unit-photos {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 }
 .receipt-card {

--- a/customer-app/modules/tracking.js
+++ b/customer-app/modules/tracking.js
@@ -225,6 +225,99 @@
     return photos.filter((photo) => clean(photo.phase || photo.label).toLowerCase() === phase).length;
   }
 
+  function unitList(data) {
+    return Array.isArray(data.units)
+      ? data.units.map((unit) => ({
+          unit_id: unit.unit_id,
+          unit_no: unit.unit_no,
+          unit_code: clean(unit.unit_code),
+          label: clean(unit.label) || `เครื่องที่ ${unit.unit_no || "-"}`,
+          btu: clean(unit.btu),
+          ac_type: clean(unit.ac_type),
+          service_type: clean(unit.service_type),
+          checklist_summary: unit.checklist_summary || {},
+          photos: Array.isArray(unit.photos)
+            ? unit.photos.map((photo) => ({
+                url: imageUrl(photo.public_url || photo.url || photo.photo_url || photo.path),
+                phase: clean(photo.phase),
+                photo_category: clean(photo.photo_category),
+              })).filter((photo) => photo.url)
+            : [],
+        })).filter((unit) => unit.unit_id || unit.unit_no || unit.photos.length)
+      : [];
+  }
+
+  function measurementSummary(photos) {
+    const pressure = phaseCount(photos, "pressure");
+    const current = phaseCount(photos, "current");
+    const temp = phaseCount(photos, "temp");
+    const total = pressure + current + temp;
+    if (!total) return "ยังไม่มีข้อมูลวัดจริง";
+    return "มีรูปการตรวจวัด แต่ยังไม่มีค่าตัวเลขที่บันทึกเป็นข้อมูล";
+  }
+
+  function checklistCopy(summary) {
+    const pre = summary && summary.pre_completed;
+    const post = summary && summary.post_completed;
+    const issues = Number(summary && summary.issue_count || 0);
+    if (!pre && !post) return "ยังไม่มีสรุปเช็คลิสต์ที่แสดงได้";
+    const parts = [];
+    if (pre) parts.push("ก่อนทำบันทึกแล้ว");
+    if (post) parts.push("หลังทำบันทึกแล้ว");
+    parts.push(issues > 0 ? `มีรายการให้ตรวจ ${issues} จุด` : "ไม่พบรายการผิดปกติในสรุป");
+    return parts.join(" · ");
+  }
+
+  function renderUnitPassportCards(units) {
+    if (!units.length) return "";
+    return `
+      <article class="passport-card passport-units-card">
+        <div class="passport-card-head">
+          <span>Unit Passport</span>
+          <strong>${units.length} เครื่อง</strong>
+        </div>
+        <h3>ข้อมูลแยกรายเครื่อง</h3>
+        <p>แสดงจากข้อมูลเครื่องและรูปหน้างานที่ผูกกับใบงานนี้เท่านั้น</p>
+        <div class="passport-unit-list">
+          ${units.map((unit) => {
+            const photos = unit.photos || [];
+            const before = phaseCount(photos, "before");
+            const after = phaseCount(photos, "after");
+            const measure = measurementSummary(photos);
+            const preview = photos.slice(0, 4);
+            return `
+              <section class="passport-unit-card">
+                <div class="passport-unit-head">
+                  <div>
+                    <b>${esc(unit.label)}</b>
+                    <span>${esc([unit.service_type, unit.ac_type, unit.btu ? `${unit.btu} BTU` : ""].filter(Boolean).join(" · ") || "เครื่องปรับอากาศ")}</span>
+                  </div>
+                  ${unit.unit_code ? `<small>${esc(unit.unit_code)}</small>` : ""}
+                </div>
+                <div class="passport-unit-stats">
+                  <span>ก่อนทำ <b>${before}</b></span>
+                  <span>หลังทำ <b>${after}</b></span>
+                  <span>รวม <b>${photos.length}</b></span>
+                </div>
+                <p>${esc(checklistCopy(unit.checklist_summary))}</p>
+                <p>${esc(measure)}</p>
+                ${preview.length ? `
+                  <div class="passport-unit-photos">
+                    ${preview.map((photo) => `
+                      <a href="${esc(photo.url)}" target="_blank" rel="noopener" aria-label="เปิดรูปงานรายเครื่อง">
+                        <img src="${esc(photo.url)}" alt="${esc(photo.phase || "รูปงาน")}" loading="lazy">
+                      </a>
+                    `).join("")}
+                  </div>
+                ` : `<small>ยังไม่มีรูปที่แยกกับเครื่องนี้</small>`}
+              </section>
+            `;
+          }).join("")}
+        </div>
+      </article>
+    `;
+  }
+
   function renderHealthBar(score) {
     const value = score == null ? 0 : score;
     return `
@@ -275,6 +368,8 @@
     const drainScore = done ? healthScore(months, drainAlertMonths) : null;
     const warranty = warrantyInfo(data, completedAt);
     const photos = photoList(data);
+    const units = unitList(data);
+    const unitMeasurementPhotos = units.reduce((sum, unit) => sum + phaseCount(unit.photos || [], "pressure") + phaseCount(unit.photos || [], "current") + phaseCount(unit.photos || [], "temp"), 0);
     const beforeCount = phaseCount(photos, "before");
     const afterCount = phaseCount(photos, "after");
     const next = recommendation(data, coilScore, drainScore, profile, done);
@@ -341,9 +436,9 @@
           <article class="passport-card passport-muted-card">
             <div class="passport-card-head">
               <span>Refrigerant / PSI</span>
-              <strong>ไม่มีค่าวัด</strong>
+              <strong>${unitMeasurementPhotos ? "มีรูปตรวจวัด" : "ไม่มีค่าวัด"}</strong>
             </div>
-            <h3>สถานะน้ำยา: ยังไม่มีข้อมูลวัดจริง</h3>
+            <h3>สถานะน้ำยา: ${unitMeasurementPhotos ? "มีรูปการตรวจวัด แต่ยังไม่มีค่าตัวเลข" : "ยังไม่มีข้อมูลวัดจริง"}</h3>
             <p>ค่า PSI จะแสดงเมื่อช่างบันทึกค่าที่วัดจริง</p>
             <small>ค่าแรงดันต้องดูร่วมกับชนิดน้ำยา อุณหภูมิ กระแสไฟ รุ่นเครื่อง และสภาพหน้างาน</small>
           </article>
@@ -351,9 +446,9 @@
           <article class="passport-card passport-muted-card">
             <div class="passport-card-head">
               <span>Temperature</span>
-              <strong>ไม่มีค่าวัด</strong>
+              <strong>${unitMeasurementPhotos ? "มีรูปตรวจวัด" : "ไม่มีค่าวัด"}</strong>
             </div>
-            <h3>สถานะอุณหภูมิ: ยังไม่มีข้อมูลวัดจริง</h3>
+            <h3>สถานะอุณหภูมิ: ${unitMeasurementPhotos ? "มีรูปการตรวจวัด แต่ยังไม่มีค่าตัวเลข" : "ยังไม่มีข้อมูลวัดจริง"}</h3>
             <p>ระบบจะแสดงลมส่ง / ลมกลับ เมื่อมีการบันทึกค่าจากช่าง</p>
             <small>ยังไม่มี delta T เพราะระบบยังไม่ได้รับค่าที่วัดจริง</small>
           </article>
@@ -389,14 +484,16 @@
             <p>${esc(next.reason)}</p>
           </article>
 
+          ${renderUnitPassportCards(units)}
+
           <article class="passport-card passport-photo-card">
             <div class="passport-card-head">
-              <span>Job Photos</span>
+              <span>${units.length ? "Photo Summary" : "Job Photos"}</span>
               <strong>${photos.length} รูป</strong>
             </div>
-            <h3>รูปงานรวมของใบงานนี้</h3>
+            <h3>${units.length ? "มีข้อมูลแยกรายเครื่องใน Passport" : "รูปงานรวมของใบงานนี้"}</h3>
             <p>ก่อนทำ ${beforeCount} รูป · หลังทำ ${afterCount} รูป · รวม ${photos.length} รูป</p>
-            <small>ยังไม่มีข้อมูลแยกรายเครื่องในระบบ จึงไม่แสดงเป็นรูปประจำเครื่อง</small>
+            <small>${units.length ? "รูปเต็มของใบงานยังแสดงในส่วนรูปงานเดิมด้านล่าง" : "ยังไม่มีข้อมูลแยกรายเครื่องในระบบ จึงไม่แสดงเป็นรูปประจำเครื่อง"}</small>
           </article>
         </div>
       </section>

--- a/index.js
+++ b/index.js
@@ -25054,7 +25054,8 @@ app.get("/public/track", async (req, res) => {
         const unitsR = await pool.query(
           `SELECT unit_id, unit_no, unit_code, item_name, ac_type, wash_type, btu, location_label
              FROM public.job_units
-            WHERE job_id=$1 AND ${activeJobUnitWhere()}
+            WHERE job_id=$1
+              AND LOWER(COALESCE(NULLIF(status,''),'pending')) NOT IN ('cancelled','removed','deleted','void','inactive')
             ORDER BY unit_no ASC, unit_id ASC`,
           [row.job_id]
         );
@@ -25077,7 +25078,7 @@ app.get("/public/track", async (req, res) => {
                   OR COALESCE(phase,'') ILIKE '%receipt%'
                   OR COALESCE(phase,'') ILIKE '%tax%'
                 )
-              ORDER BY unit_no NULLS LAST, photo_id ASC`,
+              ORDER BY photo_id ASC`,
             [row.job_id, unitIds]
           );
           for (const photo of unitPhotosR.rows || []) {

--- a/index.js
+++ b/index.js
@@ -25048,6 +25048,97 @@ app.get("/public/track", async (req, res) => {
       photos = pr.rows || [];
     }
 
+    let publicUnits = [];
+    if (isDone) {
+      try {
+        const unitsR = await pool.query(
+          `SELECT unit_id, unit_no, unit_code, item_name, ac_type, wash_type, btu, location_label
+             FROM public.job_units
+            WHERE job_id=$1 AND ${activeJobUnitWhere()}
+            ORDER BY unit_no ASC, unit_id ASC`,
+          [row.job_id]
+        );
+        const unitRows = unitsR.rows || [];
+        const unitIds = unitRows.map((u) => Number(u.unit_id)).filter(Number.isFinite);
+        const photosByUnit = new Map();
+        const checksByUnit = new Map();
+
+        if (unitIds.length) {
+          const unitPhotosR = await pool.query(
+            `SELECT photo_id, unit_id, phase, photo_category, created_at, uploaded_at, public_url
+               FROM public.job_photos
+              WHERE job_id=$1
+                AND unit_id = ANY($2::bigint[])
+                AND deleted_at IS NULL
+                AND COALESCE(public_url,'') <> ''
+                AND NOT (
+                  COALESCE(photo_category,'')='payment_slip'
+                  OR COALESCE(phase,'') ILIKE '%slip%'
+                  OR COALESCE(phase,'') ILIKE '%receipt%'
+                  OR COALESCE(phase,'') ILIKE '%tax%'
+                )
+              ORDER BY unit_no NULLS LAST, photo_id ASC`,
+            [row.job_id, unitIds]
+          );
+          for (const photo of unitPhotosR.rows || []) {
+            const key = String(photo.unit_id || "");
+            const arr = photosByUnit.get(key) || [];
+            arr.push({
+              photo_id: photo.photo_id,
+              phase: photo.phase || null,
+              photo_category: photo.photo_category || null,
+              created_at: photo.created_at || null,
+              uploaded_at: photo.uploaded_at || null,
+              public_url: photo.public_url || null,
+            });
+            photosByUnit.set(key, arr);
+          }
+
+          const checklistR = await pool.query(
+            `SELECT unit_id, checklist_type, completed_at, checklist_json
+               FROM public.job_unit_checklists
+              WHERE job_id=$1 AND unit_id = ANY($2::bigint[])`,
+            [row.job_id, unitIds]
+          );
+          for (const check of checklistR.rows || []) {
+            const key = String(check.unit_id || "");
+            const cur = checksByUnit.get(key) || { pre_completed: false, post_completed: false, issue_count: 0 };
+            const type = String(check.checklist_type || "").trim();
+            const rows = Array.isArray(check.checklist_json) ? check.checklist_json : [];
+            const issueCount = rows.reduce((sum, item) => sum + (item && item.issue ? 1 : 0), 0);
+            if (type === "pre") cur.pre_completed = !!check.completed_at;
+            if (type === "post") cur.post_completed = !!check.completed_at;
+            cur.issue_count += issueCount;
+            checksByUnit.set(key, cur);
+          }
+        }
+
+        publicUnits = unitRows.map((unit) => {
+          const labelParts = [`เครื่องที่ ${unit.unit_no || "-"}`];
+          if (unit.location_label) labelParts.push(unit.location_label);
+          const checklist = checksByUnit.get(String(unit.unit_id)) || { pre_completed: false, post_completed: false, issue_count: 0 };
+          return {
+            unit_id: unit.unit_id,
+            unit_no: unit.unit_no,
+            unit_code: unit.unit_code || null,
+            label: labelParts.join(" / "),
+            btu: unit.btu || null,
+            ac_type: unit.ac_type || null,
+            service_type: unit.wash_type || unit.item_name || null,
+            checklist_summary: {
+              pre_completed: !!checklist.pre_completed,
+              post_completed: !!checklist.post_completed,
+              issue_count: Number(checklist.issue_count || 0),
+            },
+            photos: photosByUnit.get(String(unit.unit_id)) || [],
+          };
+        });
+      } catch (e) {
+        console.warn("[public_track_units] load failed", { job_id: row.job_id, error: e.message });
+        publicUnits = [];
+      }
+    }
+
 
 
 // =======================================
@@ -25136,6 +25227,7 @@ if (FLAG_SHOW_TECH_TEAM_ON_TRACKING) {
       // ✅ notes/photos only after done
       technician_note: isDone ? (row.technician_note || "") : null,
       photos,
+      units: publicUnits,
 
       receipt_url: isDone ? `${origin}/docs/receipt/${row.job_id}` : null,
 


### PR DESCRIPTION
## Summary

Adds AC Health Passport Phase B support for safe per-unit public tracking data.

Changed files:
- `index.js`
- `customer-app/modules/tracking.js`
- `customer-app/assets/customer-app.css`

## Payload fields added

The `/public/track` response now includes optional `units` data for completed jobs only:

- `units[].unit_id`
- `units[].unit_no`
- `units[].unit_code`
- `units[].label`
- `units[].btu`
- `units[].ac_type`
- `units[].service_type`
- `units[].checklist_summary.pre_completed`
- `units[].checklist_summary.post_completed`
- `units[].checklist_summary.issue_count`
- `units[].photos[].photo_id`
- `units[].photos[].phase`
- `units[].photos[].photo_category`
- `units[].photos[].created_at`
- `units[].photos[].uploaded_at`
- `units[].photos[].public_url`

## Data privacy notes

- Unit payload is read-only and limited to the current tracked job.
- Unit payload is only returned after the job is done, matching the existing completed-job photo behavior.
- Raw checklist JSON is not returned; only a small summary is exposed.
- Technician private/internal notes are not added to the unit payload.
- Payment slip, receipt, and tax-like photo phases/categories are excluded from unit photos.
- No fake unit data, PSI values, temperature values, or per-machine measurements are generated.

## Backward compatibility

- Existing job-level `photos` response remains unchanged.
- `units` is optional and safely falls back to an empty list.
- Old completed jobs without unit records keep the Phase A job-level Health Passport fallback.
- Non-completed tracking behavior is unchanged.
- Backend booking creation, admin, technician, payment, auth, tax, receipt, and DB schema are untouched.

## Customer App behavior

- Renders per-unit Passport cards when unit payload exists.
- Keeps job-level photo summary and fallback wording for old jobs without unit data.
- Shows measurement-photo presence honestly without inventing PSI or temperature numbers.

## Tests run

```text
node --check index.js
node --check customer-app/modules/tracking.js
git diff --check
git diff --name-only
git diff --stat
```

## Manual test limitations

No local/staging DB with a real completed tracking token containing unit evidence was available in this workspace, so visual verification with real per-unit production-like data still needs to be done on staging.

Suggested manual checks:
- Completed old job with no unit records still shows Phase A fallback.
- Completed job with unit records shows per-unit cards.
- Unit photos open correctly and payment/tax/receipt/slip photos are not shown in unit Passport.
- In-progress/unconfirmed jobs do not expose completed-job unit evidence.

## Remaining risks

- Production unit evidence coverage may vary by job depending on technician app usage.
- Measurement phases are surfaced as photo evidence only; numeric PSI/temp values remain hidden unless future schema/API work explicitly adds real measured values.
- Responsive visual QA should be completed with real `/customer-app/` tracking data on mobile widths.