### PR TITLE
Add Customer App V2 LINE and Google Login

### DIFF
--- a/customer-app/assets/customer-app.css
+++ b/customer-app/assets/customer-app.css
@@ -2368,7 +2368,7 @@ body {
 /* =====================================================================
    AUTH PANEL — premium account card + authentic provider buttons
    LINE (#06C755 + LINE bubble) and Google (white + 4-colour G).
-   Both stay disabled / "coming soon": no auth backend is touched.
+   Provider availability is driven by /public/auth/config; secrets stay server-side.
    ===================================================================== */
 .auth-card {
   background: linear-gradient(180deg, #fff, var(--bg-2));
@@ -2476,6 +2476,45 @@ body {
   border: 1px solid #e3e6ea;
 }
 .google-btn[disabled] { background: #ffffff; opacity: 0.96; }
+
+.customer-session-card {
+  display: grid;
+  gap: 12px;
+  margin-top: 12px;
+}
+.customer-session-main {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+.customer-session-main img {
+  width: 46px;
+  height: 46px;
+  flex: 0 0 46px;
+  border-radius: 50%;
+  object-fit: cover;
+  border: 1px solid var(--line);
+}
+.customer-session-main strong,
+.customer-session-main span {
+  display: block;
+  min-width: 0;
+  overflow-wrap: anywhere;
+}
+.customer-session-main strong {
+  color: var(--ink);
+  font-size: 16px;
+  font-weight: 800;
+}
+.customer-session-main span {
+  margin-top: 2px;
+  color: var(--muted);
+  font-size: 12px;
+  font-weight: 700;
+}
+.auth-logout-btn {
+  width: 100%;
+}
 
 .auth-note {
   margin-top: 12px;

--- a/customer-app/index.html
+++ b/customer-app/index.html
@@ -4,14 +4,14 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>CWF Customer App V2</title>
-  <link rel="stylesheet" href="./assets/customer-app.css?v=20260617_customer_app_v2_phase2f">
+  <link rel="stylesheet" href="./assets/customer-app.css?v=20260620_customer_auth_v1">
 </head>
 <body>
   <div class="app-shell" data-app-shell>
     <header class="app-header">
       <div class="brand-lockup">
         <div class="brand-mark" aria-hidden="true">
-          <img src="/logo.png?v=20260617_customer_app_v2_phase2f" alt="" onerror="this.hidden=true;this.parentElement.classList.add('is-fallback')">
+          <img src="/logo.png?v=20260620_customer_auth_v1" alt="" onerror="this.hidden=true;this.parentElement.classList.add('is-fallback')">
           <span>CWF</span>
         </div>
         <div>
@@ -42,19 +42,19 @@
     </nav>
   </div>
 
-  <script src="./modules/state.js?v=20260617_customer_app_v2_phase2f"></script>
-  <script src="./modules/utils.js?v=20260617_customer_app_v2_phase2f"></script>
-  <script src="./modules/api.js?v=20260617_customer_app_v2_phase2f"></script>
-  <script src="./modules/services.js?v=20260617_customer_app_v2_phase2f"></script>
-  <script src="./modules/ui.js?v=20260617_customer_app_v2_phase2f"></script>
-  <script src="./modules/auth.js?v=20260617_customer_app_v2_phase2f"></script>
-  <script src="./modules/pricing.js?v=20260617_customer_app_v2_phase2f"></script>
-  <script src="./modules/availability.js?v=20260617_customer_app_v2_phase2f"></script>
-  <script src="./modules/bookingScheduled.js?v=20260617_customer_app_v2_phase2f"></script>
-  <script src="./modules/bookingUrgent.js?v=20260617_customer_app_v2_phase2f"></script>
-  <script src="./modules/tracking.js?v=20260617_customer_app_v2_phase2f"></script>
-  <script src="./modules/profile.js?v=20260617_customer_app_v2_phase2f"></script>
-  <script src="./modules/router.js?v=20260617_customer_app_v2_phase2f"></script>
-  <script src="./assets/customer-app.js?v=20260617_customer_app_v2_phase2f"></script>
+  <script src="./modules/state.js?v=20260620_customer_auth_v1"></script>
+  <script src="./modules/utils.js?v=20260620_customer_auth_v1"></script>
+  <script src="./modules/api.js?v=20260620_customer_auth_v1"></script>
+  <script src="./modules/services.js?v=20260620_customer_auth_v1"></script>
+  <script src="./modules/ui.js?v=20260620_customer_auth_v1"></script>
+  <script src="./modules/auth.js?v=20260620_customer_auth_v1"></script>
+  <script src="./modules/pricing.js?v=20260620_customer_auth_v1"></script>
+  <script src="./modules/availability.js?v=20260620_customer_auth_v1"></script>
+  <script src="./modules/bookingScheduled.js?v=20260620_customer_auth_v1"></script>
+  <script src="./modules/bookingUrgent.js?v=20260620_customer_auth_v1"></script>
+  <script src="./modules/tracking.js?v=20260620_customer_auth_v1"></script>
+  <script src="./modules/profile.js?v=20260620_customer_auth_v1"></script>
+  <script src="./modules/router.js?v=20260620_customer_auth_v1"></script>
+  <script src="./assets/customer-app.js?v=20260620_customer_auth_v1"></script>
 </body>
 </html>

--- a/customer-app/modules/api.js
+++ b/customer-app/modules/api.js
@@ -57,6 +57,14 @@
       return requestJson("/public/me");
     },
 
+    async getAuthConfig(returnTo) {
+      return requestJson("/public/auth/config", { query: { returnTo } });
+    },
+
+    async logoutCustomer() {
+      return requestJson("/public/logout", { method: "POST" });
+    },
+
     async previewPricing(payload) {
       return requestJson("/public/pricing_preview", {
         method: "POST",

--- a/customer-app/modules/auth.js
+++ b/customer-app/modules/auth.js
@@ -44,19 +44,25 @@
     const isLine = provider === "line";
     const item = config && config.providers && config.providers[provider] ? config.providers[provider] : {};
     const available = !!item.available;
-    const label = isLine ? "เข้าสู่ระบบด้วย LINE" : "เข้าสู่ระบบด้วย Google";
+    const linked = !!item.linked;
+    const linking = !!(config && config.logged_in);
+    const label = linked
+      ? (isLine ? "เชื่อมบัญชี LINE แล้ว" : "เชื่อมบัญชี Google แล้ว")
+      : linking
+        ? (isLine ? "เชื่อมบัญชี LINE" : "เชื่อมบัญชี Google")
+        : (isLine ? "เข้าสู่ระบบด้วย LINE" : "เข้าสู่ระบบด้วย Google");
     const icon = isLine ? LINE_ICON : GOOGLE_ICON;
     const cls = isLine ? "line-btn" : "google-btn";
     const href = available ? item.start_url : "";
+    const disabled = !available || linked;
     return `
-      <button class="provider-btn ${cls}" type="button" data-auth-provider="${provider}" ${available ? "" : "disabled aria-disabled=\"true\""} data-auth-url="${esc(href)}">
+      <button class="provider-btn ${cls}" type="button" data-auth-provider="${provider}" data-auth-mode="${linking ? "link" : "login"}" ${disabled ? "disabled aria-disabled=\"true\"" : ""} data-auth-url="${esc(href)}">
         <span class="prov-ico">${icon}</span>
         <span class="prov-label">${label}</span>
-        <span class="prov-soon">${available ? "พร้อมใช้งาน" : "ยังไม่พร้อม"}</span>
+        <span class="prov-soon">${linked ? "เชื่อมแล้ว" : available ? "พร้อมใช้งาน" : "ยังไม่พร้อม"}</span>
       </button>
     `;
   }
-
   function renderProviderButtons() {
     const config = root.state.authConfig;
     if (!config) return root.utils.stateBox("loading", "กำลังตรวจสอบช่องทางเข้าสู่ระบบ...");
@@ -131,8 +137,16 @@
     if (!container) return;
     container.querySelectorAll("[data-auth-provider]").forEach((button) => {
       button.addEventListener("click", () => {
-        const url = button.getAttribute("data-auth-url");
+        let url = button.getAttribute("data-auth-url");
         if (!url || button.disabled) return;
+        if (button.getAttribute("data-auth-mode") === "link") {
+          const providerName = (button.getAttribute("data-auth-provider") || "").toUpperCase();
+          if (!window.confirm(`ยืนยันการเชื่อมบัญชี ${providerName} กับบัญชีลูกค้านี้?`)) return;
+          const next = new URL(url, window.location.origin);
+          next.searchParams.set("mode", "link");
+          next.searchParams.set("confirm", "1");
+          url = `${next.pathname}${next.search}${next.hash}`;
+        }
         button.disabled = true;
         button.querySelector(".prov-soon").textContent = "กำลังพาไป...";
         window.location.href = url;

--- a/customer-app/modules/auth.js
+++ b/customer-app/modules/auth.js
@@ -3,15 +3,12 @@
 
   const root = window.CWFCustomerAppV2 = window.CWFCustomerAppV2 || {};
 
-  // Brand login marks (presentation only — no auth backend is touched).
-  // LINE: official LINE green bubble with the LINE wordmark.
   const LINE_ICON = `
     <svg viewBox="0 0 40 40" width="22" height="22" role="img" aria-hidden="true" focusable="false">
       <path fill="#fff" d="M20 5C11.16 5 4 10.74 4 17.82c0 6.35 5.68 11.66 13.35 12.66.52.11 1.23.34 1.41.78.16.4.1 1.03.05 1.43l-.22 1.36c-.07.4-.32 1.58 1.39.86 1.71-.72 9.2-5.42 12.55-9.28C35.21 24.2 36 21.13 36 17.82 36 10.74 28.84 5 20 5z"/>
       <text x="20" y="21.4" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-weight="700" font-size="8.6" fill="#06C755" letter-spacing="-0.3">LINE</text>
     </svg>`;
 
-  // Google: official 4-colour "G" mark.
   const GOOGLE_ICON = `
     <svg viewBox="0 0 48 48" width="20" height="20" role="img" aria-hidden="true" focusable="false">
       <path fill="#EA4335" d="M24 9.5c3.54 0 6.71 1.22 9.21 3.6l6.85-6.85C35.9 2.38 30.47 0 24 0 14.62 0 6.51 5.38 2.56 13.22l7.98 6.19C12.43 13.72 17.74 9.5 24 9.5z"/>
@@ -20,22 +17,53 @@
       <path fill="#34A853" d="M24 48c6.48 0 11.93-2.13 15.89-5.81l-7.73-6c-2.15 1.45-4.92 2.3-8.16 2.3-6.26 0-11.57-4.22-13.47-9.91l-7.98 6.19C6.51 42.62 14.62 48 24 48z"/>
     </svg>`;
 
-  // Both providers stay disabled / "coming soon" in Customer App V2.
-  // Legacy /auth/line exists but currently redirects to customer.html, not this V2 shell;
-  // Google OAuth is out of scope for this phase. No auth backend is touched.
+  function esc(value) {
+    return root.utils.escapeHtml(value == null ? "" : String(value));
+  }
+
+  function currentReturnTo() {
+    return `${window.location.pathname || "/customer-app/"}${window.location.search || ""}${window.location.hash || ""}`;
+  }
+
+  function authNotice() {
+    const params = new URLSearchParams(window.location.search || "");
+    const status = params.get("auth");
+    if (!status) return "";
+    const provider = params.get("provider") || "";
+    const reason = params.get("reason") || "";
+    if (status === "success") return root.utils.stateBox("success", `เข้าสู่ระบบด้วย ${provider.toUpperCase()} สำเร็จ`);
+    if (status === "linked") return root.utils.stateBox("success", `เชื่อมบัญชี ${provider.toUpperCase()} เรียบร้อย`);
+    if (reason === "access_denied" || reason === "cancel") return root.utils.stateBox("", "ยกเลิกการเข้าสู่ระบบแล้ว คุณยังใช้งานแบบ Guest ได้");
+    if (reason === "provider_unavailable") return root.utils.stateBox("error", "ผู้ให้บริการนี้ยังไม่ได้ตั้งค่าในระบบ Production");
+    if (reason === "invalid_state" || reason === "missing_state") return root.utils.stateBox("error", "เซสชันเข้าสู่ระบบหมดอายุ กรุณาลองใหม่อีกครั้ง");
+    if (reason === "account_already_linked") return root.utils.stateBox("error", "บัญชีผู้ให้บริการนี้ถูกเชื่อมกับลูกค้าอื่นแล้ว");
+    return root.utils.stateBox("error", "เข้าสู่ระบบไม่สำเร็จ กรุณาลองใหม่หรือติดต่อแอดมิน CWF");
+  }
+
+  function providerButton(provider, config) {
+    const isLine = provider === "line";
+    const item = config && config.providers && config.providers[provider] ? config.providers[provider] : {};
+    const available = !!item.available;
+    const label = isLine ? "เข้าสู่ระบบด้วย LINE" : "เข้าสู่ระบบด้วย Google";
+    const icon = isLine ? LINE_ICON : GOOGLE_ICON;
+    const cls = isLine ? "line-btn" : "google-btn";
+    const href = available ? item.start_url : "";
+    return `
+      <button class="provider-btn ${cls}" type="button" data-auth-provider="${provider}" ${available ? "" : "disabled aria-disabled=\"true\""} data-auth-url="${esc(href)}">
+        <span class="prov-ico">${icon}</span>
+        <span class="prov-label">${label}</span>
+        <span class="prov-soon">${available ? "พร้อมใช้งาน" : "ยังไม่พร้อม"}</span>
+      </button>
+    `;
+  }
+
   function renderProviderButtons() {
+    const config = root.state.authConfig;
+    if (!config) return root.utils.stateBox("loading", "กำลังตรวจสอบช่องทางเข้าสู่ระบบ...");
     return `
       <div class="auth-providers" role="group" aria-label="ตัวเลือกเข้าสู่ระบบ">
-        <button class="provider-btn line-btn" type="button" disabled aria-disabled="true" title="เข้าสู่ระบบด้วย LINE — เร็ว ๆ นี้">
-          <span class="prov-ico">${LINE_ICON}</span>
-          <span class="prov-label">เข้าสู่ระบบด้วย LINE</span>
-          <span class="prov-soon">เร็ว ๆ นี้</span>
-        </button>
-        <button class="provider-btn google-btn" type="button" disabled aria-disabled="true" title="เข้าสู่ระบบด้วย Google — เร็ว ๆ นี้">
-          <span class="prov-ico">${GOOGLE_ICON}</span>
-          <span class="prov-label">เข้าสู่ระบบด้วย Google</span>
-          <span class="prov-soon">เร็ว ๆ นี้</span>
-        </button>
+        ${providerButton("line", config)}
+        ${providerButton("google", config)}
       </div>
     `;
   }
@@ -46,36 +74,83 @@
     if (!customer.logged_in) {
       return root.utils.stateBox("", "คุณกำลังใช้งานแบบ Guest สามารถดูข้อมูลและเริ่มจองได้โดยไม่ต้องเข้าสู่ระบบ");
     }
-    const name = customer.user && customer.user.name ? customer.user.name : "ลูกค้า CWF";
+    const user = customer.user || {};
     const profile = customer.profile || {};
+    const providers = customer.linked_providers || user.linked_providers || [user.provider || customer.provider].filter(Boolean);
     return `
-      <div class="data-list">
-        <div class="data-row">
-          <strong>${root.utils.escapeHtml(name)}</strong>
-          <span class="muted">เข้าสู่ระบบแล้ว</span>
+      <div class="customer-session-card">
+        <div class="customer-session-main">
+          ${user.picture ? `<img src="${esc(user.picture)}" alt="" loading="lazy">` : ""}
+          <div>
+            <strong>${esc(user.name || "ลูกค้า CWF")}</strong>
+            <span>${providers.length ? `เชื่อมแล้ว: ${providers.map((p) => p.toUpperCase()).join(", ")}` : "เข้าสู่ระบบแล้ว"}</span>
+          </div>
         </div>
-        <div class="data-row">
-          <strong>ที่อยู่ที่บันทึกไว้</strong>
-          <span class="muted">${root.utils.escapeHtml(profile.address || "ยังไม่มีที่อยู่ที่บันทึกไว้")}</span>
+        <div class="data-list">
+          <div class="data-row">
+            <strong>อีเมล</strong>
+            <span class="muted">${esc(user.email || profile.email || "ยังไม่มีอีเมลในบัญชี")}</span>
+          </div>
+          <div class="data-row">
+            <strong>ที่อยู่ที่บันทึกไว้</strong>
+            <span class="muted">${esc(profile.address || "ยังไม่มีที่อยู่ที่บันทึกไว้")}</span>
+          </div>
         </div>
+        <button class="secondary-btn auth-logout-btn" type="button" data-auth-logout>ออกจากระบบ</button>
       </div>
     `;
   }
 
   async function loadCustomer(container) {
+    const stateMount = container ? container.querySelector("[data-customer-state]") : null;
+    const providerMount = container ? container.querySelector("[data-auth-providers]") : null;
     try {
       root.state.customer = null;
-      if (container) container.querySelector("[data-customer-state]").innerHTML = renderCustomerSummary();
-      const data = await root.api.getCurrentCustomer();
-      root.state.customer = data;
-      root.state.guestMode = !data.logged_in;
-      if (container) container.querySelector("[data-customer-state]").innerHTML = renderCustomerSummary();
+      root.state.authConfig = null;
+      if (stateMount) stateMount.innerHTML = renderCustomerSummary();
+      if (providerMount) providerMount.innerHTML = renderProviderButtons();
+      const returnTo = currentReturnTo();
+      const results = await Promise.all([
+        root.api.getCurrentCustomer(),
+        root.api.getAuthConfig(returnTo),
+      ]);
+      root.state.customer = results[0];
+      root.state.authConfig = results[1];
+      root.state.guestMode = !results[0].logged_in;
+      if (stateMount) stateMount.innerHTML = renderCustomerSummary();
+      if (providerMount) providerMount.innerHTML = renderProviderButtons();
+      bindAuthActions(container);
     } catch (error) {
       root.state.customer = { logged_in: false };
-      if (container) {
-        container.querySelector("[data-customer-state]").innerHTML =
-          root.utils.stateBox("error", `ตรวจสอบบัญชีไม่สำเร็จ: ${error.message}`);
-      }
+      if (stateMount) stateMount.innerHTML = root.utils.stateBox("error", `ตรวจสอบบัญชีไม่สำเร็จ: ${error.message}`);
+      if (providerMount) providerMount.innerHTML = renderProviderButtons();
+    }
+  }
+
+  function bindAuthActions(container) {
+    if (!container) return;
+    container.querySelectorAll("[data-auth-provider]").forEach((button) => {
+      button.addEventListener("click", () => {
+        const url = button.getAttribute("data-auth-url");
+        if (!url || button.disabled) return;
+        button.disabled = true;
+        button.querySelector(".prov-soon").textContent = "กำลังพาไป...";
+        window.location.href = url;
+      }, { once: true });
+    });
+    const logout = container.querySelector("[data-auth-logout]");
+    if (logout) {
+      logout.addEventListener("click", async () => {
+        logout.disabled = true;
+        logout.textContent = "กำลังออกจากระบบ...";
+        try {
+          await root.api.logoutCustomer();
+          await loadCustomer(container);
+        } catch (error) {
+          logout.disabled = false;
+          logout.textContent = "ออกจากระบบ";
+        }
+      });
     }
   }
 
@@ -88,10 +163,11 @@
             <h2>บัญชีลูกค้า</h2>
           </div>
           <p class="muted">เริ่มจองแบบ Guest ได้ก่อน เข้าสู่บัญชีเมื่อพร้อมเพื่อบันทึกที่อยู่ ดูประวัติ และจองซ้ำได้เร็วขึ้น</p>
+          ${authNotice()}
           <div data-customer-state>${renderCustomerSummary()}</div>
           <div class="auth-divider"><span>เข้าสู่ระบบเพื่อสิทธิ์เพิ่มเติม</span></div>
-          ${renderProviderButtons()}
-          <p class="auth-note">ระบบเข้าสู่ระบบกำลังจะเปิดให้ใช้งานเร็ว ๆ นี้ ระหว่างนี้ใช้งานแบบ Guest ได้เต็มรูปแบบ</p>
+          <div data-auth-providers>${renderProviderButtons()}</div>
+          <p class="auth-note">ระบบจะพาคุณไปยัง LINE หรือ Google อย่างปลอดภัย แล้วกลับมาที่ Customer App V2 หน้าเดิม</p>
         </section>
       `;
     },

--- a/docs/customer-auth-production.md
+++ b/docs/customer-auth-production.md
@@ -6,7 +6,6 @@
 - `GET /auth/line/start`
 - `GET /auth/line/callback`
 - `GET /auth/line/v2/callback`
-- `GET /auth/google`
 - `GET /auth/google/start`
 - `GET /auth/google/callback`
 - `GET /public/auth/config`
@@ -30,6 +29,7 @@ LINE:
 - `LINE_CHANNEL_SECRET`
 - `LINE_CALLBACK_URL=https://app.cwf-air.com/auth/line/callback` for legacy `customer.html`
 - `LINE_V2_CALLBACK_URL=https://app.cwf-air.com/auth/line/v2/callback` for Customer App V2
+- `LINE_EMAIL_SCOPE_ENABLED=true` only after LINE email permission is approved
 
 Google:
 
@@ -44,11 +44,13 @@ Do not commit provider secrets, access tokens, refresh tokens, private keys, or 
 1. Create or use a LINE Login channel, not a Messaging API-only channel.
 2. Keep legacy callback URL `https://app.cwf-air.com/auth/line/callback`.
 3. Add Customer App V2 callback URL `https://app.cwf-air.com/auth/line/v2/callback`.
-4. Enable scopes: `openid`, `profile`, `email`.
+4. Enable scopes: `openid`, `profile`.
 5. Map the channel ID to `LINE_CHANNEL_ID`.
 6. Map the channel secret to `LINE_CHANNEL_SECRET`.
 7. Map the V2 callback to `LINE_V2_CALLBACK_URL`.
 8. LINE Official Account linking is optional for this login flow; the customer login only requires LINE Login.
+
+LINE email is optional and disabled by default. Apply for email permission in LINE Developers Console first; after approval, set `LINE_EMAIL_SCOPE_ENABLED=true` and add the `email` scope in the channel settings. Without that env var, Customer App V2 requests only `openid profile`, and LINE login still works without an email address.
 
 ## Google Cloud Setup
 
@@ -72,7 +74,18 @@ New normalized table: `public.customer_identities`.
 
 Existing LINE customers keep their legacy customer profile key, e.g. `line:<LINE user id>`. The migration includes a reviewed optional backfill statement to populate `customer_identities` from existing `customer_profiles` rows.
 
-The application does not run DDL at normal startup. The owner must explicitly approve and run `migrations/20260620_customer_identities.sql` as a separate controlled deployment step before enabling providers. Until the schema is present, `/public/auth/config` reports providers as unavailable.
+The application does not run DDL at normal startup. The owner must explicitly approve and run `migrations/20260620_customer_identities.sql` as a separate controlled deployment step before enabling provider env vars. Until the schema is present, `/public/auth/config` reports providers as unavailable.
+
+Recommended deployment order:
+
+1. Deploy the code with provider env vars unset.
+2. Run and verify `migrations/20260620_customer_identities.sql`.
+3. Add provider client IDs/secrets, safe HTTPS callbacks, and JWT secret.
+4. Enable LINE email scope only after LINE approves the permission.
+
+## OAuth State Store
+
+OAuth state is stored server-side in a bounded in-memory store with expiry cleanup and oldest-entry eviction. This is safe for a single running Node instance. A horizontally scaled deployment needs a shared one-time store, such as Redis or a database-backed state table, so callbacks can be consumed by any instance without losing state.
 
 ## Rollback Plan
 

--- a/docs/customer-auth-production.md
+++ b/docs/customer-auth-production.md
@@ -5,6 +5,7 @@
 - `GET /auth/line`
 - `GET /auth/line/start`
 - `GET /auth/line/callback`
+- `GET /auth/line/v2/callback`
 - `GET /auth/google`
 - `GET /auth/google/start`
 - `GET /auth/google/callback`
@@ -13,7 +14,9 @@
 - `GET /public/logout`
 - `POST /public/logout`
 
-Both providers issue the existing `cwf_token` customer session cookie and return to Customer App V2 through a strict same-origin customer-route `returnTo` allowlist.
+Legacy `GET /auth/line` and `GET /auth/line/callback` remain reserved for `customer.html`. Customer App V2 starts LINE through `/auth/line/start` and uses `/auth/line/v2/callback`.
+
+Both V2 providers issue the existing `cwf_token` customer session cookie and return to Customer App V2 through a strict same-origin customer-route `returnTo` allowlist.
 
 ## Required Environment Variables
 
@@ -25,7 +28,8 @@ LINE:
 
 - `LINE_CHANNEL_ID`
 - `LINE_CHANNEL_SECRET`
-- `LINE_CALLBACK_URL=https://app.cwf-air.com/auth/line/callback`
+- `LINE_CALLBACK_URL=https://app.cwf-air.com/auth/line/callback` for legacy `customer.html`
+- `LINE_V2_CALLBACK_URL=https://app.cwf-air.com/auth/line/v2/callback` for Customer App V2
 
 Google:
 
@@ -38,11 +42,13 @@ Do not commit provider secrets, access tokens, refresh tokens, private keys, or 
 ## LINE Developers Setup
 
 1. Create or use a LINE Login channel, not a Messaging API-only channel.
-2. Set callback URL to `https://app.cwf-air.com/auth/line/callback`.
-3. Enable scopes: `openid`, `profile`, `email`.
-4. Map the channel ID to `LINE_CHANNEL_ID`.
-5. Map the channel secret to `LINE_CHANNEL_SECRET`.
-6. LINE Official Account linking is optional for this login flow; the customer login only requires LINE Login.
+2. Keep legacy callback URL `https://app.cwf-air.com/auth/line/callback`.
+3. Add Customer App V2 callback URL `https://app.cwf-air.com/auth/line/v2/callback`.
+4. Enable scopes: `openid`, `profile`, `email`.
+5. Map the channel ID to `LINE_CHANNEL_ID`.
+6. Map the channel secret to `LINE_CHANNEL_SECRET`.
+7. Map the V2 callback to `LINE_V2_CALLBACK_URL`.
+8. LINE Official Account linking is optional for this login flow; the customer login only requires LINE Login.
 
 ## Google Cloud Setup
 
@@ -65,6 +71,8 @@ New normalized table: `public.customer_identities`.
 - Does not store provider access tokens or refresh tokens.
 
 Existing LINE customers keep their legacy customer profile key, e.g. `line:<LINE user id>`. The migration includes a reviewed optional backfill statement to populate `customer_identities` from existing `customer_profiles` rows.
+
+The application does not run DDL at normal startup. The owner must explicitly approve and run `migrations/20260620_customer_identities.sql` as a separate controlled deployment step before enabling providers. Until the schema is present, `/public/auth/config` reports providers as unavailable.
 
 ## Rollback Plan
 

--- a/docs/customer-auth-production.md
+++ b/docs/customer-auth-production.md
@@ -1,0 +1,103 @@
+# Customer App V2 LINE + Google Login
+
+## Routes
+
+- `GET /auth/line`
+- `GET /auth/line/start`
+- `GET /auth/line/callback`
+- `GET /auth/google`
+- `GET /auth/google/start`
+- `GET /auth/google/callback`
+- `GET /public/auth/config`
+- `GET /public/me`
+- `GET /public/logout`
+- `POST /public/logout`
+
+Both providers issue the existing `cwf_token` customer session cookie and return to Customer App V2 through a strict same-origin customer-route `returnTo` allowlist.
+
+## Required Environment Variables
+
+Shared:
+
+- `CWF_JWT_SECRET` or existing `JWT_SECRET`
+
+LINE:
+
+- `LINE_CHANNEL_ID`
+- `LINE_CHANNEL_SECRET`
+- `LINE_CALLBACK_URL=https://app.cwf-air.com/auth/line/callback`
+
+Google:
+
+- `GOOGLE_CLIENT_ID`
+- `GOOGLE_CLIENT_SECRET`
+- `GOOGLE_CALLBACK_URL=https://app.cwf-air.com/auth/google/callback`
+
+Do not commit provider secrets, access tokens, refresh tokens, private keys, or production cookies.
+
+## LINE Developers Setup
+
+1. Create or use a LINE Login channel, not a Messaging API-only channel.
+2. Set callback URL to `https://app.cwf-air.com/auth/line/callback`.
+3. Enable scopes: `openid`, `profile`, `email`.
+4. Map the channel ID to `LINE_CHANNEL_ID`.
+5. Map the channel secret to `LINE_CHANNEL_SECRET`.
+6. LINE Official Account linking is optional for this login flow; the customer login only requires LINE Login.
+
+## Google Cloud Setup
+
+1. Configure OAuth consent screen for the production app.
+2. Create a Web application OAuth client.
+3. Add authorized redirect URI: `https://app.cwf-air.com/auth/google/callback`.
+4. Authorized JavaScript origin is not required for the server-side authorization-code flow unless future browser-side Google APIs are added.
+5. Use only `openid email profile` scopes.
+6. Map OAuth client ID to `GOOGLE_CLIENT_ID`.
+7. Map OAuth client secret to `GOOGLE_CLIENT_SECRET`.
+8. If consent screen is in testing mode, add real QA accounts as test users before production testing.
+
+## Identity Storage
+
+New normalized table: `public.customer_identities`.
+
+- Unique `(provider, provider_subject)`.
+- Foreign key to `public.customer_profiles(sub)`.
+- Stores optional verified email and display metadata.
+- Does not store provider access tokens or refresh tokens.
+
+Existing LINE customers keep their legacy customer profile key, e.g. `line:<LINE user id>`. The migration includes a reviewed optional backfill statement to populate `customer_identities` from existing `customer_profiles` rows.
+
+## Rollback Plan
+
+See `migrations/20260620_customer_identities.sql`.
+
+Rollback removes:
+
+- `public.customer_identities`
+- `idx_customer_profiles_verified_email`
+- `customer_profiles.email_verified`
+- `customer_profiles.email`
+
+Do not run rollback while active customer sessions depend on newly linked Google identities.
+
+## Manual QA Checklist
+
+1. Guest Customer App V2 loads and booking remains available.
+2. LINE Login succeeds and returns to the original Customer App V2 route.
+3. LINE cancellation returns to Customer App V2 with a non-blocking error.
+4. Invalid/expired LINE callback state is rejected.
+5. Existing legacy LINE customer keeps the same `customer_profiles.sub`.
+6. Google Login succeeds and returns to the original Customer App V2 route.
+7. Google cancellation returns to Customer App V2 with a non-blocking error.
+8. Existing Google identity signs in to the same customer.
+9. New Google identity creates a customer profile.
+10. Logged-in LINE customer can explicitly link Google.
+11. Logged-in Google customer can explicitly link LINE.
+12. Logout clears `cwf_token` and OAuth state cookies.
+13. Refresh after login keeps `/public/me.logged_in=true`.
+14. PWA reopen after login keeps the session until cookie expiry.
+15. Missing provider env vars show unavailable buttons.
+16. Mobile widths 360 / 390 / 430px keep provider buttons readable.
+17. Legacy `customer.html` still works with `cwf_token`.
+18. Tracking without login still works.
+19. Guest booking still works.
+20. No provider token appears in localStorage, URLs after redirect, or `/public/me`.

--- a/index.js
+++ b/index.js
@@ -27,6 +27,7 @@ const fs = require("fs");
 const normalizerHelpers = require("./server/normalizers");
 const pricingHelpers = require("./server/pricing");
 const customerPricingHelpers = require("./server/customerPricing");
+const customerAuth = require("./server/customerAuth");
 const technicianIncomeHelpers = require("./server/technicianIncome");
 const customerLookupHelpers = require("./server/customerLookup");
 const technicianJobIncomeDisplayHelpers = require("./server/technicianJobIncomeDisplay");
@@ -635,6 +636,7 @@ app.set('trust proxy', 1);
 app.use(cors());
 app.use(createLineWebhookRoutes({ pool }));
 app.use(express.json());
+app.use(customerAuth.createCustomerAuthRoutes({ pool, env: process.env, logger: console }));
 
 // =======================================
 // 🔐 Public Login (LINE OAuth) - Production-ready (Minimal / No regression)
@@ -10958,6 +10960,7 @@ await pool.query(`
   )
 `);
 await pool.query(`CREATE INDEX IF NOT EXISTS idx_customer_profiles_phone ON public.customer_profiles(phone)`);
+await customerAuth.ensureCustomerAuthSchema(pool);
 // 3.15) service zones: automatic district/amphoe mapping for dispatch
 await pool.query(`
   CREATE TABLE IF NOT EXISTS public.service_zones (

--- a/index.js
+++ b/index.js
@@ -1004,7 +1004,7 @@ app.post('/auth/password-reset/request', async (req, res) => {
   }
 });
 
-app.get('/public/me', (req, res) => {
+app.get('/public/me', async (req, res) => {
   try {
     const jwtSecret = getJwtSecret();
     if (!jwtSecret) return res.json({ logged_in: false });
@@ -1012,33 +1012,7 @@ app.get('/public/me', (req, res) => {
     if (!token) return res.json({ logged_in: false });
     const payload = jwtVerify(token, jwtSecret);
     if (!payload) return res.json({ logged_in: false });
-    // attach customer profile (address/phone/maps) if exists
-    const sub = String(payload.sub || '').trim();
-    const user = {
-      name: String(payload.name || ''),
-      picture: String(payload.picture || ''),
-      provider: String(payload.provider || 'line'),
-    };
-    if (!sub) return res.json({ logged_in: true, user, profile: null });
-
-    pool.query(
-      `SELECT phone, address, maps_url FROM public.customer_profiles WHERE sub=$1 LIMIT 1`,
-      [sub]
-    ).then((r) => {
-      const row = r.rows && r.rows[0] ? r.rows[0] : null;
-      return res.json({
-        logged_in: true,
-        user,
-        profile: row ? {
-          phone: row.phone || '',
-          address: row.address || '',
-          maps_url: row.maps_url || ''
-        } : null
-      });
-    }).catch(() => {
-      return res.json({ logged_in: true, user, profile: null });
-    });
-    return;
+    return res.json(await customerAuth.publicMePayload({ pool, payload }));
   } catch (_) {
     return res.json({ logged_in: false });
   }

--- a/index.js
+++ b/index.js
@@ -10960,7 +10960,6 @@ await pool.query(`
   )
 `);
 await pool.query(`CREATE INDEX IF NOT EXISTS idx_customer_profiles_phone ON public.customer_profiles(phone)`);
-await customerAuth.ensureCustomerAuthSchema(pool);
 // 3.15) service zones: automatic district/amphoe mapping for dispatch
 await pool.query(`
   CREATE TABLE IF NOT EXISTS public.service_zones (

--- a/migrations/20260620_customer_identities.sql
+++ b/migrations/20260620_customer_identities.sql
@@ -1,0 +1,56 @@
+-- Customer App V2 provider identity support for LINE + Google.
+-- Apply during a planned deployment window. Do not run against production until reviewed.
+
+BEGIN;
+
+ALTER TABLE public.customer_profiles
+  ADD COLUMN IF NOT EXISTS email TEXT;
+
+ALTER TABLE public.customer_profiles
+  ADD COLUMN IF NOT EXISTS email_verified BOOLEAN DEFAULT FALSE;
+
+CREATE TABLE IF NOT EXISTS public.customer_identities (
+  identity_id BIGSERIAL PRIMARY KEY,
+  customer_sub TEXT NOT NULL REFERENCES public.customer_profiles(sub) ON DELETE CASCADE,
+  provider TEXT NOT NULL,
+  provider_subject TEXT NOT NULL,
+  email TEXT,
+  email_verified BOOLEAN DEFAULT FALSE,
+  display_name TEXT,
+  picture_url TEXT,
+  linked_at TIMESTAMPTZ DEFAULT NOW(),
+  last_login_at TIMESTAMPTZ DEFAULT NOW(),
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  updated_at TIMESTAMPTZ DEFAULT NOW(),
+  UNIQUE(provider, provider_subject)
+);
+
+CREATE INDEX IF NOT EXISTS idx_customer_identities_customer_sub
+  ON public.customer_identities(customer_sub);
+
+CREATE INDEX IF NOT EXISTS idx_customer_profiles_verified_email
+  ON public.customer_profiles(lower(email))
+  WHERE email_verified = TRUE;
+
+-- Optional backfill for existing LINE customers after review:
+-- INSERT INTO public.customer_identities
+--   (customer_sub, provider, provider_subject, email, email_verified, display_name, picture_url)
+-- SELECT
+--   sub,
+--   'line',
+--   regexp_replace(sub, '^line:', ''),
+--   email,
+--   COALESCE(email_verified, FALSE),
+--   display_name,
+--   picture_url
+-- FROM public.customer_profiles
+-- WHERE sub LIKE 'line:%'
+-- ON CONFLICT (provider, provider_subject) DO NOTHING;
+
+COMMIT;
+
+-- Rollback plan:
+-- DROP TABLE IF EXISTS public.customer_identities;
+-- DROP INDEX IF EXISTS public.idx_customer_profiles_verified_email;
+-- ALTER TABLE public.customer_profiles DROP COLUMN IF EXISTS email_verified;
+-- ALTER TABLE public.customer_profiles DROP COLUMN IF EXISTS email;

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "cors": "^2.8.5",
         "dotenv": "^16.4.5",
         "express": "^4.19.2",
+        "google-auth-library": "^10.7.0",
         "multer": "^2.0.2",
         "pdf-lib": "^1.17.1",
         "pg": "^8.11.5",
@@ -89,6 +90,35 @@
         "inherits": "^2.0.1",
         "minimalistic-assert": "^1.0.0",
         "safer-buffer": "^2.1.0"
+      }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/bignumber.js": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
+      "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/bn.js": {
@@ -263,6 +293,15 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/debug": {
@@ -457,6 +496,35 @@
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "license": "MIT"
     },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "license": "MIT"
+    },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      }
+    },
     "node_modules/finalhandler": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.2.tgz",
@@ -490,6 +558,18 @@
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "license": "MIT"
     },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "license": "MIT",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
     "node_modules/forwarded": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
@@ -515,6 +595,34 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gaxios": {
+      "version": "7.1.5",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.5.tgz",
+      "integrity": "sha512-5FZy72Rh8LhtjmvDrKkI+lVhrsQrVKVsItxMoDm5mNQE+xR0WVIIs+jzPSJgBvKVsLi24fZhXJIsNI0bihDzFg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "node-fetch": "^3.3.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/gcp-metadata": {
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-8.1.2.tgz",
+      "integrity": "sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "gaxios": "^7.0.0",
+        "google-logging-utils": "^1.0.0",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/get-intrinsic": {
@@ -552,6 +660,32 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/google-auth-library": {
+      "version": "10.7.0",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.7.0.tgz",
+      "integrity": "sha512-QpTAbNJ36TliZLx3TTtahR8HG0hN9RllL1e3FymOvQSIKK8JmgV58H924ub2wa2DsS3ANjjP1Aw1N+Ramc8hqQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^7.1.4",
+        "gcp-metadata": "8.1.2",
+        "google-logging-utils": "1.1.3",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/google-logging-utils": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.3.tgz",
+      "integrity": "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/gopd": {
@@ -657,6 +791,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/json-bigint": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+      "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bignumber.js": "^9.0.0"
       }
     },
     "node_modules/jwa": {
@@ -806,6 +949,44 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "license": "MIT",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
       }
     },
     "node_modules/object-assign": {
@@ -1345,6 +1526,15 @@
       },
       "engines": {
         "node": ">= 16"
+      }
+    },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/xtend": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "version": "1.0.0",
   "main": "index.js",
   "scripts": {
-    "start": "node index.js"
+    "start": "node index.js",
+    "test": "node --test test/*.test.js"
   },
   "dependencies": {
     "@pdf-lib/fontkit": "^1.1.1",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "cors": "^2.8.5",
     "dotenv": "^16.4.5",
     "express": "^4.19.2",
+    "google-auth-library": "^10.7.0",
     "multer": "^2.0.2",
     "pdf-lib": "^1.17.1",
     "pg": "^8.11.5",

--- a/server/customerAuth.js
+++ b/server/customerAuth.js
@@ -8,6 +8,7 @@ const SESSION_COOKIE = "cwf_token";
 const SESSION_MAX_AGE_SEC = 7 * 24 * 60 * 60;
 const OAUTH_MAX_AGE_MS = 10 * 60 * 1000;
 const OAUTH_MAX_AGE_SEC = OAUTH_MAX_AGE_MS / 1000;
+const DEFAULT_OAUTH_STORE_LIMIT = 5000;
 const LINE_STATE_COOKIE = "cwf_oauth_line";
 const GOOGLE_STATE_COOKIE = "cwf_oauth_google";
 const CUSTOMER_ROUTE_ALLOWLIST = [
@@ -157,20 +158,47 @@ function baseProviderConfig(env = process.env) {
   };
 }
 
-function createMemoryOAuthStore(nowFn = () => Date.now()) {
+function truthyEnv(value) {
+  return /^(1|true|yes|on)$/i.test(clean(value));
+}
+
+function createMemoryOAuthStore(nowFn = () => Date.now(), opts = {}) {
   const map = new Map();
+  const limit = Math.max(1, Math.floor(Number(opts.maxEntries || DEFAULT_OAUTH_STORE_LIMIT)));
+  function sweepExpired(now = nowFn()) {
+    for (const [key, ctx] of map.entries()) {
+      if (Number(ctx.expiresAt || 0) <= now) map.delete(key);
+    }
+  }
+  function enforceLimit() {
+    sweepExpired();
+    while (map.size > limit) {
+      const oldest = map.keys().next();
+      if (oldest.done) break;
+      map.delete(oldest.value);
+    }
+  }
   return {
     put(ctx) {
+      const now = nowFn();
+      sweepExpired(now);
       const id = randomUrlToken(32);
-      map.set(id, { ...ctx, stateId: id, createdAt: nowFn(), expiresAt: nowFn() + OAUTH_MAX_AGE_MS });
+      map.set(id, { ...ctx, stateId: id, createdAt: now, expiresAt: now + OAUTH_MAX_AGE_MS });
+      enforceLimit();
       return id;
     },
     consume(id) {
+      const now = nowFn();
       const key = clean(id);
       const ctx = map.get(key);
+      if (ctx && Number(ctx.expiresAt || 0) <= now) {
+        map.delete(key);
+        sweepExpired(now);
+        return { ok: false, reason: "expired_state" };
+      }
+      sweepExpired(now);
       if (!ctx) return { ok: false, reason: "missing_state" };
       map.delete(key);
-      if (Number(ctx.expiresAt || 0) < nowFn()) return { ok: false, reason: "expired_state" };
       return { ok: true, ctx };
     },
     peek(id) {
@@ -179,6 +207,11 @@ function createMemoryOAuthStore(nowFn = () => Date.now()) {
     clear() {
       map.clear();
     },
+    size() {
+      sweepExpired();
+      return map.size;
+    },
+    limit,
     _map: map,
   };
 }
@@ -268,6 +301,69 @@ async function linkedProviders(pool, customerSub) {
   return (r.rows || []).map((row) => row.provider).filter(Boolean);
 }
 
+async function linkedProvidersSafe(pool, customerSub) {
+  try {
+    return await linkedProviders(pool, customerSub);
+  } catch (_) {
+    return [];
+  }
+}
+
+async function publicMePayload({ pool, payload }) {
+  const sub = clean(payload?.sub);
+  const user = {
+    name: clean(payload?.name),
+    picture: clean(payload?.picture),
+    provider: clean(payload?.provider || "line"),
+  };
+  if (!sub) return { logged_in: true, user, profile: null };
+
+  let profile = null;
+  try {
+    const r = await pool.query(
+      `SELECT phone, address, maps_url FROM public.customer_profiles WHERE sub=$1 LIMIT 1`,
+      [sub]
+    );
+    const row = r.rows && r.rows[0] ? r.rows[0] : null;
+    if (row) {
+      profile = {
+        phone: row.phone || "",
+        address: row.address || "",
+        maps_url: row.maps_url || "",
+      };
+    }
+  } catch (_) {
+    return { logged_in: true, user, profile: null };
+  }
+
+  const response = { logged_in: true, user, profile };
+  try {
+    const enriched = await pool.query(
+      `SELECT email, email_verified FROM public.customer_profiles WHERE sub=$1 LIMIT 1`,
+      [sub]
+    );
+    const row = enriched.rows && enriched.rows[0] ? enriched.rows[0] : {};
+    const providers = await linkedProvidersSafe(pool, sub);
+    const linked = providers.length
+      ? providers
+      : (Array.isArray(payload?.linked_providers) ? payload.linked_providers : [payload?.provider].filter(Boolean));
+    const email = clean(row.email || payload?.email);
+    const emailVerified = !!(row.email_verified || payload?.email_verified);
+    response.user = {
+      ...response.user,
+      email,
+      email_verified: emailVerified,
+      linked_providers: linked,
+    };
+    response.provider = response.user.provider;
+    response.linked_providers = linked;
+    response.profile = response.profile ? { ...response.profile, email, email_verified: emailVerified } : null;
+  } catch (_) {
+    // Keep the legacy response shape when the optional identity schema is not deployed yet.
+  }
+  return response;
+}
+
 async function ensureProfile(pool, identity) {
   await pool.query(
     `INSERT INTO public.customer_profiles
@@ -317,19 +413,20 @@ async function upsertIdentity(pool, identity) {
   );
 }
 
-async function resolveCustomerForIdentity(pool, identity, loggedInCustomer) {
+async function resolveCustomerForIdentity(pool, identity, loggedInCustomer, mode = "login") {
   const existing = await pool.query(
     `SELECT customer_sub FROM public.customer_identities WHERE provider=$1 AND provider_subject=$2 LIMIT 1`,
     [identity.provider, identity.provider_subject]
   );
   const existingSub = existing.rows?.[0]?.customer_sub || "";
+  if (mode === "link") {
+    if (!loggedInCustomer?.sub) return { error: "LINK_SESSION_MISSING" };
+    if (existingSub && existingSub !== loggedInCustomer.sub) return { error: "PROVIDER_ALREADY_LINKED", customerSub: existingSub };
+    return { customerSub: loggedInCustomer.sub, mode: existingSub ? "already_linked_to_session" : "linked_to_session" };
+  }
   if (existingSub) {
-    if (loggedInCustomer?.sub && loggedInCustomer.sub !== existingSub) {
-      return { error: "PROVIDER_ALREADY_LINKED", customerSub: existingSub };
-    }
     return { customerSub: existingSub, mode: "existing_identity" };
   }
-  if (loggedInCustomer?.sub) return { customerSub: loggedInCustomer.sub, mode: "linked_to_session" };
   if (identity.provider === "line") {
     const legacySub = `line:${identity.provider_subject}`;
     const legacy = await findProfile(pool, legacySub);
@@ -348,8 +445,8 @@ async function resolveCustomerForIdentity(pool, identity, loggedInCustomer) {
   return { customerSub: `${identity.provider}:${identity.provider_subject}`, mode: "new_customer" };
 }
 
-async function completeProviderLogin({ pool, identity, loggedInCustomer }) {
-  const resolved = await resolveCustomerForIdentity(pool, identity, loggedInCustomer);
+async function completeProviderLogin({ pool, identity, loggedInCustomer, mode = "login" }) {
+  const resolved = await resolveCustomerForIdentity(pool, identity, loggedInCustomer, mode);
   if (resolved.error) return resolved;
   const fullIdentity = { ...identity, customer_sub: resolved.customerSub };
   await upsertIdentity(pool, fullIdentity);
@@ -458,6 +555,14 @@ function authSuccessRedirect(provider, returnTo, linked) {
   return `${url.pathname}${url.search}${url.hash}`;
 }
 
+function flowMode(value) {
+  return clean(value) === "link" ? "link" : "login";
+}
+
+function lineScope(env = process.env) {
+  return truthyEnv(env.LINE_EMAIL_SCOPE_ENABLED) ? "openid profile email" : "openid profile";
+}
+
 function getStore(deps) {
   return deps.oauthStore || defaultOAuthStore;
 }
@@ -467,18 +572,26 @@ function createStartHandler(provider, deps) {
     const availability = await providerAvailability({ pool: deps.pool, req, env: deps.env });
     const providerCfg = availability[provider];
     const returnTo = safeReturnTo(req.query?.returnTo || req.query?.next);
+    const mode = flowMode(req.query?.mode);
     if (!providerCfg.available) return res.redirect(authErrorRedirect(provider, "provider_unavailable", returnTo));
+    const current = currentCustomer(req, availability.jwtSecret);
+    if (mode === "link") {
+      if (!current?.sub) return res.redirect(authErrorRedirect(provider, "link_session_missing", returnTo));
+      if (clean(req.query?.confirm) !== "1") return res.redirect(authErrorRedirect(provider, "link_confirmation_required", returnTo));
+      const providers = await linkedProvidersSafe(deps.pool, current.sub);
+      if (providers.includes(provider)) return res.redirect(authErrorRedirect(provider, "account_already_linked", returnTo));
+    }
     const verifier = randomUrlToken(48);
     const state = randomUrlToken(32);
     const nonce = randomUrlToken(32);
-    const current = currentCustomer(req, availability.jwtSecret);
     const stateId = getStore(deps).put({
       provider,
+      mode,
       state,
       nonce,
       codeVerifier: verifier,
       returnTo,
-      linkCustomerSub: current?.sub || "",
+      linkCustomerSub: mode === "link" ? current?.sub || "" : "",
     });
     const redirectUri = callbackUrl(req, provider, deps.env);
     setCookie(res, provider === "line" ? LINE_STATE_COOKIE : GOOGLE_STATE_COOKIE, stateId, {
@@ -490,7 +603,7 @@ function createStartHandler(provider, deps) {
     authorize.searchParams.set("client_id", providerCfg.clientId);
     authorize.searchParams.set("redirect_uri", redirectUri);
     authorize.searchParams.set("state", state);
-    authorize.searchParams.set("scope", provider === "line" ? "openid profile email" : "openid email profile");
+    authorize.searchParams.set("scope", provider === "line" ? lineScope(deps.env) : "openid email profile");
     authorize.searchParams.set("nonce", nonce);
     authorize.searchParams.set("code_challenge", sha256Base64Url(verifier));
     authorize.searchParams.set("code_challenge_method", "S256");
@@ -519,7 +632,7 @@ function createCallbackHandler(provider, deps) {
       if (!providerCfg.available) return res.redirect(authErrorRedirect(provider, "provider_unavailable", returnTo));
 
       let loggedInCustomer = null;
-      if (ctx.linkCustomerSub) {
+      if (ctx.mode === "link") {
         const current = currentCustomer(req, availability.jwtSecret);
         if (!current?.sub) return res.redirect(authErrorRedirect(provider, "link_session_missing", returnTo));
         if (current.sub !== ctx.linkCustomerSub) return res.redirect(authErrorRedirect(provider, "link_session_changed", returnTo));
@@ -537,7 +650,7 @@ function createCallbackHandler(provider, deps) {
         ? await (deps.verifyLineIdToken || verifyLineIdToken)({ fetchImpl, idToken, clientId: providerCfg.clientId, nonce: ctx.nonce })
         : await (deps.verifyGoogleIdToken || verifyGoogleIdToken)({ idToken, clientId: providerCfg.clientId, nonce: ctx.nonce, oauthClient: deps.googleOAuthClient });
       if (!identity.provider_subject) return res.redirect(authErrorRedirect(provider, "missing_provider_subject", returnTo));
-      const result = await completeProviderLogin({ pool: deps.pool, identity, loggedInCustomer });
+      const result = await completeProviderLogin({ pool: deps.pool, identity, loggedInCustomer, mode: ctx.mode === "link" ? "link" : "login" });
       if (result.error === "PROVIDER_ALREADY_LINKED") return res.redirect(authErrorRedirect(provider, "account_already_linked", returnTo));
       issueCustomerSession(res, result.customer, availability.jwtSecret, redirectUri.startsWith("https://") || isHttpsReq(req));
       return res.redirect(authSuccessRedirect(provider, returnTo, result.mode === "linked_to_session"));
@@ -546,30 +659,6 @@ function createCallbackHandler(provider, deps) {
       return res.redirect(authErrorRedirect(provider, "server", returnTo));
     }
   };
-}
-
-async function ensureCustomerAuthSchema(pool) {
-  await pool.query(`ALTER TABLE public.customer_profiles ADD COLUMN IF NOT EXISTS email TEXT`);
-  await pool.query(`ALTER TABLE public.customer_profiles ADD COLUMN IF NOT EXISTS email_verified BOOLEAN DEFAULT FALSE`);
-  await pool.query(`
-    CREATE TABLE IF NOT EXISTS public.customer_identities (
-      identity_id BIGSERIAL PRIMARY KEY,
-      customer_sub TEXT NOT NULL REFERENCES public.customer_profiles(sub) ON DELETE CASCADE,
-      provider TEXT NOT NULL,
-      provider_subject TEXT NOT NULL,
-      email TEXT,
-      email_verified BOOLEAN DEFAULT FALSE,
-      display_name TEXT,
-      picture_url TEXT,
-      linked_at TIMESTAMPTZ DEFAULT NOW(),
-      last_login_at TIMESTAMPTZ DEFAULT NOW(),
-      created_at TIMESTAMPTZ DEFAULT NOW(),
-      updated_at TIMESTAMPTZ DEFAULT NOW(),
-      UNIQUE(provider, provider_subject)
-    )
-  `);
-  await pool.query(`CREATE INDEX IF NOT EXISTS idx_customer_identities_customer_sub ON public.customer_identities(customer_sub)`);
-  await pool.query(`CREATE INDEX IF NOT EXISTS idx_customer_profiles_verified_email ON public.customer_profiles(lower(email)) WHERE email_verified=TRUE`);
 }
 
 function createCustomerAuthRoutes(deps) {
@@ -581,12 +670,24 @@ function createCustomerAuthRoutes(deps) {
   router.get("/public/auth/config", async (req, res) => {
     const availability = await providerAvailability({ pool: deps.pool, req, env: deps.env });
     const returnTo = safeReturnTo(req.query?.returnTo);
+    const current = currentCustomer(req, availability.jwtSecret);
+    const linked = current?.sub ? await linkedProvidersSafe(deps.pool, current.sub) : [];
     res.json({
       ok: true,
       schema_ready: availability.schemaReady,
+      logged_in: !!current?.sub,
+      linked_providers: linked,
       providers: {
-        line: { available: availability.line.available, start_url: `/auth/line/start?returnTo=${encodeURIComponent(returnTo)}` },
-        google: { available: availability.google.available, start_url: `/auth/google/start?returnTo=${encodeURIComponent(returnTo)}` },
+        line: {
+          available: availability.line.available,
+          linked: linked.includes("line"),
+          start_url: `/auth/line/start?mode=${current?.sub ? "link" : "login"}&returnTo=${encodeURIComponent(returnTo)}`,
+        },
+        google: {
+          available: availability.google.available,
+          linked: linked.includes("google"),
+          start_url: `/auth/google/start?mode=${current?.sub ? "link" : "login"}&returnTo=${encodeURIComponent(returnTo)}`,
+        },
       },
     });
   });
@@ -613,11 +714,12 @@ module.exports = {
   jwtVerify,
   sha256Base64Url,
   createMemoryOAuthStore,
+  lineScope,
   verifyGoogleIdToken,
   googleIdentityFromPayload,
   verifyLineIdToken,
+  publicMePayload,
   resolveCustomerForIdentity,
   completeProviderLogin,
-  ensureCustomerAuthSchema,
   createCustomerAuthRoutes,
 };

--- a/server/customerAuth.js
+++ b/server/customerAuth.js
@@ -1,0 +1,626 @@
+"use strict";
+
+const crypto = require("crypto");
+const express = require("express");
+
+const SESSION_COOKIE = "cwf_token";
+const SESSION_MAX_AGE_SEC = 7 * 24 * 60 * 60;
+const OAUTH_MAX_AGE_SEC = 10 * 60;
+const LINE_STATE_COOKIE = "cwf_oauth_line";
+const GOOGLE_STATE_COOKIE = "cwf_oauth_google";
+const CUSTOMER_ROUTE_ALLOWLIST = [
+  /^\/customer-app(?:\/|\?|$)/,
+  /^\/customer(?:\.html)?(?:\?|$)/,
+  /^\/track(?:\.html)?(?:\?|$)/,
+];
+
+function clean(value) {
+  return String(value == null ? "" : value).trim();
+}
+
+function b64urlEncode(input) {
+  const b = Buffer.isBuffer(input) ? input : Buffer.from(String(input));
+  return b.toString("base64").replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/g, "");
+}
+
+function b64urlDecodeToBuffer(str) {
+  const s = clean(str).replace(/-/g, "+").replace(/_/g, "/");
+  const pad = s.length % 4 ? "=".repeat(4 - (s.length % 4)) : "";
+  return Buffer.from(s + pad, "base64");
+}
+
+function randomUrlToken(bytes = 32) {
+  return b64urlEncode(crypto.randomBytes(bytes));
+}
+
+function sha256Base64Url(value) {
+  return b64urlEncode(crypto.createHash("sha256").update(String(value)).digest());
+}
+
+function jwtSign(payload, secret) {
+  const header = { alg: "HS256", typ: "JWT" };
+  const h = b64urlEncode(JSON.stringify(header));
+  const p = b64urlEncode(JSON.stringify(payload));
+  const data = `${h}.${p}`;
+  const sig = crypto.createHmac("sha256", String(secret)).update(data).digest();
+  return `${data}.${b64urlEncode(sig)}`;
+}
+
+function jwtVerify(token, secret) {
+  const parts = clean(token).split(".");
+  if (parts.length !== 3) return null;
+  const [h, p, s] = parts;
+  const data = `${h}.${p}`;
+  const expected = crypto.createHmac("sha256", String(secret)).update(data).digest();
+  const got = b64urlDecodeToBuffer(s);
+  if (got.length !== expected.length || !crypto.timingSafeEqual(got, expected)) return null;
+  let payload;
+  try {
+    payload = JSON.parse(b64urlDecodeToBuffer(p).toString("utf8"));
+  } catch (_) {
+    return null;
+  }
+  const now = Math.floor(Date.now() / 1000);
+  if (payload && payload.exp && now > Number(payload.exp)) return null;
+  return payload || null;
+}
+
+function parseCookies(header) {
+  const out = {};
+  String(header || "").split(";").forEach((part) => {
+    const idx = part.indexOf("=");
+    if (idx < 0) return;
+    const key = part.slice(0, idx).trim();
+    let val = part.slice(idx + 1).trim();
+    if (!key) return;
+    val = val.replace(/^"|"$/g, "");
+    try { val = decodeURIComponent(val); } catch (_) {}
+    out[key] = val;
+  });
+  return out;
+}
+
+function parseCookieValue(req, name) {
+  return parseCookies(req.headers?.cookie || "")[name] || null;
+}
+
+function appendSetCookie(res, cookieStr) {
+  const prev = res.getHeader("Set-Cookie");
+  if (!prev) return res.setHeader("Set-Cookie", cookieStr);
+  if (Array.isArray(prev)) return res.setHeader("Set-Cookie", [...prev, cookieStr]);
+  return res.setHeader("Set-Cookie", [prev, cookieStr]);
+}
+
+function setCookie(res, name, value, opts = {}) {
+  const maxAgeSec = Number(opts.maxAgeSec || SESSION_MAX_AGE_SEC);
+  const sameSite = opts.sameSite || "Lax";
+  const pathVal = opts.path || "/";
+  const encoded = encodeURIComponent(String(value));
+  let cookie = `${name}=${encoded}; Max-Age=${maxAgeSec}; Path=${pathVal}; SameSite=${sameSite}`;
+  if (opts.httpOnly !== false) cookie += "; HttpOnly";
+  if (opts.secure) cookie += "; Secure";
+  appendSetCookie(res, cookie);
+}
+
+function clearCookie(res, name) {
+  appendSetCookie(res, `${name}=; Max-Age=0; Path=/; SameSite=Lax`);
+  appendSetCookie(res, `${name}=; Max-Age=0; Path=/; SameSite=Lax; Secure`);
+}
+
+function getReqBaseUrl(req) {
+  const xfProto = clean(req.headers["x-forwarded-proto"]).split(",")[0].trim();
+  const proto = xfProto || req.protocol || "http";
+  return `${proto}://${req.get("host")}`;
+}
+
+function isHttpsReq(req) {
+  const xfProto = clean(req.headers["x-forwarded-proto"]).split(",")[0].trim();
+  return xfProto ? xfProto === "https" : req.protocol === "https";
+}
+
+function safeReturnTo(value, fallback = "/customer-app/") {
+  const raw = clean(value);
+  if (!raw) return fallback;
+  if (/^[a-z][a-z0-9+.-]*:/i.test(raw) || raw.startsWith("//")) return fallback;
+  if (!raw.startsWith("/")) return fallback;
+  return CUSTOMER_ROUTE_ALLOWLIST.some((pattern) => pattern.test(raw)) ? raw : fallback;
+}
+
+function callbackUrl(req, provider, env) {
+  const line = clean(env.LINE_CALLBACK_URL || env.LINE_LOGIN_CALLBACK_URL);
+  const google = clean(env.GOOGLE_CALLBACK_URL || env.GOOGLE_OAUTH_CALLBACK_URL);
+  if (provider === "line" && line) return line;
+  if (provider === "google" && google) return google;
+  return `${getReqBaseUrl(req)}/auth/${provider}/callback`;
+}
+
+function providerConfig(env = process.env) {
+  const lineClientId = clean(env.LINE_CHANNEL_ID || env.LINE_CLIENT_ID);
+  const lineClientSecret = clean(env.LINE_CHANNEL_SECRET || env.LINE_CLIENT_SECRET);
+  const googleClientId = clean(env.GOOGLE_CLIENT_ID || env.GOOGLE_OAUTH_CLIENT_ID);
+  const googleClientSecret = clean(env.GOOGLE_CLIENT_SECRET || env.GOOGLE_OAUTH_CLIENT_SECRET);
+  return {
+    line: {
+      clientId: lineClientId,
+      clientSecret: lineClientSecret,
+      available: !!(lineClientId && lineClientSecret),
+    },
+    google: {
+      clientId: googleClientId,
+      clientSecret: googleClientSecret,
+      available: !!(googleClientId && googleClientSecret),
+    },
+    jwtSecret: clean(env.CWF_JWT_SECRET || env.JWT_SECRET),
+  };
+}
+
+function encodeOAuthStateCookie(ctx) {
+  return b64urlEncode(JSON.stringify(ctx));
+}
+
+function decodeOAuthStateCookie(value) {
+  try {
+    const ctx = JSON.parse(b64urlDecodeToBuffer(value).toString("utf8"));
+    return ctx && typeof ctx === "object" ? ctx : null;
+  } catch (_) {
+    return null;
+  }
+}
+
+function currentCustomer(req, jwtSecret) {
+  const token = parseCookieValue(req, SESSION_COOKIE);
+  return token && jwtSecret ? jwtVerify(token, jwtSecret) : null;
+}
+
+function issueCustomerSession(res, customer, jwtSecret, secureCookie) {
+  const now = Math.floor(Date.now() / 1000);
+  const providers = Array.isArray(customer.linked_providers) ? customer.linked_providers : [customer.provider].filter(Boolean);
+  const payload = {
+    sub: clean(customer.customer_sub),
+    provider: clean(customer.provider || providers[0] || ""),
+    provider_sub: clean(customer.provider_subject || ""),
+    name: clean(customer.display_name || customer.name || "ลูกค้า CWF"),
+    picture: clean(customer.picture_url || customer.picture || ""),
+    email: clean(customer.email || ""),
+    email_verified: !!customer.email_verified,
+    linked_providers: providers,
+    iat: now,
+    exp: now + SESSION_MAX_AGE_SEC,
+  };
+  setCookie(res, SESSION_COOKIE, jwtSign(payload, jwtSecret), { maxAgeSec: SESSION_MAX_AGE_SEC, secure: secureCookie });
+  return payload;
+}
+
+async function findProfile(pool, customerSub) {
+  const r = await pool.query(
+    `SELECT sub, provider, display_name, picture_url, phone, address, maps_url, email, email_verified
+       FROM public.customer_profiles WHERE sub=$1 LIMIT 1`,
+    [customerSub]
+  );
+  return r.rows && r.rows[0] ? r.rows[0] : null;
+}
+
+async function linkedProviders(pool, customerSub) {
+  const r = await pool.query(
+    `SELECT provider FROM public.customer_identities WHERE customer_sub=$1 ORDER BY provider`,
+    [customerSub]
+  );
+  return (r.rows || []).map((row) => row.provider).filter(Boolean);
+}
+
+async function ensureProfile(pool, identity) {
+  await pool.query(
+    `INSERT INTO public.customer_profiles
+       (sub, provider, display_name, picture_url, email, email_verified, updated_at)
+     VALUES ($1,$2,$3,$4,$5,$6,NOW())
+     ON CONFLICT (sub)
+     DO UPDATE SET
+       provider=COALESCE(public.customer_profiles.provider, EXCLUDED.provider),
+       display_name=COALESCE(NULLIF(public.customer_profiles.display_name,''), EXCLUDED.display_name),
+       picture_url=COALESCE(NULLIF(public.customer_profiles.picture_url,''), EXCLUDED.picture_url),
+       email=COALESCE(NULLIF(public.customer_profiles.email,''), EXCLUDED.email),
+       email_verified=(COALESCE(public.customer_profiles.email_verified, FALSE) OR EXCLUDED.email_verified),
+       updated_at=NOW()`,
+    [
+      identity.customer_sub,
+      identity.provider,
+      identity.display_name || null,
+      identity.picture_url || null,
+      identity.email || null,
+      !!identity.email_verified,
+    ]
+  );
+}
+
+async function upsertIdentity(pool, identity) {
+  await ensureProfile(pool, identity);
+  await pool.query(
+    `INSERT INTO public.customer_identities
+       (customer_sub, provider, provider_subject, email, email_verified, display_name, picture_url, linked_at, last_login_at)
+     VALUES ($1,$2,$3,$4,$5,$6,$7,NOW(),NOW())
+     ON CONFLICT (provider, provider_subject)
+     DO UPDATE SET
+       email=EXCLUDED.email,
+       email_verified=EXCLUDED.email_verified,
+       display_name=EXCLUDED.display_name,
+       picture_url=EXCLUDED.picture_url,
+       last_login_at=NOW()`,
+    [
+      identity.customer_sub,
+      identity.provider,
+      identity.provider_subject,
+      identity.email || null,
+      !!identity.email_verified,
+      identity.display_name || null,
+      identity.picture_url || null,
+    ]
+  );
+}
+
+async function resolveCustomerForIdentity(pool, identity, loggedInCustomer) {
+  const existing = await pool.query(
+    `SELECT customer_sub FROM public.customer_identities WHERE provider=$1 AND provider_subject=$2 LIMIT 1`,
+    [identity.provider, identity.provider_subject]
+  );
+  const existingSub = existing.rows?.[0]?.customer_sub || "";
+  if (existingSub) {
+    if (loggedInCustomer?.sub && loggedInCustomer.sub !== existingSub) {
+      return { error: "PROVIDER_ALREADY_LINKED", customerSub: existingSub };
+    }
+    return { customerSub: existingSub, mode: "existing_identity" };
+  }
+
+  if (loggedInCustomer?.sub) {
+    return { customerSub: loggedInCustomer.sub, mode: "linked_to_session" };
+  }
+
+  if (identity.provider === "line") {
+    const legacySub = `line:${identity.provider_subject}`;
+    const legacy = await findProfile(pool, legacySub);
+    if (legacy) return { customerSub: legacySub, mode: "legacy_line_profile" };
+  }
+
+  if (identity.email && identity.email_verified) {
+    const emailMatch = await pool.query(
+      `SELECT sub FROM public.customer_profiles
+        WHERE lower(email)=lower($1) AND email_verified=TRUE
+        LIMIT 2`,
+      [identity.email]
+    );
+    if ((emailMatch.rows || []).length === 1) {
+      return { customerSub: emailMatch.rows[0].sub, mode: "verified_email_match" };
+    }
+    if ((emailMatch.rows || []).length > 1) {
+      return { customerSub: `${identity.provider}:${identity.provider_subject}`, mode: "ambiguous_email_new_customer" };
+    }
+  }
+
+  return { customerSub: `${identity.provider}:${identity.provider_subject}`, mode: "new_customer" };
+}
+
+async function completeProviderLogin({ pool, identity, loggedInCustomer }) {
+  const resolved = await resolveCustomerForIdentity(pool, identity, loggedInCustomer);
+  if (resolved.error) return resolved;
+  const fullIdentity = { ...identity, customer_sub: resolved.customerSub };
+  await upsertIdentity(pool, fullIdentity);
+  const profile = await findProfile(pool, resolved.customerSub);
+  const providers = await linkedProviders(pool, resolved.customerSub);
+  return {
+    mode: resolved.mode,
+    customer: {
+      customer_sub: resolved.customerSub,
+      provider: identity.provider,
+      provider_subject: identity.provider_subject,
+      display_name: profile?.display_name || identity.display_name,
+      picture_url: profile?.picture_url || identity.picture_url,
+      email: profile?.email || identity.email,
+      email_verified: profile?.email_verified || identity.email_verified,
+      linked_providers: providers.length ? providers : [identity.provider],
+    },
+  };
+}
+
+async function exchangeLineCode({ fetchImpl, code, redirectUri, clientId, clientSecret, codeVerifier }) {
+  const res = await fetchImpl("https://api.line.me/oauth2/v2.1/token", {
+    method: "POST",
+    headers: { "content-type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams({
+      grant_type: "authorization_code",
+      code,
+      redirect_uri: redirectUri,
+      client_id: clientId,
+      client_secret: clientSecret,
+      code_verifier: codeVerifier,
+    }),
+  });
+  const text = await res.text().catch(() => "");
+  let json = {};
+  try { json = text ? JSON.parse(text) : {}; } catch (_) {}
+  if (!res.ok) throw Object.assign(new Error("LINE_TOKEN_EXCHANGE_FAILED"), { status: res.status, body: text });
+  return json;
+}
+
+async function verifyLineIdToken({ fetchImpl, idToken, clientId, nonce }) {
+  const res = await fetchImpl("https://api.line.me/oauth2/v2.1/verify", {
+    method: "POST",
+    headers: { "content-type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams({ id_token: idToken, client_id: clientId }),
+  });
+  const text = await res.text().catch(() => "");
+  let json = {};
+  try { json = text ? JSON.parse(text) : {}; } catch (_) {}
+  if (!res.ok) throw Object.assign(new Error("LINE_ID_TOKEN_INVALID"), { status: res.status, body: text });
+  if (clean(json.nonce) !== clean(nonce)) throw new Error("LINE_NONCE_MISMATCH");
+  const sub = clean(json.sub);
+  if (!sub) throw new Error("LINE_SUB_MISSING");
+  return {
+    provider: "line",
+    provider_subject: sub,
+    display_name: clean(json.name) || "LINE User",
+    picture_url: clean(json.picture),
+    email: clean(json.email).toLowerCase(),
+    email_verified: !!json.email,
+  };
+}
+
+async function exchangeGoogleCode({ fetchImpl, code, redirectUri, clientId, clientSecret, codeVerifier }) {
+  const res = await fetchImpl("https://oauth2.googleapis.com/token", {
+    method: "POST",
+    headers: { "content-type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams({
+      grant_type: "authorization_code",
+      code,
+      redirect_uri: redirectUri,
+      client_id: clientId,
+      client_secret: clientSecret,
+      code_verifier: codeVerifier,
+    }),
+  });
+  const text = await res.text().catch(() => "");
+  let json = {};
+  try { json = text ? JSON.parse(text) : {}; } catch (_) {}
+  if (!res.ok) throw Object.assign(new Error("GOOGLE_TOKEN_EXCHANGE_FAILED"), { status: res.status, body: text });
+  return json;
+}
+
+function decodeJwtUnverified(token) {
+  const parts = clean(token).split(".");
+  if (parts.length !== 3) throw new Error("JWT_FORMAT_INVALID");
+  return {
+    header: JSON.parse(b64urlDecodeToBuffer(parts[0]).toString("utf8")),
+    payload: JSON.parse(b64urlDecodeToBuffer(parts[1]).toString("utf8")),
+    signingInput: `${parts[0]}.${parts[1]}`,
+    signature: b64urlDecodeToBuffer(parts[2]),
+  };
+}
+
+async function verifyGoogleIdToken({ fetchImpl, idToken, clientId, nonce }) {
+  const decoded = decodeJwtUnverified(idToken);
+  if (decoded.header.alg !== "RS256") throw new Error("GOOGLE_ALG_INVALID");
+  const certRes = await fetchImpl("https://www.googleapis.com/oauth2/v3/certs");
+  const certJson = await certRes.json();
+  const key = (certJson.keys || []).find((item) => item.kid === decoded.header.kid);
+  if (!key || !key.x5c || !key.x5c[0]) throw new Error("GOOGLE_CERT_NOT_FOUND");
+  const cert = `-----BEGIN CERTIFICATE-----\n${key.x5c[0].match(/.{1,64}/g).join("\n")}\n-----END CERTIFICATE-----\n`;
+  const ok = crypto.verify("RSA-SHA256", Buffer.from(decoded.signingInput), cert, decoded.signature);
+  if (!ok) throw new Error("GOOGLE_SIGNATURE_INVALID");
+  return googleIdentityFromPayload(decoded.payload, clientId, nonce);
+}
+
+function googleIdentityFromPayload(payload, clientId, nonce, now = Math.floor(Date.now() / 1000)) {
+  if (!["https://accounts.google.com", "accounts.google.com"].includes(payload.iss)) throw new Error("GOOGLE_ISS_INVALID");
+  if (payload.aud !== clientId) throw new Error("GOOGLE_AUD_INVALID");
+  if (payload.exp && now > Number(payload.exp)) throw new Error("GOOGLE_TOKEN_EXPIRED");
+  if (payload.nonce !== nonce) throw new Error("GOOGLE_NONCE_MISMATCH");
+  if (payload.email && payload.email_verified !== true) throw new Error("GOOGLE_EMAIL_NOT_VERIFIED");
+  return {
+    provider: "google",
+    provider_subject: clean(payload.sub),
+    display_name: clean(payload.name) || clean(payload.email) || "Google User",
+    picture_url: clean(payload.picture),
+    email: clean(payload.email).toLowerCase(),
+    email_verified: payload.email_verified === true,
+  };
+}
+
+function authErrorRedirect(provider, reason, returnTo) {
+  const url = new URL(returnTo, "https://local.invalid");
+  url.searchParams.set("auth", "failed");
+  url.searchParams.set("provider", provider);
+  url.searchParams.set("reason", reason);
+  return `${url.pathname}${url.search}${url.hash}`;
+}
+
+function authSuccessRedirect(provider, returnTo, linked) {
+  const url = new URL(returnTo, "https://local.invalid");
+  url.searchParams.set("auth", linked ? "linked" : "success");
+  url.searchParams.set("provider", provider);
+  return `${url.pathname}${url.search}${url.hash}`;
+}
+
+function createStartHandler(provider, deps) {
+  return (req, res) => {
+    const cfg = providerConfig(deps.env);
+    const providerCfg = cfg[provider];
+    const returnTo = safeReturnTo(req.query?.returnTo || req.query?.next);
+    if (!providerCfg.available) return res.redirect(authErrorRedirect(provider, "provider_unavailable", returnTo));
+    const verifier = randomUrlToken(48);
+    const state = randomUrlToken(32);
+    const nonce = randomUrlToken(32);
+    const ctx = {
+      provider,
+      state,
+      nonce,
+      codeVerifier: verifier,
+      returnTo,
+      linkCustomerSub: currentCustomer(req, cfg.jwtSecret)?.sub || "",
+      createdAt: Date.now(),
+    };
+    const secureCookie = callbackUrl(req, provider, deps.env).startsWith("https://") || isHttpsReq(req);
+    setCookie(res, provider === "line" ? LINE_STATE_COOKIE : GOOGLE_STATE_COOKIE, encodeOAuthStateCookie(ctx), {
+      maxAgeSec: OAUTH_MAX_AGE_SEC,
+      secure: secureCookie,
+    });
+    const authorize = new URL(provider === "line" ? "https://access.line.me/oauth2/v2.1/authorize" : "https://accounts.google.com/o/oauth2/v2/auth");
+    authorize.searchParams.set("response_type", "code");
+    authorize.searchParams.set("client_id", providerCfg.clientId);
+    authorize.searchParams.set("redirect_uri", callbackUrl(req, provider, deps.env));
+    authorize.searchParams.set("state", state);
+    authorize.searchParams.set("scope", provider === "line" ? "openid profile email" : "openid email profile");
+    authorize.searchParams.set("nonce", nonce);
+    authorize.searchParams.set("code_challenge", sha256Base64Url(verifier));
+    authorize.searchParams.set("code_challenge_method", "S256");
+    if (provider === "google") authorize.searchParams.set("prompt", "select_account");
+    return res.redirect(authorize.toString());
+  };
+}
+
+function createCallbackHandler(provider, deps) {
+  return async (req, res) => {
+    const cookieName = provider === "line" ? LINE_STATE_COOKIE : GOOGLE_STATE_COOKIE;
+    const cfg = providerConfig(deps.env);
+    const providerCfg = cfg[provider];
+    const ctx = decodeOAuthStateCookie(parseCookieValue(req, cookieName));
+    const returnTo = safeReturnTo(ctx?.returnTo);
+    clearCookie(res, cookieName);
+    try {
+      if (req.query?.error) return res.redirect(authErrorRedirect(provider, clean(req.query.error), returnTo));
+      if (!ctx || ctx.provider !== provider) return res.redirect(authErrorRedirect(provider, "missing_state", returnTo));
+      if (!clean(req.query?.state) || clean(req.query.state) !== ctx.state) return res.redirect(authErrorRedirect(provider, "invalid_state", returnTo));
+      if (!clean(req.query?.code)) return res.redirect(authErrorRedirect(provider, "missing_code", returnTo));
+      if (!providerCfg.available) return res.redirect(authErrorRedirect(provider, "provider_unavailable", returnTo));
+      if (!cfg.jwtSecret) return res.redirect(authErrorRedirect(provider, "session_unavailable", returnTo));
+
+      const redirectUri = callbackUrl(req, provider, deps.env);
+      const fetchImpl = deps.fetchImpl || fetch;
+      const tokens = provider === "line"
+        ? await (deps.exchangeLineCode || exchangeLineCode)({ fetchImpl, code: clean(req.query.code), redirectUri, clientId: providerCfg.clientId, clientSecret: providerCfg.clientSecret, codeVerifier: ctx.codeVerifier })
+        : await (deps.exchangeGoogleCode || exchangeGoogleCode)({ fetchImpl, code: clean(req.query.code), redirectUri, clientId: providerCfg.clientId, clientSecret: providerCfg.clientSecret, codeVerifier: ctx.codeVerifier });
+      const idToken = clean(tokens.id_token);
+      if (!idToken) return res.redirect(authErrorRedirect(provider, "missing_id_token", returnTo));
+      const identity = provider === "line"
+        ? await (deps.verifyLineIdToken || verifyLineIdToken)({ fetchImpl, idToken, clientId: providerCfg.clientId, nonce: ctx.nonce })
+        : await (deps.verifyGoogleIdToken || verifyGoogleIdToken)({ fetchImpl, idToken, clientId: providerCfg.clientId, nonce: ctx.nonce });
+      if (!identity.provider_subject) return res.redirect(authErrorRedirect(provider, "missing_provider_subject", returnTo));
+      const loggedInCustomer = ctx.linkCustomerSub ? { sub: ctx.linkCustomerSub } : currentCustomer(req, cfg.jwtSecret);
+      const result = await completeProviderLogin({ pool: deps.pool, identity, loggedInCustomer });
+      if (result.error === "PROVIDER_ALREADY_LINKED") return res.redirect(authErrorRedirect(provider, "account_already_linked", returnTo));
+      issueCustomerSession(res, result.customer, cfg.jwtSecret, redirectUri.startsWith("https://") || isHttpsReq(req));
+      return res.redirect(authSuccessRedirect(provider, returnTo, result.mode === "linked_to_session"));
+    } catch (e) {
+      if (deps.logger) deps.logger.error(`[CUSTOMER_${provider.toUpperCase()}_AUTH]`, e);
+      return res.redirect(authErrorRedirect(provider, "server", returnTo));
+    }
+  };
+}
+
+async function ensureCustomerAuthSchema(pool) {
+  await pool.query(`ALTER TABLE public.customer_profiles ADD COLUMN IF NOT EXISTS email TEXT`);
+  await pool.query(`ALTER TABLE public.customer_profiles ADD COLUMN IF NOT EXISTS email_verified BOOLEAN DEFAULT FALSE`);
+  await pool.query(`
+    CREATE TABLE IF NOT EXISTS public.customer_identities (
+      identity_id BIGSERIAL PRIMARY KEY,
+      customer_sub TEXT NOT NULL REFERENCES public.customer_profiles(sub) ON DELETE CASCADE,
+      provider TEXT NOT NULL,
+      provider_subject TEXT NOT NULL,
+      email TEXT,
+      email_verified BOOLEAN DEFAULT FALSE,
+      display_name TEXT,
+      picture_url TEXT,
+      linked_at TIMESTAMPTZ DEFAULT NOW(),
+      last_login_at TIMESTAMPTZ DEFAULT NOW(),
+      created_at TIMESTAMPTZ DEFAULT NOW(),
+      updated_at TIMESTAMPTZ DEFAULT NOW(),
+      UNIQUE(provider, provider_subject)
+    )
+  `);
+  await pool.query(`CREATE INDEX IF NOT EXISTS idx_customer_identities_customer_sub ON public.customer_identities(customer_sub)`);
+  await pool.query(`CREATE INDEX IF NOT EXISTS idx_customer_profiles_verified_email ON public.customer_profiles(lower(email)) WHERE email_verified=TRUE`);
+}
+
+function createCustomerAuthRoutes(deps) {
+  const router = express.Router();
+  router.get("/auth/line", createStartHandler("line", deps));
+  router.get("/auth/line/start", createStartHandler("line", deps));
+  router.get("/auth/line/callback", createCallbackHandler("line", deps));
+  router.get("/auth/google", createStartHandler("google", deps));
+  router.get("/auth/google/start", createStartHandler("google", deps));
+  router.get("/auth/google/callback", createCallbackHandler("google", deps));
+  router.get("/public/auth/config", (req, res) => {
+    const cfg = providerConfig(deps.env);
+    const returnTo = safeReturnTo(req.query?.returnTo);
+    res.json({
+      ok: true,
+      providers: {
+        line: { available: cfg.line.available, start_url: `/auth/line?returnTo=${encodeURIComponent(returnTo)}` },
+        google: { available: cfg.google.available, start_url: `/auth/google?returnTo=${encodeURIComponent(returnTo)}` },
+      },
+    });
+  });
+  router.get("/public/me", async (req, res) => {
+    try {
+      const cfg = providerConfig(deps.env);
+      const payload = currentCustomer(req, cfg.jwtSecret);
+      if (!payload?.sub) return res.json({ logged_in: false });
+      const profile = await findProfile(deps.pool, payload.sub);
+      const providers = await linkedProviders(deps.pool, payload.sub);
+      return res.json({
+        logged_in: true,
+        user: {
+          name: payload.name || profile?.display_name || "",
+          picture: payload.picture || profile?.picture_url || "",
+          provider: payload.provider || providers[0] || "",
+          email: payload.email || profile?.email || "",
+          email_verified: !!(payload.email_verified || profile?.email_verified),
+          linked_providers: providers,
+        },
+        provider: payload.provider || providers[0] || "",
+        linked_providers: providers,
+        profile: profile ? {
+          phone: profile.phone || "",
+          address: profile.address || "",
+          maps_url: profile.maps_url || "",
+          email: profile.email || "",
+          email_verified: !!profile.email_verified,
+        } : null,
+      });
+    } catch (_) {
+      return res.json({ logged_in: false });
+    }
+  });
+  router.get("/public/logout", (req, res) => {
+    clearCookie(res, SESSION_COOKIE);
+    clearCookie(res, LINE_STATE_COOKIE);
+    clearCookie(res, GOOGLE_STATE_COOKIE);
+    res.redirect(safeReturnTo(req.query?.returnTo, "/customer-app/?logout=1"));
+  });
+  router.post("/public/logout", (req, res) => {
+    clearCookie(res, SESSION_COOKIE);
+    clearCookie(res, LINE_STATE_COOKIE);
+    clearCookie(res, GOOGLE_STATE_COOKIE);
+    res.json({ ok: true });
+  });
+  return router;
+}
+
+module.exports = {
+  SESSION_COOKIE,
+  LINE_STATE_COOKIE,
+  GOOGLE_STATE_COOKIE,
+  safeReturnTo,
+  providerConfig,
+  b64urlEncode,
+  b64urlDecodeToBuffer,
+  jwtSign,
+  jwtVerify,
+  encodeOAuthStateCookie,
+  decodeOAuthStateCookie,
+  sha256Base64Url,
+  verifyGoogleIdToken,
+  googleIdentityFromPayload,
+  verifyLineIdToken,
+  resolveCustomerForIdentity,
+  completeProviderLogin,
+  ensureCustomerAuthSchema,
+  createCustomerAuthRoutes,
+};

--- a/server/customerAuth.js
+++ b/server/customerAuth.js
@@ -2,10 +2,12 @@
 
 const crypto = require("crypto");
 const express = require("express");
+const { OAuth2Client } = require("google-auth-library");
 
 const SESSION_COOKIE = "cwf_token";
 const SESSION_MAX_AGE_SEC = 7 * 24 * 60 * 60;
-const OAUTH_MAX_AGE_SEC = 10 * 60;
+const OAUTH_MAX_AGE_MS = 10 * 60 * 1000;
+const OAUTH_MAX_AGE_SEC = OAUTH_MAX_AGE_MS / 1000;
 const LINE_STATE_COOKIE = "cwf_oauth_line";
 const GOOGLE_STATE_COOKIE = "cwf_oauth_google";
 const CUSTOMER_ROUTE_ALLOWLIST = [
@@ -13,6 +15,8 @@ const CUSTOMER_ROUTE_ALLOWLIST = [
   /^\/customer(?:\.html)?(?:\?|$)/,
   /^\/track(?:\.html)?(?:\?|$)/,
 ];
+
+const defaultOAuthStore = createMemoryOAuthStore();
 
 function clean(value) {
   return String(value == null ? "" : value).trim();
@@ -71,9 +75,8 @@ function parseCookies(header) {
     const idx = part.indexOf("=");
     if (idx < 0) return;
     const key = part.slice(0, idx).trim();
-    let val = part.slice(idx + 1).trim();
+    let val = part.slice(idx + 1).trim().replace(/^"|"$/g, "");
     if (!key) return;
-    val = val.replace(/^"|"$/g, "");
     try { val = decodeURIComponent(val); } catch (_) {}
     out[key] = val;
   });
@@ -126,45 +129,58 @@ function safeReturnTo(value, fallback = "/customer-app/") {
   return CUSTOMER_ROUTE_ALLOWLIST.some((pattern) => pattern.test(raw)) ? raw : fallback;
 }
 
-function callbackUrl(req, provider, env) {
-  const line = clean(env.LINE_CALLBACK_URL || env.LINE_LOGIN_CALLBACK_URL);
+function callbackUrl(req, provider, env = process.env) {
+  if (provider === "line") {
+    const lineV2 = clean(env.LINE_V2_CALLBACK_URL || env.LINE_CUSTOMER_V2_CALLBACK_URL);
+    return lineV2 || `${getReqBaseUrl(req)}/auth/line/v2/callback`;
+  }
   const google = clean(env.GOOGLE_CALLBACK_URL || env.GOOGLE_OAUTH_CALLBACK_URL);
-  if (provider === "line" && line) return line;
-  if (provider === "google" && google) return google;
-  return `${getReqBaseUrl(req)}/auth/${provider}/callback`;
+  return google || `${getReqBaseUrl(req)}/auth/google/callback`;
 }
 
-function providerConfig(env = process.env) {
+function isUsableCallbackUrl(url, req) {
+  const raw = clean(url);
+  if (!raw) return false;
+  if (raw.startsWith("https://")) return true;
+  return raw.startsWith(`${getReqBaseUrl(req)}/`) && isHttpsReq(req);
+}
+
+function baseProviderConfig(env = process.env) {
   const lineClientId = clean(env.LINE_CHANNEL_ID || env.LINE_CLIENT_ID);
   const lineClientSecret = clean(env.LINE_CHANNEL_SECRET || env.LINE_CLIENT_SECRET);
   const googleClientId = clean(env.GOOGLE_CLIENT_ID || env.GOOGLE_OAUTH_CLIENT_ID);
   const googleClientSecret = clean(env.GOOGLE_CLIENT_SECRET || env.GOOGLE_OAUTH_CLIENT_SECRET);
   return {
-    line: {
-      clientId: lineClientId,
-      clientSecret: lineClientSecret,
-      available: !!(lineClientId && lineClientSecret),
-    },
-    google: {
-      clientId: googleClientId,
-      clientSecret: googleClientSecret,
-      available: !!(googleClientId && googleClientSecret),
-    },
+    line: { clientId: lineClientId, clientSecret: lineClientSecret },
+    google: { clientId: googleClientId, clientSecret: googleClientSecret },
     jwtSecret: clean(env.CWF_JWT_SECRET || env.JWT_SECRET),
   };
 }
 
-function encodeOAuthStateCookie(ctx) {
-  return b64urlEncode(JSON.stringify(ctx));
-}
-
-function decodeOAuthStateCookie(value) {
-  try {
-    const ctx = JSON.parse(b64urlDecodeToBuffer(value).toString("utf8"));
-    return ctx && typeof ctx === "object" ? ctx : null;
-  } catch (_) {
-    return null;
-  }
+function createMemoryOAuthStore(nowFn = () => Date.now()) {
+  const map = new Map();
+  return {
+    put(ctx) {
+      const id = randomUrlToken(32);
+      map.set(id, { ...ctx, stateId: id, createdAt: nowFn(), expiresAt: nowFn() + OAUTH_MAX_AGE_MS });
+      return id;
+    },
+    consume(id) {
+      const key = clean(id);
+      const ctx = map.get(key);
+      if (!ctx) return { ok: false, reason: "missing_state" };
+      map.delete(key);
+      if (Number(ctx.expiresAt || 0) < nowFn()) return { ok: false, reason: "expired_state" };
+      return { ok: true, ctx };
+    },
+    peek(id) {
+      return map.get(clean(id)) || null;
+    },
+    clear() {
+      map.clear();
+    },
+    _map: map,
+  };
 }
 
 function currentCustomer(req, jwtSecret) {
@@ -189,6 +205,50 @@ function issueCustomerSession(res, customer, jwtSecret, secureCookie) {
   };
   setCookie(res, SESSION_COOKIE, jwtSign(payload, jwtSecret), { maxAgeSec: SESSION_MAX_AGE_SEC, secure: secureCookie });
   return payload;
+}
+
+async function schemaReady(pool) {
+  try {
+    const result = await pool.query(`
+      SELECT
+        to_regclass('public.customer_identities') IS NOT NULL AS has_identities,
+        EXISTS (
+          SELECT 1 FROM information_schema.columns
+          WHERE table_schema='public' AND table_name='customer_profiles' AND column_name='email'
+        ) AS has_email,
+        EXISTS (
+          SELECT 1 FROM information_schema.columns
+          WHERE table_schema='public' AND table_name='customer_profiles' AND column_name='email_verified'
+        ) AS has_email_verified
+    `);
+    const row = result.rows && result.rows[0] ? result.rows[0] : {};
+    return !!(row.has_identities && row.has_email && row.has_email_verified);
+  } catch (_) {
+    return false;
+  }
+}
+
+async function providerAvailability({ pool, req, env }) {
+  const cfg = baseProviderConfig(env);
+  const ready = await schemaReady(pool);
+  const lineCallback = callbackUrl(req, "line", env);
+  const googleCallback = callbackUrl(req, "google", env);
+  return {
+    line: {
+      clientId: cfg.line.clientId,
+      clientSecret: cfg.line.clientSecret,
+      callback: lineCallback,
+      available: !!(cfg.line.clientId && cfg.line.clientSecret && cfg.jwtSecret && ready && isUsableCallbackUrl(lineCallback, req)),
+    },
+    google: {
+      clientId: cfg.google.clientId,
+      clientSecret: cfg.google.clientSecret,
+      callback: googleCallback,
+      available: !!(cfg.google.clientId && cfg.google.clientSecret && cfg.jwtSecret && ready && isUsableCallbackUrl(googleCallback, req)),
+    },
+    jwtSecret: cfg.jwtSecret,
+    schemaReady: ready,
+  };
 }
 
 async function findProfile(pool, customerSub) {
@@ -269,17 +329,12 @@ async function resolveCustomerForIdentity(pool, identity, loggedInCustomer) {
     }
     return { customerSub: existingSub, mode: "existing_identity" };
   }
-
-  if (loggedInCustomer?.sub) {
-    return { customerSub: loggedInCustomer.sub, mode: "linked_to_session" };
-  }
-
+  if (loggedInCustomer?.sub) return { customerSub: loggedInCustomer.sub, mode: "linked_to_session" };
   if (identity.provider === "line") {
     const legacySub = `line:${identity.provider_subject}`;
     const legacy = await findProfile(pool, legacySub);
     if (legacy) return { customerSub: legacySub, mode: "legacy_line_profile" };
   }
-
   if (identity.email && identity.email_verified) {
     const emailMatch = await pool.query(
       `SELECT sub FROM public.customer_profiles
@@ -287,14 +342,9 @@ async function resolveCustomerForIdentity(pool, identity, loggedInCustomer) {
         LIMIT 2`,
       [identity.email]
     );
-    if ((emailMatch.rows || []).length === 1) {
-      return { customerSub: emailMatch.rows[0].sub, mode: "verified_email_match" };
-    }
-    if ((emailMatch.rows || []).length > 1) {
-      return { customerSub: `${identity.provider}:${identity.provider_subject}`, mode: "ambiguous_email_new_customer" };
-    }
+    if ((emailMatch.rows || []).length === 1) return { customerSub: emailMatch.rows[0].sub, mode: "verified_email_match" };
+    if ((emailMatch.rows || []).length > 1) return { customerSub: `${identity.provider}:${identity.provider_subject}`, mode: "ambiguous_email_new_customer" };
   }
-
   return { customerSub: `${identity.provider}:${identity.provider_subject}`, mode: "new_customer" };
 }
 
@@ -324,14 +374,7 @@ async function exchangeLineCode({ fetchImpl, code, redirectUri, clientId, client
   const res = await fetchImpl("https://api.line.me/oauth2/v2.1/token", {
     method: "POST",
     headers: { "content-type": "application/x-www-form-urlencoded" },
-    body: new URLSearchParams({
-      grant_type: "authorization_code",
-      code,
-      redirect_uri: redirectUri,
-      client_id: clientId,
-      client_secret: clientSecret,
-      code_verifier: codeVerifier,
-    }),
+    body: new URLSearchParams({ grant_type: "authorization_code", code, redirect_uri: redirectUri, client_id: clientId, client_secret: clientSecret, code_verifier: codeVerifier }),
   });
   const text = await res.text().catch(() => "");
   let json = {};
@@ -367,14 +410,7 @@ async function exchangeGoogleCode({ fetchImpl, code, redirectUri, clientId, clie
   const res = await fetchImpl("https://oauth2.googleapis.com/token", {
     method: "POST",
     headers: { "content-type": "application/x-www-form-urlencoded" },
-    body: new URLSearchParams({
-      grant_type: "authorization_code",
-      code,
-      redirect_uri: redirectUri,
-      client_id: clientId,
-      client_secret: clientSecret,
-      code_verifier: codeVerifier,
-    }),
+    body: new URLSearchParams({ grant_type: "authorization_code", code, redirect_uri: redirectUri, client_id: clientId, client_secret: clientSecret, code_verifier: codeVerifier }),
   });
   const text = await res.text().catch(() => "");
   let json = {};
@@ -383,31 +419,15 @@ async function exchangeGoogleCode({ fetchImpl, code, redirectUri, clientId, clie
   return json;
 }
 
-function decodeJwtUnverified(token) {
-  const parts = clean(token).split(".");
-  if (parts.length !== 3) throw new Error("JWT_FORMAT_INVALID");
-  return {
-    header: JSON.parse(b64urlDecodeToBuffer(parts[0]).toString("utf8")),
-    payload: JSON.parse(b64urlDecodeToBuffer(parts[1]).toString("utf8")),
-    signingInput: `${parts[0]}.${parts[1]}`,
-    signature: b64urlDecodeToBuffer(parts[2]),
-  };
-}
-
-async function verifyGoogleIdToken({ fetchImpl, idToken, clientId, nonce }) {
-  const decoded = decodeJwtUnverified(idToken);
-  if (decoded.header.alg !== "RS256") throw new Error("GOOGLE_ALG_INVALID");
-  const certRes = await fetchImpl("https://www.googleapis.com/oauth2/v3/certs");
-  const certJson = await certRes.json();
-  const key = (certJson.keys || []).find((item) => item.kid === decoded.header.kid);
-  if (!key || !key.x5c || !key.x5c[0]) throw new Error("GOOGLE_CERT_NOT_FOUND");
-  const cert = `-----BEGIN CERTIFICATE-----\n${key.x5c[0].match(/.{1,64}/g).join("\n")}\n-----END CERTIFICATE-----\n`;
-  const ok = crypto.verify("RSA-SHA256", Buffer.from(decoded.signingInput), cert, decoded.signature);
-  if (!ok) throw new Error("GOOGLE_SIGNATURE_INVALID");
-  return googleIdentityFromPayload(decoded.payload, clientId, nonce);
+async function verifyGoogleIdToken({ idToken, clientId, nonce, oauthClient }) {
+  const client = oauthClient || new OAuth2Client(clientId);
+  const ticket = await client.verifyIdToken({ idToken, audience: clientId });
+  return googleIdentityFromPayload(ticket.getPayload(), clientId, nonce);
 }
 
 function googleIdentityFromPayload(payload, clientId, nonce, now = Math.floor(Date.now() / 1000)) {
+  if (!payload || typeof payload !== "object") throw new Error("GOOGLE_PAYLOAD_MISSING");
+  if (!clean(payload.sub)) throw new Error("GOOGLE_SUB_MISSING");
   if (!["https://accounts.google.com", "accounts.google.com"].includes(payload.iss)) throw new Error("GOOGLE_ISS_INVALID");
   if (payload.aud !== clientId) throw new Error("GOOGLE_AUD_INVALID");
   if (payload.exp && now > Number(payload.exp)) throw new Error("GOOGLE_TOKEN_EXPIRED");
@@ -438,33 +458,37 @@ function authSuccessRedirect(provider, returnTo, linked) {
   return `${url.pathname}${url.search}${url.hash}`;
 }
 
+function getStore(deps) {
+  return deps.oauthStore || defaultOAuthStore;
+}
+
 function createStartHandler(provider, deps) {
-  return (req, res) => {
-    const cfg = providerConfig(deps.env);
-    const providerCfg = cfg[provider];
+  return async (req, res) => {
+    const availability = await providerAvailability({ pool: deps.pool, req, env: deps.env });
+    const providerCfg = availability[provider];
     const returnTo = safeReturnTo(req.query?.returnTo || req.query?.next);
     if (!providerCfg.available) return res.redirect(authErrorRedirect(provider, "provider_unavailable", returnTo));
     const verifier = randomUrlToken(48);
     const state = randomUrlToken(32);
     const nonce = randomUrlToken(32);
-    const ctx = {
+    const current = currentCustomer(req, availability.jwtSecret);
+    const stateId = getStore(deps).put({
       provider,
       state,
       nonce,
       codeVerifier: verifier,
       returnTo,
-      linkCustomerSub: currentCustomer(req, cfg.jwtSecret)?.sub || "",
-      createdAt: Date.now(),
-    };
-    const secureCookie = callbackUrl(req, provider, deps.env).startsWith("https://") || isHttpsReq(req);
-    setCookie(res, provider === "line" ? LINE_STATE_COOKIE : GOOGLE_STATE_COOKIE, encodeOAuthStateCookie(ctx), {
+      linkCustomerSub: current?.sub || "",
+    });
+    const redirectUri = callbackUrl(req, provider, deps.env);
+    setCookie(res, provider === "line" ? LINE_STATE_COOKIE : GOOGLE_STATE_COOKIE, stateId, {
       maxAgeSec: OAUTH_MAX_AGE_SEC,
-      secure: secureCookie,
+      secure: redirectUri.startsWith("https://") || isHttpsReq(req),
     });
     const authorize = new URL(provider === "line" ? "https://access.line.me/oauth2/v2.1/authorize" : "https://accounts.google.com/o/oauth2/v2/auth");
     authorize.searchParams.set("response_type", "code");
     authorize.searchParams.set("client_id", providerCfg.clientId);
-    authorize.searchParams.set("redirect_uri", callbackUrl(req, provider, deps.env));
+    authorize.searchParams.set("redirect_uri", redirectUri);
     authorize.searchParams.set("state", state);
     authorize.searchParams.set("scope", provider === "line" ? "openid profile email" : "openid email profile");
     authorize.searchParams.set("nonce", nonce);
@@ -478,18 +502,29 @@ function createStartHandler(provider, deps) {
 function createCallbackHandler(provider, deps) {
   return async (req, res) => {
     const cookieName = provider === "line" ? LINE_STATE_COOKIE : GOOGLE_STATE_COOKIE;
-    const cfg = providerConfig(deps.env);
-    const providerCfg = cfg[provider];
-    const ctx = decodeOAuthStateCookie(parseCookieValue(req, cookieName));
+    const stateId = parseCookieValue(req, cookieName);
+    const consumed = getStore(deps).consume(stateId);
+    const ctx = consumed.ctx || null;
     const returnTo = safeReturnTo(ctx?.returnTo);
     clearCookie(res, cookieName);
     try {
       if (req.query?.error) return res.redirect(authErrorRedirect(provider, clean(req.query.error), returnTo));
-      if (!ctx || ctx.provider !== provider) return res.redirect(authErrorRedirect(provider, "missing_state", returnTo));
+      if (!consumed.ok) return res.redirect(authErrorRedirect(provider, consumed.reason, returnTo));
+      if (!ctx || ctx.provider !== provider) return res.redirect(authErrorRedirect(provider, "invalid_state", returnTo));
       if (!clean(req.query?.state) || clean(req.query.state) !== ctx.state) return res.redirect(authErrorRedirect(provider, "invalid_state", returnTo));
       if (!clean(req.query?.code)) return res.redirect(authErrorRedirect(provider, "missing_code", returnTo));
+
+      const availability = await providerAvailability({ pool: deps.pool, req, env: deps.env });
+      const providerCfg = availability[provider];
       if (!providerCfg.available) return res.redirect(authErrorRedirect(provider, "provider_unavailable", returnTo));
-      if (!cfg.jwtSecret) return res.redirect(authErrorRedirect(provider, "session_unavailable", returnTo));
+
+      let loggedInCustomer = null;
+      if (ctx.linkCustomerSub) {
+        const current = currentCustomer(req, availability.jwtSecret);
+        if (!current?.sub) return res.redirect(authErrorRedirect(provider, "link_session_missing", returnTo));
+        if (current.sub !== ctx.linkCustomerSub) return res.redirect(authErrorRedirect(provider, "link_session_changed", returnTo));
+        loggedInCustomer = current;
+      }
 
       const redirectUri = callbackUrl(req, provider, deps.env);
       const fetchImpl = deps.fetchImpl || fetch;
@@ -500,12 +535,11 @@ function createCallbackHandler(provider, deps) {
       if (!idToken) return res.redirect(authErrorRedirect(provider, "missing_id_token", returnTo));
       const identity = provider === "line"
         ? await (deps.verifyLineIdToken || verifyLineIdToken)({ fetchImpl, idToken, clientId: providerCfg.clientId, nonce: ctx.nonce })
-        : await (deps.verifyGoogleIdToken || verifyGoogleIdToken)({ fetchImpl, idToken, clientId: providerCfg.clientId, nonce: ctx.nonce });
+        : await (deps.verifyGoogleIdToken || verifyGoogleIdToken)({ idToken, clientId: providerCfg.clientId, nonce: ctx.nonce, oauthClient: deps.googleOAuthClient });
       if (!identity.provider_subject) return res.redirect(authErrorRedirect(provider, "missing_provider_subject", returnTo));
-      const loggedInCustomer = ctx.linkCustomerSub ? { sub: ctx.linkCustomerSub } : currentCustomer(req, cfg.jwtSecret);
       const result = await completeProviderLogin({ pool: deps.pool, identity, loggedInCustomer });
       if (result.error === "PROVIDER_ALREADY_LINKED") return res.redirect(authErrorRedirect(provider, "account_already_linked", returnTo));
-      issueCustomerSession(res, result.customer, cfg.jwtSecret, redirectUri.startsWith("https://") || isHttpsReq(req));
+      issueCustomerSession(res, result.customer, availability.jwtSecret, redirectUri.startsWith("https://") || isHttpsReq(req));
       return res.redirect(authSuccessRedirect(provider, returnTo, result.mode === "linked_to_session"));
     } catch (e) {
       if (deps.logger) deps.logger.error(`[CUSTOMER_${provider.toUpperCase()}_AUTH]`, e);
@@ -540,59 +574,21 @@ async function ensureCustomerAuthSchema(pool) {
 
 function createCustomerAuthRoutes(deps) {
   const router = express.Router();
-  router.get("/auth/line", createStartHandler("line", deps));
   router.get("/auth/line/start", createStartHandler("line", deps));
-  router.get("/auth/line/callback", createCallbackHandler("line", deps));
-  router.get("/auth/google", createStartHandler("google", deps));
+  router.get("/auth/line/v2/callback", createCallbackHandler("line", deps));
   router.get("/auth/google/start", createStartHandler("google", deps));
   router.get("/auth/google/callback", createCallbackHandler("google", deps));
-  router.get("/public/auth/config", (req, res) => {
-    const cfg = providerConfig(deps.env);
+  router.get("/public/auth/config", async (req, res) => {
+    const availability = await providerAvailability({ pool: deps.pool, req, env: deps.env });
     const returnTo = safeReturnTo(req.query?.returnTo);
     res.json({
       ok: true,
+      schema_ready: availability.schemaReady,
       providers: {
-        line: { available: cfg.line.available, start_url: `/auth/line?returnTo=${encodeURIComponent(returnTo)}` },
-        google: { available: cfg.google.available, start_url: `/auth/google?returnTo=${encodeURIComponent(returnTo)}` },
+        line: { available: availability.line.available, start_url: `/auth/line/start?returnTo=${encodeURIComponent(returnTo)}` },
+        google: { available: availability.google.available, start_url: `/auth/google/start?returnTo=${encodeURIComponent(returnTo)}` },
       },
     });
-  });
-  router.get("/public/me", async (req, res) => {
-    try {
-      const cfg = providerConfig(deps.env);
-      const payload = currentCustomer(req, cfg.jwtSecret);
-      if (!payload?.sub) return res.json({ logged_in: false });
-      const profile = await findProfile(deps.pool, payload.sub);
-      const providers = await linkedProviders(deps.pool, payload.sub);
-      return res.json({
-        logged_in: true,
-        user: {
-          name: payload.name || profile?.display_name || "",
-          picture: payload.picture || profile?.picture_url || "",
-          provider: payload.provider || providers[0] || "",
-          email: payload.email || profile?.email || "",
-          email_verified: !!(payload.email_verified || profile?.email_verified),
-          linked_providers: providers,
-        },
-        provider: payload.provider || providers[0] || "",
-        linked_providers: providers,
-        profile: profile ? {
-          phone: profile.phone || "",
-          address: profile.address || "",
-          maps_url: profile.maps_url || "",
-          email: profile.email || "",
-          email_verified: !!profile.email_verified,
-        } : null,
-      });
-    } catch (_) {
-      return res.json({ logged_in: false });
-    }
-  });
-  router.get("/public/logout", (req, res) => {
-    clearCookie(res, SESSION_COOKIE);
-    clearCookie(res, LINE_STATE_COOKIE);
-    clearCookie(res, GOOGLE_STATE_COOKIE);
-    res.redirect(safeReturnTo(req.query?.returnTo, "/customer-app/?logout=1"));
   });
   router.post("/public/logout", (req, res) => {
     clearCookie(res, SESSION_COOKIE);
@@ -608,14 +604,15 @@ module.exports = {
   LINE_STATE_COOKIE,
   GOOGLE_STATE_COOKIE,
   safeReturnTo,
-  providerConfig,
+  baseProviderConfig,
+  providerAvailability,
+  schemaReady,
   b64urlEncode,
   b64urlDecodeToBuffer,
   jwtSign,
   jwtVerify,
-  encodeOAuthStateCookie,
-  decodeOAuthStateCookie,
   sha256Base64Url,
+  createMemoryOAuthStore,
   verifyGoogleIdToken,
   googleIdentityFromPayload,
   verifyLineIdToken,

--- a/test/customerAuth.test.js
+++ b/test/customerAuth.test.js
@@ -1,0 +1,259 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const express = require("express");
+const http = require("node:http");
+const customerAuth = require("../server/customerAuth");
+
+function makePool({ identities = [], profiles = [] } = {}) {
+  const state = { identities: identities.map((x) => ({ ...x })), profiles: profiles.map((x) => ({ ...x })), queries: [] };
+  return {
+    state,
+    async query(sql, params = []) {
+      state.queries.push({ sql, params });
+      if (/FROM public\.customer_identities WHERE provider=\$1 AND provider_subject=\$2/.test(sql)) {
+        return { rows: state.identities.filter((x) => x.provider === params[0] && x.provider_subject === params[1]).slice(0, 1) };
+      }
+      if (/FROM public\.customer_identities WHERE customer_sub=\$1/.test(sql)) {
+        return { rows: state.identities.filter((x) => x.customer_sub === params[0]).map((x) => ({ provider: x.provider })) };
+      }
+      if (/FROM public\.customer_profiles WHERE sub=\$1/.test(sql)) {
+        return { rows: state.profiles.filter((x) => x.sub === params[0]).slice(0, 1) };
+      }
+      if (/FROM public\.customer_profiles\s+WHERE lower\(email\)=lower\(\$1\)/.test(sql)) {
+        return { rows: state.profiles.filter((x) => String(x.email || "").toLowerCase() === String(params[0]).toLowerCase() && x.email_verified).slice(0, 2) };
+      }
+      if (/INSERT INTO public\.customer_identities/.test(sql)) {
+        const next = {
+          customer_sub: params[0],
+          provider: params[1],
+          provider_subject: params[2],
+          email: params[3],
+          email_verified: params[4],
+          display_name: params[5],
+          picture_url: params[6],
+        };
+        const found = state.identities.find((x) => x.provider === next.provider && x.provider_subject === next.provider_subject);
+        if (found) Object.assign(found, next);
+        else state.identities.push(next);
+        return { rows: [] };
+      }
+      if (/INSERT INTO public\.customer_profiles/.test(sql)) {
+        const next = {
+          sub: params[0],
+          provider: params[1],
+          display_name: params[2],
+          picture_url: params[3],
+          email: params[4],
+          email_verified: params[5],
+        };
+        const found = state.profiles.find((x) => x.sub === next.sub);
+        if (found) Object.assign(found, { ...next, phone: found.phone, address: found.address, maps_url: found.maps_url });
+        else state.profiles.push(next);
+        return { rows: [] };
+      }
+      return { rows: [] };
+    },
+  };
+}
+
+async function withServer(router, fn) {
+  const app = express();
+  app.use(express.json());
+  app.use(router);
+  const server = http.createServer(app);
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const port = server.address().port;
+  try {
+    return await fn(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve) => server.close(resolve));
+  }
+}
+
+test("safeReturnTo accepts Customer App routes and rejects open redirects", () => {
+  assert.equal(customerAuth.safeReturnTo("/customer-app/?view=profile"), "/customer-app/?view=profile");
+  assert.equal(customerAuth.safeReturnTo("/track.html?q=CWF123"), "/track.html?q=CWF123");
+  assert.equal(customerAuth.safeReturnTo("https://evil.example/customer-app/"), "/customer-app/");
+  assert.equal(customerAuth.safeReturnTo("//evil.example/customer-app/"), "/customer-app/");
+  assert.equal(customerAuth.safeReturnTo("/admin/super-v2.html"), "/customer-app/");
+});
+
+test("LINE start creates state, PKCE cookie, and authorize redirect", async () => {
+  const router = customerAuth.createCustomerAuthRoutes({
+    pool: makePool(),
+    env: { LINE_CHANNEL_ID: "line-id", LINE_CHANNEL_SECRET: "line-secret", CWF_JWT_SECRET: "secret" },
+  });
+  await withServer(router, async (base) => {
+    const res = await fetch(`${base}/auth/line?returnTo=/customer-app/?view=profile`, { redirect: "manual" });
+    assert.equal(res.status, 302);
+    const location = res.headers.get("location");
+    assert.match(location, /^https:\/\/access\.line\.me\/oauth2\/v2\.1\/authorize/);
+    assert.match(location, /code_challenge=/);
+    assert.match(location, /nonce=/);
+    assert.match(res.headers.get("set-cookie"), /cwf_oauth_line=/);
+  });
+});
+
+test("Google start creates state and nonce", async () => {
+  const router = customerAuth.createCustomerAuthRoutes({
+    pool: makePool(),
+    env: { GOOGLE_CLIENT_ID: "google-id", GOOGLE_CLIENT_SECRET: "google-secret", CWF_JWT_SECRET: "secret" },
+  });
+  await withServer(router, async (base) => {
+    const res = await fetch(`${base}/auth/google`, { redirect: "manual" });
+    assert.equal(res.status, 302);
+    const location = res.headers.get("location");
+    assert.match(location, /^https:\/\/accounts\.google\.com\/o\/oauth2\/v2\/auth/);
+    assert.match(location, /scope=openid\+email\+profile/);
+    assert.match(location, /nonce=/);
+    assert.match(res.headers.get("set-cookie"), /cwf_oauth_google=/);
+  });
+});
+
+test("callbacks reject invalid or missing state before provider HTTP calls", async () => {
+  let called = false;
+  const router = customerAuth.createCustomerAuthRoutes({
+    pool: makePool(),
+    env: { GOOGLE_CLIENT_ID: "google-id", GOOGLE_CLIENT_SECRET: "google-secret", CWF_JWT_SECRET: "secret" },
+    exchangeGoogleCode: async () => { called = true; },
+  });
+  await withServer(router, async (base) => {
+    const res = await fetch(`${base}/auth/google/callback?code=abc&state=bad`, { redirect: "manual" });
+    assert.equal(res.status, 302);
+    assert.match(res.headers.get("location"), /auth=failed/);
+    assert.match(res.headers.get("location"), /reason=missing_state/);
+    assert.equal(called, false);
+  });
+});
+
+test("provider cancellation redirects safely", async () => {
+  const router = customerAuth.createCustomerAuthRoutes({
+    pool: makePool(),
+    env: { LINE_CHANNEL_ID: "line-id", LINE_CHANNEL_SECRET: "line-secret", CWF_JWT_SECRET: "secret" },
+  });
+  await withServer(router, async (base) => {
+    const res = await fetch(`${base}/auth/line/callback?error=access_denied`, { redirect: "manual" });
+    assert.equal(res.status, 302);
+    assert.match(res.headers.get("location"), /reason=access_denied/);
+  });
+});
+
+test("existing provider identity signs into the same customer", async () => {
+  const pool = makePool({
+    identities: [{ provider: "google", provider_subject: "g-1", customer_sub: "line:legacy" }],
+    profiles: [{ sub: "line:legacy", display_name: "Legacy", email: "a@example.com", email_verified: true }],
+  });
+  const result = await customerAuth.completeProviderLogin({
+    pool,
+    identity: { provider: "google", provider_subject: "g-1", display_name: "Google", email: "a@example.com", email_verified: true },
+  });
+  assert.equal(result.customer.customer_sub, "line:legacy");
+  assert.equal(result.mode, "existing_identity");
+});
+
+test("new provider identity creates a customer without duplicate display-name matching", async () => {
+  const pool = makePool({ profiles: [{ sub: "line:other", display_name: "Same Name" }] });
+  const result = await customerAuth.completeProviderLogin({
+    pool,
+    identity: { provider: "google", provider_subject: "g-new", display_name: "Same Name", email: "", email_verified: false },
+  });
+  assert.equal(result.customer.customer_sub, "google:g-new");
+  assert.equal(pool.state.identities.length, 1);
+  assert.match(pool.state.queries[1].sql, /INSERT INTO public\.customer_profiles/);
+  assert.match(pool.state.queries[2].sql, /INSERT INTO public\.customer_identities/);
+});
+
+test("logged-in customer explicitly links a new provider", async () => {
+  const pool = makePool({ profiles: [{ sub: "line:u1", display_name: "Line User" }] });
+  const result = await customerAuth.completeProviderLogin({
+    pool,
+    loggedInCustomer: { sub: "line:u1" },
+    identity: { provider: "google", provider_subject: "g-2", display_name: "Google User", email: "g@example.com", email_verified: true },
+  });
+  assert.equal(result.customer.customer_sub, "line:u1");
+  assert.equal(result.mode, "linked_to_session");
+});
+
+test("duplicate provider identity linked to another customer is rejected safely", async () => {
+  const pool = makePool({
+    identities: [{ provider: "line", provider_subject: "u1", customer_sub: "line:u1" }],
+    profiles: [{ sub: "line:u1", display_name: "Line User" }],
+  });
+  const result = await customerAuth.completeProviderLogin({
+    pool,
+    loggedInCustomer: { sub: "google:g1" },
+    identity: { provider: "line", provider_subject: "u1", display_name: "Line User" },
+  });
+  assert.equal(result.error, "PROVIDER_ALREADY_LINKED");
+});
+
+test("ambiguous verified email does not auto-link", async () => {
+  const pool = makePool({
+    profiles: [
+      { sub: "line:a", email: "same@example.com", email_verified: true },
+      { sub: "line:b", email: "same@example.com", email_verified: true },
+    ],
+  });
+  const result = await customerAuth.completeProviderLogin({
+    pool,
+    identity: { provider: "google", provider_subject: "g3", email: "same@example.com", email_verified: true, display_name: "Google" },
+  });
+  assert.equal(result.customer.customer_sub, "google:g3");
+  assert.equal(result.mode, "ambiguous_email_new_customer");
+});
+
+test("provider unavailable is reported through public config", async () => {
+  const router = customerAuth.createCustomerAuthRoutes({ pool: makePool(), env: { CWF_JWT_SECRET: "secret" } });
+  await withServer(router, async (base) => {
+    const res = await fetch(`${base}/public/auth/config`);
+    const data = await res.json();
+    assert.equal(data.providers.line.available, false);
+    assert.equal(data.providers.google.available, false);
+  });
+});
+
+test("logout clears session and OAuth cookies", async () => {
+  const router = customerAuth.createCustomerAuthRoutes({ pool: makePool(), env: { CWF_JWT_SECRET: "secret" } });
+  await withServer(router, async (base) => {
+    const res = await fetch(`${base}/public/logout`, { method: "POST" });
+    assert.equal(res.status, 200);
+    const cookie = res.headers.get("set-cookie");
+    assert.match(cookie, /cwf_token=; Max-Age=0/);
+    assert.match(cookie, /cwf_oauth_line=; Max-Age=0/);
+    assert.match(cookie, /cwf_oauth_google=; Max-Age=0/);
+  });
+});
+
+test("/public/me guest and authenticated customer", async () => {
+  const pool = makePool({
+    identities: [{ provider: "line", provider_subject: "u1", customer_sub: "line:u1" }],
+    profiles: [{ sub: "line:u1", display_name: "Line User", address: "Bangkok", maps_url: "", email: "", email_verified: false }],
+  });
+  const env = { CWF_JWT_SECRET: "secret" };
+  const router = customerAuth.createCustomerAuthRoutes({ pool, env });
+  await withServer(router, async (base) => {
+    const guest = await fetch(`${base}/public/me`);
+    assert.deepEqual(await guest.json(), { logged_in: false });
+    const token = customerAuth.jwtSign({ sub: "line:u1", provider: "line", name: "Line User", exp: Math.floor(Date.now() / 1000) + 60 }, env.CWF_JWT_SECRET);
+    const authed = await fetch(`${base}/public/me`, { headers: { cookie: `cwf_token=${encodeURIComponent(token)}` } });
+    const data = await authed.json();
+    assert.equal(data.logged_in, true);
+    assert.equal(data.user.provider, "line");
+    assert.equal(data.profile.address, "Bangkok");
+  });
+});
+
+test("Google token audience mismatch is rejected by verifier before identity use", async () => {
+  assert.throws(
+    () => customerAuth.googleIdentityFromPayload({
+      iss: "https://accounts.google.com",
+      aud: "wrong-client",
+      exp: Math.floor(Date.now() / 1000) + 60,
+      nonce: "nonce",
+      sub: "g1",
+      email: "user@example.com",
+      email_verified: true,
+    }, "expected-client", "nonce"),
+    /GOOGLE_AUD_INVALID/
+  );
+});

--- a/test/customerAuth.test.js
+++ b/test/customerAuth.test.js
@@ -84,8 +84,9 @@ function cookieValue(setCookie, name) {
   return match ? decodeURIComponent(match[1]) : "";
 }
 
-async function startFlow(base, provider, cookieName, cookie = "") {
-  const res = await fetch(`${base}/auth/${provider}/start?returnTo=/customer-app/?view=profile`, {
+async function startFlow(base, provider, cookieName, cookie = "", params = "") {
+  const qs = `returnTo=/customer-app/?view=profile${params ? `&${params}` : ""}`;
+  const res = await fetch(`${base}/auth/${provider}/start?${qs}`, {
     redirect: "manual",
     headers: cookie ? { cookie } : undefined,
   });
@@ -122,6 +123,16 @@ test("V2 /auth/line/start creates PKCE state and returns to V2 callback", async 
     assert.match(location, /code_challenge=/);
     assert.match(location, /nonce=/);
     assert.match(location, /redirect_uri=https%3A%2F%2Fapp\.cwf-air\.com%2Fauth%2Fline%2Fv2%2Fcallback/);
+    assert.match(location, /scope=openid\+profile/);
+    assert.doesNotMatch(location, /email/);
+  });
+});
+
+test("LINE email scope is included only when explicitly enabled", async () => {
+  const env = { ...READY_ENV, LINE_EMAIL_SCOPE_ENABLED: "true" };
+  await withServer(makeRouter({ env }), async (base) => {
+    const started = await startFlow(base, "line", customerAuth.LINE_STATE_COOKIE);
+    assert.match(started.res.headers.get("location"), /scope=openid\+profile\+email/);
   });
 });
 
@@ -186,6 +197,31 @@ test("provider unavailable when callback is not HTTPS", async () => {
   });
 });
 
+test("OAuth store cleans abandoned expired states and keeps valid state usable", () => {
+  let now = 1000;
+  const store = customerAuth.createMemoryOAuthStore(() => now, { maxEntries: 5 });
+  store.put({ state: "expired" });
+  now += 11 * 60 * 1000;
+  const valid = store.put({ state: "valid" });
+  assert.equal(store.size(), 1);
+  assert.equal(store.consume(valid).ctx.state, "valid");
+  assert.equal(store.size(), 0);
+});
+
+test("OAuth store enforces maximum size and evicts oldest entries first", () => {
+  let now = 1000;
+  const store = customerAuth.createMemoryOAuthStore(() => now, { maxEntries: 2 });
+  const first = store.put({ state: "first" });
+  now += 1;
+  const second = store.put({ state: "second" });
+  now += 1;
+  const third = store.put({ state: "third" });
+  assert.equal(store.size(), 2);
+  assert.equal(store.consume(first).reason, "missing_state");
+  assert.equal(store.consume(second).ctx.state, "second");
+  assert.equal(store.consume(third).ctx.state, "third");
+});
+
 test("tampered OAuth context cookie is rejected before provider exchange", async () => {
   let called = false;
   await withServer(makeRouter({ exchangeGoogleCode: async () => { called = true; } }), async (base) => {
@@ -228,10 +264,64 @@ test("replayed callback state is rejected after one successful consume", async (
   });
 });
 
+test("logged-in normal login does not silently link a new provider", async () => {
+  const pool = makePool({ profiles: [{ sub: "line:u1", display_name: "Line User" }] });
+  const token = customerAuth.jwtSign({ sub: "line:u1", exp: Math.floor(Date.now() / 1000) + 60 }, READY_ENV.CWF_JWT_SECRET);
+  await withServer(makeRouter({ pool }), async (base) => {
+    const started = await startFlow(base, "google", customerAuth.GOOGLE_STATE_COOKIE, `cwf_token=${encodeURIComponent(token)}`, "mode=login");
+    const res = await fetch(`${base}/auth/google/callback?code=abc&state=${started.state}`, {
+      redirect: "manual",
+      headers: { cookie: `${started.cookie}; cwf_token=${encodeURIComponent(token)}` },
+    });
+    assert.match(res.headers.get("location"), /auth=success/);
+    assert.equal(pool.state.identities[0].customer_sub, "google:g1");
+  });
+});
+
+test("link mode without session is rejected before provider redirect", async () => {
+  await withServer(makeRouter(), async (base) => {
+    const res = await fetch(`${base}/auth/google/start?mode=link&confirm=1&returnTo=/customer-app/`, { redirect: "manual" });
+    assert.match(res.headers.get("location"), /reason=link_session_missing/);
+  });
+});
+
+test("cancelled link confirmation creates no OAuth state and causes no link", async () => {
+  const store = customerAuth.createMemoryOAuthStore();
+  const token = customerAuth.jwtSign({ sub: "line:u1", exp: Math.floor(Date.now() / 1000) + 60 }, READY_ENV.CWF_JWT_SECRET);
+  await withServer(makeRouter({ store }), async (base) => {
+    const res = await fetch(`${base}/auth/google/start?mode=link&returnTo=/customer-app/`, {
+      redirect: "manual",
+      headers: { cookie: `cwf_token=${encodeURIComponent(token)}` },
+    });
+    assert.match(res.headers.get("location"), /reason=link_confirmation_required/);
+    assert.equal(store.size(), 0);
+  });
+});
+
+test("provider already linked is not offered for linking", async () => {
+  const pool = makePool({
+    identities: [{ provider: "google", provider_subject: "g1", customer_sub: "line:u1" }],
+    profiles: [{ sub: "line:u1", display_name: "Line User" }],
+  });
+  const token = customerAuth.jwtSign({ sub: "line:u1", exp: Math.floor(Date.now() / 1000) + 60 }, READY_ENV.CWF_JWT_SECRET);
+  await withServer(makeRouter({ pool }), async (base) => {
+    const cfg = await fetch(`${base}/public/auth/config?returnTo=/customer-app/`, {
+      headers: { cookie: `cwf_token=${encodeURIComponent(token)}` },
+    }).then((r) => r.json());
+    assert.equal(cfg.logged_in, true);
+    assert.equal(cfg.providers.google.linked, true);
+    const res = await fetch(`${base}/auth/google/start?mode=link&confirm=1&returnTo=/customer-app/`, {
+      redirect: "manual",
+      headers: { cookie: `cwf_token=${encodeURIComponent(token)}` },
+    });
+    assert.match(res.headers.get("location"), /reason=account_already_linked/);
+  });
+});
+
 test("linking after session logout is rejected", async () => {
   const token = customerAuth.jwtSign({ sub: "line:u1", exp: Math.floor(Date.now() / 1000) + 60 }, READY_ENV.CWF_JWT_SECRET);
   await withServer(makeRouter(), async (base) => {
-    const started = await startFlow(base, "google", customerAuth.GOOGLE_STATE_COOKIE, `cwf_token=${encodeURIComponent(token)}`);
+    const started = await startFlow(base, "google", customerAuth.GOOGLE_STATE_COOKIE, `cwf_token=${encodeURIComponent(token)}`, "mode=link&confirm=1");
     const res = await fetch(`${base}/auth/google/callback?code=abc&state=${started.state}`, {
       redirect: "manual",
       headers: { cookie: started.cookie },
@@ -244,7 +334,7 @@ test("linking after session changes is rejected", async () => {
   const tokenA = customerAuth.jwtSign({ sub: "line:u1", exp: Math.floor(Date.now() / 1000) + 60 }, READY_ENV.CWF_JWT_SECRET);
   const tokenB = customerAuth.jwtSign({ sub: "line:u2", exp: Math.floor(Date.now() / 1000) + 60 }, READY_ENV.CWF_JWT_SECRET);
   await withServer(makeRouter(), async (base) => {
-    const started = await startFlow(base, "google", customerAuth.GOOGLE_STATE_COOKIE, `cwf_token=${encodeURIComponent(tokenA)}`);
+    const started = await startFlow(base, "google", customerAuth.GOOGLE_STATE_COOKIE, `cwf_token=${encodeURIComponent(tokenA)}`, "mode=link&confirm=1");
     const res = await fetch(`${base}/auth/google/callback?code=abc&state=${started.state}`, {
       redirect: "manual",
       headers: { cookie: `${started.cookie}; cwf_token=${encodeURIComponent(tokenB)}` },
@@ -257,7 +347,7 @@ test("valid same-session provider linking succeeds", async () => {
   const pool = makePool({ profiles: [{ sub: "line:u1", display_name: "Line User" }] });
   const token = customerAuth.jwtSign({ sub: "line:u1", exp: Math.floor(Date.now() / 1000) + 60 }, READY_ENV.CWF_JWT_SECRET);
   await withServer(makeRouter({ pool }), async (base) => {
-    const started = await startFlow(base, "google", customerAuth.GOOGLE_STATE_COOKIE, `cwf_token=${encodeURIComponent(token)}`);
+    const started = await startFlow(base, "google", customerAuth.GOOGLE_STATE_COOKIE, `cwf_token=${encodeURIComponent(token)}`, "mode=link&confirm=1");
     const res = await fetch(`${base}/auth/google/callback?code=abc&state=${started.state}`, {
       redirect: "manual",
       headers: { cookie: `${started.cookie}; cwf_token=${encodeURIComponent(token)}` },
@@ -300,6 +390,7 @@ test("duplicate provider identity linked to another customer is rejected safely"
     pool,
     loggedInCustomer: { sub: "google:g1" },
     identity: { provider: "line", provider_subject: "u1", display_name: "Line User" },
+    mode: "link",
   });
   assert.equal(result.error, "PROVIDER_ALREADY_LINKED");
 });
@@ -317,6 +408,84 @@ test("ambiguous verified email does not auto-link", async () => {
   });
   assert.equal(result.customer.customer_sub, "google:g3");
   assert.equal(result.mode, "ambiguous_email_new_customer");
+});
+
+test("LINE identity without email still creates and signs in the correct customer", async () => {
+  const pool = makePool();
+  const result = await customerAuth.completeProviderLogin({
+    pool,
+    identity: { provider: "line", provider_subject: "line-no-email", display_name: "Line User", email: "", email_verified: false },
+  });
+  assert.equal(result.customer.customer_sub, "line:line-no-email");
+  assert.equal(result.customer.email, "");
+  assert.equal(pool.state.identities[0].provider_subject, "line-no-email");
+});
+
+test("publicMePayload preserves legacy LINE fields and adds email/provider metadata", async () => {
+  const pool = makePool({
+    identities: [{ provider: "line", provider_subject: "u1", customer_sub: "line:u1" }],
+    profiles: [{ sub: "line:u1", phone: "081", address: "Bangkok", maps_url: "https://maps.example", email: "line@example.com", email_verified: true }],
+  });
+  const data = await customerAuth.publicMePayload({
+    pool,
+    payload: { sub: "line:u1", name: "Line User", picture: "pic", provider: "line" },
+  });
+  assert.equal(data.logged_in, true);
+  assert.deepEqual(data.user, {
+    name: "Line User",
+    picture: "pic",
+    provider: "line",
+    email: "line@example.com",
+    email_verified: true,
+    linked_providers: ["line"],
+  });
+  assert.deepEqual(data.profile, {
+    phone: "081",
+    address: "Bangkok",
+    maps_url: "https://maps.example",
+    email: "line@example.com",
+    email_verified: true,
+  });
+  assert.equal(data.provider, "line");
+  assert.deepEqual(data.linked_providers, ["line"]);
+});
+
+test("publicMePayload supports Google session and LINE plus Google linked session", async () => {
+  const pool = makePool({
+    identities: [
+      { provider: "google", provider_subject: "g1", customer_sub: "google:g1" },
+      { provider: "line", provider_subject: "u1", customer_sub: "google:g1" },
+    ],
+    profiles: [{ sub: "google:g1", phone: "", address: "", maps_url: "", email: "g@example.com", email_verified: true }],
+  });
+  const data = await customerAuth.publicMePayload({
+    pool,
+    payload: { sub: "google:g1", name: "Google User", picture: "", provider: "google" },
+  });
+  assert.equal(data.user.email, "g@example.com");
+  assert.equal(data.user.email_verified, true);
+  assert.deepEqual(data.linked_providers, ["google", "line"]);
+  assert.equal(data.profile.email, "g@example.com");
+});
+
+test("publicMePayload falls back to old response when identity schema is unavailable", async () => {
+  const pool = makePool({
+    profiles: [{ sub: "line:u1", phone: "081", address: "Bangkok", maps_url: "map" }],
+  });
+  const originalQuery = pool.query;
+  pool.query = async (sql, params) => {
+    if (/customer_identities/.test(sql) || /SELECT email, email_verified/.test(sql)) throw new Error("schema missing");
+    return originalQuery.call(pool, sql, params);
+  };
+  const data = await customerAuth.publicMePayload({
+    pool,
+    payload: { sub: "line:u1", name: "Legacy", picture: "pic", provider: "line" },
+  });
+  assert.deepEqual(data, {
+    logged_in: true,
+    user: { name: "Legacy", picture: "pic", provider: "line" },
+    profile: { phone: "081", address: "Bangkok", maps_url: "map" },
+  });
 });
 
 test("Google verifier uses official OAuth2Client abstraction with n/e JWKS hidden behind library", async () => {

--- a/test/customerAuth.test.js
+++ b/test/customerAuth.test.js
@@ -4,12 +4,25 @@ const express = require("express");
 const http = require("node:http");
 const customerAuth = require("../server/customerAuth");
 
-function makePool({ identities = [], profiles = [] } = {}) {
-  const state = { identities: identities.map((x) => ({ ...x })), profiles: profiles.map((x) => ({ ...x })), queries: [] };
+const READY_ENV = {
+  CWF_JWT_SECRET: "secret",
+  LINE_CHANNEL_ID: "line-id",
+  LINE_CHANNEL_SECRET: "line-secret",
+  LINE_V2_CALLBACK_URL: "https://app.cwf-air.com/auth/line/v2/callback",
+  GOOGLE_CLIENT_ID: "google-id",
+  GOOGLE_CLIENT_SECRET: "google-secret",
+  GOOGLE_CALLBACK_URL: "https://app.cwf-air.com/auth/google/callback",
+};
+
+function makePool({ identities = [], profiles = [], schemaReady = true } = {}) {
+  const state = { identities: identities.map((x) => ({ ...x })), profiles: profiles.map((x) => ({ ...x })), queries: [], schemaReady };
   return {
     state,
     async query(sql, params = []) {
       state.queries.push({ sql, params });
+      if (/to_regclass\('public\.customer_identities'\)/.test(sql)) {
+        return { rows: [{ has_identities: state.schemaReady, has_email: state.schemaReady, has_email_verified: state.schemaReady }] };
+      }
       if (/FROM public\.customer_identities WHERE provider=\$1 AND provider_subject=\$2/.test(sql)) {
         return { rows: state.identities.filter((x) => x.provider === params[0] && x.provider_subject === params[1]).slice(0, 1) };
       }
@@ -22,33 +35,18 @@ function makePool({ identities = [], profiles = [] } = {}) {
       if (/FROM public\.customer_profiles\s+WHERE lower\(email\)=lower\(\$1\)/.test(sql)) {
         return { rows: state.profiles.filter((x) => String(x.email || "").toLowerCase() === String(params[0]).toLowerCase() && x.email_verified).slice(0, 2) };
       }
-      if (/INSERT INTO public\.customer_identities/.test(sql)) {
-        const next = {
-          customer_sub: params[0],
-          provider: params[1],
-          provider_subject: params[2],
-          email: params[3],
-          email_verified: params[4],
-          display_name: params[5],
-          picture_url: params[6],
-        };
-        const found = state.identities.find((x) => x.provider === next.provider && x.provider_subject === next.provider_subject);
-        if (found) Object.assign(found, next);
-        else state.identities.push(next);
-        return { rows: [] };
-      }
       if (/INSERT INTO public\.customer_profiles/.test(sql)) {
-        const next = {
-          sub: params[0],
-          provider: params[1],
-          display_name: params[2],
-          picture_url: params[3],
-          email: params[4],
-          email_verified: params[5],
-        };
+        const next = { sub: params[0], provider: params[1], display_name: params[2], picture_url: params[3], email: params[4], email_verified: params[5] };
         const found = state.profiles.find((x) => x.sub === next.sub);
         if (found) Object.assign(found, { ...next, phone: found.phone, address: found.address, maps_url: found.maps_url });
         else state.profiles.push(next);
+        return { rows: [] };
+      }
+      if (/INSERT INTO public\.customer_identities/.test(sql)) {
+        const next = { customer_sub: params[0], provider: params[1], provider_subject: params[2], email: params[3], email_verified: params[4], display_name: params[5], picture_url: params[6] };
+        const found = state.identities.find((x) => x.provider === next.provider && x.provider_subject === next.provider_subject);
+        if (found) Object.assign(found, next);
+        else state.identities.push(next);
         return { rows: [] };
       }
       return { rows: [] };
@@ -62,12 +60,38 @@ async function withServer(router, fn) {
   app.use(router);
   const server = http.createServer(app);
   await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
-  const port = server.address().port;
   try {
-    return await fn(`http://127.0.0.1:${port}`);
+    return await fn(`http://127.0.0.1:${server.address().port}`);
   } finally {
     await new Promise((resolve) => server.close(resolve));
   }
+}
+
+function makeRouter({ pool = makePool(), env = READY_ENV, store = customerAuth.createMemoryOAuthStore(), exchangeGoogleCode, verifyGoogleIdToken, exchangeLineCode, verifyLineIdToken } = {}) {
+  return customerAuth.createCustomerAuthRoutes({
+    pool,
+    env,
+    oauthStore: store,
+    exchangeGoogleCode: exchangeGoogleCode || (async () => ({ id_token: "google-token" })),
+    verifyGoogleIdToken: verifyGoogleIdToken || (async () => ({ provider: "google", provider_subject: "g1", display_name: "Google User", email: "g@example.com", email_verified: true })),
+    exchangeLineCode: exchangeLineCode || (async () => ({ id_token: "line-token" })),
+    verifyLineIdToken: verifyLineIdToken || (async () => ({ provider: "line", provider_subject: "line-v2", display_name: "Line User" })),
+  });
+}
+
+function cookieValue(setCookie, name) {
+  const match = String(setCookie || "").match(new RegExp(`${name}=([^;]+)`));
+  return match ? decodeURIComponent(match[1]) : "";
+}
+
+async function startFlow(base, provider, cookieName, cookie = "") {
+  const res = await fetch(`${base}/auth/${provider}/start?returnTo=/customer-app/?view=profile`, {
+    redirect: "manual",
+    headers: cookie ? { cookie } : undefined,
+  });
+  const state = new URL(res.headers.get("location")).searchParams.get("state");
+  const stateId = cookieValue(res.headers.get("set-cookie"), cookieName);
+  return { res, state, stateId, cookie: `${cookieName}=${encodeURIComponent(stateId)}` };
 }
 
 test("safeReturnTo accepts Customer App routes and rejects open redirects", () => {
@@ -78,63 +102,168 @@ test("safeReturnTo accepts Customer App routes and rejects open redirects", () =
   assert.equal(customerAuth.safeReturnTo("/admin/super-v2.html"), "/customer-app/");
 });
 
-test("LINE start creates state, PKCE cookie, and authorize redirect", async () => {
-  const router = customerAuth.createCustomerAuthRoutes({
-    pool: makePool(),
-    env: { LINE_CHANNEL_ID: "line-id", LINE_CHANNEL_SECRET: "line-secret", CWF_JWT_SECRET: "secret" },
-  });
-  await withServer(router, async (base) => {
-    const res = await fetch(`${base}/auth/line?returnTo=/customer-app/?view=profile`, { redirect: "manual" });
+test("legacy /auth/line remains owned by legacy route and returns customer.html", async () => {
+  const app = express();
+  app.use(makeRouter());
+  app.get("/auth/line", (req, res) => res.redirect("/customer.html?legacy=1"));
+  await withServer(app, async (base) => {
+    const res = await fetch(`${base}/auth/line`, { redirect: "manual" });
     assert.equal(res.status, 302);
-    const location = res.headers.get("location");
+    assert.equal(res.headers.get("location"), "/customer.html?legacy=1");
+  });
+});
+
+test("V2 /auth/line/start creates PKCE state and returns to V2 callback", async () => {
+  await withServer(makeRouter(), async (base) => {
+    const started = await startFlow(base, "line", customerAuth.LINE_STATE_COOKIE);
+    assert.equal(started.res.status, 302);
+    const location = started.res.headers.get("location");
     assert.match(location, /^https:\/\/access\.line\.me\/oauth2\/v2\.1\/authorize/);
     assert.match(location, /code_challenge=/);
     assert.match(location, /nonce=/);
-    assert.match(res.headers.get("set-cookie"), /cwf_oauth_line=/);
+    assert.match(location, /redirect_uri=https%3A%2F%2Fapp\.cwf-air\.com%2Fauth%2Fline%2Fv2%2Fcallback/);
   });
 });
 
 test("Google start creates state and nonce", async () => {
-  const router = customerAuth.createCustomerAuthRoutes({
-    pool: makePool(),
-    env: { GOOGLE_CLIENT_ID: "google-id", GOOGLE_CLIENT_SECRET: "google-secret", CWF_JWT_SECRET: "secret" },
-  });
-  await withServer(router, async (base) => {
-    const res = await fetch(`${base}/auth/google`, { redirect: "manual" });
-    assert.equal(res.status, 302);
-    const location = res.headers.get("location");
+  await withServer(makeRouter(), async (base) => {
+    const started = await startFlow(base, "google", customerAuth.GOOGLE_STATE_COOKIE);
+    assert.equal(started.res.status, 302);
+    const location = started.res.headers.get("location");
     assert.match(location, /^https:\/\/accounts\.google\.com\/o\/oauth2\/v2\/auth/);
     assert.match(location, /scope=openid\+email\+profile/);
     assert.match(location, /nonce=/);
-    assert.match(res.headers.get("set-cookie"), /cwf_oauth_google=/);
   });
 });
 
-test("callbacks reject invalid or missing state before provider HTTP calls", async () => {
-  let called = false;
-  const router = customerAuth.createCustomerAuthRoutes({
-    pool: makePool(),
-    env: { GOOGLE_CLIENT_ID: "google-id", GOOGLE_CLIENT_SECRET: "google-secret", CWF_JWT_SECRET: "secret" },
-    exchangeGoogleCode: async () => { called = true; },
+test("legacy /public/me response remains compatible when router is mounted first", async () => {
+  const app = express();
+  app.use(makeRouter());
+  app.get("/public/me", (req, res) => res.json({ logged_in: false }));
+  await withServer(app, async (base) => {
+    const res = await fetch(`${base}/public/me`);
+    assert.deepEqual(await res.json(), { logged_in: false });
   });
-  await withServer(router, async (base) => {
-    const res = await fetch(`${base}/auth/google/callback?code=abc&state=bad`, { redirect: "manual" });
-    assert.equal(res.status, 302);
-    assert.match(res.headers.get("location"), /auth=failed/);
+});
+
+test("legacy GET logout behavior remains compatible", async () => {
+  const app = express();
+  app.use(makeRouter());
+  app.get("/public/logout", (req, res) => res.redirect("/customer.html?logout=1"));
+  await withServer(app, async (base) => {
+    const res = await fetch(`${base}/public/logout`, { redirect: "manual" });
+    assert.equal(res.headers.get("location"), "/customer.html?logout=1");
+  });
+});
+
+test("V2 POST logout clears session and OAuth cookies", async () => {
+  await withServer(makeRouter(), async (base) => {
+    const res = await fetch(`${base}/public/logout`, { method: "POST" });
+    assert.equal(res.status, 200);
+    const cookie = res.headers.get("set-cookie");
+    assert.match(cookie, /cwf_token=; Max-Age=0/);
+    assert.match(cookie, /cwf_oauth_line=; Max-Age=0/);
+    assert.match(cookie, /cwf_oauth_google=; Max-Age=0/);
+  });
+});
+
+test("provider unavailable when schema is missing", async () => {
+  await withServer(makeRouter({ pool: makePool({ schemaReady: false }) }), async (base) => {
+    const res = await fetch(`${base}/public/auth/config`);
+    const data = await res.json();
+    assert.equal(data.schema_ready, false);
+    assert.equal(data.providers.line.available, false);
+    assert.equal(data.providers.google.available, false);
+  });
+});
+
+test("provider unavailable when callback is not HTTPS", async () => {
+  const env = { ...READY_ENV, LINE_V2_CALLBACK_URL: "http://app.cwf-air.com/auth/line/v2/callback" };
+  await withServer(makeRouter({ env }), async (base) => {
+    const res = await fetch(`${base}/public/auth/config`);
+    const data = await res.json();
+    assert.equal(data.providers.line.available, false);
+  });
+});
+
+test("tampered OAuth context cookie is rejected before provider exchange", async () => {
+  let called = false;
+  await withServer(makeRouter({ exchangeGoogleCode: async () => { called = true; } }), async (base) => {
+    const res = await fetch(`${base}/auth/google/callback?code=abc&state=bad`, {
+      redirect: "manual",
+      headers: { cookie: `${customerAuth.GOOGLE_STATE_COOKIE}=tampered` },
+    });
     assert.match(res.headers.get("location"), /reason=missing_state/);
     assert.equal(called, false);
   });
 });
 
-test("provider cancellation redirects safely", async () => {
-  const router = customerAuth.createCustomerAuthRoutes({
-    pool: makePool(),
-    env: { LINE_CHANNEL_ID: "line-id", LINE_CHANNEL_SECRET: "line-secret", CWF_JWT_SECRET: "secret" },
+test("expired OAuth context is rejected", async () => {
+  let now = Date.now();
+  const store = customerAuth.createMemoryOAuthStore(() => now);
+  await withServer(makeRouter({ store }), async (base) => {
+    const started = await startFlow(base, "google", customerAuth.GOOGLE_STATE_COOKIE);
+    now += 11 * 60 * 1000;
+    const res = await fetch(`${base}/auth/google/callback?code=abc&state=${started.state}`, {
+      redirect: "manual",
+      headers: { cookie: started.cookie },
+    });
+    assert.match(res.headers.get("location"), /reason=expired_state/);
   });
-  await withServer(router, async (base) => {
-    const res = await fetch(`${base}/auth/line/callback?error=access_denied`, { redirect: "manual" });
-    assert.equal(res.status, 302);
-    assert.match(res.headers.get("location"), /reason=access_denied/);
+});
+
+test("replayed callback state is rejected after one successful consume", async () => {
+  await withServer(makeRouter(), async (base) => {
+    const started = await startFlow(base, "google", customerAuth.GOOGLE_STATE_COOKIE);
+    const first = await fetch(`${base}/auth/google/callback?code=abc&state=${started.state}`, {
+      redirect: "manual",
+      headers: { cookie: started.cookie },
+    });
+    assert.match(first.headers.get("location"), /auth=success/);
+    const replay = await fetch(`${base}/auth/google/callback?code=abc&state=${started.state}`, {
+      redirect: "manual",
+      headers: { cookie: started.cookie },
+    });
+    assert.match(replay.headers.get("location"), /reason=missing_state/);
+  });
+});
+
+test("linking after session logout is rejected", async () => {
+  const token = customerAuth.jwtSign({ sub: "line:u1", exp: Math.floor(Date.now() / 1000) + 60 }, READY_ENV.CWF_JWT_SECRET);
+  await withServer(makeRouter(), async (base) => {
+    const started = await startFlow(base, "google", customerAuth.GOOGLE_STATE_COOKIE, `cwf_token=${encodeURIComponent(token)}`);
+    const res = await fetch(`${base}/auth/google/callback?code=abc&state=${started.state}`, {
+      redirect: "manual",
+      headers: { cookie: started.cookie },
+    });
+    assert.match(res.headers.get("location"), /reason=link_session_missing/);
+  });
+});
+
+test("linking after session changes is rejected", async () => {
+  const tokenA = customerAuth.jwtSign({ sub: "line:u1", exp: Math.floor(Date.now() / 1000) + 60 }, READY_ENV.CWF_JWT_SECRET);
+  const tokenB = customerAuth.jwtSign({ sub: "line:u2", exp: Math.floor(Date.now() / 1000) + 60 }, READY_ENV.CWF_JWT_SECRET);
+  await withServer(makeRouter(), async (base) => {
+    const started = await startFlow(base, "google", customerAuth.GOOGLE_STATE_COOKIE, `cwf_token=${encodeURIComponent(tokenA)}`);
+    const res = await fetch(`${base}/auth/google/callback?code=abc&state=${started.state}`, {
+      redirect: "manual",
+      headers: { cookie: `${started.cookie}; cwf_token=${encodeURIComponent(tokenB)}` },
+    });
+    assert.match(res.headers.get("location"), /reason=link_session_changed/);
+  });
+});
+
+test("valid same-session provider linking succeeds", async () => {
+  const pool = makePool({ profiles: [{ sub: "line:u1", display_name: "Line User" }] });
+  const token = customerAuth.jwtSign({ sub: "line:u1", exp: Math.floor(Date.now() / 1000) + 60 }, READY_ENV.CWF_JWT_SECRET);
+  await withServer(makeRouter({ pool }), async (base) => {
+    const started = await startFlow(base, "google", customerAuth.GOOGLE_STATE_COOKIE, `cwf_token=${encodeURIComponent(token)}`);
+    const res = await fetch(`${base}/auth/google/callback?code=abc&state=${started.state}`, {
+      redirect: "manual",
+      headers: { cookie: `${started.cookie}; cwf_token=${encodeURIComponent(token)}` },
+    });
+    assert.match(res.headers.get("location"), /auth=linked/);
+    assert.equal(pool.state.identities[0].customer_sub, "line:u1");
   });
 });
 
@@ -151,27 +280,15 @@ test("existing provider identity signs into the same customer", async () => {
   assert.equal(result.mode, "existing_identity");
 });
 
-test("new provider identity creates a customer without duplicate display-name matching", async () => {
+test("new provider identity creates profile before identity and avoids display-name matching", async () => {
   const pool = makePool({ profiles: [{ sub: "line:other", display_name: "Same Name" }] });
   const result = await customerAuth.completeProviderLogin({
     pool,
     identity: { provider: "google", provider_subject: "g-new", display_name: "Same Name", email: "", email_verified: false },
   });
   assert.equal(result.customer.customer_sub, "google:g-new");
-  assert.equal(pool.state.identities.length, 1);
   assert.match(pool.state.queries[1].sql, /INSERT INTO public\.customer_profiles/);
   assert.match(pool.state.queries[2].sql, /INSERT INTO public\.customer_identities/);
-});
-
-test("logged-in customer explicitly links a new provider", async () => {
-  const pool = makePool({ profiles: [{ sub: "line:u1", display_name: "Line User" }] });
-  const result = await customerAuth.completeProviderLogin({
-    pool,
-    loggedInCustomer: { sub: "line:u1" },
-    identity: { provider: "google", provider_subject: "g-2", display_name: "Google User", email: "g@example.com", email_verified: true },
-  });
-  assert.equal(result.customer.customer_sub, "line:u1");
-  assert.equal(result.mode, "linked_to_session");
 });
 
 test("duplicate provider identity linked to another customer is rejected safely", async () => {
@@ -202,48 +319,32 @@ test("ambiguous verified email does not auto-link", async () => {
   assert.equal(result.mode, "ambiguous_email_new_customer");
 });
 
-test("provider unavailable is reported through public config", async () => {
-  const router = customerAuth.createCustomerAuthRoutes({ pool: makePool(), env: { CWF_JWT_SECRET: "secret" } });
-  await withServer(router, async (base) => {
-    const res = await fetch(`${base}/public/auth/config`);
-    const data = await res.json();
-    assert.equal(data.providers.line.available, false);
-    assert.equal(data.providers.google.available, false);
-  });
+test("Google verifier uses official OAuth2Client abstraction with n/e JWKS hidden behind library", async () => {
+  const oauthClient = {
+    async verifyIdToken({ idToken, audience }) {
+      assert.equal(idToken, "google-id-token");
+      assert.equal(audience, "google-id");
+      return {
+        getPayload() {
+          return {
+            iss: "https://accounts.google.com",
+            aud: "google-id",
+            exp: Math.floor(Date.now() / 1000) + 60,
+            nonce: "nonce",
+            sub: "google-sub",
+            email: "user@example.com",
+            email_verified: true,
+          };
+        },
+      };
+    },
+  };
+  const identity = await customerAuth.verifyGoogleIdToken({ idToken: "google-id-token", clientId: "google-id", nonce: "nonce", oauthClient });
+  assert.equal(identity.provider_subject, "google-sub");
+  assert.equal(identity.email_verified, true);
 });
 
-test("logout clears session and OAuth cookies", async () => {
-  const router = customerAuth.createCustomerAuthRoutes({ pool: makePool(), env: { CWF_JWT_SECRET: "secret" } });
-  await withServer(router, async (base) => {
-    const res = await fetch(`${base}/public/logout`, { method: "POST" });
-    assert.equal(res.status, 200);
-    const cookie = res.headers.get("set-cookie");
-    assert.match(cookie, /cwf_token=; Max-Age=0/);
-    assert.match(cookie, /cwf_oauth_line=; Max-Age=0/);
-    assert.match(cookie, /cwf_oauth_google=; Max-Age=0/);
-  });
-});
-
-test("/public/me guest and authenticated customer", async () => {
-  const pool = makePool({
-    identities: [{ provider: "line", provider_subject: "u1", customer_sub: "line:u1" }],
-    profiles: [{ sub: "line:u1", display_name: "Line User", address: "Bangkok", maps_url: "", email: "", email_verified: false }],
-  });
-  const env = { CWF_JWT_SECRET: "secret" };
-  const router = customerAuth.createCustomerAuthRoutes({ pool, env });
-  await withServer(router, async (base) => {
-    const guest = await fetch(`${base}/public/me`);
-    assert.deepEqual(await guest.json(), { logged_in: false });
-    const token = customerAuth.jwtSign({ sub: "line:u1", provider: "line", name: "Line User", exp: Math.floor(Date.now() / 1000) + 60 }, env.CWF_JWT_SECRET);
-    const authed = await fetch(`${base}/public/me`, { headers: { cookie: `cwf_token=${encodeURIComponent(token)}` } });
-    const data = await authed.json();
-    assert.equal(data.logged_in, true);
-    assert.equal(data.user.provider, "line");
-    assert.equal(data.profile.address, "Bangkok");
-  });
-});
-
-test("Google token audience mismatch is rejected by verifier before identity use", async () => {
+test("Google token audience mismatch is rejected after official verification payload", () => {
   assert.throws(
     () => customerAuth.googleIdentityFromPayload({
       iss: "https://accounts.google.com",


### PR DESCRIPTION
## Summary
- Adds Customer App V2 LINE and Google login using the existing `cwf_token` session contract.
- Uses Google’s official `google-auth-library` `OAuth2Client.verifyIdToken` path instead of custom x5c/JWKS verification.
- Keeps legacy Customer App routes compatible while V2 uses separate auth start/callback routes.
- Stores OAuth context server-side with opaque one-time state cookies, TTL cleanup, bounded max size, oldest-entry eviction, tamper resistance, replay rejection, and explicit same-session linking checks.
- Requires explicit `mode=link` plus user confirmation before account linking; normal login does not silently attach providers to the current session.
- Makes LINE email scope opt-in via `LINE_EMAIL_SCOPE_ENABLED=true`; default LINE scope is `openid profile`.
- Adds normalized `customer_identities` storage for provider subjects and safe identity linking without display-name matching.
- Extends legacy `/public/me` additively with email and linked-provider metadata while preserving old fields and schema-missing fallback.
- Updates Customer App V2 auth UI, provider availability config, logout handling, production docs, and regression tests.

## Routes Added / Preserved
- V2 LINE: `GET /auth/line/start`, `GET /auth/line/v2/callback`
- V2 Google: `GET /auth/google/start`, `GET /auth/google/callback`
- V2 shared: `GET /public/auth/config`, `POST /public/logout`
- Legacy preserved outside the V2 router: `GET /auth/line`, `GET /auth/line/callback`, `GET /public/me`, `GET /public/logout`

## Migration Behavior
- Includes `migrations/20260620_customer_identities.sql`.
- The app no longer runs Customer Auth DDL automatically at startup.
- The runtime auth module no longer exports a DDL helper; the SQL migration is the supported schema-change path.
- Provider availability fails closed until the identity schema is present and required provider/JWT/callback configuration is safe.

## Validation
- `node --check customer-app/modules/auth.js`
- `node --check customer-app/modules/api.js`
- `node --check server/customerAuth.js`
- `node --check index.js`
- `node --check test/customerAuth.test.js`
- `npm.cmd test` (`32` tests passing)
- `git diff --check`
- `git diff --name-only origin/main...HEAD`
- `git diff --stat origin/main...HEAD`

## Notes
- Provider HTTP calls are mocked in automated tests; no real LINE/Google endpoints are called.
- Production credentials and provider dashboard callback settings still need owner configuration and manual QA.
- The included migration must be approved/run explicitly before enabling provider env vars.
- The memory OAuth state store is suitable for a single Node instance; horizontal deployments need a shared one-time state store.