### PR TITLE
Customer App Unit Passport Machine Tabs

### DIFF
--- a/customer-app/assets/customer-app.css
+++ b/customer-app/assets/customer-app.css
@@ -1189,79 +1189,93 @@ p { margin: 0; }
   grid-column: 1 / -1;
   background: linear-gradient(180deg, #ffffff 0%, #eef6ff 100%);
 }
-.passport-unit-accordion {
-  display: grid;
-  gap: 12px;
-  margin-top: 12px;
+.passport-unit-tabs {
+  display: flex;
+  gap: 8px;
+  margin: 14px -2px 12px;
+  padding: 2px 2px 8px;
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+  scrollbar-width: thin;
 }
-.passport-unit-panel {
+.passport-unit-tab {
+  flex: 0 0 auto;
+  max-width: 170px;
+  min-height: 42px;
+  padding: 9px 13px;
+  border: 1px solid rgba(11, 75, 179, 0.16);
+  border-radius: var(--radius-pill);
+  background: #fff;
+  color: #0b4bb3;
+  font-size: 13px;
+  font-weight: 950;
+  line-height: 1.2;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  box-shadow: 0 8px 18px rgba(12, 50, 110, 0.08);
+}
+.passport-unit-tab.is-active {
+  background: linear-gradient(135deg, #0b4bb3, #19b36b);
+  color: #fff;
+  border-color: transparent;
+  box-shadow: 0 12px 24px rgba(11, 75, 179, 0.22);
+}
+.passport-unit-pages {
+  display: grid;
+}
+.passport-unit-page {
+  display: none;
   overflow: hidden;
   border: 1px solid rgba(11, 75, 179, 0.12);
   border-radius: 18px;
-  background: rgba(255, 255, 255, 0.92);
+  background: rgba(255, 255, 255, 0.94);
   box-shadow: 0 12px 26px rgba(12, 50, 110, 0.08);
 }
-.passport-unit-panel summary {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 12px;
-  min-height: 68px;
-  padding: 14px;
-  cursor: pointer;
-  list-style: none;
+.passport-unit-page.is-active {
+  display: block;
 }
-.passport-unit-panel summary::-webkit-details-marker {
-  display: none;
-}
-.passport-unit-panel summary::after {
-  content: "+";
+.passport-unit-head {
   display: grid;
-  place-items: center;
-  flex: 0 0 30px;
-  width: 30px;
-  height: 30px;
-  border-radius: var(--radius-pill);
-  background: #eaf2ff;
-  color: #0b4bb3;
-  font-weight: 950;
+  grid-template-columns: minmax(0, 1fr);
+  gap: 9px;
+  padding: 14px;
+  border-bottom: 1px solid rgba(11, 75, 179, 0.1);
 }
-.passport-unit-panel[open] summary::after {
-  content: "−";
-  background: #0b4bb3;
-  color: #fff;
-}
-.passport-unit-panel summary b {
+.passport-unit-head b {
   display: block;
   color: #0a2a57;
-  font-size: 16px;
+  font-size: 17px;
   font-weight: 950;
   line-height: 1.25;
+  overflow-wrap: anywhere;
 }
-.passport-unit-panel summary span {
+.passport-unit-head span {
   display: block;
   color: var(--muted);
   font-size: 12px;
   font-weight: 800;
   line-height: 1.35;
 }
-.passport-unit-panel summary strong {
-  flex: 0 0 auto;
+.passport-unit-head strong {
+  width: fit-content;
+  max-width: 100%;
   padding: 7px 10px;
   border-radius: var(--radius-pill);
   background: #ecfdf5;
   color: #047857;
   font-size: 12px;
-  white-space: nowrap;
+  font-weight: 950;
+  line-height: 1.3;
 }
-.passport-unit-panel.is-watch summary strong { background: #fffbea; color: #9a6500; }
-.passport-unit-panel.is-warning summary strong { background: #fff7ed; color: #c2410c; }
-.passport-unit-panel.is-critical summary strong { background: #fef2f2; color: #b91c1c; }
-.passport-unit-panel.is-unknown summary strong { background: #f1f5f9; color: #475569; }
+.passport-unit-page.is-watch .passport-unit-head strong { background: #fffbea; color: #9a6500; }
+.passport-unit-page.is-warning .passport-unit-head strong { background: #fff7ed; color: #c2410c; }
+.passport-unit-page.is-critical .passport-unit-head strong { background: #fef2f2; color: #b91c1c; }
+.passport-unit-page.is-unknown .passport-unit-head strong { background: #f1f5f9; color: #475569; }
 .passport-unit-dashboard {
   display: grid;
   gap: 12px;
-  padding: 0 14px 14px;
+  padding: 14px;
 }
 .unit-overall-card {
   display: grid;
@@ -1421,6 +1435,10 @@ p { margin: 0; }
   .unit-evidence-grid {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
+  .passport-unit-head {
+    grid-template-columns: minmax(0, 1fr) auto;
+    align-items: start;
+  }
 }
 @media (max-width: 420px) {
   .passport-hero,
@@ -1436,12 +1454,11 @@ p { margin: 0; }
   .passport-card-head {
     align-items: flex-start;
   }
-  .passport-unit-panel summary {
-    align-items: flex-start;
-    flex-wrap: wrap;
-  }
-  .passport-unit-panel summary strong {
-    order: 3;
+  .passport-unit-tab {
+    max-width: 138px;
+    min-height: 40px;
+    padding: 8px 11px;
+    font-size: 12px;
   }
   .passport-unit-stats {
     grid-template-columns: 1fr;

--- a/customer-app/modules/tracking.js
+++ b/customer-app/modules/tracking.js
@@ -423,6 +423,11 @@
 
   function renderUnitPassportCards(data, units, context) {
     if (!units.length) return "";
+    const unitTabLabel = (unit) => {
+      const label = clean(unit.label);
+      const room = label.includes("/") ? clean(label.split("/").slice(1).join("/")) : "";
+      return room || `เครื่อง ${unit.unit_no || ""}`.trim() || "เครื่อง";
+    };
     return `
       <article class="passport-card passport-units-card">
         <div class="passport-card-head">
@@ -431,7 +436,19 @@
         </div>
         <h3>แดชบอร์ดสุขภาพแยกรายเครื่อง</h3>
         <p>แต่ละเครื่องมีรายงานสุขภาพของตัวเองจากเช็คลิสต์ รูปงาน และข้อมูลที่ผูกกับใบงานนี้เท่านั้น</p>
-        <div class="passport-unit-accordion">
+        <div class="passport-unit-tabs" role="tablist" aria-label="เลือกเครื่องปรับอากาศ">
+          ${units.map((unit, index) => `
+            <button
+              type="button"
+              class="passport-unit-tab ${index === 0 ? "is-active" : ""}"
+              role="tab"
+              aria-selected="${index === 0 ? "true" : "false"}"
+              data-unit-tab="${index}">
+              ${esc(unitTabLabel(unit))}
+            </button>
+          `).join("")}
+        </div>
+        <div class="passport-unit-pages">
           ${units.map((unit, index) => {
             const photos = unit.photos || [];
             const before = phaseCount(photos, "before");
@@ -440,14 +457,17 @@
             const preview = photos.slice(0, 4);
             const meta = [unit.service_type, unit.ac_type, unit.btu ? `${unit.btu} BTU` : ""].filter(Boolean).join(" · ") || "เครื่องปรับอากาศ";
             return `
-              <details class="passport-unit-panel is-${metrics.overall.tone}" ${index === 0 ? "open" : ""}>
-                <summary>
+              <section
+                class="passport-unit-page is-${metrics.overall.tone} ${index === 0 ? "is-active" : ""}"
+                data-unit-page="${index}"
+                role="tabpanel">
+                <div class="passport-unit-head">
                   <div>
                     <b>${esc(unit.label)}</b>
                     <span>${esc(meta)}</span>
                   </div>
                   <strong>${esc(metrics.overall.value)}</strong>
-                </summary>
+                </div>
                 <div class="passport-unit-dashboard">
                   <div class="unit-overall-card">
                     ${metricBar(metrics.overall)}
@@ -487,7 +507,7 @@
                     <a class="unit-photo-link" href="${esc(preview[0].url)}" target="_blank" rel="noopener">ดูรูปเครื่องนี้</a>
                   ` : `<small>ยังไม่มีรูปที่แยกกับเครื่องนี้</small>`}
                 </div>
-              </details>
+              </section>
             `;
           }).join("")}
         </div>
@@ -921,6 +941,26 @@
   }
 
   function bindResultActions(container) {
+    const result = container.querySelector("[data-tracking-result]");
+    if (result && !result.dataset.unitTabsBound) {
+      result.dataset.unitTabsBound = "1";
+      result.addEventListener("click", (event) => {
+        const tab = event.target.closest("[data-unit-tab]");
+        if (!tab) return;
+        const shell = tab.closest(".passport-units-card");
+        if (!shell) return;
+        const id = tab.getAttribute("data-unit-tab");
+        shell.querySelectorAll("[data-unit-tab]").forEach((btn) => {
+          const active = btn === tab;
+          btn.classList.toggle("is-active", active);
+          btn.setAttribute("aria-selected", active ? "true" : "false");
+        });
+        shell.querySelectorAll("[data-unit-page]").forEach((page) => {
+          page.classList.toggle("is-active", page.getAttribute("data-unit-page") === id);
+        });
+      });
+    }
+
     const refresh = container.querySelector("[data-action='track-refresh']");
     if (refresh) refresh.addEventListener("click", () => lookup(container), { once: true });
     const form = container.querySelector("[data-review-form]");


### PR DESCRIPTION
## Summary

Replaces the Unit Passport accordion UX from PR #57 with horizontal machine tabs.

## Files changed

- `customer-app/modules/tracking.js`
- `customer-app/assets/customer-app.css`

## How tabs work

- Unit Passport now renders `.passport-unit-tabs` with one `.passport-unit-tab` per machine.
- The first unit is selected by default.
- Each dashboard is rendered as a `.passport-unit-page`; only `.passport-unit-page.is-active` is visible.
- Clicking a tab uses delegated handling from the tracking result container to switch `.is-active` on the selected tab and page.
- The implementation does not use `<details>` / `<summary>` for the main UX and does not stack all unit dashboards vertically.

## Mobile layout notes

- Tabs scroll horizontally on mobile with `overflow-x: auto` and fixed max-width tab labels to avoid text overlap.
- Unit pages stack content by default on small screens.
- Two-column health/evidence grids only activate at `min-width: 720px`.
- 360/390/430px layouts should show a single selected machine dashboard with scrollable tabs above it.

## Data honesty notes

- No backend or `/public/track` payload changes.
- No fake numeric PSI, temperature, airflow, current, or measurement values are added.
- PSI and temperature continue to show only measurement-photo evidence or `ยังไม่มีข้อมูลวัดจริง` until real structured technician-entered values exist.
- Airflow remains qualitative/checklist-based only and keeps the wording `ประเมินจากเช็คลิสต์ ไม่ใช่ค่าที่วัดด้วยเครื่องมือ`.
- Phase A fallback remains when `units` is empty; machine tabs are not shown in that case.

## Tests run

```text
node --check customer-app/modules/tracking.js
git diff --check
git diff --name-only
git diff --stat
```

## Manual check limitation

No completed tracking token with real per-unit payload data was available in this workspace, so browser verification on staging/live with real unit data is still needed.

Suggested manual checks:
- Completed old job without units still shows Phase A fallback and no machine tabs.
- Completed job with multiple units shows horizontal machine tabs.
- Tapping each tab shows only that selected machine dashboard.
- Mobile widths 360/390/430px keep tabs scrollable and cards stacked cleanly.
- PSI/temp/airflow cards do not show fake numeric values.