### PR TITLE
Fix customer scheduled capacity, fair assignment, and income parity

### DIFF
--- a/admin-review-v2.js
+++ b/admin-review-v2.js
@@ -325,7 +325,7 @@ function renderTeamPickerModal(){
 
   // primary select
   const primarySel = $("mPrimaryTech");
-  const currentPrimary = primarySel.value || CURRENT?.technician_username || "";
+  const currentPrimary = CURRENT?.technician_username || primarySel.value || "";
   primarySel.innerHTML = '<option value="">-- เลือกช่างหลัก --</option>' + group.map(t=>{
     const name = t.full_name || t.username;
     return `<option value="${t.username}">${safe(name)} (${t.username})</option>`;
@@ -380,6 +380,13 @@ function renderTeamPickerModal(){
 // public wrapper called on tech type/search changes
 function renderTechPickers(){
   renderTeamPickerModal();
+}
+
+function technicianTypeForUsername(username){
+  const u = safe(username).trim();
+  if(!u) return "";
+  const row = (TECHS||[]).find(t => safe(t.username).trim() === u);
+  return safe(row?.employment_type || "company").trim().toLowerCase() || "company";
 }
 
 function setModal(show){
@@ -443,8 +450,9 @@ async function openJob(jobId){
 
     $("mNote").value = safe(CURRENT.customer_note||"");
 
-    // tech type default: urgent -> partner, else company (admin can change)
-    $("mTechType").value = (CURRENT.booking_mode === "urgent") ? "partner" : "company";
+    // Draft reservations must keep the reserved technician visible/preselected.
+    const draftType = technicianTypeForUsername(CURRENT.technician_username);
+    $("mTechType").value = draftType || ((CURRENT.booking_mode === "urgent") ? "partner" : "company");
     renderTechPickers();
 
     // pricing

--- a/app.js
+++ b/app.js
@@ -5684,6 +5684,38 @@ function cwfDayJobCount(iso){
   const it = cwfGetCalendarItem(iso);
   return Number(it?.assigned_job_count ?? __cwfWorkCalendarState.jobCounts.get(iso) ?? 0);
 }
+function cwfNullableCap(value){
+  if (value === null || value === undefined || value === '') return null;
+  const n = Number(value);
+  return Number.isFinite(n) && n >= 1 ? Math.floor(n) : null;
+}
+function cwfCapLabel(value){
+  const n = cwfNullableCap(value);
+  return n == null ? 'ใช้คิวว่างจริง' : String(n);
+}
+function cwfCapsLimited(it){
+  return cwfNullableCap(it?.max_jobs_per_day) != null || cwfNullableCap(it?.max_units_per_day) != null;
+}
+function cwfSetCapControls(prefix, limited, jobs, units){
+  const cb = document.getElementById(`${prefix}LimitEnabled`);
+  const j = document.getElementById(`${prefix}MaxJobs`);
+  const u = document.getElementById(`${prefix}MaxUnits`);
+  const fields = document.getElementById(`${prefix}LimitFields`);
+  if (cb) cb.checked = !!limited;
+  if (fields) fields.style.display = limited ? 'grid' : 'none';
+  if (j) j.value = cwfNullableCap(jobs) ?? 1;
+  if (u) u.value = cwfNullableCap(units) ?? 5;
+  if (!fields && j) {
+    j.disabled = !limited;
+    const label = j.closest('label');
+    if (label) label.style.display = limited ? 'grid' : 'none';
+  }
+  if (!fields && u) {
+    u.disabled = !limited;
+    const label = u.closest('label');
+    if (label) label.style.display = limited ? 'grid' : 'none';
+  }
+}
 function cwfIsLockedDay(iso){
   const it = cwfGetCalendarItem(iso);
   return !!it?.is_locked || cwfDayJobCount(iso) > 0;
@@ -5705,8 +5737,8 @@ function cwfCalendarApi(path=''){
 }
 function cwfDefaultCalendarItem(iso){
   const h = __cwfWorkCalendarState.holidays.get(iso);
-  if(h) return { work_date:iso, day_status:'unavailable', can_accept_advance_job:false, start_time:'09:00', end_time:'18:00', max_jobs_per_day:0, max_units_per_day:0, note:h.holiday_name || '' };
-  return { work_date:iso, day_status:'unavailable', can_accept_advance_job:false, start_time:'09:00', end_time:'18:00', max_jobs_per_day:0, max_units_per_day:0, note:'' };
+  if(h) return { work_date:iso, day_status:'unavailable', can_accept_advance_job:false, start_time:'09:00', end_time:'18:00', max_jobs_per_day:null, max_units_per_day:null, note:h.holiday_name || '' };
+  return { work_date:iso, day_status:'unavailable', can_accept_advance_job:false, start_time:'09:00', end_time:'18:00', max_jobs_per_day:null, max_units_per_day:null, note:'' };
 }
 function cwfEffectiveCalendarItem(iso){
   const raw = cwfGetCalendarItem(iso) || cwfDefaultCalendarItem(iso);
@@ -5718,8 +5750,8 @@ function cwfEffectiveCalendarItem(iso){
     can_accept_advance_job: isAdvance,
     start_time: raw.start_time || '09:00',
     end_time: raw.end_time || '18:00',
-    max_jobs_per_day: Number(raw.max_jobs_per_day ?? (isAdvance ? 1 : 0)),
-    max_units_per_day: Number(raw.max_units_per_day ?? (isAdvance ? 5 : 0)),
+    max_jobs_per_day: isAdvance ? cwfNullableCap(raw.max_jobs_per_day) : null,
+    max_units_per_day: isAdvance ? cwfNullableCap(raw.max_units_per_day) : null,
     note: raw.note || ''
   };
 }
@@ -5727,8 +5759,7 @@ function cwfHasCustomSetting(it){
   if (!it || !it.can_accept_advance_job) return String(it?.note || '').trim().length > 0;
   return (it.start_time && it.start_time !== '09:00') ||
          (it.end_time && it.end_time !== '18:00') ||
-         Number(it.max_jobs_per_day || 1) !== 1 ||
-         Number(it.max_units_per_day || 5) !== 5 ||
+         cwfCapsLimited(it) ||
          String(it.note || '').trim().length > 0;
 }
 function cwfCalendarNotify(message, type='info'){
@@ -5819,6 +5850,7 @@ function ensureWorkdaysModal(){
               <label>เวลาเลิก <input id="workDayEnd" class="premium-input" type="time" value="18:00"></label>
             </div>
             <div class="cwf-time-grid">
+              <label class="cwf-limit-toggle"><input id="workDayLimitEnabled" type="checkbox"> จำกัดจำนวนงาน/เครื่องต่อวัน</label>
               <label>งานสูงสุด/วัน <input id="workDayMaxJobs" class="premium-input" type="number" min="1" max="20" value="1"></label>
               <label>เครื่องสูงสุด/วัน <input id="workDayMaxUnits" class="premium-input" type="number" min="1" max="99" value="5"></label>
             </div>
@@ -5833,6 +5865,7 @@ function ensureWorkdaysModal(){
             <div class="cwf-section-title">☑️ ตั้งค่าหลายวันที่เลือก</div>
             <div class="cwf-quick-grid">
               <button id="bulkSetAdvanceBtn" class="cwf-save-btn" type="button">✅ ตั้งเป็นรับ</button>
+              <button id="bulkSetUnlimitedBtn" class="cwf-soft-btn" type="button">ใช้คิวว่างจริง</button>
               <button id="bulkSetUnavailableBtn" class="cwf-soft-btn" type="button">❌ ตั้งเป็นไม่รับ</button>
             </div>
             <button id="bulkCustomToggleBtn" class="cwf-soft-btn full" type="button">✏️ ตั้งค่าพิเศษให้วันที่เลือก</button>
@@ -5842,6 +5875,7 @@ function ensureWorkdaysModal(){
                 <label>เวลาเลิก <input id="bulkDayEnd" class="premium-input" type="time" value="18:00"></label>
               </div>
               <div class="cwf-time-grid">
+                <label class="cwf-limit-toggle"><input id="bulkDayLimitEnabled" type="checkbox"> จำกัดจำนวนงาน/เครื่องต่อวัน</label>
                 <label>งานสูงสุด/วัน <input id="bulkDayMaxJobs" class="premium-input" type="number" min="1" max="20" value="1"></label>
                 <label>เครื่องสูงสุด/วัน <input id="bulkDayMaxUnits" class="premium-input" type="number" min="1" max="99" value="5"></label>
               </div>
@@ -5896,9 +5930,15 @@ function ensureWorkdaysModal(){
   document.getElementById('closeSingleDetailBtn').onclick = () => { const p=document.getElementById('singleEditPanel'); if(p) p.style.display='none'; };
   document.getElementById('saveSingleDetailBtn').onclick = saveSelectedDayCustom;
   document.getElementById('bulkSetAdvanceBtn').onclick = () => saveBulkSelected(false, true);
+  document.getElementById('bulkSetUnlimitedBtn').onclick = () => saveBulkSelected(false, true, { forceUnlimited:true });
   document.getElementById('bulkSetUnavailableBtn').onclick = () => saveBulkSelected(false, false);
   document.getElementById('bulkCustomToggleBtn').onclick = () => { const p=document.getElementById('bulkCustomFields'); if(p) p.style.display = p.style.display === 'none' ? 'block' : 'none'; };
   document.getElementById('bulkSaveCustomBtn').onclick = () => saveBulkSelected(true, true);
+  const singleLimit = document.getElementById('workDayLimitEnabled');
+  if (singleLimit) singleLimit.onchange = () => cwfSetCapControls('workDay', singleLimit.checked, document.getElementById('workDayMaxJobs')?.value, document.getElementById('workDayMaxUnits')?.value);
+  const bulkLimit = document.getElementById('bulkDayLimitEnabled');
+  if (bulkLimit) bulkLimit.onchange = () => cwfSetCapControls('bulkDay', bulkLimit.checked, document.getElementById('bulkDayMaxJobs')?.value, document.getElementById('bulkDayMaxUnits')?.value);
+  cwfSetCapControls('bulkDay', false, null, null);
   document.getElementById('workCalendarRetryBtn').onclick = () => loadCwfAdvanceWorkCalendarMonthSafe();
   return wrap;
 }
@@ -5950,7 +5990,7 @@ function renderWorkCalendarGrid(){
     const custom = cwfHasCustomSetting(it);
     const picked = __cwfWorkCalendarState.selectedDates.has(iso);
     const cls = locked ? 'is-locked' : (custom && it.can_accept_advance_job ? 'is-custom' : (it.can_accept_advance_job ? 'is-advance' : 'is-off'));
-    const icons = locked ? '📌' : [custom && it.start_time !== '09:00' || custom && it.end_time !== '18:00' ? '⏰' : '', custom && (Number(it.max_jobs_per_day||1)!==1 || Number(it.max_units_per_day||5)!==5) ? '⚙️' : '', String(it.note||'').trim() ? '📝' : ''].filter(Boolean).join(' ');
+    const icons = locked ? '📌' : [custom && it.start_time !== '09:00' || custom && it.end_time !== '18:00' ? '⏰' : '', custom && cwfCapsLimited(it) ? '⚙️' : '', String(it.note||'').trim() ? '📝' : ''].filter(Boolean).join(' ');
     return `<button type="button" class="cwf-day-cell ${cls} ${iso===__cwfWorkCalendarState.selectedDate?'is-selected':''} ${picked?'is-picked':''}" data-date="${iso}">
       ${locked ? `<span class="cwf-job-dot">${cwfDayJobCount(iso)}</span>` : ''}
       <div class="cwf-day-num">${Number(iso.slice(-2))}</div>
@@ -5988,17 +6028,18 @@ function selectWorkCalendarDate(iso, rerender=true){
     summary.innerHTML = `<div class="cwf-detail-grid">
       <div><span>สถานะ</span><b>${statusText}</b></div>
       <div><span>เวลา</span><b>${it.can_accept_advance_job ? `${it.start_time || '09:00'}-${it.end_time || '18:00'}` : '-'}</b></div>
-      <div><span>งานสูงสุด</span><b>${it.can_accept_advance_job ? Number(it.max_jobs_per_day||1) : '-'}</b></div>
-      <div><span>เครื่องสูงสุด</span><b>${it.can_accept_advance_job ? Number(it.max_units_per_day||5) : '-'}</b></div>
+      <div><span>งานสูงสุด</span><b>${it.can_accept_advance_job ? cwfCapLabel(it.max_jobs_per_day) : '-'}</b></div>
+      <div><span>เครื่องสูงสุด</span><b>${it.can_accept_advance_job ? cwfCapLabel(it.max_units_per_day) : '-'}</b></div>
       <div class="cwf-detail-note"><span>หมายเหตุ</span><b>${it.note ? String(it.note) : 'ไม่มี'}</b></div>
     </div>${locked ? '<div style="margin-top:8px;color:#64748b;font-weight:850">วันนี้ล็อกไว้เพราะมีงานที่ได้รับมอบหมายแล้ว</div>' : ''}`;
   }
   const set = (id,val) => { const el=document.getElementById(id); if(el) el.value=val ?? ''; };
-  set('workDayStart', it.start_time || '09:00'); set('workDayEnd', it.end_time || '18:00'); set('workDayMaxJobs', Number(it.max_jobs_per_day || 1)); set('workDayMaxUnits', Number(it.max_units_per_day || 5)); set('workDayNote', it.note || '');
+  set('workDayStart', it.start_time || '09:00'); set('workDayEnd', it.end_time || '18:00'); set('workDayMaxJobs', cwfNullableCap(it.max_jobs_per_day) ?? 1); set('workDayMaxUnits', cwfNullableCap(it.max_units_per_day) ?? 5); set('workDayNote', it.note || '');
+  cwfSetCapControls('workDay', cwfCapsLimited(it), it.max_jobs_per_day, it.max_units_per_day);
   const editPanel = document.getElementById('singleEditPanel'); if(editPanel) editPanel.style.display = 'none';
   const openBtn = document.getElementById('singleOpenDayBtn'); if(openBtn) openBtn.disabled = locked || it.can_accept_advance_job;
   const closeBtn = document.getElementById('singleCloseDayBtn'); if(closeBtn) closeBtn.disabled = locked || !it.can_accept_advance_job;
-  const editBtn = document.getElementById('editSelectedDayBtn'); if(editBtn) editBtn.disabled = locked;
+  const editBtn = document.getElementById('editSelectedDayBtn'); if(editBtn) editBtn.disabled = false;
 }
 async function saveCalendarDays(days, label='บันทึก'){
   const clean = days.filter(Boolean).slice(0,62);
@@ -6015,6 +6056,7 @@ async function saveCalendarDays(days, label='บันทึก'){
   return data;
 }
 function buildDayPayload(iso, isAdvance, opts={}){
+  const limitEnabled = opts.limit_enabled === true || opts.limitEnabled === true;
   return {
     work_date: iso,
     day_status: isAdvance ? 'advance_only' : 'unavailable',
@@ -6022,8 +6064,8 @@ function buildDayPayload(iso, isAdvance, opts={}){
     can_accept_urgent_job: false,
     start_time: isAdvance ? (opts.start_time || '09:00') : '09:00',
     end_time: isAdvance ? (opts.end_time || '18:00') : '18:00',
-    max_jobs_per_day: isAdvance ? Number(opts.max_jobs_per_day || 1) : 0,
-    max_units_per_day: isAdvance ? Number(opts.max_units_per_day || 5) : 0,
+    max_jobs_per_day: isAdvance && limitEnabled ? cwfNullableCap(opts.max_jobs_per_day) : null,
+    max_units_per_day: isAdvance && limitEnabled ? cwfNullableCap(opts.max_units_per_day) : null,
     note: opts.note || ''
   };
 }
@@ -6067,24 +6109,23 @@ async function setSelectedDayAdvance(isAdvance){
 function showSingleEditPanel(){
   const iso = __cwfWorkCalendarState.selectedDate;
   if(!iso) return;
-  if(cwfIsLockedDay(iso)){ cwfLockedPopup(iso); return; }
   const p = document.getElementById('singleEditPanel'); if(p) p.style.display = 'grid';
 }
 async function saveSelectedDayCustom(){
   const iso = __cwfWorkCalendarState.selectedDate;
   if(!iso) return;
-  if(cwfIsLockedDay(iso)){ cwfLockedPopup(iso); return; }
   const get = (id, fallback='') => document.getElementById(id)?.value || fallback;
   const body = buildDayPayload(iso, true, {
     start_time: get('workDayStart','09:00'), end_time: get('workDayEnd','18:00'),
+    limit_enabled: document.getElementById('workDayLimitEnabled')?.checked === true,
     max_jobs_per_day: Number(get('workDayMaxJobs','1')), max_units_per_day: Number(get('workDayMaxUnits','5')),
     note: get('workDayNote','')
   });
   try{
     cwfCalendarNotify('กำลังบันทึกค่าพิเศษ...');
     await saveCalendarDays([body], 'บันทึกค่าพิเศษ');
-    __cwfWorkCalendarState.items.set(iso, body);
-    renderWorkCalendarGrid(); selectWorkCalendarDate(iso, false);
+    await loadWorkdaysModalData(__cwfWorkCalendarState.month);
+    selectWorkCalendarDate(iso, false);
     cwfCalendarNotify('✅ บันทึกค่าพิเศษแล้ว');
   }catch(e){ cwfCalendarNotify(`❌ ${e.message}`, 'error'); }
 }
@@ -6117,12 +6158,20 @@ function selectWorkCalendarPreset(kind){
   updateMultiModeUI(); renderWorkCalendarGrid();
   if(skipped) cwfCalendarNotify(`เลือกแล้ว • ข้ามวันที่มีงาน ${skipped} วัน`);
 }
-async function saveBulkSelected(custom=false, isAdvance=true){
-  const dates = Array.from(__cwfWorkCalendarState.selectedDates).filter(iso=>!cwfIsLockedDay(iso));
+async function saveBulkSelected(custom=false, isAdvance=true, extraOpts={}){
+  const dates = Array.from(__cwfWorkCalendarState.selectedDates).filter(iso=>!cwfIsLockedDay(iso) || extraOpts.forceUnlimited);
   if(!dates.length){ cwfCalendarNotify('❌ ยังไม่ได้เลือกวันที่ หรือวันที่เลือกมีงานอยู่แล้วทั้งหมด', 'error'); return; }
-  const opts = custom ? {
+  const opts = extraOpts.forceUnlimited ? {
+    start_time: '09:00',
+    end_time: '18:00',
+    limit_enabled: false,
+    max_jobs_per_day: null,
+    max_units_per_day: null,
+    note: ''
+  } : custom ? {
     start_time: document.getElementById('bulkDayStart')?.value || '09:00',
     end_time: document.getElementById('bulkDayEnd')?.value || '18:00',
+    limit_enabled: document.getElementById('bulkDayLimitEnabled')?.checked === true,
     max_jobs_per_day: Number(document.getElementById('bulkDayMaxJobs')?.value || 1),
     max_units_per_day: Number(document.getElementById('bulkDayMaxUnits')?.value || 5),
     note: document.getElementById('bulkDayNote')?.value || ''

--- a/index.js
+++ b/index.js
@@ -53,7 +53,13 @@ const createTechnicianBaseStatusDataHelpers = require("./server/helpers/technici
 const createTechnicianBaseStatusReadOnlyRoutes = require("./server/routes/technicianBaseStatusReadOnly");
 const createTechnicianCalendarReadOnlyRoutes = require("./server/routes/technicianCalendarReadOnly");
 const createTechnicianCalendarWriteRoutes = require("./server/routes/technicianCalendarWrite");
-const { toIsoDate, normWorkDayPayload, countLockedAdvanceJobsForDate } = require("./server/lib/technicianCalendar");
+const {
+  toIsoDate,
+  normWorkDayPayload,
+  countLockedAdvanceJobsForDate,
+  loadLockedAdvanceUsageForDate,
+  validateLockedDaySafeEdit,
+} = require("./server/lib/technicianCalendar");
 const { upsertTechnicianProfile } = require("./server/services/technicianProfileUpsert");
 const createTechnicianCountSummaryReadOnlyRoutes = require("./server/routes/technicianCountSummaryReadOnly");
 const createAdminAiOfficeReadOnlyRoutes = require("./server/routes/adminAiOfficeReadOnly");
@@ -13605,6 +13611,14 @@ if (mode === 'forced') try {
 
     await client.query('COMMIT');
 
+    if (mode === 'forced') {
+      try {
+        await _refreshTechnicianIncomePreviewForJob(job_id, safeTeam, { source: 'job_preview' });
+      } catch (e) {
+        try { console.warn('[income_preview] dispatch_v2 refresh failed', { job_id, error: e.message }); } catch {}
+      }
+    }
+
     // notify (best effort)
     if (mode === 'forced') notifyTechnician(technician_username, `📌 มีงานใหม่ (ยืนยันโดยแอดมิน) งาน #${job_id}`);
     else notifyTechnician(technician_username, `📨 มีข้อเสนองานใหม่ งาน #${job_id} (กดรับภายใน 10 นาที)`);
@@ -20133,11 +20147,11 @@ function normalizeCalendarRow(row, iso, jobCount=0){
   const can = row ? (row.can_accept_advance_job === true || ['advance_only','available_advance','working'].includes(String(row.day_status || ''))) : false;
   const start = can ? (row?.start_time || '09:00') : null;
   const end = can ? (row?.end_time || '18:00') : null;
-  const jobs = can ? Number(row?.max_jobs_per_day || 1) : null;
-  const units = can ? Number(row?.max_units_per_day || 5) : null;
+  const jobs = can ? (row?.max_jobs_per_day == null ? null : Number(row.max_jobs_per_day)) : null;
+  const units = can ? (row?.max_units_per_day == null ? null : Number(row.max_units_per_day)) : null;
   const note = row?.note || null;
   const hasCustom = !!(
-    (can && (start !== '09:00' || end !== '18:00' || jobs !== 1 || units !== 5)) ||
+    (can && (start !== '09:00' || end !== '18:00' || jobs !== null || units !== null)) ||
     String(note || '').trim()
   );
   return {
@@ -20362,6 +20376,8 @@ app.use(createTechnicianCalendarWriteRoutes({
   toIsoDate,
   normWorkDayPayload,
   countLockedAdvanceJobsForDate,
+  loadLockedAdvanceUsageForDate,
+  validateLockedDaySafeEdit,
 }));
 
 // Defect 4/6: technician self-service copy uses the session identity (req.effective.username)

--- a/server/lib/technicianCalendar.js
+++ b/server/lib/technicianCalendar.js
@@ -20,8 +20,8 @@ function normWorkDayPayload(input = {}){
   const canAdvance = day_status === 'advance_only';
   const start_time = canAdvance ? (/^\d{2}:\d{2}$/.test(String(input.start_time || '')) ? String(input.start_time) : '09:00') : null;
   const end_time = canAdvance ? (/^\d{2}:\d{2}$/.test(String(input.end_time || '')) ? String(input.end_time) : '18:00') : null;
-  const max_jobs_per_day = canAdvance ? Math.max(1, Math.min(20, Number(input.max_jobs_per_day || 1))) : null;
-  const max_units_per_day = canAdvance ? Math.max(1, Math.min(99, Number(input.max_units_per_day || 5))) : null;
+  const max_jobs_per_day = canAdvance ? normalizeNullableCap(input.max_jobs_per_day, 20) : null;
+  const max_units_per_day = canAdvance ? normalizeNullableCap(input.max_units_per_day, 99) : null;
   return {
     day_status,
     can_accept_advance_job: canAdvance,
@@ -33,6 +33,26 @@ function normWorkDayPayload(input = {}){
     max_units_per_day,
     note: String(input.note || '').slice(0,500)
   };
+}
+
+function normalizeNullableCap(value, max){
+  if (value === null || value === undefined || value === '') return null;
+  const text = String(value).trim().toLowerCase();
+  if (!text || ['null','none','unlimited','auto','available'].includes(text)) return null;
+  const n = Number(value);
+  if (!Number.isFinite(n)) return null;
+  return Math.max(1, Math.min(Number(max || 99), Math.floor(n)));
+}
+
+function hhmmToMin(value){
+  const m = String(value || '').slice(0,5).match(/^(\d{2}):(\d{2})$/);
+  if (!m) return NaN;
+  return Number(m[1]) * 60 + Number(m[2]);
+}
+
+function minToHHMM(value){
+  const n = Math.max(0, Math.min(24 * 60, Math.floor(Number(value || 0))));
+  return `${String(Math.floor(n / 60)).padStart(2,'0')}:${String(n % 60).padStart(2,'0')}`;
 }
 
 async function countLockedAdvanceJobsForDate(clientOrPool, username, workDate){
@@ -48,4 +68,92 @@ async function countLockedAdvanceJobsForDate(clientOrPool, username, workDate){
   return Number(q.rows?.[0]?.job_count || 0);
 }
 
-module.exports = { toIsoDate, normWorkDayPayload, countLockedAdvanceJobsForDate };
+async function loadLockedAdvanceUsageForDate(clientOrPool, username, workDate){
+  const q = await clientOrPool.query(`
+    WITH assigned AS (
+      SELECT DISTINCT j.job_id,
+             j.appointment_datetime,
+             GREATEST(1, COALESCE(j.duration_min,60))::int AS duration_min
+        FROM public.jobs j
+        LEFT JOIN public.job_assignments ja ON ja.job_id=j.job_id AND ja.technician_username=$1
+       WHERE (j.technician_username=$1 OR ja.technician_username=$1)
+         AND j.appointment_datetime IS NOT NULL
+         AND (j.appointment_datetime AT TIME ZONE 'Asia/Bangkok')::date = $2::date
+         AND COALESCE(j.job_status,'') NOT IN ('cancelled','canceled')
+    ),
+    item_units AS (
+      SELECT a.job_id, COALESCE(SUM(NULLIF(ji.qty,0)),0)::int AS units
+        FROM assigned a
+        LEFT JOIN public.job_items ji ON ji.job_id=a.job_id
+       GROUP BY a.job_id
+    )
+    SELECT a.job_id,
+           ((EXTRACT(HOUR FROM (a.appointment_datetime AT TIME ZONE 'Asia/Bangkok'))::int * 60)
+             + EXTRACT(MINUTE FROM (a.appointment_datetime AT TIME ZONE 'Asia/Bangkok'))::int) AS start_min,
+           (((EXTRACT(HOUR FROM (a.appointment_datetime AT TIME ZONE 'Asia/Bangkok'))::int * 60)
+             + EXTRACT(MINUTE FROM (a.appointment_datetime AT TIME ZONE 'Asia/Bangkok'))::int)
+             + a.duration_min) AS end_min,
+           GREATEST(COALESCE(i.units,0),1)::int AS units
+      FROM assigned a
+      LEFT JOIN item_units i ON i.job_id=a.job_id
+  `, [username, workDate]);
+  const rows = q.rows || [];
+  const usage = rows.reduce((acc, row) => {
+    const start = Number(row.start_min);
+    const end = Number(row.end_min);
+    acc.jobs_count += 1;
+    acc.units_count += Math.max(1, Number(row.units || 0));
+    if (Number.isFinite(start)) acc.earliest_start_min = Math.min(acc.earliest_start_min, start);
+    if (Number.isFinite(end)) acc.latest_end_min = Math.max(acc.latest_end_min, end);
+    return acc;
+  }, { jobs_count: 0, units_count: 0, earliest_start_min: Infinity, latest_end_min: -Infinity });
+  if (!rows.length) {
+    usage.earliest_start_min = null;
+    usage.latest_end_min = null;
+  }
+  return usage;
+}
+
+function validateLockedDaySafeEdit(payload, usage = {}){
+  const jobs = Number(usage.jobs_count || 0);
+  if (jobs <= 0) return { ok: true };
+  if (!payload || payload.can_accept_advance_job !== true || payload.day_status !== 'advance_only') {
+    return { ok: false, code: 'LOCKED_DAY_CANNOT_CLOSE' };
+  }
+  const startMin = hhmmToMin(payload.start_time);
+  const endMin = hhmmToMin(payload.end_time);
+  if (!Number.isFinite(startMin) || !Number.isFinite(endMin) || endMin <= startMin) {
+    return { ok: false, code: 'LOCKED_DAY_INVALID_WINDOW' };
+  }
+  if (usage.earliest_start_min != null && startMin > Number(usage.earliest_start_min)) {
+    return { ok: false, code: 'LOCKED_DAY_START_CUTS_JOB' };
+  }
+  if (usage.latest_end_min != null && endMin < Number(usage.latest_end_min)) {
+    return { ok: false, code: 'LOCKED_DAY_END_CUTS_JOB' };
+  }
+  if (payload.max_jobs_per_day != null && Number(payload.max_jobs_per_day) < jobs) {
+    return { ok: false, code: 'LOCKED_DAY_MAX_JOBS_BELOW_USAGE' };
+  }
+  const units = Number(usage.units_count || 0);
+  if (payload.max_units_per_day != null && Number(payload.max_units_per_day) < units) {
+    return { ok: false, code: 'LOCKED_DAY_MAX_UNITS_BELOW_USAGE' };
+  }
+  return {
+    ok: true,
+    usage: {
+      jobs_count: jobs,
+      units_count: units,
+      earliest_start: usage.earliest_start_min == null ? null : minToHHMM(usage.earliest_start_min),
+      latest_end: usage.latest_end_min == null ? null : minToHHMM(usage.latest_end_min),
+    },
+  };
+}
+
+module.exports = {
+  toIsoDate,
+  normWorkDayPayload,
+  normalizeNullableCap,
+  countLockedAdvanceJobsForDate,
+  loadLockedAdvanceUsageForDate,
+  validateLockedDaySafeEdit,
+};

--- a/server/routes/technicianCalendarReadOnly.js
+++ b/server/routes/technicianCalendarReadOnly.js
@@ -158,10 +158,10 @@ module.exports = function createTechnicianCalendarReadOnlyRoutes(deps = {}) {
         const can = !isUnset && row.can_accept_advance_job === true;
         const start = can ? (row.start_time || '09:00') : null;
         const end = can ? (row.end_time || '18:00') : null;
-        const jobs = can ? Number(row.max_jobs_per_day || 1) : null;
-        const units = can ? Number(row.max_units_per_day || 5) : null;
+        const jobs = can ? (row.max_jobs_per_day == null ? null : Number(row.max_jobs_per_day)) : null;
+        const units = can ? (row.max_units_per_day == null ? null : Number(row.max_units_per_day)) : null;
         const note = row.note || null;
-        const hasCustom = !!((can && (start !== '09:00' || end !== '18:00' || jobs !== 1 || units !== 5)) || String(note || '').trim());
+        const hasCustom = !!((can && (start !== '09:00' || end !== '18:00' || jobs !== null || units !== null)) || String(note || '').trim());
         const zones = [row.home_service_zone_code, row.secondary_service_zone_code, row.preferred_zone, [row.home_province, row.home_district].filter(Boolean).join(' ')].filter(Boolean);
         return {
           username: row.username,

--- a/server/routes/technicianCalendarWrite.js
+++ b/server/routes/technicianCalendarWrite.js
@@ -7,86 +7,118 @@ module.exports = function createTechnicianCalendarWriteRoutes(deps = {}) {
   const toIsoDate = deps.toIsoDate;
   const normWorkDayPayload = deps.normWorkDayPayload;
   const countLockedAdvanceJobsForDate = deps.countLockedAdvanceJobsForDate;
+  const loadLockedAdvanceUsageForDate = deps.loadLockedAdvanceUsageForDate;
+  const validateLockedDaySafeEdit = deps.validateLockedDaySafeEdit;
 
-  router.put('/tech/work-calendar/day', requireTechnicianSession, async (req, res) => {
+  function lockedEditMessage(code) {
+    const map = {
+      LOCKED_DAY_CANNOT_CLOSE: "This day already has jobs and cannot be closed.",
+      LOCKED_DAY_INVALID_WINDOW: "Work window is invalid.",
+      LOCKED_DAY_START_CUTS_JOB: "Start time would cut an existing job.",
+      LOCKED_DAY_END_CUTS_JOB: "End time would cut an existing job.",
+      LOCKED_DAY_MAX_JOBS_BELOW_USAGE: "Max jobs is below the current assigned jobs.",
+      LOCKED_DAY_MAX_UNITS_BELOW_USAGE: "Max units is below the current assigned units.",
+    };
+    return map[code] || "This day already has jobs. Only capacity increases, unlimited caps, or wider hours are allowed.";
+  }
+
+  async function assertLockedEditAllowed(db, username, work_date, payload) {
+    const lockedJobs = await countLockedAdvanceJobsForDate(db, username, work_date);
+    if (lockedJobs <= 0) return { lockedJobs, locked: false, allowed: true };
+    if (typeof loadLockedAdvanceUsageForDate !== "function" || typeof validateLockedDaySafeEdit !== "function") {
+      return { lockedJobs, locked: true, allowed: false, code: "LOCKED_DAY_SAFE_EDIT_UNAVAILABLE" };
+    }
+    const usage = await loadLockedAdvanceUsageForDate(db, username, work_date);
+    const check = validateLockedDaySafeEdit(payload, usage);
+    return {
+      lockedJobs,
+      locked: true,
+      allowed: check.ok === true,
+      code: check.code || null,
+      usage: check.usage || usage,
+    };
+  }
+
+  async function upsertDay(db, username, work_date, p) {
+    return db.query(`
+      INSERT INTO public.technician_monthly_work_calendar
+        (technician_username, work_date, day_status, can_accept_advance_job, can_accept_urgent_job, start_time, end_time, max_jobs_per_day, max_units_per_day, note, source, updated_by, updated_at)
+      VALUES($1,$2::date,$3,$4,$5,$6,$7,$8,$9,$10,'technician',$1,NOW())
+      ON CONFLICT(technician_username, work_date) DO UPDATE SET
+        day_status=EXCLUDED.day_status,
+        can_accept_advance_job=EXCLUDED.can_accept_advance_job,
+        can_accept_urgent_job=EXCLUDED.can_accept_urgent_job,
+        start_time=EXCLUDED.start_time,
+        end_time=EXCLUDED.end_time,
+        max_jobs_per_day=EXCLUDED.max_jobs_per_day,
+        max_units_per_day=EXCLUDED.max_units_per_day,
+        note=EXCLUDED.note,
+        source='technician', updated_by=$1, updated_at=NOW()
+      RETURNING *
+    `, [username, work_date, p.day_status, p.can_accept_advance_job, p.can_accept_urgent_job, p.start_time, p.end_time, p.max_jobs_per_day, p.max_units_per_day, p.note]);
+  }
+
+  router.put("/tech/work-calendar/day", requireTechnicianSession, async (req, res) => {
     try {
-      const username = String(req.effective?.username || '').trim();
-      const work_date = toIsoDate(String(req.body?.work_date || '').trim());
-      if (!work_date) return res.status(400).json({ error:'ต้องมี work_date' });
-      const lockedJobs = await countLockedAdvanceJobsForDate(pool, username, work_date);
-      if (lockedJobs > 0) {
+      const username = String(req.effective?.username || "").trim();
+      const work_date = toIsoDate(String(req.body?.work_date || "").trim());
+      if (!work_date) return res.status(400).json({ error: "work_date is required" });
+
+      const p = normWorkDayPayload(req.body || {});
+      const locked = await assertLockedEditAllowed(pool, username, work_date, p);
+      if (locked.locked && !locked.allowed) {
         return res.status(409).json({
-          error:'วันนี้มีงานอยู่แล้ว ช่างไม่สามารถแก้ไขวันทำงานได้ กรุณาติดต่อแอดมิน หากมีความจำเป็น',
-          locked:true,
-          job_count: lockedJobs
+          error: lockedEditMessage(locked.code),
+          locked: true,
+          code: locked.code,
+          job_count: locked.lockedJobs,
+          usage: locked.usage || null,
         });
       }
-      const p = normWorkDayPayload(req.body || {});
-      const r = await pool.query(`
-        INSERT INTO public.technician_monthly_work_calendar
-          (technician_username, work_date, day_status, can_accept_advance_job, can_accept_urgent_job, start_time, end_time, max_jobs_per_day, max_units_per_day, note, source, updated_by, updated_at)
-        VALUES($1,$2::date,$3,$4,$5,$6,$7,$8,$9,$10,'technician',$1,NOW())
-        ON CONFLICT(technician_username, work_date) DO UPDATE SET
-          day_status=EXCLUDED.day_status,
-          can_accept_advance_job=EXCLUDED.can_accept_advance_job,
-          can_accept_urgent_job=EXCLUDED.can_accept_urgent_job,
-          start_time=EXCLUDED.start_time,
-          end_time=EXCLUDED.end_time,
-          max_jobs_per_day=EXCLUDED.max_jobs_per_day,
-          max_units_per_day=EXCLUDED.max_units_per_day,
-          note=EXCLUDED.note,
-          source='technician', updated_by=$1, updated_at=NOW()
-        RETURNING *
-      `, [username, work_date, p.day_status, p.can_accept_advance_job, p.can_accept_urgent_job, p.start_time, p.end_time, p.max_jobs_per_day, p.max_units_per_day, p.note]);
-      res.json({ ok:true, item:r.rows[0] });
+
+      const r = await upsertDay(pool, username, work_date, p);
+      res.json({ ok: true, locked: locked.locked, usage: locked.usage || null, item: r.rows[0] });
     } catch (e) {
-      console.error('PUT /tech/work-calendar/day error:', e);
-      res.status(500).json({ error:'บันทึกปฏิทินรับงานไม่สำเร็จ' });
+      console.error("PUT /tech/work-calendar/day error:", e);
+      res.status(500).json({ error: "Failed to save work calendar" });
     }
   });
 
-  router.put('/tech/work-calendar/bulk', requireTechnicianSession, async (req, res) => {
+  router.put("/tech/work-calendar/bulk", requireTechnicianSession, async (req, res) => {
     const client = await pool.connect();
     try {
-      const username = String(req.effective?.username || '').trim();
+      const username = String(req.effective?.username || "").trim();
       const days = Array.isArray(req.body?.days) ? req.body.days : [];
-      if (!days.length) return res.status(400).json({ error:'ต้องเลือกวันอย่างน้อย 1 วัน' });
-      await client.query('BEGIN');
+      if (!days.length) return res.status(400).json({ error: "At least one day is required" });
+
+      await client.query("BEGIN");
       let count = 0;
       let skippedLocked = 0;
+      const locked_rejections = [];
+
       for (const d of days.slice(0, 62)) {
-        const work_date = toIsoDate(String(d.work_date || '').trim());
+        const work_date = toIsoDate(String(d.work_date || "").trim());
         if (!work_date) continue;
-        const lockedJobs = await countLockedAdvanceJobsForDate(client, username, work_date);
-        if (lockedJobs > 0) {
-          skippedLocked++;
+        const p = normWorkDayPayload(d);
+        const locked = await assertLockedEditAllowed(client, username, work_date, p);
+        if (locked.locked && !locked.allowed) {
+          skippedLocked += 1;
+          locked_rejections.push({ work_date, code: locked.code, job_count: locked.lockedJobs });
           continue;
         }
-        const p = normWorkDayPayload(d);
-        await client.query(`
-          INSERT INTO public.technician_monthly_work_calendar
-            (technician_username, work_date, day_status, can_accept_advance_job, can_accept_urgent_job, start_time, end_time, max_jobs_per_day, max_units_per_day, note, source, updated_by, updated_at)
-          VALUES($1,$2::date,$3,$4,$5,$6,$7,$8,$9,$10,'technician',$1,NOW())
-          ON CONFLICT(technician_username, work_date) DO UPDATE SET
-            day_status=EXCLUDED.day_status,
-            can_accept_advance_job=EXCLUDED.can_accept_advance_job,
-            can_accept_urgent_job=EXCLUDED.can_accept_urgent_job,
-            start_time=EXCLUDED.start_time,
-            end_time=EXCLUDED.end_time,
-            max_jobs_per_day=EXCLUDED.max_jobs_per_day,
-            max_units_per_day=EXCLUDED.max_units_per_day,
-            note=EXCLUDED.note,
-            source='technician', updated_by=$1, updated_at=NOW()
-        `, [username, work_date, p.day_status, p.can_accept_advance_job, p.can_accept_urgent_job, p.start_time, p.end_time, p.max_jobs_per_day, p.max_units_per_day, p.note]);
-        count++;
+        await upsertDay(client, username, work_date, p);
+        count += 1;
       }
-      await client.query('COMMIT');
-      res.json({ ok:true, count, skipped_locked: skippedLocked });
+
+      await client.query("COMMIT");
+      res.json({ ok: true, count, skipped_locked: skippedLocked, locked_rejections });
     } catch (e) {
-      await client.query('ROLLBACK');
-      console.error('PUT /tech/work-calendar/bulk error:', e);
-      res.status(500).json({ error:'บันทึกทั้งเดือนไม่สำเร็จ' });
-    } finally { client.release(); }
+      await client.query("ROLLBACK");
+      console.error("PUT /tech/work-calendar/bulk error:", e);
+      res.status(500).json({ error: "Failed to save work calendar batch" });
+    } finally {
+      client.release();
+    }
   });
 
   return router;

--- a/server/services/public/customerAvailability.js
+++ b/server/services/public/customerAvailability.js
@@ -1,5 +1,10 @@
 "use strict";
 
+const {
+  loadCustomerScheduledLoadMap,
+  rankCustomerScheduledCandidates,
+} = require("./customerScheduledAssignment");
+
 const SLOT_STEP_MIN = 30;
 const DEFAULT_UI_START = "09:00";
 const DEFAULT_UI_END = "18:00";
@@ -325,11 +330,11 @@ async function eligibleCustomerTechnicians(deps, options) {
     const maxJobs = calendar.max_jobs_per_day == null ? null : Number(calendar.max_jobs_per_day);
     const maxUnits = calendar.max_units_per_day == null ? null : Number(calendar.max_units_per_day);
     const usage = usageMap.get(username) || { jobs_count: 0, units_count: 0 };
-    if (Number.isFinite(maxJobs) && maxJobs >= 0 && usage.jobs_count >= maxJobs) {
+    if (Number.isFinite(maxJobs) && maxJobs >= 1 && usage.jobs_count >= maxJobs) {
       capacityFull += 1;
       return false;
     }
-    if (Number.isFinite(maxUnits) && maxUnits >= 0 && (usage.units_count + requestedUnits) > maxUnits) {
+    if (Number.isFinite(maxUnits) && maxUnits >= 1 && (usage.units_count + requestedUnits) > maxUnits) {
       capacityFull += 1;
       return false;
     }
@@ -492,7 +497,8 @@ async function reservePublicCustomerTechnician(deps, options) {
     throw error;
   }
   const criteriaList = buildCriteriaList(options);
-  const lockKey = `${date}|${start}|${durationMin}|${options.tech_type || "company"}|${JSON.stringify(criteriaList)}|${serviceUnitCount(options)}`;
+  const requestedUnits = serviceUnitCount(options);
+  const lockKey = `customer_scheduled_auto_assign|${date}`;
   if (typeof db.query === "function") {
     await db.query("SELECT pg_advisory_xact_lock(hashtext($1))", [lockKey]);
   }
@@ -501,6 +507,12 @@ async function reservePublicCustomerTechnician(deps, options) {
     { ...options, date, lock_calendar_rows: true }
   );
   const startMin = deps.toMin(start);
+  const loadMap = await loadCustomerScheduledLoadMap(
+    db,
+    date,
+    techs.map((tech) => tech.username),
+    { start_min: startMin }
+  );
   const candidates = [];
   for (const tech of techs) {
     const cal = tech.advance_calendar || {};
@@ -512,14 +524,25 @@ async function reservePublicCustomerTechnician(deps, options) {
     const intervals = deps.buildStartIntervalsByCollision(busyBlocks, windowStart, windowEnd, durationMin);
     const ok = intervals.some((it) => startMin >= it.startMin && startMin <= it.endMin);
     if (!ok) continue;
+    const load = loadMap.get(String(tech.username || "")) || {};
     candidates.push({
       username: tech.username,
-      jobs_count: Number(tech.advance_usage?.jobs_count || 0),
-      units_count: Number(tech.advance_usage?.units_count || 0),
+      jobs_count: Number(load.jobs_count ?? tech.advance_usage?.jobs_count ?? 0),
+      units_count: Number(load.units_count ?? tech.advance_usage?.units_count ?? 0),
+      scheduled_minutes: Number(load.scheduled_minutes || 0),
+      previous_job_end_min: Number(load.previous_job_end_min ?? -1),
+      last_auto_assign_ms: Number(load.last_auto_assign_ms || 0),
     });
   }
-  candidates.sort((a, b) => a.jobs_count - b.jobs_count || a.units_count - b.units_count || String(a.username).localeCompare(String(b.username)));
-  const picked = candidates[0] || null;
+  const ranked = rankCustomerScheduledCandidates(candidates, {
+    date,
+    start,
+    duration_min: durationMin,
+    tech_type: options.tech_type || "company",
+    criteria: criteriaList,
+    requested_units: requestedUnits,
+  });
+  const picked = ranked[0] || null;
   if (!picked) {
     const error = new Error("CUSTOMER_SLOT_STALE");
     error.status = 409;
@@ -594,8 +617,8 @@ async function diagnoseTechnicianEligibility(deps, options) {
   const maxJobs = calendar.max_jobs_per_day == null ? null : Number(calendar.max_jobs_per_day);
   const maxUnits = calendar.max_units_per_day == null ? null : Number(calendar.max_units_per_day);
   let capacityOk = true;
-  if (Number.isFinite(maxJobs) && maxJobs >= 0 && usage.jobs_count >= maxJobs) capacityOk = false;
-  if (Number.isFinite(maxUnits) && maxUnits >= 0 && (usage.units_count + requestedUnits) > maxUnits) capacityOk = false;
+  if (Number.isFinite(maxJobs) && maxJobs >= 1 && usage.jobs_count >= maxJobs) capacityOk = false;
+  if (Number.isFinite(maxUnits) && maxUnits >= 1 && (usage.units_count + requestedUnits) > maxUnits) capacityOk = false;
   gates.capacity_ok = capacityOk;
   gates.usage = { jobs_count: usage.jobs_count, units_count: usage.units_count, requested_units: requestedUnits, max_jobs_per_day: maxJobs, max_units_per_day: maxUnits };
   if (!capacityOk) return { username, date, gates, reason: "CAPACITY_FULL" };

--- a/server/services/public/customerScheduledAssignment.js
+++ b/server/services/public/customerScheduledAssignment.js
@@ -1,0 +1,116 @@
+"use strict";
+
+const CANCELLED_STATUSES = ["ยกเลิก", "cancelled", "canceled"];
+
+function stableHash(text) {
+  const s = String(text || "");
+  let h = 2166136261;
+  for (let i = 0; i < s.length; i += 1) {
+    h ^= s.charCodeAt(i);
+    h = Math.imul(h, 16777619);
+  }
+  return h >>> 0;
+}
+
+function rankCustomerScheduledCandidates(candidates = [], context = {}) {
+  const durationMin = Math.max(1, Number(context.duration_min || 0));
+  const key = [
+    "customer_scheduled_rotation",
+    context.date || "",
+    context.start || "",
+    context.tech_type || "",
+    JSON.stringify(context.criteria || []),
+    context.requested_units || 0,
+  ].join("|");
+  return (candidates || []).map((c) => {
+    const scheduled = Number(c.scheduled_minutes || 0);
+    return {
+      ...c,
+      projected_scheduled_minutes: scheduled + durationMin,
+      rotation_score: stableHash(`${key}|${c.username || ""}`),
+    };
+  }).sort((a, b) => (
+    Number(a.projected_scheduled_minutes || 0) - Number(b.projected_scheduled_minutes || 0) ||
+    Number(a.jobs_count || 0) - Number(b.jobs_count || 0) ||
+    Number(a.units_count || 0) - Number(b.units_count || 0) ||
+    Number(a.previous_job_end_min ?? -1) - Number(b.previous_job_end_min ?? -1) ||
+    Number(a.last_auto_assign_ms ?? 0) - Number(b.last_auto_assign_ms ?? 0) ||
+    Number(a.rotation_score || 0) - Number(b.rotation_score || 0)
+  ));
+}
+
+async function loadCustomerScheduledLoadMap(db, date, usernames = [], options = {}) {
+  const names = (Array.isArray(usernames) ? usernames : []).map((u) => String(u || "").trim()).filter(Boolean);
+  if (!names.length || !db || typeof db.query !== "function") return new Map();
+  const startMin = Number(options.start_min);
+  const params = [names, date, CANCELLED_STATUSES];
+  const result = await db.query(
+    `WITH assigned AS (
+       SELECT DISTINCT COALESCE(ja.technician_username, j.technician_username) AS technician_username,
+              j.job_id,
+              j.appointment_datetime,
+              GREATEST(1, COALESCE(j.duration_min,60))::int AS duration_min,
+              j.created_at,
+              j.job_source,
+              j.booking_mode
+         FROM public.jobs j
+         LEFT JOIN public.job_assignments ja ON ja.job_id=j.job_id
+        WHERE COALESCE(ja.technician_username, j.technician_username) = ANY($1::text[])
+          AND j.appointment_datetime IS NOT NULL
+          AND (j.appointment_datetime AT TIME ZONE 'Asia/Bangkok')::date=$2::date
+          AND COALESCE(j.job_status,'') <> ALL($3::text[])
+     ),
+     item_units AS (
+       SELECT a.technician_username, a.job_id, COALESCE(SUM(NULLIF(ji.qty,0)),0)::int AS units
+         FROM assigned a
+         LEFT JOIN public.job_items ji ON ji.job_id=a.job_id
+        GROUP BY a.technician_username, a.job_id
+     )
+     SELECT a.technician_username,
+            a.job_id,
+            a.duration_min,
+            a.created_at,
+            a.job_source,
+            a.booking_mode,
+            ((EXTRACT(HOUR FROM (a.appointment_datetime AT TIME ZONE 'Asia/Bangkok'))::int * 60)
+              + EXTRACT(MINUTE FROM (a.appointment_datetime AT TIME ZONE 'Asia/Bangkok'))::int) AS start_min,
+            (((EXTRACT(HOUR FROM (a.appointment_datetime AT TIME ZONE 'Asia/Bangkok'))::int * 60)
+              + EXTRACT(MINUTE FROM (a.appointment_datetime AT TIME ZONE 'Asia/Bangkok'))::int)
+              + a.duration_min) AS end_min,
+            GREATEST(COALESCE(i.units,0),1)::int AS units
+       FROM assigned a
+       LEFT JOIN item_units i ON i.job_id=a.job_id`,
+    params
+  );
+  const map = new Map(names.map((name) => [name, {
+    scheduled_minutes: 0,
+    jobs_count: 0,
+    units_count: 0,
+    previous_job_end_min: -1,
+    last_auto_assign_ms: 0,
+  }]));
+  for (const row of result.rows || []) {
+    const username = String(row.technician_username || "");
+    const cur = map.get(username);
+    if (!cur) continue;
+    const start = Number(row.start_min);
+    const end = Number(row.end_min);
+    cur.jobs_count += 1;
+    cur.units_count += Math.max(1, Number(row.units || 0));
+    cur.scheduled_minutes += Math.max(1, Number(row.duration_min || 0));
+    if (Number.isFinite(startMin) && Number.isFinite(end) && end <= startMin) {
+      cur.previous_job_end_min = Math.max(cur.previous_job_end_min, end);
+    }
+    if (String(row.job_source || "").toLowerCase() === "customer" && String(row.booking_mode || "").toLowerCase() === "scheduled") {
+      const ms = row.created_at ? new Date(row.created_at).getTime() : NaN;
+      if (Number.isFinite(ms)) cur.last_auto_assign_ms = Math.max(cur.last_auto_assign_ms || 0, ms);
+    }
+  }
+  return map;
+}
+
+module.exports = {
+  stableHash,
+  rankCustomerScheduledCandidates,
+  loadCustomerScheduledLoadMap,
+};

--- a/test/customerMultiServiceCalendar.test.js
+++ b/test/customerMultiServiceCalendar.test.js
@@ -210,7 +210,9 @@ test("draft reservation uses advisory lock, rechecks exact slot, and picks anony
     tech_type: "company",
     services: [{ job_type: "ล้าง", ac_type: "ผนัง", wash_variant: "ล้างธรรมดา" }],
   });
-  assert.deepEqual(Object.keys(picked).sort(), ["jobs_count", "units_count", "username"]);
+  assert.equal(picked.jobs_count, 0);
+  assert.equal(picked.units_count, 0);
+  assert.equal(picked.scheduled_minutes, 0);
   assert.equal(picked.username, "tech-a");
 });
 
@@ -241,7 +243,13 @@ test("admin review displays and preselects the draft technician reservation", ()
   const adminReview = fs.readFileSync(path.join(repoRoot, "admin-review-v2.js"), "utf8");
   assert.match(adminReview, /ร่างจองช่าง/);
   assert.match(adminReview, /CURRENT\.technician_username/);
-  assert.match(adminReview, /currentPrimary = primarySel\.value \|\| CURRENT\?\.technician_username/);
+  assert.match(adminReview, /currentPrimary = CURRENT\?\.technician_username \|\| primarySel\.value/);
+  assert.match(adminReview, /function technicianTypeForUsername/);
+  assert.match(adminReview, /draftType \|\| \(\(CURRENT\.booking_mode === "urgent"\) \? "partner" : "company"\)/);
+});
+
+test("dispatch_v2 refreshes technician income preview after forced approval", () => {
+  assert.match(source, /app\.post\("\/jobs\/:job_id\/dispatch_v2"[\s\S]*await client\.query\('COMMIT'\);[\s\S]*_refreshTechnicianIncomePreviewForJob\(job_id,\s*safeTeam,\s*\{ source: 'job_preview' \}\)/);
 });
 
 test("technician UI marks draft jobs read-only", () => {

--- a/test/customerScheduledCapacityFairness.test.js
+++ b/test/customerScheduledCapacityFairness.test.js
@@ -1,0 +1,165 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const customerAvailability = require("../server/services/public/customerAvailability");
+const {
+  normWorkDayPayload,
+  validateLockedDaySafeEdit,
+} = require("../server/lib/technicianCalendar");
+const {
+  rankCustomerScheduledCandidates,
+} = require("../server/services/public/customerScheduledAssignment");
+
+const GOOD_MATRIX = { job_types: { wash: true }, ac_types: { wall: true }, wash_wall_variants: { normal: true } };
+const CRITERIA = {
+  date: "2026-06-22",
+  tech_type: "company",
+  duration_min: 60,
+  services: [{ job_type: "wash", ac_type: "wall", wash_variant: "normal", machine_count: 1 }],
+};
+
+function intervalsFromBusy(blocks, startMin, endMin, durationMin) {
+  const dur = Math.max(1, Number(durationMin || 0));
+  const busy = (blocks || []).slice().sort((a, b) => a.startMin - b.startMin);
+  const out = [];
+  let cursor = startMin;
+  for (const b of busy) {
+    const bs = Math.max(startMin, Number(b.startMin));
+    const be = Math.min(endMin, Number(b.endMin));
+    if (bs - cursor >= dur) out.push({ startMin: cursor, endMin: bs - dur });
+    cursor = Math.max(cursor, be);
+  }
+  if (endMin - cursor >= dur) out.push({ startMin: cursor, endMin: endMin - dur });
+  return out;
+}
+
+function makeDeps({ calendar = {}, usage = {}, busyByTech = {} } = {}) {
+  const techs = Object.keys(calendar).length ? Object.keys(calendar) : ["tech-a"];
+  return {
+    pool: {
+      async query(sql, params = []) {
+        const text = String(sql);
+        if (text.includes("technician_service_matrix")) {
+          return { rows: techs.map((username) => ({ username, matrix_json: GOOD_MATRIX })) };
+        }
+        if (text.includes("technician_monthly_work_calendar")) {
+          const date = params[1];
+          return { rows: techs.map((technician_username) => ({
+            technician_username,
+            work_date: date,
+            day_status: "advance_only",
+            can_accept_advance_job: true,
+            start_time: "09:00",
+            end_time: "18:00",
+            max_jobs_per_day: calendar[technician_username]?.max_jobs_per_day ?? null,
+            max_units_per_day: calendar[technician_username]?.max_units_per_day ?? null,
+          })) };
+        }
+        if (text.includes("WITH assigned AS")) {
+          return { rows: Object.entries(usage).map(([technician_username, u]) => ({ technician_username, ...u })) };
+        }
+        return { rows: [] };
+      },
+    },
+    listTechniciansByType: async () => techs.map((username) => ({ username, customer_slot_visible: true })),
+    listBusyBlocksForTechOnDate: async (username) => busyByTech[username] || [],
+    buildStartIntervalsByCollision: intervalsFromBusy,
+    toMin(value) {
+      const [h, m] = String(value).split(":").map(Number);
+      return h * 60 + m;
+    },
+    minToHHMM(value) {
+      return `${String(Math.floor(value / 60)).padStart(2, "0")}:${String(value % 60).padStart(2, "0")}`;
+    },
+    getNowBangkokParts: () => ({ Y: "2026", M: "06", D: "01", hh: 8, mm: 0 }),
+  };
+}
+
+test("default advance caps normalize to null, while explicit cap 1 survives", () => {
+  const open = normWorkDayPayload({ can_accept_advance_job: true });
+  assert.equal(open.max_jobs_per_day, null);
+  assert.equal(open.max_units_per_day, null);
+
+  const capped = normWorkDayPayload({ can_accept_advance_job: true, max_jobs_per_day: 1, max_units_per_day: 1 });
+  assert.equal(capped.max_jobs_per_day, 1);
+  assert.equal(capped.max_units_per_day, 1);
+});
+
+test("null caps do not close a day with existing usage; explicit caps still apply", async () => {
+  let result = await customerAvailability.computePublicCustomerSlots(makeDeps({
+    calendar: { "tech-a": { max_jobs_per_day: null, max_units_per_day: null } },
+    usage: { "tech-a": { jobs_count: 3, units_count: 9 } },
+  }), CRITERIA);
+  assert.ok(result.slots.length > 0);
+
+  result = await customerAvailability.computePublicCustomerSlots(makeDeps({
+    calendar: { "tech-a": { max_jobs_per_day: 1, max_units_per_day: null } },
+    usage: { "tech-a": { jobs_count: 1, units_count: 1 } },
+  }), CRITERIA);
+  assert.equal(result.reason_code, "CAPACITY_FULL");
+
+  result = await customerAvailability.computePublicCustomerSlots(makeDeps({
+    calendar: { "tech-a": { max_jobs_per_day: null, max_units_per_day: 2 } },
+    usage: { "tech-a": { jobs_count: 0, units_count: 1 } },
+  }), { ...CRITERIA, services: [{ ...CRITERIA.services[0], machine_count: 2 }] });
+  assert.equal(result.reason_code, "CAPACITY_FULL");
+});
+
+test("busy afternoon leaves morning slots and busy morning leaves afternoon slots", async () => {
+  const morning = await customerAvailability.computePublicCustomerSlots(makeDeps({
+    calendar: { "tech-a": {} },
+    busyByTech: { "tech-a": [{ startMin: 13 * 60, endMin: 18 * 60 }] },
+  }), CRITERIA);
+  assert.ok(morning.slots.some((s) => s.start === "09:00"));
+
+  const afternoon = await customerAvailability.computePublicCustomerSlots(makeDeps({
+    calendar: { "tech-a": {} },
+    busyByTech: { "tech-a": [{ startMin: 9 * 60, endMin: 12 * 60 }] },
+  }), CRITERIA);
+  assert.ok(afternoon.slots.some((s) => s.start === "12:00" || s.start === "12:30"));
+});
+
+test("duration controls slot visibility inside real gaps", async () => {
+  const deps = makeDeps({
+    calendar: { "tech-a": {} },
+    busyByTech: { "tech-a": [{ startMin: 10 * 60, endMin: 18 * 60 }] },
+  });
+  const sixty = await customerAvailability.computePublicCustomerSlots(deps, { ...CRITERIA, duration_min: 60 });
+  assert.ok(sixty.slots.some((s) => s.start === "09:00"));
+
+  const twoHours = await customerAvailability.computePublicCustomerSlots(deps, { ...CRITERIA, duration_min: 120 });
+  assert.equal(twoHours.slots.length, 0);
+  assert.equal(twoHours.reason_code, "COLLISION_FULL");
+});
+
+test("locked-day safe validation allows unlimited/increase and rejects unsafe decreases", () => {
+  const usage = { jobs_count: 2, units_count: 4, earliest_start_min: 600, latest_end_min: 780 };
+  assert.equal(validateLockedDaySafeEdit({ day_status: "advance_only", can_accept_advance_job: true, start_time: "09:00", end_time: "18:00", max_jobs_per_day: null, max_units_per_day: null }, usage).ok, true);
+  assert.equal(validateLockedDaySafeEdit({ day_status: "advance_only", can_accept_advance_job: true, start_time: "09:00", end_time: "18:00", max_jobs_per_day: 3, max_units_per_day: 5 }, usage).ok, true);
+  assert.equal(validateLockedDaySafeEdit({ day_status: "unavailable", can_accept_advance_job: false }, usage).code, "LOCKED_DAY_CANNOT_CLOSE");
+  assert.equal(validateLockedDaySafeEdit({ day_status: "advance_only", can_accept_advance_job: true, start_time: "11:00", end_time: "18:00", max_jobs_per_day: null, max_units_per_day: null }, usage).code, "LOCKED_DAY_START_CUTS_JOB");
+  assert.equal(validateLockedDaySafeEdit({ day_status: "advance_only", can_accept_advance_job: true, start_time: "09:00", end_time: "12:00", max_jobs_per_day: null, max_units_per_day: null }, usage).code, "LOCKED_DAY_END_CUTS_JOB");
+  assert.equal(validateLockedDaySafeEdit({ day_status: "advance_only", can_accept_advance_job: true, start_time: "09:00", end_time: "18:00", max_jobs_per_day: 1, max_units_per_day: null }, usage).code, "LOCKED_DAY_MAX_JOBS_BELOW_USAGE");
+});
+
+test("fair assignment ranking prioritizes projected minutes, older auto assignment, and non-username rotation", () => {
+  let ranked = rankCustomerScheduledCandidates([
+    { username: "a-user", scheduled_minutes: 120, jobs_count: 0, units_count: 0, previous_job_end_min: -1, last_auto_assign_ms: 0 },
+    { username: "z-user", scheduled_minutes: 30, jobs_count: 0, units_count: 0, previous_job_end_min: -1, last_auto_assign_ms: 0 },
+  ], { date: "2026-06-22", start: "09:00", duration_min: 60 });
+  assert.equal(ranked[0].username, "z-user");
+
+  ranked = rankCustomerScheduledCandidates([
+    { username: "newer", scheduled_minutes: 0, jobs_count: 0, units_count: 0, previous_job_end_min: -1, last_auto_assign_ms: 200 },
+    { username: "older", scheduled_minutes: 0, jobs_count: 0, units_count: 0, previous_job_end_min: -1, last_auto_assign_ms: 100 },
+  ], { date: "2026-06-22", start: "09:00", duration_min: 60 });
+  assert.equal(ranked[0].username, "older");
+
+  const base = [
+    { username: "alice", scheduled_minutes: 0, jobs_count: 0, units_count: 0, previous_job_end_min: -1, last_auto_assign_ms: 0 },
+    { username: "bob", scheduled_minutes: 0, jobs_count: 0, units_count: 0, previous_job_end_min: -1, last_auto_assign_ms: 0 },
+  ];
+  const firstA = rankCustomerScheduledCandidates(base, { date: "2026-06-22", start: "09:00", duration_min: 60 })[0].username;
+  const firstB = rankCustomerScheduledCandidates(base, { date: "2026-06-22", start: "10:00", duration_min: 60 })[0].username;
+  assert.notEqual(firstA, firstB);
+});

--- a/test/technicianCalendarWriteAndProfile.integration.test.js
+++ b/test/technicianCalendarWriteAndProfile.integration.test.js
@@ -5,7 +5,13 @@ const express = require("express");
 const { Pool } = require("pg");
 
 const createTechnicianCalendarWriteRoutes = require("../server/routes/technicianCalendarWrite");
-const { toIsoDate, normWorkDayPayload, countLockedAdvanceJobsForDate } = require("../server/lib/technicianCalendar");
+const {
+  toIsoDate,
+  normWorkDayPayload,
+  countLockedAdvanceJobsForDate,
+  loadLockedAdvanceUsageForDate,
+  validateLockedDaySafeEdit,
+} = require("../server/lib/technicianCalendar");
 const { upsertTechnicianProfile } = require("../server/services/technicianProfileUpsert");
 
 // These tests exercise the REAL production route module / helper against a real
@@ -21,9 +27,18 @@ const PG_CONFIG = {
 let pool;
 let server;
 let baseUrl;
+let dbUnavailableReason = "";
 
 test.before(async () => {
   pool = new Pool(PG_CONFIG);
+  try {
+    await pool.query("SELECT 1");
+  } catch (e) {
+    dbUnavailableReason = e.message || "Postgres test database is unavailable";
+    await pool.end().catch(() => {});
+    pool = null;
+    return;
+  }
   await pool.query(`
     CREATE TABLE IF NOT EXISTS public.technician_monthly_work_calendar (
       technician_username TEXT NOT NULL,
@@ -54,6 +69,12 @@ test.before(async () => {
     CREATE TABLE IF NOT EXISTS public.job_assignments (
       job_id BIGINT,
       technician_username TEXT
+    )
+  `);
+  await pool.query(`
+    CREATE TABLE IF NOT EXISTS public.job_items (
+      job_id BIGINT,
+      qty INT
     )
   `);
   await pool.query(`
@@ -88,6 +109,8 @@ test.before(async () => {
     toIsoDate,
     normWorkDayPayload,
     countLockedAdvanceJobsForDate,
+    loadLockedAdvanceUsageForDate,
+    validateLockedDaySafeEdit,
   }));
   app._setSessionUsername = (u) => { sessionUsername = u; };
 
@@ -98,14 +121,19 @@ test.before(async () => {
 });
 
 test.after(async () => {
-  await new Promise((resolve) => server.close(resolve));
-  await pool.end();
+  if (server) await new Promise((resolve) => server.close(resolve));
+  if (pool) await pool.end();
 });
 
-test.beforeEach(async () => {
+test.beforeEach(async (t) => {
+  if (dbUnavailableReason) {
+    t.skip(`Postgres integration database unavailable: ${dbUnavailableReason}`);
+    return;
+  }
   await pool.query("DELETE FROM public.technician_monthly_work_calendar");
   await pool.query("DELETE FROM public.jobs");
   await pool.query("DELETE FROM public.job_assignments");
+  await pool.query("DELETE FROM public.job_items");
   await pool.query("DELETE FROM public.technician_profiles");
 });
 
@@ -119,8 +147,15 @@ async function putJson(path, body) {
   return { status: res.status, data };
 }
 
+function dbTest(name, fn) {
+  test(name, async (t) => {
+    if (dbUnavailableReason) return t.skip(`Postgres integration database unavailable: ${dbUnavailableReason}`);
+    return fn(t);
+  });
+}
+
 // ============ Blocker 2: PUT /tech/work-calendar/day real contract ============
-test("Blocker 2: single-day save via real route persists a real row keyed by req.effective.username", async () => {
+dbTest("Blocker 2: single-day save via real route persists a real row keyed by req.effective.username", async () => {
   global.__cwfTestApp._setSessionUsername("p1");
   const body = {
     work_date: "2026-07-10",
@@ -145,7 +180,7 @@ test("Blocker 2: single-day save via real route persists a real row keyed by req
   assert.equal(row.rows[0].can_accept_advance_job, true);
 });
 
-test("Blocker 2: username is sourced from req.effective.username, not client-supplied body", async () => {
+dbTest("Blocker 2: username is sourced from req.effective.username, not client-supplied body", async () => {
   global.__cwfTestApp._setSessionUsername("session-user");
   const body = {
     // Even if the body carried an unrelated "username"-like field, the route never reads it.
@@ -162,7 +197,7 @@ test("Blocker 2: username is sourced from req.effective.username, not client-sup
   assert.equal(row.rows[0].technician_username, "session-user");
 });
 
-test("Blocker 2: reading the month back after save shows the same saved date", async () => {
+dbTest("Blocker 2: reading the month back after save shows the same saved date", async () => {
   global.__cwfTestApp._setSessionUsername("p1");
   await putJson("/tech/work-calendar/day", { work_date: "2026-07-12", can_accept_advance_job: true });
 
@@ -176,20 +211,50 @@ test("Blocker 2: reading the month back after save shows the same saved date", a
   assert.equal(monthRows.rows[0].can_accept_advance_job, true);
 });
 
-test("Blocker 2: locked day (existing job) is rejected with 409 and no row mutation", async () => {
+dbTest("locked day safe edit can increase capacity or switch to unlimited", async () => {
   global.__cwfTestApp._setSessionUsername("p1");
   await pool.query(
     `INSERT INTO public.jobs (technician_username, appointment_datetime, job_status) VALUES ('p1', '2026-07-13 10:00:00+07', 'assigned')`
   );
-  const { status, data } = await putJson("/tech/work-calendar/day", { work_date: "2026-07-13", can_accept_advance_job: true });
+  const { status, data } = await putJson("/tech/work-calendar/day", {
+    work_date: "2026-07-13",
+    can_accept_advance_job: true,
+    start_time: "09:00",
+    end_time: "18:00",
+    max_jobs_per_day: null,
+    max_units_per_day: null,
+  });
+  assert.equal(status, 200);
+  assert.equal(data.locked, true);
+  const row = await pool.query(`SELECT max_jobs_per_day, max_units_per_day FROM public.technician_monthly_work_calendar WHERE work_date='2026-07-13'`);
+  assert.equal(row.rows.length, 1);
+  assert.equal(row.rows[0].max_jobs_per_day, null);
+  assert.equal(row.rows[0].max_units_per_day, null);
+});
+
+dbTest("locked day unsafe cap decrease is rejected with 409 and no row mutation", async () => {
+  global.__cwfTestApp._setSessionUsername("p1");
+  const job = await pool.query(
+    `INSERT INTO public.jobs (technician_username, appointment_datetime, job_status) VALUES ('p1', '2026-07-14 10:00:00+07', 'assigned') RETURNING job_id`
+  );
+  await pool.query(`INSERT INTO public.job_items (job_id, qty) VALUES ($1, 3)`, [job.rows[0].job_id]);
+  const { status, data } = await putJson("/tech/work-calendar/day", {
+    work_date: "2026-07-14",
+    can_accept_advance_job: true,
+    start_time: "09:00",
+    end_time: "18:00",
+    max_jobs_per_day: 1,
+    max_units_per_day: 2,
+  });
   assert.equal(status, 409);
   assert.equal(data.locked, true);
-  const row = await pool.query(`SELECT 1 FROM public.technician_monthly_work_calendar WHERE work_date='2026-07-13'`);
+  assert.equal(data.code, "LOCKED_DAY_MAX_UNITS_BELOW_USAGE");
+  const row = await pool.query(`SELECT 1 FROM public.technician_monthly_work_calendar WHERE work_date='2026-07-14'`);
   assert.equal(row.rows.length, 0);
 });
 
 // ============ Blocker 3: admin technician profile UPSERT INSERT path ============
-test("Blocker 3: existing profile is updated and read-back matches submitted values", async () => {
+dbTest("Blocker 3: existing profile is updated and read-back matches submitted values", async () => {
   await pool.query(
     `INSERT INTO public.technician_profiles (username, technician_code, employment_type, customer_slot_visible) VALUES ('c1','C001','company',false)`
   );
@@ -215,7 +280,7 @@ test("Blocker 3: existing profile is updated and read-back matches submitted val
   assert.equal(row.rows[0].customer_slot_visible, true);
 });
 
-test("Blocker 3: first-time insert (no existing profile row) sets employment_type and customer_slot_visible on INSERT, not only ON CONFLICT", async () => {
+dbTest("Blocker 3: first-time insert (no existing profile row) sets employment_type and customer_slot_visible on INSERT, not only ON CONFLICT", async () => {
   const before = await pool.query(`SELECT 1 FROM public.technician_profiles WHERE username='new1'`);
   assert.equal(before.rows.length, 0);
 


### PR DESCRIPTION
## Summary
- Make technician calendar caps nullable by default so customer scheduled availability uses real free time unless a technician explicitly sets caps.
- Allow safe locked-day edits that increase capacity, switch caps to unlimited, or widen hours while rejecting unsafe closes/decreases/window cuts.
- Rank customer scheduled draft reservations by projected minutes, load, idle time, last customer auto assignment, and deterministic non-username rotation under a same-day advisory lock.
- Preserve draft technician preselect in Admin Review by resolving the reserved technician employment type, and refresh technician income preview after forced dispatch approval.

## Validation
- npm.cmd ci
- npm.cmd test
- node --test test\\technicianCalendarWriteAndProfile.integration.test.js (skipped locally because Postgres test DB auth failed for user postgres)
- node --check changed JS files
- git diff --check
- startup smoke: node -e "require('./index.js'); setTimeout(()=>process.exit(0), 1500)" (server loaded; local DB SSL warning only)

## Notes
- No migrations or direct production data updates.
- No pricing, payout, payroll, auth, urgent booking, or admin-add assignment behavior changes.
- In-app Browser QA was blocked by the browser runtime metadata error in this session; static responsive/control checks were performed instead.