### PR TITLE
Fix Customer availability calendar reason states

### DIFF
--- a/customer-app/assets/customer-app.js
+++ b/customer-app/assets/customer-app.js
@@ -3,7 +3,7 @@
 
   const App = window.CWFCustomerAppV2;
   const BOOT_TIMEOUT_MS = 3500;
-  const BUILD_ID = "20260621_advance_slots_three_step_draft_v1";
+  const BUILD_ID = "20260621_availability_reason_hotfix_v1";
 
   function withTimeout(promise, timeoutMs) {
     return Promise.race([

--- a/customer-app/index.html
+++ b/customer-app/index.html
@@ -9,10 +9,10 @@
   <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
   <meta name="apple-mobile-web-app-title" content="CWF Service">
   <title>CWF Customer Service</title>
-  <link rel="manifest" href="./manifest.webmanifest?v=20260621_advance_slots_three_step_draft_v1">
+  <link rel="manifest" href="./manifest.webmanifest?v=20260621_availability_reason_hotfix_v1">
   <link rel="icon" type="image/png" sizes="192x192" href="./assets/icons/cwf-customer-192.png">
   <link rel="apple-touch-icon" sizes="180x180" href="./assets/icons/cwf-customer-180.png">
-  <link rel="stylesheet" href="./assets/customer-app.css?v=20260621_advance_slots_three_step_draft_v1">
+  <link rel="stylesheet" href="./assets/customer-app.css?v=20260621_availability_reason_hotfix_v1">
 </head>
 <body class="is-app-booting">
   <div class="app-shell" data-app-shell>
@@ -49,19 +49,19 @@
     </nav>
   </div>
 
-  <script src="./modules/state.js?v=20260621_advance_slots_three_step_draft_v1"></script>
-  <script src="./modules/utils.js?v=20260621_advance_slots_three_step_draft_v1"></script>
-  <script src="./modules/api.js?v=20260621_advance_slots_three_step_draft_v1"></script>
-  <script src="./modules/services.js?v=20260621_advance_slots_three_step_draft_v1"></script>
-  <script src="./modules/ui.js?v=20260621_advance_slots_three_step_draft_v1"></script>
-  <script src="./modules/auth.js?v=20260621_advance_slots_three_step_draft_v1"></script>
-  <script src="./modules/pricing.js?v=20260621_advance_slots_three_step_draft_v1"></script>
-  <script src="./modules/availability.js?v=20260621_advance_slots_three_step_draft_v1"></script>
-  <script src="./modules/bookingScheduled.js?v=20260621_advance_slots_three_step_draft_v1"></script>
-  <script src="./modules/bookingUrgent.js?v=20260621_advance_slots_three_step_draft_v1"></script>
-  <script src="./modules/tracking.js?v=20260621_advance_slots_three_step_draft_v1"></script>
-  <script src="./modules/profile.js?v=20260621_advance_slots_three_step_draft_v1"></script>
-  <script src="./modules/router.js?v=20260621_advance_slots_three_step_draft_v1"></script>
-  <script src="./assets/customer-app.js?v=20260621_advance_slots_three_step_draft_v1"></script>
+  <script src="./modules/state.js?v=20260621_availability_reason_hotfix_v1"></script>
+  <script src="./modules/utils.js?v=20260621_availability_reason_hotfix_v1"></script>
+  <script src="./modules/api.js?v=20260621_availability_reason_hotfix_v1"></script>
+  <script src="./modules/services.js?v=20260621_availability_reason_hotfix_v1"></script>
+  <script src="./modules/ui.js?v=20260621_availability_reason_hotfix_v1"></script>
+  <script src="./modules/auth.js?v=20260621_availability_reason_hotfix_v1"></script>
+  <script src="./modules/pricing.js?v=20260621_availability_reason_hotfix_v1"></script>
+  <script src="./modules/availability.js?v=20260621_availability_reason_hotfix_v1"></script>
+  <script src="./modules/bookingScheduled.js?v=20260621_availability_reason_hotfix_v1"></script>
+  <script src="./modules/bookingUrgent.js?v=20260621_availability_reason_hotfix_v1"></script>
+  <script src="./modules/tracking.js?v=20260621_availability_reason_hotfix_v1"></script>
+  <script src="./modules/profile.js?v=20260621_availability_reason_hotfix_v1"></script>
+  <script src="./modules/router.js?v=20260621_availability_reason_hotfix_v1"></script>
+  <script src="./assets/customer-app.js?v=20260621_availability_reason_hotfix_v1"></script>
 </body>
 </html>

--- a/customer-app/manifest.webmanifest
+++ b/customer-app/manifest.webmanifest
@@ -2,7 +2,7 @@
   "name": "CWF Customer Service",
   "short_name": "CWF Service",
   "description": "แอปลูกค้า Coldwindflow สำหรับเลือกบริการ จองคิว และติดตามงาน",
-  "start_url": "/customer-app/index.html?v=20260621_advance_slots_three_step_draft_v1#home",
+  "start_url": "/customer-app/index.html?v=20260621_availability_reason_hotfix_v1#home",
   "scope": "/customer-app/",
   "id": "/customer-app/",
   "display": "standalone",

--- a/customer-app/modules/availability.js
+++ b/customer-app/modules/availability.js
@@ -119,6 +119,8 @@
       map.set(date, {
         date,
         available: day.available === true,
+        status: String(day.status || (day.available === true ? "available" : "no_open_slots")).trim(),
+        reason_code: String(day.reason_code || "").trim(),
         first_available: day.first_available || null,
       });
     });

--- a/customer-app/modules/bookingScheduled.js
+++ b/customer-app/modules/bookingScheduled.js
@@ -409,11 +409,16 @@
       const isToday = dateValue === today;
       const status = dayMap.get(dateValue);
       const available = status && status.available === true;
-      const full = status && status.available === false;
-      const disabled = outsideRange || full || (!isLoading && expectedKey && !available);
-      const label = outsideRange ? "" : (isLoading ? "..." : (available ? "มีคิว" : "เต็ม"));
+      const dayStatus = status?.status || (available ? "available" : "");
+      const full = dayStatus === "full";
+      const noOpenSlots = dayStatus === "no_open_slots";
+      const systemIssue = dayStatus === "error";
+      const disabled = outsideRange || !available || (!isLoading && expectedKey && !available);
+      const label = outsideRange
+        ? ""
+        : (isLoading ? "..." : (available ? "มีคิว" : (full ? "เต็ม" : (systemIssue ? "ลองใหม่" : "ยังไม่มีคิวเปิด"))));
       cells.push(`
-        <button type="button" class="calendar-day ${selected ? "is-selected" : ""} ${isToday ? "is-today" : ""} ${available ? "is-available" : ""} ${full ? "is-full" : ""} ${isLoading ? "is-loading" : ""}"
+        <button type="button" class="calendar-day ${selected ? "is-selected" : ""} ${isToday ? "is-today" : ""} ${available ? "is-available" : ""} ${full ? "is-full" : ""} ${noOpenSlots ? "is-no-open-slots" : ""} ${systemIssue ? "is-error" : ""} ${isLoading ? "is-loading" : ""}"
           data-calendar-date="${dateValue}" ${disabled ? "disabled" : ""}
           aria-pressed="${selected ? "true" : "false"}" aria-label="${root.utils.escapeHtml(`${dateValue} ${label}`)}">
           <span>${day}</span>${label ? `<small>${root.utils.escapeHtml(label)}</small>` : ""}
@@ -446,7 +451,14 @@
     if (!availability.data) return root.utils.stateBox("", "เลือกวันที่มีคิว ระบบจะแสดงช่วงเวลาว่างด้านล่าง");
     const slots = normalizedSlots();
     if (!slots.length) {
-      return `${root.utils.stateBox("warning", "วันที่เลือกเต็มแล้ว กรุณาเลือกวันอื่น")}<button type="button" class="secondary-btn" data-action="reload-slots">ตรวจคิววันนี้อีกครั้ง</button>`;
+      const status = String(availability.data.availability_status || "").trim();
+      const message = status === "full"
+        ? "วันที่เลือกเต็มแล้ว กรุณาเลือกวันอื่น"
+        : status === "error"
+          ? "ระบบตรวจคิววันนี้ไม่สำเร็จ กรุณาลองใหม่"
+          : "ยังไม่มีคิวเปิดในวันนี้ กรุณาเลือกวันอื่น";
+      const tone = status === "error" ? "error" : "warning";
+      return `${root.utils.stateBox(tone, message)}<button type="button" class="secondary-btn" data-action="reload-slots">ตรวจคิววันนี้อีกครั้ง</button>`;
     }
     return `
       <div class="availability-meta"><strong>คิวว่างวันที่ ${root.utils.escapeHtml(draft().date)}</strong><span>ระบบจะตรวจซ้ำก่อนส่งคำขอจอง</span></div>

--- a/customer-app/sw.js
+++ b/customer-app/sw.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const BUILD_ID = "20260621_advance_slots_three_step_draft_v1";
+const BUILD_ID = "20260621_availability_reason_hotfix_v1";
 const CACHE_NAME = `cwf-customer-app-v2-${BUILD_ID}`;
 const APP_SHELL = [
   `./index.html?v=${BUILD_ID}`,

--- a/server/services/public/customerAvailability.js
+++ b/server/services/public/customerAvailability.js
@@ -4,6 +4,59 @@ const SLOT_STEP_MIN = 30;
 const DEFAULT_UI_START = "09:00";
 const DEFAULT_UI_END = "18:00";
 const CANCELLED_STATUSES = new Set(["ยกเลิก", "cancelled", "canceled"]);
+const REASON_STATUS = {
+  AVAILABLE: "available",
+  NO_TECHNICIAN_TYPE: "no_open_slots",
+  NO_CUSTOMER_VISIBLE_TECH: "no_open_slots",
+  TECH_OFF: "no_open_slots",
+  NO_MATCHING_SERVICE_MATRIX: "no_open_slots",
+  NO_ADVANCE_CALENDAR_ROW: "no_open_slots",
+  ADVANCE_CLOSED: "no_open_slots",
+  NO_ADVANCE_TIME_WINDOW: "no_open_slots",
+  INVALID_ADVANCE_WINDOW: "error",
+  CUSTOMER_SLOT_SERVICE_CRITERIA_REQUIRED: "error",
+  CAPACITY_FULL: "full",
+  COLLISION_FULL: "full",
+};
+const REASON_PRIORITY = [
+  "CUSTOMER_SLOT_SERVICE_CRITERIA_REQUIRED",
+  "CAPACITY_FULL",
+  "COLLISION_FULL",
+  "INVALID_ADVANCE_WINDOW",
+  "NO_ADVANCE_TIME_WINDOW",
+  "NO_ADVANCE_CALENDAR_ROW",
+  "ADVANCE_CLOSED",
+  "NO_MATCHING_SERVICE_MATRIX",
+  "TECH_OFF",
+  "NO_CUSTOMER_VISIBLE_TECH",
+  "NO_TECHNICIAN_TYPE",
+];
+
+function makeDiagnostic() {
+  const codes = new Set();
+  return {
+    add(code) {
+      if (code) codes.add(String(code));
+    },
+    primary() {
+      for (const code of REASON_PRIORITY) {
+        if (codes.has(code)) return code;
+      }
+      return codes.values().next().value || "";
+    },
+    codes() {
+      return Array.from(codes);
+    },
+  };
+}
+
+function publicDiagnostic(code) {
+  const reason = code || "NO_ADVANCE_TIME_WINDOW";
+  return {
+    availability_status: REASON_STATUS[reason] || "no_open_slots",
+    reason_code: reason,
+  };
+}
 
 function normalizeJobKey(value) {
   const v = String(value || "").toLowerCase();
@@ -223,41 +276,74 @@ async function eligibleCustomerTechnicians(deps, options) {
   const date = options.date;
   const techType = options.tech_type || "company";
   const criteriaList = buildCriteriaList(options);
+  const diagnostic = options.diagnostic || null;
   if (!validateCriteriaList(criteriaList)) {
+    diagnostic?.add("CUSTOMER_SLOT_SERVICE_CRITERIA_REQUIRED");
     const error = new Error("CUSTOMER_SLOT_SERVICE_CRITERIA_REQUIRED");
     error.status = 400;
     throw error;
   }
 
   const allTechs = await listTechniciansByType(techType, { include_paused: true });
+  if (!(allTechs || []).length) diagnostic?.add("NO_TECHNICIAN_TYPE");
   const visibleTechs = (allTechs || []).filter((tech) => tech && tech.customer_slot_visible === true);
+  if (!visibleTechs.length) diagnostic?.add("NO_CUSTOMER_VISIBLE_TECH");
   const offMap = await buildOffMapForDate(date, visibleTechs.map((tech) => tech.username));
   const notOff = visibleTechs.filter((tech) => !isTechOffOnDate(tech, date, offMap));
+  if (visibleTechs.length && !notOff.length) diagnostic?.add("TECH_OFF");
   const matrixMap = await loadServiceMatrixMap(pool, notOff.map((tech) => tech.username));
   const matrixMatched = notOff.filter((tech) => {
     const username = String(tech.username || "");
     if (!matrixMap.has(username)) return false;
     return techMatchesAllCriteriaStrict(matrixMap.get(username), criteriaList);
   });
+  if (notOff.length && !matrixMatched.length) diagnostic?.add("NO_MATCHING_SERVICE_MATRIX");
   const calendarMap = await loadAdvanceCalendarMap(pool, date, matrixMatched.map((tech) => tech.username), Boolean(options.lock_calendar_rows));
   const requestedUnits = serviceUnitCount(options);
   const usageMap = await loadDailyUsageMap(pool, date, matrixMatched.map((tech) => tech.username), options.ignore_job_id);
-  return matrixMatched.filter((tech) => {
+  let missingCalendar = 0;
+  let closedCalendar = 0;
+  let invalidWindow = 0;
+  let capacityFull = 0;
+  const eligible = matrixMatched.filter((tech) => {
     const username = String(tech.username || "");
     const calendar = calendarMap.get(username);
-    if (!calendar || calendar.can_accept_advance_job !== true) return false;
+    if (!calendar) {
+      missingCalendar += 1;
+      return false;
+    }
+    if (calendar.can_accept_advance_job !== true) {
+      closedCalendar += 1;
+      return false;
+    }
     const start = String(calendar.start_time || "").slice(0, 5);
     const end = String(calendar.end_time || "").slice(0, 5);
-    if (!/^\d{2}:\d{2}$/.test(start) || !/^\d{2}:\d{2}$/.test(end)) return false;
+    if (!/^\d{2}:\d{2}$/.test(start) || !/^\d{2}:\d{2}$/.test(end)) {
+      invalidWindow += 1;
+      return false;
+    }
     const maxJobs = calendar.max_jobs_per_day == null ? null : Number(calendar.max_jobs_per_day);
     const maxUnits = calendar.max_units_per_day == null ? null : Number(calendar.max_units_per_day);
     const usage = usageMap.get(username) || { jobs_count: 0, units_count: 0 };
-    if (Number.isFinite(maxJobs) && maxJobs >= 0 && usage.jobs_count >= maxJobs) return false;
-    if (Number.isFinite(maxUnits) && maxUnits >= 0 && (usage.units_count + requestedUnits) > maxUnits) return false;
+    if (Number.isFinite(maxJobs) && maxJobs >= 0 && usage.jobs_count >= maxJobs) {
+      capacityFull += 1;
+      return false;
+    }
+    if (Number.isFinite(maxUnits) && maxUnits >= 0 && (usage.units_count + requestedUnits) > maxUnits) {
+      capacityFull += 1;
+      return false;
+    }
     tech.advance_calendar = calendar;
     tech.advance_usage = usage;
     return true;
   });
+  if (matrixMatched.length && !eligible.length) {
+    if (capacityFull) diagnostic?.add("CAPACITY_FULL");
+    if (invalidWindow) diagnostic?.add("INVALID_ADVANCE_WINDOW");
+    if (missingCalendar) diagnostic?.add("NO_ADVANCE_CALENDAR_ROW");
+    if (closedCalendar) diagnostic?.add("ADVANCE_CLOSED");
+  }
+  return eligible;
 }
 
 async function computePublicCustomerSlots(deps, options) {
@@ -274,8 +360,11 @@ async function computePublicCustomerSlots(deps, options) {
   const durationMin = Math.max(15, Number(options.duration_min || 60));
   const uiStartMin = toMin(DEFAULT_UI_START);
   const uiEndMin = toMin(DEFAULT_UI_END);
-  const techs = await eligibleCustomerTechnicians(deps, { ...options, date });
+  const diagnostic = options.diagnostic || makeDiagnostic();
+  const techs = await eligibleCustomerTechnicians(deps, { ...options, date, diagnostic });
   const events = new Map();
+  let sawWindow = false;
+  let sawStartInterval = false;
   const addEvent = (minute, type, username) => {
     const key = Math.round(minute);
     if (!events.has(key)) events.set(key, { add: [], remove: [] });
@@ -301,9 +390,11 @@ async function computePublicCustomerSlots(deps, options) {
       ? [{ startMin: windowStart, endMin: windowEnd }]
       : [];
     if (!windows.length) continue;
+    sawWindow = true;
     const busyBlocks = await listBusyBlocksForTechOnDate(tech.username, date, null);
     for (const window of windows) {
       const intervals = buildStartIntervalsByCollision(busyBlocks, window.startMin, window.endMin, durationMin);
+      if (intervals.length) sawStartInterval = true;
       for (const interval of intervals) {
         addEvent(interval.startMin, "add", tech.username);
         addEvent(interval.endMin + 1, "remove", tech.username);
@@ -343,6 +434,9 @@ async function computePublicCustomerSlots(deps, options) {
     duration_min: durationMin,
     slot_step_min: SLOT_STEP_MIN,
     slots,
+    ...(slots.length
+      ? { availability_status: "available", reason_code: "AVAILABLE" }
+      : publicDiagnostic(diagnostic.primary() || (!sawWindow ? "NO_ADVANCE_TIME_WINDOW" : (!sawStartInterval ? "COLLISION_FULL" : "NO_ADVANCE_TIME_WINDOW")))),
   };
 }
 
@@ -367,11 +461,14 @@ async function computeCalendarSummary(deps, options) {
   const month = String(options.month || "").slice(0, 7);
   const days = [];
   for (const date of monthDays(month)) {
-    const result = await computePublicCustomerSlots(deps, { ...options, date });
+    const diagnostic = makeDiagnostic();
+    const result = await computePublicCustomerSlots(deps, { ...options, date, diagnostic });
     const first = (result.slots || []).find((slot) => slot.available);
     days.push({
       date,
       available: Boolean(first),
+      status: first ? "available" : (result.availability_status || publicDiagnostic(diagnostic.primary()).availability_status),
+      reason_code: first ? "AVAILABLE" : (result.reason_code || publicDiagnostic(diagnostic.primary()).reason_code),
       first_available: first ? first.start : null,
     });
   }
@@ -441,4 +538,5 @@ module.exports = {
   computeCalendarSummary,
   hasAvailableStart,
   reservePublicCustomerTechnician,
+  makeDiagnostic,
 };

--- a/test/customerAppRecovery.test.js
+++ b/test/customerAppRecovery.test.js
@@ -135,7 +135,7 @@ test("Customer App build id is consistent across shell and service worker", () =
   const sw = read("customer-app/sw.js");
   const app = read("customer-app/assets/customer-app.js");
   const manifest = read("customer-app/manifest.webmanifest");
-  const build = "20260621_advance_slots_three_step_draft_v1";
+  const build = "20260621_availability_reason_hotfix_v1";
 
   assert.match(index, new RegExp(`customer-app\\.css\\?v=${build}`));
   assert.match(index, new RegExp(`bookingUrgent\\.js\\?v=${build}`));

--- a/test/customerAppThreeStepBooking.test.js
+++ b/test/customerAppThreeStepBooking.test.js
@@ -204,18 +204,25 @@ test("review screen displays selected time preference", () => {
 test("calendar marks available and full dates without technician identity", () => {
   const { root } = loadBooking();
   root.state.setScheduledPreview("pricing", { status: "success", data: { duration_min: 60, active_price: 500 }, error: "" });
+  const month = root.state.draft.scheduled.calendar_month;
+  const [year, monthNumber] = month.split("-").map(Number);
+  const fullDate = `${year}-${String(monthNumber).padStart(2, "0")}-25`;
+  const noOpenDate = `${year}-${String(monthNumber).padStart(2, "0")}-26`;
   const key = root.availability.calendarQueryKey(root.bookingScheduled._test.currentCalendarQuery());
   root.state.setScheduledPreview("calendar", {
     status: "success",
     data: { month: root.state.draft.scheduled.calendar_month, days: [
       { date: root.state.draft.scheduled.date, available: true, first_available: "09:00", technician_name: "Hidden" },
-      { date: "2099-12-31", available: false, first_available: null, technician_count: 3 },
+      { date: fullDate, available: false, status: "full", reason_code: "COLLISION_FULL", first_available: null, technician_count: 3 },
+      { date: noOpenDate, available: false, status: "no_open_slots", reason_code: "NO_ADVANCE_CALENDAR_ROW", first_available: null },
     ] },
     error: "",
     query_key: key,
   });
   const html = renderInto(root, 2);
   assert.match(html, /มีคิว/);
+  assert.match(html, /เต็ม/);
+  assert.match(html, /ยังไม่มีคิวเปิด/);
   assert.doesNotMatch(html, /Hidden|technician_name|technician_id|technician_count|matrix_json/);
 });
 

--- a/test/customerMultiServiceCalendar.test.js
+++ b/test/customerMultiServiceCalendar.test.js
@@ -134,8 +134,10 @@ test("calendar summary contains only date availability and first available start
   assert.equal(summary.month, "2026-06");
   assert.equal(summary.days[0].date, "2026-06-01");
   assert.equal(summary.days[0].available, true);
+  assert.equal(summary.days[0].status, "available");
+  assert.equal(summary.days[0].reason_code, "AVAILABLE");
   assert.equal(summary.days[0].first_available, "09:00");
-  assert.deepEqual(Object.keys(summary.days[0]).sort(), ["available", "date", "first_available"]);
+  assert.deepEqual(Object.keys(summary.days[0]).sort(), ["available", "date", "first_available", "reason_code", "status"]);
 });
 
 test("monthly advance calendar is required for customer slots", async () => {
@@ -150,9 +152,13 @@ test("monthly advance calendar is required for customer slots", async () => {
 
   result = await customerAvailability.computePublicCustomerSlots(makeAvailabilityDeps({ calendar: false }), base);
   assert.equal(result.slots.length, 0);
+  assert.equal(result.availability_status, "no_open_slots");
+  assert.equal(result.reason_code, "NO_ADVANCE_CALENDAR_ROW");
 
   result = await customerAvailability.computePublicCustomerSlots(makeAvailabilityDeps({ calendar: "false" }), base);
   assert.equal(result.slots.length, 0);
+  assert.equal(result.availability_status, "no_open_slots");
+  assert.equal(result.reason_code, "ADVANCE_CLOSED");
 });
 
 test("advance calendar daily job and unit caps block public slots", async () => {
@@ -167,12 +173,30 @@ test("advance calendar daily job and unit caps block public slots", async () => 
     usage: { rows: [{ technician_username: "tech-a", jobs_count: 1, units_count: 1 }] },
   }), base);
   assert.equal(result.slots.length, 0);
+  assert.equal(result.availability_status, "full");
+  assert.equal(result.reason_code, "CAPACITY_FULL");
 
   result = await customerAvailability.computePublicCustomerSlots(makeAvailabilityDeps({
     calendar: { max_jobs_per_day: 2, max_units_per_day: 2 },
     usage: { rows: [{ technician_username: "tech-a", jobs_count: 0, units_count: 1 }] },
   }), base);
   assert.equal(result.slots.length, 0);
+  assert.equal(result.availability_status, "full");
+  assert.equal(result.reason_code, "CAPACITY_FULL");
+});
+
+test("collision-only unavailable slots are marked full", async () => {
+  const result = await customerAvailability.computePublicCustomerSlots(makeAvailabilityDeps({
+    busyBlocks: [{ startMin: 540, endMin: 720 }],
+  }), {
+    date: "2026-06-02",
+    duration_min: 60,
+    tech_type: "company",
+    services: [{ job_type: "ล้าง", ac_type: "ผนัง", wash_variant: "ล้างธรรมดา", machine_count: 1 }],
+  });
+  assert.equal(result.slots.length, 0);
+  assert.equal(result.availability_status, "full");
+  assert.equal(result.reason_code, "COLLISION_FULL");
 });
 
 test("draft reservation uses advisory lock, rechecks exact slot, and picks anonymous technician", async () => {


### PR DESCRIPTION
## Summary
- Add anonymous availability status/reason codes to customer calendar and selected-day availability responses.
- Distinguish no-open-slot days from truly full/collision/capacity-full days.
- Update Customer App calendar labels so "เต็ม" appears only for explicit full status, while missing/opening issues show "ยังไม่มีคิวเปิด" or retry messaging.
- Bump Customer App build/cache IDs.

## Production evidence before deploy
Read-only production API check against `https://app.cwf-air.com/public/availability_calendar_v2` for wall clean service:
- `2026-06`: HTTP 200, 30 days, `available: 0`, no `status` fields, no `reason_code` fields.
- `2026-07`: HTTP 200, 31 days, `available: 0`, no `status` fields, no `reason_code` fields.

## Tests
- `node --check server/services/public/customerAvailability.js`
- `node --check customer-app/modules/availability.js`
- `node --check customer-app/modules/bookingScheduled.js`
- `node --check customer-app/assets/customer-app.js`
- `node --check customer-app/sw.js`
- `node --test test/customerAppRecovery.test.js test/customerAppThreeStepBooking.test.js test/customerMultiServiceCalendar.test.js --test-reporter=spec` => 44/44 passed
- `npm test` => 112/112 passed
- `git diff --check` => passed

## Notes
- No technician names, usernames, IDs, matrices, counts, or internal capacity values are exposed in public responses.
- No database migration or production data changes.
- No 3-step booking rewrite or rollback.