### PR TITLE
Add Safe Customer Auth Migration Runner

### DIFF
--- a/docs/customer-auth-production.md
+++ b/docs/customer-auth-production.md
@@ -74,14 +74,47 @@ New normalized table: `public.customer_identities`.
 
 Existing LINE customers keep their legacy customer profile key, e.g. `line:<LINE user id>`. The migration includes a reviewed optional backfill statement to populate `customer_identities` from existing `customer_profiles` rows.
 
-The application does not run DDL at normal startup. The owner must explicitly approve and run `migrations/20260620_customer_identities.sql` as a separate controlled deployment step before enabling provider env vars. Until the schema is present, `/public/auth/config` reports providers as unavailable.
+The application does not run DDL at normal startup. The owner must explicitly approve and run the Customer Auth migration as a separate controlled deployment step before enabling provider env vars. Until the schema is present, `/public/auth/config` reports providers as unavailable.
 
 Recommended deployment order:
 
 1. Deploy the code with provider env vars unset.
-2. Run and verify `migrations/20260620_customer_identities.sql`.
-3. Add provider client IDs/secrets, safe HTTPS callbacks, and JWT secret.
-4. Enable LINE email scope only after LINE approves the permission.
+2. Confirm a recent Render PostgreSQL backup or restore point exists.
+3. Configure the Render Web Service Pre-Deploy Command:
+
+   ```text
+   npm run migrate:customer-auth
+   ```
+
+   In Render this is:
+
+   ```text
+   Render Web Service
+   -> Settings
+   -> Pre-Deploy Command
+   -> npm run migrate:customer-auth
+   ```
+
+4. Deploy. Render must stop the deployment if the migration runner exits non-zero.
+5. Verify `https://app.cwf-air.com/public/auth/config`.
+6. Add provider client IDs/secrets, safe HTTPS callbacks, and JWT secret.
+7. Enable LINE email scope only after LINE approves the permission.
+
+The runner reads and executes the merged SQL file `migrations/20260620_customer_identities.sql` exactly as committed. It uses a PostgreSQL advisory lock, verifies the resulting schema, closes the database connection in success and failure paths, and does not run the optional commented LINE backfill separately. It is intentionally not attached to `npm start`, `prestart`, `postinstall`, application boot, request handlers, or health checks.
+
+After a successful migration and complete provider env configuration, `/public/auth/config` should report:
+
+```json
+{
+  "schema_ready": true,
+  "providers": {
+    "line": { "available": true },
+    "google": { "available": true }
+  }
+}
+```
+
+Provider availability may remain `false` when required provider env vars, JWT secret, or safe HTTPS callback URLs are incomplete, even when `schema_ready` is `true`.
 
 ## OAuth State Store
 

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "main": "index.js",
   "scripts": {
     "start": "node index.js",
+    "migrate:customer-auth": "node scripts/run-customer-auth-migration.js",
     "test": "node --test test/*.test.js"
   },
   "dependencies": {

--- a/scripts/run-customer-auth-migration.js
+++ b/scripts/run-customer-auth-migration.js
@@ -1,0 +1,150 @@
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+const { Client } = require("pg");
+
+const MIGRATION_RELATIVE_PATH = "migrations/20260620_customer_identities.sql";
+const ADVISORY_LOCK_KEY = "202606200063";
+
+function clean(value) {
+  return String(value == null ? "" : value).trim();
+}
+
+function safeErrorMessage(error) {
+  const msg = clean(error && error.message ? error.message : error) || "unknown error";
+  return msg
+    .replace(/postgres(?:ql)?:\/\/[^\s"'<>]+/gi, "[REDACTED_DATABASE_URL]")
+    .replace(/(password|passwd|pwd|secret|token)=([^&\s]+)/gi, "$1=[REDACTED]");
+}
+
+function resolveMigrationPath(repoRoot = path.resolve(__dirname, "..")) {
+  const root = path.resolve(repoRoot);
+  const migrationPath = path.resolve(root, MIGRATION_RELATIVE_PATH);
+  const expected = path.resolve(root, "migrations", "20260620_customer_identities.sql");
+  if (migrationPath !== expected || !migrationPath.startsWith(root + path.sep)) {
+    throw new Error("migration path rejected");
+  }
+  return migrationPath;
+}
+
+function readMigrationSql(repoRoot) {
+  return fs.readFileSync(resolveMigrationPath(repoRoot), "utf8");
+}
+
+function createClientConfig(env = process.env) {
+  const databaseUrl = clean(env.DATABASE_URL);
+  if (!databaseUrl) throw new Error("DATABASE_URL is required");
+  return {
+    connectionString: databaseUrl,
+    options: "-c timezone=Asia/Bangkok",
+    ssl: { rejectUnauthorized: false },
+  };
+}
+
+async function verifySchema(client) {
+  const table = await client.query("SELECT to_regclass('public.customer_identities') AS customer_identities");
+  if (!table.rows?.[0]?.customer_identities) throw new Error("customer_identities table missing after migration");
+
+  const columns = await client.query(`
+    SELECT column_name, data_type
+    FROM information_schema.columns
+    WHERE table_schema = 'public'
+      AND table_name = 'customer_profiles'
+      AND column_name IN ('email', 'email_verified')
+    ORDER BY column_name
+  `);
+  const columnTypes = new Map((columns.rows || []).map((row) => [row.column_name, row.data_type]));
+  if (columnTypes.get("email") !== "text") throw new Error("customer_profiles.email missing after migration");
+  if (columnTypes.get("email_verified") !== "boolean") throw new Error("customer_profiles.email_verified missing after migration");
+
+  const constraints = await client.query(`
+    SELECT con.conname AS constraint_name,
+           array_agg(att.attname ORDER BY cols.ordinality) AS column_names
+    FROM pg_constraint con
+    JOIN pg_class rel ON rel.oid = con.conrelid
+    JOIN pg_namespace nsp ON nsp.oid = rel.relnamespace
+    JOIN unnest(con.conkey) WITH ORDINALITY AS cols(attnum, ordinality) ON TRUE
+    JOIN pg_attribute att ON att.attrelid = rel.oid AND att.attnum = cols.attnum
+    WHERE nsp.nspname = 'public'
+      AND rel.relname = 'customer_identities'
+      AND con.contype = 'u'
+    GROUP BY con.conname
+  `);
+  const hasProviderUnique = (constraints.rows || []).some((row) => {
+    const names = Array.isArray(row.column_names) ? row.column_names : [];
+    return names.length === 2 && names[0] === "provider" && names[1] === "provider_subject";
+  });
+  if (!hasProviderUnique) throw new Error("customer_identities provider unique constraint missing after migration");
+
+  const indexes = await client.query(`
+    SELECT tablename, indexname
+    FROM pg_indexes
+    WHERE schemaname = 'public'
+      AND tablename IN ('customer_profiles', 'customer_identities')
+    ORDER BY tablename, indexname
+  `);
+  const indexNames = new Set((indexes.rows || []).map((row) => row.indexname));
+  if (!indexNames.has("idx_customer_identities_customer_sub")) {
+    throw new Error("idx_customer_identities_customer_sub missing after migration");
+  }
+  if (!indexNames.has("idx_customer_profiles_verified_email")) {
+    throw new Error("idx_customer_profiles_verified_email missing after migration");
+  }
+}
+
+async function runMigration(options = {}) {
+  const env = options.env || process.env;
+  const logger = options.logger || console;
+  const repoRoot = options.repoRoot || path.resolve(__dirname, "..");
+  const clientFactory = options.clientFactory || ((config) => new Client(config));
+  const sql = readMigrationSql(repoRoot);
+  const config = createClientConfig(env);
+  const client = clientFactory(config);
+  let locked = false;
+
+  logger.log("CUSTOMER_AUTH_MIGRATION_START");
+  try {
+    await client.connect();
+    await client.query("SELECT pg_advisory_lock($1::bigint)", [ADVISORY_LOCK_KEY]);
+    locked = true;
+    await client.query(sql);
+    await verifySchema(client);
+    logger.log("CUSTOMER_AUTH_MIGRATION_OK");
+  } finally {
+    try {
+      if (locked) await client.query("SELECT pg_advisory_unlock($1::bigint)", [ADVISORY_LOCK_KEY]);
+    } finally {
+      await client.end();
+    }
+  }
+}
+
+async function runCli(options = {}) {
+  const logger = options.logger || console;
+  try {
+    await runMigration(options);
+    return 0;
+  } catch (error) {
+    logger.error(`CUSTOMER_AUTH_MIGRATION_FAILED: ${safeErrorMessage(error)}`);
+    return 1;
+  }
+}
+
+if (require.main === module) {
+  runCli().then((code) => {
+    process.exitCode = code;
+  });
+}
+
+module.exports = {
+  ADVISORY_LOCK_KEY,
+  MIGRATION_RELATIVE_PATH,
+  createClientConfig,
+  readMigrationSql,
+  resolveMigrationPath,
+  runCli,
+  runMigration,
+  safeErrorMessage,
+  verifySchema,
+};

--- a/scripts/run-customer-auth-migration.js
+++ b/scripts/run-customer-auth-migration.js
@@ -98,25 +98,51 @@ async function runMigration(options = {}) {
   const logger = options.logger || console;
   const repoRoot = options.repoRoot || path.resolve(__dirname, "..");
   const clientFactory = options.clientFactory || ((config) => new Client(config));
-  const sql = readMigrationSql(repoRoot);
   const config = createClientConfig(env);
+  const sql = readMigrationSql(repoRoot);
   const client = clientFactory(config);
   let locked = false;
+  let migrationFailed = false;
+  let originalError = null;
 
   logger.log("CUSTOMER_AUTH_MIGRATION_START");
   try {
     await client.connect();
     await client.query("SELECT pg_advisory_lock($1::bigint)", [ADVISORY_LOCK_KEY]);
     locked = true;
-    await client.query(sql);
+    try {
+      await client.query(sql);
+    } catch (error) {
+      migrationFailed = true;
+      throw error;
+    }
     await verifySchema(client);
     logger.log("CUSTOMER_AUTH_MIGRATION_OK");
+  } catch (error) {
+    originalError = error;
+    throw error;
   } finally {
-    try {
-      if (locked) await client.query("SELECT pg_advisory_unlock($1::bigint)", [ADVISORY_LOCK_KEY]);
-    } finally {
-      await client.end();
+    let cleanupError = null;
+    if (migrationFailed) {
+      try {
+        await client.query("ROLLBACK");
+      } catch (error) {
+        cleanupError = cleanupError || error;
+      }
     }
+    if (locked) {
+      try {
+        await client.query("SELECT pg_advisory_unlock($1::bigint)", [ADVISORY_LOCK_KEY]);
+      } catch (error) {
+        cleanupError = cleanupError || error;
+      }
+    }
+    try {
+      await client.end();
+    } catch (error) {
+      cleanupError = cleanupError || error;
+    }
+    if (!originalError && cleanupError) throw cleanupError;
   }
 }
 

--- a/test/customerAuthMigration.test.js
+++ b/test/customerAuthMigration.test.js
@@ -1,0 +1,207 @@
+"use strict";
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("fs");
+const path = require("path");
+const runner = require("../scripts/run-customer-auth-migration");
+
+const REPO_ROOT = path.resolve(__dirname, "..");
+const DATABASE_URL = "postgres://user:super-secret-password@db.example.invalid:5432/cwf";
+
+class FakeClient {
+  constructor(options = {}) {
+    this.options = options;
+    this.connected = false;
+    this.ended = false;
+    this.queries = [];
+  }
+
+  async connect() {
+    this.connected = true;
+    if (this.options.failConnect) throw new Error(this.options.failConnect);
+  }
+
+  async query(sql, params) {
+    this.queries.push({ sql, params });
+    if (this.options.failSql && String(sql).includes("BEGIN;")) throw new Error(this.options.failSql);
+    if (String(sql).includes("to_regclass('public.customer_identities')")) {
+      return { rows: [{ customer_identities: this.options.missingTable ? null : "public.customer_identities" }] };
+    }
+    if (String(sql).includes("information_schema.columns")) {
+      return {
+        rows: this.options.missingColumn ? [{ column_name: "email", data_type: "text" }] : [
+          { column_name: "email", data_type: "text" },
+          { column_name: "email_verified", data_type: "boolean" },
+        ],
+      };
+    }
+    if (String(sql).includes("pg_constraint")) {
+      return {
+        rows: this.options.missingUnique ? [] : [
+          { constraint_name: "customer_identities_provider_provider_subject_key", column_names: ["provider", "provider_subject"] },
+        ],
+      };
+    }
+    if (String(sql).includes("pg_indexes")) {
+      return {
+        rows: this.options.missingIndex ? [{ tablename: "customer_identities", indexname: "idx_customer_identities_customer_sub" }] : [
+          { tablename: "customer_identities", indexname: "idx_customer_identities_customer_sub" },
+          { tablename: "customer_profiles", indexname: "idx_customer_profiles_verified_email" },
+        ],
+      };
+    }
+    return { rows: [] };
+  }
+
+  async end() {
+    this.ended = true;
+  }
+}
+
+function makeLogger() {
+  const lines = [];
+  return {
+    lines,
+    log(message) { lines.push(String(message)); },
+    error(message) { lines.push(String(message)); },
+  };
+}
+
+test("migration runner fails safely when DATABASE_URL is missing", async () => {
+  let created = false;
+  const logger = makeLogger();
+  const code = await runner.runCli({
+    env: {},
+    repoRoot: REPO_ROOT,
+    logger,
+    clientFactory() {
+      created = true;
+      return new FakeClient();
+    },
+  });
+  assert.equal(code, 1);
+  assert.equal(created, false);
+  assert.match(logger.lines.join("\n"), /CUSTOMER_AUTH_MIGRATION_FAILED: DATABASE_URL is required/);
+});
+
+test("migration runner executes the exact merged SQL file and verifies schema", async () => {
+  let client;
+  const logger = makeLogger();
+  await runner.runMigration({
+    env: { DATABASE_URL },
+    repoRoot: REPO_ROOT,
+    logger,
+    clientFactory(config) {
+      assert.equal(config.connectionString, DATABASE_URL);
+      assert.deepEqual(config.ssl, { rejectUnauthorized: false });
+      client = new FakeClient();
+      return client;
+    },
+  });
+  const migrationSql = fs.readFileSync(path.join(REPO_ROOT, runner.MIGRATION_RELATIVE_PATH), "utf8");
+  assert.equal(client.queries[0].sql, "SELECT pg_advisory_lock($1::bigint)");
+  assert.deepEqual(client.queries[0].params, [runner.ADVISORY_LOCK_KEY]);
+  assert.equal(client.queries[1].sql, migrationSql);
+  assert.equal(client.queries.at(-1).sql, "SELECT pg_advisory_unlock($1::bigint)");
+  assert.equal(client.ended, true);
+  assert.deepEqual(logger.lines, ["CUSTOMER_AUTH_MIGRATION_START", "CUSTOMER_AUTH_MIGRATION_OK"]);
+});
+
+test("migration runner releases advisory lock and closes connection on SQL failure", async () => {
+  let client;
+  const logger = makeLogger();
+  const code = await runner.runCli({
+    env: { DATABASE_URL },
+    repoRoot: REPO_ROOT,
+    logger,
+    clientFactory() {
+      client = new FakeClient({ failSql: "migration boom" });
+      return client;
+    },
+  });
+  assert.equal(code, 1);
+  assert.equal(client.ended, true);
+  assert.equal(client.queries.at(-1).sql, "SELECT pg_advisory_unlock($1::bigint)");
+  assert.match(logger.lines.join("\n"), /CUSTOMER_AUTH_MIGRATION_FAILED: migration boom/);
+});
+
+test("migration runner fails non-zero when post-migration verification fails", async () => {
+  let client;
+  const logger = makeLogger();
+  const code = await runner.runCli({
+    env: { DATABASE_URL },
+    repoRoot: REPO_ROOT,
+    logger,
+    clientFactory() {
+      client = new FakeClient({ missingUnique: true });
+      return client;
+    },
+  });
+  assert.equal(code, 1);
+  assert.equal(client.ended, true);
+  assert.equal(client.queries.at(-1).sql, "SELECT pg_advisory_unlock($1::bigint)");
+  assert.match(logger.lines.join("\n"), /provider unique constraint missing/);
+  assert.doesNotMatch(logger.lines.join("\n"), /CUSTOMER_AUTH_MIGRATION_OK/);
+});
+
+test("migration runner closes connection when connect fails before advisory lock", async () => {
+  let client;
+  const logger = makeLogger();
+  const code = await runner.runCli({
+    env: { DATABASE_URL },
+    repoRoot: REPO_ROOT,
+    logger,
+    clientFactory() {
+      client = new FakeClient({ failConnect: "connect boom" });
+      return client;
+    },
+  });
+  assert.equal(code, 1);
+  assert.equal(client.ended, true);
+  assert.equal(client.queries.length, 0);
+});
+
+test("migration runner does not print database secrets", async () => {
+  const logger = makeLogger();
+  const code = await runner.runCli({
+    env: { DATABASE_URL },
+    repoRoot: REPO_ROOT,
+    logger,
+    clientFactory() {
+      return new FakeClient({ failConnect: `cannot connect ${DATABASE_URL}` });
+    },
+  });
+  const output = logger.lines.join("\n");
+  assert.equal(code, 1);
+  assert.doesNotMatch(output, /super-secret-password/);
+  assert.doesNotMatch(output, /db\.example\.invalid/);
+  assert.match(output, /\[REDACTED_DATABASE_URL\]/);
+});
+
+test("migration file path is fixed to the expected merged SQL file", () => {
+  assert.equal(runner.MIGRATION_RELATIVE_PATH, "migrations/20260620_customer_identities.sql");
+  assert.equal(
+    runner.resolveMigrationPath(REPO_ROOT),
+    path.join(REPO_ROOT, "migrations", "20260620_customer_identities.sql")
+  );
+});
+
+test("optional LINE backfill remains commented and is not separately executed", async () => {
+  let client;
+  const logger = makeLogger();
+  await runner.runMigration({
+    env: { DATABASE_URL },
+    repoRoot: REPO_ROOT,
+    logger,
+    clientFactory() {
+      client = new FakeClient();
+      return client;
+    },
+  });
+  const migrationSql = fs.readFileSync(path.join(REPO_ROOT, runner.MIGRATION_RELATIVE_PATH), "utf8");
+  assert.match(migrationSql, /-- INSERT INTO public\.customer_identities/);
+  const backfillQueries = client.queries.filter((q) => /INSERT INTO public\.customer_identities/.test(q.sql));
+  assert.equal(backfillQueries.length, 1);
+  assert.equal(backfillQueries[0].sql, migrationSql);
+});

--- a/test/customerAuthMigration.test.js
+++ b/test/customerAuthMigration.test.js
@@ -15,6 +15,7 @@ class FakeClient {
     this.connected = false;
     this.ended = false;
     this.queries = [];
+    this.aborted = false;
   }
 
   async connect() {
@@ -24,7 +25,17 @@ class FakeClient {
 
   async query(sql, params) {
     this.queries.push({ sql, params });
-    if (this.options.failSql && String(sql).includes("BEGIN;")) throw new Error(this.options.failSql);
+    if (this.aborted && sql !== "ROLLBACK") throw new Error("current transaction is aborted");
+    if (sql === "ROLLBACK") {
+      if (this.options.failRollback) throw new Error(this.options.failRollback);
+      this.aborted = false;
+      return { rows: [] };
+    }
+    if (String(sql).includes("pg_advisory_unlock") && this.options.failUnlock) throw new Error(this.options.failUnlock);
+    if (this.options.failSql && String(sql).includes("BEGIN;")) {
+      this.aborted = true;
+      throw new Error(this.options.failSql);
+    }
     if (String(sql).includes("to_regclass('public.customer_identities')")) {
       return { rows: [{ customer_identities: this.options.missingTable ? null : "public.customer_identities" }] };
     }
@@ -56,6 +67,7 @@ class FakeClient {
 
   async end() {
     this.ended = true;
+    if (this.options.failEnd) throw new Error(this.options.failEnd);
   }
 }
 
@@ -70,19 +82,30 @@ function makeLogger() {
 
 test("migration runner fails safely when DATABASE_URL is missing", async () => {
   let created = false;
+  let fileRead = false;
   const logger = makeLogger();
-  const code = await runner.runCli({
-    env: {},
-    repoRoot: REPO_ROOT,
-    logger,
-    clientFactory() {
-      created = true;
-      return new FakeClient();
-    },
-  });
-  assert.equal(code, 1);
-  assert.equal(created, false);
-  assert.match(logger.lines.join("\n"), /CUSTOMER_AUTH_MIGRATION_FAILED: DATABASE_URL is required/);
+  const originalRead = fs.readFileSync;
+  fs.readFileSync = (...args) => {
+    fileRead = true;
+    return originalRead(...args);
+  };
+  try {
+    const code = await runner.runCli({
+      env: {},
+      repoRoot: REPO_ROOT,
+      logger,
+      clientFactory() {
+        created = true;
+        return new FakeClient();
+      },
+    });
+    assert.equal(code, 1);
+    assert.equal(created, false);
+    assert.equal(fileRead, false);
+    assert.match(logger.lines.join("\n"), /CUSTOMER_AUTH_MIGRATION_FAILED: DATABASE_URL is required/);
+  } finally {
+    fs.readFileSync = originalRead;
+  }
 });
 
 test("migration runner executes the exact merged SQL file and verifies schema", async () => {
@@ -122,8 +145,62 @@ test("migration runner releases advisory lock and closes connection on SQL failu
   });
   assert.equal(code, 1);
   assert.equal(client.ended, true);
+  assert.equal(client.queries.at(-2).sql, "ROLLBACK");
   assert.equal(client.queries.at(-1).sql, "SELECT pg_advisory_unlock($1::bigint)");
   assert.match(logger.lines.join("\n"), /CUSTOMER_AUTH_MIGRATION_FAILED: migration boom/);
+});
+
+test("migration failure rolls back before unlock and preserves original error", async () => {
+  let client;
+  const logger = makeLogger();
+  const code = await runner.runCli({
+    env: { DATABASE_URL },
+    repoRoot: REPO_ROOT,
+    logger,
+    clientFactory() {
+      client = new FakeClient({ failSql: "migration boom" });
+      return client;
+    },
+  });
+  assert.equal(code, 1);
+  assert.equal(client.ended, true);
+  const migrationIndex = client.queries.findIndex((q) => String(q.sql).includes("BEGIN;"));
+  const rollbackIndex = client.queries.findIndex((q) => q.sql === "ROLLBACK");
+  const unlockIndex = client.queries.findIndex((q) => q.sql === "SELECT pg_advisory_unlock($1::bigint)");
+  assert.ok(migrationIndex >= 0);
+  assert.ok(rollbackIndex > migrationIndex);
+  assert.ok(unlockIndex > rollbackIndex);
+  assert.match(logger.lines.join("\n"), /CUSTOMER_AUTH_MIGRATION_FAILED: migration boom/);
+  assert.doesNotMatch(logger.lines.join("\n"), /current transaction is aborted/);
+});
+
+test("rollback unlock and end cleanup errors do not mask migration failure", async () => {
+  let client;
+  const logger = makeLogger();
+  const code = await runner.runCli({
+    env: { DATABASE_URL },
+    repoRoot: REPO_ROOT,
+    logger,
+    clientFactory() {
+      client = new FakeClient({
+        failSql: "migration boom",
+        failRollback: "rollback boom",
+        failUnlock: "unlock boom",
+        failEnd: "end boom",
+      });
+      return client;
+    },
+  });
+  assert.equal(code, 1);
+  assert.equal(client.ended, true);
+  assert.equal(client.queries.at(-2).sql, "ROLLBACK");
+  assert.equal(client.queries.at(-1).sql, "SELECT pg_advisory_unlock($1::bigint)");
+  const output = logger.lines.join("\n");
+  assert.match(output, /CUSTOMER_AUTH_MIGRATION_FAILED: migration boom/);
+  assert.doesNotMatch(output, /rollback boom/);
+  assert.doesNotMatch(output, /unlock boom/);
+  assert.doesNotMatch(output, /end boom/);
+  assert.doesNotMatch(output, /current transaction is aborted/);
 });
 
 test("migration runner fails non-zero when post-migration verification fails", async () => {


### PR DESCRIPTION
## Summary
- Adds `npm run migrate:customer-auth` for Render Pre-Deploy execution of the existing Customer Auth migration.
- Creates a safe runner that validates `DATABASE_URL` before reading the migration file, reads `migrations/20260620_customer_identities.sql` exactly, uses `pg.Client` with Render-compatible SSL, takes a PostgreSQL advisory lock, runs the SQL, verifies the resulting schema, releases the lock, and closes the connection.
- Preserves the original migration SQL error on failure; cleanup runs `ROLLBACK` before advisory unlock and cleanup errors cannot mask the root cause.
- Adds focused mock-only tests covering missing `DATABASE_URL`, successful migration, SQL failure, PostgreSQL aborted transaction behavior, verification failure, cleanup, advisory lock behavior, secret-safe logging, fixed migration path, and ensuring the optional LINE backfill is not separately executed.
- Updates production docs with the Render Pre-Deploy Command procedure and post-deploy `/public/auth/config` expectations.

## Safety Notes
- No production connection was attempted.
- No changes to `index.js`, app startup, request handlers, health checks, OAuth behavior, cookies, booking, payment, technician, admin, or customer data.
- No changes to `migrations/20260620_customer_identities.sql`.
- No new dependencies and no `package-lock.json` changes.
- The runner is intentionally not attached to `start`, `prestart`, `postinstall`, or ordinary app boot.

## Validation
- `node --check scripts/run-customer-auth-migration.js`
- `node --check test/customerAuthMigration.test.js`
- `node --test test/customerAuthMigration.test.js` (`10` tests passing)
- `npm.cmd test` (`42` tests passing)
- `git diff --check`
- `git diff --check HEAD~1..HEAD`
- `git diff --name-only origin/main...HEAD`
- `git diff --stat origin/main...HEAD`

## Remaining Production Steps
- Confirm a recent Render PostgreSQL backup or restore point.
- Configure Render Web Service Pre-Deploy Command: `npm run migrate:customer-auth`.
- Deploy and allow Render to stop if the runner exits non-zero.
- Verify `https://app.cwf-air.com/public/auth/config` after deployment.
- Enable provider env vars only after migration succeeds; keep `LINE_EMAIL_SCOPE_ENABLED` off until LINE email permission is approved.