### PR TITLE
Redesign AC Health Passport into Flat Premium Mobile Report

### DIFF
--- a/customer-app/assets/customer-app.css
+++ b/customer-app/assets/customer-app.css
@@ -1303,124 +1303,191 @@ p { margin: 0; }
 }
 .passport-units-card {
   grid-column: 1 / -1;
-  border-color: rgba(11, 75, 179, 0.14);
-  background: linear-gradient(180deg, #ffffff 0%, #f3f8ff 100%);
+  min-width: 0;
+  padding: 4px 0 0;
+}
+.passport-units-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 10px;
+  margin-bottom: 8px;
+}
+.passport-units-head span {
+  color: var(--muted);
+  font-size: 11px;
+  font-weight: 900;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+.passport-units-head strong {
+  color: #0a2a57;
+  font-size: 14px;
+  font-weight: 950;
+  text-align: right;
+}
+.passport-units-card h3 {
+  margin: 0 0 5px;
+  color: var(--ink);
+  font-size: 18px;
+  line-height: 1.2;
+}
+.passport-units-card > p {
+  margin: 0;
+  color: var(--muted);
+  font-weight: 750;
+  line-height: 1.5;
 }
 .passport-unit-tabs {
   display: flex;
-  gap: 9px;
-  margin: 14px -2px 14px;
-  padding: 2px 2px 10px;
+  gap: 18px;
+  margin: 14px -12px 0;
+  padding: 0 12px;
   overflow-x: auto;
   -webkit-overflow-scrolling: touch;
-  scrollbar-width: thin;
+  border-bottom: 1px solid rgba(11, 75, 179, 0.12);
+  scrollbar-width: none;
+}
+.passport-unit-tabs::-webkit-scrollbar {
+  display: none;
 }
 .passport-unit-tab {
+  position: relative;
   flex: 0 0 auto;
-  max-width: 170px;
-  min-height: 44px;
-  padding: 10px 15px;
-  border: 1px solid rgba(11, 75, 179, 0.12);
-  border-radius: var(--radius-pill);
-  background: linear-gradient(180deg, #ffffff, #f8fbff);
-  color: #0b4bb3;
+  max-width: 150px;
+  min-height: 42px;
+  padding: 9px 0 12px;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  color: var(--muted);
   font-size: 13px;
   font-weight: 950;
   line-height: 1.2;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-  box-shadow: 0 8px 18px rgba(12, 50, 110, 0.07);
+  box-shadow: none;
 }
 .passport-unit-tab.is-active {
-  background: linear-gradient(135deg, #0b4bb3 0%, #1479d4 48%, #19b36b 100%);
-  color: #fff;
-  border-color: transparent;
-  box-shadow: 0 14px 30px rgba(11, 75, 179, 0.28);
-  transform: translateY(-1px);
+  color: #0b4bb3;
+  box-shadow: inset 0 -3px 0 #0b4bb3;
+  transform: none;
 }
 .passport-unit-pages {
   display: grid;
+  margin-top: 0;
 }
 .passport-unit-page {
   display: none;
   overflow: hidden;
-  border: 1px solid rgba(11, 75, 179, 0.1);
-  border-radius: 20px;
+  border: 1px solid rgba(11, 75, 179, 0.14);
+  border-top: 0;
+  border-radius: 0 0 18px 18px;
   background: #ffffff;
-  box-shadow: 0 16px 34px rgba(12, 50, 110, 0.09);
+  box-shadow: 0 16px 34px -28px rgba(6, 24, 47, 0.5);
 }
 .passport-unit-page.is-active {
   display: block;
 }
 .passport-unit-head {
   display: grid;
-  grid-template-columns: minmax(0, 1fr);
-  gap: 10px;
-  padding: 15px;
-  border-bottom: 1px solid rgba(11, 75, 179, 0.08);
-  background: linear-gradient(135deg, #f8fbff 0%, #fffdf0 100%);
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 12px;
+  align-items: start;
+  padding: 16px 14px 14px;
+  border-bottom: 1px solid rgba(11, 75, 179, 0.1);
+  background: #ffffff;
 }
 .passport-unit-head b {
   display: block;
   color: #0a2a57;
-  font-size: 17px;
+  font-size: 18px;
   font-weight: 950;
   line-height: 1.25;
   overflow-wrap: anywhere;
 }
-.passport-unit-head span {
+.unit-title-block span,
+.unit-title-block small {
   display: block;
+  margin-top: 3px;
   color: var(--muted);
   font-size: 12px;
   font-weight: 800;
   line-height: 1.35;
 }
-.passport-unit-head strong {
-  width: fit-content;
-  max-width: 100%;
-  padding: 8px 11px;
-  border-radius: var(--radius-pill);
-  background: #ecfdf5;
+.unit-score-block {
+  display: grid;
+  gap: 2px;
+  min-width: 74px;
+  text-align: right;
+}
+.unit-score-number {
+  color: #047857;
+  font-size: 27px;
+  font-weight: 950;
+  line-height: 1;
+  letter-spacing: 0;
+}
+.unit-score-label {
   color: #047857;
   font-size: 12px;
   font-weight: 950;
   line-height: 1.3;
 }
-.passport-unit-page.is-watch .passport-unit-head strong { background: #fffbea; color: #9a6500; }
-.passport-unit-page.is-warning .passport-unit-head strong { background: #fff7ed; color: #c2410c; }
-.passport-unit-page.is-critical .passport-unit-head strong { background: #fef2f2; color: #b91c1c; }
-.passport-unit-page.is-unknown .passport-unit-head strong { background: #f1f5f9; color: #475569; }
+.passport-unit-page.is-watch .unit-score-number,
+.passport-unit-page.is-watch .unit-score-label { color: #9a6500; }
+.passport-unit-page.is-warning .unit-score-number,
+.passport-unit-page.is-warning .unit-score-label { color: #c2410c; }
+.passport-unit-page.is-critical .unit-score-number,
+.passport-unit-page.is-critical .unit-score-label { color: #b91c1c; }
+.passport-unit-page.is-unknown .unit-score-number,
+.passport-unit-page.is-unknown .unit-score-label { color: #475569; }
 .passport-unit-dashboard {
   display: grid;
-  gap: 11px;
-  padding: 13px;
+  gap: 0;
+  padding: 0 14px 14px;
 }
-.unit-overall-card {
+.unit-overall-summary {
   display: grid;
-  gap: 9px;
-  padding: 11px;
-  border-radius: 16px;
-  background: linear-gradient(135deg, #eef6ff 0%, #ffffff 68%);
-  border: 1px solid rgba(11, 75, 179, 0.08);
+  gap: 6px;
+  padding: 13px 0;
+  border-bottom: 1px solid rgba(11, 75, 179, 0.1);
+}
+.unit-overall-summary span,
+.unit-overall-summary strong {
+  color: #0b4bb3;
+  font-size: 12px;
+  font-weight: 950;
+  line-height: 1.35;
+}
+.unit-overall-summary strong {
+  color: #c2410c;
+}
+.unit-overall-summary p,
+.unit-overall-summary small {
+  margin: 0;
+  color: var(--muted);
+  font-size: 12px;
+  font-weight: 750;
+  line-height: 1.5;
 }
 .unit-health-grid {
   display: grid;
-  gap: 8px;
+  gap: 0;
 }
 .unit-health-row {
   display: grid;
-  gap: 6px;
-  padding: 10px;
-  border: 1px solid rgba(11, 75, 179, 0.08);
-  border-radius: 15px;
-  background: linear-gradient(180deg, #ffffff, #fafdff);
+  gap: 7px;
+  padding: 13px 0;
+  border-bottom: 1px solid rgba(11, 75, 179, 0.1);
+  background: transparent;
 }
 .unit-health-top {
   display: flex;
   justify-content: space-between;
   gap: 9px;
-  align-items: center;
+  align-items: flex-start;
 }
 .unit-health-title {
   display: inline-flex;
@@ -1440,12 +1507,13 @@ p { margin: 0; }
   background: #19b36b;
   box-shadow: 0 0 0 4px rgba(25, 179, 107, 0.12);
 }
+.unit-health-value,
 .unit-status-pill {
   flex: 0 0 auto;
-  max-width: 54%;
-  padding: 5px 8px;
-  border-radius: var(--radius-pill);
-  background: #ecfdf5;
+  max-width: 46%;
+  padding: 0;
+  border-radius: 0;
+  background: transparent;
   color: #047857;
   font-size: 11px;
   font-weight: 950;
@@ -1474,10 +1542,14 @@ p { margin: 0; }
 .unit-health-row.is-warning .unit-health-title i { background: #f97316; box-shadow: 0 0 0 4px rgba(249, 115, 22, 0.14); }
 .unit-health-row.is-critical .unit-health-title i { background: #dc2626; box-shadow: 0 0 0 4px rgba(220, 38, 38, 0.14); }
 .unit-health-row.is-unknown .unit-health-title i { background: #64748b; box-shadow: 0 0 0 4px rgba(100, 116, 139, 0.12); }
-.unit-health-row.is-watch .unit-status-pill { background: #fffbea; color: #9a6500; }
-.unit-health-row.is-warning .unit-status-pill { background: #fff7ed; color: #c2410c; }
-.unit-health-row.is-critical .unit-status-pill { background: #fef2f2; color: #b91c1c; }
-.unit-health-row.is-unknown .unit-status-pill { background: #f1f5f9; color: #475569; }
+.unit-health-row.is-watch .unit-health-value,
+.unit-health-row.is-watch .unit-status-pill { color: #9a6500; }
+.unit-health-row.is-warning .unit-health-value,
+.unit-health-row.is-warning .unit-status-pill { color: #c2410c; }
+.unit-health-row.is-critical .unit-health-value,
+.unit-health-row.is-critical .unit-status-pill { color: #b91c1c; }
+.unit-health-row.is-unknown .unit-health-value,
+.unit-health-row.is-unknown .unit-status-pill { color: #475569; }
 .unit-health-row p,
 .unit-health-row small {
   margin: 0;
@@ -1514,16 +1586,20 @@ p { margin: 0; }
 }
 .unit-evidence-grid {
   display: grid;
-  gap: 9px;
+  gap: 0;
+  border-bottom: 1px solid rgba(11, 75, 179, 0.1);
 }
 .unit-checklist-box,
 .unit-photo-box {
   display: grid;
   gap: 7px;
-  padding: 10px;
-  border-radius: 15px;
-  background: #f8fbff;
-  border: 1px solid rgba(11, 75, 179, 0.07);
+  padding: 13px 0;
+  border-radius: 0;
+  background: transparent;
+  border: 0;
+}
+.unit-checklist-box + .unit-photo-box {
+  border-top: 1px solid rgba(11, 75, 179, 0.1);
 }
 .unit-checklist-box b,
 .unit-photo-box b {
@@ -1531,19 +1607,33 @@ p { margin: 0; }
   font-size: 12px;
   font-weight: 950;
 }
+.unit-checklist-box p,
+.unit-checklist-box small,
+.unit-photo-box p,
+.passport-unit-dashboard > small {
+  display: block;
+  margin: 0;
+  color: var(--muted);
+  font-size: 12px;
+  font-weight: 750;
+  line-height: 1.5;
+}
+.passport-unit-dashboard > small {
+  padding-top: 13px;
+}
 .passport-unit-stats {
-  display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: 6px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px 12px;
 }
 .passport-unit-stats span {
-  padding: 7px;
-  border-radius: 12px;
-  background: #ffffff;
+  padding: 0;
+  border-radius: 0;
+  background: transparent;
   color: var(--muted);
   font-size: 12px;
   font-weight: 850;
-  text-align: center;
+  text-align: left;
 }
 .passport-unit-stats b {
   color: #0b4bb3;
@@ -1552,7 +1642,8 @@ p { margin: 0; }
 .passport-unit-photos {
   display: grid;
   grid-template-columns: repeat(4, minmax(0, 1fr));
-  gap: 6px;
+  gap: 7px;
+  padding-top: 13px;
 }
 .passport-unit-photos a {
   display: block;
@@ -1571,25 +1662,28 @@ p { margin: 0; }
 .unit-photo-link {
   display: inline-flex;
   align-items: center;
-  justify-content: center;
-  min-height: 44px;
-  width: 100%;
-  padding: 11px 14px;
-  border-radius: 15px;
-  background: linear-gradient(135deg, #0b4bb3 0%, #1479d4 44%, #19b36b 100%);
-  color: #fff;
+  justify-content: flex-start;
+  min-height: 34px;
+  width: fit-content;
+  margin-top: 9px;
+  padding: 0;
+  border-radius: 0;
+  background: transparent;
+  color: #0b4bb3;
   font-size: 13px;
   font-weight: 950;
-  text-decoration: none;
-  box-shadow: 0 14px 28px rgba(11, 75, 179, 0.22);
+  text-decoration: underline;
+  text-underline-offset: 4px;
+  box-shadow: none;
 }
 .unit-photo-link:hover {
-  filter: brightness(1.04);
-  transform: translateY(-1px);
+  filter: none;
+  color: #0a2a57;
+  transform: none;
 }
 .unit-photo-link:active {
   transform: translateY(0);
-  box-shadow: 0 8px 18px rgba(11, 75, 179, 0.2);
+  box-shadow: none;
 }
 @media (min-width: 720px) {
   .passport-grid {
@@ -1631,12 +1725,19 @@ p { margin: 0; }
   .passport-unit-tab {
     max-width: 138px;
     min-height: 42px;
-    padding: 8px 11px;
+    padding: 8px 0 11px;
     font-size: 12px;
+  }
+  .unit-score-block {
+    min-width: 64px;
+  }
+  .unit-score-number {
+    font-size: 25px;
   }
   .unit-health-top {
     align-items: flex-start;
   }
+  .unit-health-value,
   .unit-status-pill {
     max-width: 48%;
   }

--- a/customer-app/assets/customer-app.css
+++ b/customer-app/assets/customer-app.css
@@ -1478,15 +1478,15 @@ p { margin: 0; }
 }
 .unit-health-row {
   display: grid;
-  gap: 7px;
-  padding: 13px 0;
+  gap: 5px;
+  padding: 10px 0;
   border-bottom: 1px solid rgba(11, 75, 179, 0.1);
   background: transparent;
 }
 .unit-health-top {
   display: flex;
   justify-content: space-between;
-  gap: 9px;
+  gap: 10px;
   align-items: flex-start;
 }
 .unit-health-title {
@@ -1521,23 +1521,6 @@ p { margin: 0; }
   line-height: 1.25;
   overflow-wrap: anywhere;
 }
-.unit-health-meter {
-  height: 8px;
-  overflow: hidden;
-  border-radius: var(--radius-pill);
-  background: #e5edf8;
-}
-.unit-health-meter i {
-  display: block;
-  height: 100%;
-  min-width: 8px;
-  border-radius: inherit;
-  background: linear-gradient(90deg, #22c55e, #86efac);
-}
-.unit-health-row.is-watch .unit-health-meter i { background: linear-gradient(90deg, #facc15, #f59e0b); }
-.unit-health-row.is-warning .unit-health-meter i { background: linear-gradient(90deg, #fb923c, #f97316); }
-.unit-health-row.is-critical .unit-health-meter i { background: linear-gradient(90deg, #ef4444, #b91c1c); }
-.unit-health-row.is-unknown .unit-health-meter i { background: #94a3b8; }
 .unit-health-row.is-watch .unit-health-title i { background: #facc15; box-shadow: 0 0 0 4px rgba(250, 204, 21, 0.16); }
 .unit-health-row.is-warning .unit-health-title i { background: #f97316; box-shadow: 0 0 0 4px rgba(249, 115, 22, 0.14); }
 .unit-health-row.is-critical .unit-health-title i { background: #dc2626; box-shadow: 0 0 0 4px rgba(220, 38, 38, 0.14); }
@@ -1555,13 +1538,14 @@ p { margin: 0; }
   margin: 0;
   color: var(--muted);
   font-size: 12px;
-  font-weight: 760;
-  line-height: 1.38;
+  font-weight: 750;
+  line-height: 1.42;
 }
 .unit-helper-text {
-  opacity: 0.72;
+  opacity: 0.68;
   font-size: 11px !important;
-  font-weight: 700 !important;
+  font-weight: 680 !important;
+  line-height: 1.36 !important;
 }
 .unit-badges {
   display: flex;

--- a/customer-app/modules/tracking.js
+++ b/customer-app/modules/tracking.js
@@ -298,7 +298,7 @@
       <div class="unit-health-row is-${tone}">
         <div class="unit-health-top">
           <span class="unit-health-title"><i aria-hidden="true"></i>${esc(metric.label)}</span>
-          <strong class="unit-status-pill">${esc(metric.value)}</strong>
+          <strong class="unit-health-value">${esc(metric.value)}</strong>
         </div>
         <div class="unit-health-meter" aria-label="${esc(metric.label)} ${esc(metric.value)}">
           <i style="width:${score}%"></i>
@@ -307,6 +307,16 @@
         ${metric.meta ? `<small class="unit-helper-text">${esc(metric.meta)}</small>` : ""}
       </div>
     `;
+  }
+
+  function overallParts(metric) {
+    const value = clean(metric && metric.value);
+    if (!value) return { score: "รอข้อมูล", label: toneLabel(metric && metric.score) };
+    const parts = value.split(/\s*[—-]\s*/).map(clean).filter(Boolean);
+    return {
+      score: parts[0] || value,
+      label: parts[1] || toneLabel(metric && metric.score),
+    };
   }
 
   function unitMetrics(data, unit, context) {
@@ -447,9 +457,9 @@
       return room || `เครื่อง ${unit.unit_no || ""}`.trim() || "เครื่อง";
     };
     return `
-      <article class="passport-card passport-units-card">
-        <div class="passport-card-head">
-          <span>Unit Passport</span>
+      <article class="passport-units-card">
+        <div class="passport-units-head">
+          <span>สุขภาพแอร์รายเครื่อง</span>
           <strong>${units.length} เครื่อง</strong>
         </div>
         <h3>แดชบอร์ดสุขภาพแยกรายเครื่อง</h3>
@@ -474,26 +484,32 @@
             const metrics = unitMetrics(data, unit, context);
             const preview = photos.slice(0, 4);
             const meta = [unit.service_type, unit.ac_type, unit.btu ? `${unit.btu} BTU` : ""].filter(Boolean).join(" · ") || "เครื่องปรับอากาศ";
+            const overall = overallParts(metrics.overall);
+            const checklistStatus = metrics.hasChecklist
+              ? (metrics.issueCount > 0 ? "ประเมินจากเช็คลิสต์" : "ระบบปกติจากเช็คลิสต์")
+              : "รอเช็คลิสต์";
             return `
               <section
                 class="passport-unit-page is-${metrics.overall.tone} ${index === 0 ? "is-active" : ""}"
                 data-unit-page="${index}"
                 role="tabpanel">
                 <div class="passport-unit-head">
-                  <div>
+                  <div class="unit-title-block">
                     <b>${esc(unit.label)}</b>
                     <span>${esc(meta)}</span>
+                    ${unit.unit_code ? `<small>${esc(unit.unit_code)}</small>` : ""}
                   </div>
-                  <strong>${esc(metrics.overall.value)}</strong>
+                  <div class="unit-score-block">
+                    <strong class="unit-score-number">${esc(overall.score)}</strong>
+                    <span class="unit-score-label">${esc(overall.label)}</span>
+                  </div>
                 </div>
                 <div class="passport-unit-dashboard">
-                  <div class="unit-overall-card">
-                    ${metricBar(metrics.overall)}
-                    <div class="unit-badges">
-                      ${unit.unit_code ? `<span>${esc(unit.unit_code)}</span>` : ""}
-                      <span>${metrics.hasChecklist ? (metrics.issueCount > 0 ? "ประเมินจากเช็คลิสต์" : "ระบบปกติจากเช็คลิสต์") : "รอเช็คลิสต์"}</span>
-                      ${metrics.issueCount > 0 ? `<span class="is-warning">พบ ${metrics.issueCount} จุดที่ควรตรวจ</span>` : ""}
-                    </div>
+                  <div class="unit-overall-summary">
+                    <span>${esc(checklistStatus)}</span>
+                    ${metrics.issueCount > 0 ? `<strong>พบ ${metrics.issueCount} จุดที่ควรตรวจ</strong>` : ""}
+                    <p>${esc(metrics.overall.detail)}</p>
+                    ${metrics.overall.meta ? `<small>${esc(metrics.overall.meta)}</small>` : ""}
                   </div>
                   <div class="unit-health-grid">
                     ${metrics.rows.map(metricBar).join("")}

--- a/customer-app/modules/tracking.js
+++ b/customer-app/modules/tracking.js
@@ -292,16 +292,12 @@
   }
 
   function metricBar(metric) {
-    const score = metric.score == null ? 0 : Math.max(0, Math.min(100, Number(metric.score) || 0));
     const tone = metric.tone || scoreTone(metric.score);
     return `
       <div class="unit-health-row is-${tone}">
         <div class="unit-health-top">
           <span class="unit-health-title"><i aria-hidden="true"></i>${esc(metric.label)}</span>
           <strong class="unit-health-value">${esc(metric.value)}</strong>
-        </div>
-        <div class="unit-health-meter" aria-label="${esc(metric.label)} ${esc(metric.value)}">
-          <i style="width:${score}%"></i>
         </div>
         <p>${esc(metric.detail)}</p>
         ${metric.meta ? `<small class="unit-helper-text">${esc(metric.meta)}</small>` : ""}


### PR DESCRIPTION
## Summary
- Redesigns the AC Health Passport per-machine report into a flatter mobile-first layout.
- Replaces nested cards/pills with a single unit report surface, compact unit tabs, flat health rows, and divider-based evidence sections.
- Keeps existing unit selector behavior, health/passport calculations, photos, warranty/aftercare behavior, and tracking IA intact.

## Validation
- `node --check customer-app/modules/tracking.js`
- `git diff --check`
- `git diff --name-only`
- `git diff --stat`

## Visual QA
- Browser screenshot capture was blocked by the in-app browser URL security policy for the generated preview.
- Fallback static preview was created outside the repo at `C:/Users/ADMIN/AppData/Local/Temp/cwf-passport-screenshots/ac-health-passport-preview.html`.