### PR TITLE
Fix Customer booking recovery and monthly availability source of truth

### DIFF
--- a/customer-app/assets/customer-app.js
+++ b/customer-app/assets/customer-app.js
@@ -3,7 +3,7 @@
 
   const App = window.CWFCustomerAppV2;
   const BOOT_TIMEOUT_MS = 3500;
-  const BUILD_ID = "20260621_availability_reason_hotfix_v1";
+  const BUILD_ID = "20260621_booking_recovery_soT_v2";
 
   function withTimeout(promise, timeoutMs) {
     return Promise.race([

--- a/customer-app/index.html
+++ b/customer-app/index.html
@@ -9,10 +9,10 @@
   <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
   <meta name="apple-mobile-web-app-title" content="CWF Service">
   <title>CWF Customer Service</title>
-  <link rel="manifest" href="./manifest.webmanifest?v=20260621_availability_reason_hotfix_v1">
+  <link rel="manifest" href="./manifest.webmanifest?v=20260621_booking_recovery_soT_v2">
   <link rel="icon" type="image/png" sizes="192x192" href="./assets/icons/cwf-customer-192.png">
   <link rel="apple-touch-icon" sizes="180x180" href="./assets/icons/cwf-customer-180.png">
-  <link rel="stylesheet" href="./assets/customer-app.css?v=20260621_availability_reason_hotfix_v1">
+  <link rel="stylesheet" href="./assets/customer-app.css?v=20260621_booking_recovery_soT_v2">
 </head>
 <body class="is-app-booting">
   <div class="app-shell" data-app-shell>
@@ -49,19 +49,19 @@
     </nav>
   </div>
 
-  <script src="./modules/state.js?v=20260621_availability_reason_hotfix_v1"></script>
-  <script src="./modules/utils.js?v=20260621_availability_reason_hotfix_v1"></script>
-  <script src="./modules/api.js?v=20260621_availability_reason_hotfix_v1"></script>
-  <script src="./modules/services.js?v=20260621_availability_reason_hotfix_v1"></script>
-  <script src="./modules/ui.js?v=20260621_availability_reason_hotfix_v1"></script>
-  <script src="./modules/auth.js?v=20260621_availability_reason_hotfix_v1"></script>
-  <script src="./modules/pricing.js?v=20260621_availability_reason_hotfix_v1"></script>
-  <script src="./modules/availability.js?v=20260621_availability_reason_hotfix_v1"></script>
-  <script src="./modules/bookingScheduled.js?v=20260621_availability_reason_hotfix_v1"></script>
-  <script src="./modules/bookingUrgent.js?v=20260621_availability_reason_hotfix_v1"></script>
-  <script src="./modules/tracking.js?v=20260621_availability_reason_hotfix_v1"></script>
-  <script src="./modules/profile.js?v=20260621_availability_reason_hotfix_v1"></script>
-  <script src="./modules/router.js?v=20260621_availability_reason_hotfix_v1"></script>
-  <script src="./assets/customer-app.js?v=20260621_availability_reason_hotfix_v1"></script>
+  <script src="./modules/state.js?v=20260621_booking_recovery_soT_v2"></script>
+  <script src="./modules/utils.js?v=20260621_booking_recovery_soT_v2"></script>
+  <script src="./modules/api.js?v=20260621_booking_recovery_soT_v2"></script>
+  <script src="./modules/services.js?v=20260621_booking_recovery_soT_v2"></script>
+  <script src="./modules/ui.js?v=20260621_booking_recovery_soT_v2"></script>
+  <script src="./modules/auth.js?v=20260621_booking_recovery_soT_v2"></script>
+  <script src="./modules/pricing.js?v=20260621_booking_recovery_soT_v2"></script>
+  <script src="./modules/availability.js?v=20260621_booking_recovery_soT_v2"></script>
+  <script src="./modules/bookingScheduled.js?v=20260621_booking_recovery_soT_v2"></script>
+  <script src="./modules/bookingUrgent.js?v=20260621_booking_recovery_soT_v2"></script>
+  <script src="./modules/tracking.js?v=20260621_booking_recovery_soT_v2"></script>
+  <script src="./modules/profile.js?v=20260621_booking_recovery_soT_v2"></script>
+  <script src="./modules/router.js?v=20260621_booking_recovery_soT_v2"></script>
+  <script src="./assets/customer-app.js?v=20260621_booking_recovery_soT_v2"></script>
 </body>
 </html>

--- a/customer-app/manifest.webmanifest
+++ b/customer-app/manifest.webmanifest
@@ -2,7 +2,7 @@
   "name": "CWF Customer Service",
   "short_name": "CWF Service",
   "description": "แอปลูกค้า Coldwindflow สำหรับเลือกบริการ จองคิว และติดตามงาน",
-  "start_url": "/customer-app/index.html?v=20260621_availability_reason_hotfix_v1#home",
+  "start_url": "/customer-app/index.html?v=20260621_booking_recovery_soT_v2#home",
   "scope": "/customer-app/",
   "id": "/customer-app/",
   "display": "standalone",

--- a/customer-app/modules/bookingScheduled.js
+++ b/customer-app/modules/bookingScheduled.js
@@ -6,6 +6,7 @@
   const STEP_MAX = 3;
   let availabilityRequestSeq = 0;
   let calendarRequestSeq = 0;
+  let recoveryInFlight = false;
 
   function draft() {
     return root.state.draft.scheduled || {};
@@ -398,8 +399,14 @@
     const daysInMonth = new Date(year, monthNumber, 0).getDate();
     const calendarState = root.state.scheduledPreview.calendar;
     const expectedKey = currentCalendarKey();
-    const dayMap = calendarState.query_key === expectedKey ? root.availability.normalizeCalendarDays(calendarState.data) : new Map();
-    const isLoading = calendarState.status === "loading" || (expectedKey && calendarState.query_key !== expectedKey);
+    // Defect B: only trust calendar day data when the backend successfully answered the CURRENT
+    // query. While pricing/calendar are still resolving (idle, loading, recovering, or a stale key)
+    // we render a neutral pending state and never manufacture "ยังไม่มีคิวเปิด" from missing data.
+    const hasData = Boolean(expectedKey) && calendarState.status === "success" && calendarState.query_key === expectedKey;
+    const isError = Boolean(expectedKey) && calendarState.status === "error" && calendarState.query_key === expectedKey;
+    const isPending = !hasData && !isError;
+    const dayMap = hasData ? root.availability.normalizeCalendarDays(calendarState.data) : new Map();
+    const isLoading = isPending;
     const cells = [];
     for (let i = 0; i < startOffset; i += 1) cells.push(`<span class="calendar-day is-empty" aria-hidden="true"></span>`);
     for (let day = 1; day <= daysInMonth; day += 1) {
@@ -413,10 +420,19 @@
       const full = dayStatus === "full";
       const noOpenSlots = dayStatus === "no_open_slots";
       const systemIssue = dayStatus === "error";
-      const disabled = outsideRange || !available || (!isLoading && expectedKey && !available);
+      // Days are only selectable once a confirmed availability response marks them available.
+      const disabled = outsideRange || isPending || !available;
       const label = outsideRange
         ? ""
-        : (isLoading ? "..." : (available ? "มีคิว" : (full ? "เต็ม" : (systemIssue ? "ลองใหม่" : "ยังไม่มีคิวเปิด"))));
+        : (isPending
+            ? "..."
+            : (available
+                ? "มีคิว"
+                : (full
+                    ? "เต็ม"
+                    : (systemIssue
+                        ? "ลองใหม่"
+                        : (noOpenSlots ? "ยังไม่มีคิวเปิด" : "")))));
       cells.push(`
         <button type="button" class="calendar-day ${selected ? "is-selected" : ""} ${isToday ? "is-today" : ""} ${available ? "is-available" : ""} ${full ? "is-full" : ""} ${noOpenSlots ? "is-no-open-slots" : ""} ${systemIssue ? "is-error" : ""} ${isLoading ? "is-loading" : ""}"
           data-calendar-date="${dateValue}" ${disabled ? "disabled" : ""}
@@ -451,13 +467,22 @@
     if (!availability.data) return root.utils.stateBox("", "เลือกวันที่มีคิว ระบบจะแสดงช่วงเวลาว่างด้านล่าง");
     const slots = normalizedSlots();
     if (!slots.length) {
+      // Defect B: derive the empty message strictly from the backend status. "ยังไม่มีคิวเปิด" is
+      // shown only when the backend explicitly returns no_open_slots; any other/unknown status is
+      // treated as a recoverable condition rather than a manufactured "no open slots".
       const status = String(availability.data.availability_status || "").trim();
-      const message = status === "full"
-        ? "วันที่เลือกเต็มแล้ว กรุณาเลือกวันอื่น"
-        : status === "error"
-          ? "ระบบตรวจคิววันนี้ไม่สำเร็จ กรุณาลองใหม่"
-          : "ยังไม่มีคิวเปิดในวันนี้ กรุณาเลือกวันอื่น";
-      const tone = status === "error" ? "error" : "warning";
+      let message;
+      let tone = "warning";
+      if (status === "full") {
+        message = "วันที่เลือกเต็มแล้ว กรุณาเลือกวันอื่น";
+      } else if (status === "error") {
+        message = "ระบบตรวจคิววันนี้ไม่สำเร็จ กรุณาลองใหม่";
+        tone = "error";
+      } else if (status === "no_open_slots") {
+        message = "ยังไม่มีคิวเปิดในวันนี้ กรุณาเลือกวันอื่น";
+      } else {
+        message = "ไม่พบช่วงเวลาว่างในวันนี้ กรุณาลองใหม่อีกครั้งหรือเลือกวันอื่น";
+      }
       return `${root.utils.stateBox(tone, message)}<button type="button" class="secondary-btn" data-action="reload-slots">ตรวจคิววันนี้อีกครั้ง</button>`;
     }
     return `
@@ -649,13 +674,17 @@
     };
   }
 
-  async function refreshPricing(container) {
+  async function refreshPricing(container, opts = {}) {
     const payload = payloadFromDraft();
     if (!payload) throw new Error("ข้อมูลบริการไม่ครบ");
     root.state.setScheduledPreview("pricing", { status: "loading", data: null, error: "" });
-    root.state.setScheduledPreview("availability", { status: "idle", data: null, error: "", query_key: "", loaded_at: "" });
-    root.state.setScheduledPreview("calendar", { status: "idle", data: null, error: "", query_key: "", loaded_at: "" });
-    root.state.updateDraft("scheduled", { selectedSlot: null });
+    // During recovery the service has not changed, so keep any restored calendar/slot selection
+    // and only recompute the missing pricing. A normal (re)calculation invalidates dependents.
+    if (!opts.preserveDependents) {
+      root.state.setScheduledPreview("availability", { status: "idle", data: null, error: "", query_key: "", loaded_at: "" });
+      root.state.setScheduledPreview("calendar", { status: "idle", data: null, error: "", query_key: "", loaded_at: "" });
+      root.state.updateDraft("scheduled", { selectedSlot: null });
+    }
     paint(container);
     try {
       const data = await root.api.previewPricing(payload);
@@ -695,7 +724,7 @@
     }
   }
 
-  async function refreshAvailability(container) {
+  async function refreshAvailability(container, opts = {}) {
     const query = currentAvailabilityQuery();
     if (!query) {
       root.state.setScheduledPreview("availability", { status: "error", data: null, error: "ข้อมูลบริการ ราคา หรือวันที่ยังไม่พร้อม", query_key: "", loaded_at: "" });
@@ -709,7 +738,11 @@
     }
     const expectedKey = root.availability.queryKey(query);
     const requestId = ++availabilityRequestSeq;
-    root.state.updateDraft("scheduled", { selectedSlot: null });
+    // During recovery a restored slot selection (same service/date) is kept so the customer is not
+    // silently bumped; selectedSlotIsCurrent() still re-validates it against the fresh response.
+    if (!opts.preserveSelection) {
+      root.state.updateDraft("scheduled", { selectedSlot: null });
+    }
     root.state.setScheduledPreview("availability", { status: "loading", data: null, error: "", query_key: expectedKey, loaded_at: "" });
     paint(container);
     try {
@@ -1000,15 +1033,44 @@
     });
   }
 
+  // Defect A: when Step 2/3 is restored from storage (e.g. reload, returning to the tab) the
+  // in-memory pricing/calendar/slot preview is gone because only the draft + step are persisted.
+  // Recover the dependency chain in order pricing -> calendar -> selected-day availability, without
+  // firing competing requests and without bouncing the customer back to Step 1.
+  async function recoverScheduledDependencies(container) {
+    if (recoveryInFlight) return;
+    if (step() < 2) return;
+    const preview = root.state.scheduledPreview;
+    const needPricing = !preview.pricing.data && preview.pricing.status !== "loading";
+    const needCalendar = preview.calendar.status === "idle";
+    const needAvailability = preview.availability.status === "idle";
+    if (!needPricing && !needCalendar && !needAvailability) return;
+    recoveryInFlight = true;
+    try {
+      if (needPricing) {
+        try { await refreshPricing(container, { preserveDependents: true }); }
+        catch (_) { return; }
+      }
+      if (!root.state.scheduledPreview.pricing.data) return;
+      if (root.state.scheduledPreview.calendar.status === "idle") {
+        await refreshCalendar(container);
+      }
+      if (root.state.scheduledPreview.availability.status === "idle") {
+        await refreshAvailability(container, { preserveSelection: true });
+      }
+    } finally {
+      recoveryInFlight = false;
+    }
+  }
+
   function render(container) {
     paint(container);
-    if (step() === 1 && root.state.scheduledPreview.pricing.status === "idle") {
-      refreshPricing(container).catch(() => {});
-    }
-    if (step() === 2 && root.state.scheduledPreview.pricing.data && root.state.scheduledPreview.calendar.status === "idle") {
-      refreshCalendar(container);
-    } else if (step() === 2 && root.state.scheduledPreview.pricing.data && root.state.scheduledPreview.availability.status === "idle") {
-      refreshAvailability(container);
+    if (step() === 1) {
+      if (root.state.scheduledPreview.pricing.status === "idle") {
+        refreshPricing(container).catch(() => {});
+      }
+    } else {
+      recoverScheduledDependencies(container);
     }
     root.state.ensureSavedAddressPrefill("scheduled", () => paint(container));
   }

--- a/customer-app/sw.js
+++ b/customer-app/sw.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const BUILD_ID = "20260621_availability_reason_hotfix_v1";
+const BUILD_ID = "20260621_booking_recovery_soT_v2";
 const CACHE_NAME = `cwf-customer-app-v2-${BUILD_ID}`;
 const APP_SHELL = [
   `./index.html?v=${BUILD_ID}`,

--- a/server/services/public/customerAvailability.js
+++ b/server/services/public/customerAvailability.js
@@ -270,8 +270,6 @@ async function eligibleCustomerTechnicians(deps, options) {
   const {
     pool,
     listTechniciansByType,
-    buildOffMapForDate,
-    isTechOffOnDate,
   } = deps;
   const date = options.date;
   const techType = options.tech_type || "company";
@@ -288,16 +286,18 @@ async function eligibleCustomerTechnicians(deps, options) {
   if (!(allTechs || []).length) diagnostic?.add("NO_TECHNICIAN_TYPE");
   const visibleTechs = (allTechs || []).filter((tech) => tech && tech.customer_slot_visible === true);
   if (!visibleTechs.length) diagnostic?.add("NO_CUSTOMER_VISIBLE_TECH");
-  const offMap = await buildOffMapForDate(date, visibleTechs.map((tech) => tech.username));
-  const notOff = visibleTechs.filter((tech) => !isTechOffOnDate(tech, date, offMap));
-  if (visibleTechs.length && !notOff.length) diagnostic?.add("TECH_OFF");
-  const matrixMap = await loadServiceMatrixMap(pool, notOff.map((tech) => tech.username));
-  const matrixMatched = notOff.filter((tech) => {
+  // Defect E: technician_monthly_work_calendar is the single source of truth for scheduled
+  // customer availability. An explicit monthly opt-in (can_accept_advance_job=true for the date)
+  // must NOT be closed by legacy weekly_off_days / technician_workdays_v2. Eligibility for the
+  // date is therefore decided solely by the monthly calendar gate below, not by legacy off-days.
+  // (Urgent Booking keeps its own legacy off-day handling elsewhere and is untouched.)
+  const matrixMap = await loadServiceMatrixMap(pool, visibleTechs.map((tech) => tech.username));
+  const matrixMatched = visibleTechs.filter((tech) => {
     const username = String(tech.username || "");
     if (!matrixMap.has(username)) return false;
     return techMatchesAllCriteriaStrict(matrixMap.get(username), criteriaList);
   });
-  if (notOff.length && !matrixMatched.length) diagnostic?.add("NO_MATCHING_SERVICE_MATRIX");
+  if (visibleTechs.length && !matrixMatched.length) diagnostic?.add("NO_MATCHING_SERVICE_MATRIX");
   const calendarMap = await loadAdvanceCalendarMap(pool, date, matrixMatched.map((tech) => tech.username), Boolean(options.lock_calendar_rows));
   const requestedUnits = serviceUnitCount(options);
   const usageMap = await loadDailyUsageMap(pool, date, matrixMatched.map((tech) => tech.username), options.ignore_job_id);

--- a/test/customerAppRecovery.test.js
+++ b/test/customerAppRecovery.test.js
@@ -135,7 +135,7 @@ test("Customer App build id is consistent across shell and service worker", () =
   const sw = read("customer-app/sw.js");
   const app = read("customer-app/assets/customer-app.js");
   const manifest = read("customer-app/manifest.webmanifest");
-  const build = "20260621_availability_reason_hotfix_v1";
+  const build = "20260621_booking_recovery_soT_v2";
 
   assert.match(index, new RegExp(`customer-app\\.css\\?v=${build}`));
   assert.match(index, new RegExp(`bookingUrgent\\.js\\?v=${build}`));

--- a/test/customerBookingRecovery.test.js
+++ b/test/customerBookingRecovery.test.js
@@ -1,0 +1,290 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const vm = require("node:vm");
+
+const REPO_ROOT = path.resolve(__dirname, "..");
+const customerAvailability = require("../server/services/public/customerAvailability");
+
+function read(relativePath) {
+  return fs.readFileSync(path.join(REPO_ROOT, relativePath), "utf8");
+}
+
+function makeContext() {
+  const storage = new Map();
+  const window = {
+    CWFCustomerAppV2: {},
+    location: { protocol: "https:", origin: "https://app.example.test", pathname: "/customer-app/index.html", search: "", hash: "" },
+    sessionStorage: {
+      getItem(key) { return storage.has(key) ? storage.get(key) : null; },
+      setItem(key, value) { storage.set(key, String(value)); },
+      removeItem(key) { storage.delete(key); },
+    },
+    addEventListener() {},
+  };
+  const context = {
+    window,
+    document: {
+      body: { classList: { add() {}, remove() {} } },
+      addEventListener() {},
+      querySelectorAll() { return []; },
+      getElementById() { return null; },
+    },
+    history: { replaceState() {} },
+    URL,
+    URLSearchParams,
+    Intl,
+    Date,
+    console,
+    setTimeout,
+    clearTimeout,
+    requestAnimationFrame(fn) { return fn(); },
+    fetch: async () => ({ ok: true, text: async () => "{}" }),
+  };
+  context.globalThis = context;
+  return vm.createContext(context);
+}
+
+function load(context, modules) {
+  for (const modulePath of modules) {
+    vm.runInContext(read(modulePath), context, { filename: modulePath });
+  }
+  return context.window.CWFCustomerAppV2;
+}
+
+const FRONTEND_MODULES = [
+  "customer-app/modules/utils.js",
+  "customer-app/modules/state.js",
+  "customer-app/modules/api.js",
+  "customer-app/modules/services.js",
+  "customer-app/modules/ui.js",
+  "customer-app/modules/auth.js",
+  "customer-app/modules/availability.js",
+  "customer-app/modules/bookingScheduled.js",
+  "customer-app/modules/bookingUrgent.js",
+  "customer-app/modules/router.js",
+];
+
+class WizardContainer {
+  constructor() {
+    this._innerHTML = "";
+    this.buttons = [];
+  }
+  set innerHTML(value) {
+    this._innerHTML = String(value || "");
+    this.buttons = [];
+    [...this._innerHTML.matchAll(/data-action="([^"]+)"/g)].forEach((m) => this.buttons.push({ attr: m[1] }));
+  }
+  get innerHTML() { return this._innerHTML; }
+  scrollIntoView() {}
+  querySelector() { return null; }
+  querySelectorAll() { return []; }
+}
+
+function flush() {
+  return new Promise((resolve) => setTimeout(resolve, 30));
+}
+
+// Persist a scheduled draft at a given step using a throwaway state load, then return a fresh
+// frontend whose state.init() restores it — exactly the "reload into Step N" production path.
+function restoreFrontendAtStep(step, draftPatch = {}) {
+  const context = makeContext();
+  let root = load(context, ["customer-app/modules/state.js"]);
+  if (Object.keys(draftPatch).length) root.state.updateDraft("scheduled", draftPatch);
+  root.state.setScheduledWizard({ step });
+
+  context.window.CWFCustomerAppV2 = {};
+  root = load(context, FRONTEND_MODULES);
+  root.state.init();
+  root.state.customer = { logged_in: false };
+  root.utils.routeTo = () => {};
+  return { context, root };
+}
+
+test("Restored Step 2 recovers pricing, calendar, and selected-day slots", async () => {
+  const { root } = restoreFrontendAtStep(2);
+  assert.equal(root.state.scheduledWizard.step, 2);
+  // Reload clears the in-memory preview: nothing is persisted except the draft + step.
+  assert.equal(root.state.scheduledPreview.pricing.data, null);
+
+  const d = root.state.draft.scheduled;
+  let pricingCalls = 0;
+  let calendarCalls = 0;
+  let availabilityCalls = 0;
+  root.api.previewPricing = async () => { pricingCalls += 1; return { duration_min: 90, active_price: 1200, standard_price: 1200 }; };
+  root.api.loadAvailabilityCalendar = async () => { calendarCalls += 1; return { month: d.calendar_month, days: [{ date: d.date, available: true, status: "available", first_available: "09:00" }] }; };
+  root.api.loadAvailability = async () => { availabilityCalls += 1; return { date: d.date, duration_min: 90, slot_step_min: 30, slots: [{ start: "09:00", end: "12:00", available: true }] }; };
+
+  const container = new WizardContainer();
+  root.bookingScheduled.render(container);
+  await flush();
+
+  assert.equal(root.state.scheduledPreview.pricing.status, "success");
+  assert.equal(root.state.scheduledPreview.calendar.status, "success");
+  assert.equal(root.state.scheduledPreview.availability.status, "success");
+  assert.equal(pricingCalls, 1, "pricing recovered exactly once (no duplicate requests)");
+  assert.equal(calendarCalls, 1);
+  assert.equal(availabilityCalls, 1);
+  assert.doesNotMatch(container.innerHTML, /ข้อมูลบริการหรือราคายังไม่พร้อม/);
+  assert.match(container.innerHTML, /09:00/);
+});
+
+test("Restored Step 3 recovers dependencies and preserves the selected slot", async () => {
+  const seedDate = (() => {
+    const ctx = makeContext();
+    const r = load(ctx, ["customer-app/modules/state.js"]);
+    return r.state.draft.scheduled.date;
+  })();
+  const { root } = restoreFrontendAtStep(3, {
+    customer_name: "Step3 Customer",
+    customer_phone: "0812345678",
+    address_text: "Step3 Condo",
+    selectedSlot: { key: `${seedDate}|09:00|90`, date: seedDate, start: "09:00", end: "10:30", duration_min: 90, query_key: "stale-key-from-previous-session" },
+  });
+  assert.equal(root.state.scheduledWizard.step, 3);
+  assert.ok(root.state.draft.scheduled.selectedSlot, "restored draft still carries the chosen slot");
+
+  const d = root.state.draft.scheduled;
+  root.api.previewPricing = async () => ({ duration_min: 90, active_price: 1200, standard_price: 1200 });
+  root.api.loadAvailabilityCalendar = async () => ({ month: d.calendar_month, days: [{ date: d.date, available: true, status: "available", first_available: "09:00" }] });
+  root.api.loadAvailability = async () => ({ date: d.date, duration_min: 90, slot_step_min: 30, slots: [{ start: "09:00", end: "12:00", available: true }] });
+
+  const container = new WizardContainer();
+  root.bookingScheduled.render(container);
+  await flush();
+
+  assert.equal(root.state.scheduledPreview.pricing.status, "success");
+  assert.equal(root.state.scheduledPreview.availability.status, "success");
+  assert.ok(root.state.draft.scheduled.selectedSlot, "recovery must not drop the customer's slot");
+  assert.equal(root.state.draft.scheduled.selectedSlot.start, "09:00");
+  assert.equal(root.state.scheduledWizard.step, 3, "customer is not bounced back to an earlier step");
+});
+
+test("Calendar shows pending (not no-open-slots) while data is unresolved", () => {
+  const { root } = restoreFrontendAtStep(2);
+  // APIs that never resolve: the recovery chain stays in-flight, calendar data is unavailable.
+  root.api.previewPricing = () => new Promise(() => {});
+  root.api.loadAvailabilityCalendar = () => new Promise(() => {});
+  root.api.loadAvailability = () => new Promise(() => {});
+
+  const container = new WizardContainer();
+  root.bookingScheduled.render(container);
+
+  // No backend no_open_slots response yet -> must not manufacture "ยังไม่มีคิวเปิด".
+  assert.doesNotMatch(container.innerHTML, /ยังไม่มีคิวเปิด/);
+  assert.match(container.innerHTML, /\.\.\./);
+});
+
+test("Calendar shows explicit no_open_slots and full only from backend status", () => {
+  const { root } = restoreFrontendAtStep(2);
+  const d = root.state.draft.scheduled;
+  root.state.setScheduledPreview("pricing", { status: "success", data: { duration_min: 60, active_price: 900 }, error: "" });
+  const query = root.availability.publicCalendarQuery(d, root.services.payloadFromScheduledDraft(d), root.state.scheduledPreview.pricing.data);
+  const key = root.availability.calendarQueryKey(query);
+  // Keep recovery a no-op by marking availability resolved.
+  root.state.setScheduledPreview("availability", { status: "success", data: { date: d.date, slots: [], availability_status: "no_open_slots" }, error: "", query_key: "k", loaded_at: "x" });
+
+  function calendarHtmlFor(status) {
+    // d.date is "today" in Asia/Bangkok, always inside the selectable range and the rendered month.
+    root.state.setScheduledPreview("calendar", {
+      status: "success",
+      data: { month: query.month, days: [{ date: d.date, available: false, status }] },
+      error: "",
+      query_key: key,
+      loaded_at: "x",
+    });
+    const container = new WizardContainer();
+    root.bookingScheduled.render(container);
+    return container.innerHTML;
+  }
+
+  assert.match(calendarHtmlFor("no_open_slots"), /ยังไม่มีคิวเปิด/);
+  assert.match(calendarHtmlFor("full"), /เต็ม/);
+});
+
+test("Slot list shows full / no_open_slots strictly from backend status", () => {
+  const { root } = restoreFrontendAtStep(2);
+  const d = root.state.draft.scheduled;
+  root.state.setScheduledPreview("pricing", { status: "success", data: { duration_min: 60, active_price: 900 }, error: "" });
+  root.state.setScheduledPreview("calendar", { status: "success", data: { month: d.calendar_month, days: [] }, error: "", query_key: "k", loaded_at: "x" });
+
+  function slotsHtmlFor(status) {
+    root.state.setScheduledPreview("availability", { status: "success", data: { date: d.date, duration_min: 60, slots: [], availability_status: status }, error: "", query_key: "k", loaded_at: "x" });
+    const container = new WizardContainer();
+    root.bookingScheduled.render(container);
+    return container.innerHTML;
+  }
+
+  assert.match(slotsHtmlFor("full"), /เต็มแล้ว/);
+  assert.match(slotsHtmlFor("no_open_slots"), /ยังไม่มีคิวเปิดในวันนี้/);
+  // Unknown/empty status must not be reported as a manufactured "no open slots".
+  assert.doesNotMatch(slotsHtmlFor(""), /ยังไม่มีคิวเปิด/);
+});
+
+// --- Defect E: monthly work calendar is the source of truth ---
+
+function makeOffDeps(overrides = {}) {
+  return {
+    pool: {
+      async query(sql, params = []) {
+        const text = String(sql);
+        if (text.includes("pg_advisory_xact_lock")) return { rows: [] };
+        if (text.includes("technician_service_matrix")) {
+          return { rows: [{ username: "tech-a", matrix_json: { job_types: { wash: true }, ac_types: { wall: true }, wash_wall_variants: { normal: true } } }] };
+        }
+        if (text.includes("technician_monthly_work_calendar")) {
+          if (overrides.calendar === false) return { rows: [] };
+          return { rows: [{
+            technician_username: "tech-a",
+            work_date: params[1],
+            day_status: "available",
+            can_accept_advance_job: true,
+            start_time: "09:00",
+            end_time: "12:00",
+            max_jobs_per_day: 2,
+            max_units_per_day: 4,
+          }] };
+        }
+        if (text.includes("WITH assigned AS")) return { rows: [] };
+        if (text.includes("technician_special_slots_v2")) return { rows: [] };
+        return { rows: [] };
+      },
+    },
+    listTechniciansByType: async () => [{ username: "tech-a", customer_slot_visible: true, weekly_off_days: "0,1,2,3,4,5,6", work_start: "09:00", work_end: "12:00" }],
+    // Legacy off-day logic reports the technician as OFF for every date.
+    buildOffMapForDate: async () => new Map([["tech-a", true]]),
+    isTechOffOnDate: () => true,
+    buildTechWindowsMin: () => [{ startMin: 540, endMin: 720 }],
+    listBusyBlocksForTechOnDate: async () => [],
+    buildStartIntervalsByCollision: (blocks, startMin, endMin, durationMin) => ((blocks || []).length ? [] : [{ startMin, endMin: endMin - durationMin }]),
+    toMin(value) { const [h, m] = value.split(":").map(Number); return h * 60 + m; },
+    minToHHMM(value) { return `${String(Math.floor(value / 60)).padStart(2, "0")}:${String(value % 60).padStart(2, "0")}`; },
+    getNowBangkokParts: () => ({ Y: "2026", M: "06", D: "01", hh: 8, mm: 0 }),
+  };
+}
+
+test("Monthly advance opt-in is not overridden by legacy weekly off-days", async () => {
+  const base = {
+    date: "2026-06-02",
+    duration_min: 60,
+    tech_type: "company",
+    services: [{ job_type: "ล้าง", ac_type: "ผนัง", wash_variant: "ล้างธรรมดา" }],
+  };
+  const result = await customerAvailability.computePublicCustomerSlots(makeOffDeps(), base);
+  assert.ok(result.slots.length > 0, "technician opted in via monthly calendar must remain available");
+  assert.equal(result.availability_status, "available");
+});
+
+test("Missing monthly calendar row stays fail-closed even if legacy off-day allows it", async () => {
+  const base = {
+    date: "2026-06-02",
+    duration_min: 60,
+    tech_type: "company",
+    services: [{ job_type: "ล้าง", ac_type: "ผนัง", wash_variant: "ล้างธรรมดา" }],
+  };
+  const result = await customerAvailability.computePublicCustomerSlots(makeOffDeps({ calendar: false }), base);
+  assert.equal(result.slots.length, 0);
+  assert.equal(result.availability_status, "no_open_slots");
+  assert.equal(result.reason_code, "NO_ADVANCE_CALENDAR_ROW");
+});


### PR DESCRIPTION
## Summary
- Fixes Step 2/3 recovery so reloading mid-booking re-derives pricing → calendar → selected-day availability in order, without duplicate/stale requests, and without dropping a restored slot selection.
- Calendar/slot UI no longer manufactures "ยังไม่มีคิวเปิด" from missing/loading/stale data — only from a confirmed backend `no_open_slots`/`full` status.
- Scheduled customer availability now uses `technician_monthly_work_calendar` as the sole source of truth; legacy `weekly_off_days`/`technician_workdays_v2` can no longer override an explicit monthly opt-in. Missing calendar rows remain fail-closed. Urgent Booking is untouched.
- Bumps customer-app build/cache id to `20260621_booking_recovery_soT_v2`.

## Test plan
- [x] `npm ci`
- [x] `npm test` — 119/119 passing (112 existing + 7 new in `test/customerBookingRecovery.test.js`)
- [x] `node --check` on all changed JS files
- [x] `git diff --check` (no whitespace errors)
- [x] Diff scope verified — only the 8 files listed below changed

## Changed files
- `customer-app/modules/bookingScheduled.js`
- `customer-app/assets/customer-app.js`
- `customer-app/index.html`
- `customer-app/manifest.webmanifest`
- `customer-app/sw.js`
- `server/services/public/customerAvailability.js`
- `test/customerAppRecovery.test.js`
- `test/customerBookingRecovery.test.js`

https://claude.ai/code/session_01UqBGbqA8mXNTX9aHqidjs7

---
_Generated by [Claude Code](https://claude.ai/code/session_01UqBGbqA8mXNTX9aHqidjs7)_