### PR TITLE
Redesign Customer Tracking into Separate Premium Views

### DIFF
--- a/customer-app/assets/customer-app.css
+++ b/customer-app/assets/customer-app.css
@@ -970,7 +970,7 @@ p { margin: 0; }
 .tracking-code-pill::before { content: "#"; opacity: 0.7; }
 .tracking-view-tabs {
   display: grid;
-  grid-template-columns: repeat(4, minmax(0, 1fr));
+  grid-template-columns: repeat(3, minmax(0, 1fr));
   gap: 8px;
   padding: 8px;
   border: 1px solid rgba(11, 75, 179, 0.12);
@@ -1041,6 +1041,30 @@ p { margin: 0; }
   display: flex;
   flex-direction: column;
   gap: 12px;
+}
+.tracking-quick-grid {
+  display: grid;
+  gap: 10px;
+}
+.tracking-quick-grid div {
+  display: grid;
+  gap: 5px;
+  padding: 13px;
+  border: 1px solid rgba(11, 75, 179, 0.1);
+  border-radius: 17px;
+  background: linear-gradient(180deg, #ffffff 0%, #f8fbff 100%);
+}
+.tracking-quick-grid span {
+  color: #0b4bb3;
+  font-size: 11px;
+  font-weight: 950;
+  text-transform: uppercase;
+}
+.tracking-quick-grid strong {
+  color: var(--ink);
+  font-size: 14px;
+  font-weight: 900;
+  line-height: 1.45;
 }
 .tracking-summary-list {
   overflow: hidden;

--- a/customer-app/assets/customer-app.css
+++ b/customer-app/assets/customer-app.css
@@ -968,6 +968,98 @@ p { margin: 0; }
   box-shadow: 0 12px 24px -12px rgba(22, 89, 224, 0.8);
 }
 .tracking-code-pill::before { content: "#"; opacity: 0.7; }
+.tracking-view-tabs {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 8px;
+  padding: 8px;
+  border: 1px solid rgba(11, 75, 179, 0.12);
+  border-radius: 18px;
+  background: linear-gradient(180deg, #f8fbff, #eef6ff);
+  box-shadow: inset 0 1px 0 rgba(255,255,255,0.9);
+}
+.tracking-view-tab {
+  display: grid;
+  place-items: center;
+  align-content: center;
+  gap: 2px;
+  min-height: 56px;
+  padding: 8px 6px;
+  border-radius: 13px;
+  color: #0a2a57;
+  background: transparent;
+  border: 1px solid transparent;
+  text-align: center;
+  transition: background 0.18s ease, border-color 0.18s ease, color 0.18s ease, transform 0.12s ease, box-shadow 0.18s ease;
+}
+.tracking-view-tab span {
+  display: block;
+  max-width: 100%;
+  font-size: 12.5px;
+  font-weight: 950;
+  line-height: 1.15;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.tracking-view-tab small {
+  display: block;
+  max-width: 100%;
+  color: var(--muted);
+  font-size: 10px;
+  font-weight: 800;
+  line-height: 1.15;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.tracking-view-tab.is-active {
+  color: #fff;
+  border-color: rgba(255,255,255,0.24);
+  background: linear-gradient(135deg, #06182f 0%, #0b4bb3 58%, #19b36b 100%);
+  box-shadow: 0 14px 26px -16px rgba(6, 24, 47, 0.72);
+  transform: translateY(-1px);
+}
+.tracking-view-tab.is-active small { color: rgba(255,255,255,0.76); }
+.tracking-view-stack {
+  display: grid;
+  gap: 12px;
+}
+.tracking-view-panel {
+  display: none;
+  min-width: 0;
+}
+.tracking-view-panel.is-active {
+  display: block;
+  animation: tracking-panel-in 0.28s ease both;
+}
+@keyframes tracking-panel-in {
+  from { opacity: 0; transform: translateY(8px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+.tracking-premium-overview {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+.tracking-summary-list {
+  overflow: hidden;
+  border: 1px solid rgba(11, 75, 179, 0.1);
+  border-radius: 18px;
+  background: #fff;
+}
+.tracking-summary-list .data-row {
+  padding: 12px 14px;
+}
+.tracking-timeline-panel {
+  padding: 15px;
+  border: 1px solid rgba(11, 75, 179, 0.12);
+  border-radius: 20px;
+  background:
+    radial-gradient(120% 90% at 100% 0%, rgba(255, 210, 59, 0.16), transparent 48%),
+    linear-gradient(180deg, #ffffff 0%, #f5f9ff 100%);
+  box-shadow: 0 16px 36px -28px rgba(6, 24, 47, 0.45);
+}
 .tracking-extra-card {
   display: flex;
   flex-direction: column;
@@ -1529,6 +1621,12 @@ p { margin: 0; }
   }
   .passport-unit-photos {
     grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+  .tracking-view-tabs {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+  .tracking-view-tab {
+    min-height: 52px;
   }
 }
 .receipt-card {

--- a/customer-app/modules/tracking.js
+++ b/customer-app/modules/tracking.js
@@ -547,45 +547,42 @@
     return current ? "current" : "pending";
   }
 
-  function statusCopy(data, mode) {
-    const status = clean(data.job_status);
-    const assigned = hasAssignedTech(data);
-    const done = isDone(data);
-    const traveling = clean(data.travel_started_at);
-    const started = clean(data.started_at) || clean(data.checkin_at);
-    const noTech = status.includes("ไม่พบช่าง") || status.includes("ตีกลับ");
-
-    if (mode === "urgent") {
-      if (done) return "งานเสร็จแล้ว";
-      if (started) return "กำลังให้บริการ";
-      if (traveling) return "ช่างกำลังเดินทาง";
-      if (assigned) return "ช่างรับงานแล้ว";
-      if (noTech) return "แอดมินกำลังช่วยตรวจสอบคิวด่วน";
-      return "ส่งคำขอคิวด่วนแล้ว กำลังรอช่างพาร์ทเนอร์กดรับงาน ยังไม่ถือว่ายืนยันงานจนกว่าจะมีช่างรับหรือแอดมินยืนยัน";
-    }
-
-    if (done) return "งานเสร็จแล้ว";
-    if (started) return "กำลังให้บริการ";
-    if (traveling) return "ช่างกำลังเดินทาง";
-    if (assigned || status.includes("รอดำเนินการ")) return "ยืนยันคิวแล้ว";
-    return "รับคำขอจองแล้ว รอแอดมินตรวจสอบคิว";
+  function hasPhotoContent(data) {
+    return photoList(data).length > 0 || !!clean(data.technician_note);
   }
 
   function jobPhase(data, mode) {
     const status = clean(data.job_status);
     const noTech = status.includes("ไม่พบช่าง") || status.includes("ตีกลับ");
     if (isDone(data)) return "completed";
+    if (mode === "urgent" && noTech) return "urgent_no_tech";
     if (clean(data.started_at)) return "started";
     if (clean(data.checkin_at)) return "checked_in";
     if (clean(data.travel_started_at)) return "traveling";
     if (hasAssignedTech(data) || status.includes("รอดำเนินการ")) return "assigned";
-    if (mode === "urgent" && noTech) return "urgent_no_tech";
     return mode === "urgent" ? "urgent_waiting" : "waiting";
+  }
+
+  function statusCopy(data, mode) {
+    const phase = jobPhase(data, mode);
+    if (phase === "completed") return "งานเสร็จแล้ว";
+    if (phase === "started") return "กำลังให้บริการ";
+    if (phase === "checked_in") return "ช่างถึงหน้างานแล้ว";
+    if (phase === "traveling") return "ช่างกำลังเดินทาง";
+    if (phase === "assigned") return mode === "urgent" ? "ช่างรับงานแล้ว" : "ยืนยันคิวแล้ว";
+    if (phase === "urgent_no_tech") return "แอดมินกำลังช่วยตรวจสอบคิวด่วน";
+    if (phase === "urgent_waiting") return "ส่งคำขอคิวด่วนแล้ว รอช่างรับงานหรือแอดมินยืนยัน";
+    return "รับคำขอจองแล้ว รอแอดมินตรวจสอบคิว";
   }
 
   function statusDetailCopy(data, mode) {
     const phase = jobPhase(data, mode);
-    if (phase === "completed") return "งานบริการเสร็จสิ้นแล้ว สามารถดูรูปงาน เอกสาร และการรับประกันได้";
+    const hasPhotos = hasPhotoContent(data);
+    if (phase === "completed") {
+      return hasPhotos
+        ? "งานบริการเสร็จสิ้นแล้ว สามารถดูรูปงาน เอกสาร การรับประกัน และรีวิวได้"
+        : "งานบริการเสร็จสิ้นแล้ว สามารถดูเอกสาร การรับประกัน และการให้คะแนนได้";
+    }
     if (phase === "started") return "ทีมช่างกำลังให้บริการ";
     if (phase === "checked_in") return "ทีมช่างถึงหน้างานแล้ว";
     if (phase === "traveling") return "ช่างกำลังเดินทางไปยังสถานที่นัดหมาย";
@@ -597,8 +594,13 @@
 
   function nextActionCopy(data, mode) {
     const phase = jobPhase(data, mode);
-    if (phase === "completed") return "ดูรูปงาน เอกสาร การรับประกัน หรือให้คะแนนงานนี้";
-    if (phase === "started") return "รอทีมช่างทำงานให้เสร็จ หลังจบงานจะเห็นรูปและเอกสาร";
+    const hasPhotos = hasPhotoContent(data);
+    if (phase === "completed") {
+      return hasPhotos
+        ? "ดูรูปงาน เอกสาร การรับประกัน และรีวิวงานนี้"
+        : "ดูเอกสาร การรับประกัน และให้คะแนนงานนี้";
+    }
+    if (phase === "started") return "รอทีมช่างทำงานให้เสร็จ หลังจบงานจะเห็นเอกสารหลังบริการ";
     if (phase === "checked_in") return "เตรียมพื้นที่หน้างานให้พร้อมสำหรับเริ่มบริการ";
     if (phase === "traveling") return "รอรับทีมช่างที่กำลังเดินทางไปหน้างาน";
     if (phase === "assigned") return "รอถึงเวลานัด หรือเปิดแผนที่หากต้องการดูสถานที่งาน";
@@ -1002,7 +1004,7 @@
       });
     }
 
-    if (done && (photos.length || clean(data.technician_note))) {
+    if (done && hasPhotoContent(data)) {
       views.push({
         id: "photos",
         label: "รูปงาน",

--- a/customer-app/modules/tracking.js
+++ b/customer-app/modules/tracking.js
@@ -852,6 +852,41 @@
     `;
   }
 
+  function renderTrackingViewButton(id, label, meta, active) {
+    return `
+      <button
+        class="tracking-view-tab ${active ? "is-active" : ""}"
+        type="button"
+        data-tracking-view="${esc(id)}"
+        aria-selected="${active ? "true" : "false"}">
+        <span>${esc(label)}</span>
+        <small>${esc(meta)}</small>
+      </button>
+    `;
+  }
+
+  function renderTrackingPanel(id, content, active) {
+    return `
+      <section
+        class="tracking-view-panel ${active ? "is-active" : ""}"
+        data-tracking-panel="${esc(id)}"
+        ${active ? "" : "hidden"}>
+        ${content}
+      </section>
+    `;
+  }
+
+  function renderAftercare(data) {
+    const content = [
+      renderTechnicianNote(data),
+      renderPhotos(data),
+      renderReceipt(data),
+      renderReview(data),
+      renderWarranty(data),
+    ].filter(Boolean).join("");
+    return content || root.utils.stateBox("", "รายละเอียดหลังบริการจะแสดงหลังงานเสร็จ");
+  }
+
   function renderTrackingResult() {
     const state = root.state.tracking;
     if (state.status === "idle") return root.utils.stateBox("", "กรอกเลขงานหรือรหัสติดตามเพื่อดูสถานะจากระบบ");
@@ -863,17 +898,16 @@
     const photos = photoList(data);
     const maps = mapUrl(data);
     const trackingKey = data.booking_token || data.booking_code || "";
-    return `
-      <div class="tracking-result-card">
-        <div class="tracking-topline">
-          <span class="mode-badge is-${mode}">${mode === "urgent" ? "คิวด่วน" : "จองล่วงหน้า"}</span>
-          <div class="tracking-code-pill">${esc(data.booking_code || "ไม่พบเลขงาน")}</div>
-        </div>
+    const done = isDone(data);
+    const units = unitList(data);
+    const activeView = "overview";
+    const overview = `
+      <div class="tracking-premium-overview">
         <div class="status-hero is-${mode}">
           <strong>${esc(statusCopy(data, mode))}</strong>
           <span>${mode === "urgent" ? "คิวด่วนจะยืนยันเมื่อมีช่างรับงานหรือแอดมินยืนยันเท่านั้น" : "แอดมินจะตรวจสอบคิวและมอบหมายทีมก่อนถึงเวลานัด"}</span>
         </div>
-        <div class="data-list">
+        <div class="data-list tracking-summary-list">
           <div class="data-row"><strong>รหัสติดตาม</strong><span class="muted">${esc(trackingKey || "-")}</span></div>
           <div class="data-row"><strong>นัดหมาย</strong><span class="muted">${root.utils.formatDateTime(data.appointment_datetime)}</span></div>
           <div class="data-row"><strong>บริการ</strong><span class="muted">${esc(serviceSummary(data))}</span></div>
@@ -893,12 +927,27 @@
           ${mode === "urgent" && !hasAssignedTech(data) ? `<button class="secondary-btn" type="button" data-route="scheduled">เปลี่ยนเป็นจองล่วงหน้า</button>` : ""}
         </div>
         <p class="muted support-note">ต้องการแก้ไขเวลา เลื่อนนัด หรือยกเลิกงาน กรุณาติดต่อแอดมิน CWF</p>
-        ${renderPassport(data)}
-        ${renderTechnicianNote(data)}
-        ${renderPhotos(data)}
-        ${renderReceipt(data)}
-        ${renderReview(data)}
-        ${renderWarranty(data)}
+      </div>
+    `;
+
+    return `
+      <div class="tracking-result-card">
+        <div class="tracking-topline">
+          <span class="mode-badge is-${mode}">${mode === "urgent" ? "คิวด่วน" : "จองล่วงหน้า"}</span>
+          <div class="tracking-code-pill">${esc(data.booking_code || "ไม่พบเลขงาน")}</div>
+        </div>
+        <div class="tracking-view-tabs" role="tablist" aria-label="Tracking views">
+          ${renderTrackingViewButton("overview", "สถานะ", mode === "urgent" ? "คิวด่วน" : "จองล่วงหน้า", activeView === "overview")}
+          ${renderTrackingViewButton("timeline", "ไทม์ไลน์", done ? "เสร็จแล้ว" : "Live steps", activeView === "timeline")}
+          ${renderTrackingViewButton("passport", "Passport", units.length ? `${units.length} เครื่อง` : "AC health", activeView === "passport")}
+          ${renderTrackingViewButton("aftercare", "หลังบริการ", done ? `${photos.length} รูป` : "หลังจบงาน", activeView === "aftercare")}
+        </div>
+        <div class="tracking-view-stack">
+          ${renderTrackingPanel("overview", overview, activeView === "overview")}
+          ${renderTrackingPanel("timeline", `<div class="tracking-timeline-panel">${renderTimeline()}</div>`, activeView === "timeline")}
+          ${renderTrackingPanel("passport", renderPassport(data), activeView === "passport")}
+          ${renderTrackingPanel("aftercare", renderAftercare(data), activeView === "aftercare")}
+        </div>
       </div>
     `;
   }
@@ -963,6 +1012,24 @@
     if (result && !result.dataset.unitTabsBound) {
       result.dataset.unitTabsBound = "1";
       result.addEventListener("click", (event) => {
+        const viewTab = event.target.closest("[data-tracking-view]");
+        if (viewTab) {
+          const id = viewTab.getAttribute("data-tracking-view");
+          const resultCard = viewTab.closest(".tracking-result-card");
+          if (!resultCard) return;
+          resultCard.querySelectorAll("[data-tracking-view]").forEach((btn) => {
+            const active = btn.getAttribute("data-tracking-view") === id;
+            btn.classList.toggle("is-active", active);
+            btn.setAttribute("aria-selected", active ? "true" : "false");
+          });
+          resultCard.querySelectorAll("[data-tracking-panel]").forEach((panel) => {
+            const active = panel.getAttribute("data-tracking-panel") === id;
+            panel.classList.toggle("is-active", active);
+            panel.hidden = !active;
+          });
+          return;
+        }
+
         const tab = event.target.closest("[data-unit-tab]");
         if (!tab) return;
         const shell = tab.closest(".passport-units-card");
@@ -1038,13 +1105,6 @@
               <h2>ผลการติดตาม</h2>
             </div>
             <div data-tracking-result>${renderTrackingResult()}</div>
-          </section>
-          <section class="card">
-            <div class="section-head">
-              <span class="section-kicker">Timeline</span>
-              <h2>ขั้นตอนถัดไป</h2>
-            </div>
-            <div data-tracking-timeline>${root.state.tracking.data ? renderTimeline() : root.utils.stateBox("", "ระบบจะแสดงขั้นตอนตามประเภทงานหลังค้นหา")}</div>
           </section>
         </section>
       `;

--- a/customer-app/modules/tracking.js
+++ b/customer-app/modules/tracking.js
@@ -571,6 +571,42 @@
     return "รับคำขอจองแล้ว รอแอดมินตรวจสอบคิว";
   }
 
+  function jobPhase(data, mode) {
+    const status = clean(data.job_status);
+    const noTech = status.includes("ไม่พบช่าง") || status.includes("ตีกลับ");
+    if (isDone(data)) return "completed";
+    if (clean(data.started_at)) return "started";
+    if (clean(data.checkin_at)) return "checked_in";
+    if (clean(data.travel_started_at)) return "traveling";
+    if (hasAssignedTech(data) || status.includes("รอดำเนินการ")) return "assigned";
+    if (mode === "urgent" && noTech) return "urgent_no_tech";
+    return mode === "urgent" ? "urgent_waiting" : "waiting";
+  }
+
+  function statusDetailCopy(data, mode) {
+    const phase = jobPhase(data, mode);
+    if (phase === "completed") return "งานบริการเสร็จสิ้นแล้ว สามารถดูรูปงาน เอกสาร และการรับประกันได้";
+    if (phase === "started") return "ทีมช่างกำลังให้บริการ";
+    if (phase === "checked_in") return "ทีมช่างถึงหน้างานแล้ว";
+    if (phase === "traveling") return "ช่างกำลังเดินทางไปยังสถานที่นัดหมาย";
+    if (phase === "assigned") return "มีทีมช่างรับผิดชอบงานนี้แล้ว";
+    if (phase === "urgent_no_tech") return "แอดมินกำลังช่วยตรวจสอบคิวด่วน คำขอยังไม่ถือว่ายืนยันงาน";
+    if (phase === "urgent_waiting") return "กำลังรอช่างรับงานหรือแอดมินยืนยัน คำขอยังไม่ถือว่ายืนยันงาน";
+    return "แอดมินจะตรวจสอบคิวและมอบหมายทีมก่อนถึงเวลานัด";
+  }
+
+  function nextActionCopy(data, mode) {
+    const phase = jobPhase(data, mode);
+    if (phase === "completed") return "ดูรูปงาน เอกสาร การรับประกัน หรือให้คะแนนงานนี้";
+    if (phase === "started") return "รอทีมช่างทำงานให้เสร็จ หลังจบงานจะเห็นรูปและเอกสาร";
+    if (phase === "checked_in") return "เตรียมพื้นที่หน้างานให้พร้อมสำหรับเริ่มบริการ";
+    if (phase === "traveling") return "รอรับทีมช่างที่กำลังเดินทางไปหน้างาน";
+    if (phase === "assigned") return "รอถึงเวลานัด หรือเปิดแผนที่หากต้องการดูสถานที่งาน";
+    if (phase === "urgent_no_tech") return "รอแอดมินช่วยตรวจสอบ หรือเปลี่ยนเป็นจองล่วงหน้าถ้าไม่รีบด่วน";
+    if (phase === "urgent_waiting") return "รอช่างรับงาน หรือให้แอดมินช่วยยืนยันคิวด่วน";
+    return "รอแอดมินยืนยันคิว หรือติดต่อ CWF หากต้องการเลื่อนนัด";
+  }
+
   function renderPassport(data) {
     const done = isDone(data);
     const date = serviceDate(data);
@@ -603,8 +639,8 @@
     return `
       <section class="passport-shell">
         <div class="passport-hero">
-          <span class="passport-kicker">AC Health Passport</span>
-          <h2>CWF AC Health Passport</h2>
+          <span class="passport-kicker">สุขภาพแอร์</span>
+          <h2>รายงานสุขภาพแอร์ CWF</h2>
           <p>สมุดสุขภาพแอร์จากงานบริการ Coldwindflow</p>
         </div>
         <div class="passport-grid">
@@ -615,7 +651,7 @@
             </div>
             <p class="passport-lead">รายงานสุขภาพแอร์จากงานบริการล่าสุด</p>
             <div class="passport-data">
-              <div><b>Booking</b><span>${esc(data.booking_code || "-")}</span></div>
+              <div><b>ข้อมูลงาน</b><span>${esc(data.booking_code || "-")}</span></div>
               <div><b>สถานะ</b><span>${esc(data.job_status || "-")}</span></div>
               <div><b>บริการ</b><span>${esc(serviceSummary(data))}</span></div>
               <div><b>วันที่บริการ</b><span>${esc(serviceDateText)}</span></div>
@@ -907,18 +943,12 @@
     const trackingKey = data.booking_token || data.booking_code || "";
     const done = isDone(data);
     const units = unitList(data);
-    const activeView = "overview";
     const appointmentText = data.appointment_datetime ? root.utils.formatDateTime(data.appointment_datetime) : "-";
-    const nextAction = mode === "urgent" && !hasAssignedTech(data)
-      ? "รอช่างรับงาน หรือให้แอดมินช่วยยืนยันคิวด่วน"
-      : done
-        ? "ตรวจเอกสารหลังบริการ รูปงาน หรือให้คะแนนงานนี้"
-        : "ติดตามสถานะล่าสุด หรือโทร/LINE หา CWF หากต้องการเลื่อนนัด";
     const overview = `
       <div class="tracking-premium-overview">
         <div class="status-hero is-${mode}">
           <strong>${esc(statusCopy(data, mode))}</strong>
-          <span>${mode === "urgent" ? "คิวด่วนจะยืนยันเมื่อมีช่างรับงานหรือแอดมินยืนยันเท่านั้น" : "แอดมินจะตรวจสอบคิวและมอบหมายทีมก่อนถึงเวลานัด"}</span>
+          <span>${esc(statusDetailCopy(data, mode))}</span>
         </div>
         <div class="tracking-quick-grid">
           <div>
@@ -927,7 +957,7 @@
           </div>
           <div>
             <span>ขั้นตอนถัดไป</span>
-            <strong>${esc(nextAction)}</strong>
+            <strong>${esc(nextActionCopy(data, mode))}</strong>
           </div>
         </div>
         ${renderTechnicianCard(data)}
@@ -942,6 +972,56 @@
       </div>
     `;
 
+    const views = [
+      {
+        id: "overview",
+        label: "สถานะ",
+        meta: mode === "urgent" ? "คิวด่วน" : "จองล่วงหน้า",
+        content: overview,
+      },
+      {
+        id: "details",
+        label: "รายละเอียด",
+        meta: "ข้อมูลงาน",
+        content: renderJobDetails(data, photos, maps, trackingKey),
+      },
+      {
+        id: "timeline",
+        label: "ไทม์ไลน์",
+        meta: done ? "เสร็จแล้ว" : "ขั้นตอนงาน",
+        content: `<div class="tracking-timeline-panel">${renderTimeline()}</div>`,
+      },
+    ];
+
+    if (done || units.length) {
+      views.push({
+        id: "passport",
+        label: "สุขภาพแอร์",
+        meta: units.length ? `${units.length} เครื่อง` : "สุขภาพแอร์",
+        content: renderPassport(data),
+      });
+    }
+
+    if (done && (photos.length || clean(data.technician_note))) {
+      views.push({
+        id: "photos",
+        label: "รูปงาน",
+        meta: photos.length ? `${photos.length} รูป` : "หมายเหตุช่าง",
+        content: renderPhotoView(data),
+      });
+    }
+
+    if (done) {
+      views.push({
+        id: "aftercare",
+        label: "เอกสาร",
+        meta: "รีวิว/ประกัน",
+        content: renderAftercare(data),
+      });
+    }
+
+    const activeView = views[0].id;
+
     return `
       <div class="tracking-result-card">
         <div class="tracking-topline">
@@ -949,20 +1029,10 @@
           <div class="tracking-code-pill">${esc(data.booking_code || "ไม่พบเลขงาน")}</div>
         </div>
         <div class="tracking-view-tabs" role="tablist" aria-label="Tracking views">
-          ${renderTrackingViewButton("overview", "สถานะ", mode === "urgent" ? "คิวด่วน" : "จองล่วงหน้า", activeView === "overview")}
-          ${renderTrackingViewButton("details", "รายละเอียด", data.job_zone || data.duration_min ? "ข้อมูลงาน" : "Booking", activeView === "details")}
-          ${renderTrackingViewButton("timeline", "ไทม์ไลน์", done ? "เสร็จแล้ว" : "Live steps", activeView === "timeline")}
-          ${renderTrackingViewButton("passport", "Passport", units.length ? `${units.length} เครื่อง` : "AC health", activeView === "passport")}
-          ${renderTrackingViewButton("photos", "รูปงาน", done ? `${photos.length} รูป` : "หลังจบงาน", activeView === "photos")}
-          ${renderTrackingViewButton("aftercare", "เอกสาร", done ? "รีวิว/ประกัน" : "หลังบริการ", activeView === "aftercare")}
+          ${views.map((view) => renderTrackingViewButton(view.id, view.label, view.meta, view.id === activeView)).join("")}
         </div>
         <div class="tracking-view-stack">
-          ${renderTrackingPanel("overview", overview, activeView === "overview")}
-          ${renderTrackingPanel("details", renderJobDetails(data, photos, maps, trackingKey), activeView === "details")}
-          ${renderTrackingPanel("timeline", `<div class="tracking-timeline-panel">${renderTimeline()}</div>`, activeView === "timeline")}
-          ${renderTrackingPanel("passport", renderPassport(data), activeView === "passport")}
-          ${renderTrackingPanel("photos", renderPhotoView(data), activeView === "photos")}
-          ${renderTrackingPanel("aftercare", renderAftercare(data), activeView === "aftercare")}
+          ${views.map((view) => renderTrackingPanel(view.id, view.content, view.id === activeView)).join("")}
         </div>
       </div>
     `;

--- a/customer-app/modules/tracking.js
+++ b/customer-app/modules/tracking.js
@@ -582,11 +582,8 @@
     const drainAlertMonths = hasDrainRisk(data) ? 4 : 6;
     const drainScore = done ? healthScore(months, drainAlertMonths) : null;
     const warranty = warrantyInfo(data, completedAt);
-    const photos = photoList(data);
     const units = unitList(data);
     const unitMeasurementPhotos = units.reduce((sum, unit) => sum + phaseCount(unit.photos || [], "pressure") + phaseCount(unit.photos || [], "current") + phaseCount(unit.photos || [], "temp"), 0);
-    const beforeCount = phaseCount(photos, "before");
-    const afterCount = phaseCount(photos, "after");
     const next = recommendation(data, coilScore, drainScore, profile, done);
     const completionText = done ? "งานเสร็จสิ้นแล้ว" : "รอข้อมูลงานเสร็จสิ้น";
     const serviceDateText = date ? root.utils.formatDateTime(date.toISOString()) : "-";
@@ -701,15 +698,6 @@
 
           ${renderUnitPassportCards(data, units, { coilScore, drainScore, drainRisk: hasDrainRisk(data), healthEstimateText, drainEstimateText })}
 
-          <article class="passport-card passport-photo-card">
-            <div class="passport-card-head">
-              <span>${units.length ? "Photo Summary" : "Job Photos"}</span>
-              <strong>${photos.length} รูป</strong>
-            </div>
-            <h3>${units.length ? "มีข้อมูลแยกรายเครื่องใน Passport" : "รูปงานรวมของใบงานนี้"}</h3>
-            <p>ก่อนทำ ${beforeCount} รูป · หลังทำ ${afterCount} รูป · รวม ${photos.length} รูป</p>
-            <small>${units.length ? "รูปเต็มของใบงานยังแสดงในส่วนรูปงานเดิมด้านล่าง" : "ยังไม่มีข้อมูลแยกรายเครื่องในระบบ จึงไม่แสดงเป็นรูปประจำเครื่อง"}</small>
-          </article>
         </div>
       </section>
     `;
@@ -878,13 +866,32 @@
 
   function renderAftercare(data) {
     const content = [
-      renderTechnicianNote(data),
-      renderPhotos(data),
       renderReceipt(data),
       renderReview(data),
       renderWarranty(data),
     ].filter(Boolean).join("");
     return content || root.utils.stateBox("", "รายละเอียดหลังบริการจะแสดงหลังงานเสร็จ");
+  }
+
+  function renderJobDetails(data, photos, maps, trackingKey) {
+    return `
+      <div class="data-list tracking-summary-list">
+        <div class="data-row"><strong>รหัสติดตาม</strong><span class="muted">${esc(trackingKey || "-")}</span></div>
+        <div class="data-row"><strong>นัดหมาย</strong><span class="muted">${root.utils.formatDateTime(data.appointment_datetime)}</span></div>
+        <div class="data-row"><strong>บริการ</strong><span class="muted">${esc(serviceSummary(data))}</span></div>
+        <div class="data-row"><strong>ราคาโดยประมาณ</strong><span class="muted">${esc(money(data.job_price || data.base_total))}</span></div>
+        <div class="data-row"><strong>ระยะเวลา</strong><span class="muted">${data.duration_min ? `${Number(data.duration_min)} นาที` : "-"}</span></div>
+        <div class="data-row"><strong>ที่อยู่</strong><span class="muted">${esc(data.address_text || "-")}</span></div>
+        ${data.job_zone ? `<div class="data-row"><strong>พื้นที่</strong><span class="muted">${esc(data.job_zone)}</span></div>` : ""}
+        ${maps ? `<div class="data-row"><strong>แผนที่</strong><span><a class="mini-link" href="${esc(maps)}" target="_blank" rel="noopener">นำทางไปหน้างาน</a></span></div>` : ""}
+        <div class="data-row"><strong>หลังจบงาน</strong><span class="muted">รูปงาน ${photos.length} รายการ ${data.receipt_url ? "และมีเอกสารหลังบริการ" : ""}</span></div>
+      </div>
+    `;
+  }
+
+  function renderPhotoView(data) {
+    const content = [renderPhotos(data), renderTechnicianNote(data)].filter(Boolean).join("");
+    return content || root.utils.stateBox("", "รูปงานจะแสดงหลังช่างอัปโหลดและงานเสร็จ");
   }
 
   function renderTrackingResult() {
@@ -901,22 +908,27 @@
     const done = isDone(data);
     const units = unitList(data);
     const activeView = "overview";
+    const appointmentText = data.appointment_datetime ? root.utils.formatDateTime(data.appointment_datetime) : "-";
+    const nextAction = mode === "urgent" && !hasAssignedTech(data)
+      ? "รอช่างรับงาน หรือให้แอดมินช่วยยืนยันคิวด่วน"
+      : done
+        ? "ตรวจเอกสารหลังบริการ รูปงาน หรือให้คะแนนงานนี้"
+        : "ติดตามสถานะล่าสุด หรือโทร/LINE หา CWF หากต้องการเลื่อนนัด";
     const overview = `
       <div class="tracking-premium-overview">
         <div class="status-hero is-${mode}">
           <strong>${esc(statusCopy(data, mode))}</strong>
           <span>${mode === "urgent" ? "คิวด่วนจะยืนยันเมื่อมีช่างรับงานหรือแอดมินยืนยันเท่านั้น" : "แอดมินจะตรวจสอบคิวและมอบหมายทีมก่อนถึงเวลานัด"}</span>
         </div>
-        <div class="data-list tracking-summary-list">
-          <div class="data-row"><strong>รหัสติดตาม</strong><span class="muted">${esc(trackingKey || "-")}</span></div>
-          <div class="data-row"><strong>นัดหมาย</strong><span class="muted">${root.utils.formatDateTime(data.appointment_datetime)}</span></div>
-          <div class="data-row"><strong>บริการ</strong><span class="muted">${esc(serviceSummary(data))}</span></div>
-          <div class="data-row"><strong>ราคาโดยประมาณ</strong><span class="muted">${esc(money(data.job_price || data.base_total))}</span></div>
-          <div class="data-row"><strong>ระยะเวลา</strong><span class="muted">${data.duration_min ? `${Number(data.duration_min)} นาที` : "-"}</span></div>
-          <div class="data-row"><strong>ที่อยู่</strong><span class="muted">${esc(data.address_text || "-")}</span></div>
-          ${data.job_zone ? `<div class="data-row"><strong>พื้นที่</strong><span class="muted">${esc(data.job_zone)}</span></div>` : ""}
-          ${maps ? `<div class="data-row"><strong>แผนที่</strong><span><a class="mini-link" href="${esc(maps)}" target="_blank" rel="noopener">นำทางไปหน้างาน</a></span></div>` : ""}
-          <div class="data-row"><strong>หลังจบงาน</strong><span class="muted">รูปงาน ${photos.length} รายการ ${data.receipt_url ? "และมีเอกสารหลังบริการ" : ""}</span></div>
+        <div class="tracking-quick-grid">
+          <div>
+            <span>นัดหมาย</span>
+            <strong>${esc(appointmentText)}</strong>
+          </div>
+          <div>
+            <span>ขั้นตอนถัดไป</span>
+            <strong>${esc(nextAction)}</strong>
+          </div>
         </div>
         ${renderTechnicianCard(data)}
         <div class="support-strip">
@@ -938,14 +950,18 @@
         </div>
         <div class="tracking-view-tabs" role="tablist" aria-label="Tracking views">
           ${renderTrackingViewButton("overview", "สถานะ", mode === "urgent" ? "คิวด่วน" : "จองล่วงหน้า", activeView === "overview")}
+          ${renderTrackingViewButton("details", "รายละเอียด", data.job_zone || data.duration_min ? "ข้อมูลงาน" : "Booking", activeView === "details")}
           ${renderTrackingViewButton("timeline", "ไทม์ไลน์", done ? "เสร็จแล้ว" : "Live steps", activeView === "timeline")}
           ${renderTrackingViewButton("passport", "Passport", units.length ? `${units.length} เครื่อง` : "AC health", activeView === "passport")}
-          ${renderTrackingViewButton("aftercare", "หลังบริการ", done ? `${photos.length} รูป` : "หลังจบงาน", activeView === "aftercare")}
+          ${renderTrackingViewButton("photos", "รูปงาน", done ? `${photos.length} รูป` : "หลังจบงาน", activeView === "photos")}
+          ${renderTrackingViewButton("aftercare", "เอกสาร", done ? "รีวิว/ประกัน" : "หลังบริการ", activeView === "aftercare")}
         </div>
         <div class="tracking-view-stack">
           ${renderTrackingPanel("overview", overview, activeView === "overview")}
+          ${renderTrackingPanel("details", renderJobDetails(data, photos, maps, trackingKey), activeView === "details")}
           ${renderTrackingPanel("timeline", `<div class="tracking-timeline-panel">${renderTimeline()}</div>`, activeView === "timeline")}
           ${renderTrackingPanel("passport", renderPassport(data), activeView === "passport")}
+          ${renderTrackingPanel("photos", renderPhotoView(data), activeView === "photos")}
           ${renderTrackingPanel("aftercare", renderAftercare(data), activeView === "aftercare")}
         </div>
       </div>


### PR DESCRIPTION
## Summary
- Split Customer App tracking results into separate premium views: Status, Details, Timeline, AC Health, Photos, and Aftercare.
- Kept the primary tracking screen focused on current status, appointment, next action, technician availability, and support actions.
- Made `jobPhase()` the single source of truth for the main status title, status detail, and next action copy.
- Ensured checked-in jobs no longer display started-work copy, and urgent no-tech/failure wording takes precedence over stale assignment indicators.
- Built secondary navigation from one applicable `views` array so tabs and panels stay matched and empty views are not rendered.
- Aligned completed copy with the Photos tab condition: photo wording appears only when job photos or technician note exist.
- Preserved per-machine health tabs and removed the duplicate Passport photo-summary card so Photos has one clear home.

## Validation
- `node --check customer-app/modules/tracking.js`
- Targeted VM render checks confirmed checked-in, started, urgent no-tech with stale assignment, completed without photos, and completed with photos scenarios
- `git diff --check`
- `git diff --name-only`
- `git diff --stat`

## Notes
- In-app browser visual QA was attempted through the local mock server, but local URLs were blocked by the browser runtime with `ERR_BLOCKED_BY_CLIENT`; validation fell back to syntax and rendered-markup checks.