### PR TITLE
Fix Customer V2 advance slots, 3-step booking, and draft approval

### DIFF
--- a/admin-review-v2.html
+++ b/admin-review-v2.html
@@ -167,7 +167,7 @@
   </div>
 
   <script src="admin-v2-common.js?v=20260428_allpages_ui1"></script>
-  <script src="admin-review-v2.js?v=20260612_phase35a_review_queue_dedup"></script>
+  <script src="admin-review-v2.js?v=20260621_draft_reservation_v1"></script>
   <script src="admin-review-ai-intake.js?v=ai-booking-intake-customer-cards-v10"></script>
 </body>
 </html>

--- a/admin-review-v2.js
+++ b/admin-review-v2.js
@@ -427,7 +427,7 @@ async function openJob(jobId){
 
     // fill
     $("mTitle").textContent = `ตรวจงาน #${CURRENT.job_id}`;
-    $("mSub").textContent = `${safe(CURRENT.booking_code||"")} • สถานะ: ${safe(CURRENT.job_status||"")}`;
+    $("mSub").textContent = `${safe(CURRENT.booking_code||"")} • สถานะ: ${safe(CURRENT.job_status||"")}${CURRENT.job_status === "รอตรวจสอบ" && CURRENT.technician_username ? ` • ร่างจองช่าง: ${safe(CURRENT.technician_username)}` : ""}`;
 
     $("mCustomerName").value = safe(CURRENT.customer_name||"");
     $("mCustomerPhone").value = safe(CURRENT.customer_phone||"");

--- a/admin-technicians-v2.html
+++ b/admin-technicians-v2.html
@@ -242,6 +242,14 @@
             <label class="pill" style="gap:10px;justify-content:flex-start"><input id="cap_wash_coil" type="checkbox" style="width:18px;height:18px"> แขวนคอยล์</label>
             <label class="pill" style="gap:10px;justify-content:flex-start"><input id="cap_wash_overhaul" type="checkbox" style="width:18px;height:18px"> ตัดล้าง</label>
           </div>
+
+          <div class="muted" style="margin:12px 0 8px 0">ประเภทงานซ่อม</div>
+          <div class="grid2">
+            <label class="pill" style="gap:10px;justify-content:flex-start"><input id="cap_repair_leak_check" type="checkbox" style="width:18px;height:18px"> เช็ครั่ว</label>
+            <label class="pill" style="gap:10px;justify-content:flex-start"><input id="cap_repair_inspection" type="checkbox" style="width:18px;height:18px"> ตรวจอาการ</label>
+            <label class="pill" style="gap:10px;justify-content:flex-start"><input id="cap_repair_parts" type="checkbox" style="width:18px;height:18px"> อะไหล่</label>
+            <label class="pill" style="gap:10px;justify-content:flex-start"><input id="cap_repair_general" type="checkbox" style="width:18px;height:18px"> ซ่อมทั่วไป</label>
+          </div>
         </div>
 
         <div style="margin-top:14px;display:flex;gap:8px;flex-wrap:wrap">
@@ -253,6 +261,6 @@
   </div>
 
   <script src="admin-v2-common.js?v=20260428_allpages_ui1"></script>
-  <script src="admin-technicians-v2.js"></script>
+  <script src="admin-technicians-v2.js?v=20260621_repair_matrix_v1"></script>
 </body>
 </html>

--- a/admin-technicians-v2.js
+++ b/admin-technicians-v2.js
@@ -13,6 +13,7 @@
     const jt = mx.job_types || {};
     const at = mx.ac_types || {};
     const wv = mx.wash_wall_variants || {};
+    const rv = mx.repair_variants || {};
     setCap('cap_job_install', jt.install);
     setCap('cap_job_wash', jt.wash);
     setCap('cap_job_repair', jt.repair);
@@ -24,6 +25,10 @@
     setCap('cap_wash_premium', wv.premium);
     setCap('cap_wash_coil', wv.coil);
     setCap('cap_wash_overhaul', wv.overhaul);
+    setCap('cap_repair_leak_check', rv.leak_check);
+    setCap('cap_repair_inspection', rv.inspection);
+    setCap('cap_repair_parts', rv.parts);
+    setCap('cap_repair_general', rv.general);
     updateMatrixSummary();
   }
 
@@ -32,16 +37,19 @@
     const jt = mx.job_types || {};
     const at = mx.ac_types || {};
     const wv = mx.wash_wall_variants || {};
+    const rv = mx.repair_variants || {};
     const pick = (obj, map) => Object.keys(map).filter(k=>obj && obj[k]).map(k=>map[k]);
     const jobs = pick(jt, {install:'ติดตั้ง', wash:'ล้าง', repair:'ซ่อม'});
     const acs = pick(at, {wall:'ผนัง', fourway:'สี่ทิศทาง', hanging:'แขวน', ceiling:'ใต้ฝ้า/เปลือย'});
     const wss = pick(wv, {normal:'ธรรมดา', premium:'พรีเมียม', coil:'แขวนคอยล์', overhaul:'ตัดล้าง'});
-    const any = jobs.length || acs.length || wss.length;
+    const reps = pick(rv, {leak_check:'เช็ครั่ว', inspection:'ตรวจอาการ', parts:'อะไหล่', general:'ซ่อมทั่วไป'});
+    const any = jobs.length || acs.length || wss.length || reps.length;
     if (!any) return 'ยังไม่ได้เลือกงานที่รับได้ (จะไม่แสดงในสลอตลูกค้า)';
     const parts = [];
     if (jobs.length) parts.push(`งาน: ${jobs.join(', ')}`);
     if (acs.length) parts.push(`แอร์: ${acs.join(', ')}`);
     if (wss.length) parts.push(`ล้างผนัง: ${wss.join(', ')}`);
+    if (reps.length) parts.push(`ซ่อม: ${reps.join(', ')}`);
     return parts.join(' • ');
   }
 
@@ -69,9 +77,21 @@
       coil: getCap('cap_wash_coil'),
       overhaul: getCap('cap_wash_overhaul'),
     };
+    const rv = {
+      leak_check: getCap('cap_repair_leak_check'),
+      inspection: getCap('cap_repair_inspection'),
+      parts: getCap('cap_repair_parts'),
+      general: getCap('cap_repair_general'),
+    };
 
     // ✅ Spec: If not tick anything => DO NOT show in customer slots
-    return { job_types: jt, ac_types: at, wash_wall_variants: wv };
+    return {
+      ...(currentMatrix && typeof currentMatrix === 'object' ? currentMatrix : {}),
+      job_types: { ...((currentMatrix && currentMatrix.job_types) || {}), ...jt },
+      ac_types: { ...((currentMatrix && currentMatrix.ac_types) || {}), ...at },
+      wash_wall_variants: { ...((currentMatrix && currentMatrix.wash_wall_variants) || {}), ...wv },
+      repair_variants: { ...((currentMatrix && currentMatrix.repair_variants) || {}), ...rv },
+    };
   }
 
   function openMatrix(){
@@ -83,7 +103,7 @@
     if ($('matrixModal')) $('matrixModal').style.display = 'none';
   }
   function clearMatrix(){
-    ['cap_job_install','cap_job_wash','cap_job_repair','cap_ac_wall','cap_ac_fourway','cap_ac_hanging','cap_ac_ceiling','cap_wash_normal','cap_wash_premium','cap_wash_coil','cap_wash_overhaul']
+    ['cap_job_install','cap_job_wash','cap_job_repair','cap_ac_wall','cap_ac_fourway','cap_ac_hanging','cap_ac_ceiling','cap_wash_normal','cap_wash_premium','cap_wash_coil','cap_wash_overhaul','cap_repair_leak_check','cap_repair_inspection','cap_repair_parts','cap_repair_general']
       .forEach(id=>{ const el=$(id); if(el) el.checked=false; });
     updateMatrixSummary();
   }
@@ -341,7 +361,7 @@
   if ($('btnClearMatrix')) $('btnClearMatrix').addEventListener('click', clearMatrix);
 
   // update summary when toggling caps
-  ['cap_job_install','cap_job_wash','cap_job_repair','cap_ac_wall','cap_ac_fourway','cap_ac_hanging','cap_ac_ceiling','cap_wash_normal','cap_wash_premium','cap_wash_coil','cap_wash_overhaul']
+    ['cap_job_install','cap_job_wash','cap_job_repair','cap_ac_wall','cap_ac_fourway','cap_ac_hanging','cap_ac_ceiling','cap_wash_normal','cap_wash_premium','cap_wash_coil','cap_wash_overhaul','cap_repair_leak_check','cap_repair_inspection','cap_repair_parts','cap_repair_general']
     .forEach(id=>{ const el=$(id); if(el) el.addEventListener('change', updateMatrixSummary); });
   $('btnUploadPhoto').addEventListener('click', ()=> uploadTechPhoto().catch(e=>showToast(e.message||'อัปโหลดไม่สำเร็จ','error')));
   $('btnOpenSpecial').addEventListener('click', ()=>{

--- a/app.js
+++ b/app.js
@@ -4992,6 +4992,7 @@ function buildJobCard(job, historyMode = false) {
   if (job && job.job_id != null) div.setAttribute("data-jobid", String(job.job_id));
 
   const status = normStatus(job.job_status) || "รอดำเนินการ";
+  const isDraftJob = status === "รอตรวจสอบ" || status === "pending_review";
 
   const badge = technicianJobStatusBadge(job);
 
@@ -5011,13 +5012,13 @@ function buildJobCard(job, historyMode = false) {
   const isWorking = status === "กำลังทำ";
   const revisitFlow = isRevisitJob(job);
   const revisitReason = String(job.return_reason || "").trim();
-  const canEdit = !historyMode && (status === "รอดำเนินการ" || status === "กำลังทำ" || status === "งานแก้ไข");
+  const canEdit = !isDraftJob && !historyMode && (status === "รอดำเนินการ" || status === "กำลังทำ" || status === "งานแก้ไข");
   const paymentSettled = revisitFlow ? false : paid;
 
   // ✅ ปุ่มอัปเดตสถานะ (ปุ่มเดียว) + e-slip (ขั้นตอนสุดท้าย)
   // - งานประวัติ: ปุ่มนี้จะกลายเป็น "🧾 e-slip" อย่างเดียว (ดูได้ตลอดถ้าจ่ายแล้ว)
   // - งานแก้ไข: อย่าให้สถานะ paid เดิมจากงานรอบแรก มาบัง flow การกลับไปแก้
-  const workflowDisabled = historyMode
+  const workflowDisabled = isDraftJob || historyMode
     ? !paid
     : (revisitFlow && isWorking
         ? true
@@ -5086,6 +5087,7 @@ function buildJobCard(job, historyMode = false) {
         <span style="width:42px;height:42px;border-radius:14px;background:#ccfbf1;display:flex;align-items:center;justify-content:center;font-size:22px;">🔁</span>
         <div><b style="display:block;color:#0f172a;">งานรับผิดชอบเคสเดิม</b><span class="muted">งานนี้ไม่มีค่าบริการที่ต้องเก็บจากลูกค้า และไม่มีค่าตอบแทนเพิ่มเติม</span></div>
       </div>` : renderTechnicianMoneySummary(job, historyMode ? "history" : "current")}
+    ${isDraftJob ? `<div class="pill" style="margin-top:10px;background:#fff7ed;border-color:rgba(234,88,12,0.18);color:#7c2d12;display:block;border-radius:16px;line-height:1.55;"><b>ร่างงาน — รอแอดมินอนุมัติ</b><br><span>ดูข้อมูลเพื่อเตรียมตัวได้ แต่ยังโทรลูกค้า เปิดแผนที่ เริ่มเดินทาง เช็กอิน เริ่มงาน ลงรูป เก็บเงิน หรือปิดงานไม่ได้</span></div>` : ``}
 
     <p style="margin-top:8px;"><b>ลูกค้า:</b> ${escape(job.customer_name || "-")}</p>
     <p><b>โทร:</b> ${escape(job.customer_phone || "-")}</p>
@@ -5103,12 +5105,12 @@ function buildJobCard(job, historyMode = false) {
       <div style="margin-top:10px;">
         <!-- ✅ แถวปุ่มโทร: กดได้ตลอด -->
         <div class="row" style="gap:10px;flex-wrap:wrap;">
-          <button class="secondary" type="button" style="width:auto;" ${telPhone ? "" : "disabled"} onclick="callCustomer('${jobKeyJs}', '${telPhone}')">📞 โทรลูกค้า</button>
+          <button class="secondary" type="button" style="width:auto;" ${telPhone && !isDraftJob ? "" : "disabled"} onclick="callCustomer('${jobKeyJs}', '${telPhone}')">📞 โทรลูกค้า</button>
         </div>
 
         <!-- ✅ แถวปุ่มแผนที่: อยู่ใต้ปุ่มโทร และกดดูได้ตลอด -->
         <div class="row" style="margin-top:10px;gap:10px;flex-wrap:wrap;">
-          <button class="secondary" type="button" style="width:auto;" data-role="job-map" data-jobkey="${escapeAttr(keyBase)}" ${((job.address_text || job.maps_url || (job.gps_latitude != null && job.gps_longitude != null)) ? "" : "disabled")} onclick="openJobMap(${jobKeyArg})">🧭 แผนที่</button>
+          <button class="secondary" type="button" style="width:auto;" data-role="job-map" data-jobkey="${escapeAttr(keyBase)}" ${(!isDraftJob && (job.address_text || job.maps_url || (job.gps_latitude != null && job.gps_longitude != null)) ? "" : "disabled")} onclick="openJobMap(${jobKeyArg})">🧭 แผนที่</button>
         </div>
 
         <!-- ✅ ปุ่มอัปเดตสถานะ / e-slip (ปุ่มเดียว) -->

--- a/customer-app/assets/customer-app.css
+++ b/customer-app/assets/customer-app.css
@@ -3144,6 +3144,14 @@ img.account-avatar {
 
 .booking-stepper li.is-done:not(:last-child)::after { background: var(--success); }
 
+.section-head-compact { margin-top: 0; }
+.section-head-compact h2 { font-size: 1.08rem; }
+.slot-section-divider {
+  height: 1px;
+  margin: 18px 0;
+  background: rgba(15, 23, 42, 0.10);
+}
+
 .booking-wizard-card {
   display: grid;
   gap: 16px;

--- a/customer-app/assets/customer-app.js
+++ b/customer-app/assets/customer-app.js
@@ -3,7 +3,7 @@
 
   const App = window.CWFCustomerAppV2;
   const BOOT_TIMEOUT_MS = 3500;
-  const BUILD_ID = "20260621_three_step_booking_v1";
+  const BUILD_ID = "20260621_advance_slots_three_step_draft_v1";
 
   function withTimeout(promise, timeoutMs) {
     return Promise.race([

--- a/customer-app/index.html
+++ b/customer-app/index.html
@@ -9,10 +9,10 @@
   <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
   <meta name="apple-mobile-web-app-title" content="CWF Service">
   <title>CWF Customer Service</title>
-  <link rel="manifest" href="./manifest.webmanifest?v=20260621_three_step_booking_v1">
+  <link rel="manifest" href="./manifest.webmanifest?v=20260621_advance_slots_three_step_draft_v1">
   <link rel="icon" type="image/png" sizes="192x192" href="./assets/icons/cwf-customer-192.png">
   <link rel="apple-touch-icon" sizes="180x180" href="./assets/icons/cwf-customer-180.png">
-  <link rel="stylesheet" href="./assets/customer-app.css?v=20260621_three_step_booking_v1">
+  <link rel="stylesheet" href="./assets/customer-app.css?v=20260621_advance_slots_three_step_draft_v1">
 </head>
 <body class="is-app-booting">
   <div class="app-shell" data-app-shell>
@@ -49,19 +49,19 @@
     </nav>
   </div>
 
-  <script src="./modules/state.js?v=20260621_three_step_booking_v1"></script>
-  <script src="./modules/utils.js?v=20260621_three_step_booking_v1"></script>
-  <script src="./modules/api.js?v=20260621_three_step_booking_v1"></script>
-  <script src="./modules/services.js?v=20260621_three_step_booking_v1"></script>
-  <script src="./modules/ui.js?v=20260621_three_step_booking_v1"></script>
-  <script src="./modules/auth.js?v=20260621_three_step_booking_v1"></script>
-  <script src="./modules/pricing.js?v=20260621_three_step_booking_v1"></script>
-  <script src="./modules/availability.js?v=20260621_three_step_booking_v1"></script>
-  <script src="./modules/bookingScheduled.js?v=20260621_three_step_booking_v1"></script>
-  <script src="./modules/bookingUrgent.js?v=20260621_three_step_booking_v1"></script>
-  <script src="./modules/tracking.js?v=20260621_three_step_booking_v1"></script>
-  <script src="./modules/profile.js?v=20260621_three_step_booking_v1"></script>
-  <script src="./modules/router.js?v=20260621_three_step_booking_v1"></script>
-  <script src="./assets/customer-app.js?v=20260621_three_step_booking_v1"></script>
+  <script src="./modules/state.js?v=20260621_advance_slots_three_step_draft_v1"></script>
+  <script src="./modules/utils.js?v=20260621_advance_slots_three_step_draft_v1"></script>
+  <script src="./modules/api.js?v=20260621_advance_slots_three_step_draft_v1"></script>
+  <script src="./modules/services.js?v=20260621_advance_slots_three_step_draft_v1"></script>
+  <script src="./modules/ui.js?v=20260621_advance_slots_three_step_draft_v1"></script>
+  <script src="./modules/auth.js?v=20260621_advance_slots_three_step_draft_v1"></script>
+  <script src="./modules/pricing.js?v=20260621_advance_slots_three_step_draft_v1"></script>
+  <script src="./modules/availability.js?v=20260621_advance_slots_three_step_draft_v1"></script>
+  <script src="./modules/bookingScheduled.js?v=20260621_advance_slots_three_step_draft_v1"></script>
+  <script src="./modules/bookingUrgent.js?v=20260621_advance_slots_three_step_draft_v1"></script>
+  <script src="./modules/tracking.js?v=20260621_advance_slots_three_step_draft_v1"></script>
+  <script src="./modules/profile.js?v=20260621_advance_slots_three_step_draft_v1"></script>
+  <script src="./modules/router.js?v=20260621_advance_slots_three_step_draft_v1"></script>
+  <script src="./assets/customer-app.js?v=20260621_advance_slots_three_step_draft_v1"></script>
 </body>
 </html>

--- a/customer-app/manifest.webmanifest
+++ b/customer-app/manifest.webmanifest
@@ -2,7 +2,7 @@
   "name": "CWF Customer Service",
   "short_name": "CWF Service",
   "description": "แอปลูกค้า Coldwindflow สำหรับเลือกบริการ จองคิว และติดตามงาน",
-  "start_url": "/customer-app/index.html?v=20260621_three_step_booking_v1#home",
+  "start_url": "/customer-app/index.html?v=20260621_advance_slots_three_step_draft_v1#home",
   "scope": "/customer-app/",
   "id": "/customer-app/",
   "display": "standalone",

--- a/customer-app/modules/bookingScheduled.js
+++ b/customer-app/modules/bookingScheduled.js
@@ -3,7 +3,7 @@
 
   const root = window.CWFCustomerAppV2 = window.CWFCustomerAppV2 || {};
   const MAX_ADVANCE_DAYS = 90;
-  const STEP_MAX = 5;
+  const STEP_MAX = 3;
   let availabilityRequestSeq = 0;
   let calendarRequestSeq = 0;
 
@@ -165,10 +165,10 @@
   }
 
   function renderProgress() {
-    const labels = ["ข้อมูลลูกค้า", "รายการบริการ", "ราคา", "วันและเวลา", "ยืนยัน"];
+    const labels = ["บริการและราคา", "ข้อมูลหน้างานและคิว", "ตรวจสอบและยืนยัน"];
     const current = step();
     return `
-      <ol class="booking-stepper booking-stepper-five" aria-label="ขั้นตอนจองล้างแอร์">
+      <ol class="booking-stepper" aria-label="ขั้นตอนจองล้างแอร์">
         ${labels.map((label, index) => {
           const n = index + 1;
           const status = n < current ? "is-done" : (n === current ? "is-active" : "");
@@ -182,11 +182,11 @@
     const d = draft();
     const saved = root.state.savedAddress();
     return `
-      <section class="card booking-wizard-card" data-booking-step="1">
+      <section class="card booking-wizard-card" data-booking-step="2">
         <div class="section-head">
-          <span class="section-kicker">ขั้นตอน 1 จาก 5</span>
-          <h2>ข้อมูลลูกค้า</h2>
-          <p class="muted">กรอกข้อมูลสำหรับติดต่อ เดินทาง และเตรียมเข้าบริการ</p>
+          <span class="section-kicker">ขั้นตอน 2 จาก 3</span>
+          <h2>ข้อมูลหน้างานและคิว</h2>
+          <p class="muted">กรอกข้อมูลสำหรับติดต่อ เดินทาง เลือกวันที่ และเลือกช่วงเวลาว่างจริง</p>
         </div>
         <div class="form-grid">
           <div class="field">
@@ -215,6 +215,17 @@
           </div>
         </div>
         ${saved.address && !String(d.address_text || "").trim() ? `<button type="button" class="secondary-btn" data-action="use-saved-address">ใช้ที่อยู่ที่บันทึกไว้</button>` : ""}
+        <div class="slot-section-divider"></div>
+        <div class="section-head section-head-compact">
+          <h2>ปฏิทิน วัน เวลา และเงื่อนไขการเสนอเวลา</h2>
+          <p class="muted">เลือกวันที่มีคิวและช่วงเวลาว่างจริงสำหรับรายการทั้งหมด</p>
+        </div>
+        ${renderCalendar()}
+        <div class="slot-section" data-availability-preview>${renderSlots()}</div>
+        <div class="field field-wide">
+          <label>หากเวลาที่เลือกมีการเปลี่ยนแปลง</label>
+          ${renderTimePreference()}
+        </div>
       </section>
     `;
   }
@@ -260,16 +271,38 @@
   function renderStepServices() {
     const lines = services();
     return `
-      <section class="card booking-wizard-card" data-booking-step="2">
+      <section class="card booking-wizard-card" data-booking-step="1">
         <div class="section-head">
-          <span class="section-kicker">ขั้นตอน 2 จาก 5</span>
-          <h2>รายการบริการ/เครื่องทั้งหมด</h2>
+          <span class="section-kicker">ขั้นตอน 1 จาก 3</span>
+          <h2>บริการและราคา</h2>
           <p class="muted">เพิ่มรายการแยกตามชนิดแอร์ BTU จำนวน และวิธีล้าง</p>
         </div>
         <div class="service-line-list">
           ${lines.map(renderServiceLineCard).join("")}
         </div>
         <button type="button" class="secondary-btn" data-action="add-line">+ เพิ่มเครื่อง / เพิ่มรายการ</button>
+        <div class="slot-section-divider"></div>
+        <div class="section-head section-head-compact">
+          <h2>ราคาและระยะเวลารวม</h2>
+          <p class="muted">ราคาเป็นราคาประเมินจากรายการที่เลือก แอดมินจะตรวจสอบอีกครั้งก่อนยืนยันคิว</p>
+        </div>
+        <div class="service-line-review-list">
+          ${lines.map((line, index) => {
+            const summary = root.services.serviceLineSummary(line, index);
+            const priceLine = priceLineFor(index);
+            const linePrice = priceLine && (priceLine.line_total != null || priceLine.total != null)
+              ? root.utils.formatBaht(priceLine.line_total ?? priceLine.total)
+              : "-";
+            return `
+              <div class="service-summary-box">
+                <span>${root.utils.escapeHtml(summary.title)}</span>
+                <strong>${root.utils.escapeHtml(summary.line1)}</strong>
+                <small>${root.utils.escapeHtml(summary.line2)} · ${root.utils.escapeHtml(linePrice)}</small>
+              </div>
+            `;
+          }).join("")}
+        </div>
+        ${renderPricingSummary()}
       </section>
     `;
   }
@@ -503,14 +536,14 @@
     const submit = root.state.scheduledSubmit;
     const pending = ["validating", "checking_slot", "submitting"].includes(submit.status);
     return `
-      <section class="card booking-wizard-card review-card" data-booking-step="5">
+      <section class="card booking-wizard-card review-card" data-booking-step="3">
         <div class="section-head">
-          <span class="section-kicker">ขั้นตอน 5 จาก 5</span>
+          <span class="section-kicker">ขั้นตอน 3 จาก 3</span>
           <h2>ตรวจสอบและยืนยัน</h2>
           <p class="muted">ตรวจข้อมูลทั้งหมดก่อนส่งคำขอจอง</p>
         </div>
         ${renderReviewRows()}
-        <div class="notice">การส่งรายการนี้เป็นคำขอจองล้างแอร์ล่วงหน้า ระบบจะสร้างรหัสติดตามจากข้อมูลจริงหลังส่งสำเร็จ</div>
+        <div class="notice">การส่งรายการนี้เป็นคำขอจองล้างแอร์ล่วงหน้า แอดมินจะตรวจสอบและยืนยันคิวอีกครั้ง</div>
         ${submit.status === "checking_slot" ? root.utils.stateBox("loading", "กำลังตรวจคิวล่าสุด...") : ""}
         ${submit.status === "submitting" ? root.utils.stateBox("loading", "กำลังส่งข้อมูลจอง...") : ""}
         ${submit.status === "error" ? root.utils.stateBox("error", submit.error || "ส่งคำขอจองไม่สำเร็จ") : ""}
@@ -528,7 +561,7 @@
         <div class="success-mark">✓</div>
         <span class="section-kicker">ส่งคำขอแล้ว</span>
         <h2>ส่งคำขอจองเรียบร้อย</h2>
-        <div class="state-box is-success">ระบบสร้างรหัสติดตามจากข้อมูลจริงแล้ว โปรดเก็บรหัสไว้เพื่อติดตามสถานะและการยืนยันงาน</div>
+        <div class="state-box is-success">รอแอดมินตรวจสอบและยืนยันคิว โปรดเก็บรหัสนี้ไว้เพื่อติดตามสถานะงาน</div>
         <div class="data-list">
           <div class="data-row"><strong>Booking Code</strong><span class="booking-code-value">${root.utils.escapeHtml(result.booking_code || "-")}</span></div>
           <div class="data-row"><strong>วันและเวลา</strong><span class="muted">${root.utils.escapeHtml(selected.date || draft().date || "-")} · ${root.utils.escapeHtml(selected.start || "-")}-${root.utils.escapeHtml(selected.end || "-")} น.</span></div>
@@ -704,14 +737,6 @@
     const current = step();
     root.state.setScheduledWizard({ error: "" });
     if (current === 1) {
-      const error = validateContactStep();
-      if (error) { root.state.setScheduledWizard({ error }); paint(container); scrollToWizardTop(container); return; }
-      root.state.setScheduledWizard({ step: 2, error: "" });
-      paint(container);
-      scrollToWizardTop(container);
-      return;
-    }
-    if (current === 2) {
       const error = validateServiceStep();
       if (error) { root.state.setScheduledWizard({ error }); paint(container); scrollToWizardTop(container); return; }
       try { await refreshPricing(container); }
@@ -721,25 +746,17 @@
         scrollToWizardTop(container);
         return;
       }
-      root.state.setScheduledWizard({ step: 3, error: "" });
-      paint(container);
-      scrollToWizardTop(container);
-      return;
-    }
-    if (current === 3) {
-      const error = validatePricingStep();
-      if (error) { root.state.setScheduledWizard({ error }); paint(container); scrollToWizardTop(container); return; }
-      root.state.setScheduledWizard({ step: 4, error: "" });
+      root.state.setScheduledWizard({ step: 2, error: "" });
       paint(container);
       scrollToWizardTop(container);
       await refreshCalendar(container);
       await refreshAvailability(container);
       return;
     }
-    if (current === 4) {
-      const error = validateSlotStep();
+    if (current === 2) {
+      const error = validateContactStep() || validatePricingStep() || validateSlotStep();
       if (error) { root.state.setScheduledWizard({ error }); paint(container); scrollToWizardTop(container); return; }
-      root.state.setScheduledWizard({ step: 5, error: "" });
+      root.state.setScheduledWizard({ step: 3, error: "" });
       paint(container);
       scrollToWizardTop(container);
     }
@@ -765,7 +782,7 @@
     if (contactError || serviceError || pricingError || slotError || !payload.appointment_datetime) {
       const error = contactError || serviceError || pricingError || slotError || "ข้อมูลจองไม่ครบ";
       root.state.setScheduledSubmit({ status: "error", error, result: null });
-      root.state.setScheduledWizard({ step: contactError ? 1 : serviceError ? 2 : pricingError ? 3 : 4, error });
+      root.state.setScheduledWizard({ step: serviceError ? 1 : 2, error });
       if (slotError) root.state.updateDraft("scheduled", { selectedSlot: null });
       paint(container);
       scrollToWizardTop(container);
@@ -780,14 +797,17 @@
       const result = await root.api.submitScheduledBooking(buildSubmitPayload());
       if (!result?.success || (!result.booking_code && !result.token)) throw new Error("ระบบไม่ได้ส่งรหัสติดตามกลับมา");
       root.state.setScheduledSubmit({ status: "success", error: "", result });
-      try { window.sessionStorage.removeItem("cwf_customer_app_v2_scheduled_v4"); } catch (_) { /* ignore */ }
+      try {
+        window.sessionStorage.removeItem("cwf_customer_app_v2_scheduled_v5");
+        window.sessionStorage.removeItem("cwf_customer_app_v2_scheduled_v4");
+      } catch (_) { /* ignore */ }
       paint(container);
       scrollToWizardTop(container);
     } catch (error) {
       root.state.setScheduledSubmit({ status: "error", error: error.message || "ส่งคำขอจองไม่สำเร็จ", result: null });
       if (Number(error.status) === 400 || Number(error.status) === 409) {
         root.state.updateDraft("scheduled", { selectedSlot: null });
-        root.state.setScheduledWizard({ step: 4, error: "คิวที่เลือกอาจเต็มแล้ว กรุณาเลือกช่วงเวลาใหม่" });
+        root.state.setScheduledWizard({ step: 2, error: "คิวที่เลือกอาจเต็มแล้ว กรุณาเลือกช่วงเวลาใหม่" });
       }
       paint(container);
       scrollToWizardTop(container);
@@ -797,14 +817,12 @@
   function renderActions() {
     if (root.state.scheduledSubmit.status === "success") return "";
     const current = step();
-    if (current === 5) {
+    if (current === 3) {
       return `<div class="wizard-action-bar"><button type="button" class="secondary-btn" data-action="wizard-back">ย้อนกลับ</button></div>`;
     }
     const nextLabels = {
-      1: "ต่อไป: รายการบริการ",
-      2: "ต่อไป: ราคา",
-      3: "ต่อไป: เลือกคิว",
-      4: "ต่อไป: ตรวจสอบ",
+      1: "ต่อไป: ข้อมูลหน้างานและคิว",
+      2: "ต่อไป: ตรวจสอบและยืนยัน",
     };
     return `
       <div class="wizard-action-bar">
@@ -821,11 +839,9 @@
     const success = root.state.scheduledSubmit.status === "success";
     const content = success
       ? renderSuccess()
-      : current === 1 ? renderStepContactLocation()
-        : current === 2 ? renderStepServices()
-          : current === 3 ? renderStepPricing()
-            : current === 4 ? renderStepCalendarSlot()
-              : renderStepReview();
+      : current === 1 ? renderStepServices()
+        : current === 2 ? renderStepContactLocation()
+          : renderStepReview();
     container.innerHTML = `
       <div class="page booking-wizard-page">
         <div class="page-toolbar">
@@ -974,9 +990,12 @@
 
   function render(container) {
     paint(container);
-    if (step() === 4 && root.state.scheduledPreview.pricing.data && root.state.scheduledPreview.calendar.status === "idle") {
+    if (step() === 1 && root.state.scheduledPreview.pricing.status === "idle") {
+      refreshPricing(container).catch(() => {});
+    }
+    if (step() === 2 && root.state.scheduledPreview.pricing.data && root.state.scheduledPreview.calendar.status === "idle") {
       refreshCalendar(container);
-    } else if (step() === 4 && root.state.scheduledPreview.pricing.data && root.state.scheduledPreview.availability.status === "idle") {
+    } else if (step() === 2 && root.state.scheduledPreview.pricing.data && root.state.scheduledPreview.availability.status === "idle") {
       refreshAvailability(container);
     }
     root.state.ensureSavedAddressPrefill("scheduled", () => paint(container));

--- a/customer-app/modules/state.js
+++ b/customer-app/modules/state.js
@@ -2,13 +2,14 @@
   "use strict";
 
   const root = window.CWFCustomerAppV2 = window.CWFCustomerAppV2 || {};
-  const SCHEDULED_STORAGE_KEY = "cwf_customer_app_v2_scheduled_v4";
+  const SCHEDULED_STORAGE_KEY = "cwf_customer_app_v2_scheduled_v5";
   const SCHEDULED_LEGACY_STORAGE_KEYS = [
+    "cwf_customer_app_v2_scheduled_v4",
     "cwf_customer_app_v2_scheduled_v3",
     "cwf_customer_app_v2_scheduled_v2",
   ];
   const SCHEDULED_STORAGE_TTL_MS = 7 * 24 * 60 * 60 * 1000;
-  const MAX_SCHEDULED_STEP = 5;
+  const MAX_SCHEDULED_STEP = 3;
 
   function bangkokTodayYmd() {
     try {
@@ -200,7 +201,7 @@
     },
     persistScheduledDraft() {
       const payload = {
-        version: 4,
+        version: 5,
         saved_at: Date.now(),
         step: Math.max(1, Math.min(MAX_SCHEDULED_STEP, Number(this.scheduledWizard?.step || 1))),
         draft: this.draft.scheduled || defaultScheduledDraft(),
@@ -226,7 +227,7 @@
       if (!raw) return false;
       try {
         const parsed = JSON.parse(raw);
-        if (!parsed || (parsed.version !== 1 && parsed.version !== 2 && parsed.version !== 3 && parsed.version !== 4) || !parsed.draft) return false;
+        if (!parsed || ![1, 2, 3, 4, 5].includes(Number(parsed.version)) || !parsed.draft) return false;
         if (!Number.isFinite(parsed.saved_at) || Date.now() - parsed.saved_at > SCHEDULED_STORAGE_TTL_MS) {
           removeScheduledStorage();
           return false;
@@ -250,9 +251,12 @@
         restored.calendar_month = String(restored.calendar_month || restored.date.slice(0, 7));
         this.draft.scheduled = restored;
         const parsedStep = Number(parsed.step || 1);
-        const nextStep = fromLegacy || parsed.version < 4
-          ? (parsedStep >= 4 ? 1 : Math.max(1, Math.min(3, parsedStep)))
-          : Math.max(1, Math.min(MAX_SCHEDULED_STEP, parsedStep));
+        const nextStep = (() => {
+          if (parsed.version >= 5 && !fromLegacy) return Math.max(1, Math.min(MAX_SCHEDULED_STEP, parsedStep));
+          if (parsedStep <= 2) return 1;
+          if (parsedStep <= 4) return 2;
+          return 3;
+        })();
         this.scheduledWizard = {
           ...this.scheduledWizard,
           step: nextStep,

--- a/customer-app/modules/ui.js
+++ b/customer-app/modules/ui.js
@@ -294,6 +294,7 @@
           <button class="primary-btn" type="button" data-commerce-service="wall-normal">จองล้างแอร์</button>
           <button class="secondary-btn" type="button" data-route="urgent">เรียกช่างด่วน</button>
           <button class="secondary-btn" type="button" data-route="tracking">ติดตามงาน</button>
+          <button class="secondary-btn" type="button" data-route="profile">ติดต่อ CWF</button>
         </section>
 
           <section class="card commerce-section">

--- a/customer-app/sw.js
+++ b/customer-app/sw.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const BUILD_ID = "20260621_three_step_booking_v1";
+const BUILD_ID = "20260621_advance_slots_three_step_draft_v1";
 const CACHE_NAME = `cwf-customer-app-v2-${BUILD_ID}`;
 const APP_SHELL = [
   `./index.html?v=${BUILD_ID}`,

--- a/index.js
+++ b/index.js
@@ -17318,6 +17318,7 @@ app.put("/jobs/:job_id/status", async (req, res) => {
   try {
     const realId = await resolveJobIdAny(pool, job_id);
     if (!realId) return res.status(400).json({ error: "job_id ไม่ถูกต้อง" });
+    if (status === 'กำลังทำ') await assertJobActionableForTechnician(pool, realId);
 
     // ✅ เมื่อเริ่มงานครั้งแรก ให้บันทึก started_at
     if (status === 'กำลังทำ') {
@@ -17350,7 +17351,7 @@ app.put("/jobs/:job_id/status", async (req, res) => {
     res.json({ success: true });
   } catch (e) {
     console.error(e);
-    res.status(500).json({ error: "อัปเดตสถานะไม่สำเร็จ" });
+    res.status(Number(e.status || 500)).json({ error: e.message || "อัปเดตสถานะไม่สำเร็จ", code: e.code || undefined });
   }
 });
 
@@ -18795,6 +18796,20 @@ app.post("/offers/:offer_id/decline", requireTechnicianSession, async (req, res)
 // =======================================
 // 🚗 TRAVEL START (เริ่มเดินทาง)
 // =======================================
+async function assertJobActionableForTechnician(db, job_id) {
+  const r = await db.query(
+    `SELECT job_status FROM public.jobs WHERE job_id=$1 LIMIT 1`,
+    [job_id]
+  );
+  const status = String(r.rows?.[0]?.job_status || '').trim();
+  if (['รอตรวจสอบ', 'pending_review'].includes(status)) {
+    const err = new Error('ร่างงาน — รอแอดมินอนุมัติ');
+    err.status = 409;
+    err.code = 'TECHNICIAN_DRAFT_JOB_LOCKED';
+    throw err;
+  }
+}
+
 app.post("/jobs/:job_id/travel-start", requireTechnicianSession, async (req, res) => {
   const { job_id } = req.params;
   try {
@@ -18802,6 +18817,7 @@ app.post("/jobs/:job_id/travel-start", requireTechnicianSession, async (req, res
     if (!realId) return res.status(400).json({ error: "job_id ไม่ถูกต้อง" });
     const technician_username = await requireTechOwnsResolvedJob(req, res, realId, pool);
     if (!technician_username) return;
+    await assertJobActionableForTechnician(pool, realId);
 
     await pool.query(
       `UPDATE public.jobs
@@ -18812,7 +18828,7 @@ app.post("/jobs/:job_id/travel-start", requireTechnicianSession, async (req, res
     res.json({ success: true });
   } catch (e) {
     console.error(e);
-    res.status(500).json({ error: "บันทึกเริ่มเดินทางไม่สำเร็จ" });
+    res.status(Number(e.status || 500)).json({ error: e.message || "บันทึกเริ่มเดินทางไม่สำเร็จ", code: e.code || undefined });
   }
 });
 
@@ -18830,6 +18846,7 @@ app.post("/jobs/:job_id/checkin", requireTechnicianSession, async (req, res) => 
     if (!realId) return res.status(400).json({ error: "job_id ไม่ถูกต้อง" });
     const technician_username = await requireTechOwnsResolvedJob(req, res, realId, pool);
     if (!technician_username) return;
+    await assertJobActionableForTechnician(pool, realId);
 
     const r = await pool.query(
       `SELECT gps_latitude, gps_longitude, maps_url FROM public.jobs WHERE job_id=$1`,
@@ -18987,7 +19004,7 @@ app.post("/jobs/:job_id/checkin", requireTechnicianSession, async (req, res) => 
     res.json({ success: true, distance: distance == null ? null : Math.round(distance), site_required: hasSiteLatLng });
   } catch (e) {
     console.error(e);
-    res.status(500).json({ error: "เช็คอินไม่สำเร็จ" });
+    res.status(Number(e.status || 500)).json({ error: e.message || "เช็คอินไม่สำเร็จ", code: e.code || undefined });
   }
 });
 
@@ -19025,6 +19042,7 @@ app.post("/jobs/:job_id/photos/meta", async (req, res) => {
   try {
     const realId = await resolveJobIdAny(pool, job_id);
     if (!realId) return res.status(400).json({ error: "job_id ไม่ถูกต้อง" });
+    await assertJobActionableForTechnician(pool, realId);
     let unitMeta = { unit_id: null, unit_code: null, unit_no: null };
     if (Number.isFinite(bodyUnitId) && bodyUnitId > 0) {
       const unitR = await pool.query(`SELECT unit_id, unit_code, unit_no FROM public.job_units WHERE job_id=$1 AND unit_id=$2 AND ${activeJobUnitWhere()} LIMIT 1`, [realId, bodyUnitId]);
@@ -19115,6 +19133,7 @@ app.post("/jobs/:job_id/photos/:photo_id/upload", upload.single("photo"), async 
   try {
     const realId = await resolveJobIdAny(pool, job_id);
     if (!realId) return res.status(400).json({ error: "job_id ไม่ถูกต้อง" });
+    await assertJobActionableForTechnician(pool, realId);
 
     const meta = await pool.query(
       `SELECT photo_id, phase, mime_type FROM public.job_photos WHERE photo_id=$1 AND job_id=$2`,
@@ -19396,6 +19415,7 @@ app.put("/jobs/:job_id/note", async (req, res) => {
   try {
     const realId = await resolveJobIdAny(pool, job_id);
     if (!realId) return res.status(400).json({ error: "job_id ไม่ถูกต้อง" });
+    await assertJobActionableForTechnician(pool, realId);
 
     await pool.query(
       `UPDATE public.jobs SET technician_note=$1, technician_note_at=NOW() WHERE job_id=$2`,
@@ -19404,7 +19424,7 @@ app.put("/jobs/:job_id/note", async (req, res) => {
     res.json({ success: true });
   } catch (e) {
     console.error(e);
-    res.status(500).json({ error: "บันทึกหมายเหตุไม่สำเร็จ" });
+    res.status(Number(e.status || 500)).json({ error: e.message || "บันทึกหมายเหตุไม่สำเร็จ", code: e.code || undefined });
   }
 });
 
@@ -19465,6 +19485,7 @@ app.post("/jobs/:job_id/finalize", requireTechnicianSession, async (req, res) =>
       await client.query("ROLLBACK");
       return;
     }
+    await assertJobActionableForTechnician(client, realId);
     const perUnitEvidenceRequested = req.body?.per_unit_evidence === true || String(req.body?.per_unit_evidence || '').trim().toLowerCase() === 'true' || String(req.body?.per_unit_evidence || '').trim() === '1';
     const perUnitFlagR = await client.query(`SELECT COALESCE(per_unit_evidence_enabled,FALSE) AS enabled FROM public.jobs WHERE job_id=$1 LIMIT 1`, [realId]);
     const perUnitEnabled = perUnitEvidenceRequested || !!perUnitFlagR.rows?.[0]?.enabled;
@@ -23910,9 +23931,10 @@ function http409Conflict(res, conflict){
 // =======================================
 // 💲 Pricing + Duration Preview (public)
 // =======================================
-function publicCustomerAvailabilityDeps() {
+function publicCustomerAvailabilityDeps(db = pool) {
   return {
-    pool,
+    pool: db,
+    db,
     listTechniciansByType,
     buildOffMapForDate,
     isTechOffOnDate,
@@ -24898,6 +24920,21 @@ console.log("[latlng_parse]", { ok: !!parsedLL });
   try {
     await client.query("BEGIN");
 
+    let draftReservationTech = null;
+    if (bm === "scheduled" && clientApp === "customer_app_v2") {
+      const startIso = normalizeAppointmentDatetime(appointment_datetime);
+      draftReservationTech = await customerAvailability.reservePublicCustomerTechnician(
+        publicCustomerAvailabilityDeps(client),
+        {
+          ...payloadV2,
+          date: String(startIso).slice(0, 10),
+          start: String(startIso).slice(11, 16),
+          tech_type: requestedTechType,
+          duration_min: duration_min_v2,
+        }
+      );
+    }
+
     // 1) ดึงราคา base_price จาก DB
 const serviceLineItems = await customerPricingHelpers.buildCustomerServiceLineItemsFromPayload(
   (payloadV2.services && Array.isArray(payloadV2.services))
@@ -24980,7 +25017,7 @@ if (itemIdQty.length) {
        address_text, technician_team, technician_username, job_status,
        booking_token, job_source, dispatch_mode, customer_note,
        maps_url, job_zone, duration_min, booking_mode, allow_time_proposal)
-      VALUES ($1,$2,$3,$4,$5,$6,NULL,NULL,$11,$7,'customer',$14,$8,$9,$10,$12,$13,$15)
+      VALUES ($1,$2,$3,$4,$5,$6,NULL,$16,$11,$7,'customer',$14,$8,$9,$10,$12,$13,$15)
       RETURNING job_id, booking_token
       `,
       [
@@ -24999,6 +25036,7 @@ if (itemIdQty.length) {
         (bm === 'urgent' ? 'urgent' : 'scheduled'),
         dispatchMode,
         allowTimeProposal,
+        draftReservationTech ? draftReservationTech.username : null,
       ]
     );
 
@@ -25174,6 +25212,7 @@ app.get("/public/track", async (req, res) => {
     // ✅ กันลูกค้าสับสน: สถานะ "ตีกลับ" เป็นสถานะภายใน (ให้ลูกค้าเห็นเป็นรอดำเนินการ)
     const rawStatus = String(row.job_status || "").trim();
     const publicStatus = (rawStatus === "ตีกลับ" || rawStatus === "งานแก้ไข") ? "รอดำเนินการ" : rawStatus;
+    const canShowPublicTechnician = !['รอตรวจสอบ', 'pending_review'].includes(rawStatus);
 
     let photos = [];
     if (isDone) {
@@ -25288,7 +25327,7 @@ app.get("/public/track", async (req, res) => {
 // =======================================
 let technician_team = null;
 
-if (FLAG_SHOW_TECH_TEAM_ON_TRACKING) {
+if (FLAG_SHOW_TECH_TEAM_ON_TRACKING && canShowPublicTechnician) {
   try {
     // ดึงสมาชิกทีมจากตารางใหม่ (job_team_members)
     const tmR = await pool.query(
@@ -25379,7 +25418,7 @@ if (FLAG_SHOW_TECH_TEAM_ON_TRACKING) {
         reviewed_at: row.reviewed_at || null,
       },
 
-      technician: row.technician_username
+      technician: row.technician_username && canShowPublicTechnician
         ? {
             username: row.technician_username,
             full_name: row.tech_name,

--- a/server/services/public/customerAvailability.js
+++ b/server/services/public/customerAvailability.js
@@ -3,6 +3,7 @@
 const SLOT_STEP_MIN = 30;
 const DEFAULT_UI_START = "09:00";
 const DEFAULT_UI_END = "18:00";
+const CANCELLED_STATUSES = new Set(["ยกเลิก", "cancelled", "canceled"]);
 
 function normalizeJobKey(value) {
   const v = String(value || "").toLowerCase();
@@ -139,6 +140,74 @@ async function loadSpecialMap(pool, date) {
   return map;
 }
 
+function serviceUnitCount(options = {}) {
+  const services = parseServices(options.services);
+  const source = services && services.length ? services : [options];
+  return source.reduce((sum, service) => {
+    const n = Number(service && service.machine_count);
+    return sum + (Number.isFinite(n) && n > 0 ? Math.floor(n) : 1);
+  }, 0);
+}
+
+async function loadAdvanceCalendarMap(db, date, usernames, lockRows = false) {
+  const names = (Array.isArray(usernames) ? usernames : []).map((u) => String(u || "").trim()).filter(Boolean);
+  if (!names.length) return new Map();
+  const result = await db.query(
+    `SELECT technician_username, work_date::date AS work_date, day_status, can_accept_advance_job,
+            start_time, end_time, max_jobs_per_day, max_units_per_day
+       FROM public.technician_monthly_work_calendar
+      WHERE technician_username = ANY($1::text[])
+        AND work_date=$2::date
+      ${lockRows ? "FOR UPDATE" : ""}`,
+    [names, date]
+  );
+  const map = new Map();
+  for (const row of result.rows || []) map.set(String(row.technician_username), row);
+  return map;
+}
+
+async function loadDailyUsageMap(db, date, usernames, ignoreJobId) {
+  const names = (Array.isArray(usernames) ? usernames : []).map((u) => String(u || "").trim()).filter(Boolean);
+  if (!names.length) return new Map();
+  const params = [names, date];
+  let ignoreSql = "";
+  if (ignoreJobId) {
+    params.push(Number(ignoreJobId));
+    ignoreSql = `AND j.job_id <> $${params.length}`;
+  }
+  const result = await db.query(
+    `WITH assigned AS (
+       SELECT j.job_id, COALESCE(ja.technician_username, j.technician_username) AS technician_username
+         FROM public.jobs j
+         LEFT JOIN public.job_assignments ja ON ja.job_id=j.job_id
+        WHERE COALESCE(ja.technician_username, j.technician_username) = ANY($1::text[])
+          AND (j.appointment_datetime AT TIME ZONE 'Asia/Bangkok')::date=$2::date
+          ${ignoreSql}
+          AND COALESCE(j.job_status,'') <> ALL($${params.length + 1}::text[])
+     ),
+     item_units AS (
+       SELECT a.technician_username, a.job_id, COALESCE(SUM(NULLIF(ji.qty,0)),0)::int AS units
+         FROM assigned a
+         LEFT JOIN public.job_items ji ON ji.job_id=a.job_id
+        GROUP BY a.technician_username, a.job_id
+     )
+     SELECT technician_username,
+            COUNT(DISTINCT job_id)::int AS jobs_count,
+            COALESCE(SUM(GREATEST(units,1)),0)::int AS units_count
+       FROM item_units
+      GROUP BY technician_username`,
+    [...params, Array.from(CANCELLED_STATUSES)]
+  );
+  const map = new Map();
+  for (const row of result.rows || []) {
+    map.set(String(row.technician_username), {
+      jobs_count: Number(row.jobs_count || 0),
+      units_count: Number(row.units_count || 0),
+    });
+  }
+  return map;
+}
+
 function bangkokTodayYmd(nowParts) {
   if (nowParts && nowParts.Y && nowParts.M && nowParts.D) return `${nowParts.Y}-${nowParts.M}-${nowParts.D}`;
   return new Date(Date.now() + (7 * 60 * 60 * 1000)).toISOString().slice(0, 10);
@@ -165,10 +234,29 @@ async function eligibleCustomerTechnicians(deps, options) {
   const offMap = await buildOffMapForDate(date, visibleTechs.map((tech) => tech.username));
   const notOff = visibleTechs.filter((tech) => !isTechOffOnDate(tech, date, offMap));
   const matrixMap = await loadServiceMatrixMap(pool, notOff.map((tech) => tech.username));
-  return notOff.filter((tech) => {
+  const matrixMatched = notOff.filter((tech) => {
     const username = String(tech.username || "");
     if (!matrixMap.has(username)) return false;
     return techMatchesAllCriteriaStrict(matrixMap.get(username), criteriaList);
+  });
+  const calendarMap = await loadAdvanceCalendarMap(pool, date, matrixMatched.map((tech) => tech.username), Boolean(options.lock_calendar_rows));
+  const requestedUnits = serviceUnitCount(options);
+  const usageMap = await loadDailyUsageMap(pool, date, matrixMatched.map((tech) => tech.username), options.ignore_job_id);
+  return matrixMatched.filter((tech) => {
+    const username = String(tech.username || "");
+    const calendar = calendarMap.get(username);
+    if (!calendar || calendar.can_accept_advance_job !== true) return false;
+    const start = String(calendar.start_time || "").slice(0, 5);
+    const end = String(calendar.end_time || "").slice(0, 5);
+    if (!/^\d{2}:\d{2}$/.test(start) || !/^\d{2}:\d{2}$/.test(end)) return false;
+    const maxJobs = calendar.max_jobs_per_day == null ? null : Number(calendar.max_jobs_per_day);
+    const maxUnits = calendar.max_units_per_day == null ? null : Number(calendar.max_units_per_day);
+    const usage = usageMap.get(username) || { jobs_count: 0, units_count: 0 };
+    if (Number.isFinite(maxJobs) && maxJobs >= 0 && usage.jobs_count >= maxJobs) return false;
+    if (Number.isFinite(maxUnits) && maxUnits >= 0 && (usage.units_count + requestedUnits) > maxUnits) return false;
+    tech.advance_calendar = calendar;
+    tech.advance_usage = usage;
+    return true;
   });
 }
 
@@ -186,7 +274,6 @@ async function computePublicCustomerSlots(deps, options) {
   const durationMin = Math.max(15, Number(options.duration_min || 60));
   const uiStartMin = toMin(DEFAULT_UI_START);
   const uiEndMin = toMin(DEFAULT_UI_END);
-  const specialMap = await loadSpecialMap(pool, date);
   const techs = await eligibleCustomerTechnicians(deps, { ...options, date });
   const events = new Map();
   const addEvent = (minute, type, username) => {
@@ -207,7 +294,12 @@ async function computePublicCustomerSlots(deps, options) {
   }
 
   for (const tech of techs) {
-    const windows = buildTechWindowsMin(tech, date, specialMap, startFloor, uiEndMin);
+    const cal = tech.advance_calendar || {};
+    const windowStart = Math.max(startFloor, toMin(String(cal.start_time || DEFAULT_UI_START).slice(0, 5)));
+    const windowEnd = Math.min(uiEndMin, toMin(String(cal.end_time || DEFAULT_UI_END).slice(0, 5)));
+    const windows = (Number.isFinite(windowStart) && Number.isFinite(windowEnd) && windowEnd > windowStart)
+      ? [{ startMin: windowStart, endMin: windowEnd }]
+      : [];
     if (!windows.length) continue;
     const busyBlocks = await listBusyBlocksForTechOnDate(tech.username, date, null);
     for (const window of windows) {
@@ -240,7 +332,7 @@ async function computePublicCustomerSlots(deps, options) {
     for (let start = segmentStart; start <= lastStart; start += SLOT_STEP_MIN) {
       slots.push({
         start: minToHHMM(start),
-        end: minToHHMM(Math.min(uiEndMin, start + SLOT_STEP_MIN)),
+        end: minToHHMM(Math.min(uiEndMin, start + durationMin)),
         available: true,
       });
     }
@@ -292,6 +384,53 @@ async function hasAvailableStart(deps, options) {
   return (result.slots || []).some((slot) => slot.available && slot.start === start);
 }
 
+async function reservePublicCustomerTechnician(deps, options) {
+  const db = deps.db || deps.pool;
+  const date = String(options.date || "").slice(0, 10);
+  const start = String(options.start || "").slice(0, 5);
+  const durationMin = Math.max(15, Number(options.duration_min || 60));
+  if (!date || !start) {
+    const error = new Error("CUSTOMER_SLOT_START_REQUIRED");
+    error.status = 400;
+    throw error;
+  }
+  const criteriaList = buildCriteriaList(options);
+  const lockKey = `${date}|${start}|${durationMin}|${options.tech_type || "company"}|${JSON.stringify(criteriaList)}|${serviceUnitCount(options)}`;
+  if (typeof db.query === "function") {
+    await db.query("SELECT pg_advisory_xact_lock(hashtext($1))", [lockKey]);
+  }
+  const techs = await eligibleCustomerTechnicians(
+    { ...deps, pool: db },
+    { ...options, date, lock_calendar_rows: true }
+  );
+  const startMin = deps.toMin(start);
+  const candidates = [];
+  for (const tech of techs) {
+    const cal = tech.advance_calendar || {};
+    const windowStart = deps.toMin(String(cal.start_time || DEFAULT_UI_START).slice(0, 5));
+    const windowEnd = deps.toMin(String(cal.end_time || DEFAULT_UI_END).slice(0, 5));
+    if (!Number.isFinite(startMin) || !Number.isFinite(windowStart) || !Number.isFinite(windowEnd)) continue;
+    if (startMin < windowStart || startMin + durationMin > windowEnd) continue;
+    const busyBlocks = await deps.listBusyBlocksForTechOnDate(tech.username, date, options.ignore_job_id || null);
+    const intervals = deps.buildStartIntervalsByCollision(busyBlocks, windowStart, windowEnd, durationMin);
+    const ok = intervals.some((it) => startMin >= it.startMin && startMin <= it.endMin);
+    if (!ok) continue;
+    candidates.push({
+      username: tech.username,
+      jobs_count: Number(tech.advance_usage?.jobs_count || 0),
+      units_count: Number(tech.advance_usage?.units_count || 0),
+    });
+  }
+  candidates.sort((a, b) => a.jobs_count - b.jobs_count || a.units_count - b.units_count || String(a.username).localeCompare(String(b.username)));
+  const picked = candidates[0] || null;
+  if (!picked) {
+    const error = new Error("CUSTOMER_SLOT_STALE");
+    error.status = 409;
+    throw error;
+  }
+  return picked;
+}
+
 module.exports = {
   buildCriteriaList,
   validateCriteriaList,
@@ -301,4 +440,5 @@ module.exports = {
   computePublicCustomerSlots,
   computeCalendarSummary,
   hasAvailableStart,
+  reservePublicCustomerTechnician,
 };

--- a/tech.html
+++ b/tech.html
@@ -3431,7 +3431,7 @@
     }
   </style>
 
-<script src="app.js?v=20260612_phase34_tech_api_dedup"></script>
+<script src="app.js?v=20260621_draft_readonly_v1"></script>
   <script src="tech-onboarding.js?v=phase2a-fix-restore-onboarding-panel"></script>
   <script>
         function goEditProfile(){ location.href = '/edit-profile.html'; }

--- a/test/customerAppRecovery.test.js
+++ b/test/customerAppRecovery.test.js
@@ -135,7 +135,7 @@ test("Customer App build id is consistent across shell and service worker", () =
   const sw = read("customer-app/sw.js");
   const app = read("customer-app/assets/customer-app.js");
   const manifest = read("customer-app/manifest.webmanifest");
-  const build = "20260621_three_step_booking_v1";
+  const build = "20260621_advance_slots_three_step_draft_v1";
 
   assert.match(index, new RegExp(`customer-app\\.css\\?v=${build}`));
   assert.match(index, new RegExp(`bookingUrgent\\.js\\?v=${build}`));
@@ -182,7 +182,7 @@ test("account chip has narrow-screen avatar-only protection", () => {
   assert.match(css, /text-overflow: ellipsis/);
 });
 
-test("scheduled draft persists and restores five-step state", () => {
+test("scheduled draft persists and restores three-step state", () => {
   const context = makeContext();
   let root = load(context, ["customer-app/modules/state.js"]);
   root.state.updateDraft("scheduled", { customer_name: "Persisted Customer", address_text: "Persisted Address" });
@@ -193,12 +193,12 @@ test("scheduled draft persists and restores five-step state", () => {
   root.state.init();
 
   assert.equal(root.state.scheduledWizard.step, 3);
-  assert.equal(root.state.scheduledWizard.maxStep, 5);
+  assert.equal(root.state.scheduledWizard.maxStep, 3);
   assert.equal(root.state.draft.scheduled.customer_name, "Persisted Customer");
   assert.equal(root.state.draft.scheduled.address_text, "Persisted Address");
 });
 
-test("legacy scheduled draft from older flow is mapped safely into the five-step flow", () => {
+test("legacy scheduled draft from older flow is mapped safely into the three-step flow", () => {
   const context = makeContext();
   context.window.sessionStorage.setItem("cwf_customer_app_v2_scheduled_v2", JSON.stringify({
     version: 2,
@@ -213,8 +213,8 @@ test("legacy scheduled draft from older flow is mapped safely into the five-step
   const root = load(context, ["customer-app/modules/state.js"]);
   root.state.init();
 
-  assert.equal(root.state.scheduledWizard.step, 1);
-  assert.equal(root.state.scheduledWizard.maxStep, 5);
+  assert.equal(root.state.scheduledWizard.step, 3);
+  assert.equal(root.state.scheduledWizard.maxStep, 3);
   assert.equal(root.state.draft.scheduled.customer_name, "Legacy Customer");
   assert.equal(root.state.draft.scheduled.address_text, "Legacy Address");
 });
@@ -241,7 +241,7 @@ test("home CTA click writes scheduled draft and routes to scheduled flow", async
   assert.equal(root.state.draft.scheduled.selectedSlot, null);
 });
 
-test("scheduled booking renders one active step and preserves draft across five steps", async () => {
+test("scheduled booking renders one active step and preserves draft across three steps", async () => {
   const context = makeContext();
   const root = loadCustomerFrontend(context);
   root.state.customer = { logged_in: false };
@@ -256,6 +256,7 @@ test("scheduled booking renders one active step and preserves draft across five 
   root.bookingScheduled.render(container);
   assert.match(container.innerHTML, /data-booking-step="1"/);
   assert.doesNotMatch(container.innerHTML, /data-booking-step="2"|data-booking-step="3"|data-booking-step="4"|data-booking-step="5"/);
+  assert.match(container.innerHTML, /data-line-choice="ac_type"/);
 
   root.state.updateDraft("scheduled", {
     customer_name: "Test Customer",
@@ -268,28 +269,22 @@ test("scheduled booking renders one active step and preserves draft across five 
   assert.match(container.innerHTML, /data-booking-step="2"/);
   assert.doesNotMatch(container.innerHTML, /data-booking-step="1"|data-booking-step="3"|data-booking-step="4"|data-booking-step="5"/);
   assert.equal(root.state.draft.scheduled.address_text, "123 Test Condo");
-
-  await container.querySelectorAll("[data-action]").find((button) => button.getAttribute("data-action") === "wizard-next").click();
-  assert.equal(root.state.scheduledWizard.step, 3);
-  assert.match(container.innerHTML, /data-booking-step="3"/);
-  assert.doesNotMatch(container.innerHTML, /data-booking-step="1"|data-booking-step="2"|data-booking-step="4"|data-booking-step="5"/);
-
-  await container.querySelectorAll("[data-action]").find((button) => button.getAttribute("data-action") === "wizard-next").click();
-  assert.equal(root.state.scheduledWizard.step, 4);
-  assert.match(container.innerHTML, /data-booking-step="4"/);
   assert.match(container.innerHTML, /09:00/);
 
   const slot = root.availability.normalizePublicSlots(root.state.scheduledPreview.availability.data, 90)[0];
   root.state.updateDraft("scheduled", { selectedSlot: { ...slot, query_key: root.state.scheduledPreview.availability.query_key } });
   root.bookingScheduled.render(container);
-  assert.equal(root.state.scheduledWizard.step, 4);
-  assert.doesNotMatch(container.innerHTML, /data-booking-step="1"|data-booking-step="2"|data-booking-step="3"|data-booking-step="5"/);
+  await container.querySelectorAll("[data-action]").find((button) => button.getAttribute("data-action") === "wizard-next").click();
+  assert.equal(root.state.scheduledWizard.step, 3);
+  assert.match(container.innerHTML, /data-booking-step="3"/);
+  assert.doesNotMatch(container.innerHTML, /data-booking-step="1"|data-booking-step="2"|data-booking-step="4"|data-booking-step="5"/);
+  assert.equal(root.state.draft.scheduled.address_text, "123 Test Condo");
 });
 test("anonymous slots render without technician identity or counts", () => {
   const context = makeContext();
   const root = loadCustomerFrontend(context);
   const container = new WizardContainer(root);
-  root.state.setScheduledWizard({ step: 4 });
+  root.state.setScheduledWizard({ step: 2 });
   root.state.setScheduledPreview("pricing", { status: "success", data: { duration_min: 60, active_price: 900 }, error: "" });
   root.state.setScheduledPreview("availability", {
     status: "success",
@@ -307,7 +302,7 @@ test("anonymous slots render without technician identity or counts", () => {
 test("stale slot rejection returns customer to date and time step", async () => {
   const context = makeContext();
   const root = loadCustomerFrontend(context);
-  root.state.setScheduledWizard({ step: 5 });
+  root.state.setScheduledWizard({ step: 3 });
   root.state.setScheduledPreview("pricing", { status: "success", data: { duration_min: 60, active_price: 900 }, error: "" });
   const query = root.availability.publicAvailabilityQuery(root.state.draft.scheduled, root.services.payloadFromServiceDraft(root.state.draft.scheduled), root.state.scheduledPreview.pricing.data);
   const queryKey = root.availability.queryKey(query);
@@ -325,7 +320,7 @@ test("stale slot rejection returns customer to date and time step", async () => 
   root.bookingScheduled.render(container);
   await container.querySelectorAll("[data-action]").find((button) => button.getAttribute("data-action") === "submit-scheduled").click();
 
-  assert.equal(root.state.scheduledWizard.step, 4);
+  assert.equal(root.state.scheduledWizard.step, 2);
   assert.equal(root.state.draft.scheduled.selectedSlot, null);
 });
 

--- a/test/customerAppThreeStepBooking.test.js
+++ b/test/customerAppThreeStepBooking.test.js
@@ -95,11 +95,11 @@ function sampleLines(root) {
   ];
 }
 
-test("scheduled wizard state has exactly five steps", () => {
+test("scheduled wizard state has exactly three steps", () => {
   const { root } = loadBooking();
-  assert.equal(root.state.scheduledWizard.maxStep, 5);
+  assert.equal(root.state.scheduledWizard.maxStep, 3);
   root.state.setScheduledWizard({ step: 99 });
-  assert.equal(root.state.scheduledWizard.step, 5);
+  assert.equal(root.state.scheduledWizard.step, 3);
 });
 
 test("Customer App customer-facing UI does not expose internal public endpoint names", () => {
@@ -121,7 +121,7 @@ test("Customer App customer-facing UI does not expose internal public endpoint n
 
 test("service step omits redundant single-option service-kind selector", () => {
   const { root } = loadBooking();
-  const html = renderInto(root, 2);
+  const html = renderInto(root, 1);
   assert.doesNotMatch(html, /data-scheduled-choice="service_kind"|service-kind-grid|ประเภทบริการ/);
   assert.match(html, /data-line-choice="ac_type"/);
   assert.match(html, /data-line-choice="btu"/);
@@ -196,7 +196,7 @@ test("time preference defaults exact and submit payload sends boolean", () => {
 test("review screen displays selected time preference", () => {
   const { root } = loadBooking();
   root.state.updateDraft("scheduled", { allow_time_proposal: true });
-  const html = renderInto(root, 5);
+  const html = renderInto(root, 3);
   assert.match(html, /สามารถเสนอเวลาใหม่ให้ฉันได้/);
   assert.match(html, /การเสนอเวลา/);
 });
@@ -214,14 +214,14 @@ test("calendar marks available and full dates without technician identity", () =
     error: "",
     query_key: key,
   });
-  const html = renderInto(root, 4);
+  const html = renderInto(root, 2);
   assert.match(html, /มีคิว/);
   assert.doesNotMatch(html, /Hidden|technician_name|technician_id|technician_count|matrix_json/);
 });
 
 test("anonymous slots render complete time range without technician identity or counts", () => {
   const { root } = loadBooking();
-  root.state.setScheduledWizard({ step: 4 });
+  root.state.setScheduledWizard({ step: 2 });
   root.state.setScheduledPreview("pricing", { status: "success", data: { duration_min: 90, active_price: 900 }, error: "" });
   const query = root.bookingScheduled._test.currentAvailabilityQuery();
   root.state.setScheduledPreview("availability", {
@@ -230,7 +230,7 @@ test("anonymous slots render complete time range without technician identity or 
     error: "",
     query_key: root.availability.queryKey(query),
   });
-  const html = renderInto(root, 4);
+  const html = renderInto(root, 2);
   assert.match(html, /10:00-11:30/);
   assert.doesNotMatch(html, /Hidden Tech|technician_id|42|candidate|คน/);
 });

--- a/test/customerMultiServiceCalendar.test.js
+++ b/test/customerMultiServiceCalendar.test.js
@@ -28,6 +28,9 @@ test("public availability and public booking share the customer availability hel
   const booking = section('app.post("/public/book"', 'app.get("/public/track"');
   assert.match(availability, /customerAvailability\.computePublicCustomerSlots/);
   assert.match(booking, /customerAvailability\.hasAvailableStart/);
+  assert.match(booking, /customerAvailability\.reservePublicCustomerTechnician/);
+  assert.match(booking, /technician_username/);
+  assert.match(booking, /job_status='รอตรวจสอบ'|VALUES \([\s\S]*'รอตรวจสอบ'/);
 });
 
 test("public book validates and persists allow_time_proposal as a jobs column", () => {
@@ -71,21 +74,44 @@ test("helper requires one technician matrix to support every selected service li
   }, list), true);
 });
 
-test("calendar summary contains only date availability and first available start", async () => {
-  const deps = {
+function makeAvailabilityDeps({ calendar = true, usage = {}, matrix, busyBlocks = [] } = {}) {
+  return {
     pool: {
-      async query(sql) {
-        if (String(sql).includes("technician_service_matrix")) return { rows: [{ username: "tech-a", matrix_json: { job_types: { wash: true }, ac_types: { wall: true }, wash_wall_variants: { normal: true } } }] };
-        if (String(sql).includes("technician_special_slots_v2")) return { rows: [] };
+      async query(sql, params = []) {
+        const text = String(sql);
+        if (text.includes("pg_advisory_xact_lock")) return { rows: [] };
+        if (text.includes("technician_service_matrix")) {
+          return { rows: [{ username: "tech-a", matrix_json: matrix || { job_types: { wash: true }, ac_types: { wall: true }, wash_wall_variants: { normal: true } } }] };
+        }
+        if (text.includes("technician_monthly_work_calendar")) {
+          if (!calendar) return { rows: [] };
+          return { rows: [{
+            technician_username: "tech-a",
+            work_date: params[1],
+            day_status: "available",
+            can_accept_advance_job: calendar === "false" ? false : true,
+            start_time: "09:00",
+            end_time: "12:00",
+            max_jobs_per_day: calendar?.max_jobs_per_day ?? 2,
+            max_units_per_day: calendar?.max_units_per_day ?? 4,
+          }] };
+        }
+        if (text.includes("WITH assigned AS")) {
+          return { rows: usage.rows || [] };
+        }
+        if (text.includes("technician_special_slots_v2")) return { rows: [] };
         return { rows: [] };
       },
     },
-    listTechniciansByType: async () => [{ username: "tech-a", customer_slot_visible: true, work_start: "09:00", work_end: "10:00", weekly_off_days: "" }],
+    listTechniciansByType: async () => [{ username: "tech-a", customer_slot_visible: true, work_start: "09:00", work_end: "12:00", weekly_off_days: "" }],
     buildOffMapForDate: async () => new Map(),
     isTechOffOnDate: () => false,
-    buildTechWindowsMin: () => [{ startMin: 540, endMin: 600 }],
-    listBusyBlocksForTechOnDate: async () => [],
-    buildStartIntervalsByCollision: () => [{ startMin: 540, endMin: 540 }],
+    buildTechWindowsMin: () => [{ startMin: 540, endMin: 720 }],
+    listBusyBlocksForTechOnDate: async () => busyBlocks,
+    buildStartIntervalsByCollision: (blocks, startMin, endMin, durationMin) => {
+      if ((blocks || []).length) return [];
+      return [{ startMin, endMin: endMin - durationMin }];
+    },
     toMin(value) {
       const [h, m] = value.split(":").map(Number);
       return h * 60 + m;
@@ -95,6 +121,10 @@ test("calendar summary contains only date availability and first available start
     },
     getNowBangkokParts: () => ({ Y: "2026", M: "06", D: "01", hh: 8, mm: 0 }),
   };
+}
+
+test("calendar summary contains only date availability and first available start", async () => {
+  const deps = makeAvailabilityDeps();
   const summary = await customerAvailability.computeCalendarSummary(deps, {
     month: "2026-06",
     duration_min: 60,
@@ -106,4 +136,104 @@ test("calendar summary contains only date availability and first available start
   assert.equal(summary.days[0].available, true);
   assert.equal(summary.days[0].first_available, "09:00");
   assert.deepEqual(Object.keys(summary.days[0]).sort(), ["available", "date", "first_available"]);
+});
+
+test("monthly advance calendar is required for customer slots", async () => {
+  const base = {
+    date: "2026-06-02",
+    duration_min: 60,
+    tech_type: "company",
+    services: [{ job_type: "ล้าง", ac_type: "ผนัง", wash_variant: "ล้างธรรมดา" }],
+  };
+  let result = await customerAvailability.computePublicCustomerSlots(makeAvailabilityDeps({ calendar: true }), base);
+  assert.ok(result.slots.length > 0);
+
+  result = await customerAvailability.computePublicCustomerSlots(makeAvailabilityDeps({ calendar: false }), base);
+  assert.equal(result.slots.length, 0);
+
+  result = await customerAvailability.computePublicCustomerSlots(makeAvailabilityDeps({ calendar: "false" }), base);
+  assert.equal(result.slots.length, 0);
+});
+
+test("advance calendar daily job and unit caps block public slots", async () => {
+  const base = {
+    date: "2026-06-02",
+    duration_min: 60,
+    tech_type: "company",
+    services: [{ job_type: "ล้าง", ac_type: "ผนัง", wash_variant: "ล้างธรรมดา", machine_count: 2 }],
+  };
+  let result = await customerAvailability.computePublicCustomerSlots(makeAvailabilityDeps({
+    calendar: { max_jobs_per_day: 1, max_units_per_day: 4 },
+    usage: { rows: [{ technician_username: "tech-a", jobs_count: 1, units_count: 1 }] },
+  }), base);
+  assert.equal(result.slots.length, 0);
+
+  result = await customerAvailability.computePublicCustomerSlots(makeAvailabilityDeps({
+    calendar: { max_jobs_per_day: 2, max_units_per_day: 2 },
+    usage: { rows: [{ technician_username: "tech-a", jobs_count: 0, units_count: 1 }] },
+  }), base);
+  assert.equal(result.slots.length, 0);
+});
+
+test("draft reservation uses advisory lock, rechecks exact slot, and picks anonymous technician", async () => {
+  const picked = await customerAvailability.reservePublicCustomerTechnician({
+    ...makeAvailabilityDeps(),
+    db: makeAvailabilityDeps().pool,
+  }, {
+    date: "2026-06-02",
+    start: "09:00",
+    duration_min: 60,
+    tech_type: "company",
+    services: [{ job_type: "ล้าง", ac_type: "ผนัง", wash_variant: "ล้างธรรมดา" }],
+  });
+  assert.deepEqual(Object.keys(picked).sort(), ["jobs_count", "units_count", "username"]);
+  assert.equal(picked.username, "tech-a");
+});
+
+test("stale requested slot returns 409 during draft reservation", async () => {
+  await assert.rejects(
+    customerAvailability.reservePublicCustomerTechnician({
+      ...makeAvailabilityDeps({ busyBlocks: [{ startMin: 540, endMin: 600 }] }),
+      db: makeAvailabilityDeps({ busyBlocks: [{ startMin: 540, endMin: 600 }] }).pool,
+    }, {
+      date: "2026-06-02",
+      start: "09:00",
+      duration_min: 60,
+      tech_type: "company",
+      services: [{ job_type: "ล้าง", ac_type: "ผนัง", wash_variant: "ล้างธรรมดา" }],
+    }),
+    (err) => err && err.status === 409 && err.message === "CUSTOMER_SLOT_STALE"
+  );
+});
+
+test("technician draft jobs are locked in backend workflow before approval", () => {
+  assert.match(source, /TECHNICIAN_DRAFT_JOB_LOCKED/);
+  assert.match(source, /ร่างงาน — รอแอดมินอนุมัติ/);
+  assert.match(source, /assertJobActionableForTechnician\(pool, realId\)/);
+  assert.match(source, /assertJobActionableForTechnician\(client, realId\)/);
+});
+
+test("admin review displays and preselects the draft technician reservation", () => {
+  const adminReview = fs.readFileSync(path.join(repoRoot, "admin-review-v2.js"), "utf8");
+  assert.match(adminReview, /ร่างจองช่าง/);
+  assert.match(adminReview, /CURRENT\.technician_username/);
+  assert.match(adminReview, /currentPrimary = primarySel\.value \|\| CURRENT\?\.technician_username/);
+});
+
+test("technician UI marks draft jobs read-only", () => {
+  const app = fs.readFileSync(path.join(repoRoot, "app.js"), "utf8");
+  assert.match(app, /ร่างงาน — รอแอดมินอนุมัติ/);
+  assert.match(app, /workflowDisabled = isDraftJob \|\| historyMode/);
+  assert.match(app, /isDraftJob[\s\S]*โทรลูกค้า[\s\S]*disabled/);
+});
+
+test("repair matrix round-trip includes repair variants and preserves unknown keys", () => {
+  const adminTech = fs.readFileSync(path.join(repoRoot, "admin-technicians-v2.js"), "utf8");
+  const adminHtml = fs.readFileSync(path.join(repoRoot, "admin-technicians-v2.html"), "utf8");
+  assert.match(adminHtml, /cap_repair_leak_check/);
+  assert.match(adminHtml, /cap_repair_inspection/);
+  assert.match(adminHtml, /cap_repair_parts/);
+  assert.match(adminHtml, /cap_repair_general/);
+  assert.match(adminTech, /repair_variants/);
+  assert.match(adminTech, /\.\.\.\(currentMatrix && typeof currentMatrix === 'object' \? currentMatrix : \{\}\)/);
 });


### PR DESCRIPTION
## Summary
- Reduce Customer App V2 scheduled booking to a 3-step flow while preserving multi-service lines, combined pricing, calendar slots, and time preference.
- Make public scheduled availability use technician_monthly_work_calendar as the source of truth, including advance opt-in, working window, daily job/unit caps, service matrix matching, and anonymous responses.
- Revalidate and reserve a draft technician during /public/book with transaction locking, keeping customer jobs in pending admin review.
- Add draft read-only protections for technician workflow, admin review draft technician visibility/preselection, repair variant matrix UI, and cache bumps.

## Tests
- npm ci
- node --check customer-app/modules/state.js customer-app/modules/services.js customer-app/modules/bookingScheduled.js customer-app/modules/availability.js customer-app/modules/api.js customer-app/modules/ui.js customer-app/assets/customer-app.js customer-app/sw.js server/services/public/customerAvailability.js index.js admin-technicians-v2.js admin-review-v2.js app.js
- node --test test/customerAppRecovery.test.js test/customerAppThreeStepBooking.test.js test/customerMultiServiceCalendar.test.js --test-reporter=spec
- npm test
- git diff --check

## Browser QA
- Playwright static Customer App QA at 320, 360, 390, and 430 px.
- Verified home paths, logged-in header avatar/account text, no guest/login buttons after /public/me login, 3-step scheduled flow, multi-service at 320 px, real anonymous slot display/selection/revalidation payload, flexible time payload at 430 px, stale slot clearing after service change at 390 px, no technician identity, no overflow/bottom obstruction, and no console errors.
- Evidence directory: C:\Users\ADMIN\AppData\Local\Temp\cwf-customer-v2-qa-1782058818565