### PR TITLE
Turn Unit Passport into per-unit health dashboard

### DIFF
--- a/customer-app/assets/customer-app.css
+++ b/customer-app/assets/customer-app.css
@@ -1187,48 +1187,184 @@ p { margin: 0; }
 }
 .passport-units-card {
   grid-column: 1 / -1;
-  background: linear-gradient(180deg, #ffffff, #eef6ff);
+  background: linear-gradient(180deg, #ffffff 0%, #eef6ff 100%);
 }
-.passport-unit-list {
+.passport-unit-accordion {
   display: grid;
-  gap: 10px;
+  gap: 12px;
   margin-top: 12px;
 }
-.passport-unit-card {
-  display: grid;
-  gap: 10px;
-  padding: 12px;
+.passport-unit-panel {
+  overflow: hidden;
   border: 1px solid rgba(11, 75, 179, 0.12);
-  border-radius: 16px;
-  background: rgba(255, 255, 255, 0.86);
+  border-radius: 18px;
+  background: rgba(255, 255, 255, 0.92);
+  box-shadow: 0 12px 26px rgba(12, 50, 110, 0.08);
 }
-.passport-unit-head {
+.passport-unit-panel summary {
   display: flex;
-  align-items: flex-start;
+  align-items: center;
   justify-content: space-between;
-  gap: 10px;
+  gap: 12px;
+  min-height: 68px;
+  padding: 14px;
+  cursor: pointer;
+  list-style: none;
 }
-.passport-unit-head b {
+.passport-unit-panel summary::-webkit-details-marker {
+  display: none;
+}
+.passport-unit-panel summary::after {
+  content: "+";
+  display: grid;
+  place-items: center;
+  flex: 0 0 30px;
+  width: 30px;
+  height: 30px;
+  border-radius: var(--radius-pill);
+  background: #eaf2ff;
+  color: #0b4bb3;
+  font-weight: 950;
+}
+.passport-unit-panel[open] summary::after {
+  content: "−";
+  background: #0b4bb3;
+  color: #fff;
+}
+.passport-unit-panel summary b {
   display: block;
   color: #0a2a57;
   font-size: 16px;
   font-weight: 950;
   line-height: 1.25;
 }
-.passport-unit-head span,
-.passport-unit-head small {
+.passport-unit-panel summary span {
   display: block;
   color: var(--muted);
   font-size: 12px;
   font-weight: 800;
   line-height: 1.35;
 }
-.passport-unit-head small {
+.passport-unit-panel summary strong {
   flex: 0 0 auto;
-  padding: 5px 8px;
+  padding: 7px 10px;
   border-radius: var(--radius-pill);
-  background: #fffbea;
-  color: #7a5a00;
+  background: #ecfdf5;
+  color: #047857;
+  font-size: 12px;
+  white-space: nowrap;
+}
+.passport-unit-panel.is-watch summary strong { background: #fffbea; color: #9a6500; }
+.passport-unit-panel.is-warning summary strong { background: #fff7ed; color: #c2410c; }
+.passport-unit-panel.is-critical summary strong { background: #fef2f2; color: #b91c1c; }
+.passport-unit-panel.is-unknown summary strong { background: #f1f5f9; color: #475569; }
+.passport-unit-dashboard {
+  display: grid;
+  gap: 12px;
+  padding: 0 14px 14px;
+}
+.unit-overall-card {
+  display: grid;
+  gap: 10px;
+  padding: 12px;
+  border-radius: 16px;
+  background: linear-gradient(135deg, #f8fbff 0%, #ffffff 72%);
+  border: 1px solid rgba(11, 75, 179, 0.1);
+}
+.unit-health-grid {
+  display: grid;
+  gap: 10px;
+}
+.unit-health-row {
+  display: grid;
+  gap: 7px;
+  padding: 11px;
+  border: 1px solid rgba(11, 75, 179, 0.1);
+  border-radius: 15px;
+  background: #fff;
+}
+.unit-health-copy {
+  display: flex;
+  justify-content: space-between;
+  gap: 10px;
+  align-items: baseline;
+}
+.unit-health-copy span {
+  color: #0a2a57;
+  font-size: 13px;
+  font-weight: 950;
+}
+.unit-health-copy strong {
+  color: var(--ink);
+  font-size: 13px;
+  font-weight: 950;
+  text-align: right;
+}
+.unit-health-meter {
+  height: 11px;
+  overflow: hidden;
+  border-radius: var(--radius-pill);
+  background: #e5edf8;
+}
+.unit-health-meter i {
+  display: block;
+  height: 100%;
+  min-width: 8px;
+  border-radius: inherit;
+  background: linear-gradient(90deg, #22c55e, #86efac);
+}
+.unit-health-row.is-watch .unit-health-meter i { background: linear-gradient(90deg, #facc15, #f59e0b); }
+.unit-health-row.is-warning .unit-health-meter i { background: linear-gradient(90deg, #fb923c, #f97316); }
+.unit-health-row.is-critical .unit-health-meter i { background: linear-gradient(90deg, #ef4444, #b91c1c); }
+.unit-health-row.is-unknown .unit-health-meter i { background: #94a3b8; }
+.unit-health-row p,
+.unit-health-row small {
+  margin: 0;
+  color: var(--muted);
+  font-size: 12px;
+  font-weight: 760;
+  line-height: 1.45;
+}
+.unit-badges {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 7px;
+}
+.unit-badges span,
+.unit-photo-link {
+  display: inline-flex;
+  align-items: center;
+  width: fit-content;
+  padding: 7px 10px;
+  border-radius: var(--radius-pill);
+  background: #eef6ff;
+  color: #0b4bb3;
+  font-size: 12px;
+  font-weight: 900;
+  text-decoration: none;
+}
+.unit-badges .is-warning {
+  background: #fff7ed;
+  color: #c2410c;
+}
+.unit-evidence-grid {
+  display: grid;
+  gap: 10px;
+}
+.unit-checklist-box,
+.unit-photo-box {
+  display: grid;
+  gap: 8px;
+  padding: 11px;
+  border-radius: 15px;
+  background: #f8fbff;
+  border: 1px solid rgba(11, 75, 179, 0.1);
+}
+.unit-checklist-box b,
+.unit-photo-box b {
+  color: #0b4bb3;
+  font-size: 12px;
+  font-weight: 950;
 }
 .passport-unit-stats {
   display: grid;
@@ -1279,7 +1415,10 @@ p { margin: 0; }
   .passport-warranty-lists {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
-  .passport-unit-list {
+  .unit-health-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+  .unit-evidence-grid {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 }
@@ -1296,6 +1435,13 @@ p { margin: 0; }
   }
   .passport-card-head {
     align-items: flex-start;
+  }
+  .passport-unit-panel summary {
+    align-items: flex-start;
+    flex-wrap: wrap;
+  }
+  .passport-unit-panel summary strong {
+    order: 3;
   }
   .passport-unit-stats {
     grid-template-columns: 1fr;

--- a/customer-app/modules/tracking.js
+++ b/customer-app/modules/tracking.js
@@ -268,17 +268,6 @@
     return parts.join(" · ");
   }
 
-  function seededNumber(seed, min, max) {
-    const raw = clean(seed) || "cwf";
-    let hash = 2166136261;
-    for (let i = 0; i < raw.length; i += 1) {
-      hash ^= raw.charCodeAt(i);
-      hash = Math.imul(hash, 16777619);
-    }
-    const span = Math.max(0, max - min);
-    return min + (Math.abs(hash) % (span + 1));
-  }
-
   function scoreTone(score) {
     if (score == null) return "unknown";
     if (score >= 80) return "good";
@@ -300,10 +289,6 @@
     if (issueCount >= 3) return 35;
     if (issueCount >= 1) return 58;
     return 92;
-  }
-
-  function unitSeed(data, unit, suffix) {
-    return [data.booking_code, data.job_id, unit.unit_id, unit.unit_no, suffix].filter(Boolean).join("|");
   }
 
   function metricBar(metric) {
@@ -330,85 +315,64 @@
     const hasChecklist = !!(summary.pre_completed || summary.post_completed);
     const normal = hasChecklist && issueCount <= 0;
     const issueBasedScore = hasChecklist ? issueScore(issueCount) : null;
-    const seed = (suffix) => unitSeed(data, unit, suffix);
-    const psi = seededNumber(seed("psi"), 125, 150);
-    const returnAir = seededNumber(seed("return"), 26, 30);
-    const supplyAir = seededNumber(seed("supply"), 14, 18);
-    const delta = Math.max(9, Math.min(12, returnAir - supplyAir));
-    const airflow = normal ? seededNumber(seed("airflow"), 80, 100) : (issueBasedScore == null ? null : Math.max(35, issueBasedScore + 5));
+    const photos = unit.photos || [];
+    const hasPressurePhoto = phaseCount(photos, "pressure") > 0;
+    const hasTempPhoto = phaseCount(photos, "temp") > 0;
     const coilScore = context.coilScore;
     const drainScore = context.drainScore == null ? null : Math.max(0, context.drainScore - (issueCount * 12) - (context.drainRisk ? 8 : 0));
 
-    const psiMetric = !hasChecklist
+    const psiMetric = hasPressurePhoto
       ? {
           label: "น้ำยาแอร์ / PSI",
-          value: "รอข้อมูล",
+          value: "มีรูปตรวจวัด",
           score: null,
           tone: "unknown",
-          detail: "ยังไม่มีข้อมูลเช็คลิสต์สำหรับประเมินน้ำยา",
-          meta: "จะแสดงค่าจริงเมื่อมีการบันทึกแบบตัวเลข",
+          detail: "มีรูปการตรวจวัดน้ำยา",
+          meta: "ยังไม่มีค่าตัวเลข PSI ที่บันทึกเป็นข้อมูล",
         }
-      : normal
-        ? {
-            label: "น้ำยาแอร์ / PSI",
-            value: `${psi} PSI`,
-            score: 92,
-            tone: "good",
-            detail: "น้ำยาอยู่ในช่วงปกติ",
-            meta: "ค่าประเมินจากเช็คลิสต์ ยังไม่มีค่าที่ช่างวัดเป็นตัวเลข",
-          }
-        : {
-            label: "น้ำยาแอร์ / PSI",
-            value: "ประเมินจากเช็คลิสต์",
-            score: issueBasedScore,
-            tone: scoreTone(issueBasedScore),
-            detail: issueCount >= 3 ? "ควรตรวจน้ำยาและระบบทำความเย็นเพิ่มเติม" : "มีสัญญาณให้เฝ้าระวังจากเช็คลิสต์",
-            meta: "ยังไม่มีค่าที่ช่างวัดเป็นตัวเลข",
-          };
+      : {
+          label: "น้ำยาแอร์ / PSI",
+          value: "ยังไม่มีข้อมูลวัดจริง",
+          score: null,
+          tone: "unknown",
+          detail: "ยังไม่มีข้อมูลวัดจริง",
+          meta: "จะแสดงค่าตัวเลขเมื่อมีฟิลด์ที่ช่างบันทึกเป็นข้อมูลจริง",
+        };
 
-    const tempMetric = !hasChecklist
+    const tempMetric = hasTempPhoto
       ? {
           label: "อุณหภูมิ",
-          value: "รอข้อมูล",
+          value: "มีรูปตรวจวัด",
           score: null,
           tone: "unknown",
-          detail: "ยังไม่มีข้อมูลเช็คลิสต์สำหรับประเมินอุณหภูมิ",
-          meta: "จะแสดงค่าจริงเมื่อมีการบันทึกแบบตัวเลข",
+          detail: "มีรูปการตรวจวัดอุณหภูมิ",
+          meta: "ยังไม่มีค่าลมส่ง / ลมกลับที่บันทึกเป็นข้อมูล",
         }
-      : normal
-        ? {
-            label: "อุณหภูมิ",
-            value: `ΔT ประมาณ ${delta}°C`,
-            score: 90,
-            tone: "good",
-            detail: `อุณหภูมิปกติ ประเมินลมกลับ ${returnAir}°C / ลมส่ง ${supplyAir}°C`,
-            meta: "ค่าประเมินจากเช็คลิสต์ ไม่ใช่อุณหภูมิจริง",
-          }
-        : {
-            label: "อุณหภูมิ",
-            value: "ควรตรวจเพิ่ม",
-            score: issueBasedScore,
-            tone: scoreTone(issueBasedScore),
-            detail: "ควรตรวจอุณหภูมิหน้างานเพิ่มเติม",
-            meta: "ยังไม่มีค่าที่ช่างวัดเป็นตัวเลข",
-          };
+      : {
+          label: "อุณหภูมิ",
+          value: "ยังไม่มีข้อมูลวัดจริง",
+          score: null,
+          tone: "unknown",
+          detail: "ยังไม่มีข้อมูลวัดจริง",
+          meta: "จะแสดงค่าตัวเลขเมื่อมีฟิลด์ที่ช่างบันทึกเป็นข้อมูลจริง",
+        };
 
     const airflowMetric = !hasChecklist
       ? {
           label: "แรงลม",
-          value: "รอข้อมูล",
+          value: "ยังไม่มีข้อมูลวัดจริง",
           score: null,
           tone: "unknown",
-          detail: "ยังไม่มีข้อมูลเช็คลิสต์สำหรับประเมินแรงลม",
-          meta: "ระบบจะแสดงค่าจริงเมื่อมีการบันทึกแบบตัวเลข",
+          detail: "สถานะแรงลม: ยังไม่มีข้อมูลวัดจริง",
+          meta: "จะแสดงค่าตัวเลขเมื่อมีฟิลด์ที่ช่างบันทึกเป็นข้อมูลจริง",
         }
       : {
           label: "แรงลม",
-          value: `${airflow}%`,
-          score: airflow,
-          tone: scoreTone(airflow),
-          detail: airflow >= 80 ? "แรงลมอยู่ในเกณฑ์ดี" : (airflow >= 55 ? "แรงลมเริ่มควรเฝ้าระวัง" : "แรงลมต่ำ ควรตรวจหน้างาน"),
-          meta: "ค่าประเมินจากเช็คลิสต์",
+          value: normal ? "ปกติ" : "ควรตรวจ",
+          score: issueBasedScore,
+          tone: scoreTone(issueBasedScore),
+          detail: normal ? "ประเมินจากเช็คลิสต์: ปกติ" : "ประเมินจากเช็คลิสต์: ควรตรวจแรงลมเพิ่มเติม",
+          meta: "ประเมินจากเช็คลิสต์ ไม่ใช่ค่าที่วัดด้วยเครื่องมือ",
         };
 
     const coilMetric = {
@@ -429,8 +393,9 @@
       meta: context.drainRisk ? "พบสัญญาณเกี่ยวกับน้ำหยดหรือการระบาย จึงประเมินเข้มขึ้น" : context.drainEstimateText,
     };
 
-    const usableScores = [psiMetric, tempMetric, airflowMetric, coilMetric, drainMetric]
-      .map((metric) => metric.score)
+    const photoEvidenceScore = (hasPressurePhoto || hasTempPhoto) ? 82 : 68;
+    const checklistScore = hasChecklist ? issueBasedScore : null;
+    const usableScores = [coilMetric.score, drainMetric.score, checklistScore, photoEvidenceScore]
       .filter((score) => score != null && Number.isFinite(score));
     const overallScore = usableScores.length
       ? Math.max(0, Math.min(100, Math.round(usableScores.reduce((sum, score) => sum + score, 0) / usableScores.length) - Math.min(issueCount * 4, 16)))
@@ -445,7 +410,7 @@
         : (overallScore >= 80
             ? "เครื่องนี้ยังอยู่ในสภาพดี แนะนำล้างรอบถัดไปตามกำหนด"
             : (overallScore >= 60 ? "ควรติดตามอาการและวางแผนตรวจรอบถัดไป" : "ควรให้ช่างตรวจหน้างานเพิ่มเติม")),
-      meta: "สรุปจากเช็คลิสต์ รูปงาน และรอบเวลาหลังบริการ",
+      meta: "ไม่รวมค่าน้ำยาและอุณหภูมิ เพราะยังไม่มีค่าที่วัดจริง",
     };
 
     return {

--- a/customer-app/modules/tracking.js
+++ b/customer-app/modules/tracking.js
@@ -268,7 +268,195 @@
     return parts.join(" · ");
   }
 
-  function renderUnitPassportCards(units) {
+  function seededNumber(seed, min, max) {
+    const raw = clean(seed) || "cwf";
+    let hash = 2166136261;
+    for (let i = 0; i < raw.length; i += 1) {
+      hash ^= raw.charCodeAt(i);
+      hash = Math.imul(hash, 16777619);
+    }
+    const span = Math.max(0, max - min);
+    return min + (Math.abs(hash) % (span + 1));
+  }
+
+  function scoreTone(score) {
+    if (score == null) return "unknown";
+    if (score >= 80) return "good";
+    if (score >= 60) return "watch";
+    if (score >= 40) return "warning";
+    return "critical";
+  }
+
+  function toneLabel(score) {
+    const tone = scoreTone(score);
+    if (tone === "good") return "ปกติ";
+    if (tone === "watch") return "เฝ้าระวัง";
+    if (tone === "warning") return "ควรตรวจ";
+    if (tone === "critical") return "วิกฤต";
+    return "รอข้อมูล";
+  }
+
+  function issueScore(issueCount) {
+    if (issueCount >= 3) return 35;
+    if (issueCount >= 1) return 58;
+    return 92;
+  }
+
+  function unitSeed(data, unit, suffix) {
+    return [data.booking_code, data.job_id, unit.unit_id, unit.unit_no, suffix].filter(Boolean).join("|");
+  }
+
+  function metricBar(metric) {
+    const score = metric.score == null ? 0 : Math.max(0, Math.min(100, Number(metric.score) || 0));
+    const tone = metric.tone || scoreTone(metric.score);
+    return `
+      <div class="unit-health-row is-${tone}">
+        <div class="unit-health-copy">
+          <span>${esc(metric.label)}</span>
+          <strong>${esc(metric.value)}</strong>
+        </div>
+        <div class="unit-health-meter" aria-label="${esc(metric.label)} ${esc(metric.value)}">
+          <i style="width:${score}%"></i>
+        </div>
+        <p>${esc(metric.detail)}</p>
+        ${metric.meta ? `<small>${esc(metric.meta)}</small>` : ""}
+      </div>
+    `;
+  }
+
+  function unitMetrics(data, unit, context) {
+    const summary = unit.checklist_summary || {};
+    const issueCount = Number(summary.issue_count || 0);
+    const hasChecklist = !!(summary.pre_completed || summary.post_completed);
+    const normal = hasChecklist && issueCount <= 0;
+    const issueBasedScore = hasChecklist ? issueScore(issueCount) : null;
+    const seed = (suffix) => unitSeed(data, unit, suffix);
+    const psi = seededNumber(seed("psi"), 125, 150);
+    const returnAir = seededNumber(seed("return"), 26, 30);
+    const supplyAir = seededNumber(seed("supply"), 14, 18);
+    const delta = Math.max(9, Math.min(12, returnAir - supplyAir));
+    const airflow = normal ? seededNumber(seed("airflow"), 80, 100) : (issueBasedScore == null ? null : Math.max(35, issueBasedScore + 5));
+    const coilScore = context.coilScore;
+    const drainScore = context.drainScore == null ? null : Math.max(0, context.drainScore - (issueCount * 12) - (context.drainRisk ? 8 : 0));
+
+    const psiMetric = !hasChecklist
+      ? {
+          label: "น้ำยาแอร์ / PSI",
+          value: "รอข้อมูล",
+          score: null,
+          tone: "unknown",
+          detail: "ยังไม่มีข้อมูลเช็คลิสต์สำหรับประเมินน้ำยา",
+          meta: "จะแสดงค่าจริงเมื่อมีการบันทึกแบบตัวเลข",
+        }
+      : normal
+        ? {
+            label: "น้ำยาแอร์ / PSI",
+            value: `${psi} PSI`,
+            score: 92,
+            tone: "good",
+            detail: "น้ำยาอยู่ในช่วงปกติ",
+            meta: "ค่าประเมินจากเช็คลิสต์ ยังไม่มีค่าที่ช่างวัดเป็นตัวเลข",
+          }
+        : {
+            label: "น้ำยาแอร์ / PSI",
+            value: "ประเมินจากเช็คลิสต์",
+            score: issueBasedScore,
+            tone: scoreTone(issueBasedScore),
+            detail: issueCount >= 3 ? "ควรตรวจน้ำยาและระบบทำความเย็นเพิ่มเติม" : "มีสัญญาณให้เฝ้าระวังจากเช็คลิสต์",
+            meta: "ยังไม่มีค่าที่ช่างวัดเป็นตัวเลข",
+          };
+
+    const tempMetric = !hasChecklist
+      ? {
+          label: "อุณหภูมิ",
+          value: "รอข้อมูล",
+          score: null,
+          tone: "unknown",
+          detail: "ยังไม่มีข้อมูลเช็คลิสต์สำหรับประเมินอุณหภูมิ",
+          meta: "จะแสดงค่าจริงเมื่อมีการบันทึกแบบตัวเลข",
+        }
+      : normal
+        ? {
+            label: "อุณหภูมิ",
+            value: `ΔT ประมาณ ${delta}°C`,
+            score: 90,
+            tone: "good",
+            detail: `อุณหภูมิปกติ ประเมินลมกลับ ${returnAir}°C / ลมส่ง ${supplyAir}°C`,
+            meta: "ค่าประเมินจากเช็คลิสต์ ไม่ใช่อุณหภูมิจริง",
+          }
+        : {
+            label: "อุณหภูมิ",
+            value: "ควรตรวจเพิ่ม",
+            score: issueBasedScore,
+            tone: scoreTone(issueBasedScore),
+            detail: "ควรตรวจอุณหภูมิหน้างานเพิ่มเติม",
+            meta: "ยังไม่มีค่าที่ช่างวัดเป็นตัวเลข",
+          };
+
+    const airflowMetric = !hasChecklist
+      ? {
+          label: "แรงลม",
+          value: "รอข้อมูล",
+          score: null,
+          tone: "unknown",
+          detail: "ยังไม่มีข้อมูลเช็คลิสต์สำหรับประเมินแรงลม",
+          meta: "ระบบจะแสดงค่าจริงเมื่อมีการบันทึกแบบตัวเลข",
+        }
+      : {
+          label: "แรงลม",
+          value: `${airflow}%`,
+          score: airflow,
+          tone: scoreTone(airflow),
+          detail: airflow >= 80 ? "แรงลมอยู่ในเกณฑ์ดี" : (airflow >= 55 ? "แรงลมเริ่มควรเฝ้าระวัง" : "แรงลมต่ำ ควรตรวจหน้างาน"),
+          meta: "ค่าประเมินจากเช็คลิสต์",
+        };
+
+    const coilMetric = {
+      label: "ความสะอาดคอยล์",
+      value: coilScore == null ? "รอข้อมูล" : `${coilScore}%`,
+      score: coilScore,
+      tone: scoreTone(coilScore),
+      detail: coilLabel(coilScore),
+      meta: context.healthEstimateText,
+    };
+
+    const drainMetric = {
+      label: "ระบบน้ำทิ้ง",
+      value: drainScore == null ? "รอข้อมูล" : `${drainScore}%`,
+      score: drainScore,
+      tone: scoreTone(drainScore),
+      detail: drainLabel(drainScore),
+      meta: context.drainRisk ? "พบสัญญาณเกี่ยวกับน้ำหยดหรือการระบาย จึงประเมินเข้มขึ้น" : context.drainEstimateText,
+    };
+
+    const usableScores = [psiMetric, tempMetric, airflowMetric, coilMetric, drainMetric]
+      .map((metric) => metric.score)
+      .filter((score) => score != null && Number.isFinite(score));
+    const overallScore = usableScores.length
+      ? Math.max(0, Math.min(100, Math.round(usableScores.reduce((sum, score) => sum + score, 0) / usableScores.length) - Math.min(issueCount * 4, 16)))
+      : null;
+    const overallMetric = {
+      label: "ภาพรวมสุขภาพเครื่อง",
+      value: overallScore == null ? "รอข้อมูล" : `${overallScore}% — ${toneLabel(overallScore)}`,
+      score: overallScore,
+      tone: scoreTone(overallScore),
+      detail: overallScore == null
+        ? "ยังไม่มีข้อมูลพอสำหรับสรุปสุขภาพเครื่องนี้"
+        : (overallScore >= 80
+            ? "เครื่องนี้ยังอยู่ในสภาพดี แนะนำล้างรอบถัดไปตามกำหนด"
+            : (overallScore >= 60 ? "ควรติดตามอาการและวางแผนตรวจรอบถัดไป" : "ควรให้ช่างตรวจหน้างานเพิ่มเติม")),
+      meta: "สรุปจากเช็คลิสต์ รูปงาน และรอบเวลาหลังบริการ",
+    };
+
+    return {
+      overall: overallMetric,
+      rows: [psiMetric, tempMetric, airflowMetric, coilMetric, drainMetric],
+      hasChecklist,
+      issueCount,
+    };
+  }
+
+  function renderUnitPassportCards(data, units, context) {
     if (!units.length) return "";
     return `
       <article class="passport-card passport-units-card">
@@ -276,41 +464,65 @@
           <span>Unit Passport</span>
           <strong>${units.length} เครื่อง</strong>
         </div>
-        <h3>ข้อมูลแยกรายเครื่อง</h3>
-        <p>แสดงจากข้อมูลเครื่องและรูปหน้างานที่ผูกกับใบงานนี้เท่านั้น</p>
-        <div class="passport-unit-list">
-          ${units.map((unit) => {
+        <h3>แดชบอร์ดสุขภาพแยกรายเครื่อง</h3>
+        <p>แต่ละเครื่องมีรายงานสุขภาพของตัวเองจากเช็คลิสต์ รูปงาน และข้อมูลที่ผูกกับใบงานนี้เท่านั้น</p>
+        <div class="passport-unit-accordion">
+          ${units.map((unit, index) => {
             const photos = unit.photos || [];
             const before = phaseCount(photos, "before");
             const after = phaseCount(photos, "after");
-            const measure = measurementSummary(photos);
+            const metrics = unitMetrics(data, unit, context);
             const preview = photos.slice(0, 4);
+            const meta = [unit.service_type, unit.ac_type, unit.btu ? `${unit.btu} BTU` : ""].filter(Boolean).join(" · ") || "เครื่องปรับอากาศ";
             return `
-              <section class="passport-unit-card">
-                <div class="passport-unit-head">
+              <details class="passport-unit-panel is-${metrics.overall.tone}" ${index === 0 ? "open" : ""}>
+                <summary>
                   <div>
                     <b>${esc(unit.label)}</b>
-                    <span>${esc([unit.service_type, unit.ac_type, unit.btu ? `${unit.btu} BTU` : ""].filter(Boolean).join(" · ") || "เครื่องปรับอากาศ")}</span>
+                    <span>${esc(meta)}</span>
                   </div>
-                  ${unit.unit_code ? `<small>${esc(unit.unit_code)}</small>` : ""}
-                </div>
-                <div class="passport-unit-stats">
-                  <span>ก่อนทำ <b>${before}</b></span>
-                  <span>หลังทำ <b>${after}</b></span>
-                  <span>รวม <b>${photos.length}</b></span>
-                </div>
-                <p>${esc(checklistCopy(unit.checklist_summary))}</p>
-                <p>${esc(measure)}</p>
-                ${preview.length ? `
-                  <div class="passport-unit-photos">
-                    ${preview.map((photo) => `
-                      <a href="${esc(photo.url)}" target="_blank" rel="noopener" aria-label="เปิดรูปงานรายเครื่อง">
-                        <img src="${esc(photo.url)}" alt="${esc(photo.phase || "รูปงาน")}" loading="lazy">
-                      </a>
-                    `).join("")}
+                  <strong>${esc(metrics.overall.value)}</strong>
+                </summary>
+                <div class="passport-unit-dashboard">
+                  <div class="unit-overall-card">
+                    ${metricBar(metrics.overall)}
+                    <div class="unit-badges">
+                      ${unit.unit_code ? `<span>${esc(unit.unit_code)}</span>` : ""}
+                      <span>${metrics.hasChecklist ? (metrics.issueCount > 0 ? "ประเมินจากเช็คลิสต์" : "ระบบปกติจากเช็คลิสต์") : "รอเช็คลิสต์"}</span>
+                      ${metrics.issueCount > 0 ? `<span class="is-warning">พบ ${metrics.issueCount} จุดที่ควรตรวจ</span>` : ""}
+                    </div>
                   </div>
-                ` : `<small>ยังไม่มีรูปที่แยกกับเครื่องนี้</small>`}
-              </section>
+                  <div class="unit-health-grid">
+                    ${metrics.rows.map(metricBar).join("")}
+                  </div>
+                  <div class="unit-evidence-grid">
+                    <div class="unit-checklist-box">
+                      <b>เช็คลิสต์</b>
+                      <p>${esc(checklistCopy(unit.checklist_summary))}</p>
+                      <small>ค่าประเมินจากเช็คลิสต์ ยังไม่มีค่าที่ช่างวัดเป็นตัวเลข</small>
+                    </div>
+                    <div class="unit-photo-box">
+                      <b>รูปก่อน / หลัง</b>
+                      <div class="passport-unit-stats">
+                        <span>ก่อนทำ <b>${before}</b></span>
+                        <span>หลังทำ <b>${after}</b></span>
+                        <span>รวม <b>${photos.length}</b></span>
+                      </div>
+                      <p>${esc(measurementSummary(photos))}</p>
+                    </div>
+                  </div>
+                  ${preview.length ? `
+                    <div class="passport-unit-photos">
+                      ${preview.map((photo) => `
+                        <a href="${esc(photo.url)}" target="_blank" rel="noopener" aria-label="เปิดรูปงานรายเครื่อง">
+                          <img src="${esc(photo.url)}" alt="${esc(photo.phase || "รูปงาน")}" loading="lazy">
+                        </a>
+                      `).join("")}
+                    </div>
+                    <a class="unit-photo-link" href="${esc(preview[0].url)}" target="_blank" rel="noopener">ดูรูปเครื่องนี้</a>
+                  ` : `<small>ยังไม่มีรูปที่แยกกับเครื่องนี้</small>`}
+                </div>
+              </details>
             `;
           }).join("")}
         </div>
@@ -484,7 +696,7 @@
             <p>${esc(next.reason)}</p>
           </article>
 
-          ${renderUnitPassportCards(units)}
+          ${renderUnitPassportCards(data, units, { coilScore, drainScore, drainRisk: hasDrainRisk(data), healthEstimateText, drainEstimateText })}
 
           <article class="passport-card passport-photo-card">
             <div class="passport-card-head">


### PR DESCRIPTION
## Summary

Follow-up to merged PR #56. The original change request asked to update the existing PR branch, but PR #56 was already merged, so this is opened as a new follow-up PR from latest `main`.

This turns the Customer App Unit Passport from plain per-unit cards into a per-air-conditioner health dashboard.

Changed files:
- `customer-app/modules/tracking.js`
- `customer-app/assets/customer-app.css`

## UX changes

- Replaces the plain stacked unit cards with accordion-style per-unit reports.
- Each AC unit opens as its own dashboard page/report.
- Adds visual health meters for:
  - น้ำยาแอร์ / PSI
  - อุณหภูมิ
  - แรงลม
  - ความสะอาดคอยล์
  - ระบบน้ำทิ้ง
  - ภาพรวมสุขภาพเครื่อง
- Adds green/yellow/orange/red/unknown visual states, including an obvious critical state.
- Keeps per-unit before/after/total photo counts, preview images, and a `ดูรูปเครื่องนี้` link.
- Keeps old job-level Phase A fallback when `units` is empty.

## Data honesty

- Does not add DB fields or backend payload fields.
- Uses the existing PR #56 unit payload only.
- Does not expose raw checklist JSON.
- Does not show fake numeric PSI, return-air temperature, supply-air temperature, delta T, airflow, current, or measurement values.
- PSI shows either measurement-photo evidence or `ยังไม่มีข้อมูลวัดจริง`; numeric PSI remains hidden until real structured technician-entered fields exist.
- Temperature shows either measurement-photo evidence or `ยังไม่มีข้อมูลวัดจริง`; numeric supply/return/delta T remains hidden until real structured technician-entered fields exist.
- Airflow is qualitative only: `ปกติ`, `ควรตรวจ`, or `ยังไม่มีข้อมูลวัดจริง`, and is labeled as checklist-based when applicable.
- Overall health does not include fake PSI/temp numeric scores; it is based on coil/drain estimates, checklist status, and photo evidence availability.

## Health logic

- Coil cleanliness and drain health remain time/checklist-based estimates from Phase A.
- Checklist issues affect qualitative warning/critical states.
- Measurement-related cards stay honest even when photos exist: photos prove evidence exists, not a structured numeric reading.

## Scope confirmations

- No DB schema changes.
- No migrations.
- No technician app changes.
- No admin app changes.
- No payment/auth/tax/receipt logic changes.
- No backend `/public/track` payload change in this follow-up.
- Existing Phase A fallback remains.
- Old tracking behavior is preserved when `units` is empty.

## Tests run

```text
node --check customer-app/modules/tracking.js
git diff --check
git diff --name-only
git diff --stat
```

Earlier PR validation also included:
```text
node --check index.js
```

## Manual test limitations

No staging/preview token with completed per-unit evidence was available in this workspace, so the dashboard still needs manual browser testing against a real completed job with unit payload data.

Suggested manual checks:
- Completed old job without units still shows Phase A fallback.
- Completed job with units shows accordion dashboards per AC unit.
- Measurement-photo units show evidence text without numeric PSI/temp values.
- Checklist issue unit shows yellow/orange/red status without measured-value wording.
- Mobile widths 360/390/430px keep text and meters readable.