### PR TITLE
Separate Customer LINE Login Credentials from Messaging API

### DIFF
--- a/docs/customer-auth-production.md
+++ b/docs/customer-auth-production.md
@@ -28,9 +28,12 @@ LINE Messaging API:
 - `LINE_CHANNEL_ID`
 - `LINE_CHANNEL_SECRET`
 - `LINE_CHANNEL_ACCESS_TOKEN`
+
+Legacy Customer LINE Login:
+
 - `LINE_CALLBACK_URL=https://app.cwf-air.com/auth/line/callback` for legacy `customer.html`
 
-Customer LINE Login:
+Customer App V2 LINE Login:
 
 - `LINE_LOGIN_CHANNEL_ID`
 - `LINE_LOGIN_CHANNEL_SECRET`

--- a/docs/customer-auth-production.md
+++ b/docs/customer-auth-production.md
@@ -23,11 +23,17 @@ Shared:
 
 - `CWF_JWT_SECRET` or existing `JWT_SECRET`
 
-LINE:
+LINE Messaging API:
 
 - `LINE_CHANNEL_ID`
 - `LINE_CHANNEL_SECRET`
+- `LINE_CHANNEL_ACCESS_TOKEN`
 - `LINE_CALLBACK_URL=https://app.cwf-air.com/auth/line/callback` for legacy `customer.html`
+
+Customer LINE Login:
+
+- `LINE_LOGIN_CHANNEL_ID`
+- `LINE_LOGIN_CHANNEL_SECRET`
 - `LINE_V2_CALLBACK_URL=https://app.cwf-air.com/auth/line/v2/callback` for Customer App V2
 - `LINE_EMAIL_SCOPE_ENABLED=true` only after LINE email permission is approved
 
@@ -41,14 +47,15 @@ Do not commit provider secrets, access tokens, refresh tokens, private keys, or 
 
 ## LINE Developers Setup
 
-1. Create or use a LINE Login channel, not a Messaging API-only channel.
+1. Create or use a dedicated LINE Login channel, not the Messaging API channel used for webhooks/replies.
 2. Keep legacy callback URL `https://app.cwf-air.com/auth/line/callback`.
 3. Add Customer App V2 callback URL `https://app.cwf-air.com/auth/line/v2/callback`.
 4. Enable scopes: `openid`, `profile`.
-5. Map the channel ID to `LINE_CHANNEL_ID`.
-6. Map the channel secret to `LINE_CHANNEL_SECRET`.
+5. Map the LINE Login channel ID to `LINE_LOGIN_CHANNEL_ID`.
+6. Map the LINE Login channel secret to `LINE_LOGIN_CHANNEL_SECRET`.
 7. Map the V2 callback to `LINE_V2_CALLBACK_URL`.
-8. LINE Official Account linking is optional for this login flow; the customer login only requires LINE Login.
+8. Keep Messaging API values (`LINE_CHANNEL_ID`, `LINE_CHANNEL_SECRET`, `LINE_CHANNEL_ACCESS_TOKEN`) unchanged for webhook, inbox, reply, and customer messaging flows.
+9. LINE Official Account linking is optional for this login flow; the customer login only requires LINE Login.
 
 LINE email is optional and disabled by default. Apply for email permission in LINE Developers Console first; after approval, set `LINE_EMAIL_SCOPE_ENABLED=true` and add the `email` scope in the channel settings. Without that env var, Customer App V2 requests only `openid profile`, and LINE login still works without an email address.
 

--- a/server/customerAuth.js
+++ b/server/customerAuth.js
@@ -132,8 +132,7 @@ function safeReturnTo(value, fallback = "/customer-app/") {
 
 function callbackUrl(req, provider, env = process.env) {
   if (provider === "line") {
-    const lineV2 = clean(env.LINE_V2_CALLBACK_URL || env.LINE_CUSTOMER_V2_CALLBACK_URL);
-    return lineV2 || `${getReqBaseUrl(req)}/auth/line/v2/callback`;
+    return clean(env.LINE_V2_CALLBACK_URL);
   }
   const google = clean(env.GOOGLE_CALLBACK_URL || env.GOOGLE_OAUTH_CALLBACK_URL);
   return google || `${getReqBaseUrl(req)}/auth/google/callback`;
@@ -147,8 +146,8 @@ function isUsableCallbackUrl(url, req) {
 }
 
 function baseProviderConfig(env = process.env) {
-  const lineClientId = clean(env.LINE_CHANNEL_ID || env.LINE_CLIENT_ID);
-  const lineClientSecret = clean(env.LINE_CHANNEL_SECRET || env.LINE_CLIENT_SECRET);
+  const lineClientId = clean(env.LINE_LOGIN_CHANNEL_ID);
+  const lineClientSecret = clean(env.LINE_LOGIN_CHANNEL_SECRET);
   const googleClientId = clean(env.GOOGLE_CLIENT_ID || env.GOOGLE_OAUTH_CLIENT_ID);
   const googleClientSecret = clean(env.GOOGLE_CLIENT_SECRET || env.GOOGLE_OAUTH_CLIENT_SECRET);
   return {

--- a/test/customerAuth.test.js
+++ b/test/customerAuth.test.js
@@ -6,8 +6,8 @@ const customerAuth = require("../server/customerAuth");
 
 const READY_ENV = {
   CWF_JWT_SECRET: "secret",
-  LINE_CHANNEL_ID: "line-id",
-  LINE_CHANNEL_SECRET: "line-secret",
+  LINE_LOGIN_CHANNEL_ID: "line-login-id",
+  LINE_LOGIN_CHANNEL_SECRET: "line-login-secret",
   LINE_V2_CALLBACK_URL: "https://app.cwf-air.com/auth/line/v2/callback",
   GOOGLE_CLIENT_ID: "google-id",
   GOOGLE_CLIENT_SECRET: "google-secret",
@@ -185,6 +185,98 @@ test("provider unavailable when schema is missing", async () => {
     assert.equal(data.schema_ready, false);
     assert.equal(data.providers.line.available, false);
     assert.equal(data.providers.google.available, false);
+  });
+});
+
+test("LINE Login is unavailable when only Messaging API variables exist", async () => {
+  const env = {
+    CWF_JWT_SECRET: "secret",
+    LINE_CHANNEL_ID: "messaging-id",
+    LINE_CHANNEL_SECRET: "messaging-secret",
+    LINE_CHANNEL_ACCESS_TOKEN: "messaging-token",
+    LINE_V2_CALLBACK_URL: "https://app.cwf-air.com/auth/line/v2/callback",
+    GOOGLE_CLIENT_ID: "google-id",
+    GOOGLE_CLIENT_SECRET: "google-secret",
+    GOOGLE_CALLBACK_URL: "https://app.cwf-air.com/auth/google/callback",
+  };
+  await withServer(makeRouter({ env }), async (base) => {
+    const res = await fetch(`${base}/public/auth/config`);
+    const data = await res.json();
+    assert.equal(data.schema_ready, true);
+    assert.equal(data.providers.line.available, false);
+    assert.equal(data.providers.google.available, true);
+    assert.doesNotMatch(JSON.stringify(data), /messaging-secret|messaging-token|google-secret/);
+  });
+});
+
+test("LINE Login becomes available with dedicated LINE Login variables", async () => {
+  const env = {
+    CWF_JWT_SECRET: "secret",
+    LINE_LOGIN_CHANNEL_ID: "line-login-id",
+    LINE_LOGIN_CHANNEL_SECRET: "line-login-secret",
+    LINE_CHANNEL_ID: "messaging-id",
+    LINE_CHANNEL_SECRET: "messaging-secret",
+    LINE_CHANNEL_ACCESS_TOKEN: "messaging-token",
+    LINE_V2_CALLBACK_URL: "https://app.cwf-air.com/auth/line/v2/callback",
+  };
+  await withServer(makeRouter({ env }), async (base) => {
+    const res = await fetch(`${base}/public/auth/config`);
+    const data = await res.json();
+    assert.equal(data.providers.line.available, true);
+    assert.doesNotMatch(JSON.stringify(data), /line-login-secret|messaging-secret|messaging-token/);
+  });
+});
+
+test("Customer Auth V2 does not use Messaging API variable names for LINE Login config", () => {
+  const cfg = customerAuth.baseProviderConfig({
+    CWF_JWT_SECRET: "secret",
+    LINE_CHANNEL_ID: "messaging-id",
+    LINE_CHANNEL_SECRET: "messaging-secret",
+    LINE_CHANNEL_ACCESS_TOKEN: "messaging-token",
+    LINE_LOGIN_CHANNEL_ID: "line-login-id",
+    LINE_LOGIN_CHANNEL_SECRET: "line-login-secret",
+  });
+  assert.equal(cfg.line.clientId, "line-login-id");
+  assert.equal(cfg.line.clientSecret, "line-login-secret");
+
+  const messagingOnly = customerAuth.baseProviderConfig({
+    CWF_JWT_SECRET: "secret",
+    LINE_CHANNEL_ID: "messaging-id",
+    LINE_CHANNEL_SECRET: "messaging-secret",
+    LINE_CHANNEL_ACCESS_TOKEN: "messaging-token",
+  });
+  assert.equal(messagingOnly.line.clientId, "");
+  assert.equal(messagingOnly.line.clientSecret, "");
+});
+
+test("Google availability remains unchanged by LINE credential isolation", async () => {
+  const env = {
+    CWF_JWT_SECRET: "secret",
+    LINE_CHANNEL_ID: "messaging-id",
+    LINE_CHANNEL_SECRET: "messaging-secret",
+    LINE_CHANNEL_ACCESS_TOKEN: "messaging-token",
+    GOOGLE_CLIENT_ID: "google-id",
+    GOOGLE_CLIENT_SECRET: "google-secret",
+    GOOGLE_CALLBACK_URL: "https://app.cwf-air.com/auth/google/callback",
+  };
+  await withServer(makeRouter({ env }), async (base) => {
+    const res = await fetch(`${base}/public/auth/config`);
+    const data = await res.json();
+    assert.equal(data.providers.line.available, false);
+    assert.equal(data.providers.google.available, true);
+  });
+});
+
+test("LINE Login requires explicit V2 callback configuration", async () => {
+  const env = {
+    CWF_JWT_SECRET: "secret",
+    LINE_LOGIN_CHANNEL_ID: "line-login-id",
+    LINE_LOGIN_CHANNEL_SECRET: "line-login-secret",
+  };
+  await withServer(makeRouter({ env }), async (base) => {
+    const res = await fetch(`${base}/public/auth/config`);
+    const data = await res.json();
+    assert.equal(data.providers.line.available, false);
   });
 });
 


### PR DESCRIPTION
## Summary
- Updates Customer Auth V2 to use only dedicated LINE Login env vars: `LINE_LOGIN_CHANNEL_ID`, `LINE_LOGIN_CHANNEL_SECRET`, and `LINE_V2_CALLBACK_URL`.
- Removes Customer Auth V2 fallback to Messaging API env vars `LINE_CHANNEL_ID` and `LINE_CHANNEL_SECRET` to prevent credential collision.
- Keeps Google auth availability behavior unchanged.
- Documents separate Messaging API, legacy Customer LINE Login callback, and Customer App V2 LINE Login env var groups.
- Synchronizes the PR branch with current `origin/main`, including the Customer Auth migration runner tests from PR #64.

## Scope / Safety
- Did not modify `server/routes/lineWebhook.js`.
- Did not modify `index.js` or legacy Messaging API handling.
- Did not rename or remove `LINE_CHANNEL_ID`, `LINE_CHANNEL_SECRET`, or `LINE_CHANNEL_ACCESS_TOKEN`.
- Did not change webhook, inbox, reply, customer messaging, cookies, schema, migrations, payment, admin, technician, or production config.
- No dependencies added and no production connection attempted.

## Validation
- `git fetch origin`
- `git status`
- `git diff --name-only origin/main...HEAD`
- `node --check server/customerAuth.js`
- `node --check test/customerAuth.test.js`
- `node --check test/customerAuthMigration.test.js`
- `node --test test/customerAuth.test.js` (`37` tests passing)
- `node --test test/customerAuthMigration.test.js` (`10` tests passing)
- `npm.cmd test` (`47` tests passing)
- `git diff --check`
- `git diff --check HEAD~1..HEAD`
- `git diff --stat origin/main...HEAD`

## Notes
- LINE Login is now unavailable when only Messaging API credentials exist.
- LINE Login becomes available only with the dedicated LINE Login credentials, explicit V2 callback URL, JWT secret, and ready Customer Auth schema.
- Provider config responses do not expose secret values.