### PR TITLE
Fix customer booking technician eligibility and calendar persistence

### DIFF
--- a/admin-technicians-v2.js
+++ b/admin-technicians-v2.js
@@ -144,9 +144,11 @@
     if ($('editMonthlySalary')) $('editMonthlySalary').value = (t.monthly_salary_amount!=null ? String(t.monthly_salary_amount) : '');
     $('editWorkStart').value = t.work_start || '09:00';
     $('editWorkEnd').value = t.work_end || '18:00';
-    // slot visibility (default true)
-    const sv = (t.customer_slot_visible === false) ? false : true;
-    if ($('editCustomerSlotVisible')) $('editCustomerSlotVisible').checked = !!sv;
+    // slot visibility (Defect 2: only an explicit true means visible-to-customers).
+    // null / missing / false must render unchecked so the admin sees the SAME fail-closed
+    // state the customer eligibility query enforces (listTechniciansByType requires === true).
+    const sv = (t.customer_slot_visible === true);
+    if ($('editCustomerSlotVisible')) $('editCustomerSlotVisible').checked = sv;
     $('editNewPass').value = '';
     $('editConfirmPass').value = '';
     $('photoStatus').textContent = '—';
@@ -300,10 +302,23 @@
       customer_slot_visible: !!($('editCustomerSlotVisible') && $('editCustomerSlotVisible').checked),
     };
 
-    await apiFetch(`/admin/technicians/${encodeURIComponent(currentTech.username)}`,{
+    const saveResp = await apiFetch(`/admin/technicians/${encodeURIComponent(currentTech.username)}`,{
       method:'PUT',
       body: JSON.stringify(payload)
     });
+
+    // Defect 3: verify the server-persisted record matches what we submitted before reporting
+    // success. Do NOT show "saved" or close the modal until the read-back confirms the value.
+    const persisted = (saveResp && saveResp.technician) || {};
+    const persistedVisible = persisted.customer_slot_visible === true;
+    if (persistedVisible !== payload.customer_slot_visible) {
+      if ($('editCustomerSlotVisible')) $('editCustomerSlotVisible').checked = persistedVisible;
+      showToast('บันทึกการแสดงคิวลูกค้าไม่ตรงกับค่าที่ส่ง กรุณาลองใหม่','error');
+      return;
+    }
+    if (persisted.employment_type) {
+      $('editEmployment').value = persisted.employment_type;
+    }
 
     // save service matrix (Option B - strict)
     const matrix_json = collectMatrixFromUI();
@@ -311,7 +326,7 @@
       method:'PUT',
       body: JSON.stringify({ matrix_json })
     });
-    showToast('บันทึกแล้ว','success');
+    showToast(`บันทึกแล้ว • แสดงคิวลูกค้า: ${persistedVisible ? 'เปิด' : 'ปิด'} • ประเภท: ${persisted.employment_type || $('editEmployment').value}`,'success');
     closeEdit();
     loadTechs();
   }

--- a/app.js
+++ b/app.js
@@ -5697,9 +5697,11 @@ function cwfCalendarUsername(){
   } catch { return ''; }
 }
 function cwfCalendarApi(path=''){
-  const u = cwfCalendarUsername();
-  if (!u) return `${API_BASE}/tech/work-calendar${path}`;
-  return `${API_BASE}/technicians/${encodeURIComponent(u)}/work-calendar-v2${path}`;
+  // Defect 4/6: technician self-service calendar must always use the session-identity
+  // endpoints (req.effective.username on the server). Never key the calendar off a
+  // client-supplied/localStorage username, which could read or write a different
+  // technician's rows than the customer availability pipeline reads.
+  return `${API_BASE}/tech/work-calendar${path}`;
 }
 function cwfDefaultCalendarItem(iso){
   const h = __cwfWorkCalendarState.holidays.get(iso);
@@ -6001,34 +6003,11 @@ function selectWorkCalendarDate(iso, rerender=true){
 async function saveCalendarDays(days, label='บันทึก'){
   const clean = days.filter(Boolean).slice(0,62);
   if(!clean.length) throw new Error('ไม่มีวันที่ให้บันทึก');
-  const useV2 = !!cwfCalendarUsername();
-  let body;
-  if (useV2 && clean.length === 1) {
-    const d = clean[0];
-    body = {
-      date: d.work_date || d.date,
-      can_accept_advance_job: !!d.can_accept_advance_job,
-      start_time: d.start_time,
-      end_time: d.end_time,
-      max_jobs_per_day: d.max_jobs_per_day,
-      max_units_per_day: d.max_units_per_day,
-      note: d.note || null
-    };
-  } else if (useV2) {
-    const first = clean[0] || {};
-    body = {
-      dates: clean.map(d => d.work_date || d.date).filter(Boolean),
-      can_accept_advance_job: !!first.can_accept_advance_job,
-      start_time: first.start_time,
-      end_time: first.end_time,
-      max_jobs_per_day: first.max_jobs_per_day,
-      max_units_per_day: first.max_units_per_day,
-      note: first.note || null
-    };
-  } else {
-    body = { days: clean };
-  }
-  const endpoint = useV2 ? cwfCalendarApi(clean.length === 1 ? '/day' : '/batch') : `${API_BASE}/tech/work-calendar/bulk`;
+  // Defect 4/6: always persist through the session-identity endpoints
+  // (PUT /tech/work-calendar/day for a single day, /bulk for many).
+  const single = clean.length === 1;
+  const endpoint = cwfCalendarApi(single ? '/day' : '/bulk');
+  const body = single ? clean[0] : { days: clean };
   const res = await fetch(endpoint, { method:'PUT', headers:{'Content-Type':'application/json'}, credentials:'include', body:JSON.stringify(body) });
   const data = await res.json().catch(()=>({}));
   if(!res.ok) throw new Error(data.error || `${label}ไม่สำเร็จ`);
@@ -6057,8 +6036,9 @@ async function toggleAdvanceDay(iso, userAction=false){
   try{
     cwfCalendarNotify(`กำลัง${nextAdvance?'เปิด':'ปิด'}รับงาน ${cwfFormatThaiDate(iso)}...`);
     const data = await saveCalendarDays([body], 'บันทึกวัน');
-    __cwfWorkCalendarState.items.set(iso, body);
-    renderWorkCalendarGrid();
+    // Defect 5: never paint the submitted payload as confirmed. Reload the month from the
+    // server so the grid reflects only persisted rows.
+    await loadWorkdaysModalData(__cwfWorkCalendarState.month);
     selectWorkCalendarDate(iso, false);
     const skipped = Number(data.skipped_locked || 0);
     cwfCalendarNotify(`${nextAdvance?'เปิด':'ปิด'}รับงานล่วงหน้าวันที่ ${cwfFormatThaiDate(iso)} แล้ว${skipped ? ` • ข้ามวันที่มีงาน ${skipped} วัน` : ''}`);
@@ -6077,8 +6057,8 @@ async function setSelectedDayAdvance(isAdvance){
   try{
     cwfCalendarNotify(`กำลัง${isAdvance?'เปิด':'ปิด'}รับงาน ${cwfFormatThaiDate(iso)}...`);
     const data = await saveCalendarDays([body], 'บันทึกวัน');
-    __cwfWorkCalendarState.items.set(iso, body);
-    renderWorkCalendarGrid();
+    // Defect 5: reload from server instead of painting the submitted payload.
+    await loadWorkdaysModalData(__cwfWorkCalendarState.month);
     selectWorkCalendarDate(iso, false);
     const skipped = Number(data.skipped_locked || 0);
     cwfCalendarNotify(`${isAdvance?'เปิด':'ปิด'}รับงานล่วงหน้าวันที่ ${cwfFormatThaiDate(iso)} แล้ว${skipped ? ` • ข้ามวันที่มีงาน ${skipped} วัน` : ''}`);
@@ -6151,10 +6131,11 @@ async function saveBulkSelected(custom=false, isAdvance=true){
   try{
     cwfCalendarNotify('กำลังบันทึกวันที่เลือก...');
     const data = await saveCalendarDays(days, 'บันทึกวันที่เลือก');
-    days.forEach(d=>__cwfWorkCalendarState.items.set(d.work_date, d));
     const skipped = Number(data.skipped_locked || 0) + (Array.from(__cwfWorkCalendarState.selectedDates).length - dates.length);
     __cwfWorkCalendarState.selectedDates.clear();
-    updateMultiModeUI(); renderWorkCalendarGrid();
+    // Defect 5: reload month from server; draw only persisted rows (partial saves reflected).
+    await loadWorkdaysModalData(__cwfWorkCalendarState.month);
+    updateMultiModeUI();
     cwfCalendarNotify(`บันทึกแล้ว ${data.saved ?? data.count ?? days.length} วัน${skipped ? ` ข้าม ${skipped} วันที่มีงานอยู่แล้ว` : ''}`);
   }catch(e){ cwfCalendarNotify(`❌ ${e.message}`, 'error'); }
 }

--- a/customer-app/assets/customer-app.js
+++ b/customer-app/assets/customer-app.js
@@ -3,7 +3,7 @@
 
   const App = window.CWFCustomerAppV2;
   const BOOT_TIMEOUT_MS = 3500;
-  const BUILD_ID = "20260621_booking_recovery_soT_v2";
+  const BUILD_ID = "20260621_eligibility_techtype_v3";
 
   function withTimeout(promise, timeoutMs) {
     return Promise.race([

--- a/customer-app/index.html
+++ b/customer-app/index.html
@@ -9,10 +9,10 @@
   <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
   <meta name="apple-mobile-web-app-title" content="CWF Service">
   <title>CWF Customer Service</title>
-  <link rel="manifest" href="./manifest.webmanifest?v=20260621_booking_recovery_soT_v2">
+  <link rel="manifest" href="./manifest.webmanifest?v=20260621_eligibility_techtype_v3">
   <link rel="icon" type="image/png" sizes="192x192" href="./assets/icons/cwf-customer-192.png">
   <link rel="apple-touch-icon" sizes="180x180" href="./assets/icons/cwf-customer-180.png">
-  <link rel="stylesheet" href="./assets/customer-app.css?v=20260621_booking_recovery_soT_v2">
+  <link rel="stylesheet" href="./assets/customer-app.css?v=20260621_eligibility_techtype_v3">
 </head>
 <body class="is-app-booting">
   <div class="app-shell" data-app-shell>
@@ -49,19 +49,19 @@
     </nav>
   </div>
 
-  <script src="./modules/state.js?v=20260621_booking_recovery_soT_v2"></script>
-  <script src="./modules/utils.js?v=20260621_booking_recovery_soT_v2"></script>
-  <script src="./modules/api.js?v=20260621_booking_recovery_soT_v2"></script>
-  <script src="./modules/services.js?v=20260621_booking_recovery_soT_v2"></script>
-  <script src="./modules/ui.js?v=20260621_booking_recovery_soT_v2"></script>
-  <script src="./modules/auth.js?v=20260621_booking_recovery_soT_v2"></script>
-  <script src="./modules/pricing.js?v=20260621_booking_recovery_soT_v2"></script>
-  <script src="./modules/availability.js?v=20260621_booking_recovery_soT_v2"></script>
-  <script src="./modules/bookingScheduled.js?v=20260621_booking_recovery_soT_v2"></script>
-  <script src="./modules/bookingUrgent.js?v=20260621_booking_recovery_soT_v2"></script>
-  <script src="./modules/tracking.js?v=20260621_booking_recovery_soT_v2"></script>
-  <script src="./modules/profile.js?v=20260621_booking_recovery_soT_v2"></script>
-  <script src="./modules/router.js?v=20260621_booking_recovery_soT_v2"></script>
-  <script src="./assets/customer-app.js?v=20260621_booking_recovery_soT_v2"></script>
+  <script src="./modules/state.js?v=20260621_eligibility_techtype_v3"></script>
+  <script src="./modules/utils.js?v=20260621_eligibility_techtype_v3"></script>
+  <script src="./modules/api.js?v=20260621_eligibility_techtype_v3"></script>
+  <script src="./modules/services.js?v=20260621_eligibility_techtype_v3"></script>
+  <script src="./modules/ui.js?v=20260621_eligibility_techtype_v3"></script>
+  <script src="./modules/auth.js?v=20260621_eligibility_techtype_v3"></script>
+  <script src="./modules/pricing.js?v=20260621_eligibility_techtype_v3"></script>
+  <script src="./modules/availability.js?v=20260621_eligibility_techtype_v3"></script>
+  <script src="./modules/bookingScheduled.js?v=20260621_eligibility_techtype_v3"></script>
+  <script src="./modules/bookingUrgent.js?v=20260621_eligibility_techtype_v3"></script>
+  <script src="./modules/tracking.js?v=20260621_eligibility_techtype_v3"></script>
+  <script src="./modules/profile.js?v=20260621_eligibility_techtype_v3"></script>
+  <script src="./modules/router.js?v=20260621_eligibility_techtype_v3"></script>
+  <script src="./assets/customer-app.js?v=20260621_eligibility_techtype_v3"></script>
 </body>
 </html>

--- a/customer-app/manifest.webmanifest
+++ b/customer-app/manifest.webmanifest
@@ -2,7 +2,7 @@
   "name": "CWF Customer Service",
   "short_name": "CWF Service",
   "description": "แอปลูกค้า Coldwindflow สำหรับเลือกบริการ จองคิว และติดตามงาน",
-  "start_url": "/customer-app/index.html?v=20260621_booking_recovery_soT_v2#home",
+  "start_url": "/customer-app/index.html?v=20260621_eligibility_techtype_v3#home",
   "scope": "/customer-app/",
   "id": "/customer-app/",
   "display": "standalone",

--- a/customer-app/modules/availability.js
+++ b/customer-app/modules/availability.js
@@ -40,7 +40,11 @@
     const durationMin = Math.max(15, Number(pricingData && pricingData.duration_min || 0));
     const query = {
       date: String(d.date || "").trim(),
-      tech_type: "company",
+      // Defect 1: scheduled customer availability must consider every employment type the
+      // admin has explicitly opted in via customer_slot_visible=true (company OR partner).
+      // Hardcoding company silently hid admin-enabled partner technicians. The backend still
+      // filters strictly by customer_slot_visible + service matrix + monthly calendar.
+      tech_type: "all",
       duration_min: durationMin,
       mode: "start",
       job_type: payload.job_type || "",
@@ -62,7 +66,8 @@
     const durationMin = Math.max(15, Number(pricingData && pricingData.duration_min || 0));
     const query = {
       month: String(d.calendar_month || d.date?.slice(0, 7) || "").trim(),
-      tech_type: "company",
+      // Defect 1: see publicAvailabilityQuery — calendar must use the same all-types query.
+      tech_type: "all",
       duration_min: durationMin,
       job_type: payload.job_type || "",
       ac_type: payload.ac_type || "",

--- a/customer-app/modules/state.js
+++ b/customer-app/modules/state.js
@@ -76,7 +76,8 @@
       services: [firstLine],
       date: today,
       calendar_month: today.slice(0, 7),
-      tech_type: "company",
+      // Defect 1: all admin-enabled employment types (filtered strictly server-side).
+      tech_type: "all",
       selectedSlot: null,
       allow_time_proposal: false,
       customer_name: "",

--- a/customer-app/sw.js
+++ b/customer-app/sw.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const BUILD_ID = "20260621_booking_recovery_soT_v2";
+const BUILD_ID = "20260621_eligibility_techtype_v3";
 const CACHE_NAME = `cwf-customer-app-v2-${BUILD_ID}`;
 const APP_SHELL = [
   `./index.html?v=${BUILD_ID}`,

--- a/index.js
+++ b/index.js
@@ -52,6 +52,9 @@ const createAdminDeductionsReadOnlyRoutes = require("./server/routes/adminDeduct
 const createTechnicianBaseStatusDataHelpers = require("./server/helpers/technicianBaseStatusDataHelpers");
 const createTechnicianBaseStatusReadOnlyRoutes = require("./server/routes/technicianBaseStatusReadOnly");
 const createTechnicianCalendarReadOnlyRoutes = require("./server/routes/technicianCalendarReadOnly");
+const createTechnicianCalendarWriteRoutes = require("./server/routes/technicianCalendarWrite");
+const { toIsoDate, normWorkDayPayload, countLockedAdvanceJobsForDate } = require("./server/lib/technicianCalendar");
+const { upsertTechnicianProfile } = require("./server/services/technicianProfileUpsert");
 const createTechnicianCountSummaryReadOnlyRoutes = require("./server/routes/technicianCountSummaryReadOnly");
 const createAdminAiOfficeReadOnlyRoutes = require("./server/routes/adminAiOfficeReadOnly");
 const createAdminAiBookingIntakeRoutes = require("./server/routes/adminAiBookingIntake");
@@ -19967,15 +19970,6 @@ app.put("/technicians/:username/accept-status", async (req, res) => {
 const ENABLE_TECH_WORKDAYS_V2 = (process.env.ENABLE_TECH_WORKDAYS_V2 || "1") === "1";
 const TECH_WORKDAYS_MAX_AHEAD_DAYS = Number(process.env.TECH_WORKDAYS_MAX_AHEAD_DAYS || 14);
 
-function toIsoDate(d){
-  const dt = (d instanceof Date) ? d : new Date(d);
-  if (Number.isNaN(dt.getTime())) return '';
-  const y = dt.getFullYear();
-  const m = String(dt.getMonth()+1).padStart(2,'0');
-  const dd = String(dt.getDate()).padStart(2,'0');
-  return `${y}-${m}-${dd}`;
-}
-
 app.get('/technicians/:username/weekly-off-days', async (req, res) => {
   const { username } = req.params;
   try {
@@ -20098,45 +20092,6 @@ function isStrictIsoDate(value){
 function isStrictMonth(value){
   const s = String(value || '').trim();
   return /^\d{4}-\d{2}$/.test(s) && toIsoDate(`${s}-01`).startsWith(s);
-}
-function normWorkDayPayload(input = {}){
-  // Advance calendar v3 intentionally has only 2 statuses:
-  // advance_only = รับงานล่วงหน้า, unavailable = ไม่รับงานล่วงหน้า
-  // Holiday/leave are treated as unavailable and can be explained in note.
-  let raw = String(input.day_status || '').trim();
-  if (input.can_accept_advance_job === true) raw = 'advance_only';
-  else if (input.can_accept_advance_job === false) raw = 'unavailable';
-  else if (['advance_only','available_advance','working','available','accept'].includes(raw)) raw = 'advance_only';
-  else raw = 'unavailable';
-  const day_status = raw;
-  const canAdvance = day_status === 'advance_only';
-  const start_time = canAdvance ? (/^\d{2}:\d{2}$/.test(String(input.start_time || '')) ? String(input.start_time) : '09:00') : null;
-  const end_time = canAdvance ? (/^\d{2}:\d{2}$/.test(String(input.end_time || '')) ? String(input.end_time) : '18:00') : null;
-  const max_jobs_per_day = canAdvance ? Math.max(1, Math.min(20, Number(input.max_jobs_per_day || 1))) : null;
-  const max_units_per_day = canAdvance ? Math.max(1, Math.min(99, Number(input.max_units_per_day || 5))) : null;
-  return {
-    day_status,
-    can_accept_advance_job: canAdvance,
-    // This calendar is NOT for urgent jobs. Urgent jobs continue using accept_status flow only.
-    can_accept_urgent_job: false,
-    start_time,
-    end_time,
-    max_jobs_per_day,
-    max_units_per_day,
-    note: String(input.note || '').slice(0,500)
-  };
-}
-async function countLockedAdvanceJobsForDate(clientOrPool, username, workDate){
-  const q = await clientOrPool.query(`
-    SELECT COUNT(DISTINCT j.job_id)::int AS job_count
-    FROM public.jobs j
-    LEFT JOIN public.job_assignments ja ON ja.job_id=j.job_id AND ja.technician_username=$1
-    WHERE (j.technician_username=$1 OR ja.technician_username=$1)
-      AND j.appointment_datetime IS NOT NULL
-      AND (j.appointment_datetime AT TIME ZONE 'Asia/Bangkok')::date = $2::date
-      AND COALESCE(j.job_status,'') NOT IN ('cancelled','canceled')
-  `, [username, workDate]);
-  return Number(q.rows?.[0]?.job_count || 0);
 }
 async function getTechTodayJobs(username){
   const r = await pool.query(`
@@ -20401,86 +20356,13 @@ app.use(createTechnicianCalendarReadOnlyRoutes({
   isStrictIsoDate,
 }));
 
-app.put('/tech/work-calendar/day', requireTechnicianSession, async (req, res) => {
-  try {
-    const username = String(req.effective?.username || '').trim();
-    const work_date = toIsoDate(String(req.body?.work_date || '').trim());
-    if (!work_date) return res.status(400).json({ error:'ต้องมี work_date' });
-    const lockedJobs = await countLockedAdvanceJobsForDate(pool, username, work_date);
-    if (lockedJobs > 0) {
-      return res.status(409).json({
-        error:'วันนี้มีงานอยู่แล้ว ช่างไม่สามารถแก้ไขวันทำงานได้ กรุณาติดต่อแอดมิน หากมีความจำเป็น',
-        locked:true,
-        job_count: lockedJobs
-      });
-    }
-    const p = normWorkDayPayload(req.body || {});
-    const r = await pool.query(`
-      INSERT INTO public.technician_monthly_work_calendar
-        (technician_username, work_date, day_status, can_accept_advance_job, can_accept_urgent_job, start_time, end_time, max_jobs_per_day, max_units_per_day, note, source, updated_by, updated_at)
-      VALUES($1,$2::date,$3,$4,$5,$6,$7,$8,$9,$10,'technician',$1,NOW())
-      ON CONFLICT(technician_username, work_date) DO UPDATE SET
-        day_status=EXCLUDED.day_status,
-        can_accept_advance_job=EXCLUDED.can_accept_advance_job,
-        can_accept_urgent_job=EXCLUDED.can_accept_urgent_job,
-        start_time=EXCLUDED.start_time,
-        end_time=EXCLUDED.end_time,
-        max_jobs_per_day=EXCLUDED.max_jobs_per_day,
-        max_units_per_day=EXCLUDED.max_units_per_day,
-        note=EXCLUDED.note,
-        source='technician', updated_by=$1, updated_at=NOW()
-      RETURNING *
-    `, [username, work_date, p.day_status, p.can_accept_advance_job, p.can_accept_urgent_job, p.start_time, p.end_time, p.max_jobs_per_day, p.max_units_per_day, p.note]);
-    res.json({ ok:true, item:r.rows[0] });
-  } catch (e) {
-    console.error('PUT /tech/work-calendar/day error:', e);
-    res.status(500).json({ error:'บันทึกปฏิทินรับงานไม่สำเร็จ' });
-  }
-});
-
-app.put('/tech/work-calendar/bulk', requireTechnicianSession, async (req, res) => {
-  const client = await pool.connect();
-  try {
-    const username = String(req.effective?.username || '').trim();
-    const days = Array.isArray(req.body?.days) ? req.body.days : [];
-    if (!days.length) return res.status(400).json({ error:'ต้องเลือกวันอย่างน้อย 1 วัน' });
-    await client.query('BEGIN');
-    let count = 0;
-    let skippedLocked = 0;
-    for (const d of days.slice(0, 62)) {
-      const work_date = toIsoDate(String(d.work_date || '').trim());
-      if (!work_date) continue;
-      const lockedJobs = await countLockedAdvanceJobsForDate(client, username, work_date);
-      if (lockedJobs > 0) {
-        skippedLocked++;
-        continue;
-      }
-      const p = normWorkDayPayload(d);
-      await client.query(`
-        INSERT INTO public.technician_monthly_work_calendar
-          (technician_username, work_date, day_status, can_accept_advance_job, can_accept_urgent_job, start_time, end_time, max_jobs_per_day, max_units_per_day, note, source, updated_by, updated_at)
-        VALUES($1,$2::date,$3,$4,$5,$6,$7,$8,$9,$10,'technician',$1,NOW())
-        ON CONFLICT(technician_username, work_date) DO UPDATE SET
-          day_status=EXCLUDED.day_status,
-          can_accept_advance_job=EXCLUDED.can_accept_advance_job,
-          can_accept_urgent_job=EXCLUDED.can_accept_urgent_job,
-          start_time=EXCLUDED.start_time,
-          end_time=EXCLUDED.end_time,
-          max_jobs_per_day=EXCLUDED.max_jobs_per_day,
-          max_units_per_day=EXCLUDED.max_units_per_day,
-          note=EXCLUDED.note,
-          source='technician', updated_by=$1, updated_at=NOW()
-      `, [username, work_date, p.day_status, p.can_accept_advance_job, p.can_accept_urgent_job, p.start_time, p.end_time, p.max_jobs_per_day, p.max_units_per_day, p.note]);
-      count++;
-    }
-    await client.query('COMMIT');
-    res.json({ ok:true, count, skipped_locked: skippedLocked });
-  } catch (e) {
-    await client.query('ROLLBACK');
-    console.error('PUT /tech/work-calendar/bulk error:', e);
-    res.status(500).json({ error:'บันทึกทั้งเดือนไม่สำเร็จ' });
-  } finally { client.release(); }
-});
+app.use(createTechnicianCalendarWriteRoutes({
+  pool,
+  requireTechnicianSession,
+  toIsoDate,
+  normWorkDayPayload,
+  countLockedAdvanceJobsForDate,
+}));
 
 // Defect 4/6: technician self-service copy uses the session identity (req.effective.username)
 // so it can never write to a username supplied by the client. Mirrors the admin v2 copy logic.
@@ -21114,38 +20996,21 @@ app.put("/admin/technicians/:username", requireAdminSession, async (req, res) =>
     }
 
     // profile
-    const profileUpsert = await pool.query(
-      `INSERT INTO public.technician_profiles (username, technician_code, full_name, position, phone)
-       VALUES ($1,$2,$3,$4,$5)
-       ON CONFLICT (username) DO UPDATE SET
-         technician_code = EXCLUDED.technician_code,
-         full_name = COALESCE(EXCLUDED.full_name, public.technician_profiles.full_name),
-         position = COALESCE(EXCLUDED.position, public.technician_profiles.position),
-         phone = COALESCE(EXCLUDED.phone, public.technician_profiles.phone),
-         employment_type = COALESCE($6, public.technician_profiles.employment_type),
-         work_start = COALESCE($7, public.technician_profiles.work_start),
-         work_end = COALESCE($8, public.technician_profiles.work_end),
-         customer_slot_visible = COALESCE($9, public.technician_profiles.customer_slot_visible),
-         compensation_mode = COALESCE($10, public.technician_profiles.compensation_mode),
-         daily_wage_amount = COALESCE($11, public.technician_profiles.daily_wage_amount),
-         monthly_salary_amount = COALESCE($12, public.technician_profiles.monthly_salary_amount),
-         updated_at = CURRENT_TIMESTAMP
-       RETURNING username, employment_type, customer_slot_visible`,
-      [
-        username,
-        technician_code,
-        full_name || null,
-        position,
-        phoneRaw || null,
-        employment_type ? String(employment_type).toLowerCase() : null,
-        work_start,
-        work_end,
-        hasCustomerSlotVisible ? customer_slot_visible : null,
-        compensation_mode,
-        daily_wage_amount,
-        monthly_salary_amount,
-      ]
-    );
+    const persistedProfile = await upsertTechnicianProfile(pool, {
+      username,
+      technician_code,
+      full_name,
+      position,
+      phone: phoneRaw,
+      employment_type,
+      work_start,
+      work_end,
+      customer_slot_visible: hasCustomerSlotVisible ? customer_slot_visible : null,
+      compensation_mode,
+      daily_wage_amount,
+      monthly_salary_amount,
+    });
+    const profileUpsert = { rows: [persistedProfile] };
 
     // password (optional)
     if (newPassword) {

--- a/index.js
+++ b/index.js
@@ -20482,6 +20482,50 @@ app.put('/tech/work-calendar/bulk', requireTechnicianSession, async (req, res) =
   } finally { client.release(); }
 });
 
+// Defect 4/6: technician self-service copy uses the session identity (req.effective.username)
+// so it can never write to a username supplied by the client. Mirrors the admin v2 copy logic.
+app.post('/tech/work-calendar/copy-previous-month', requireTechnicianSession, async (req, res) => {
+  const client = await pool.connect();
+  try {
+    const username = String(req.effective?.username || '').trim();
+    const targetMonth = String(req.body?.target_month || '').trim();
+    if (!isStrictMonth(targetMonth)) return res.status(400).json({ error:'target_month ต้องเป็นรูปแบบ YYYY-MM' });
+    const [y,m] = targetMonth.split('-').map(Number);
+    const prev = new Date(y, m - 2, 1);
+    const prevMonth = toIsoDate(prev).slice(0,7);
+    const prevData = await loadWorkCalendarV2Month(username, prevMonth);
+    const prevByDay = new Map(prevData.days.map(d => [String(d.date).slice(-2), d]));
+    await client.query('BEGIN');
+    let saved = 0;
+    let skippedLocked = 0;
+    for (const workDate of cwfDateRange(firstDayOfMonthIso(targetMonth), endDayOfMonthIso(targetMonth))) {
+      const source = prevByDay.get(workDate.slice(-2));
+      if (!source) continue;
+      const lockedJobs = await countLockedAdvanceJobsForDate(client, username, workDate);
+      if (lockedJobs > 0) {
+        skippedLocked++;
+        continue;
+      }
+      await upsertCalendarDay(client, username, workDate, {
+        work_date: workDate,
+        can_accept_advance_job: !!source.can_accept_advance_job,
+        start_time: source.start_time,
+        end_time: source.end_time,
+        max_jobs_per_day: source.max_jobs_per_day,
+        max_units_per_day: source.max_units_per_day,
+        note: source.note
+      });
+      saved++;
+    }
+    await client.query('COMMIT');
+    res.json({ ok:true, saved, skipped_locked:skippedLocked });
+  } catch (e) {
+    await client.query('ROLLBACK');
+    console.error('POST /tech/work-calendar/copy-previous-month error:', e);
+    res.status(500).json({ error:'ตั้งค่าเหมือนเดือนก่อนไม่สำเร็จ' });
+  } finally { client.release(); }
+});
+
 app.get('/tech/daily-readiness/today', requireTechnicianSession, async (req, res) => {
   try {
     const username = String(req.effective?.username || '').trim();
@@ -20911,7 +20955,9 @@ app.get("/admin/technicians", requireAdminSession, async (req, res) => {
               COALESCE(p.monthly_salary_amount,0)::numeric AS monthly_salary_amount,
               COALESCE(p.work_start,'09:00') AS work_start,
               COALESCE(p.work_end,'18:00') AS work_end,
-              COALESCE(p.customer_slot_visible, TRUE) AS customer_slot_visible,
+              -- Defect 2: surface the TRUE persisted visibility (null stays null) so the admin UI
+              -- reflects the same fail-closed state the customer eligibility query enforces.
+              p.customer_slot_visible AS customer_slot_visible,
               p.rating, p.grade, p.done_count,
               COALESCE(p.accept_status,'ready') AS accept_status, p.accept_status_updated_at
        FROM public.users u
@@ -21068,7 +21114,7 @@ app.put("/admin/technicians/:username", requireAdminSession, async (req, res) =>
     }
 
     // profile
-    await pool.query(
+    const profileUpsert = await pool.query(
       `INSERT INTO public.technician_profiles (username, technician_code, full_name, position, phone)
        VALUES ($1,$2,$3,$4,$5)
        ON CONFLICT (username) DO UPDATE SET
@@ -21083,7 +21129,8 @@ app.put("/admin/technicians/:username", requireAdminSession, async (req, res) =>
          compensation_mode = COALESCE($10, public.technician_profiles.compensation_mode),
          daily_wage_amount = COALESCE($11, public.technician_profiles.daily_wage_amount),
          monthly_salary_amount = COALESCE($12, public.technician_profiles.monthly_salary_amount),
-         updated_at = CURRENT_TIMESTAMP`,
+         updated_at = CURRENT_TIMESTAMP
+       RETURNING username, employment_type, customer_slot_visible`,
       [
         username,
         technician_code,
@@ -21111,7 +21158,19 @@ app.put("/admin/technicians/:username", requireAdminSession, async (req, res) =>
       await pool.query(`UPDATE public.users SET password=$2 WHERE username=$1`, [username, newPassword]);
     }
 
-    res.json({ ok: true });
+    // Defect 3: return the persisted record so the admin UI can verify the read-back
+    // (customer_slot_visible/employment_type) matches what it submitted before reporting success.
+    const persisted = profileUpsert.rows[0] || {};
+    res.json({
+      ok: true,
+      technician: {
+        username: persisted.username || username,
+        employment_type: persisted.employment_type || null,
+        customer_slot_visible: persisted.customer_slot_visible === true
+          ? true
+          : (persisted.customer_slot_visible === false ? false : null),
+      },
+    });
   } catch (e) {
     console.error("PUT admin technician error:", e);
     res.status(500).json({ error: "บันทึกไม่สำเร็จ" });
@@ -24627,6 +24686,30 @@ for (let t = startMin; t < endMin; t += slot_step_min) {
   }
 });
 
+// Defect 7: Admin-only scheduled-availability eligibility diagnostic.
+// Reports each gate (account, employment type, explicit visibility, service matrix,
+// monthly calendar row, advance flag, time window, capacity, collision, final eligible)
+// for a single technician + date + service criteria. Admin-only; never public.
+app.get("/admin/customer-eligibility-diagnostic", requireAdminSession, async (req, res) => {
+  try {
+    const username = String(req.query.username || "").trim();
+    const date = String(req.query.date || "").slice(0, 10);
+    if (!username || !/^\d{4}-\d{2}-\d{2}$/.test(date)) {
+      return res.status(400).json({ error: "ต้องระบุ username และ date (YYYY-MM-DD)" });
+    }
+    const duration_min = Math.max(15, Number(req.query.duration_min || 60));
+    const result = await customerAvailability.diagnoseTechnicianEligibility(
+      publicCustomerAvailabilityDeps(),
+      { ...req.query, username, date, duration_min }
+    );
+    res.json({ ok: true, ...result });
+  } catch (e) {
+    console.error("GET /admin/customer-eligibility-diagnostic error:", e);
+    const status = Number(e.status || 500);
+    res.status(status >= 400 && status < 600 ? status : 500).json({ error: "วิเคราะห์สิทธิ์การแสดงคิวไม่สำเร็จ" });
+  }
+});
+
 app.get("/public/availability", async (req, res) => {
   const date = (req.query.date || getBangkokTodayYMD()).toString();
   const start = (req.query.start || "08:00").toString();
@@ -24753,8 +24836,15 @@ console.log("[latlng_parse]", { ok: !!parsedLL });
 
 
   // ✅ Server-side validation: ต้องมีอย่างน้อย 1 ช่างว่างจริงในช่วงเวลานี้ (คิด buffer)
-  // - scheduled => company, urgent => partner
-  const requestedTechType = bm === "urgent" ? "partner" : "company";
+  // - urgent => partner
+  // - scheduled (Customer App V2) => all employment types the admin opted in (customer_slot_visible)
+  // - scheduled (legacy callers) => company (unchanged)
+  // Defect 1: Customer App V2 scheduled booking must not be limited to company technicians;
+  // it mirrors the public availability query (tech_type=all) and stays strict via the
+  // customer_slot_visible + service matrix + monthly calendar gates below.
+  const requestedTechType = bm === "urgent"
+    ? "partner"
+    : (clientApp === "customer_app_v2" ? "all" : "company");
   try {
     if (bm === "scheduled" && clientApp === "customer_app_v2") {
       const startIso = normalizeAppointmentDatetime(appointment_datetime);

--- a/server/lib/technicianCalendar.js
+++ b/server/lib/technicianCalendar.js
@@ -1,0 +1,51 @@
+function toIsoDate(d){
+  const dt = (d instanceof Date) ? d : new Date(d);
+  if (Number.isNaN(dt.getTime())) return '';
+  const y = dt.getFullYear();
+  const m = String(dt.getMonth()+1).padStart(2,'0');
+  const dd = String(dt.getDate()).padStart(2,'0');
+  return `${y}-${m}-${dd}`;
+}
+
+function normWorkDayPayload(input = {}){
+  // Advance calendar v3 intentionally has only 2 statuses:
+  // advance_only = รับงานล่วงหน้า, unavailable = ไม่รับงานล่วงหน้า
+  // Holiday/leave are treated as unavailable and can be explained in note.
+  let raw = String(input.day_status || '').trim();
+  if (input.can_accept_advance_job === true) raw = 'advance_only';
+  else if (input.can_accept_advance_job === false) raw = 'unavailable';
+  else if (['advance_only','available_advance','working','available','accept'].includes(raw)) raw = 'advance_only';
+  else raw = 'unavailable';
+  const day_status = raw;
+  const canAdvance = day_status === 'advance_only';
+  const start_time = canAdvance ? (/^\d{2}:\d{2}$/.test(String(input.start_time || '')) ? String(input.start_time) : '09:00') : null;
+  const end_time = canAdvance ? (/^\d{2}:\d{2}$/.test(String(input.end_time || '')) ? String(input.end_time) : '18:00') : null;
+  const max_jobs_per_day = canAdvance ? Math.max(1, Math.min(20, Number(input.max_jobs_per_day || 1))) : null;
+  const max_units_per_day = canAdvance ? Math.max(1, Math.min(99, Number(input.max_units_per_day || 5))) : null;
+  return {
+    day_status,
+    can_accept_advance_job: canAdvance,
+    // This calendar is NOT for urgent jobs. Urgent jobs continue using accept_status flow only.
+    can_accept_urgent_job: false,
+    start_time,
+    end_time,
+    max_jobs_per_day,
+    max_units_per_day,
+    note: String(input.note || '').slice(0,500)
+  };
+}
+
+async function countLockedAdvanceJobsForDate(clientOrPool, username, workDate){
+  const q = await clientOrPool.query(`
+    SELECT COUNT(DISTINCT j.job_id)::int AS job_count
+    FROM public.jobs j
+    LEFT JOIN public.job_assignments ja ON ja.job_id=j.job_id AND ja.technician_username=$1
+    WHERE (j.technician_username=$1 OR ja.technician_username=$1)
+      AND j.appointment_datetime IS NOT NULL
+      AND (j.appointment_datetime AT TIME ZONE 'Asia/Bangkok')::date = $2::date
+      AND COALESCE(j.job_status,'') NOT IN ('cancelled','canceled')
+  `, [username, workDate]);
+  return Number(q.rows?.[0]?.job_count || 0);
+}
+
+module.exports = { toIsoDate, normWorkDayPayload, countLockedAdvanceJobsForDate };

--- a/server/routes/technicianCalendarWrite.js
+++ b/server/routes/technicianCalendarWrite.js
@@ -1,0 +1,93 @@
+module.exports = function createTechnicianCalendarWriteRoutes(deps = {}) {
+  const express = require("express");
+  const router = express.Router();
+
+  const pool = deps.pool;
+  const requireTechnicianSession = deps.requireTechnicianSession;
+  const toIsoDate = deps.toIsoDate;
+  const normWorkDayPayload = deps.normWorkDayPayload;
+  const countLockedAdvanceJobsForDate = deps.countLockedAdvanceJobsForDate;
+
+  router.put('/tech/work-calendar/day', requireTechnicianSession, async (req, res) => {
+    try {
+      const username = String(req.effective?.username || '').trim();
+      const work_date = toIsoDate(String(req.body?.work_date || '').trim());
+      if (!work_date) return res.status(400).json({ error:'ต้องมี work_date' });
+      const lockedJobs = await countLockedAdvanceJobsForDate(pool, username, work_date);
+      if (lockedJobs > 0) {
+        return res.status(409).json({
+          error:'วันนี้มีงานอยู่แล้ว ช่างไม่สามารถแก้ไขวันทำงานได้ กรุณาติดต่อแอดมิน หากมีความจำเป็น',
+          locked:true,
+          job_count: lockedJobs
+        });
+      }
+      const p = normWorkDayPayload(req.body || {});
+      const r = await pool.query(`
+        INSERT INTO public.technician_monthly_work_calendar
+          (technician_username, work_date, day_status, can_accept_advance_job, can_accept_urgent_job, start_time, end_time, max_jobs_per_day, max_units_per_day, note, source, updated_by, updated_at)
+        VALUES($1,$2::date,$3,$4,$5,$6,$7,$8,$9,$10,'technician',$1,NOW())
+        ON CONFLICT(technician_username, work_date) DO UPDATE SET
+          day_status=EXCLUDED.day_status,
+          can_accept_advance_job=EXCLUDED.can_accept_advance_job,
+          can_accept_urgent_job=EXCLUDED.can_accept_urgent_job,
+          start_time=EXCLUDED.start_time,
+          end_time=EXCLUDED.end_time,
+          max_jobs_per_day=EXCLUDED.max_jobs_per_day,
+          max_units_per_day=EXCLUDED.max_units_per_day,
+          note=EXCLUDED.note,
+          source='technician', updated_by=$1, updated_at=NOW()
+        RETURNING *
+      `, [username, work_date, p.day_status, p.can_accept_advance_job, p.can_accept_urgent_job, p.start_time, p.end_time, p.max_jobs_per_day, p.max_units_per_day, p.note]);
+      res.json({ ok:true, item:r.rows[0] });
+    } catch (e) {
+      console.error('PUT /tech/work-calendar/day error:', e);
+      res.status(500).json({ error:'บันทึกปฏิทินรับงานไม่สำเร็จ' });
+    }
+  });
+
+  router.put('/tech/work-calendar/bulk', requireTechnicianSession, async (req, res) => {
+    const client = await pool.connect();
+    try {
+      const username = String(req.effective?.username || '').trim();
+      const days = Array.isArray(req.body?.days) ? req.body.days : [];
+      if (!days.length) return res.status(400).json({ error:'ต้องเลือกวันอย่างน้อย 1 วัน' });
+      await client.query('BEGIN');
+      let count = 0;
+      let skippedLocked = 0;
+      for (const d of days.slice(0, 62)) {
+        const work_date = toIsoDate(String(d.work_date || '').trim());
+        if (!work_date) continue;
+        const lockedJobs = await countLockedAdvanceJobsForDate(client, username, work_date);
+        if (lockedJobs > 0) {
+          skippedLocked++;
+          continue;
+        }
+        const p = normWorkDayPayload(d);
+        await client.query(`
+          INSERT INTO public.technician_monthly_work_calendar
+            (technician_username, work_date, day_status, can_accept_advance_job, can_accept_urgent_job, start_time, end_time, max_jobs_per_day, max_units_per_day, note, source, updated_by, updated_at)
+          VALUES($1,$2::date,$3,$4,$5,$6,$7,$8,$9,$10,'technician',$1,NOW())
+          ON CONFLICT(technician_username, work_date) DO UPDATE SET
+            day_status=EXCLUDED.day_status,
+            can_accept_advance_job=EXCLUDED.can_accept_advance_job,
+            can_accept_urgent_job=EXCLUDED.can_accept_urgent_job,
+            start_time=EXCLUDED.start_time,
+            end_time=EXCLUDED.end_time,
+            max_jobs_per_day=EXCLUDED.max_jobs_per_day,
+            max_units_per_day=EXCLUDED.max_units_per_day,
+            note=EXCLUDED.note,
+            source='technician', updated_by=$1, updated_at=NOW()
+        `, [username, work_date, p.day_status, p.can_accept_advance_job, p.can_accept_urgent_job, p.start_time, p.end_time, p.max_jobs_per_day, p.max_units_per_day, p.note]);
+        count++;
+      }
+      await client.query('COMMIT');
+      res.json({ ok:true, count, skipped_locked: skippedLocked });
+    } catch (e) {
+      await client.query('ROLLBACK');
+      console.error('PUT /tech/work-calendar/bulk error:', e);
+      res.status(500).json({ error:'บันทึกทั้งเดือนไม่สำเร็จ' });
+    } finally { client.release(); }
+  });
+
+  return router;
+};

--- a/server/services/public/customerAvailability.js
+++ b/server/services/public/customerAvailability.js
@@ -528,9 +528,104 @@ async function reservePublicCustomerTechnician(deps, options) {
   return picked;
 }
 
+// Defect 7: Admin-only eligibility diagnostic. Runs every scheduled-availability gate for a
+// single technician + date + service criteria and reports exactly where eligibility fails.
+// This must never be exposed via a public route (it reveals technician identity/config).
+async function diagnoseTechnicianEligibility(deps, options) {
+  const { pool, listTechniciansByType } = deps;
+  const username = String(options.username || "").trim();
+  const date = String(options.date || "").slice(0, 10);
+  const durationMin = Math.max(15, Number(options.duration_min || 60));
+  const criteriaList = buildCriteriaList(options);
+  const criteriaValid = validateCriteriaList(criteriaList);
+
+  const gates = {
+    account_exists: false,
+    employment_type: null,
+    criteria_valid: criteriaValid,
+    explicit_visible: false,
+    matrix_exists: false,
+    matrix_matched: false,
+    calendar_row_exists: false,
+    advance_enabled: false,
+    time_window_valid: false,
+    capacity_ok: false,
+    collision_ok: false,
+    final_eligible: false,
+  };
+
+  if (!username || !date) {
+    return { username, date, gates, reason: "USERNAME_AND_DATE_REQUIRED" };
+  }
+
+  const allTechs = await listTechniciansByType("all", { include_paused: true });
+  const tech = (allTechs || []).find((t) => String(t.username || "") === username) || null;
+  gates.account_exists = Boolean(tech);
+  if (!tech) return { username, date, gates, reason: "TECHNICIAN_NOT_FOUND" };
+  gates.employment_type = tech.employment_type || null;
+
+  gates.explicit_visible = tech.customer_slot_visible === true;
+  if (!gates.explicit_visible) return { username, date, gates, reason: "NOT_CUSTOMER_VISIBLE" };
+
+  if (!criteriaValid) return { username, date, gates, reason: "CUSTOMER_SLOT_SERVICE_CRITERIA_REQUIRED" };
+
+  const matrixMap = await loadServiceMatrixMap(pool, [username]);
+  gates.matrix_exists = matrixMap.has(username);
+  if (!gates.matrix_exists) return { username, date, gates, reason: "NO_SERVICE_MATRIX" };
+  gates.matrix_matched = techMatchesAllCriteriaStrict(matrixMap.get(username), criteriaList);
+  if (!gates.matrix_matched) return { username, date, gates, reason: "NO_MATCHING_SERVICE_MATRIX" };
+
+  const calendarMap = await loadAdvanceCalendarMap(pool, date, [username]);
+  const calendar = calendarMap.get(username) || null;
+  gates.calendar_row_exists = Boolean(calendar);
+  if (!calendar) return { username, date, gates, reason: "NO_ADVANCE_CALENDAR_ROW" };
+  gates.advance_enabled = calendar.can_accept_advance_job === true;
+  if (!gates.advance_enabled) return { username, date, gates, reason: "ADVANCE_CLOSED" };
+
+  const start = String(calendar.start_time || "").slice(0, 5);
+  const end = String(calendar.end_time || "").slice(0, 5);
+  gates.time_window_valid = /^\d{2}:\d{2}$/.test(start) && /^\d{2}:\d{2}$/.test(end);
+  gates.calendar_window = { start, end };
+  if (!gates.time_window_valid) return { username, date, gates, reason: "INVALID_ADVANCE_WINDOW" };
+
+  const requestedUnits = serviceUnitCount(options);
+  const usageMap = await loadDailyUsageMap(pool, date, [username], options.ignore_job_id);
+  const usage = usageMap.get(username) || { jobs_count: 0, units_count: 0 };
+  const maxJobs = calendar.max_jobs_per_day == null ? null : Number(calendar.max_jobs_per_day);
+  const maxUnits = calendar.max_units_per_day == null ? null : Number(calendar.max_units_per_day);
+  let capacityOk = true;
+  if (Number.isFinite(maxJobs) && maxJobs >= 0 && usage.jobs_count >= maxJobs) capacityOk = false;
+  if (Number.isFinite(maxUnits) && maxUnits >= 0 && (usage.units_count + requestedUnits) > maxUnits) capacityOk = false;
+  gates.capacity_ok = capacityOk;
+  gates.usage = { jobs_count: usage.jobs_count, units_count: usage.units_count, requested_units: requestedUnits, max_jobs_per_day: maxJobs, max_units_per_day: maxUnits };
+  if (!capacityOk) return { username, date, gates, reason: "CAPACITY_FULL" };
+
+  // Collision: is there at least one startable interval inside the technician window today?
+  try {
+    const uiStart = deps.toMin(DEFAULT_UI_START);
+    const uiEnd = deps.toMin(DEFAULT_UI_END);
+    const windowStart = Math.max(uiStart, deps.toMin(start));
+    const windowEnd = Math.min(uiEnd, deps.toMin(end));
+    if (Number.isFinite(windowStart) && Number.isFinite(windowEnd) && windowEnd > windowStart) {
+      const busyBlocks = await deps.listBusyBlocksForTechOnDate(username, date, options.ignore_job_id || null);
+      const intervals = deps.buildStartIntervalsByCollision(busyBlocks, windowStart, windowEnd, durationMin);
+      gates.collision_ok = Array.isArray(intervals) && intervals.length > 0;
+    } else {
+      gates.collision_ok = false;
+    }
+  } catch (_) {
+    gates.collision_ok = false;
+  }
+  if (!gates.collision_ok) return { username, date, gates, reason: "COLLISION_FULL" };
+
+  gates.final_eligible = true;
+  return { username, date, gates, reason: "AVAILABLE" };
+}
+
 module.exports = {
   buildCriteriaList,
   validateCriteriaList,
+  diagnoseTechnicianEligibility,
   techMatchesMatrixStrict,
   techMatchesAllCriteriaStrict,
   eligibleCustomerTechnicians,

--- a/server/services/technicianProfileUpsert.js
+++ b/server/services/technicianProfileUpsert.js
@@ -1,0 +1,53 @@
+async function upsertTechnicianProfile(pool, payload) {
+  const {
+    username,
+    technician_code,
+    full_name,
+    position,
+    phone,
+    employment_type,
+    work_start,
+    work_end,
+    customer_slot_visible,
+    compensation_mode,
+    daily_wage_amount,
+    monthly_salary_amount,
+  } = payload;
+
+  const r = await pool.query(
+    `INSERT INTO public.technician_profiles
+       (username, technician_code, full_name, position, phone, employment_type, work_start, work_end, customer_slot_visible, compensation_mode, daily_wage_amount, monthly_salary_amount)
+     VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12)
+     ON CONFLICT (username) DO UPDATE SET
+       technician_code = EXCLUDED.technician_code,
+       full_name = COALESCE(EXCLUDED.full_name, public.technician_profiles.full_name),
+       position = COALESCE(EXCLUDED.position, public.technician_profiles.position),
+       phone = COALESCE(EXCLUDED.phone, public.technician_profiles.phone),
+       employment_type = COALESCE($6, public.technician_profiles.employment_type),
+       work_start = COALESCE($7, public.technician_profiles.work_start),
+       work_end = COALESCE($8, public.technician_profiles.work_end),
+       customer_slot_visible = COALESCE($9, public.technician_profiles.customer_slot_visible),
+       compensation_mode = COALESCE($10, public.technician_profiles.compensation_mode),
+       daily_wage_amount = COALESCE($11, public.technician_profiles.daily_wage_amount),
+       monthly_salary_amount = COALESCE($12, public.technician_profiles.monthly_salary_amount),
+       updated_at = CURRENT_TIMESTAMP
+     RETURNING username, employment_type, customer_slot_visible`,
+    [
+      username,
+      technician_code,
+      full_name || null,
+      position,
+      phone || null,
+      employment_type ? String(employment_type).toLowerCase() : null,
+      work_start,
+      work_end,
+      customer_slot_visible,
+      compensation_mode,
+      daily_wage_amount,
+      monthly_salary_amount,
+    ]
+  );
+  return r.rows[0];
+}
+
+module.exports = { upsertTechnicianProfile };

--- a/test/customerAppRecovery.test.js
+++ b/test/customerAppRecovery.test.js
@@ -135,7 +135,7 @@ test("Customer App build id is consistent across shell and service worker", () =
   const sw = read("customer-app/sw.js");
   const app = read("customer-app/assets/customer-app.js");
   const manifest = read("customer-app/manifest.webmanifest");
-  const build = "20260621_booking_recovery_soT_v2";
+  const build = "20260621_eligibility_techtype_v3";
 
   assert.match(index, new RegExp(`customer-app\\.css\\?v=${build}`));
   assert.match(index, new RegExp(`bookingUrgent\\.js\\?v=${build}`));

--- a/test/customerEligibilityTechType.test.js
+++ b/test/customerEligibilityTechType.test.js
@@ -1,0 +1,206 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+
+const repoRoot = path.resolve(__dirname, "..");
+const customerAvailability = require("../server/services/public/customerAvailability");
+
+function read(rel) {
+  return fs.readFileSync(path.join(repoRoot, rel), "utf8").replace(/\r\n/g, "\n");
+}
+
+function section(source, start, end) {
+  const from = source.indexOf(start);
+  assert.notEqual(from, -1, `missing section start: ${start}`);
+  const to = source.indexOf(end, from + start.length);
+  assert.notEqual(to, -1, `missing section end: ${end}`);
+  return source.slice(from, to);
+}
+
+// ---- Shared fake deps for the eligibility engine ----
+function makeDeps({ techs = [], matrix = {}, calendar = {}, usage = {}, busy = [] } = {}) {
+  const pool = {
+    async query(sql, params) {
+      if (/technician_service_matrix/.test(sql)) {
+        return { rows: Object.entries(matrix).map(([username, matrix_json]) => ({ username, matrix_json })) };
+      }
+      if (/technician_monthly_work_calendar/.test(sql)) {
+        const date = (params && params[1]) || null;
+        return { rows: Object.entries(calendar).map(([technician_username, row]) => ({ technician_username, work_date: date, ...row })) };
+      }
+      if (/item_units|assigned AS/.test(sql)) {
+        return { rows: Object.entries(usage).map(([technician_username, u]) => ({ technician_username, jobs_count: u.jobs_count, units_count: u.units_count })) };
+      }
+      return { rows: [] };
+    },
+  };
+  return {
+    pool,
+    db: pool,
+    listTechniciansByType: async () => techs,
+    toMin: (hhmm) => { const [h, m] = String(hhmm).split(":").map(Number); return (h * 60) + m; },
+    minToHHMM: (min) => `${String(Math.floor(min / 60)).padStart(2, "0")}:${String(min % 60).padStart(2, "0")}`,
+    listBusyBlocksForTechOnDate: async () => busy,
+    buildStartIntervalsByCollision: (blocks, startMin, endMin, dur) => (
+      (endMin - startMin) >= dur ? [{ startMin, endMin: endMin - dur }] : []
+    ),
+    buildTechWindowsMin: () => [],
+    getNowBangkokParts: () => ({ Y: "2026", M: "06", D: "01", hh: 0, mm: 0 }),
+  };
+}
+
+const CRITERIA = { date: "2026-06-22", tech_type: "all", duration_min: 90, job_type: "ล้าง", ac_type: "ผนัง", wash_variant: "ธรรมดา" };
+const GOOD_MATRIX = { job_types: { wash: true }, ac_types: { wall: true }, wash_wall_variants: { normal: true } };
+const GOOD_CAL = { day_status: "advance_only", can_accept_advance_job: true, start_time: "09:00", end_time: "18:00", max_jobs_per_day: 5, max_units_per_day: 10 };
+
+// ============ Defect 1: all admin-enabled employment types eligible ============
+test("Defect 1: visible PARTNER technician can produce scheduled customer slots (tech_type=all)", async () => {
+  const deps = makeDeps({
+    techs: [{ username: "p1", employment_type: "partner", customer_slot_visible: true }],
+    matrix: { p1: GOOD_MATRIX },
+    calendar: { p1: GOOD_CAL },
+  });
+  const eligible = await customerAvailability.eligibleCustomerTechnicians(deps, { ...CRITERIA });
+  assert.deepEqual(eligible.map((t) => t.username), ["p1"]);
+});
+
+test("Defect 1: visible COMPANY technician also eligible under tech_type=all", async () => {
+  const deps = makeDeps({
+    techs: [{ username: "c1", employment_type: "company", customer_slot_visible: true }],
+    matrix: { c1: GOOD_MATRIX },
+    calendar: { c1: GOOD_CAL },
+  });
+  const eligible = await customerAvailability.eligibleCustomerTechnicians(deps, { ...CRITERIA });
+  assert.deepEqual(eligible.map((t) => t.username), ["c1"]);
+});
+
+test("Customer frontend queries use tech_type=all, never hardcoded company", () => {
+  const availability = read("customer-app/modules/availability.js");
+  assert.match(availability, /tech_type:\s*"all"/);
+  assert.doesNotMatch(availability, /tech_type:\s*"company"/);
+  const state = read("customer-app/modules/state.js");
+  assert.match(state, /tech_type:\s*"all"/);
+  assert.doesNotMatch(state, /tech_type:\s*"company"/);
+});
+
+test("Customer App V2 scheduled booking requests tech_type=all server-side", () => {
+  const index = read("index.js");
+  const booking = section(index, 'app.post("/public/book"', 'app.get("/public/track"');
+  assert.match(booking, /clientApp === "customer_app_v2" \? "all" : "company"/);
+});
+
+// ============ Defect 2/3: explicit visibility, fail-closed ============
+test("Invisible technician is excluded (visibility=false)", async () => {
+  const deps = makeDeps({
+    techs: [{ username: "x", employment_type: "partner", customer_slot_visible: false }],
+    matrix: { x: GOOD_MATRIX },
+    calendar: { x: GOOD_CAL },
+  });
+  const eligible = await customerAvailability.eligibleCustomerTechnicians(deps, { ...CRITERIA });
+  assert.deepEqual(eligible, []);
+});
+
+test("Null/unset visibility is excluded (fail-closed)", async () => {
+  const deps = makeDeps({
+    techs: [{ username: "x", employment_type: "company", customer_slot_visible: null }],
+    matrix: { x: GOOD_MATRIX },
+    calendar: { x: GOOD_CAL },
+  });
+  const eligible = await customerAvailability.eligibleCustomerTechnicians(deps, { ...CRITERIA });
+  assert.deepEqual(eligible, []);
+});
+
+test("Admin visibility UI only checks when value is strictly true; save verifies read-back", () => {
+  const adminJs = read("admin-technicians-v2.js");
+  assert.match(adminJs, /const sv = \(t\.customer_slot_visible === true\)/);
+  assert.match(adminJs, /persistedVisible !== payload\.customer_slot_visible/);
+  const index = read("index.js");
+  assert.match(index, /RETURNING username, employment_type, customer_slot_visible/);
+});
+
+// ============ Defect 7: admin-only eligibility diagnostic ============
+test("Diagnostic: fully-configured visible partner reports AVAILABLE with all gates true", async () => {
+  const deps = makeDeps({
+    techs: [{ username: "p1", employment_type: "partner", customer_slot_visible: true }],
+    matrix: { p1: GOOD_MATRIX },
+    calendar: { p1: GOOD_CAL },
+  });
+  const r = await customerAvailability.diagnoseTechnicianEligibility(deps, { username: "p1", ...CRITERIA });
+  assert.equal(r.reason, "AVAILABLE");
+  assert.equal(r.gates.final_eligible, true);
+  assert.equal(r.gates.explicit_visible, true);
+  assert.equal(r.gates.matrix_matched, true);
+  assert.equal(r.gates.advance_enabled, true);
+  assert.equal(r.gates.collision_ok, true);
+});
+
+test("Diagnostic pinpoints NOT_CUSTOMER_VISIBLE gate", async () => {
+  const deps = makeDeps({
+    techs: [{ username: "p1", employment_type: "partner", customer_slot_visible: null }],
+    matrix: { p1: GOOD_MATRIX },
+    calendar: { p1: GOOD_CAL },
+  });
+  const r = await customerAvailability.diagnoseTechnicianEligibility(deps, { username: "p1", ...CRITERIA });
+  assert.equal(r.reason, "NOT_CUSTOMER_VISIBLE");
+  assert.equal(r.gates.account_exists, true);
+  assert.equal(r.gates.explicit_visible, false);
+  assert.equal(r.gates.final_eligible, false);
+});
+
+test("Diagnostic pinpoints NO_ADVANCE_CALENDAR_ROW gate", async () => {
+  const deps = makeDeps({
+    techs: [{ username: "p1", employment_type: "partner", customer_slot_visible: true }],
+    matrix: { p1: GOOD_MATRIX },
+    calendar: {},
+  });
+  const r = await customerAvailability.diagnoseTechnicianEligibility(deps, { username: "p1", ...CRITERIA });
+  assert.equal(r.reason, "NO_ADVANCE_CALENDAR_ROW");
+  assert.equal(r.gates.matrix_matched, true);
+  assert.equal(r.gates.calendar_row_exists, false);
+});
+
+test("Diagnostic pinpoints ADVANCE_CLOSED gate", async () => {
+  const deps = makeDeps({
+    techs: [{ username: "p1", employment_type: "partner", customer_slot_visible: true }],
+    matrix: { p1: GOOD_MATRIX },
+    calendar: { p1: { ...GOOD_CAL, can_accept_advance_job: false } },
+  });
+  const r = await customerAvailability.diagnoseTechnicianEligibility(deps, { username: "p1", ...CRITERIA });
+  assert.equal(r.reason, "ADVANCE_CLOSED");
+  assert.equal(r.gates.calendar_row_exists, true);
+  assert.equal(r.gates.advance_enabled, false);
+});
+
+test("Diagnostic pinpoints unknown technician", async () => {
+  const deps = makeDeps({ techs: [] });
+  const r = await customerAvailability.diagnoseTechnicianEligibility(deps, { username: "ghost", ...CRITERIA });
+  assert.equal(r.reason, "TECHNICIAN_NOT_FOUND");
+  assert.equal(r.gates.account_exists, false);
+});
+
+test("Diagnostic route is admin-only and never public", () => {
+  const index = read("index.js");
+  assert.match(index, /app\.get\("\/admin\/customer-eligibility-diagnostic", requireAdminSession/);
+  // The diagnostic must not be wired under any /public/ path.
+  assert.doesNotMatch(index, /\/public\/[a-z-]*eligibility-diagnostic/);
+});
+
+// ============ Defect 4/6: technician calendar identity ============
+test("Technician calendar uses session endpoints only (no username-keyed admin route)", () => {
+  const appJs = read("app.js");
+  const fn = section(appJs, "function cwfCalendarApi", "function cwfDefaultCalendarItem");
+  assert.match(fn, /\/tech\/work-calendar\$\{path\}/);
+  assert.doesNotMatch(fn, /work-calendar-v2/);
+  // Session copy endpoint exists server-side.
+  const index = read("index.js");
+  assert.match(index, /app\.post\('\/tech\/work-calendar\/copy-previous-month', requireTechnicianSession/);
+});
+
+test("Technician calendar reloads from server after save (no submitted-payload paint)", () => {
+  const appJs = read("app.js");
+  const save = section(appJs, "async function saveCalendarDays", "function buildDayPayload");
+  // single -> /day, many -> /bulk; never /batch
+  assert.match(save, /single \? '\/day' : '\/bulk'/);
+  assert.doesNotMatch(save, /\/batch/);
+});

--- a/test/customerEligibilityTechType.test.js
+++ b/test/customerEligibilityTechType.test.js
@@ -115,8 +115,8 @@ test("Admin visibility UI only checks when value is strictly true; save verifies
   const adminJs = read("admin-technicians-v2.js");
   assert.match(adminJs, /const sv = \(t\.customer_slot_visible === true\)/);
   assert.match(adminJs, /persistedVisible !== payload\.customer_slot_visible/);
-  const index = read("index.js");
-  assert.match(index, /RETURNING username, employment_type, customer_slot_visible/);
+  const upsertSvc = read("server/services/technicianProfileUpsert.js");
+  assert.match(upsertSvc, /RETURNING username, employment_type, customer_slot_visible/);
 });
 
 // ============ Defect 7: admin-only eligibility diagnostic ============

--- a/test/technicianCalendarWriteAndProfile.integration.test.js
+++ b/test/technicianCalendarWriteAndProfile.integration.test.js
@@ -1,0 +1,247 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const http = require("node:http");
+const express = require("express");
+const { Pool } = require("pg");
+
+const createTechnicianCalendarWriteRoutes = require("../server/routes/technicianCalendarWrite");
+const { toIsoDate, normWorkDayPayload, countLockedAdvanceJobsForDate } = require("../server/lib/technicianCalendar");
+const { upsertTechnicianProfile } = require("../server/services/technicianProfileUpsert");
+
+// These tests exercise the REAL production route module / helper against a real
+// local Postgres instance (not a regex/source assertion, not a fake in-memory pool).
+const PG_CONFIG = {
+  host: process.env.PGHOST || "127.0.0.1",
+  port: Number(process.env.PGPORT || 5432),
+  user: process.env.PGUSER || "postgres",
+  password: process.env.PGPASSWORD || "postgres",
+  database: process.env.PGDATABASE || "cwf_test",
+};
+
+let pool;
+let server;
+let baseUrl;
+
+test.before(async () => {
+  pool = new Pool(PG_CONFIG);
+  await pool.query(`
+    CREATE TABLE IF NOT EXISTS public.technician_monthly_work_calendar (
+      technician_username TEXT NOT NULL,
+      work_date DATE NOT NULL,
+      day_status TEXT,
+      can_accept_advance_job BOOLEAN,
+      can_accept_urgent_job BOOLEAN,
+      start_time TEXT,
+      end_time TEXT,
+      max_jobs_per_day INT,
+      max_units_per_day INT,
+      note TEXT,
+      source TEXT,
+      updated_by TEXT,
+      updated_at TIMESTAMPTZ,
+      PRIMARY KEY (technician_username, work_date)
+    )
+  `);
+  await pool.query(`
+    CREATE TABLE IF NOT EXISTS public.jobs (
+      job_id BIGSERIAL PRIMARY KEY,
+      technician_username TEXT,
+      appointment_datetime TIMESTAMPTZ,
+      job_status TEXT
+    )
+  `);
+  await pool.query(`
+    CREATE TABLE IF NOT EXISTS public.job_assignments (
+      job_id BIGINT,
+      technician_username TEXT
+    )
+  `);
+  await pool.query(`
+    CREATE TABLE IF NOT EXISTS public.technician_profiles (
+      username TEXT PRIMARY KEY,
+      technician_code TEXT,
+      full_name TEXT,
+      position TEXT,
+      phone TEXT,
+      employment_type TEXT,
+      work_start TEXT,
+      work_end TEXT,
+      customer_slot_visible BOOLEAN,
+      compensation_mode TEXT,
+      daily_wage_amount NUMERIC,
+      monthly_salary_amount NUMERIC,
+      updated_at TIMESTAMPTZ
+    )
+  `);
+
+  let sessionUsername = "p1";
+  const fakeRequireTechnicianSession = (req, res, next) => {
+    req.effective = { username: sessionUsername };
+    next();
+  };
+
+  const app = express();
+  app.use(express.json());
+  app.use(createTechnicianCalendarWriteRoutes({
+    pool,
+    requireTechnicianSession: fakeRequireTechnicianSession,
+    toIsoDate,
+    normWorkDayPayload,
+    countLockedAdvanceJobsForDate,
+  }));
+  app._setSessionUsername = (u) => { sessionUsername = u; };
+
+  server = http.createServer(app);
+  await new Promise((resolve) => server.listen(0, resolve));
+  baseUrl = `http://127.0.0.1:${server.address().port}`;
+  global.__cwfTestApp = app;
+});
+
+test.after(async () => {
+  await new Promise((resolve) => server.close(resolve));
+  await pool.end();
+});
+
+test.beforeEach(async () => {
+  await pool.query("DELETE FROM public.technician_monthly_work_calendar");
+  await pool.query("DELETE FROM public.jobs");
+  await pool.query("DELETE FROM public.job_assignments");
+  await pool.query("DELETE FROM public.technician_profiles");
+});
+
+async function putJson(path, body) {
+  const res = await fetch(`${baseUrl}${path}`, {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  const data = await res.json().catch(() => ({}));
+  return { status: res.status, data };
+}
+
+// ============ Blocker 2: PUT /tech/work-calendar/day real contract ============
+test("Blocker 2: single-day save via real route persists a real row keyed by req.effective.username", async () => {
+  global.__cwfTestApp._setSessionUsername("p1");
+  const body = {
+    work_date: "2026-07-10",
+    day_status: "advance_only",
+    can_accept_advance_job: true,
+    start_time: "09:00",
+    end_time: "18:00",
+    max_jobs_per_day: 3,
+    max_units_per_day: 6,
+    note: "",
+  };
+  const { status, data } = await putJson("/tech/work-calendar/day", body);
+  assert.equal(status, 200);
+  assert.equal(data.ok, true);
+  assert.equal(data.item.technician_username, "p1");
+
+  const row = await pool.query(
+    `SELECT technician_username, work_date::text AS work_date, can_accept_advance_job FROM public.technician_monthly_work_calendar WHERE technician_username='p1'`
+  );
+  assert.equal(row.rows.length, 1);
+  assert.equal(row.rows[0].work_date, "2026-07-10");
+  assert.equal(row.rows[0].can_accept_advance_job, true);
+});
+
+test("Blocker 2: username is sourced from req.effective.username, not client-supplied body", async () => {
+  global.__cwfTestApp._setSessionUsername("session-user");
+  const body = {
+    // Even if the body carried an unrelated "username"-like field, the route never reads it.
+    work_date: "2026-07-11",
+    can_accept_advance_job: true,
+  };
+  const { status, data } = await putJson("/tech/work-calendar/day", body);
+  assert.equal(status, 200);
+  assert.equal(data.item.technician_username, "session-user");
+
+  const row = await pool.query(
+    `SELECT technician_username FROM public.technician_monthly_work_calendar WHERE work_date='2026-07-11'`
+  );
+  assert.equal(row.rows[0].technician_username, "session-user");
+});
+
+test("Blocker 2: reading the month back after save shows the same saved date", async () => {
+  global.__cwfTestApp._setSessionUsername("p1");
+  await putJson("/tech/work-calendar/day", { work_date: "2026-07-12", can_accept_advance_job: true });
+
+  const monthRows = await pool.query(
+    `SELECT work_date::text AS work_date, can_accept_advance_job
+     FROM public.technician_monthly_work_calendar
+     WHERE technician_username='p1' AND work_date BETWEEN '2026-07-01' AND '2026-07-31'
+     ORDER BY work_date ASC`
+  );
+  assert.deepEqual(monthRows.rows.map((r) => r.work_date), ["2026-07-12"]);
+  assert.equal(monthRows.rows[0].can_accept_advance_job, true);
+});
+
+test("Blocker 2: locked day (existing job) is rejected with 409 and no row mutation", async () => {
+  global.__cwfTestApp._setSessionUsername("p1");
+  await pool.query(
+    `INSERT INTO public.jobs (technician_username, appointment_datetime, job_status) VALUES ('p1', '2026-07-13 10:00:00+07', 'assigned')`
+  );
+  const { status, data } = await putJson("/tech/work-calendar/day", { work_date: "2026-07-13", can_accept_advance_job: true });
+  assert.equal(status, 409);
+  assert.equal(data.locked, true);
+  const row = await pool.query(`SELECT 1 FROM public.technician_monthly_work_calendar WHERE work_date='2026-07-13'`);
+  assert.equal(row.rows.length, 0);
+});
+
+// ============ Blocker 3: admin technician profile UPSERT INSERT path ============
+test("Blocker 3: existing profile is updated and read-back matches submitted values", async () => {
+  await pool.query(
+    `INSERT INTO public.technician_profiles (username, technician_code, employment_type, customer_slot_visible) VALUES ('c1','C001','company',false)`
+  );
+  const persisted = await upsertTechnicianProfile(pool, {
+    username: "c1",
+    technician_code: "C001",
+    full_name: "Test C1",
+    position: null,
+    phone: null,
+    employment_type: "partner",
+    work_start: "09:00",
+    work_end: "18:00",
+    customer_slot_visible: true,
+    compensation_mode: null,
+    daily_wage_amount: null,
+    monthly_salary_amount: null,
+  });
+  assert.equal(persisted.employment_type, "partner");
+  assert.equal(persisted.customer_slot_visible, true);
+
+  const row = await pool.query(`SELECT employment_type, customer_slot_visible FROM public.technician_profiles WHERE username='c1'`);
+  assert.equal(row.rows[0].employment_type, "partner");
+  assert.equal(row.rows[0].customer_slot_visible, true);
+});
+
+test("Blocker 3: first-time insert (no existing profile row) sets employment_type and customer_slot_visible on INSERT, not only ON CONFLICT", async () => {
+  const before = await pool.query(`SELECT 1 FROM public.technician_profiles WHERE username='new1'`);
+  assert.equal(before.rows.length, 0);
+
+  const persisted = await upsertTechnicianProfile(pool, {
+    username: "new1",
+    technician_code: "N001",
+    full_name: "New Tech",
+    position: null,
+    phone: null,
+    employment_type: "partner",
+    work_start: "09:00",
+    work_end: "18:00",
+    customer_slot_visible: true,
+    compensation_mode: null,
+    daily_wage_amount: null,
+    monthly_salary_amount: null,
+  });
+  assert.equal(persisted.employment_type, "partner");
+  assert.equal(persisted.customer_slot_visible, true);
+
+  const row = await pool.query(
+    `SELECT employment_type, customer_slot_visible, work_start, work_end FROM public.technician_profiles WHERE username='new1'`
+  );
+  assert.equal(row.rows.length, 1);
+  assert.equal(row.rows[0].employment_type, "partner");
+  assert.equal(row.rows[0].customer_slot_visible, true);
+  assert.equal(row.rows[0].work_start, "09:00");
+  assert.equal(row.rows[0].work_end, "18:00");
+});


### PR DESCRIPTION
## Goal
ซ่อมสาเหตุจริงที่ "ช่างเปิดรับงานแล้ว แต่ Customer App ยังไม่แสดงคิว" — โดยไม่กลบปัญหาด้วยการแก้ข้อความ และไม่แตะ Urgent Booking.

Base: `origin/main` @ `e1cd98a` (merge ของ PR #74).

## Root causes fixed

**Defect 1 — tech_type hardcoded to `company`.** Scheduled customer availability/booking ส่ง `tech_type=company` ตายตัว ทำให้ช่าง **partner** ที่แอดมินเปิด `customer_slot_visible=true` ไม่เคยถูกนำมาคำนวณสล็อตเลย. เปลี่ยนเป็น `tech_type=all` ทั้งฝั่ง frontend (`availability.js`, `state.js`) และ `/public/book` (เฉพาะ `customer_app_v2`) โดยยังกรองเข้มด้วย customer_slot_visible + service matrix + monthly calendar + capacity + collision. Urgent และ legacy callers ไม่เปลี่ยน.

**Defect 2/3 — Admin visibility persistence.** UI เดิม treat `null/missing` เป็น checked แต่ eligibility ต้องการ `=== true` → แอดมินเข้าใจผิดว่าช่างถูกเปิดแล้ว. ตอนนี้:
- `/admin/technicians` คืนค่า `customer_slot_visible` จริง (ไม่ COALESCE null→true)
- modal เช็ค checkbox เฉพาะค่า `true` แท้
- PUT คืน persisted record (`RETURNING`)
- `saveEdit` อ่านค่ากลับมายืนยันก่อนขึ้น success/ปิด modal

**Defect 4/6 — Technician calendar identity.** ปฏิทินช่างเคย route ผ่าน endpoint admin ที่ผูกกับ username จาก localStorage. เปลี่ยนให้ใช้ session-identity เท่านั้น (`GET /tech/work-calendar`, `PUT /day`, `PUT /bulk`) + เพิ่ม session route `POST /tech/work-calendar/copy-previous-month` ที่ผูกกับ `req.effective.username`.

**Defect 5 (paint) — Server-confirmed UI.** การบันทึกปฏิทินเดิมวาด payload ที่ส่ง. ตอนนี้ reload เดือนจาก server หลังบันทึก วาดเฉพาะ row ที่อ่านกลับได้ (สะท้อน partial save วันที่ถูกล็อก).

**Defect 7 — Admin-only eligibility diagnostic.** เพิ่ม `GET /admin/customer-eligibility-diagnostic` + `diagnoseTechnicianEligibility()` คืนผลแต่ละ gate (account / employment type / explicit visibility / matrix / calendar row / advance flag / time window / capacity / collision / final) — admin-only, ไม่อยู่ใต้ `/public/`.

**Defect 5 (mapping)** — ตรวจ Service Matrix mapping `wash`/`wall`/`normal` แล้ว สอดคล้องกันต้นทางถึงปลายทาง (ไม่ต้องแก้).

## Review round 2 fixes (post-review)
- Branch history reset onto clean `origin/main` (removed already-merged PR #74 files from the diff).
- Verified `/tech/work-calendar/day` contract reads `work_date` (not `date`) — frontend already conforms; extracted route into `server/routes/technicianCalendarWrite.js` for real integration testing.
- Fixed admin technician profile UPSERT: INSERT column list now includes `employment_type`, `work_start`, `work_end`, `customer_slot_visible`, `compensation_mode`, `daily_wage_amount`, `monthly_salary_amount` (previously only set via `ON CONFLICT DO UPDATE`, so first-time profile creation silently dropped them). Extracted into `server/services/technicianProfileUpsert.js`.
- Added real Postgres-backed integration tests (no regex/source-only assertions) proving single-day save persistence, `req.effective.username` sourcing, month read-back, locked-day rejection, and both update/first-insert profile paths.

## Tests
- `test/customerEligibilityTechType.test.js` (15 cases): partner/company visible eligible, invisible/null excluded, admin read-back, diagnostic ทุก gate, session calendar identity, server-confirmed reload.
- `test/technicianCalendarWriteAndProfile.integration.test.js` (6 cases, real local Postgres): real route execution for calendar write contract + profile upsert insert/update paths.
- Full suite: **140/140 pass**. `node --check` ผ่านทุกไฟล์, `git diff --check` สะอาด. Startup smoke test (`node index.js`) confirmed server boots and serves HTTP 200 without crashing.
- Cache `BUILD_ID` → `20260621_eligibility_techtype_v3`.

## ⚠️ Production verification — BLOCKED (ไม่ปิดงาน)
Phase 1/Production read-only diagnosis ยิงไม่ได้จาก sandbox นี้: network egress allowlist ปฏิเสธ `app.cwf-air.com` (`Host not in allowlist`). จึง **ยังไม่ยืนยันว่าเสร็จ** ตามเงื่อนไข. ต้องรันคำสั่ง read-only ต่อไปนี้หลัง deploy เพื่อยืนยัน (ขอวันที่/บริการตรงกับที่ลูกค้าเลือกจริง):

```
# ปฏิทิน (ต้องมีอย่างน้อย 1 วัน available:true)
GET /public/availability_calendar_v2?month=2026-06&tech_type=all&duration_min=90&job_type=ล้าง&ac_type=ผนัง&wash_variant=ธรรมดา

# วันที่เลือก (ต้องมี slot จริง, reason_code=AVAILABLE, ไม่มี technician identity)
GET /public/availability_v2?date=2026-06-22&tech_type=all&duration_min=90&job_type=ล้าง&ac_type=ผนัง&wash_variant=ธรรมดา&mode=start

# วินิจฉัย gate ที่ตก (admin session)
GET /admin/customer-eligibility-diagnostic?username=&date=2026-06-22&job_type=ล้าง&ac_type=ผนัง&wash_variant=ธรรมดา&duration_min=90
```
หาก production ยังคืน `no_open_slots` ให้ดูผล diagnostic เพื่อระบุ gate ที่ตกพร้อมค่าจริง (น่าจะเป็น calendar row/visibility/matrix ที่ยังไม่ตั้งค่าสำหรับช่างจริง) — ยังไม่ถือว่าเสร็จจนได้หลักฐาน available.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UqBGbqA8mXNTX9aHqidjs7)_