### PR TITLE
Make Customer App V2 a Real Service Storefront with Saved Address Editing

### DIFF
--- a/customer-app/assets/customer-app.css
+++ b/customer-app/assets/customer-app.css
@@ -1804,6 +1804,144 @@ p { margin: 0; }
 .guest-card { background: linear-gradient(180deg, #fff, var(--bg-2)); }
 .support-strip { display: flex; flex-direction: column; gap: 10px; }
 
+/* ===================== Commerce home ===================== */
+.commerce-home { gap: 16px; }
+.commerce-primary-cta {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 10px;
+}
+.commerce-section {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+.commerce-category-grid,
+.quick-service-grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 10px;
+}
+.commerce-category-card,
+.quick-service-card,
+.method-row {
+  width: 100%;
+  border: 1px solid var(--line);
+  background: #fff;
+  border-radius: 14px;
+  padding: 14px;
+  text-align: left;
+  display: grid;
+  gap: 7px;
+  box-shadow: 0 12px 28px -24px rgba(15, 35, 64, 0.42);
+}
+.commerce-category-card {
+  grid-template-columns: 42px 1fr;
+  align-items: start;
+}
+.commerce-category-card .trust-ico { grid-row: span 2; }
+.commerce-category-card strong,
+.quick-service-card strong,
+.method-row strong,
+.commerce-list-row strong {
+  font-size: 15px;
+  font-weight: 900;
+  line-height: 1.35;
+  color: var(--ink);
+}
+.commerce-category-card span:not(.trust-ico),
+.quick-service-card > span:not(.quick-kicker):not(.quick-price),
+.method-row span,
+.commerce-list-row span,
+.urgent-commerce-card p {
+  font-size: 13px;
+  line-height: 1.55;
+  color: var(--muted);
+}
+.quick-service-card {
+  min-height: 150px;
+  align-content: start;
+  position: relative;
+}
+.quick-service-card.is-urgent {
+  border-color: rgba(222, 130, 38, 0.34);
+  background: linear-gradient(180deg, #fff, var(--soft-yellow));
+}
+.quick-kicker {
+  width: max-content;
+  max-width: 100%;
+  border-radius: 999px;
+  padding: 4px 9px;
+  background: var(--soft-blue);
+  color: var(--blue);
+  font-size: 11px;
+  font-weight: 900;
+}
+.quick-service-card.is-urgent .quick-kicker {
+  color: var(--warning);
+  background: rgba(255, 184, 56, 0.18);
+}
+.quick-price {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 7px;
+  margin-top: auto;
+  padding-top: 5px;
+}
+.price-text {
+  font-size: 16px;
+  font-weight: 900;
+  color: var(--blue);
+}
+.price-text.is-estimate {
+  font-size: 13px;
+  color: var(--muted);
+}
+.promo-chip {
+  border-radius: 999px;
+  padding: 4px 8px;
+  background: var(--soft-green);
+  color: var(--success);
+  font-size: 11px;
+  font-weight: 900;
+}
+.urgent-commerce-card {
+  border: 1px solid rgba(222, 130, 38, 0.3);
+  border-radius: 14px;
+  padding: 14px;
+  background: var(--soft-yellow);
+  display: grid;
+  gap: 12px;
+}
+.method-grid,
+.commerce-list {
+  display: grid;
+  gap: 9px;
+}
+.method-row { min-height: 0; }
+.commerce-list-row {
+  display: grid;
+  gap: 4px;
+  padding: 12px 0;
+  border-bottom: 1px solid var(--line);
+}
+.commerce-list-row:last-child { border-bottom: 0; }
+.commerce-tags { gap: 8px; }
+.account-shortcut {
+  display: grid;
+  gap: 10px;
+  background: linear-gradient(180deg, #fff, var(--bg-2));
+}
+
+@media (min-width: 640px) {
+  .commerce-primary-cta,
+  .commerce-category-grid,
+  .quick-service-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
 /* ===================== Bottom nav ===================== */
 .bottom-nav {
   position: fixed;

--- a/customer-app/assets/customer-app.css
+++ b/customer-app/assets/customer-app.css
@@ -1803,6 +1803,16 @@ p { margin: 0; }
 /* ===================== Profile ===================== */
 .guest-card { background: linear-gradient(180deg, #fff, var(--bg-2)); }
 .support-strip { display: flex; flex-direction: column; gap: 10px; }
+.profile-address-summary,
+.profile-address-form {
+  display: grid;
+  gap: 12px;
+}
+.profile-address-summary .secondary-btn,
+.profile-address-form .primary-btn,
+.profile-address-form .secondary-btn {
+  width: 100%;
+}
 
 /* ===================== Commerce home ===================== */
 .commerce-home { gap: 16px; }

--- a/customer-app/index.html
+++ b/customer-app/index.html
@@ -4,14 +4,14 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>CWF Customer App V2</title>
-  <link rel="stylesheet" href="./assets/customer-app.css?v=20260620_customer_auth_v1">
+  <link rel="stylesheet" href="./assets/customer-app.css?v=20260620_commerce_home_address_v1">
 </head>
 <body>
   <div class="app-shell" data-app-shell>
     <header class="app-header">
       <div class="brand-lockup">
         <div class="brand-mark" aria-hidden="true">
-          <img src="/logo.png?v=20260620_customer_auth_v1" alt="" onerror="this.hidden=true;this.parentElement.classList.add('is-fallback')">
+          <img src="/logo.png?v=20260620_commerce_home_address_v1" alt="" onerror="this.hidden=true;this.parentElement.classList.add('is-fallback')">
           <span>CWF</span>
         </div>
         <div>
@@ -42,19 +42,19 @@
     </nav>
   </div>
 
-  <script src="./modules/state.js?v=20260620_customer_auth_v1"></script>
-  <script src="./modules/utils.js?v=20260620_customer_auth_v1"></script>
-  <script src="./modules/api.js?v=20260620_customer_auth_v1"></script>
-  <script src="./modules/services.js?v=20260620_customer_auth_v1"></script>
-  <script src="./modules/ui.js?v=20260620_customer_auth_v1"></script>
-  <script src="./modules/auth.js?v=20260620_customer_auth_v1"></script>
-  <script src="./modules/pricing.js?v=20260620_customer_auth_v1"></script>
-  <script src="./modules/availability.js?v=20260620_customer_auth_v1"></script>
-  <script src="./modules/bookingScheduled.js?v=20260620_customer_auth_v1"></script>
-  <script src="./modules/bookingUrgent.js?v=20260620_customer_auth_v1"></script>
-  <script src="./modules/tracking.js?v=20260620_customer_auth_v1"></script>
-  <script src="./modules/profile.js?v=20260620_customer_auth_v1"></script>
-  <script src="./modules/router.js?v=20260620_customer_auth_v1"></script>
-  <script src="./assets/customer-app.js?v=20260620_customer_auth_v1"></script>
+  <script src="./modules/state.js?v=20260620_commerce_home_address_v1"></script>
+  <script src="./modules/utils.js?v=20260620_commerce_home_address_v1"></script>
+  <script src="./modules/api.js?v=20260620_commerce_home_address_v1"></script>
+  <script src="./modules/services.js?v=20260620_commerce_home_address_v1"></script>
+  <script src="./modules/ui.js?v=20260620_commerce_home_address_v1"></script>
+  <script src="./modules/auth.js?v=20260620_commerce_home_address_v1"></script>
+  <script src="./modules/pricing.js?v=20260620_commerce_home_address_v1"></script>
+  <script src="./modules/availability.js?v=20260620_commerce_home_address_v1"></script>
+  <script src="./modules/bookingScheduled.js?v=20260620_commerce_home_address_v1"></script>
+  <script src="./modules/bookingUrgent.js?v=20260620_commerce_home_address_v1"></script>
+  <script src="./modules/tracking.js?v=20260620_commerce_home_address_v1"></script>
+  <script src="./modules/profile.js?v=20260620_commerce_home_address_v1"></script>
+  <script src="./modules/router.js?v=20260620_commerce_home_address_v1"></script>
+  <script src="./assets/customer-app.js?v=20260620_commerce_home_address_v1"></script>
 </body>
 </html>

--- a/customer-app/modules/api.js
+++ b/customer-app/modules/api.js
@@ -65,6 +65,16 @@
       return requestJson("/public/logout", { method: "POST" });
     },
 
+    async updateProfileAddress(payload) {
+      return requestJson("/public/profile/address", {
+        method: "PATCH",
+        body: {
+          address: String((payload && payload.address) || "").trim(),
+          maps_url: String((payload && payload.maps_url) || "").trim(),
+        },
+      });
+    },
+
     async previewPricing(payload) {
       return requestJson("/public/pricing_preview", {
         method: "POST",

--- a/customer-app/modules/bookingScheduled.js
+++ b/customer-app/modules/bookingScheduled.js
@@ -447,6 +447,9 @@
     // Customer submits scheduled bookings through existing /public/book only.
     // This flow always sends booking_mode="scheduled" and never starts urgent dispatch.
     render(container) {
+      root.state.ensureSavedAddressPrefill("scheduled", () => {
+        if (root.state.currentRoute === "scheduled") root.bookingScheduled.render(container);
+      });
       const d = draft();
       const s = service();
       container.innerHTML = `

--- a/customer-app/modules/bookingUrgent.js
+++ b/customer-app/modules/bookingUrgent.js
@@ -489,6 +489,9 @@
 
   root.bookingUrgent = {
     render(container) {
+      root.state.ensureSavedAddressPrefill("urgent", () => {
+        if (root.state.currentRoute === "urgent") root.bookingUrgent.render(container);
+      });
       root.state.setUrgentFlow({ step: "form", status: "idle", error: "", result: null });
       paint(container);
     },

--- a/customer-app/modules/profile.js
+++ b/customer-app/modules/profile.js
@@ -3,23 +3,106 @@
 
   const root = window.CWFCustomerAppV2 = window.CWFCustomerAppV2 || {};
 
+  function profile() {
+    const customer = root.state.customer || {};
+    return customer.profile || {};
+  }
+
   function renderSavedAddress() {
     const customer = root.state.customer;
+    const form = root.state.profileAddressForm || {};
     if (!customer) return root.utils.stateBox("loading", "กำลังโหลดข้อมูลบัญชี...");
     if (!customer.logged_in) return root.utils.stateBox("", "ใช้งานแบบ Guest ยังไม่มีที่อยู่ที่บันทึกไว้");
-    const profile = customer.profile || {};
+    const p = profile();
+    const address = String(p.address || "").trim();
+    const mapsUrl = String(p.maps_url || "").trim();
+    if (form.editing) {
+      return `
+        <form class="profile-address-form" data-profile-address-form>
+          <div class="field field-wide">
+            <label for="profile-address">ที่อยู่หลัก</label>
+            <textarea id="profile-address" class="input textarea" name="address" rows="4" minlength="5" required placeholder="บ้าน/คอนโด อาคาร ชั้น ห้อง เขต/อำเภอ">${root.utils.escapeHtml(address)}</textarea>
+          </div>
+          <div class="field field-wide">
+            <label for="profile-maps">ลิงก์ Google Maps (ถ้ามี)</label>
+            <input id="profile-maps" class="input" name="maps_url" value="${root.utils.escapeHtml(mapsUrl)}" inputmode="url" placeholder="วางลิงก์ Google Maps">
+          </div>
+          ${form.error ? `<div class="state-box is-error">${root.utils.escapeHtml(form.error)}</div>` : ""}
+          ${form.success ? `<div class="state-box is-success">${root.utils.escapeHtml(form.success)}</div>` : ""}
+          <div class="button-row">
+            <button class="primary-btn" type="submit" ${form.status === "saving" ? "disabled" : ""}>${form.status === "saving" ? "กำลังบันทึก..." : "บันทึกที่อยู่"}</button>
+            <button class="secondary-btn" type="button" data-profile-address-cancel ${form.status === "saving" ? "disabled" : ""}>ยกเลิก</button>
+          </div>
+        </form>
+      `;
+    }
     return `
-      <div class="data-list">
-        <div class="data-row">
-          <strong>ที่อยู่</strong>
-          <span class="muted">${root.utils.escapeHtml(profile.address || "ยังไม่มีที่อยู่ที่บันทึกไว้")}</span>
+      <div class="profile-address-summary">
+        <div class="data-list">
+          <div class="data-row">
+            <strong>ที่อยู่</strong>
+            <span class="muted">${root.utils.escapeHtml(address || "ยังไม่มีที่อยู่ที่บันทึกไว้")}</span>
+          </div>
+          <div class="data-row">
+            <strong>แผนที่</strong>
+            <span class="muted">${mapsUrl ? `<a href="${root.utils.escapeHtml(mapsUrl)}" target="_blank" rel="noopener">เปิด Google Maps</a>` : "ยังไม่มีลิงก์แผนที่"}</span>
+          </div>
         </div>
-        <div class="data-row">
-          <strong>แผนที่</strong>
-          <span class="muted">${root.utils.escapeHtml(profile.maps_url || "ยังไม่มีลิงก์แผนที่")}</span>
-        </div>
+        ${form.success ? `<div class="state-box is-success">${root.utils.escapeHtml(form.success)}</div>` : ""}
+        <button class="secondary-btn" type="button" data-profile-address-edit>${address || mapsUrl ? "แก้ไขที่อยู่" : "เพิ่มที่อยู่"}</button>
       </div>
     `;
+  }
+
+  function paintAddress(container) {
+    const mount = container.querySelector("[data-profile-address]");
+    if (!mount) return;
+    mount.innerHTML = renderSavedAddress();
+    bindAddress(container);
+  }
+
+  function bindAddress(container) {
+    const edit = container.querySelector("[data-profile-address-edit]");
+    if (edit) {
+      edit.addEventListener("click", () => {
+        root.state.setProfileAddressForm({ editing: true, status: "idle", error: "", success: "" });
+        paintAddress(container);
+      }, { once: true });
+    }
+    const cancel = container.querySelector("[data-profile-address-cancel]");
+    if (cancel) {
+      cancel.addEventListener("click", () => {
+        root.state.setProfileAddressForm({ editing: false, status: "idle", error: "", success: "" });
+        paintAddress(container);
+      }, { once: true });
+    }
+    const form = container.querySelector("[data-profile-address-form]");
+    if (!form) return;
+    form.addEventListener("submit", async (event) => {
+      event.preventDefault();
+      const address = String(form.elements.address.value || "").trim();
+      const mapsUrl = String(form.elements.maps_url.value || "").trim();
+      if (address.length < 5) {
+        root.state.setProfileAddressForm({ editing: true, status: "error", error: "กรุณากรอกที่อยู่อย่างน้อย 5 ตัวอักษร", success: "" });
+        paintAddress(container);
+        return;
+      }
+      if (mapsUrl.length > 600) {
+        root.state.setProfileAddressForm({ editing: true, status: "error", error: "ลิงก์แผนที่ยาวเกินไป", success: "" });
+        paintAddress(container);
+        return;
+      }
+      root.state.setProfileAddressForm({ editing: true, status: "saving", error: "", success: "" });
+      paintAddress(container);
+      try {
+        const result = await root.api.updateProfileAddress({ address, maps_url: mapsUrl });
+        root.state.updateCustomerProfile((result && result.profile) || { address, maps_url: mapsUrl });
+        root.state.setProfileAddressForm({ editing: false, status: "success", error: "", success: "บันทึกที่อยู่แล้ว" });
+      } catch (error) {
+        root.state.setProfileAddressForm({ editing: true, status: "error", error: error.message || "บันทึกที่อยู่ไม่สำเร็จ", success: "" });
+      }
+      paintAddress(container);
+    }, { once: true });
   }
 
   root.profile = {
@@ -43,6 +126,7 @@
             <div class="section-head">
               <span class="section-kicker">Saved address</span>
               <h2>ที่อยู่ที่บันทึกไว้</h2>
+              <p class="muted">ระบบจะเติมที่อยู่นี้ให้ในหน้าจองเมื่อช่องที่อยู่ยังว่าง และจะไม่ทับข้อมูลที่คุณพิมพ์ไว้</p>
             </div>
             <div data-profile-address>${renderSavedAddress()}</div>
           </section>
@@ -60,9 +144,10 @@
           ${root.ui.supportButtons()}
         </section>
       `;
+      bindAddress(container);
       root.auth.loadCustomer(container).then(() => {
-        const mount = container.querySelector("[data-profile-address]");
-        if (mount) mount.innerHTML = renderSavedAddress();
+        root.state.setProfileAddressForm({ editing: false, status: "idle", error: "", success: "" });
+        paintAddress(container);
       });
     },
   };

--- a/customer-app/modules/services.js
+++ b/customer-app/modules/services.js
@@ -130,6 +130,108 @@
     return parts.join(" / ");
   }
 
+  const commerceCategories = [
+    {
+      id: "clean",
+      route: "scheduled",
+      glyph: "sparkle",
+      title: "ล้างแอร์",
+      copy: "เลือกวิธีล้างและดูราคาประเมินจากระบบก่อนจอง",
+      draft: { service_kind: "clean", job_type: "ล้าง", ac_type: "ผนัง", wash_variant: "ล้างธรรมดา", btu: "12000", machine_count: 1 },
+    },
+    {
+      id: "repair",
+      route: "urgent",
+      glyph: "tool",
+      title: "ซ่อม / ตรวจอาการ",
+      copy: "ส่งอาการให้ทีมช่วยประเมินและจัดคิวที่เหมาะสม",
+      draft: { service_kind: "inspect", job_type: "ซ่อม", ac_type: UNKNOWN_AC, repair_variant: "ตรวจอาการ", btu: UNKNOWN_BTU, machine_count: 1 },
+    },
+    {
+      id: "install",
+      route: "scheduled",
+      glyph: "shield",
+      title: "ติดตั้งแอร์",
+      copy: "ให้ทีมช่วยประเมินหน้างานและคิวติดตั้ง",
+      draft: { service_kind: "install", job_type: "ติดตั้ง", ac_type: UNKNOWN_AC, btu: UNKNOWN_BTU, machine_count: 1 },
+    },
+    {
+      id: "care",
+      route: "scheduled",
+      glyph: "tag",
+      title: "ดูแลตามรอบ",
+      copy: "เริ่มจากล้างมาตรฐาน แล้วเลือกจำนวนเครื่องในขั้นตอนจอง",
+      draft: { service_kind: "clean", job_type: "ล้าง", ac_type: "ผนัง", wash_variant: "ล้างธรรมดา", btu: "12000", machine_count: 2 },
+    },
+  ];
+
+  const quickServices = [
+    {
+      id: "wall-normal",
+      route: "scheduled",
+      title: "ล้างแอร์ผนัง",
+      kicker: "ยอดนิยม",
+      copy: "เหมาะกับบ้านและคอนโดทั่วไป",
+      draft: { service_kind: "clean", job_type: "ล้าง", ac_type: "ผนัง", wash_variant: "ล้างธรรมดา", btu: "12000", machine_count: 1 },
+      priceable: true,
+    },
+    {
+      id: "wall-premium",
+      route: "scheduled",
+      title: "ล้างพรีเมียม",
+      kicker: "ดูแลลึกขึ้น",
+      copy: "สำหรับแอร์ใช้งานหนักหรืออยากล้างละเอียดขึ้น",
+      draft: { service_kind: "clean", job_type: "ล้าง", ac_type: "ผนัง", wash_variant: "ล้างพรีเมียม", btu: "12000", machine_count: 1 },
+      priceable: true,
+    },
+    {
+      id: "cassette",
+      route: "scheduled",
+      title: "ล้างแอร์สี่ทิศทาง",
+      kicker: "ร้านค้า / ออฟฟิศ",
+      copy: "เลือกชนิดแอร์ไว้ให้ แล้วระบบประเมินจากข้อมูลจริง",
+      draft: { service_kind: "clean", job_type: "ล้าง", ac_type: "สี่ทิศทาง", btu: "24000", machine_count: 1 },
+      priceable: true,
+    },
+    {
+      id: "urgent-inspect",
+      route: "urgent",
+      title: "แอร์ไม่เย็น / มีอาการ",
+      kicker: "คิวด่วน",
+      copy: "ส่งคำขอให้ช่างพาร์ทเนอร์หรือแอดมินช่วยตรวจสอบ ไม่ถือว่ายืนยันงานจนกว่าจะมีช่างรับหรือแอดมินยืนยัน",
+      draft: { service_kind: "inspect", job_type: "ซ่อม", ac_type: UNKNOWN_AC, repair_variant: "ตรวจอาการ", btu: UNKNOWN_BTU, machine_count: 1 },
+      priceable: false,
+    },
+  ];
+
+  const cleaningMethods = [
+    { title: "ล้างปกติ", copy: "ดูแลตามรอบ ใช้กับแอร์ผนังที่อาการปกติ", draft: quickServices[0].draft },
+    { title: "ล้างพรีเมียม", copy: "เพิ่มความละเอียดสำหรับแอร์ใช้งานหนัก", draft: quickServices[1].draft },
+    { title: "ล้างแบบแขวนคอยล์", copy: "ลดการถอดใหญ่ เหมาะกับงานที่ต้องดูหน้างานประกอบ", draft: { service_kind: "clean", job_type: "ล้าง", ac_type: "ผนัง", wash_variant: "ล้างแขวนคอยล์", btu: "12000", machine_count: 1 } },
+    { title: "ตัดล้างใหญ่", copy: "งานล้างหนักเมื่อสกปรกมาก ให้ทีมประเมินก่อนยืนยัน", draft: { service_kind: "clean", job_type: "ล้าง", ac_type: "ผนัง", wash_variant: "ล้างแบบตัดล้าง", btu: "12000", machine_count: 1 } },
+  ];
+
+  function commerceItem(id) {
+    return [...commerceCategories, ...quickServices, ...cleaningMethods].find((item) => item.id === id || item.title === id) || null;
+  }
+
+  function applyCommerceDraft(scope, item) {
+    const target = item && item.draft ? item.draft : {};
+    root.state.updateDraft(scope, {
+      ...target,
+      selectedSlot: null,
+    });
+    root.state.selectedService = { id: item.id || item.title || "", route: scope };
+    if (scope === "scheduled") {
+      root.state.setScheduledPreview("pricing", { status: "idle", data: null, error: "" });
+      root.state.setScheduledPreview("availability", { status: "idle", data: null, error: "" });
+      root.state.setScheduledSubmit({ status: "idle", error: "", result: null });
+    }
+    if (scope === "urgent") {
+      root.state.setUrgentFlow({ step: "form", status: "idle", error: "", result: null });
+    }
+  }
+
   root.services = {
     UNKNOWN_AC,
     UNKNOWN_BTU,
@@ -165,6 +267,11 @@
       { title: "รอช่างพาร์ทเนอร์กดรับ", copy: "ช่างอาจกดรับหรือปฏิเสธงานได้ตามความพร้อม" },
       { title: "แอดมินช่วยต่อ", copy: "ถ้าไม่มีช่างรับ แอดมินจะช่วยจัดคิวหรือเปลี่ยนเป็นจองล่วงหน้า" },
     ],
+    commerceCategories,
+    quickServices,
+    cleaningMethods,
+    commerceItem,
+    applyCommerceDraft,
     normalizeServiceDraft,
     payloadFromServiceDraft,
     serviceLabel,

--- a/customer-app/modules/state.js
+++ b/customer-app/modules/state.js
@@ -12,6 +12,9 @@
     catalog: { status: "idle", items: [], error: "" },
     promotions: { status: "idle", items: [], error: "" },
     zones: { status: "idle", items: [], error: "" },
+    homePricing: { status: "idle", items: {}, error: "" },
+    addressPrefill: { status: "idle", scopes: {}, error: "" },
+    profileAddressForm: { editing: false, status: "idle", error: "", success: "" },
     scheduledPreview: {
       pricing: { status: "idle", data: null, error: "" },
       availability: { status: "idle", data: null, error: "" },
@@ -87,6 +90,67 @@
       this[name] = {
         ...(this[name] || {}),
         ...(patch || {}),
+      };
+    },
+    setHomePricing(patch) {
+      this.homePricing = {
+        ...(this.homePricing || {}),
+        ...(patch || {}),
+      };
+    },
+    setProfileAddressForm(patch) {
+      this.profileAddressForm = {
+        ...(this.profileAddressForm || {}),
+        ...(patch || {}),
+      };
+    },
+    savedAddress() {
+      const profile = this.customer && this.customer.logged_in ? (this.customer.profile || {}) : {};
+      return {
+        address: String(profile.address || "").trim(),
+        maps_url: String(profile.maps_url || "").trim(),
+      };
+    },
+    prefillSavedAddress(scope) {
+      const saved = this.savedAddress();
+      if (!saved.address && !saved.maps_url) return false;
+      const current = this.draft[scope] || {};
+      const patch = {};
+      if (!String(current.address_text || "").trim() && saved.address) patch.address_text = saved.address;
+      if (!String(current.maps_url || "").trim() && saved.maps_url) patch.maps_url = saved.maps_url;
+      if (!Object.keys(patch).length) return false;
+      this.updateDraft(scope, patch);
+      this.addressPrefill.scopes = {
+        ...(this.addressPrefill.scopes || {}),
+        [scope]: true,
+      };
+      return true;
+    },
+    async ensureSavedAddressPrefill(scope, onDone) {
+      if (this.prefillSavedAddress(scope)) return true;
+      if (this.customer || this.addressPrefill.status === "loading" || !root.api || !root.api.getCurrentCustomer) return false;
+      this.addressPrefill = { ...(this.addressPrefill || {}), status: "loading", error: "" };
+      try {
+        const customer = await root.api.getCurrentCustomer();
+        this.customer = customer;
+        this.guestMode = !customer || !customer.logged_in;
+        this.addressPrefill = { ...(this.addressPrefill || {}), status: "success", error: "" };
+        const changed = this.prefillSavedAddress(scope);
+        if (changed && typeof onDone === "function") onDone();
+        return changed;
+      } catch (error) {
+        this.addressPrefill = { ...(this.addressPrefill || {}), status: "error", error: error.message || "" };
+        return false;
+      }
+    },
+    updateCustomerProfile(patch) {
+      if (!this.customer) return;
+      this.customer = {
+        ...this.customer,
+        profile: {
+          ...(this.customer.profile || {}),
+          ...(patch || {}),
+        },
       };
     },
     setScheduledPreview(name, patch) {

--- a/customer-app/modules/ui.js
+++ b/customer-app/modules/ui.js
@@ -118,8 +118,9 @@
   }
 
   async function loadHomeData(container) {
+    const hadCustomer = !!root.state.customer;
     root.auth.loadCustomer(container).then(() => {
-      if (root.state.currentRoute === "home") root.router.render();
+      if (!hadCustomer && root.state.currentRoute === "home") root.router.render();
     });
     const load = async (name, fn, key) => {
       root.state.setCollection(name, { status: "loading", items: [], error: "" });

--- a/customer-app/modules/ui.js
+++ b/customer-app/modules/ui.js
@@ -11,12 +11,119 @@
     return renderItems(bucket.items);
   }
 
+  function priceFromPreview(data) {
+    if (!data) return null;
+    if (data.promo && data.promo.total_after_discount != null) return data.promo.total_after_discount;
+    return data.active_price || data.standard_price || null;
+  }
+
+  function renderQuickPrice(card) {
+    if (!card.priceable) return `<span class="price-text is-estimate">ให้แอดมินประเมินราคา</span>`;
+    const state = root.state.homePricing || { items: {} };
+    const item = (state.items || {})[card.id];
+    if (state.status === "loading" && (!item || item.status === "loading")) return `<span class="price-text">กำลังประเมินราคา...</span>`;
+    if (!item || item.status === "idle") return `<span class="price-text is-estimate">แตะเพื่อเลือกบริการ</span>`;
+    if (item.status === "error" || !item.data) return `<span class="price-text is-estimate">ให้แอดมินประเมินราคา</span>`;
+    const price = priceFromPreview(item.data);
+    if (!price) return `<span class="price-text is-estimate">ให้แอดมินประเมินราคา</span>`;
+    return `
+      <span class="price-text">${root.utils.formatBaht(price)}</span>
+      ${item.data.promo ? `<span class="promo-chip">มีโปรที่ใช้ได้</span>` : ""}
+    `;
+  }
+
+  function renderCatalogSummary() {
+    return collectionState("catalog", "ยังไม่มีรายการบริการที่เปิดให้แสดง", (items) => `
+      <div class="tag-row commerce-tags">
+        ${items.slice(0, 8).map((item) => `<span class="tag">${root.utils.escapeHtml(item.item_name || item.name || "-")}</span>`).join("")}
+      </div>
+    `);
+  }
+
+  function renderPromotionSummary() {
+    return collectionState("promotions", "ยังไม่มีโปรโมชันสำหรับลูกค้าในตอนนี้ ระบบจะคำนวณโปรที่ใช้ได้ให้อัตโนมัติเมื่อประเมินราคา", (items) => `
+      <div class="commerce-list">
+        ${items.slice(0, 3).map((promo) => `
+          <div class="commerce-list-row">
+            <strong>${root.utils.escapeHtml(promo.promo_name || "-")}</strong>
+            <span>ระบบจะเลือกโปรที่ตรงเงื่อนไขในหน้าประเมินราคา</span>
+          </div>
+        `).join("")}
+      </div>
+    `);
+  }
+
+  function renderCoverageSummary() {
+    return collectionState("zones", "ยังไม่พบข้อมูลพื้นที่ให้บริการ", (items) => `
+      <div class="tag-row commerce-tags">
+        ${items.slice(0, 10).map((zone) => `<span class="tag">${root.utils.escapeHtml(zone.zone_label || zone.zone_name || zone.zone_code || "-")}</span>`).join("")}
+      </div>
+    `);
+  }
+
+  function renderAccountShortcut() {
+    const customer = root.state.customer;
+    if (!customer) {
+      return `
+        <section class="card account-shortcut">
+          <span class="section-kicker">Account</span>
+          <h2>กำลังตรวจสอบบัญชี...</h2>
+          <p class="muted">ยังเลือกบริการและจองแบบ Guest ได้ทันที</p>
+        </section>
+      `;
+    }
+    if (!customer.logged_in) {
+      return `
+        <section class="card account-shortcut">
+          <span class="section-kicker">Account</span>
+          <h2>จองแบบ Guest ได้เลย</h2>
+          <p class="muted">ล็อกอินเมื่อต้องการบันทึกที่อยู่ ดูประวัติ และจองซ้ำได้สะดวกขึ้น</p>
+          <button class="secondary-btn" type="button" data-route="profile">เข้าสู่ระบบ / ดูบัญชี</button>
+        </section>
+      `;
+    }
+    const profile = customer.profile || {};
+    const displayName = customer.display_name || profile.display_name || "ลูกค้า CWF";
+    const hasAddress = String(profile.address || "").trim();
+    return `
+      <section class="card account-shortcut">
+        <span class="section-kicker">Account</span>
+        <h2>สวัสดี ${root.utils.escapeHtml(displayName)}</h2>
+        <p class="muted">${hasAddress ? "มีที่อยู่บันทึกไว้ พร้อมเติมให้อัตโนมัติเมื่อเริ่มจอง" : "ยังไม่มีที่อยู่บันทึกไว้ เพิ่มครั้งเดียวแล้วใช้จองครั้งถัดไปได้เร็วขึ้น"}</p>
+        <button class="secondary-btn" type="button" data-route="profile">${hasAddress ? "จัดการที่อยู่" : "เพิ่มที่อยู่"}</button>
+      </section>
+    `;
+  }
+
+  async function loadHomePricing() {
+    if (root.state.homePricing.status !== "idle") return;
+    const items = {};
+    root.services.quickServices.forEach((card) => {
+      if (card.priceable) items[card.id] = { status: "loading", data: null, error: "" };
+    });
+    root.state.setHomePricing({ status: "loading", items, error: "" });
+    if (root.state.currentRoute === "home") root.router.render();
+    const entries = await Promise.all(root.services.quickServices.filter((card) => card.priceable).map(async (card) => {
+      const payload = root.services.payloadFromServiceDraft(card.draft);
+      if (!payload) return [card.id, { status: "error", data: null, error: "ADMIN_ESTIMATE" }];
+      try {
+        const data = await root.api.previewPricing(payload);
+        return [card.id, { status: "success", data, error: "" }];
+      } catch (error) {
+        return [card.id, { status: "error", data: null, error: error.message || "PRICE_UNAVAILABLE" }];
+      }
+    }));
+    root.state.setHomePricing({ status: "success", items: Object.fromEntries(entries), error: "" });
+    if (root.state.currentRoute === "home") root.router.render();
+  }
+
   async function loadHomeData(container) {
-    root.auth.loadCustomer(container);
+    root.auth.loadCustomer(container).then(() => {
+      if (root.state.currentRoute === "home") root.router.render();
+    });
     const load = async (name, fn, key) => {
-      const mount = container.querySelector(`[data-${name}]`);
       root.state.setCollection(name, { status: "loading", items: [], error: "" });
-      if (mount) root.router.render();
+      if (root.state.currentRoute === "home") root.router.render();
       try {
         const data = await fn();
         root.state.setCollection(name, {
@@ -33,78 +140,116 @@
     if (root.state.catalog.status === "idle") load("catalog", root.api.loadCatalogItems, "items");
     if (root.state.promotions.status === "idle") load("promotions", root.api.loadPromotions, "promotions");
     if (root.state.zones.status === "idle") load("zones", root.api.loadServiceZones, "zones");
+    loadHomePricing();
+  }
+
+  function bindCommerceHome(container) {
+    container.querySelectorAll("[data-commerce-service]").forEach((button) => {
+      button.addEventListener("click", () => {
+        const item = root.services.commerceItem(button.getAttribute("data-commerce-service"));
+        if (!item) return;
+        root.services.applyCommerceDraft(item.route, item);
+        root.utils.routeTo(item.route);
+      });
+    });
+    container.querySelectorAll("[data-commerce-method]").forEach((button) => {
+      button.addEventListener("click", () => {
+        const item = root.services.commerceItem(button.getAttribute("data-commerce-method"));
+        if (!item) return;
+        root.services.applyCommerceDraft("scheduled", item);
+        root.utils.routeTo("scheduled");
+      });
+    });
   }
 
   const ui = {
     renderHome(container) {
       container.innerHTML = `
-        <section class="screen">
+        <section class="screen commerce-home">
           <div class="hero home-hero">
             <div class="hero-badge">CWF Premium Air Service</div>
-            <h2>บริการแอร์ที่จองง่าย ติดตามได้ชัดเจน</h2>
-            <p>เริ่มจองแบบ Guest ได้ทันที เห็นราคาประมาณการ เลือกเวลาว่าง และติดตามสถานะงานในที่เดียว</p>
+            <h2>เลือกบริการแอร์ จองง่าย และติดตามงานได้ในที่เดียว</h2>
+            <p>เริ่มจากบริการที่ต้องการ ดูราคาจากระบบเมื่อข้อมูลพร้อม แล้วส่งคำขอจองหรือคิวด่วนโดยไม่ต้องล็อกอินก่อน</p>
             <div class="hero-proof-row" aria-label="จุดเด่น CWF">
-              <span>ราคาชัดเจน</span>
-              <span>ช่างผ่านการทดสอบ</span>
-              <span>รับประกันงานล้าง</span>
+              <span>ราคาจากระบบจริง</span>
+              <span>ช่างผ่านมาตรฐาน</span>
+              <span>รองรับ Guest booking</span>
             </div>
           </div>
-          <section class="quick-actions">
-            ${root.services.primaryActions.map((action, idx) => `
-              <button class="action-card ${idx === 0 ? "is-primary" : ""} ${idx === 2 ? "is-accent" : ""}" type="button" data-route="${root.utils.escapeHtml(action.route)}" data-icon="${root.utils.escapeHtml(action.icon)}">
-                <span class="ico-chip">${root.utils.icon(action.glyph || "sparkle", 24)}</span>
-                <span class="action-text">
-                  <strong>${root.utils.escapeHtml(action.title)}</strong>
-                  <span>${root.utils.escapeHtml(action.copy)}</span>
-                </span>
-              </button>
-            `).join("")}
+
+          <section class="commerce-primary-cta">
+            <button class="primary-btn" type="button" data-commerce-service="wall-normal">จองล้างแอร์ยอดนิยม</button>
+            <button class="secondary-btn" type="button" data-route="tracking">ติดตามงาน</button>
           </section>
-          <section class="card service-card">
+
+          <section class="card commerce-section">
             <div class="section-head">
               <span class="section-kicker">Services</span>
-              <h2>บริการสำหรับลูกค้า</h2>
+              <h2>เลือกหมวดบริการ</h2>
             </div>
-            <div data-catalog>
-              ${collectionState("catalog", "ยังไม่มีรายการบริการที่เปิดให้แสดง", (items) => `
-                <div class="tag-row">
-                  ${items.slice(0, 8).map((item) => `<span class="tag">${root.utils.escapeHtml(item.item_name || item.name || "-")}</span>`).join("")}
-                </div>
-              `)}
+            <div class="commerce-category-grid">
+              ${root.services.commerceCategories.map((item) => `
+                <button class="commerce-category-card" type="button" data-commerce-service="${root.utils.escapeHtml(item.id)}">
+                  <span class="trust-ico">${root.utils.icon(item.glyph || "sparkle", 20)}</span>
+                  <strong>${root.utils.escapeHtml(item.title)}</strong>
+                  <span>${root.utils.escapeHtml(item.copy)}</span>
+                </button>
+              `).join("")}
             </div>
           </section>
-          <section class="card">
+
+          <section class="card commerce-section">
             <div class="section-head">
-              <span class="section-kicker">Smart price</span>
-              <h2>โปรโมชันที่ใช้ได้</h2>
+              <span class="section-kicker">Quick book</span>
+              <h2>บริการที่ลูกค้าเลือกบ่อย</h2>
             </div>
-            <div data-promotions>
-              ${collectionState("promotions", "ยังไม่มีโปรโมชันสำหรับลูกค้าในตอนนี้", (items) => `
-                <div class="data-list">
-                  ${items.slice(0, 3).map((promo) => `
-                    <div class="data-row">
-                      <strong>${root.utils.escapeHtml(promo.promo_name || "-")}</strong>
-                      <span class="muted">ระบบจะเลือกโปรโมชันที่เหมาะสมในหน้าประเมินราคา</span>
-                    </div>
-                  `).join("")}
-                </div>
-              `)}
+            <div class="quick-service-grid">
+              ${root.services.quickServices.map((card) => `
+                <button class="quick-service-card ${card.route === "urgent" ? "is-urgent" : ""}" type="button" data-commerce-service="${root.utils.escapeHtml(card.id)}">
+                  <span class="quick-kicker">${root.utils.escapeHtml(card.kicker || "")}</span>
+                  <strong>${root.utils.escapeHtml(card.title)}</strong>
+                  <span>${root.utils.escapeHtml(card.copy)}</span>
+                  <span class="quick-price">${renderQuickPrice(card)}</span>
+                </button>
+              `).join("")}
             </div>
           </section>
-          <section class="card">
+
+          <section class="card commerce-section">
             <div class="section-head">
-              <span class="section-kicker">Coverage</span>
-              <h2>พื้นที่ให้บริการ</h2>
+              <span class="section-kicker">Urgent</span>
+              <h2>ต้องการให้ช่วยดูอาการเร็ว</h2>
             </div>
-            <div data-zones>
-              ${collectionState("zones", "ยังไม่พบข้อมูลพื้นที่ให้บริการ", (items) => `
-                <div class="tag-row">
-                  ${items.slice(0, 10).map((zone) => `<span class="tag">${root.utils.escapeHtml(zone.zone_label || zone.zone_name || zone.zone_code || "-")}</span>`).join("")}
-                </div>
-              `)}
+            <div class="urgent-commerce-card">
+              <p>คิวด่วนเป็นการส่งคำขอให้ช่างพาร์ทเนอร์หรือแอดมินช่วยตรวจสอบก่อน ยังไม่ถือว่ายืนยันงานจนกว่าจะมีช่างรับหรือแอดมินยืนยัน</p>
+              <button class="secondary-btn" type="button" data-commerce-service="urgent-inspect">เริ่มคำขอคิวด่วน</button>
             </div>
           </section>
-          <section class="card trust-card">
+
+          <section class="card commerce-section">
+            <div class="section-head">
+              <span class="section-kicker">Promotions</span>
+              <h2>โปรโมชันที่เปิดใช้งาน</h2>
+            </div>
+            <div data-promotions>${renderPromotionSummary()}</div>
+          </section>
+
+          <section class="card commerce-section">
+            <div class="section-head">
+              <span class="section-kicker">Cleaning methods</span>
+              <h2>วิธีล้างแอร์ผนัง 4 แบบ</h2>
+            </div>
+            <div class="method-grid">
+              ${root.services.cleaningMethods.map((item) => `
+                <button class="method-row" type="button" data-commerce-method="${root.utils.escapeHtml(item.title)}">
+                  <strong>${root.utils.escapeHtml(item.title)}</strong>
+                  <span>${root.utils.escapeHtml(item.copy)}</span>
+                </button>
+              `).join("")}
+            </div>
+          </section>
+
+          <section class="card trust-card commerce-section">
             <div class="section-head">
               <span class="section-kicker">Trust</span>
               <h2>ทำไมลูกค้าเลือก CWF</h2>
@@ -119,9 +264,27 @@
               `).join("")}
             </div>
           </section>
-          ${root.auth.renderLoginPanel()}
+
+          <section class="card commerce-section">
+            <div class="section-head">
+              <span class="section-kicker">Coverage</span>
+              <h2>พื้นที่ให้บริการ</h2>
+            </div>
+            <div data-zones>${renderCoverageSummary()}</div>
+          </section>
+
+          <section class="card commerce-section">
+            <div class="section-head">
+              <span class="section-kicker">Catalog</span>
+              <h2>รายการบริการในระบบ</h2>
+            </div>
+            <div data-catalog>${renderCatalogSummary()}</div>
+          </section>
+
+          ${renderAccountShortcut()}
         </section>
       `;
+      bindCommerceHome(container);
       loadHomeData(container);
     },
     renderBookingMode(container) {


### PR DESCRIPTION
## Goal
Turn Customer App V2 into a usable production storefront where customers can discover services, select a service from home, enter the existing booking flow with safe prefill, and manage a single saved address from the account page.

## Business outcome
Customers can open the app, understand what CWF sells, choose a suitable service, see a real price when the pricing-preview API can calculate one or an honest admin-estimate state when it cannot, and begin booking in a few taps. Logged-in customers can save an address before booking and reuse it without overwriting typed booking details.

## Summary
- Rebuilt the home page into a service storefront with hero, primary CTA, service categories, quick-book cards, urgent card, active promotions, cleaning-method comparison, trust content, coverage, catalog summary, and compact account shortcut.
- Added service-card selection helpers that write normalized service choices into the existing scheduled or urgent draft state and route into existing booking flows without submitting.
- Added `PATCH /public/profile/address` API helper and editable saved-address UI on the account page.
- Added saved-address prefill for scheduled and urgent booking drafts only when address/maps fields are empty.
- Updated Customer App asset query versions to avoid stale production JS/CSS.

## Changed files
- `customer-app/assets/customer-app.css`
- `customer-app/index.html`
- `customer-app/modules/api.js`
- `customer-app/modules/bookingScheduled.js`
- `customer-app/modules/bookingUrgent.js`
- `customer-app/modules/profile.js`
- `customer-app/modules/services.js`
- `customer-app/modules/state.js`
- `customer-app/modules/ui.js`

## Data sources used for cards
- Existing service taxonomy in `customer-app/modules/services.js`
- Existing pricing-preview contract via `root.api.previewPricing()` / `/public/pricing_preview`
- Existing customer-facing catalog via `/catalog/items?customer=1`
- Existing promotions via `/promotions?customer=1`
- Existing zones via `/service_zones`

## How pricing avoids fake values
Quick-book cards call the existing pricing-preview API when their draft is priceable. If preview data returns a price, the UI shows that value through `formatBaht()`. If the item is unpriceable, still loading, or the API errors, the card displays `ให้แอดมินประเมินราคา` and never shows zero, placeholder, guessed, or duplicated formula prices. Promo chips appear only when the preview response includes `promo`.

## How service-card prefill works
Home cards carry existing service draft fields only. Selection calls `root.services.applyCommerceDraft()`, writes into the scheduled or urgent draft, clears dependent preview/submit state where needed, and routes to the existing booking screen. The customer can change all fields afterward. No booking is submitted from the home page.

## How address save works
The account page uses the existing authenticated `PATCH /public/profile/address` route with `{ address, maps_url }`. On success, it updates `root.state.customer.profile` immediately and re-renders the saved-address section without logging out or changing provider state.

## How booking prefill avoids overwriting customer input
`root.state.prefillSavedAddress(scope)` only fills `address_text` and `maps_url` when the current draft fields are empty. It does not overwrite typed one-time booking addresses, and guest booking remains unchanged.

## Test commands and exact results
- `git status` -> clean before push
- `git diff --name-only origin/main...HEAD` -> 9 intended files
- `node --check customer-app/assets/customer-app.js` -> pass
- `node --check customer-app/modules/ui.js` -> pass
- `node --check customer-app/modules/services.js` -> pass
- `node --check customer-app/modules/state.js` -> pass
- `node --check customer-app/modules/router.js` -> pass
- `node --check customer-app/modules/api.js` -> pass
- `node --check customer-app/modules/profile.js` -> pass
- `node --check customer-app/modules/pricing.js` -> pass
- `node --check customer-app/modules/bookingScheduled.js` -> pass
- `node --check customer-app/modules/bookingUrgent.js` -> pass
- `npm.cmd test` -> 47 tests, 47 pass, 0 fail
- `git diff --check` -> pass

Note: `npm test` through PowerShell hit local execution policy for `npm.ps1`, so the equivalent `npm.cmd test` was used and passed.

## Manual QA results
- Guest opens home: pass in local browser at `/customer-app/index.html`.
- Guest selects cleaning service: pass; routes to `#scheduled`.
- Booking opens with service prefilled: pass; selected `ล้างแอร์`, `แอร์ผนัง`, `12,000 BTU`, count `1`.
- Guest changes service selection: not exhaustively clicked; existing booking controls remain rendered and editable.
- Guest booking remains possible: booking form, price preview, availability, and submit controls still render; no backend booking submitted during QA.
- Logged-in Google customer opens home: not manually verified without authenticated local session.
- Logged-in LINE customer opens home: not manually verified without authenticated local session.
- Logged-in customer opens account with no saved address: not manually verified without authenticated local session.
- Logged-in customer adds address and maps URL: not manually submitted without authenticated local session; form behavior was syntax/static checked.
- Address appears immediately after save: implemented through state update after API success; not manually verified against authenticated backend.
- Saved address prefills scheduled booking: implemented through shared non-overwrite helper; not manually verified with authenticated local session.
- Saved address prefills urgent booking: implemented through shared non-overwrite helper; not manually verified with authenticated local session.
- Existing manually typed draft address is not overwritten: implemented with empty-field guard; not manually verified with authenticated local session.
- Customer edits saved address: implemented via same profile form; not manually submitted without authenticated local session.
- Logout still works: auth module untouched; not manually verified.
- Tracking still opens normally: pass; `#tracking` renders lookup UI.
- Promotion API empty/failure state: local no-backend smoke renders honest empty/error state paths; no fake promo content.
- Pricing API failure state: pass locally; quick cards show `ให้แอดมินประเมินราคา` when preview cannot be reached.
- Catalog API failure state: local no-backend smoke renders state-box failure/empty behavior without page break.
- Mobile widths 320, 360, 390, 430px: pass; 12 storefront cards render and document scroll width stays within viewport. Browser console warnings/errors: none.

## Visual evidence
Local in-app browser smoke was run at 320, 360, 390, and 430px. No screenshots were committed. The smoke check confirmed home rendering, card count, no page-level horizontal overflow, home-to-scheduled selection, urgent selection, tracking render, profile guest render, and no browser warnings/errors.

## Remaining risks
- Authenticated Google/LINE saved-address flows need staging or production-session QA because local smoke had no authenticated customer cookie.
- Real pricing/promotion/catalog success states should be spot-checked against the deployed API; local no-backend smoke verified fallback states only.
- Home service-card content is curated from existing frontend service definitions; no backend catalog-driven product merchandising was added.

## Safety confirmations
- Auth, OAuth, cookies, JWT, account linking, LINE Messaging API, tracking behavior, payment, database schema, migrations, admin, and technician flows were not modified.
- No migration was run.
- No backend route was added.
- No dependencies were added.