### PR TITLE
Add Multi-Service Scheduled Booking and Real Availability Calendar

### DIFF
--- a/customer-app/assets/customer-app.css
+++ b/customer-app/assets/customer-app.css
@@ -3086,6 +3086,8 @@ img.account-avatar {
   list-style: none;
 }
 
+.booking-stepper-five { grid-template-columns: repeat(5, minmax(0, 1fr)); }
+
 .booking-stepper li {
   position: relative;
   display: grid;
@@ -3145,6 +3147,65 @@ img.account-avatar {
 .booking-wizard-card {
   display: grid;
   gap: 16px;
+}
+
+.service-line-list,
+.service-line-review-list {
+  display: grid;
+  gap: 12px;
+}
+
+.service-line-card {
+  display: grid;
+  gap: 14px;
+  padding: 14px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-sm);
+  background: #fff;
+}
+
+.service-line-head {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: start;
+  gap: 10px;
+}
+
+.service-line-head strong,
+.service-line-head small {
+  display: block;
+}
+
+.service-line-head strong {
+  margin-top: 2px;
+  color: var(--navy);
+  font-size: 1rem;
+}
+
+.service-line-head small {
+  margin-top: 3px;
+  color: var(--muted);
+  font-size: 0.82rem;
+  line-height: 1.45;
+}
+
+.danger-text {
+  color: var(--danger) !important;
+}
+
+.danger-text[disabled] {
+  color: var(--muted-2) !important;
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+.time-preference {
+  display: grid;
+  gap: 10px;
+}
+
+.time-preference-card {
+  width: 100%;
 }
 
 .booking-wizard-card .section-head p { margin-top: 6px; }
@@ -3250,6 +3311,21 @@ img.account-avatar {
 }
 
 .calendar-day.is-today { border-color: var(--soft-blue-2); }
+.calendar-day.is-available {
+  border-color: #bfe8cf;
+  background: var(--soft-green);
+  color: var(--success);
+}
+.calendar-day.is-full {
+  border-color: var(--line);
+  background: #f1f5fa;
+  color: var(--muted-2);
+}
+.calendar-day.is-loading {
+  border-color: #e6edf7;
+  background: linear-gradient(90deg, #f4f7fb 0%, #eef3f9 50%, #f4f7fb 100%);
+  color: var(--muted-2);
+}
 .calendar-day.is-selected {
   border-color: var(--blue);
   color: #fff;
@@ -3347,6 +3423,7 @@ body.has-contact-sheet { overflow: hidden; }
 
 @media (max-width: 380px) {
   .booking-stepper li > strong { font-size: 0.61rem; }
+  .booking-stepper-five li > strong { font-size: 0.54rem; }
   .booking-stepper li > span { width: 29px; height: 29px; }
   .booking-stepper li:not(:last-child)::after { top: 14px; left: calc(50% + 17px); width: calc(100% - 34px); }
   .calendar-day { min-height: 42px; font-size: 0.8rem; }

--- a/customer-app/modules/api.js
+++ b/customer-app/modules/api.js
@@ -85,6 +85,10 @@
       return requestJson("/public/availability_v2", { query });
     },
 
+    async loadAvailabilityCalendar(query) {
+      return requestJson("/public/availability_calendar_v2", { query });
+    },
+
     async trackBooking(q) {
       return requestJson("/public/track", { query: { q } });
     },

--- a/customer-app/modules/availability.js
+++ b/customer-app/modules/availability.js
@@ -56,6 +56,27 @@
     return query;
   }
 
+  function publicCalendarQuery(draft, servicePayload, pricingData) {
+    const d = draft || {};
+    const payload = servicePayload || {};
+    const durationMin = Math.max(15, Number(pricingData && pricingData.duration_min || 0));
+    const query = {
+      month: String(d.calendar_month || d.date?.slice(0, 7) || "").trim(),
+      tech_type: "company",
+      duration_min: durationMin,
+      job_type: payload.job_type || "",
+      ac_type: payload.ac_type || "",
+      btu: payload.btu || "",
+      machine_count: payload.machine_count || "",
+      wash_variant: payload.wash_variant || "",
+      repair_variant: payload.repair_variant || "",
+    };
+    if (Array.isArray(payload.services) && payload.services.length) {
+      query.services = JSON.stringify(payload.services);
+    }
+    return query;
+  }
+
   function queryKey(query) {
     const q = query || {};
     return [
@@ -70,6 +91,38 @@
       q.repair_variant,
       q.services,
     ].map((value) => String(value == null ? "" : value)).join("|");
+  }
+
+  function calendarQueryKey(query) {
+    const q = query || {};
+    return [
+      q.month,
+      q.tech_type,
+      q.duration_min,
+      q.job_type,
+      q.ac_type,
+      q.btu,
+      q.machine_count,
+      q.wash_variant,
+      q.repair_variant,
+      q.services,
+    ].map((value) => String(value == null ? "" : value)).join("|");
+  }
+
+  function normalizeCalendarDays(response) {
+    const data = response || {};
+    const days = Array.isArray(data.days) ? data.days : [];
+    const map = new Map();
+    days.forEach((day) => {
+      const date = String(day && day.date || "").slice(0, 10);
+      if (!date) return;
+      map.set(date, {
+        date,
+        available: day.available === true,
+        first_available: day.first_available || null,
+      });
+    });
+    return map;
   }
 
   function normalizePublicSlots(response, fallbackDurationMin) {
@@ -134,7 +187,10 @@
     minutesToHhmm,
     bangkokTodayYmd,
     publicAvailabilityQuery,
+    publicCalendarQuery,
     queryKey,
+    calendarQueryKey,
+    normalizeCalendarDays,
     normalizePublicSlots,
     selectedSlotIsCurrent,
   };

--- a/customer-app/modules/bookingScheduled.js
+++ b/customer-app/modules/bookingScheduled.js
@@ -3,22 +3,24 @@
 
   const root = window.CWFCustomerAppV2 = window.CWFCustomerAppV2 || {};
   const MAX_ADVANCE_DAYS = 90;
+  const STEP_MAX = 5;
   let availabilityRequestSeq = 0;
+  let calendarRequestSeq = 0;
 
   function draft() {
     return root.state.draft.scheduled || {};
   }
 
-  function service() {
-    return root.services.normalizeServiceDraft(draft());
+  function services() {
+    return root.services.normalizeServiceLines(draft());
   }
 
   function payloadFromDraft() {
-    return root.services.payloadFromServiceDraft(draft());
+    return root.services.payloadFromScheduledDraft(draft());
   }
 
   function step() {
-    return Math.max(1, Math.min(3, Number(root.state.scheduledWizard?.step || 1)));
+    return Math.max(1, Math.min(STEP_MAX, Number(root.state.scheduledWizard?.step || 1)));
   }
 
   function finalPrice() {
@@ -105,15 +107,26 @@
     });
   }
 
-  function resetPriceAndSlots() {
+  function clearPriceCalendarSlots() {
     availabilityRequestSeq += 1;
+    calendarRequestSeq += 1;
     root.state.updateDraft("scheduled", { selectedSlot: null });
     root.state.setScheduledPreview("pricing", { status: "idle", data: null, error: "" });
     root.state.setScheduledPreview("availability", { status: "idle", data: null, error: "", query_key: "", loaded_at: "" });
+    root.state.setScheduledPreview("calendar", { status: "idle", data: null, error: "", query_key: "", loaded_at: "" });
     root.state.setScheduledSubmit({ status: "idle", error: "", result: null });
   }
 
-  function resetSlots() {
+  function clearCalendarSlots() {
+    availabilityRequestSeq += 1;
+    calendarRequestSeq += 1;
+    root.state.updateDraft("scheduled", { selectedSlot: null });
+    root.state.setScheduledPreview("availability", { status: "idle", data: null, error: "", query_key: "", loaded_at: "" });
+    root.state.setScheduledPreview("calendar", { status: "idle", data: null, error: "", query_key: "", loaded_at: "" });
+    root.state.setScheduledSubmit({ status: "idle", error: "", result: null });
+  }
+
+  function clearSlotsOnly() {
     availabilityRequestSeq += 1;
     root.state.updateDraft("scheduled", { selectedSlot: null });
     root.state.setScheduledPreview("availability", { status: "idle", data: null, error: "", query_key: "", loaded_at: "" });
@@ -135,12 +148,13 @@
     root.state.prefillSavedAddress("scheduled");
   }
 
-  function choiceGroup(field, options, selected, className) {
+  function choiceGroup(field, options, selected, className, lineId) {
     return `<div class="choice-grid ${className || ""}">${options.map((option) => {
       const active = String(selected || "") === String(option.value);
       return `
         <button class="choice-card ${active ? "is-selected" : ""}" type="button"
-          data-scheduled-choice="${root.utils.escapeHtml(field)}"
+          data-line-choice="${root.utils.escapeHtml(field)}"
+          data-line-id="${root.utils.escapeHtml(lineId || "")}"
           data-choice-value="${root.utils.escapeHtml(option.value)}"
           aria-pressed="${active ? "true" : "false"}">
           <strong>${root.utils.escapeHtml(option.label)}</strong>
@@ -151,10 +165,10 @@
   }
 
   function renderProgress() {
-    const labels = ["บริการและราคา", "ข้อมูลหน้างาน", "คิวและยืนยัน"];
+    const labels = ["ข้อมูลลูกค้า", "รายการบริการ", "ราคา", "วันและเวลา", "ยืนยัน"];
     const current = step();
     return `
-      <ol class="booking-stepper" aria-label="ขั้นตอนจองล้างแอร์">
+      <ol class="booking-stepper booking-stepper-five" aria-label="ขั้นตอนจองล้างแอร์">
         ${labels.map((label, index) => {
           const n = index + 1;
           const status = n < current ? "is-done" : (n === current ? "is-active" : "");
@@ -164,72 +178,15 @@
     `;
   }
 
-  function renderPricingSummary() {
-    const pricing = root.state.scheduledPreview.pricing;
-    const data = pricing.data;
-    if (pricing.status === "loading") return root.utils.stateBox("loading", "กำลังคำนวณราคาและเวลาทำงานจากระบบจริง...");
-    if (pricing.status === "error") return root.utils.stateBox("error", pricing.error || "คำนวณราคาไม่สำเร็จ");
-    if (!data) return root.utils.stateBox("", "ระบบจะคำนวณราคาและเวลาทำงานหลังเลือกบริการ");
-    return `
-      <div class="wizard-price-summary">
-        <div><span>ราคาประมาณการ</span><strong>${root.utils.formatBaht(finalPrice())}</strong></div>
-        <div><span>เวลาทำงานโดยประมาณ</span><strong>${root.utils.escapeHtml(data.duration_min || "-")} นาที</strong></div>
-        ${data.promo ? `<small>ใช้โปรโมชั่น: ${root.utils.escapeHtml(data.promo.promo_name || "โปรโมชั่นปัจจุบัน")}</small>` : `<small>ยังไม่มีโปรโมชั่นที่ระบบเลือกให้สำหรับรายการนี้</small>`}
-      </div>
-    `;
-  }
-
-  function renderStepServicePrice() {
-    const d = draft();
-    const s = service();
-    return `
-      <section class="card booking-wizard-card" data-booking-step="1">
-        <div class="section-head">
-          <span class="section-kicker">ขั้นตอน 1 จาก 3</span>
-          <h2>เลือกบริการและดูราคา</h2>
-          <p class="muted">เลือกงานล้างที่ระบบรองรับ ราคา โปรโมชัน และเวลาทำงานจะมาจากระบบจริง</p>
-        </div>
-        <div class="field field-wide">
-          <label>ชนิดแอร์</label>
-          ${choiceGroup("ac_type", root.services.bookableAcTypes, s.ac_type, "ac-type-grid")}
-        </div>
-        ${s.ac_type === "ผนัง" ? `
-          <div class="field field-wide">
-            <label>รูปแบบการล้าง</label>
-            ${choiceGroup("wash_variant", root.services.washVariants, s.wash_variant || d.wash_variant, "wash-variant-grid")}
-          </div>
-        ` : `
-          <div class="state-box">แอร์ชนิดนี้ใช้ราคามาตรฐานตามชนิดเครื่อง จำนวน และ BTU โดยไม่ต้องเลือกรูปแบบล้างแอร์ผนัง</div>
-        `}
-        <div class="field field-wide">
-          <label>ขนาด BTU</label>
-          ${choiceGroup("btu", root.services.bookableBtuOptions, s.btu_value || d.btu, "btu-choice-grid")}
-        </div>
-        <div class="field">
-          <label for="scheduled-count">จำนวนเครื่อง</label>
-          <select id="scheduled-count" class="select" data-scheduled-field="machine_count">
-            ${root.services.machineCounts.map((n) => `<option value="${n}" ${Number(s.machine_count) === n ? "selected" : ""}>${n} เครื่อง</option>`).join("")}
-          </select>
-        </div>
-        <div class="service-summary-box">
-          <span>สรุปบริการ</span>
-          <strong>${root.utils.escapeHtml(root.services.serviceLabel(s))}</strong>
-        </div>
-        ${s.needs_admin_estimate ? root.utils.stateBox("warning", s.admin_reason || "บริการนี้ต้องให้แอดมินประเมินราคา") : ""}
-        ${renderPricingSummary()}
-      </section>
-    `;
-  }
-
   function renderStepContactLocation() {
     const d = draft();
     const saved = root.state.savedAddress();
     return `
-      <section class="card booking-wizard-card" data-booking-step="2">
+      <section class="card booking-wizard-card" data-booking-step="1">
         <div class="section-head">
-          <span class="section-kicker">ขั้นตอน 2 จาก 3</span>
-          <h2>ข้อมูลผู้ติดต่อและหน้างาน</h2>
-          <p class="muted">ข้อมูลนี้ใช้ให้ทีมงานติดต่อ เดินทาง และเตรียมเข้าบริการ</p>
+          <span class="section-kicker">ขั้นตอน 1 จาก 5</span>
+          <h2>ข้อมูลลูกค้า</h2>
+          <p class="muted">กรอกข้อมูลสำหรับติดต่อ เดินทาง และเตรียมเข้าบริการ</p>
         </div>
         <div class="form-grid">
           <div class="field">
@@ -254,7 +211,7 @@
           </div>
           <div class="field field-wide">
             <label for="scheduled-note">หมายเหตุหน้างาน</label>
-            <textarea id="scheduled-note" class="textarea" rows="4" data-scheduled-field="customer_note" placeholder="ที่จอดรถ เวลาเข้าอาคาร ชั้น ห้อง ข้อจำกัดการเข้าอาคาร หรือข้อมูลอื่นที่ควรทราบ">${root.utils.escapeHtml(d.customer_note || "")}</textarea>
+            <textarea id="scheduled-note" class="textarea" rows="4" data-scheduled-field="customer_note" placeholder="ที่จอดรถ เวลาเข้าอาคาร ชั้น ห้อง หรือข้อมูลอื่นที่ควรทราบ">${root.utils.escapeHtml(d.customer_note || "")}</textarea>
           </div>
         </div>
         ${saved.address && !String(d.address_text || "").trim() ? `<button type="button" class="secondary-btn" data-action="use-saved-address">ใช้ที่อยู่ที่บันทึกไว้</button>` : ""}
@@ -262,43 +219,122 @@
     `;
   }
 
-  function renderCalendar() {
-    const d = draft();
-    const today = root.availability.bangkokTodayYmd();
-    const maxDate = addDays(today, MAX_ADVANCE_DAYS);
-    const month = monthWithinRange(d.calendar_month || "") ? d.calendar_month : d.date.slice(0, 7);
-    const [year, monthNumber] = month.split("-").map(Number);
-    const first = new Date(year, monthNumber - 1, 1, 12);
-    const startOffset = first.getDay();
-    const daysInMonth = new Date(year, monthNumber, 0).getDate();
-    const cells = [];
-    for (let i = 0; i < startOffset; i += 1) cells.push(`<span class="calendar-day is-empty" aria-hidden="true"></span>`);
-    for (let day = 1; day <= daysInMonth; day += 1) {
-      const dateValue = `${year}-${String(monthNumber).padStart(2, "0")}-${String(day).padStart(2, "0")}`;
-      const disabled = dateValue < today || dateValue > maxDate;
-      const selected = dateValue === d.date;
-      const isToday = dateValue === today;
-      cells.push(`
-        <button type="button" class="calendar-day ${selected ? "is-selected" : ""} ${isToday ? "is-today" : ""}"
-          data-calendar-date="${dateValue}" ${disabled ? "disabled" : ""}
-          aria-pressed="${selected ? "true" : "false"}" aria-label="${root.utils.escapeHtml(dateValue)}">
-          <span>${day}</span>${isToday ? "<small>วันนี้</small>" : ""}
-        </button>
-      `);
-    }
-    const previous = changeMonth(month, -1);
-    const next = changeMonth(month, 1);
+  function renderServiceLineCard(line, index) {
+    const s = root.services.normalizeServiceLine(line);
+    const summary = root.services.serviceLineSummary(s, index);
+    const canRemove = services().length > 1;
     return `
-      <div class="booking-calendar">
-        <div class="calendar-toolbar">
-          <button type="button" class="calendar-nav" data-calendar-month="-1" ${monthWithinRange(previous) ? "" : "disabled"} aria-label="เดือนก่อน">‹</button>
-          <strong>${root.utils.escapeHtml(monthLabel(month))}</strong>
-          <button type="button" class="calendar-nav" data-calendar-month="1" ${monthWithinRange(next) ? "" : "disabled"} aria-label="เดือนถัดไป">›</button>
+      <article class="service-line-card" data-service-line-card="${root.utils.escapeHtml(s.line_id)}">
+        <div class="service-line-head">
+          <div>
+            <span class="section-kicker">${root.utils.escapeHtml(summary.title)}</span>
+            <strong>${root.utils.escapeHtml(summary.line1)}</strong>
+            <small>${root.utils.escapeHtml(summary.line2)}</small>
+          </div>
+          <button type="button" class="text-btn danger-text" data-action="remove-line" data-line-id="${root.utils.escapeHtml(s.line_id)}" ${canRemove ? "" : "disabled"}>ลบ</button>
         </div>
-        <div class="calendar-weekdays" aria-hidden="true"><span>อา</span><span>จ</span><span>อ</span><span>พ</span><span>พฤ</span><span>ศ</span><span>ส</span></div>
-        <div class="calendar-grid">${cells.join("")}</div>
+        <div class="field field-wide">
+          <label>ชนิดแอร์</label>
+          ${choiceGroup("ac_type", root.services.bookableAcTypes, s.ac_type, "ac-type-grid", s.line_id)}
+        </div>
+        ${s.ac_type === root.services.WALL_AC ? `
+          <div class="field field-wide">
+            <label>วิธีล้าง</label>
+            ${choiceGroup("wash_variant", root.services.washVariants, s.wash_variant, "wash-variant-grid", s.line_id)}
+          </div>
+        ` : ""}
+        <div class="field field-wide">
+          <label>BTU</label>
+          ${choiceGroup("btu", root.services.bookableBtuOptions, s.btu, "btu-choice-grid", s.line_id)}
+        </div>
+        <div class="field">
+          <label for="line-count-${root.utils.escapeHtml(s.line_id)}">จำนวนเครื่อง</label>
+          <select id="line-count-${root.utils.escapeHtml(s.line_id)}" class="select" data-line-field="machine_count" data-line-id="${root.utils.escapeHtml(s.line_id)}">
+            ${root.services.machineCounts.map((n) => `<option value="${n}" ${Number(s.machine_count) === n ? "selected" : ""}>${n} เครื่อง</option>`).join("")}
+          </select>
+        </div>
+      </article>
+    `;
+  }
+
+  function renderStepServices() {
+    const lines = services();
+    return `
+      <section class="card booking-wizard-card" data-booking-step="2">
+        <div class="section-head">
+          <span class="section-kicker">ขั้นตอน 2 จาก 5</span>
+          <h2>รายการบริการ/เครื่องทั้งหมด</h2>
+          <p class="muted">เพิ่มรายการแยกตามชนิดแอร์ BTU จำนวน และวิธีล้าง</p>
+        </div>
+        <div class="service-line-list">
+          ${lines.map(renderServiceLineCard).join("")}
+        </div>
+        <button type="button" class="secondary-btn" data-action="add-line">+ เพิ่มเครื่อง / เพิ่มรายการ</button>
+      </section>
+    `;
+  }
+
+  function priceLineFor(index) {
+    const pricing = root.state.scheduledPreview.pricing.data || {};
+    const lines = Array.isArray(pricing.price_lines) ? pricing.price_lines : [];
+    return lines[index] || null;
+  }
+
+  function renderPricingSummary() {
+    const pricing = root.state.scheduledPreview.pricing;
+    const data = pricing.data;
+    if (pricing.status === "loading") return root.utils.stateBox("loading", "กำลังคำนวณราคาและเวลาทำงาน...");
+    if (pricing.status === "error") return root.utils.stateBox("error", pricing.error || "คำนวณราคาไม่สำเร็จ");
+    if (!data) return root.utils.stateBox("", "ระบบจะคำนวณราคาและเวลาทำงานหลังเลือกบริการ");
+    return `
+      <div class="wizard-price-summary">
+        <div><span>ราคารวมประมาณการ</span><strong>${root.utils.formatBaht(finalPrice())}</strong></div>
+        <div><span>เวลาทำงานรวม</span><strong>${root.utils.escapeHtml(data.duration_min || "-")} นาที</strong></div>
+        ${data.promo ? `<small>ใช้โปรโมชัน: ${root.utils.escapeHtml(data.promo.promo_name || "โปรโมชันปัจจุบัน")}</small>` : `<small>ยังไม่มีโปรโมชันที่ระบบเลือกให้สำหรับรายการนี้</small>`}
       </div>
     `;
+  }
+
+  function renderStepPricing() {
+    const lines = services();
+    return `
+      <section class="card booking-wizard-card" data-booking-step="3">
+        <div class="section-head">
+          <span class="section-kicker">ขั้นตอน 3 จาก 5</span>
+          <h2>ราคาและระยะเวลารวม</h2>
+          <p class="muted">ตรวจสอบรายการและยอดรวมก่อนเลือกคิว</p>
+        </div>
+        <div class="service-line-review-list">
+          ${lines.map((line, index) => {
+            const summary = root.services.serviceLineSummary(line, index);
+            const priceLine = priceLineFor(index);
+            const linePrice = priceLine && (priceLine.line_total != null || priceLine.total != null)
+              ? root.utils.formatBaht(priceLine.line_total ?? priceLine.total)
+              : "-";
+            return `
+              <div class="service-summary-box">
+                <span>${root.utils.escapeHtml(summary.title)}</span>
+                <strong>${root.utils.escapeHtml(summary.line1)}</strong>
+                <small>${root.utils.escapeHtml(summary.line2)} · ${root.utils.escapeHtml(linePrice)}</small>
+              </div>
+            `;
+          }).join("")}
+        </div>
+        ${renderPricingSummary()}
+      </section>
+    `;
+  }
+
+  function currentCalendarQuery() {
+    const payload = payloadFromDraft();
+    const pricing = root.state.scheduledPreview.pricing.data;
+    if (!payload || !pricing) return null;
+    return root.availability.publicCalendarQuery(draft(), payload, pricing);
+  }
+
+  function currentCalendarKey() {
+    const query = currentCalendarQuery();
+    return query ? root.availability.calendarQueryKey(query) : "";
   }
 
   function currentAvailabilityQuery() {
@@ -318,25 +354,74 @@
     return root.availability.normalizePublicSlots(state.data, root.state.scheduledPreview.pricing.data?.duration_min);
   }
 
+  function renderCalendar() {
+    const d = draft();
+    const today = root.availability.bangkokTodayYmd();
+    const maxDate = addDays(today, MAX_ADVANCE_DAYS);
+    const month = monthWithinRange(d.calendar_month || "") ? d.calendar_month : d.date.slice(0, 7);
+    const [year, monthNumber] = month.split("-").map(Number);
+    const first = new Date(year, monthNumber - 1, 1, 12);
+    const startOffset = first.getDay();
+    const daysInMonth = new Date(year, monthNumber, 0).getDate();
+    const calendarState = root.state.scheduledPreview.calendar;
+    const expectedKey = currentCalendarKey();
+    const dayMap = calendarState.query_key === expectedKey ? root.availability.normalizeCalendarDays(calendarState.data) : new Map();
+    const isLoading = calendarState.status === "loading" || (expectedKey && calendarState.query_key !== expectedKey);
+    const cells = [];
+    for (let i = 0; i < startOffset; i += 1) cells.push(`<span class="calendar-day is-empty" aria-hidden="true"></span>`);
+    for (let day = 1; day <= daysInMonth; day += 1) {
+      const dateValue = `${year}-${String(monthNumber).padStart(2, "0")}-${String(day).padStart(2, "0")}`;
+      const outsideRange = dateValue < today || dateValue > maxDate;
+      const selected = dateValue === d.date;
+      const isToday = dateValue === today;
+      const status = dayMap.get(dateValue);
+      const available = status && status.available === true;
+      const full = status && status.available === false;
+      const disabled = outsideRange || full || (!isLoading && expectedKey && !available);
+      const label = outsideRange ? "" : (isLoading ? "..." : (available ? "มีคิว" : "เต็ม"));
+      cells.push(`
+        <button type="button" class="calendar-day ${selected ? "is-selected" : ""} ${isToday ? "is-today" : ""} ${available ? "is-available" : ""} ${full ? "is-full" : ""} ${isLoading ? "is-loading" : ""}"
+          data-calendar-date="${dateValue}" ${disabled ? "disabled" : ""}
+          aria-pressed="${selected ? "true" : "false"}" aria-label="${root.utils.escapeHtml(`${dateValue} ${label}`)}">
+          <span>${day}</span>${label ? `<small>${root.utils.escapeHtml(label)}</small>` : ""}
+        </button>
+      `);
+    }
+    const previous = changeMonth(month, -1);
+    const next = changeMonth(month, 1);
+    return `
+      <div class="booking-calendar">
+        <div class="calendar-toolbar">
+          <button type="button" class="calendar-nav" data-calendar-month="-1" ${monthWithinRange(previous) ? "" : "disabled"} aria-label="เดือนก่อน">‹</button>
+          <strong>${root.utils.escapeHtml(monthLabel(month))}</strong>
+          <button type="button" class="calendar-nav" data-calendar-month="1" ${monthWithinRange(next) ? "" : "disabled"} aria-label="เดือนถัดไป">›</button>
+        </div>
+        <div class="calendar-weekdays" aria-hidden="true"><span>อา</span><span>จ</span><span>อ</span><span>พ</span><span>พฤ</span><span>ศ</span><span>ส</span></div>
+        <div class="calendar-grid">${cells.join("")}</div>
+      </div>
+      ${calendarState.status === "error" ? `${root.utils.stateBox("error", calendarState.error || "โหลดปฏิทินไม่สำเร็จ")}<button type="button" class="secondary-btn" data-action="reload-calendar">ลองโหลดปฏิทินอีกครั้ง</button>` : ""}
+    `;
+  }
+
   function renderSlots() {
     const availability = root.state.scheduledPreview.availability;
     const selected = draft().selectedSlot || null;
-    if (availability.status === "loading") return root.utils.stateBox("loading", "กำลังตรวจคิวว่างจริงจากตารางงานช่าง CWF...");
+    if (availability.status === "loading") return root.utils.stateBox("loading", "กำลังตรวจคิวว่างจริง...");
     if (availability.status === "error") {
       return `${root.utils.stateBox("error", availability.error || "โหลดคิวว่างไม่สำเร็จ")}<button type="button" class="secondary-btn" data-action="reload-slots">ลองโหลดคิวอีกครั้ง</button>`;
     }
-    if (!availability.data) return root.utils.stateBox("", "เลือกวันที่ในปฏิทิน ระบบจะโหลดเฉพาะช่วงเวลาที่ช่าง CWF ว่างจริง");
+    if (!availability.data) return root.utils.stateBox("", "เลือกวันที่มีคิว ระบบจะแสดงช่วงเวลาว่างด้านล่าง");
     const slots = normalizedSlots();
     if (!slots.length) {
-      return `${root.utils.stateBox("warning", "วันที่เลือกไม่มีคิวช่างว่างสำหรับระยะเวลางานนี้ กรุณาเลือกวันอื่น")}<button type="button" class="secondary-btn" data-action="reload-slots">ตรวจคิววันนี้อีกครั้ง</button>`;
+      return `${root.utils.stateBox("warning", "วันที่เลือกเต็มแล้ว กรุณาเลือกวันอื่น")}<button type="button" class="secondary-btn" data-action="reload-slots">ตรวจคิววันนี้อีกครั้ง</button>`;
     }
     return `
-      <div class="availability-meta"><strong>คิวว่างวันที่ ${root.utils.escapeHtml(draft().date)}</strong><span>ระบบจะตรวจซ้ำอีกครั้งก่อนส่งจอง</span></div>
+      <div class="availability-meta"><strong>คิวว่างวันที่ ${root.utils.escapeHtml(draft().date)}</strong><span>ระบบจะตรวจซ้ำก่อนส่งคำขอจอง</span></div>
       <div class="real-slot-grid">
         ${slots.map((slot) => {
           const active = selected && selected.key === slot.key && selected.query_key === availability.query_key;
           return `<button class="real-slot-card ${active ? "is-selected" : ""}" type="button" data-real-slot-key="${root.utils.escapeHtml(slot.key)}" aria-pressed="${active ? "true" : "false"}">
-            <strong>${root.utils.escapeHtml(slot.start)}</strong><span>ถึงประมาณ ${root.utils.escapeHtml(slot.end)}</span><small>คิวว่าง</small>
+            <strong>${root.utils.escapeHtml(slot.start)}-${root.utils.escapeHtml(slot.end)}</strong><span>ช่วงเวลาว่าง</span><small>เลือกคิวนี้</small>
           </button>`;
         }).join("")}
       </div>
@@ -344,16 +429,62 @@
     `;
   }
 
+  function renderTimePreference() {
+    const flexible = draft().allow_time_proposal === true;
+    const options = [
+      { value: "false", title: "ต้องการเวลานี้เท่านั้น", copy: "หากช่วงเวลานี้ไม่ว่างแล้ว กรุณาให้ฉันเลือกเวลาใหม่" },
+      { value: "true", title: "สามารถเสนอเวลาใหม่ให้ฉันได้", copy: "หากคิวมีการเปลี่ยนแปลง แอดมินหรือช่างสามารถเสนอช่วงเวลาใหม่เพื่อให้ฉันยืนยัน" },
+    ];
+    return `
+      <div class="time-preference" role="radiogroup" aria-label="เงื่อนไขการเสนอเวลา">
+        ${options.map((option) => {
+          const active = String(flexible) === option.value;
+          return `
+            <button type="button" class="choice-card time-preference-card ${active ? "is-selected" : ""}" data-time-proposal="${option.value}" role="radio" aria-checked="${active ? "true" : "false"}">
+              <strong>${root.utils.escapeHtml(option.title)}</strong>
+              <span>${root.utils.escapeHtml(option.copy)}</span>
+            </button>
+          `;
+        }).join("")}
+      </div>
+    `;
+  }
+
+  function renderStepCalendarSlot() {
+    return `
+      <section class="card booking-wizard-card" data-booking-step="4">
+        <div class="section-head">
+          <span class="section-kicker">ขั้นตอน 4 จาก 5</span>
+          <h2>ปฏิทิน วัน เวลา และเงื่อนไขการเสนอเวลา</h2>
+          <p class="muted">เลือกวันที่มีคิวและช่วงเวลาว่างจริงสำหรับรายการทั้งหมด</p>
+        </div>
+        ${renderCalendar()}
+        <div class="slot-section" data-availability-preview>${renderSlots()}</div>
+        <div class="field field-wide">
+          <label>หากเวลาที่เลือกมีการเปลี่ยนแปลง</label>
+          ${renderTimePreference()}
+        </div>
+      </section>
+    `;
+  }
+
+  function timePreferenceLabel() {
+    return draft().allow_time_proposal === true
+      ? "สามารถเสนอเวลาใหม่ให้ฉันได้"
+      : "ต้องการเวลานี้เท่านั้น";
+  }
+
   function renderReviewRows() {
     const d = draft();
-    const s = service();
     const selected = d.selectedSlot || {};
     const map = String(d.maps_url || "").trim();
     const pricing = root.state.scheduledPreview.pricing.data || {};
     return `
       <div class="data-list review-data-list">
-        <div class="data-row"><strong>บริการ</strong><span class="muted">${root.utils.escapeHtml(root.services.serviceLabel(s))}</span></div>
-        <div class="data-row"><strong>จำนวน</strong><span class="muted">${root.utils.escapeHtml(s.machine_count || 1)} เครื่อง</span></div>
+        ${services().map((line, index) => {
+          const summary = root.services.serviceLineSummary(line, index);
+          return `<div class="data-row"><strong>${root.utils.escapeHtml(summary.title)}</strong><span class="muted">${root.utils.escapeHtml(summary.line1)} · ${root.utils.escapeHtml(summary.line2)}</span></div>`;
+        }).join("")}
         <div class="data-row"><strong>ราคา</strong><span class="muted">${root.utils.formatBaht(finalPrice())}</span></div>
         <div class="data-row"><strong>โปรโมชัน</strong><span class="muted">${root.utils.escapeHtml(pricing.promo?.promo_name || "-")}</span></div>
         <div class="data-row"><strong>ระยะเวลา</strong><span class="muted">${root.utils.escapeHtml(pricing.duration_min || "-")} นาที</span></div>
@@ -363,35 +494,27 @@
         <div class="data-row"><strong>พื้นที่</strong><span class="muted">${root.utils.escapeHtml(d.job_zone || "-")}</span></div>
         <div class="data-row"><strong>หมายเหตุ</strong><span class="muted">${root.utils.escapeHtml(d.customer_note || "-")}</span></div>
         <div class="data-row"><strong>วันและเวลา</strong><span class="muted">${root.utils.escapeHtml(d.date || "-")} · ${root.utils.escapeHtml(selected.start || "-")}-${root.utils.escapeHtml(selected.end || "-")} น.</span></div>
+        <div class="data-row"><strong>การเสนอเวลา</strong><span class="muted">${root.utils.escapeHtml(timePreferenceLabel())}</span></div>
       </div>
     `;
   }
 
-  function renderStepSlotReview() {
+  function renderStepReview() {
     const submit = root.state.scheduledSubmit;
     const pending = ["validating", "checking_slot", "submitting"].includes(submit.status);
-    const selected = draft().selectedSlot || null;
     return `
-      <section class="card booking-wizard-card" data-booking-step="3">
+      <section class="card booking-wizard-card review-card" data-booking-step="5">
         <div class="section-head">
-          <span class="section-kicker">ขั้นตอน 3 จาก 3</span>
-          <h2>เลือกคิว ตรวจสอบ และยืนยัน</h2>
-          <p class="muted">เลือกวันที่และคิวว่างจริง จากนั้นตรวจข้อมูลทั้งหมดก่อนส่งคำขอจอง</p>
-        </div>
-        ${renderCalendar()}
-        <div class="slot-section" data-availability-preview>${renderSlots()}</div>
-      </section>
-      <section class="card booking-wizard-card review-card">
-        <div class="section-head">
-          <h2>สรุปก่อนยืนยัน</h2>
-          <p class="muted">ระบบจะตรวจคิวล่าสุดอีกครั้งก่อนสร้าง Booking จริง</p>
+          <span class="section-kicker">ขั้นตอน 5 จาก 5</span>
+          <h2>ตรวจสอบและยืนยัน</h2>
+          <p class="muted">ตรวจข้อมูลทั้งหมดก่อนส่งคำขอจอง</p>
         </div>
         ${renderReviewRows()}
-        <div class="notice">การส่งรายการนี้เป็นคำขอจองล้างแอร์ล่วงหน้า Booking Code และ Token จะใช้จาก Server เท่านั้น</div>
-        ${submit.status === "checking_slot" ? root.utils.stateBox("loading", "กำลังตรวจคิวช่างล่าสุด...") : ""}
+        <div class="notice">การส่งรายการนี้เป็นคำขอจองล้างแอร์ล่วงหน้า ระบบจะสร้างรหัสติดตามจากข้อมูลจริงหลังส่งสำเร็จ</div>
+        ${submit.status === "checking_slot" ? root.utils.stateBox("loading", "กำลังตรวจคิวล่าสุด...") : ""}
         ${submit.status === "submitting" ? root.utils.stateBox("loading", "กำลังส่งข้อมูลจอง...") : ""}
         ${submit.status === "error" ? root.utils.stateBox("error", submit.error || "ส่งคำขอจองไม่สำเร็จ") : ""}
-        <button type="button" class="primary-btn wizard-submit-btn" data-action="submit-scheduled" ${pending || !selected ? "disabled" : ""}>${pending ? "กำลังตรวจสอบ..." : "ยืนยันส่งคำขอจอง"}</button>
+        <button type="button" class="primary-btn wizard-submit-btn" data-action="submit-scheduled" ${pending ? "disabled" : ""}>${pending ? "กำลังตรวจสอบ..." : "ยืนยันส่งคำขอจอง"}</button>
       </section>
     `;
   }
@@ -403,14 +526,14 @@
     return `
       <section class="card success-card booking-result-card">
         <div class="success-mark">✓</div>
-        <span class="section-kicker">Server response</span>
+        <span class="section-kicker">ส่งคำขอแล้ว</span>
         <h2>ส่งคำขอจองเรียบร้อย</h2>
-        <div class="state-box is-success">ระบบสร้าง Booking จากข้อมูลจริงแล้ว โปรดเก็บรหัสเพื่อติดตามสถานะและการยืนยันงาน</div>
+        <div class="state-box is-success">ระบบสร้างรหัสติดตามจากข้อมูลจริงแล้ว โปรดเก็บรหัสไว้เพื่อติดตามสถานะและการยืนยันงาน</div>
         <div class="data-list">
           <div class="data-row"><strong>Booking Code</strong><span class="booking-code-value">${root.utils.escapeHtml(result.booking_code || "-")}</span></div>
           <div class="data-row"><strong>วันและเวลา</strong><span class="muted">${root.utils.escapeHtml(selected.date || draft().date || "-")} · ${root.utils.escapeHtml(selected.start || "-")}-${root.utils.escapeHtml(selected.end || "-")} น.</span></div>
-          <div class="data-row"><strong>ราคาจากระบบ</strong><span class="muted">${root.utils.formatBaht(result.base_total)}</span></div>
-          <div class="data-row"><strong>เวลาทำงานโดยประมาณ</strong><span class="muted">${root.utils.escapeHtml(result.duration_min || "-")} นาที</span></div>
+          <div class="data-row"><strong>ราคา</strong><span class="muted">${root.utils.formatBaht(result.base_total)}</span></div>
+          <div class="data-row"><strong>เวลาทำงาน</strong><span class="muted">${root.utils.escapeHtml(result.duration_min || "-")} นาที</span></div>
         </div>
         <div class="button-row">
           <button type="button" class="primary-btn" data-action="track-created" data-tracking-key="${root.utils.escapeHtml(trackingKey)}">ติดตามสถานะงาน</button>
@@ -418,16 +541,6 @@
         </div>
       </section>
     `;
-  }
-
-  function validateServiceStep() {
-    const s = service();
-    const pricing = root.state.scheduledPreview.pricing;
-    if (!payloadFromDraft() || s.job_type !== "ล้าง") return "บริการนี้ยังไม่เปิดจองออนไลน์ กรุณาติดต่อแอดมิน";
-    if (!s.ac_type || !s.btu || s.machine_count < 1) return "กรุณาเลือกรายละเอียดงานล้างให้ครบ";
-    if (s.ac_type === "ผนัง" && !s.wash_variant) return "กรุณาเลือกรูปแบบการล้าง";
-    if (!pricing.data || !Number(pricing.data.duration_min || 0)) return "กรุณารอให้ระบบคำนวณราคาและระยะเวลางานให้สำเร็จ";
-    return "";
   }
 
   function validateContactStep() {
@@ -441,6 +554,25 @@
     return "";
   }
 
+  function validateServiceStep() {
+    const lines = services();
+    if (!lines.length) return "ต้องมีอย่างน้อย 1 รายการ";
+    for (const line of lines) {
+      if (line.needs_admin_estimate) return line.admin_reason || "กรุณาเลือกข้อมูลบริการให้ครบ";
+      if (!line.ac_type || !line.btu || line.machine_count < 1) return "กรุณาเลือกรายละเอียดงานล้างให้ครบ";
+      if (line.ac_type === root.services.WALL_AC && !line.wash_variant) return "กรุณาเลือกวิธีล้างสำหรับแอร์ผนัง";
+    }
+    return "";
+  }
+
+  function validatePricingStep() {
+    const serviceError = validateServiceStep();
+    if (serviceError) return serviceError;
+    const pricing = root.state.scheduledPreview.pricing;
+    if (!pricing.data || !Number(pricing.data.duration_min || 0)) return "กรุณารอให้ระบบคำนวณราคาและระยะเวลางานให้สำเร็จ";
+    return "";
+  }
+
   function validateSlotStep() {
     const d = draft();
     const selected = d.selectedSlot || null;
@@ -448,8 +580,9 @@
     const expectedKey = currentAvailabilityKey();
     if (!d.date) return "กรุณาเลือกวันที่";
     if (!availability.data || availability.query_key !== expectedKey) return "กรุณารอให้ระบบโหลดคิวว่างของวันที่เลือก";
-    if (!selected) return "กรุณาเลือกช่วงเวลาที่ช่างว่าง";
+    if (!selected) return "กรุณาเลือกช่วงเวลาที่ว่าง";
     if (!root.availability.selectedSlotIsCurrent(selected, availability.data, availability.query_key)) return "คิวที่เลือกไม่ตรงกับข้อมูลล่าสุด กรุณาเลือกเวลาใหม่";
+    if (draft().allow_time_proposal !== true && draft().allow_time_proposal !== false) return "กรุณาเลือกเงื่อนไขการเสนอเวลา";
     return "";
   }
 
@@ -466,6 +599,7 @@
       client_app: "customer_app_v2",
       job_zone: String(d.job_zone || "").trim(),
       service_kind: "clean",
+      allow_time_proposal: d.allow_time_proposal === true,
       ...payloadFromDraft(),
     };
   }
@@ -475,6 +609,7 @@
     if (!payload) throw new Error("ข้อมูลบริการไม่ครบ");
     root.state.setScheduledPreview("pricing", { status: "loading", data: null, error: "" });
     root.state.setScheduledPreview("availability", { status: "idle", data: null, error: "", query_key: "", loaded_at: "" });
+    root.state.setScheduledPreview("calendar", { status: "idle", data: null, error: "", query_key: "", loaded_at: "" });
     root.state.updateDraft("scheduled", { selectedSlot: null });
     paint(container);
     try {
@@ -487,6 +622,31 @@
       throw error;
     } finally {
       paint(container);
+    }
+  }
+
+  async function refreshCalendar(container) {
+    const query = currentCalendarQuery();
+    if (!query || !query.month) {
+      root.state.setScheduledPreview("calendar", { status: "error", data: null, error: "ข้อมูลบริการหรือราคายังไม่พร้อม", query_key: "", loaded_at: "" });
+      paint(container);
+      return null;
+    }
+    const expectedKey = root.availability.calendarQueryKey(query);
+    const requestId = ++calendarRequestSeq;
+    root.state.setScheduledPreview("calendar", { status: "loading", data: null, error: "", query_key: expectedKey, loaded_at: "" });
+    paint(container);
+    try {
+      const data = await root.api.loadAvailabilityCalendar(query);
+      if (requestId !== calendarRequestSeq || expectedKey !== currentCalendarKey()) return null;
+      root.state.setScheduledPreview("calendar", { status: "success", data, error: "", query_key: expectedKey, loaded_at: new Date().toISOString() });
+      return data;
+    } catch (error) {
+      if (requestId !== calendarRequestSeq) return null;
+      root.state.setScheduledPreview("calendar", { status: "error", data: null, error: error.message || "โหลดปฏิทินไม่สำเร็จ", query_key: expectedKey, loaded_at: "" });
+      return null;
+    } finally {
+      if (requestId === calendarRequestSeq) paint(container);
     }
   }
 
@@ -544,29 +704,44 @@
     const current = step();
     root.state.setScheduledWizard({ error: "" });
     if (current === 1) {
-      if (!root.state.scheduledPreview.pricing.data) {
-        try {
-          await refreshPricing(container);
-        } catch (_) {
-          root.state.setScheduledWizard({ error: root.state.scheduledPreview.pricing.error || "คำนวณราคาไม่สำเร็จ" });
-          paint(container);
-          return;
-        }
-      }
-      const error = validateServiceStep();
-      if (error) { root.state.setScheduledWizard({ error }); paint(container); return; }
+      const error = validateContactStep();
+      if (error) { root.state.setScheduledWizard({ error }); paint(container); scrollToWizardTop(container); return; }
       root.state.setScheduledWizard({ step: 2, error: "" });
       paint(container);
       scrollToWizardTop(container);
       return;
     }
     if (current === 2) {
-      const error = validateContactStep();
-      if (error) { root.state.setScheduledWizard({ error }); paint(container); return; }
+      const error = validateServiceStep();
+      if (error) { root.state.setScheduledWizard({ error }); paint(container); scrollToWizardTop(container); return; }
+      try { await refreshPricing(container); }
+      catch (_) {
+        root.state.setScheduledWizard({ error: root.state.scheduledPreview.pricing.error || "คำนวณราคาไม่สำเร็จ" });
+        paint(container);
+        scrollToWizardTop(container);
+        return;
+      }
       root.state.setScheduledWizard({ step: 3, error: "" });
       paint(container);
       scrollToWizardTop(container);
+      return;
+    }
+    if (current === 3) {
+      const error = validatePricingStep();
+      if (error) { root.state.setScheduledWizard({ error }); paint(container); scrollToWizardTop(container); return; }
+      root.state.setScheduledWizard({ step: 4, error: "" });
+      paint(container);
+      scrollToWizardTop(container);
+      await refreshCalendar(container);
       await refreshAvailability(container);
+      return;
+    }
+    if (current === 4) {
+      const error = validateSlotStep();
+      if (error) { root.state.setScheduledWizard({ error }); paint(container); scrollToWizardTop(container); return; }
+      root.state.setScheduledWizard({ step: 5, error: "" });
+      paint(container);
+      scrollToWizardTop(container);
     }
   }
 
@@ -582,14 +757,15 @@
 
   async function submit(container) {
     if (["validating", "checking_slot", "submitting"].includes(root.state.scheduledSubmit.status)) return;
-    const serviceError = validateServiceStep();
     const contactError = validateContactStep();
+    const serviceError = validateServiceStep();
+    const pricingError = validatePricingStep();
     const slotError = validateSlotStep();
     const payload = buildSubmitPayload();
-    if (serviceError || contactError || slotError || !payload.appointment_datetime) {
-      const error = serviceError || contactError || slotError || "ข้อมูลจองไม่ครบ";
+    if (contactError || serviceError || pricingError || slotError || !payload.appointment_datetime) {
+      const error = contactError || serviceError || pricingError || slotError || "ข้อมูลจองไม่ครบ";
       root.state.setScheduledSubmit({ status: "error", error, result: null });
-      root.state.setScheduledWizard({ step: serviceError ? 1 : contactError ? 2 : 3, error });
+      root.state.setScheduledWizard({ step: contactError ? 1 : serviceError ? 2 : pricingError ? 3 : 4, error });
       if (slotError) root.state.updateDraft("scheduled", { selectedSlot: null });
       paint(container);
       scrollToWizardTop(container);
@@ -602,16 +778,16 @@
       root.state.setScheduledSubmit({ status: "submitting", error: "", result: null });
       paint(container);
       const result = await root.api.submitScheduledBooking(buildSubmitPayload());
-      if (!result?.success || (!result.booking_code && !result.token)) throw new Error("Server ไม่ได้ส่ง Booking Code กลับมา");
+      if (!result?.success || (!result.booking_code && !result.token)) throw new Error("ระบบไม่ได้ส่งรหัสติดตามกลับมา");
       root.state.setScheduledSubmit({ status: "success", error: "", result });
-      try { window.sessionStorage.removeItem("cwf_customer_app_v2_scheduled_v3"); } catch (_) { /* ignore */ }
+      try { window.sessionStorage.removeItem("cwf_customer_app_v2_scheduled_v4"); } catch (_) { /* ignore */ }
       paint(container);
       scrollToWizardTop(container);
     } catch (error) {
       root.state.setScheduledSubmit({ status: "error", error: error.message || "ส่งคำขอจองไม่สำเร็จ", result: null });
       if (Number(error.status) === 400 || Number(error.status) === 409) {
         root.state.updateDraft("scheduled", { selectedSlot: null });
-        root.state.setScheduledWizard({ step: 3, error: "คิวที่เลือกอาจเต็มแล้ว กรุณาเลือกช่วงเวลาใหม่" });
+        root.state.setScheduledWizard({ step: 4, error: "คิวที่เลือกอาจเต็มแล้ว กรุณาเลือกช่วงเวลาใหม่" });
       }
       paint(container);
       scrollToWizardTop(container);
@@ -621,14 +797,19 @@
   function renderActions() {
     if (root.state.scheduledSubmit.status === "success") return "";
     const current = step();
-    if (current === 3) {
+    if (current === 5) {
       return `<div class="wizard-action-bar"><button type="button" class="secondary-btn" data-action="wizard-back">ย้อนกลับ</button></div>`;
     }
-    const nextLabel = current === 1 ? "ต่อไป: ข้อมูลหน้างาน" : "ต่อไป: เลือกคิว";
+    const nextLabels = {
+      1: "ต่อไป: รายการบริการ",
+      2: "ต่อไป: ราคา",
+      3: "ต่อไป: เลือกคิว",
+      4: "ต่อไป: ตรวจสอบ",
+    };
     return `
       <div class="wizard-action-bar">
         <button type="button" class="secondary-btn" data-action="wizard-back">${current === 1 ? "กลับหน้าเลือกบริการ" : "ย้อนกลับ"}</button>
-        <button type="button" class="primary-btn" data-action="wizard-next">${nextLabel}</button>
+        <button type="button" class="primary-btn" data-action="wizard-next">${nextLabels[current] || "ต่อไป"}</button>
       </div>
     `;
   }
@@ -640,9 +821,11 @@
     const success = root.state.scheduledSubmit.status === "success";
     const content = success
       ? renderSuccess()
-      : current === 1 ? renderStepServicePrice()
-        : current === 2 ? renderStepContactLocation()
-          : renderStepSlotReview();
+      : current === 1 ? renderStepContactLocation()
+        : current === 2 ? renderStepServices()
+          : current === 3 ? renderStepPricing()
+            : current === 4 ? renderStepCalendarSlot()
+              : renderStepReview();
     container.innerHTML = `
       <div class="page booking-wizard-page">
         <div class="page-toolbar">
@@ -650,9 +833,9 @@
           <a class="text-btn" href="https://line.me/R/ti/p/@cwfair" target="_blank" rel="noopener noreferrer">ติดต่อแอดมิน</a>
         </div>
         <section class="booking-wizard-intro">
-          <span class="section-kicker">Scheduled cleaning</span>
-          <h1>จองล้างแอร์ล่วงหน้า</h1>
-          <p>เลือกบริการและราคา กรอกข้อมูลหน้างาน แล้วเลือกคิวว่างจากระบบจริง</p>
+          <span class="section-kicker">จองล้างแอร์ล่วงหน้า</span>
+          <h1>จองล้างแอร์</h1>
+          <p>เพิ่มรายการเครื่องทั้งหมด ดูราคารวม แล้วเลือกคิวว่างจริงจากปฏิทิน</p>
         </section>
         ${success ? "" : renderProgress()}
         ${root.state.scheduledWizard.error ? root.utils.stateBox("error", root.state.scheduledWizard.error) : ""}
@@ -663,44 +846,59 @@
     bind(container);
   }
 
+  function patchLine(lineId, patch, container) {
+    const next = root.services.linePatchToDraftServices(draft(), lineId, patch);
+    const first = next[0] || root.services.createServiceLine();
+    root.state.updateDraft("scheduled", {
+      services: next,
+      ac_type: first.ac_type,
+      btu: String(first.btu),
+      machine_count: first.machine_count,
+      wash_variant: first.wash_variant || "",
+    });
+    clearPriceCalendarSlots();
+    root.state.setScheduledWizard({ error: "" });
+    paint(container);
+  }
+
   function bind(container) {
-    container.querySelectorAll("[data-scheduled-choice]").forEach((button) => {
-      button.addEventListener("click", async () => {
-        const field = button.getAttribute("data-scheduled-choice");
+    container.querySelectorAll("[data-line-choice]").forEach((button) => {
+      button.addEventListener("click", () => {
+        const field = button.getAttribute("data-line-choice");
+        const lineId = button.getAttribute("data-line-id");
         const value = button.getAttribute("data-choice-value");
-        const patch = { [field]: value, service_kind: "clean", job_type: "ล้าง" };
-        if (field === "ac_type" && value !== "ผนัง") patch.wash_variant = "";
-        if (field === "ac_type" && value === "ผนัง" && !draft().wash_variant) patch.wash_variant = "ล้างธรรมดา";
-        root.state.updateDraft("scheduled", patch);
-        resetPriceAndSlots();
-        root.state.setScheduledWizard({ error: "" });
-        paint(container);
-        try { await refreshPricing(container); } catch (_) { /* rendered */ }
+        const patch = field === "btu" ? { [field]: Number(value || 0) } : { [field]: value };
+        patchLine(lineId, patch, container);
+      });
+    });
+
+    container.querySelectorAll("[data-line-field]").forEach((input) => {
+      input.addEventListener("change", () => {
+        const field = input.getAttribute("data-line-field");
+        const lineId = input.getAttribute("data-line-id");
+        const value = field === "machine_count" ? Number(input.value || 1) : input.value;
+        patchLine(lineId, { [field]: value }, container);
       });
     });
 
     container.querySelectorAll("[data-scheduled-field]").forEach((input) => {
       const eventName = input.tagName === "SELECT" ? "change" : "input";
-      input.addEventListener(eventName, async () => {
+      input.addEventListener(eventName, () => {
         const field = input.getAttribute("data-scheduled-field");
-        const value = field === "machine_count" ? Number(input.value || 1) : input.value;
-        root.state.updateDraft("scheduled", { [field]: value });
+        root.state.updateDraft("scheduled", { [field]: input.value });
         root.state.setScheduledWizard({ error: "" });
-        if (field === "machine_count") {
-          resetPriceAndSlots();
-          paint(container);
-          try { await refreshPricing(container); } catch (_) { /* rendered */ }
-        }
       });
       if (eventName === "input") input.addEventListener("change", () => root.state.persistScheduledDraft());
     });
 
     container.querySelectorAll("[data-calendar-month]").forEach((button) => {
-      button.addEventListener("click", () => {
+      button.addEventListener("click", async () => {
         const nextMonth = changeMonth(draft().calendar_month || draft().date.slice(0, 7), Number(button.getAttribute("data-calendar-month") || 0));
         if (!monthWithinRange(nextMonth)) return;
         root.state.updateDraft("scheduled", { calendar_month: nextMonth });
+        clearSlotsOnly();
         paint(container);
+        await refreshCalendar(container);
       });
     });
 
@@ -708,7 +906,7 @@
       button.addEventListener("click", async () => {
         const date = button.getAttribute("data-calendar-date");
         root.state.updateDraft("scheduled", { date, calendar_month: date.slice(0, 7), selectedSlot: null });
-        resetSlots();
+        clearSlotsOnly();
         root.state.setScheduledWizard({ error: "" });
         paint(container);
         await refreshAvailability(container);
@@ -726,11 +924,35 @@
       });
     });
 
+    container.querySelectorAll("[data-time-proposal]").forEach((button) => {
+      button.addEventListener("click", () => {
+        root.state.updateDraft("scheduled", { allow_time_proposal: button.getAttribute("data-time-proposal") === "true" });
+        root.state.setScheduledWizard({ error: "" });
+        paint(container);
+      });
+    });
+
     container.querySelectorAll("[data-action]").forEach((button) => {
       button.addEventListener("click", async () => {
         const action = button.getAttribute("data-action");
         if (action === "wizard-next") await goNext(container);
         if (action === "wizard-back") goBack(container);
+        if (action === "add-line") {
+          const next = [...services(), root.services.createServiceLine()];
+          root.state.updateDraft("scheduled", { services: next, selectedSlot: null });
+          clearPriceCalendarSlots();
+          paint(container);
+        }
+        if (action === "remove-line") {
+          const lineId = button.getAttribute("data-line-id");
+          const next = services().filter((line) => String(line.line_id) !== String(lineId));
+          if (!next.length) return;
+          const first = next[0];
+          root.state.updateDraft("scheduled", { services: next, ac_type: first.ac_type, btu: String(first.btu), machine_count: first.machine_count, wash_variant: first.wash_variant || "", selectedSlot: null });
+          clearPriceCalendarSlots();
+          paint(container);
+        }
+        if (action === "reload-calendar") await refreshCalendar(container);
         if (action === "reload-slots") await refreshAvailability(container);
         if (action === "use-saved-address") {
           root.state.prefillSavedAddress("scheduled");
@@ -745,7 +967,6 @@
         if (action === "new-cleaning-booking") {
           root.state.resetScheduledDraft();
           paint(container);
-          try { await refreshPricing(container); } catch (_) { /* rendered */ }
         }
       });
     });
@@ -753,9 +974,9 @@
 
   function render(container) {
     paint(container);
-    if (step() === 1 && !root.state.scheduledPreview.pricing.data && root.state.scheduledPreview.pricing.status === "idle") {
-      refreshPricing(container).catch(() => {});
-    } else if (step() === 3 && root.state.scheduledPreview.pricing.data && root.state.scheduledPreview.availability.status === "idle") {
+    if (step() === 4 && root.state.scheduledPreview.pricing.data && root.state.scheduledPreview.calendar.status === "idle") {
+      refreshCalendar(container);
+    } else if (step() === 4 && root.state.scheduledPreview.pricing.data && root.state.scheduledPreview.availability.status === "idle") {
       refreshAvailability(container);
     }
     root.state.ensureSavedAddressPrefill("scheduled", () => paint(container));
@@ -764,12 +985,15 @@
   root.bookingScheduled = {
     render,
     refreshAvailability,
+    refreshCalendar,
     _test: {
       buildSubmitPayload,
-      validateServiceStep,
       validateContactStep,
+      validateServiceStep,
+      validatePricingStep,
       validateSlotStep,
       currentAvailabilityQuery,
+      currentCalendarQuery,
     },
   };
 })();

--- a/customer-app/modules/services.js
+++ b/customer-app/modules/services.js
@@ -5,17 +5,19 @@
 
   const UNKNOWN_AC = "__unknown_ac__";
   const UNKNOWN_BTU = "__unknown_btu__";
+  const WALL_AC = "ผนัง";
+  const DEFAULT_WASH = "ล้างธรรมดา";
 
   const serviceKinds = [
-    { value: "clean", label: "ล้างแอร์", short: "ล้าง", job_type: "ล้าง", bookable: true, copy: "เลือกชนิดแอร์ รูปแบบการล้าง และคิวช่างจริง" },
-    { value: "repair", label: "ซ่อมแอร์", short: "ซ่อม", job_type: "ซ่อม", bookable: false, repair_variant: "ซ่อมทั่วไป", copy: "ติดต่อแอดมินเพื่อคัดกรองอาการและจัดช่างที่เหมาะสม" },
+    { value: "clean", label: "ล้างแอร์", short: "ล้าง", job_type: "ล้าง", bookable: true, copy: "เลือกชนิดแอร์ จำนวน และคิวว่างจริง" },
+    { value: "repair", label: "ซ่อมแอร์", short: "ซ่อม", job_type: "ซ่อม", bookable: false, repair_variant: "ซ่อมทั่วไป", copy: "ติดต่อแอดมินเพื่อประเมินอาการและจัดช่าง" },
     { value: "install", label: "ติดตั้งแอร์", short: "ติดตั้ง", job_type: "ติดตั้ง", bookable: false, copy: "ติดต่อแอดมินเพื่อประเมินหน้างาน ราคา และคิวติดตั้ง" },
-    { value: "move", label: "ย้ายแอร์", short: "ย้าย", job_type: "ย้าย", bookable: false, copy: "ติดต่อแอดมินเพื่อประเมินระยะท่อและหน้างาน" },
+    { value: "move", label: "ย้ายแอร์", short: "ย้าย", job_type: "ย้าย", bookable: false, copy: "ติดต่อแอดมินเพื่อประเมินระยะท่อและพื้นที่ติดตั้งใหม่" },
     { value: "inspect", label: "ตรวจอาการ / ปรึกษา", short: "ตรวจอาการ", job_type: "ซ่อม", bookable: false, repair_variant: "ตรวจอาการ", copy: "ส่งรายละเอียดให้แอดมินช่วยคัดกรองก่อนนัดช่าง" },
   ];
 
   const acTypes = [
-    { value: "ผนัง", label: "แอร์ผนัง", copy: "บ้านและคอนโดทั่วไป", priced: true },
+    { value: WALL_AC, label: "แอร์ผนัง", copy: "บ้านและคอนโดทั่วไป", priced: true },
     { value: "สี่ทิศทาง", label: "แอร์สี่ทิศทาง", copy: "แอร์ฝังคาสเซ็ตในสำนักงานหรือร้านค้า", priced: true },
     { value: "แขวน", label: "แอร์แขวน", copy: "แอร์แขวนเพดานหรือพื้นที่ขนาดใหญ่", priced: true },
     { value: "เปลือยใต้ฝ้า", label: "แอร์เปลือยใต้ฝ้า", copy: "งานใต้ฝ้าที่เข้าถึงตัวเครื่องได้", priced: true },
@@ -25,7 +27,7 @@
   const washVariants = [
     { value: "ล้างธรรมดา", label: "ล้างปกติ", copy: "ฟิลเตอร์ คอยล์เย็น คอยล์ร้อน และท่อน้ำทิ้ง" },
     { value: "ล้างพรีเมียม", label: "ล้างพรีเมียม", copy: "ล้างละเอียดขึ้น รวมชิ้นส่วนภายในที่ถอดทำความสะอาดได้" },
-    { value: "ล้างแขวนคอยล์", label: "ล้างแบบแขวนคอยล์", copy: "งานล้างละเอียดโดยแขวนชุดคอยล์" },
+    { value: "ล้างแขวนคอยล์", label: "ล้างแบบแขวนคอยล์", copy: "ล้างละเอียดโดยแขวนชุดคอยล์" },
     { value: "ล้างแบบตัดล้าง", label: "ตัดล้างใหญ่", copy: "ถอดล้างครั้งใหญ่สำหรับเครื่องสกปรกมาก" },
   ];
 
@@ -49,170 +51,169 @@
   const machineCounts = Array.from({ length: 10 }, (_, index) => index + 1);
 
   function find(list, value, fallbackIndex = 0) {
-    return list.find((item) => item.value === value) || list[fallbackIndex] || null;
-  }
-
-  function serviceKind(value) {
-    return find(serviceKinds, value || "clean");
+    return list.find((item) => String(item.value) === String(value)) || list[fallbackIndex] || null;
   }
 
   function acType(value) {
-    return find(acTypes, value || "ผนัง");
+    return find(acTypes, value || WALL_AC);
   }
 
   function btuOption(value) {
     return find(btuOptions, String(value || "12000"));
   }
 
-  function normalizeServiceDraft(draft) {
-    const d = draft || {};
-    const kind = serviceKind(d.service_kind || "clean");
-    const ac = acType(d.ac_type);
-    const btu = btuOption(d.btu);
-    const machineCount = Math.max(1, Math.min(10, Number(d.machine_count || 1)));
-    const service = {
-      service_kind: kind.value,
-      job_type: kind.job_type,
+  function washVariant(value) {
+    return find(washVariants, value || DEFAULT_WASH);
+  }
+
+  function makeLineId() {
+    return `line-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
+  }
+
+  function createServiceLine(patch) {
+    const input = patch || {};
+    const line = {
+      line_id: String(input.line_id || makeLineId()),
+      job_type: "ล้าง",
+      ac_type: String(input.ac_type || WALL_AC),
+      btu: Number(input.btu || 12000),
+      machine_count: Math.max(1, Math.min(10, Number(input.machine_count || 1))),
+      wash_variant: "",
+    };
+    if (line.ac_type === WALL_AC) line.wash_variant = String(input.wash_variant || DEFAULT_WASH);
+    return line;
+  }
+
+  function normalizeServiceLine(line) {
+    const input = line || {};
+    const ac = acType(input.ac_type);
+    const btu = btuOption(input.btu);
+    const normalized = {
+      line_id: String(input.line_id || makeLineId()),
+      job_type: "ล้าง",
       ac_type: ac.value,
       btu: btu.btu,
-      btu_value: btu.value,
-      machine_count: machineCount,
+      machine_count: Math.max(1, Math.min(10, Number(input.machine_count || 1))),
       wash_variant: "",
-      repair_variant: kind.repair_variant || "",
-      needs_admin_estimate: !kind.bookable,
-      admin_reason: kind.bookable ? "" : "บริการนี้ต้องติดต่อแอดมิน",
+      needs_admin_estimate: !ac.priced || !btu.priced,
+      admin_reason: "",
     };
+    if (normalized.ac_type === WALL_AC) normalized.wash_variant = washVariant(input.wash_variant || DEFAULT_WASH).value;
+    if (!ac.priced) normalized.admin_reason = "กรุณาติดต่อแอดมินเพื่อประเมินชนิดแอร์นี้";
+    if (!btu.priced) normalized.admin_reason = "กรุณาเลือก BTU ให้ชัดเจนก่อนจอง";
+    return normalized;
+  }
 
-    if (service.job_type === "ล้าง" && service.ac_type === "ผนัง") {
-      service.wash_variant = find(washVariants, d.wash_variant || "ล้างธรรมดา").value;
-    }
-    if (service.job_type === "ซ่อม" && !service.repair_variant) {
-      service.repair_variant = find(repairVariants, d.repair_variant || "ซ่อมทั่วไป").value;
-    }
-    if (!ac.priced) {
-      service.needs_admin_estimate = true;
-      service.admin_reason = "ยังไม่ทราบชนิดแอร์ กรุณาติดต่อแอดมิน";
-    } else if (!btu.priced) {
-      service.needs_admin_estimate = true;
-      service.admin_reason = "ยังไม่ทราบ BTU กรุณาติดต่อแอดมิน";
-    }
-    return service;
+  function normalizeServiceLines(draft) {
+    const d = draft || {};
+    const raw = Array.isArray(d.services) && d.services.length
+      ? d.services
+      : [{
+          line_id: "line-1",
+          job_type: d.job_type || "ล้าง",
+          ac_type: d.ac_type || WALL_AC,
+          btu: d.btu || 12000,
+          machine_count: d.machine_count || 1,
+          wash_variant: d.wash_variant || DEFAULT_WASH,
+        }];
+    return raw.map(normalizeServiceLine);
+  }
+
+  function toBackendServiceLine(line) {
+    const normalized = normalizeServiceLine(line);
+    if (normalized.needs_admin_estimate || normalized.job_type !== "ล้าง") return null;
+    const out = {
+      job_type: "ล้าง",
+      ac_type: normalized.ac_type,
+      btu: normalized.btu,
+      machine_count: normalized.machine_count,
+    };
+    if (normalized.ac_type === WALL_AC && normalized.wash_variant) out.wash_variant = normalized.wash_variant;
+    return out;
+  }
+
+  function payloadFromServiceLines(lines) {
+    const normalized = (Array.isArray(lines) && lines.length ? lines : [createServiceLine()])
+      .map(toBackendServiceLine);
+    if (!normalized.length || normalized.some((line) => !line)) return null;
+    const first = normalized[0];
+    return {
+      job_type: "ล้าง",
+      ac_type: first.ac_type,
+      btu: first.btu,
+      machine_count: first.machine_count,
+      wash_variant: first.wash_variant || "",
+      repair_variant: "",
+      services: normalized,
+    };
+  }
+
+  function payloadFromScheduledDraft(draft) {
+    return payloadFromServiceLines(normalizeServiceLines(draft));
+  }
+
+  function normalizeServiceDraft(draft) {
+    return normalizeServiceLines(draft)[0] || normalizeServiceLine(createServiceLine());
   }
 
   function payloadFromServiceDraft(draft) {
-    const service = normalizeServiceDraft(draft);
-    if (service.needs_admin_estimate || service.job_type !== "ล้าง") return null;
-    const payload = {
-      job_type: "ล้าง",
-      ac_type: service.ac_type,
-      btu: service.btu,
-      machine_count: service.machine_count,
-    };
-    if (service.wash_variant) payload.wash_variant = service.wash_variant;
-    payload.services = [{ ...payload }];
-    return payload;
+    return payloadFromScheduledDraft(draft);
   }
 
   function serviceLabel(service) {
-    const s = service || {};
+    const s = normalizeServiceLine(service);
     const ac = acType(s.ac_type);
-    const btu = btuOption(s.btu_value || s.btu);
+    const btu = btuOption(s.btu);
     const parts = [
-      "ล้าง",
       ac.label,
       btu.label,
+      s.ac_type === WALL_AC && s.wash_variant ? washVariant(s.wash_variant).label : "",
       `${s.machine_count || 1} เครื่อง`,
-      s.wash_variant ? find(washVariants, s.wash_variant).label : "",
     ].filter(Boolean);
-    return parts.join(" / ");
+    return parts.join(" · ");
+  }
+
+  function serviceLineSummary(line, index) {
+    const s = normalizeServiceLine(line);
+    return {
+      title: `รายการที่ ${Number(index || 0) + 1}`,
+      line1: `${acType(s.ac_type).label} · ${btuOption(s.btu).label}`,
+      line2: [s.ac_type === WALL_AC && s.wash_variant ? washVariant(s.wash_variant).label : "", `${s.machine_count} เครื่อง`].filter(Boolean).join(" · "),
+    };
+  }
+
+  function linePatchToDraftServices(draft, lineId, patch) {
+    const services = normalizeServiceLines(draft);
+    const index = services.findIndex((line) => String(line.line_id) === String(lineId));
+    if (index < 0) return services;
+    const nextLine = { ...services[index], ...(patch || {}) };
+    if (patch && Object.prototype.hasOwnProperty.call(patch, "ac_type")) {
+      nextLine.wash_variant = patch.ac_type === WALL_AC ? (nextLine.wash_variant || DEFAULT_WASH) : "";
+    }
+    services[index] = normalizeServiceLine(nextLine);
+    return services;
   }
 
   const commerceCategories = [
-    {
-      id: "clean",
-      action: "book",
-      route: "scheduled",
-      glyph: "sparkle",
-      title: "ล้างแอร์",
-      copy: "จองเองได้ เลือกวัน เวลา และคิวช่างว่างจริง",
-      draft: { service_kind: "clean", job_type: "ล้าง", ac_type: "ผนัง", wash_variant: "ล้างธรรมดา", btu: "12000", machine_count: 1 },
-    },
-    {
-      id: "repair",
-      action: "contact",
-      glyph: "wrench",
-      title: "ซ่อมแอร์",
-      copy: "ติดต่อแอดมินเพื่อสอบถามอาการและจัดช่างเฉพาะทาง",
-    },
-    {
-      id: "install",
-      action: "contact",
-      glyph: "shield",
-      title: "ติดตั้งแอร์",
-      copy: "ติดต่อแอดมินเพื่อประเมินหน้างานและราคา",
-    },
-    {
-      id: "move",
-      action: "contact",
-      glyph: "pin",
-      title: "ย้ายแอร์",
-      copy: "ติดต่อแอดมินเพื่อประเมินระยะท่อและพื้นที่ติดตั้งใหม่",
-    },
-    {
-      id: "inspect",
-      action: "contact",
-      glyph: "chat",
-      title: "ตรวจอาการ / ปรึกษา",
-      copy: "ส่งอาการให้แอดมินช่วยคัดกรองก่อนนัดช่าง",
-    },
-    {
-      id: "urgent",
-      action: "urgent",
-      route: "urgent",
-      glyph: "bolt",
-      title: "คิวด่วน",
-      copy: "ส่งคำขอด่วนให้พาร์ทเนอร์ช่างกดรับ ยังไม่ยืนยันงานจนกว่าจะมีช่างรับ",
-    },
+    { id: "clean", action: "book", route: "scheduled", glyph: "sparkle", title: "ล้างแอร์", copy: "เลือกวัน เวลา และคิวช่างว่างจริง", draft: createServiceLine() },
+    { id: "repair", action: "contact", glyph: "wrench", title: "ซ่อมแอร์", copy: "ติดต่อแอดมินเพื่อประเมินอาการและจัดช่าง" },
+    { id: "install", action: "contact", glyph: "shield", title: "ติดตั้งแอร์", copy: "ติดต่อแอดมินเพื่อประเมินหน้างานและราคา" },
+    { id: "move", action: "contact", glyph: "pin", title: "ย้ายแอร์", copy: "ติดต่อแอดมินเพื่อประเมินระยะท่อและพื้นที่ใหม่" },
+    { id: "inspect", action: "contact", glyph: "chat", title: "ตรวจอาการ / ปรึกษา", copy: "ส่งรายละเอียดให้แอดมินช่วยคัดกรองก่อนนัดช่าง" },
+    { id: "urgent", action: "urgent", route: "urgent", glyph: "bolt", title: "คิวด่วน", copy: "ส่งคำขอด่วนสำหรับงานล้าง รอช่างหรือแอดมินยืนยันก่อนเริ่มงาน" },
   ];
 
   const quickServices = [
-    {
-      id: "wall-normal",
-      action: "book",
-      route: "scheduled",
-      title: "ล้างแอร์ผนัง",
-      kicker: "ยอดนิยม",
-      copy: "เหมาะกับบ้านและคอนโดทั่วไป",
-      draft: { service_kind: "clean", job_type: "ล้าง", ac_type: "ผนัง", wash_variant: "ล้างธรรมดา", btu: "12000", machine_count: 1 },
-      priceable: true,
-    },
-    {
-      id: "wall-premium",
-      action: "book",
-      route: "scheduled",
-      title: "ล้างพรีเมียม",
-      kicker: "ดูแลละเอียด",
-      copy: "สำหรับแอร์ใช้งานหนักหรือต้องการล้างลึกขึ้น",
-      draft: { service_kind: "clean", job_type: "ล้าง", ac_type: "ผนัง", wash_variant: "ล้างพรีเมียม", btu: "12000", machine_count: 1 },
-      priceable: true,
-    },
-    {
-      id: "cassette",
-      action: "book",
-      route: "scheduled",
-      title: "ล้างแอร์สี่ทิศทาง",
-      kicker: "ร้านค้า / ออฟฟิศ",
-      copy: "ระบบคำนวณราคาและเวลาจากข้อมูลจริง",
-      draft: { service_kind: "clean", job_type: "ล้าง", ac_type: "สี่ทิศทาง", btu: "24000", machine_count: 1 },
-      priceable: true,
-    },
+    { id: "wall-normal", action: "book", route: "scheduled", title: "ล้างแอร์ผนัง", kicker: "ยอดนิยม", copy: "เหมาะกับบ้านและคอนโดทั่วไป", draft: createServiceLine({ ac_type: WALL_AC, wash_variant: DEFAULT_WASH, btu: 12000, machine_count: 1 }), priceable: true },
+    { id: "wall-premium", action: "book", route: "scheduled", title: "ล้างพรีเมียม", kicker: "ดูแลละเอียด", copy: "สำหรับแอร์ใช้งานหนักหรือต้องการล้างลึกขึ้น", draft: createServiceLine({ ac_type: WALL_AC, wash_variant: "ล้างพรีเมียม", btu: 12000, machine_count: 1 }), priceable: true },
+    { id: "cassette", action: "book", route: "scheduled", title: "ล้างแอร์สี่ทิศทาง", kicker: "ร้านค้า / ออฟฟิศ", copy: "ระบบคำนวณราคาและเวลาทำงานหลังเลือกบริการ", draft: createServiceLine({ ac_type: "สี่ทิศทาง", btu: 24000, machine_count: 1, wash_variant: "" }), priceable: true },
   ];
 
   const cleaningMethods = [
     { id: "method-normal", title: "ล้างปกติ", copy: "ดูแลตามรอบสำหรับแอร์ผนังที่ใช้งานปกติ", draft: quickServices[0].draft },
     { id: "method-premium", title: "ล้างพรีเมียม", copy: "เพิ่มความละเอียดสำหรับแอร์ใช้งานหนัก", draft: quickServices[1].draft },
-    { id: "method-coil", title: "ล้างแบบแขวนคอยล์", copy: "ล้างละเอียดถึงชุดคอยล์และชิ้นส่วนภายใน", draft: { service_kind: "clean", job_type: "ล้าง", ac_type: "ผนัง", wash_variant: "ล้างแขวนคอยล์", btu: "12000", machine_count: 1 } },
-    { id: "method-overhaul", title: "ตัดล้างใหญ่", copy: "งานล้างใหญ่สำหรับเครื่องสกปรกมาก", draft: { service_kind: "clean", job_type: "ล้าง", ac_type: "ผนัง", wash_variant: "ล้างแบบตัดล้าง", btu: "12000", machine_count: 1 } },
+    { id: "method-coil", title: "ล้างแบบแขวนคอยล์", copy: "ล้างละเอียดถึงชุดคอยล์และชิ้นส่วนภายใน", draft: createServiceLine({ ac_type: WALL_AC, wash_variant: "ล้างแขวนคอยล์", btu: 12000, machine_count: 1 }) },
+    { id: "method-overhaul", title: "ตัดล้างใหญ่", copy: "งานล้างใหญ่สำหรับเครื่องสกปรกมาก", draft: createServiceLine({ ac_type: WALL_AC, wash_variant: "ล้างแบบตัดล้าง", btu: 12000, machine_count: 1 }) },
   ];
 
   function commerceItem(id) {
@@ -221,10 +222,15 @@
 
   function applyCommerceDraft(scope, item) {
     if (!item || item.action === "contact" || !item.draft) return false;
+    const line = normalizeServiceLine(item.draft);
     root.state.updateDraft(scope, {
-      ...item.draft,
       service_kind: "clean",
       job_type: "ล้าง",
+      ac_type: line.ac_type,
+      btu: String(line.btu),
+      machine_count: line.machine_count,
+      wash_variant: line.wash_variant,
+      services: [line],
       selectedSlot: null,
     });
     root.state.selectedService = { id: item.id || item.title || "", route: scope };
@@ -232,6 +238,7 @@
       root.state.setScheduledWizard({ step: 1, error: "" });
       root.state.setScheduledPreview("pricing", { status: "idle", data: null, error: "" });
       root.state.setScheduledPreview("availability", { status: "idle", data: null, error: "", query_key: "", loaded_at: "" });
+      root.state.setScheduledPreview("calendar", { status: "idle", data: null, error: "", query_key: "", loaded_at: "" });
       root.state.setScheduledSubmit({ status: "idle", error: "", result: null });
     }
     return true;
@@ -240,6 +247,8 @@
   root.services = {
     UNKNOWN_AC,
     UNKNOWN_BTU,
+    WALL_AC,
+    DEFAULT_WASH,
     serviceKinds,
     acTypes,
     bookableAcTypes,
@@ -249,23 +258,34 @@
     bookableBtuOptions,
     machineCounts,
     primaryActions: [
-      { route: "scheduled", glyph: "calendar", title: "จองล้างแอร์", copy: "เลือกวัน เวลา และคิวช่างว่างจริง" },
+      { route: "scheduled", glyph: "calendar", title: "จองล้างแอร์", copy: "เลือกวัน เวลา และคิวว่างจริง" },
+      { route: "urgent", glyph: "bolt", title: "คิวด่วน", copy: "สำหรับงานล้างที่ต้องการช่างเร็วที่สุด" },
       { route: "tracking", glyph: "pin", title: "ติดตามงาน", copy: "ดูสถานะงานด้วย Booking Code" },
       { route: "profile", glyph: "phone", title: "ติดต่อ CWF", copy: "โทรหรือ LINE หาแอดมิน" },
     ],
     trustItems: [
-      { glyph: "shield", title: "ช่างผ่านการทดสอบ", copy: "คัดกรองทักษะและมาตรฐานบริการก่อนรับงาน" },
-      { glyph: "tag", title: "แจ้งราคาก่อนเริ่ม", copy: "ระบบแสดงราคาประมาณการก่อนส่งคำขอจอง" },
-      { glyph: "sparkle", title: "รับประกันงานล้าง 30 วัน", copy: "ดูแลหลังงานตามเงื่อนไขบริการของ CWF" },
-      { glyph: "pin", title: "ติดตามสถานะงานได้", copy: "ใช้ Booking Code ดูสถานะสำคัญของงาน" },
+      { glyph: "shield", title: "ช่างผ่านการคัดกรอง", copy: "แสดงคิวเฉพาะช่างที่เปิดให้ลูกค้าจองได้" },
+      { glyph: "tag", title: "แจ้งราคาก่อนส่งคำขอ", copy: "ระบบคำนวณราคาและเวลาทำงานหลังเลือกบริการ" },
+      { glyph: "sparkle", title: "รองรับหลายเครื่อง", copy: "แยกรายการตามชนิดแอร์ BTU และวิธีล้าง" },
+      { glyph: "pin", title: "ติดตามสถานะได้", copy: "ใช้ Booking Code ดูสถานะสำคัญของงาน" },
     ],
     commerceCategories,
     quickServices,
     cleaningMethods,
     commerceItem,
     applyCommerceDraft,
+    createServiceLine,
+    normalizeServiceLine,
+    normalizeServiceLines,
+    linePatchToDraftServices,
+    payloadFromServiceLines,
+    payloadFromScheduledDraft,
     normalizeServiceDraft,
     payloadFromServiceDraft,
     serviceLabel,
+    serviceLineSummary,
+    acType,
+    btuOption,
+    washVariant,
   };
 })();

--- a/customer-app/modules/state.js
+++ b/customer-app/modules/state.js
@@ -2,11 +2,13 @@
   "use strict";
 
   const root = window.CWFCustomerAppV2 = window.CWFCustomerAppV2 || {};
-  const SCHEDULED_STORAGE_KEY = "cwf_customer_app_v2_scheduled_v3";
+  const SCHEDULED_STORAGE_KEY = "cwf_customer_app_v2_scheduled_v4";
   const SCHEDULED_LEGACY_STORAGE_KEYS = [
+    "cwf_customer_app_v2_scheduled_v3",
     "cwf_customer_app_v2_scheduled_v2",
   ];
   const SCHEDULED_STORAGE_TTL_MS = 7 * 24 * 60 * 60 * 1000;
+  const MAX_SCHEDULED_STEP = 5;
 
   function bangkokTodayYmd() {
     try {
@@ -23,20 +25,59 @@
     }
   }
 
+  function defaultServiceLine(index) {
+    return {
+      line_id: `line-${Date.now().toString(36)}-${index || 1}`,
+      job_type: "ล้าง",
+      ac_type: "ผนัง",
+      btu: 12000,
+      machine_count: 1,
+      wash_variant: "ล้างธรรมดา",
+    };
+  }
+
+  function normalizeRestoredServices(restored) {
+    const raw = Array.isArray(restored.services) && restored.services.length
+      ? restored.services
+      : [{
+          line_id: "line-1",
+          job_type: restored.job_type || "ล้าง",
+          ac_type: restored.ac_type || "ผนัง",
+          btu: restored.btu || 12000,
+          machine_count: restored.machine_count || 1,
+          wash_variant: restored.wash_variant || "ล้างธรรมดา",
+        }];
+    return raw.map((line, index) => {
+      const acType = String(line.ac_type || "ผนัง").trim();
+      const machineCount = Math.max(1, Math.min(10, Number(line.machine_count || 1)));
+      return {
+        line_id: String(line.line_id || `line-${index + 1}`).trim() || `line-${index + 1}`,
+        job_type: "ล้าง",
+        ac_type: acType,
+        btu: Number(line.btu || 12000),
+        machine_count: machineCount,
+        wash_variant: acType === "ผนัง" ? String(line.wash_variant || "ล้างธรรมดา").trim() : "",
+      };
+    });
+  }
+
   function defaultScheduledDraft() {
     const today = bangkokTodayYmd();
+    const firstLine = defaultServiceLine(1);
     return {
       service_kind: "clean",
       job_type: "ล้าง",
-      ac_type: "ผนัง",
-      wash_variant: "ล้างธรรมดา",
+      ac_type: firstLine.ac_type,
+      wash_variant: firstLine.wash_variant,
       repair_variant: "",
-      btu: "12000",
-      machine_count: 1,
+      btu: String(firstLine.btu),
+      machine_count: firstLine.machine_count,
+      services: [firstLine],
       date: today,
       calendar_month: today.slice(0, 7),
       tech_type: "company",
       selectedSlot: null,
+      allow_time_proposal: false,
       customer_name: "",
       customer_phone: "",
       address_text: "",
@@ -61,6 +102,14 @@
     catch (_) { /* ignore */ }
   }
 
+  function removeScheduledStorage() {
+    safeSessionRemove();
+    for (const key of SCHEDULED_LEGACY_STORAGE_KEYS) {
+      try { window.sessionStorage.removeItem(key); }
+      catch (_) { /* ignore */ }
+    }
+  }
+
   const state = {
     currentRoute: "home",
     bookingMode: null,
@@ -78,12 +127,13 @@
     profileAddressForm: { editing: false, status: "idle", error: "", success: "" },
     scheduledWizard: {
       step: 1,
-      maxStep: 3,
+      maxStep: MAX_SCHEDULED_STEP,
       error: "",
     },
     scheduledPreview: {
       pricing: { status: "idle", data: null, error: "" },
       availability: { status: "idle", data: null, error: "", query_key: "", loaded_at: "" },
+      calendar: { status: "idle", data: null, error: "", query_key: "", loaded_at: "" },
     },
     scheduledSubmit: {
       status: "idle",
@@ -139,19 +189,20 @@
     },
     resetScheduledDraft() {
       this.draft.scheduled = defaultScheduledDraft();
-      this.scheduledWizard = { step: 1, maxStep: 3, error: "" };
+      this.scheduledWizard = { step: 1, maxStep: MAX_SCHEDULED_STEP, error: "" };
       this.scheduledPreview = {
         pricing: { status: "idle", data: null, error: "" },
         availability: { status: "idle", data: null, error: "", query_key: "", loaded_at: "" },
+        calendar: { status: "idle", data: null, error: "", query_key: "", loaded_at: "" },
       };
       this.scheduledSubmit = { status: "idle", error: "", result: null };
-      safeSessionRemove();
+      removeScheduledStorage();
     },
     persistScheduledDraft() {
       const payload = {
-        version: 3,
+        version: 4,
         saved_at: Date.now(),
-        step: Math.max(1, Math.min(3, Number(this.scheduledWizard?.step || 1))),
+        step: Math.max(1, Math.min(MAX_SCHEDULED_STEP, Number(this.scheduledWizard?.step || 1))),
         draft: this.draft.scheduled || defaultScheduledDraft(),
       };
       safeSessionSet(JSON.stringify(payload));
@@ -175,9 +226,9 @@
       if (!raw) return false;
       try {
         const parsed = JSON.parse(raw);
-        if (!parsed || (parsed.version !== 1 && parsed.version !== 2 && parsed.version !== 3) || !parsed.draft) return false;
+        if (!parsed || (parsed.version !== 1 && parsed.version !== 2 && parsed.version !== 3 && parsed.version !== 4) || !parsed.draft) return false;
         if (!Number.isFinite(parsed.saved_at) || Date.now() - parsed.saved_at > SCHEDULED_STORAGE_TTL_MS) {
-          safeSessionRemove();
+          removeScheduledStorage();
           return false;
         }
         const defaults = defaultScheduledDraft();
@@ -185,7 +236,13 @@
         restored.service_kind = "clean";
         restored.job_type = "ล้าง";
         restored.repair_variant = "";
-        restored.machine_count = Math.max(1, Math.min(10, Number(restored.machine_count || 1)));
+        restored.services = normalizeRestoredServices(restored);
+        const first = restored.services[0] || defaultServiceLine(1);
+        restored.ac_type = first.ac_type;
+        restored.wash_variant = first.wash_variant || "";
+        restored.btu = String(first.btu || 12000);
+        restored.machine_count = Math.max(1, Math.min(10, Number(first.machine_count || 1)));
+        restored.allow_time_proposal = restored.allow_time_proposal === true;
         if (!restored.date || restored.date < bangkokTodayYmd()) {
           restored.date = bangkokTodayYmd();
           restored.selectedSlot = null;
@@ -193,19 +250,19 @@
         restored.calendar_month = String(restored.calendar_month || restored.date.slice(0, 7));
         this.draft.scheduled = restored;
         const parsedStep = Number(parsed.step || 1);
-        const nextStep = fromLegacy || parsed.version < 3
+        const nextStep = fromLegacy || parsed.version < 4
           ? (parsedStep >= 4 ? 1 : Math.max(1, Math.min(3, parsedStep)))
-          : Math.max(1, Math.min(3, parsedStep));
+          : Math.max(1, Math.min(MAX_SCHEDULED_STEP, parsedStep));
         this.scheduledWizard = {
           ...this.scheduledWizard,
           step: nextStep,
-          maxStep: 3,
+          maxStep: MAX_SCHEDULED_STEP,
           error: "",
         };
         this.persistScheduledDraft();
         return true;
       } catch (_) {
-        safeSessionRemove();
+        removeScheduledStorage();
         return false;
       }
     },
@@ -281,8 +338,8 @@
         ...(this.scheduledWizard || {}),
         ...(patch || {}),
       };
-      this.scheduledWizard.maxStep = 3;
-      this.scheduledWizard.step = Math.max(1, Math.min(3, Number(this.scheduledWizard.step || 1)));
+      this.scheduledWizard.maxStep = MAX_SCHEDULED_STEP;
+      this.scheduledWizard.step = Math.max(1, Math.min(MAX_SCHEDULED_STEP, Number(this.scheduledWizard.step || 1)));
       this.persistScheduledDraft();
     },
     setScheduledPreview(name, patch) {

--- a/index.js
+++ b/index.js
@@ -33,6 +33,7 @@ const customerLookupHelpers = require("./server/customerLookup");
 const technicianJobIncomeDisplayHelpers = require("./server/technicianJobIncomeDisplay");
 const technicianReworkHelpers = require("./server/technicianRework");
 const adminJobItemsHelpers = require("./server/adminJobItems");
+const customerAvailability = require("./server/services/public/customerAvailability");
 const { createTechnicianJobMoneyHelpers } = require("./server/technicianJobMoneySummary");
 const createSystemRoutes = require("./server/routes/system");
 const createTechnicianDirectoryRoutes = require("./server/routes/users/technicians");
@@ -23909,6 +23910,21 @@ function http409Conflict(res, conflict){
 // =======================================
 // 💲 Pricing + Duration Preview (public)
 // =======================================
+function publicCustomerAvailabilityDeps() {
+  return {
+    pool,
+    listTechniciansByType,
+    buildOffMapForDate,
+    isTechOffOnDate,
+    buildTechWindowsMin,
+    listBusyBlocksForTechOnDate,
+    buildStartIntervalsByCollision,
+    toMin,
+    minToHHMM,
+    getNowBangkokParts,
+  };
+}
+
 app.post("/public/pricing_preview", async (req, res) => {
   try {
     const payload = req.body || {};
@@ -23982,6 +23998,22 @@ app.get("/public/availability_v2", async (req, res) => {
   const debugFree = {};
   const debugReasons = [];
   const debugInfo = { busy_by_tech: debugBusy, free_by_tech: debugFree, reasons: debugReasons };
+
+  if (!forced) {
+    try {
+      const data = await customerAvailability.computePublicCustomerSlots(
+        publicCustomerAvailabilityDeps(),
+        { ...req.query, date, tech_type, duration_min }
+      );
+      return res.json(data);
+    } catch (e) {
+      const status = Number(e.status || 503);
+      const message = status === 400
+        ? "ข้อมูลบริการไม่ครบสำหรับตรวจคิว กรุณาเลือกรายการบริการใหม่"
+        : "โหลดตารางว่างไม่สำเร็จ";
+      return res.status(status >= 400 && status < 600 ? status : 503).json({ error: message });
+    }
+  }
 
   // ===== Service Matrix (Option B) =====
   // criteria from customer booking page (Thai values)
@@ -24432,6 +24464,29 @@ app.get("/public/availability_v2", async (req, res) => {
   }
 });
 
+app.get("/public/availability_calendar_v2", async (req, res) => {
+  if (!ENABLE_AVAILABILITY_V2) return res.status(404).json({ error: "DISABLED" });
+  const month = String(req.query.month || "").slice(0, 7);
+  if (!/^\d{4}-\d{2}$/.test(month)) {
+    return res.status(400).json({ error: "กรุณาระบุเดือนให้ถูกต้อง" });
+  }
+  const duration_min = Math.max(15, Number(req.query.duration_min || 60));
+  const tech_type = String(req.query.tech_type || "company").trim().toLowerCase();
+  try {
+    const data = await customerAvailability.computeCalendarSummary(
+      publicCustomerAvailabilityDeps(),
+      { ...req.query, month, tech_type, duration_min }
+    );
+    res.json(data);
+  } catch (e) {
+    const status = Number(e.status || 503);
+    const message = status === 400
+      ? "ข้อมูลบริการไม่ครบสำหรับตรวจคิว กรุณาเลือกรายการบริการใหม่"
+      : "โหลดปฏิทินคิวไม่สำเร็จ";
+    res.status(status >= 400 && status < 600 ? status : 503).json({ error: message });
+  }
+});
+
 // Admin: availability by technician (v2) - used for colored rows per tech
 app.get("/admin/availability_by_tech_v2", async (req, res) => {
   if (!ENABLE_AVAILABILITY_V2) return res.status(404).json({ error: "DISABLED" });
@@ -24618,6 +24673,7 @@ app.post("/public/book", async (req, res) => {
     booking_mode,
     client_app,
     allow_admin_schedule_fallback,
+    allow_time_proposal,
     ac_type,
     btu,
     machine_count,
@@ -24643,6 +24699,14 @@ app.post("/public/book", async (req, res) => {
   const allowAdminScheduleFallback = allow_admin_schedule_fallback === true || String(allow_admin_schedule_fallback || "").trim() === "true";
   const canUseAdminScheduleFallback = bm === "scheduled" && allowAdminScheduleFallback && clientApp === "customer_app_v2";
   const urgentOfferEnabled = bm === "urgent" && ENABLE_URGENT_FLOW;
+  const allowTimeProposal = allow_time_proposal === true
+    ? true
+    : allow_time_proposal === false || allow_time_proposal == null
+      ? false
+      : null;
+  if (clientApp === "customer_app_v2" && allowTimeProposal == null) {
+    return res.status(400).json({ error: "กรุณาเลือกเงื่อนไขการเสนอเวลา" });
+  }
   const payloadV2 = {
     job_type: String(job_type).trim(),
     ac_type: (ac_type || "").toString().trim(),
@@ -24670,6 +24734,23 @@ console.log("[latlng_parse]", { ok: !!parsedLL });
   // - scheduled => company, urgent => partner
   const requestedTechType = bm === "urgent" ? "partner" : "company";
   try {
+    if (bm === "scheduled" && clientApp === "customer_app_v2") {
+      const startIso = normalizeAppointmentDatetime(appointment_datetime);
+      const start = String(startIso).slice(11, 16);
+      const available = await customerAvailability.hasAvailableStart(
+        publicCustomerAvailabilityDeps(),
+        {
+          ...payloadV2,
+          date: String(startIso).slice(0, 10),
+          start,
+          tech_type: requestedTechType,
+          duration_min: duration_min_v2,
+        }
+      );
+      if (!available) {
+        return res.status(409).json({ error: "ช่วงเวลานี้เต็มแล้ว กรุณาเลือกเวลาอื่น" });
+      }
+    } else {
     let techs = await listTechniciansByType(requestedTechType, { include_paused: bm === "scheduled" });
 
     // Customer booking must use the same strict technician boundary as the public slot list.
@@ -24799,6 +24880,7 @@ console.log("[latlng_parse]", { ok: !!parsedLL });
         return res.status(409).json({ error: "ช่วงเวลานี้เต็มแล้ว กรุณาเลือกเวลาอื่น" });
       }
     }
+    }
   } catch (e) {
     console.warn("[public_book] availability_check_fail", { bm, clientApp, err: e.message });
     if (bm === "scheduled" && clientApp === "customer_app_v2") {
@@ -24897,8 +24979,8 @@ if (itemIdQty.length) {
       (customer_name, customer_phone, job_type, appointment_datetime, job_price,
        address_text, technician_team, technician_username, job_status,
        booking_token, job_source, dispatch_mode, customer_note,
-       maps_url, job_zone, duration_min, booking_mode)
-      VALUES ($1,$2,$3,$4,$5,$6,NULL,NULL,$11,$7,'customer',$14,$8,$9,$10,$12,$13)
+       maps_url, job_zone, duration_min, booking_mode, allow_time_proposal)
+      VALUES ($1,$2,$3,$4,$5,$6,NULL,NULL,$11,$7,'customer',$14,$8,$9,$10,$12,$13,$15)
       RETURNING job_id, booking_token
       `,
       [
@@ -24916,6 +24998,7 @@ if (itemIdQty.length) {
         duration_min_v2,
         (bm === 'urgent' ? 'urgent' : 'scheduled'),
         dispatchMode,
+        allowTimeProposal,
       ]
     );
 

--- a/server/services/public/customerAvailability.js
+++ b/server/services/public/customerAvailability.js
@@ -1,0 +1,304 @@
+"use strict";
+
+const SLOT_STEP_MIN = 30;
+const DEFAULT_UI_START = "09:00";
+const DEFAULT_UI_END = "18:00";
+
+function normalizeJobKey(value) {
+  const v = String(value || "").toLowerCase();
+  if (!v) return null;
+  if (v.includes("ติดตั้ง") || v.includes("install")) return "install";
+  if (v.includes("ซ่อม") || v.includes("repair")) return "repair";
+  if (v.includes("ล้าง") || v.includes("wash") || v.includes("clean")) return "wash";
+  return null;
+}
+
+function normalizeAcKey(value) {
+  const v = String(value || "").toLowerCase();
+  if (!v) return null;
+  if (v.includes("ผนัง") || v.includes("wall")) return "wall";
+  if (v.includes("สี่ทิศ") || v.includes("4") || v.includes("four")) return "fourway";
+  if (v.includes("แขวน")) return "hanging";
+  if (v.includes("ใต้ฝ้า") || v.includes("เปลือย") || v.includes("ฝัง")) return "ceiling";
+  return null;
+}
+
+function normalizeWashKey(value) {
+  const v = String(value || "").toLowerCase();
+  if (!v) return null;
+  if (v.includes("ธรรมดา") || v.includes("ปกติ") || v.includes("normal")) return "normal";
+  if (v.includes("พรีเมียม") || v.includes("premium")) return "premium";
+  if (v.includes("แขวนคอย") || v.includes("coil")) return "coil";
+  if (v.includes("ตัดล้าง") || v.includes("overhaul") || v.includes("ใหญ่")) return "overhaul";
+  return null;
+}
+
+function normalizeRepairKey(value) {
+  const v = String(value || "").toLowerCase();
+  if (!v) return null;
+  if (v.includes("รั่ว") || v.includes("leak")) return "leak_check";
+  if (v.includes("อะไหล่") || v.includes("part")) return "parts";
+  if (v.includes("ตรวจ") || v.includes("inspect")) return "inspection";
+  if (v.includes("ทั่วไป") || v.includes("general")) return "general";
+  return v.replace(/[^a-z0-9_]+/g, "_").replace(/^_+|_+$/g, "") || null;
+}
+
+function parseServices(rawServices) {
+  if (Array.isArray(rawServices)) return rawServices;
+  if (!rawServices) return null;
+  try {
+    const parsed = JSON.parse(String(rawServices));
+    return Array.isArray(parsed) ? parsed : null;
+  } catch (_) {
+    return null;
+  }
+}
+
+function buildCriteriaList(input = {}) {
+  const services = parseServices(input.services);
+  const fallback = {
+    job_type: input.job_type || input.jobType,
+    ac_type: input.ac_type || input.acType,
+    wash_variant: input.wash_variant || input.washVariant,
+    repair_variant: input.repair_variant || input.repairVariant,
+  };
+  const source = services && services.length ? services : [fallback];
+  const list = source.map((service) => ({
+    job: normalizeJobKey(service.job_type || fallback.job_type),
+    ac: normalizeAcKey(service.ac_type || fallback.ac_type),
+    wash: normalizeWashKey(service.wash_variant || fallback.wash_variant),
+    repair: normalizeRepairKey(service.repair_variant || fallback.repair_variant),
+    repair_variant: String(service.repair_variant || fallback.repair_variant || "").trim() || null,
+  }));
+  return list;
+}
+
+function hasCompleteCriteria(criteria) {
+  return Boolean(
+    criteria && criteria.job && criteria.ac &&
+    !(criteria.job === "wash" && criteria.ac === "wall" && !criteria.wash) &&
+    !(criteria.job === "repair" && !criteria.repair_variant)
+  );
+}
+
+function validateCriteriaList(list) {
+  return Array.isArray(list) && list.length > 0 && list.every(hasCompleteCriteria);
+}
+
+function techMatchesMatrixStrict(matrix, criteria) {
+  if (!matrix || typeof matrix !== "object") return false;
+  const mustTrue = (obj, key) => {
+    if (!key) return true;
+    if (!obj || typeof obj !== "object") return false;
+    return Boolean(obj[key]);
+  };
+  const hasTrue = (obj, keys) => {
+    if (!obj || typeof obj !== "object") return false;
+    return (keys || []).filter(Boolean).some((key) => Boolean(obj[key]));
+  };
+  if (!mustTrue(matrix.job_types, criteria.job)) return false;
+  if (!mustTrue(matrix.ac_types, criteria.ac)) return false;
+  if (criteria.job === "wash" && criteria.ac === "wall") {
+    if (!mustTrue(matrix.wash_wall_variants, criteria.wash)) return false;
+  }
+  if (criteria.job === "repair" && criteria.repair_variant) {
+    if (!hasTrue(matrix.repair_variants, [criteria.repair, criteria.repair_variant])) return false;
+  }
+  return true;
+}
+
+function techMatchesAllCriteriaStrict(matrix, criteriaList) {
+  if (!validateCriteriaList(criteriaList)) return false;
+  return criteriaList.every((criteria) => techMatchesMatrixStrict(matrix, criteria));
+}
+
+async function loadServiceMatrixMap(pool, usernames) {
+  if (!Array.isArray(usernames) || !usernames.length) return new Map();
+  const result = await pool.query(
+    "SELECT username, matrix_json FROM public.technician_service_matrix WHERE username = ANY($1::text[])",
+    [usernames]
+  );
+  const map = new Map();
+  for (const row of result.rows || []) map.set(String(row.username), row.matrix_json || {});
+  return map;
+}
+
+async function loadSpecialMap(pool, date) {
+  const map = new Map();
+  const result = await pool.query(
+    `SELECT technician_username, start_time, end_time
+     FROM public.technician_special_slots_v2
+     WHERE slot_date=$1::date`,
+    [date]
+  );
+  for (const row of result.rows || []) {
+    const username = row.technician_username;
+    if (!map.has(username)) map.set(username, []);
+    map.get(username).push({ start: row.start_time, end: row.end_time });
+  }
+  return map;
+}
+
+function bangkokTodayYmd(nowParts) {
+  if (nowParts && nowParts.Y && nowParts.M && nowParts.D) return `${nowParts.Y}-${nowParts.M}-${nowParts.D}`;
+  return new Date(Date.now() + (7 * 60 * 60 * 1000)).toISOString().slice(0, 10);
+}
+
+async function eligibleCustomerTechnicians(deps, options) {
+  const {
+    pool,
+    listTechniciansByType,
+    buildOffMapForDate,
+    isTechOffOnDate,
+  } = deps;
+  const date = options.date;
+  const techType = options.tech_type || "company";
+  const criteriaList = buildCriteriaList(options);
+  if (!validateCriteriaList(criteriaList)) {
+    const error = new Error("CUSTOMER_SLOT_SERVICE_CRITERIA_REQUIRED");
+    error.status = 400;
+    throw error;
+  }
+
+  const allTechs = await listTechniciansByType(techType, { include_paused: true });
+  const visibleTechs = (allTechs || []).filter((tech) => tech && tech.customer_slot_visible === true);
+  const offMap = await buildOffMapForDate(date, visibleTechs.map((tech) => tech.username));
+  const notOff = visibleTechs.filter((tech) => !isTechOffOnDate(tech, date, offMap));
+  const matrixMap = await loadServiceMatrixMap(pool, notOff.map((tech) => tech.username));
+  return notOff.filter((tech) => {
+    const username = String(tech.username || "");
+    if (!matrixMap.has(username)) return false;
+    return techMatchesAllCriteriaStrict(matrixMap.get(username), criteriaList);
+  });
+}
+
+async function computePublicCustomerSlots(deps, options) {
+  const {
+    pool,
+    buildTechWindowsMin,
+    listBusyBlocksForTechOnDate,
+    buildStartIntervalsByCollision,
+    toMin,
+    minToHHMM,
+    getNowBangkokParts,
+  } = deps;
+  const date = String(options.date || "").slice(0, 10);
+  const durationMin = Math.max(15, Number(options.duration_min || 60));
+  const uiStartMin = toMin(DEFAULT_UI_START);
+  const uiEndMin = toMin(DEFAULT_UI_END);
+  const specialMap = await loadSpecialMap(pool, date);
+  const techs = await eligibleCustomerTechnicians(deps, { ...options, date });
+  const events = new Map();
+  const addEvent = (minute, type, username) => {
+    const key = Math.round(minute);
+    if (!events.has(key)) events.set(key, { add: [], remove: [] });
+    events.get(key)[type].push(username);
+  };
+
+  let startFloor = uiStartMin;
+  try {
+    const nowBkk = getNowBangkokParts();
+    if (date === bangkokTodayYmd(nowBkk)) {
+      const nowMin = (Number(nowBkk.hh || 0) * 60) + Number(nowBkk.mm || 0);
+      startFloor = Math.max(startFloor, Math.min(Math.ceil(nowMin / SLOT_STEP_MIN) * SLOT_STEP_MIN, uiEndMin));
+    }
+  } catch (_) {
+    startFloor = uiStartMin;
+  }
+
+  for (const tech of techs) {
+    const windows = buildTechWindowsMin(tech, date, specialMap, startFloor, uiEndMin);
+    if (!windows.length) continue;
+    const busyBlocks = await listBusyBlocksForTechOnDate(tech.username, date, null);
+    for (const window of windows) {
+      const intervals = buildStartIntervalsByCollision(busyBlocks, window.startMin, window.endMin, durationMin);
+      for (const interval of intervals) {
+        addEvent(interval.startMin, "add", tech.username);
+        addEvent(interval.endMin + 1, "remove", tech.username);
+      }
+    }
+  }
+
+  if (!events.has(startFloor)) events.set(startFloor, { add: [], remove: [] });
+  if (!events.has(uiEndMin + 1)) events.set(uiEndMin + 1, { add: [], remove: [] });
+
+  const points = Array.from(events.keys()).sort((a, b) => a - b);
+  const active = new Set();
+  const slots = [];
+
+  for (let i = 0; i < points.length; i += 1) {
+    const minute = points[i];
+    const bucket = events.get(minute) || { add: [], remove: [] };
+    for (const username of bucket.remove) active.delete(username);
+    for (const username of bucket.add) active.add(username);
+    const next = points[i + 1];
+    if (next == null) continue;
+    const segmentStart = Math.max(startFloor, minute);
+    const segmentEnd = Math.min(uiEndMin + 1, next) - 1;
+    if (segmentEnd < segmentStart || !active.size) continue;
+    const lastStart = Math.min(segmentEnd, uiEndMin - SLOT_STEP_MIN);
+    for (let start = segmentStart; start <= lastStart; start += SLOT_STEP_MIN) {
+      slots.push({
+        start: minToHHMM(start),
+        end: minToHHMM(Math.min(uiEndMin, start + SLOT_STEP_MIN)),
+        available: true,
+      });
+    }
+  }
+
+  return {
+    date,
+    duration_min: durationMin,
+    slot_step_min: SLOT_STEP_MIN,
+    slots,
+  };
+}
+
+function addDaysYmd(ymd, days) {
+  const [year, month, day] = String(ymd).split("-").map(Number);
+  const date = new Date(Date.UTC(year, (month || 1) - 1, day || 1));
+  date.setUTCDate(date.getUTCDate() + Number(days || 0));
+  return `${date.getUTCFullYear()}-${String(date.getUTCMonth() + 1).padStart(2, "0")}-${String(date.getUTCDate()).padStart(2, "0")}`;
+}
+
+function monthDays(month) {
+  const match = String(month || "").match(/^(\d{4})-(\d{2})$/);
+  if (!match) return [];
+  const year = Number(match[1]);
+  const monthIndex = Number(match[2]) - 1;
+  const count = new Date(Date.UTC(year, monthIndex + 1, 0)).getUTCDate();
+  const first = `${match[1]}-${match[2]}-01`;
+  return Array.from({ length: count }, (_, index) => addDaysYmd(first, index));
+}
+
+async function computeCalendarSummary(deps, options) {
+  const month = String(options.month || "").slice(0, 7);
+  const days = [];
+  for (const date of monthDays(month)) {
+    const result = await computePublicCustomerSlots(deps, { ...options, date });
+    const first = (result.slots || []).find((slot) => slot.available);
+    days.push({
+      date,
+      available: Boolean(first),
+      first_available: first ? first.start : null,
+    });
+  }
+  return { month, days };
+}
+
+async function hasAvailableStart(deps, options) {
+  const result = await computePublicCustomerSlots(deps, options);
+  const start = String(options.start || "").slice(0, 5);
+  return (result.slots || []).some((slot) => slot.available && slot.start === start);
+}
+
+module.exports = {
+  buildCriteriaList,
+  validateCriteriaList,
+  techMatchesMatrixStrict,
+  techMatchesAllCriteriaStrict,
+  eligibleCustomerTechnicians,
+  computePublicCustomerSlots,
+  computeCalendarSummary,
+  hasAvailableStart,
+};

--- a/test/customerAppRecovery.test.js
+++ b/test/customerAppRecovery.test.js
@@ -182,7 +182,7 @@ test("account chip has narrow-screen avatar-only protection", () => {
   assert.match(css, /text-overflow: ellipsis/);
 });
 
-test("scheduled draft persists and restores three-step state", () => {
+test("scheduled draft persists and restores five-step state", () => {
   const context = makeContext();
   let root = load(context, ["customer-app/modules/state.js"]);
   root.state.updateDraft("scheduled", { customer_name: "Persisted Customer", address_text: "Persisted Address" });
@@ -193,12 +193,12 @@ test("scheduled draft persists and restores three-step state", () => {
   root.state.init();
 
   assert.equal(root.state.scheduledWizard.step, 3);
-  assert.equal(root.state.scheduledWizard.maxStep, 3);
+  assert.equal(root.state.scheduledWizard.maxStep, 5);
   assert.equal(root.state.draft.scheduled.customer_name, "Persisted Customer");
   assert.equal(root.state.draft.scheduled.address_text, "Persisted Address");
 });
 
-test("legacy scheduled draft from five-step flow is mapped back to the new three-step flow", () => {
+test("legacy scheduled draft from older flow is mapped safely into the five-step flow", () => {
   const context = makeContext();
   context.window.sessionStorage.setItem("cwf_customer_app_v2_scheduled_v2", JSON.stringify({
     version: 2,
@@ -214,7 +214,7 @@ test("legacy scheduled draft from five-step flow is mapped back to the new three
   root.state.init();
 
   assert.equal(root.state.scheduledWizard.step, 1);
-  assert.equal(root.state.scheduledWizard.maxStep, 3);
+  assert.equal(root.state.scheduledWizard.maxStep, 5);
   assert.equal(root.state.draft.scheduled.customer_name, "Legacy Customer");
   assert.equal(root.state.draft.scheduled.address_text, "Legacy Address");
 });
@@ -241,17 +241,21 @@ test("home CTA click writes scheduled draft and routes to scheduled flow", async
   assert.equal(root.state.draft.scheduled.selectedSlot, null);
 });
 
-test("scheduled booking renders one active step and preserves draft across three steps", async () => {
+test("scheduled booking renders one active step and preserves draft across five steps", async () => {
   const context = makeContext();
   const root = loadCustomerFrontend(context);
   root.state.customer = { logged_in: false };
   root.api.previewPricing = async () => ({ duration_min: 90, active_price: 1200, standard_price: 1200 });
+  root.api.loadAvailabilityCalendar = async () => ({
+    month: root.state.draft.scheduled.calendar_month,
+    days: [{ date: root.state.draft.scheduled.date, available: true, first_available: "09:00" }],
+  });
   root.api.loadAvailability = async () => ({ date: root.state.draft.scheduled.date, duration_min: 90, slot_step_min: 30, slots: [{ start: "09:00", end: "12:00", available: true }] });
 
   const container = new WizardContainer(root);
   root.bookingScheduled.render(container);
   assert.match(container.innerHTML, /data-booking-step="1"/);
-  assert.doesNotMatch(container.innerHTML, /data-booking-step="4"|data-booking-step="5"/);
+  assert.doesNotMatch(container.innerHTML, /data-booking-step="2"|data-booking-step="3"|data-booking-step="4"|data-booking-step="5"/);
 
   root.state.updateDraft("scheduled", {
     customer_name: "Test Customer",
@@ -262,24 +266,30 @@ test("scheduled booking renders one active step and preserves draft across three
   await container.querySelectorAll("[data-action]").find((button) => button.getAttribute("data-action") === "wizard-next").click();
   assert.equal(root.state.scheduledWizard.step, 2);
   assert.match(container.innerHTML, /data-booking-step="2"/);
+  assert.doesNotMatch(container.innerHTML, /data-booking-step="1"|data-booking-step="3"|data-booking-step="4"|data-booking-step="5"/);
   assert.equal(root.state.draft.scheduled.address_text, "123 Test Condo");
 
   await container.querySelectorAll("[data-action]").find((button) => button.getAttribute("data-action") === "wizard-next").click();
   assert.equal(root.state.scheduledWizard.step, 3);
   assert.match(container.innerHTML, /data-booking-step="3"/);
+  assert.doesNotMatch(container.innerHTML, /data-booking-step="1"|data-booking-step="2"|data-booking-step="4"|data-booking-step="5"/);
+
+  await container.querySelectorAll("[data-action]").find((button) => button.getAttribute("data-action") === "wizard-next").click();
+  assert.equal(root.state.scheduledWizard.step, 4);
+  assert.match(container.innerHTML, /data-booking-step="4"/);
   assert.match(container.innerHTML, /09:00/);
 
   const slot = root.availability.normalizePublicSlots(root.state.scheduledPreview.availability.data, 90)[0];
   root.state.updateDraft("scheduled", { selectedSlot: { ...slot, query_key: root.state.scheduledPreview.availability.query_key } });
   root.bookingScheduled.render(container);
-  assert.equal(root.state.scheduledWizard.step, 3);
-  assert.doesNotMatch(container.innerHTML, /data-booking-step="4"|data-booking-step="5"/);
+  assert.equal(root.state.scheduledWizard.step, 4);
+  assert.doesNotMatch(container.innerHTML, /data-booking-step="1"|data-booking-step="2"|data-booking-step="3"|data-booking-step="5"/);
 });
 test("anonymous slots render without technician identity or counts", () => {
   const context = makeContext();
   const root = loadCustomerFrontend(context);
   const container = new WizardContainer(root);
-  root.state.setScheduledWizard({ step: 3 });
+  root.state.setScheduledWizard({ step: 4 });
   root.state.setScheduledPreview("pricing", { status: "success", data: { duration_min: 60, active_price: 900 }, error: "" });
   root.state.setScheduledPreview("availability", {
     status: "success",
@@ -297,7 +307,7 @@ test("anonymous slots render without technician identity or counts", () => {
 test("stale slot rejection returns customer to date and time step", async () => {
   const context = makeContext();
   const root = loadCustomerFrontend(context);
-  root.state.setScheduledWizard({ step: 3 });
+  root.state.setScheduledWizard({ step: 5 });
   root.state.setScheduledPreview("pricing", { status: "success", data: { duration_min: 60, active_price: 900 }, error: "" });
   const query = root.availability.publicAvailabilityQuery(root.state.draft.scheduled, root.services.payloadFromServiceDraft(root.state.draft.scheduled), root.state.scheduledPreview.pricing.data);
   const queryKey = root.availability.queryKey(query);
@@ -315,7 +325,7 @@ test("stale slot rejection returns customer to date and time step", async () => 
   root.bookingScheduled.render(container);
   await container.querySelectorAll("[data-action]").find((button) => button.getAttribute("data-action") === "submit-scheduled").click();
 
-  assert.equal(root.state.scheduledWizard.step, 3);
+  assert.equal(root.state.scheduledWizard.step, 4);
   assert.equal(root.state.draft.scheduled.selectedSlot, null);
 });
 

--- a/test/customerAppThreeStepBooking.test.js
+++ b/test/customerAppThreeStepBooking.test.js
@@ -28,12 +28,7 @@ function makeContext({ session = {} } = {}) {
       body: { classList: { add() {}, remove() {} } },
       addEventListener() {},
       createElement(tagName) {
-        return {
-          tagName: String(tagName || "").toUpperCase(),
-          className: "",
-          dataset: {},
-          textContent: "",
-        };
+        return { tagName: String(tagName || "").toUpperCase(), className: "", dataset: {}, textContent: "" };
       },
       querySelector() { return null; },
       querySelectorAll() { return []; },
@@ -72,8 +67,8 @@ function loadBooking(opts) {
   ], opts);
 }
 
-function renderInto(root, route = "scheduled") {
-  root.state.currentRoute = route;
+function renderInto(root, step = 1) {
+  root.state.setScheduledWizard({ step });
   const container = {
     html: "",
     dataset: {},
@@ -85,35 +80,26 @@ function renderInto(root, route = "scheduled") {
   };
   root.api = {
     previewPricing: async () => ({ active_price: 500, duration_min: 60, promo: { promo_name: "Promo" } }),
+    loadAvailabilityCalendar: async () => ({ month: root.state.draft.scheduled.calendar_month, days: [] }),
     loadAvailability: async () => ({ date: root.state.draft.scheduled.date, duration_min: 60, slots: [{ start: "09:00", end: "10:00", available: true }] }),
   };
   root.bookingScheduled.render(container);
   return container.html;
 }
 
-test("scheduled wizard state has exactly three steps", () => {
+function sampleLines(root) {
+  return [
+    root.services.createServiceLine({ line_id: "a", ac_type: "ผนัง", btu: 12000, machine_count: 2, wash_variant: "ล้างธรรมดา" }),
+    root.services.createServiceLine({ line_id: "b", ac_type: "ผนัง", btu: 18000, machine_count: 1, wash_variant: "ล้างพรีเมียม" }),
+    root.services.createServiceLine({ line_id: "c", ac_type: "สี่ทิศทาง", btu: 24000, machine_count: 1, wash_variant: "" }),
+  ];
+}
+
+test("scheduled wizard state has exactly five steps", () => {
   const { root } = loadBooking();
-  assert.equal(root.state.scheduledWizard.maxStep, 3);
+  assert.equal(root.state.scheduledWizard.maxStep, 5);
   root.state.setScheduledWizard({ step: 99 });
-  assert.equal(root.state.scheduledWizard.step, 3);
-});
-
-test("old labels or routes for separate steps 4 and 5 are absent", () => {
-  const source = file("customer-app/modules/bookingScheduled.js");
-  assert.doesNotMatch(source, /ขั้นตอน\s*4\s*จาก\s*5|ขั้นตอน\s*5\s*จาก\s*5/);
-  assert.doesNotMatch(source, /renderStepPrice|renderStepFour|maxStep:\s*5|Math\.min\(5/);
-});
-
-test("step 1 contains air selection and real price preview", () => {
-  const { root } = loadBooking();
-  root.state.setScheduledPreview("pricing", { status: "success", data: { active_price: 500, duration_min: 60, promo: { promo_name: "Promo" } }, error: "" });
-  const html = renderInto(root);
-  assert.match(html, /ขั้นตอน 1 จาก 3/);
-  assert.match(html, /เลือกบริการและดูราคา/);
-  assert.match(html, /data-scheduled-choice="ac_type"/);
-  assert.match(html, /data-scheduled-choice="btu"/);
-  assert.match(html, /ราคาประมาณการ/);
-  assert.match(html, /Promo/);
+  assert.equal(root.state.scheduledWizard.step, 5);
 });
 
 test("Customer App customer-facing UI does not expose internal public endpoint names", () => {
@@ -129,66 +115,135 @@ test("Customer App customer-facing UI does not expose internal public endpoint n
     "customer-app/modules/ui.js",
   ].map(file).join("\n");
   assert.doesNotMatch(uiSources, /\/public\/|pricing_preview|availability_v2|public\/book|endpoint|implementation/i);
-
   const { root } = loadBooking();
-  const html = renderInto(root);
-  assert.doesNotMatch(html, /\/public\/|pricing_preview|availability_v2|public\/book|endpoint|implementation/i);
+  assert.doesNotMatch(renderInto(root, 3), /\/public\/|pricing_preview|availability_v2|public\/book|endpoint|implementation/i);
 });
 
-test("scheduled step 1 omits redundant single-option service-kind selector", () => {
+test("service step omits redundant single-option service-kind selector", () => {
   const { root } = loadBooking();
-  root.state.setScheduledPreview("pricing", { status: "success", data: { active_price: 500, duration_min: 60 }, error: "" });
-  const html = renderInto(root);
-  assert.doesNotMatch(html, /data-scheduled-choice="service_kind"/);
-  assert.doesNotMatch(html, /service-kind-grid/);
-  assert.match(html, /data-scheduled-choice="ac_type"/);
-  assert.match(html, /data-scheduled-choice="btu"/);
-  assert.match(html, /data-scheduled-field="machine_count"/);
+  const html = renderInto(root, 2);
+  assert.doesNotMatch(html, /data-scheduled-choice="service_kind"|service-kind-grid|ประเภทบริการ/);
+  assert.match(html, /data-line-choice="ac_type"/);
+  assert.match(html, /data-line-choice="btu"/);
+  assert.match(html, /data-line-field="machine_count"/);
 });
 
-test("step 2 contains all required contact and location fields", () => {
+test("multi-service draft keeps wall methods, quantities, and non-wall blank method", () => {
   const { root } = loadBooking();
-  root.state.setScheduledWizard({ step: 2 });
-  const html = renderInto(root);
-  assert.match(html, /ขั้นตอน 2 จาก 3/);
-  for (const field of ["customer_name", "customer_phone", "address_text", "maps_url", "job_zone", "customer_note"]) {
-    assert.match(html, new RegExp(`data-scheduled-field="${field}"`));
-  }
+  root.state.updateDraft("scheduled", { services: sampleLines(root) });
+  const lines = root.services.normalizeServiceLines(root.state.draft.scheduled);
+  assert.equal(lines.length, 3);
+  assert.equal(lines[0].machine_count, 2);
+  assert.equal(lines[0].wash_variant, "ล้างธรรมดา");
+  assert.equal(lines[1].wash_variant, "ล้างพรีเมียม");
+  assert.equal(lines[2].ac_type, "สี่ทิศทาง");
+  assert.equal(lines[2].wash_variant, "");
 });
 
-test("step 3 contains date, real slots, final summary, and submit", () => {
+test("pricing, availability, and submit payload include every service line", () => {
   const { root } = loadBooking();
-  root.state.setScheduledWizard({ step: 3 });
-  root.state.setScheduledPreview("pricing", { status: "success", data: { active_price: 500, duration_min: 60 }, error: "" });
+  root.state.updateDraft("scheduled", {
+    services: sampleLines(root),
+    customer_name: "A",
+    customer_phone: "0812345678",
+    address_text: "Address",
+    selectedSlot: { date: root.state.draft.scheduled.date, start: "09:00", end: "10:00", key: "k", query_key: "q" },
+  });
+  root.state.setScheduledPreview("pricing", { status: "success", data: { duration_min: 120, active_price: 2000 }, error: "" });
+  const pricingPayload = root.services.payloadFromScheduledDraft(root.state.draft.scheduled);
+  const availabilityQuery = root.bookingScheduled._test.currentAvailabilityQuery();
+  const submitPayload = root.bookingScheduled._test.buildSubmitPayload();
+  assert.equal(pricingPayload.services.length, 3);
+  assert.match(availabilityQuery.services, /"machine_count":2/);
+  assert.equal(submitPayload.services.length, 3);
+  assert.equal(submitPayload.services[2].wash_variant, undefined);
+  assert.equal(submitPayload.ac_type, "ผนัง");
+});
+
+test("calendar query includes normalized service list and combined duration", () => {
+  const { root } = loadBooking();
+  root.state.updateDraft("scheduled", { services: sampleLines(root) });
+  root.state.setScheduledPreview("pricing", { status: "success", data: { duration_min: 210, active_price: 3000 }, error: "" });
+  const query = root.bookingScheduled._test.currentCalendarQuery();
+  assert.equal(query.duration_min, 210);
+  assert.equal(query.month, root.state.draft.scheduled.calendar_month);
+  assert.match(query.services, /"btu":18000/);
+});
+
+test("changing a service line invalidates stale price, calendar, and selected slot through commerce draft reset", () => {
+  const { root } = loadBooking();
+  root.state.setScheduledPreview("pricing", { status: "success", data: { duration_min: 60 }, error: "" });
+  root.state.setScheduledPreview("availability", { status: "success", data: { slots: [] }, query_key: "x", error: "" });
+  root.state.setScheduledPreview("calendar", { status: "success", data: { days: [] }, query_key: "y", error: "" });
+  root.state.updateDraft("scheduled", { selectedSlot: { key: "old" } });
+  root.services.applyCommerceDraft("scheduled", root.services.commerceItem("cassette"));
+  assert.equal(root.state.scheduledPreview.pricing.status, "idle");
+  assert.equal(root.state.scheduledPreview.availability.status, "idle");
+  assert.equal(root.state.scheduledPreview.calendar.status, "idle");
+  assert.equal(root.state.draft.scheduled.selectedSlot, null);
+});
+
+test("time preference defaults exact and submit payload sends boolean", () => {
+  const { root } = loadBooking();
+  assert.equal(root.state.draft.scheduled.allow_time_proposal, false);
+  let payload = root.bookingScheduled._test.buildSubmitPayload();
+  assert.equal(payload.allow_time_proposal, false);
+  root.state.updateDraft("scheduled", { allow_time_proposal: true });
+  payload = root.bookingScheduled._test.buildSubmitPayload();
+  assert.equal(payload.allow_time_proposal, true);
+});
+
+test("review screen displays selected time preference", () => {
+  const { root } = loadBooking();
+  root.state.updateDraft("scheduled", { allow_time_proposal: true });
+  const html = renderInto(root, 5);
+  assert.match(html, /สามารถเสนอเวลาใหม่ให้ฉันได้/);
+  assert.match(html, /การเสนอเวลา/);
+});
+
+test("calendar marks available and full dates without technician identity", () => {
+  const { root } = loadBooking();
+  root.state.setScheduledPreview("pricing", { status: "success", data: { duration_min: 60, active_price: 500 }, error: "" });
+  const key = root.availability.calendarQueryKey(root.bookingScheduled._test.currentCalendarQuery());
+  root.state.setScheduledPreview("calendar", {
+    status: "success",
+    data: { month: root.state.draft.scheduled.calendar_month, days: [
+      { date: root.state.draft.scheduled.date, available: true, first_available: "09:00", technician_name: "Hidden" },
+      { date: "2099-12-31", available: false, first_available: null, technician_count: 3 },
+    ] },
+    error: "",
+    query_key: key,
+  });
+  const html = renderInto(root, 4);
+  assert.match(html, /มีคิว/);
+  assert.doesNotMatch(html, /Hidden|technician_name|technician_id|technician_count|matrix_json/);
+});
+
+test("anonymous slots render complete time range without technician identity or counts", () => {
+  const { root } = loadBooking();
+  root.state.setScheduledWizard({ step: 4 });
+  root.state.setScheduledPreview("pricing", { status: "success", data: { duration_min: 90, active_price: 900 }, error: "" });
+  const query = root.bookingScheduled._test.currentAvailabilityQuery();
   root.state.setScheduledPreview("availability", {
     status: "success",
-    data: { date: root.state.draft.scheduled.date, duration_min: 60, slots: [{ start: "09:00", end: "10:00", available: true }] },
+    data: { date: root.state.draft.scheduled.date, duration_min: 90, slots: [{ start: "10:00", end: "10:30", available: true, technician_name: "Hidden Tech", technician_id: 42 }] },
     error: "",
-    query_key: root.availability.queryKey(root.bookingScheduled._test.currentAvailabilityQuery()),
+    query_key: root.availability.queryKey(query),
   });
-  const html = renderInto(root);
-  assert.match(html, /ขั้นตอน 3 จาก 3/);
-  assert.match(html, /booking-calendar/);
-  assert.match(html, /real-slot-card/);
-  assert.match(html, /สรุปก่อนยืนยัน/);
-  assert.match(html, /data-action="submit-scheduled"/);
+  const html = renderInto(root, 4);
+  assert.match(html, /10:00-11:30/);
+  assert.doesNotMatch(html, /Hidden Tech|technician_id|42|candidate|คน/);
 });
 
-test("old persisted five-step draft maps safely to the new flow", () => {
-  const saved = JSON.stringify({
-    version: 2,
-    saved_at: Date.now(),
-    step: 5,
-    draft: { customer_name: "Saved", customer_phone: "0812345678", address_text: "Address" },
-  });
-  const { root } = loadBooking({ session: { cwf_customer_app_v2_scheduled_v2: saved } });
-  root.state.init();
-  assert.equal(root.state.scheduledWizard.step, 1);
-  assert.equal(root.state.scheduledWizard.maxStep, 3);
-  assert.equal(root.state.draft.scheduled.customer_name, "Saved");
+test("stale slot cannot be submitted", () => {
+  const { root } = loadBooking();
+  root.state.setScheduledPreview("pricing", { status: "success", data: { duration_min: 60, active_price: 500 }, error: "" });
+  root.state.updateDraft("scheduled", { selectedSlot: { key: "old", date: root.state.draft.scheduled.date, start: "09:00", end: "10:00", query_key: "old" } });
+  root.state.setScheduledPreview("availability", { status: "success", data: { date: root.state.draft.scheduled.date, duration_min: 60, slots: [] }, query_key: "new", error: "" });
+  assert.match(root.bookingScheduled._test.validateSlotStep(), /ข้อมูลล่าสุด|เลือกเวลาใหม่|โหลดคิว/);
 });
 
-test("home primary booking CTA opens scheduled booking", () => {
+test("home primary booking CTA opens scheduled booking and all service categories remain visible", () => {
   const { root } = load(["customer-app/modules/state.js", "customer-app/modules/utils.js", "customer-app/modules/services.js", "customer-app/modules/ui.js"]);
   let routed = "";
   root.utils.routeTo = (route) => { routed = route; };
@@ -197,25 +252,15 @@ test("home primary booking CTA opens scheduled booking", () => {
   root.utils.routeTo("scheduled");
   assert.equal(routed, "scheduled");
   assert.equal(root.state.scheduledWizard.step, 1);
-});
-
-test("home displays all six required service categories", () => {
-  const { root } = load(["customer-app/modules/state.js", "customer-app/modules/utils.js", "customer-app/modules/services.js"]);
-  assert.equal(root.services.commerceCategories.map((item) => item.id).join(","), "clean,repair,install,move,inspect,urgent");
+  assert.equal(root.services.commerceCategories.map((entry) => entry.id).join(","), "clean,repair,install,move,inspect,urgent");
 });
 
 test("login controls disappear when authenticated", () => {
   const { root } = load(["customer-app/modules/state.js", "customer-app/modules/utils.js", "customer-app/modules/auth.js"]);
   root.state.customer = { logged_in: true, user: { name: "User", provider: "google" }, profile: {} };
   const html = root.auth.renderLoginPanel();
-  assert.doesNotMatch(html, /data-auth-provider/);
+  assert.doesNotMatch(html, /data-auth-provider|Guest/);
   assert.match(html, /data-auth-logout/);
-});
-
-test("guest content disappears when authenticated", () => {
-  const { root } = load(["customer-app/modules/state.js", "customer-app/modules/utils.js", "customer-app/modules/auth.js"]);
-  root.state.customer = { logged_in: true, user: { name: "User" }, profile: {} };
-  assert.doesNotMatch(root.auth.renderLoginPanel(), /Guest/);
 });
 
 test("header account chip markup has one label mount and one avatar mount", () => {
@@ -224,35 +269,17 @@ test("header account chip markup has one label mount and one avatar mount", () =
   assert.equal((html.match(/data-account-chip-avatar/g) || []).length, 1);
 });
 
-test("profile renders exactly one avatar for a logged-in account card", () => {
-  const { root } = load([
-    "customer-app/modules/state.js",
-    "customer-app/modules/utils.js",
-    "customer-app/modules/auth.js",
-  ]);
+test("profile renders exactly one avatar and no inline onerror handler", () => {
+  const { root } = load(["customer-app/modules/state.js", "customer-app/modules/utils.js", "customer-app/modules/auth.js"]);
   root.state.customer = { logged_in: true, user: { name: "User", picture: "https://example.test/u.jpg" }, profile: {} };
   const html = root.auth.renderLoginPanel();
   assert.equal((html.match(/<(?:img|span) class="account-avatar"/g) || []).length, 1);
   assert.match(html, /<img class="account-avatar"/);
   assert.doesNotMatch(html, /onerror=/);
-  assert.match(html, /data-avatar-initial=/);
-});
-
-test("Customer App avatar markup has no inline onerror handlers", () => {
-  const sources = [
-    "customer-app/modules/auth.js",
-    "customer-app/modules/ui.js",
-  ].map(file).join("\n");
-  assert.doesNotMatch(sources, /onerror\s*=/i);
 });
 
 test("avatar image fallback keeps valid images and replaces broken images with one initial", () => {
   const { root } = load(["customer-app/modules/state.js", "customer-app/modules/utils.js", "customer-app/modules/auth.js"]);
-  root.state.customer = { logged_in: true, user: { name: "User", picture: "https://example.test/u.jpg" }, profile: {} };
-  const html = root.auth.renderLoginPanel();
-  assert.equal((html.match(/<img class="account-avatar"/g) || []).length, 1);
-  assert.equal((html.match(/class="account-avatar"/g) || []).length, 1);
-
   let errorHandler = null;
   let replacement = null;
   const img = {
@@ -260,9 +287,7 @@ test("avatar image fallback keeps valid images and replaces broken images with o
     dataset: { avatarInitial: "U" },
     complete: false,
     naturalWidth: 1,
-    addEventListener(type, handler) {
-      if (type === "error") errorHandler = handler;
-    },
+    addEventListener(type, handler) { if (type === "error") errorHandler = handler; },
     replaceWith(node) { replacement = node; },
   };
   const container = { querySelectorAll(selector) { return selector === "img[data-avatar-initial]" ? [img] : []; } };
@@ -274,79 +299,14 @@ test("avatar image fallback keeps valid images and replaces broken images with o
   assert.equal(replacement.textContent, "U");
 });
 
-test("saved information prefills empty fields only", () => {
+test("saved address prefills empty fields only and never overwrites typed address", () => {
   const { root } = loadBooking();
   root.state.customer = { logged_in: true, profile: { address: "Saved address", maps_url: "https://maps.google.com/?q=1" } };
   assert.equal(root.state.prefillSavedAddress("scheduled"), true);
   assert.equal(root.state.draft.scheduled.address_text, "Saved address");
-});
-
-test("manual customer edits are not overwritten", () => {
-  const { root } = loadBooking();
-  root.state.customer = { logged_in: true, profile: { address: "Saved address", maps_url: "https://maps.google.com/?q=1" } };
   root.state.updateDraft("scheduled", { address_text: "Typed address", maps_url: "https://maps.google.com/?q=typed" });
   assert.equal(root.state.prefillSavedAddress("scheduled"), false);
   assert.equal(root.state.draft.scheduled.address_text, "Typed address");
-});
-
-test("slot request uses service payload and calculated duration", () => {
-  const { root } = loadBooking();
-  root.state.setScheduledPreview("pricing", { status: "success", data: { duration_min: 75, active_price: 700 }, error: "" });
-  const query = root.bookingScheduled._test.currentAvailabilityQuery();
-  assert.equal(query.duration_min, 75);
-  assert.equal(query.job_type, "ล้าง");
-  assert.equal(query.ac_type, "ผนัง");
-  assert.equal(query.machine_count, 1);
-  assert.match(query.services, /"job_type":"ล้าง"/);
-});
-
-test("technician identity is absent from customer slot output", () => {
-  const { root } = loadBooking();
-  const slots = root.availability.normalizePublicSlots({
-    date: "2026-06-22",
-    duration_min: 60,
-    slots: [{ start: "09:00", end: "11:00", available: true, technician_username: "tech1", team_count: 2 }],
-  }, 60);
-  assert.ok(slots.length > 0);
-  assert.equal("technician_username" in slots[0], false);
-  assert.equal("team_count" in slots[0], false);
-});
-
-test("stale slot cannot be submitted", () => {
-  const { root } = loadBooking();
-  root.state.setScheduledPreview("pricing", { status: "success", data: { duration_min: 60, active_price: 500 }, error: "" });
-  root.state.updateDraft("scheduled", { selectedSlot: { key: "old", date: root.state.draft.scheduled.date, start: "09:00", end: "10:00", query_key: "old" } });
-  root.state.setScheduledPreview("availability", { status: "success", data: { date: root.state.draft.scheduled.date, duration_min: 60, slots: [] }, query_key: "new", error: "" });
-  assert.match(root.bookingScheduled._test.validateSlotStep(), /ข้อมูลล่าสุด|เลือกเวลาใหม่|โหลดคิว/);
-});
-
-test("pricing and slot state reset after service changes", () => {
-  const { root } = loadBooking();
-  root.state.setScheduledPreview("pricing", { status: "success", data: { duration_min: 60 }, error: "" });
-  root.state.setScheduledPreview("availability", { status: "success", data: { slots: [] }, query_key: "x", error: "" });
-  root.services.applyCommerceDraft("scheduled", root.services.commerceItem("cassette"));
-  assert.equal(root.state.scheduledPreview.pricing.status, "idle");
-  assert.equal(root.state.scheduledPreview.availability.status, "idle");
-  assert.equal(root.state.draft.scheduled.selectedSlot, null);
-});
-
-test("/public/book payload retains all required customer-safe fields", () => {
-  const { root } = loadBooking();
-  const date = root.state.draft.scheduled.date;
-  root.state.updateDraft("scheduled", {
-    customer_name: "A",
-    customer_phone: "0812345678",
-    address_text: "Address",
-    maps_url: "https://maps.google.com/?q=1",
-    customer_note: "Parking",
-    job_zone: "Bangna",
-    selectedSlot: { date, start: "09:00", end: "10:00", key: `${date}|09:00|60`, query_key: "q" },
-  });
-  const payload = root.bookingScheduled._test.buildSubmitPayload();
-  for (const key of ["customer_name", "customer_phone", "appointment_datetime", "address_text", "maps_url", "customer_note", "job_zone", "booking_mode", "client_app", "job_type", "service_kind", "ac_type", "btu", "machine_count", "services"]) {
-    assert.ok(Object.prototype.hasOwnProperty.call(payload, key), key);
-  }
-  assert.equal(payload.booking_mode, "scheduled");
 });
 
 test("Customer App does not send Admin-only fields", () => {

--- a/test/customerMultiServiceCalendar.test.js
+++ b/test/customerMultiServiceCalendar.test.js
@@ -1,0 +1,109 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+
+const repoRoot = path.resolve(__dirname, "..");
+const source = fs.readFileSync(path.join(repoRoot, "index.js"), "utf8").replace(/\r\n/g, "\n");
+const customerAvailability = require("../server/services/public/customerAvailability");
+
+function section(start, end) {
+  const from = source.indexOf(start);
+  assert.notEqual(from, -1, `missing section start: ${start}`);
+  const to = source.indexOf(end, from + start.length);
+  assert.notEqual(to, -1, `missing section end: ${end}`);
+  return source.slice(from, to);
+}
+
+test("calendar route is public-safe and mounted through shared availability helper", () => {
+  const calendar = section('app.get("/public/availability_calendar_v2"', '// Admin: availability by technician');
+  assert.match(calendar, /customerAvailability\.computeCalendarSummary/);
+  assert.doesNotMatch(calendar, /username|technician_name|technician_id|tech_count|available_count|capacity|matrix_json/);
+  assert.match(calendar, /month/);
+  assert.match(calendar, /duration_min/);
+});
+
+test("public availability and public booking share the customer availability helper", () => {
+  const availability = section('app.get("/public/availability_v2"', 'app.get("/public/availability_calendar_v2"');
+  const booking = section('app.post("/public/book"', 'app.get("/public/track"');
+  assert.match(availability, /customerAvailability\.computePublicCustomerSlots/);
+  assert.match(booking, /customerAvailability\.hasAvailableStart/);
+});
+
+test("public book validates and persists allow_time_proposal as a jobs column", () => {
+  const booking = section('app.post("/public/book"', 'app.get("/public/track"');
+  assert.match(booking, /allow_time_proposal/);
+  assert.match(booking, /allowTimeProposal == null/);
+  assert.match(booking, /booking_mode, allow_time_proposal\)/);
+  assert.match(booking, /\$13,\$15\)/);
+  assert.match(booking, /allowTimeProposal/);
+  assert.doesNotMatch(booking, /customer_note\s*[:=][\s\S]{0,200}allowTimeProposal/);
+});
+
+test("helper rejects incomplete multi-service criteria", () => {
+  const list = customerAvailability.buildCriteriaList({
+    services: [
+      { job_type: "ล้าง", ac_type: "ผนัง", wash_variant: "ล้างธรรมดา" },
+      { job_type: "ล้าง", ac_type: "ผนัง", wash_variant: "" },
+    ],
+  });
+  assert.equal(customerAvailability.validateCriteriaList(list), false);
+});
+
+test("helper requires one technician matrix to support every selected service line", () => {
+  const list = customerAvailability.buildCriteriaList({
+    services: [
+      { job_type: "ล้าง", ac_type: "ผนัง", wash_variant: "ล้างธรรมดา" },
+      { job_type: "ล้าง", ac_type: "ผนัง", wash_variant: "ล้างพรีเมียม" },
+      { job_type: "ล้าง", ac_type: "สี่ทิศทาง", wash_variant: "" },
+    ],
+  });
+  assert.equal(customerAvailability.validateCriteriaList(list), true);
+  assert.equal(customerAvailability.techMatchesAllCriteriaStrict({
+    job_types: { wash: true },
+    ac_types: { wall: true, fourway: true },
+    wash_wall_variants: { normal: true, premium: false },
+  }, list), false);
+  assert.equal(customerAvailability.techMatchesAllCriteriaStrict({
+    job_types: { wash: true },
+    ac_types: { wall: true, fourway: true },
+    wash_wall_variants: { normal: true, premium: true },
+  }, list), true);
+});
+
+test("calendar summary contains only date availability and first available start", async () => {
+  const deps = {
+    pool: {
+      async query(sql) {
+        if (String(sql).includes("technician_service_matrix")) return { rows: [{ username: "tech-a", matrix_json: { job_types: { wash: true }, ac_types: { wall: true }, wash_wall_variants: { normal: true } } }] };
+        if (String(sql).includes("technician_special_slots_v2")) return { rows: [] };
+        return { rows: [] };
+      },
+    },
+    listTechniciansByType: async () => [{ username: "tech-a", customer_slot_visible: true, work_start: "09:00", work_end: "10:00", weekly_off_days: "" }],
+    buildOffMapForDate: async () => new Map(),
+    isTechOffOnDate: () => false,
+    buildTechWindowsMin: () => [{ startMin: 540, endMin: 600 }],
+    listBusyBlocksForTechOnDate: async () => [],
+    buildStartIntervalsByCollision: () => [{ startMin: 540, endMin: 540 }],
+    toMin(value) {
+      const [h, m] = value.split(":").map(Number);
+      return h * 60 + m;
+    },
+    minToHHMM(value) {
+      return `${String(Math.floor(value / 60)).padStart(2, "0")}:${String(value % 60).padStart(2, "0")}`;
+    },
+    getNowBangkokParts: () => ({ Y: "2026", M: "06", D: "01", hh: 8, mm: 0 }),
+  };
+  const summary = await customerAvailability.computeCalendarSummary(deps, {
+    month: "2026-06",
+    duration_min: 60,
+    tech_type: "company",
+    services: [{ job_type: "ล้าง", ac_type: "ผนัง", wash_variant: "ล้างธรรมดา" }],
+  });
+  assert.equal(summary.month, "2026-06");
+  assert.equal(summary.days[0].date, "2026-06-01");
+  assert.equal(summary.days[0].available, true);
+  assert.equal(summary.days[0].first_available, "09:00");
+  assert.deepEqual(Object.keys(summary.days[0]).sort(), ["available", "date", "first_available"]);
+});


### PR DESCRIPTION
## Proposal
- Replace the scheduled booking draft's single grouped service model with a persisted `services[]` line model while keeping legacy top-level service fields from the first line for compatibility.
- Send the full normalized service list to pricing preview, calendar availability, selected-day slots, and public booking submit.
- Add a bounded `/public/availability_calendar_v2` summary route that uses the same public customer availability helper as day slots and scheduled booking revalidation.
- Filter public customer slots to technicians explicitly visible to customers, not off that date, with Service Matrix support for every selected service line and wall cleaning method.
- Persist the customer's exact/flexible time preference as `jobs.allow_time_proposal`.

## Changes
- Multi-service scheduled wizard with separate editable service-line cards, add/remove, draft persistence, five active steps, combined pricing, calendar states, real slot ranges, and time preference review.
- Public calendar/day availability helper under `server/services/public/customerAvailability.js` with no technician PII in public responses.
- `/public/book` scheduled Customer App revalidation now uses the shared helper and persists `allow_time_proposal`.
- Focused frontend/backend tests for services payloads, calendar safety, matrix matching, stale slot invalidation, and time preference persistence.

## Validation
- `node --check customer-app/modules/state.js customer-app/modules/services.js customer-app/modules/bookingScheduled.js customer-app/modules/availability.js customer-app/modules/api.js customer-app/modules/ui.js`
- `node --check server/services/public/customerAvailability.js index.js`
- `node --test test/customerAppThreeStepBooking.test.js`
- `node --test test/customerAppRecovery.test.js`
- `node --test test/customerMultiServiceCalendar.test.js test/customerSlotBoundary.test.js`
- `npm test` -> 103 passing
- `git diff --check` and `git diff --cached --check`

## Browser QA
Temporary Playwright harness against local Customer App files with mocked public customer endpoints at 320px, 360px, 390px, and 430px:
- Home booking card opened scheduled Step 1.
- All six service categories visible.
- Logged-in state hid guest/login controls.
- Header/profile avatar rendered as an image with no visible overlap.
- Scenario A built three separate service lines: 2x wall 12,000 normal, 1x wall 18,000 premium, 1x four-way 24,000.
- Combined price and duration shown; calendar showed available/full state; selected slot showed 09:00-12:30.
- No technician identity text appeared.
- Submit payload contained 3 service lines and `allow_time_proposal=false`.
- No horizontal overflow and no console errors at all four widths.

## Scope Mismatch
- None. No migration, schema change, payment, tracking, urgent, LINE webhook, or package dependency change.

## Remaining Risks
- Browser QA used mocked public endpoint responses to avoid touching production data; database-backed availability behavior is covered by focused helper/source tests rather than live production data.