### PR TITLE
Fix legacy calendar caps and technician app cache

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,7 +1,7 @@
 
 
 // CWF Technician App Stable fix12: force real 20-row history page + cache-bust marker
-window.__CWF_TECH_APP_VERSION__ = "20260612_phase34_tech_api_dedup";
+window.__CWF_TECH_APP_VERSION__ = "20260622_legacy_cap_policy_tech_cache_v1";
 try { console.info('[CWF_TECH_APP_VERSION]', window.__CWF_TECH_APP_VERSION__); } catch (_) {}
 
 // ✅ งานปัจจุบัน: งานล่วงหน้า (sub-tab)
@@ -1235,7 +1235,7 @@ function setPushUi(state, text) {
 
 async function ensureServiceWorkerForPush() {
   if (!('serviceWorker' in navigator)) throw new Error('เครื่องนี้ไม่รองรับ Service Worker');
-  const reg = await navigator.serviceWorker.register('/sw.js?v=push-v1');
+  const reg = await navigator.serviceWorker.register('/sw.js?v=20260622_legacy_cap_policy_tech_cache_v1', { updateViaCache: 'none' });
   try { await navigator.serviceWorker.ready; } catch (_) {}
   return reg;
 }
@@ -5716,6 +5716,44 @@ function cwfSetCapControls(prefix, limited, jobs, units){
     if (label) label.style.display = limited ? 'grid' : 'none';
   }
 }
+function cwfIsCustomCapMode(it){
+  return String(it?.cap_mode || '').trim() === 'technician_custom';
+}
+function cwfJobCapLimited(it){
+  return cwfIsCustomCapMode(it) && cwfNullableCap(it?.raw_max_jobs_per_day ?? it?.max_jobs_per_day) != null;
+}
+function cwfUnitCapLimited(it){
+  return cwfIsCustomCapMode(it) && cwfNullableCap(it?.raw_max_units_per_day ?? it?.max_units_per_day) != null;
+}
+function cwfJobCapLabel(it){
+  if (!it?.can_accept_advance_job) return '-';
+  if (cwfJobCapLimited(it)) return `ตั้งเอง ${cwfNullableCap(it.raw_max_jobs_per_day ?? it.max_jobs_per_day)} งาน`;
+  return `ค่าเริ่มต้นระบบ ${Number(it.effective_max_jobs_per_day ?? 4)} งาน`;
+}
+function cwfUnitCapLabel(it){
+  if (!it?.can_accept_advance_job) return '-';
+  if (cwfUnitCapLimited(it)) return `ตั้งเอง ${cwfNullableCap(it.raw_max_units_per_day ?? it.max_units_per_day)} เครื่อง`;
+  return 'ไม่จำกัด';
+}
+function cwfCapsLimited(it){
+  return cwfJobCapLimited(it) || cwfUnitCapLimited(it);
+}
+function cwfSetCapControls(prefix, jobLimited, jobs, unitLimited, units){
+  const jobCb = document.getElementById(`${prefix}JobLimitEnabled`);
+  const unitCb = document.getElementById(`${prefix}UnitLimitEnabled`);
+  const j = document.getElementById(`${prefix}MaxJobs`);
+  const u = document.getElementById(`${prefix}MaxUnits`);
+  const jobField = document.getElementById(`${prefix}JobLimitField`);
+  const unitField = document.getElementById(`${prefix}UnitLimitField`);
+  if (jobCb) jobCb.checked = !!jobLimited;
+  if (unitCb) unitCb.checked = !!unitLimited;
+  if (j) j.value = cwfNullableCap(jobs) ?? 4;
+  if (u) u.value = cwfNullableCap(units) ?? 5;
+  if (j) j.disabled = !jobLimited;
+  if (u) u.disabled = !unitLimited;
+  if (jobField) jobField.style.display = jobLimited ? 'grid' : 'none';
+  if (unitField) unitField.style.display = unitLimited ? 'grid' : 'none';
+}
 function cwfIsLockedDay(iso){
   const it = cwfGetCalendarItem(iso);
   return !!it?.is_locked || cwfDayJobCount(iso) > 0;
@@ -5750,8 +5788,14 @@ function cwfEffectiveCalendarItem(iso){
     can_accept_advance_job: isAdvance,
     start_time: raw.start_time || '09:00',
     end_time: raw.end_time || '18:00',
-    max_jobs_per_day: isAdvance ? cwfNullableCap(raw.max_jobs_per_day) : null,
-    max_units_per_day: isAdvance ? cwfNullableCap(raw.max_units_per_day) : null,
+    max_jobs_per_day: isAdvance ? cwfNullableCap(raw.raw_max_jobs_per_day ?? raw.max_jobs_per_day) : null,
+    max_units_per_day: isAdvance ? cwfNullableCap(raw.raw_max_units_per_day ?? raw.max_units_per_day) : null,
+    raw_max_jobs_per_day: isAdvance ? cwfNullableCap(raw.raw_max_jobs_per_day ?? raw.max_jobs_per_day) : null,
+    raw_max_units_per_day: isAdvance ? cwfNullableCap(raw.raw_max_units_per_day ?? raw.max_units_per_day) : null,
+    cap_mode: raw.cap_mode || ((raw.max_jobs_per_day == null && raw.max_units_per_day == null) ? 'system_default' : 'technician_custom'),
+    effective_max_jobs_per_day: isAdvance ? (cwfNullableCap(raw.effective_max_jobs_per_day) ?? 4) : null,
+    effective_max_units_per_day: isAdvance ? cwfNullableCap(raw.effective_max_units_per_day) : null,
+    is_legacy_system_default: raw.is_legacy_system_default === true,
     note: raw.note || ''
   };
 }
@@ -5850,9 +5894,10 @@ function ensureWorkdaysModal(){
               <label>เวลาเลิก <input id="workDayEnd" class="premium-input" type="time" value="18:00"></label>
             </div>
             <div class="cwf-time-grid">
-              <label class="cwf-limit-toggle"><input id="workDayLimitEnabled" type="checkbox"> จำกัดจำนวนงาน/เครื่องต่อวัน</label>
-              <label>งานสูงสุด/วัน <input id="workDayMaxJobs" class="premium-input" type="number" min="1" max="20" value="1"></label>
-              <label>เครื่องสูงสุด/วัน <input id="workDayMaxUnits" class="premium-input" type="number" min="1" max="99" value="5"></label>
+              <label class="cwf-limit-toggle"><input id="workDayJobLimitEnabled" type="checkbox"> Limit jobs per day</label>
+              <label id="workDayJobLimitField">Max jobs/day <input id="workDayMaxJobs" class="premium-input" type="number" min="1" max="20" value="4"></label>
+              <label class="cwf-limit-toggle"><input id="workDayUnitLimitEnabled" type="checkbox"> Limit units per day</label>
+              <label id="workDayUnitLimitField">Max units/day <input id="workDayMaxUnits" class="premium-input" type="number" min="1" max="99" value="5"></label>
             </div>
             <label>หมายเหตุถึงแอดมิน <textarea id="workDayNote" class="premium-input" rows="3" placeholder="เช่น รับได้เฉพาะช่วงบ่าย / โทรคอนเฟิร์มก่อนมอบหมาย"></textarea></label>
             <div class="cwf-quick-grid">
@@ -5875,9 +5920,10 @@ function ensureWorkdaysModal(){
                 <label>เวลาเลิก <input id="bulkDayEnd" class="premium-input" type="time" value="18:00"></label>
               </div>
               <div class="cwf-time-grid">
-                <label class="cwf-limit-toggle"><input id="bulkDayLimitEnabled" type="checkbox"> จำกัดจำนวนงาน/เครื่องต่อวัน</label>
-                <label>งานสูงสุด/วัน <input id="bulkDayMaxJobs" class="premium-input" type="number" min="1" max="20" value="1"></label>
-                <label>เครื่องสูงสุด/วัน <input id="bulkDayMaxUnits" class="premium-input" type="number" min="1" max="99" value="5"></label>
+                <label class="cwf-limit-toggle"><input id="bulkDayJobLimitEnabled" type="checkbox"> Limit jobs per day</label>
+                <label id="bulkDayJobLimitField">Max jobs/day <input id="bulkDayMaxJobs" class="premium-input" type="number" min="1" max="20" value="4"></label>
+                <label class="cwf-limit-toggle"><input id="bulkDayUnitLimitEnabled" type="checkbox"> Limit units per day</label>
+                <label id="bulkDayUnitLimitField">Max units/day <input id="bulkDayMaxUnits" class="premium-input" type="number" min="1" max="99" value="5"></label>
               </div>
               <label>หมายเหตุถึงแอดมิน <textarea id="bulkDayNote" class="premium-input" rows="3" placeholder="หมายเหตุที่จะใส่ให้ทุกวันที่เลือก"></textarea></label>
               <button id="bulkSaveCustomBtn" class="cwf-save-btn full" type="button">💾 บันทึกค่าพิเศษให้วันที่เลือก</button>
@@ -5930,15 +5976,21 @@ function ensureWorkdaysModal(){
   document.getElementById('closeSingleDetailBtn').onclick = () => { const p=document.getElementById('singleEditPanel'); if(p) p.style.display='none'; };
   document.getElementById('saveSingleDetailBtn').onclick = saveSelectedDayCustom;
   document.getElementById('bulkSetAdvanceBtn').onclick = () => saveBulkSelected(false, true);
-  document.getElementById('bulkSetUnlimitedBtn').onclick = () => saveBulkSelected(false, true, { forceUnlimited:true });
+  document.getElementById('bulkSetUnlimitedBtn').onclick = () => saveBulkSelected(false, true);
   document.getElementById('bulkSetUnavailableBtn').onclick = () => saveBulkSelected(false, false);
   document.getElementById('bulkCustomToggleBtn').onclick = () => { const p=document.getElementById('bulkCustomFields'); if(p) p.style.display = p.style.display === 'none' ? 'block' : 'none'; };
   document.getElementById('bulkSaveCustomBtn').onclick = () => saveBulkSelected(true, true);
-  const singleLimit = document.getElementById('workDayLimitEnabled');
-  if (singleLimit) singleLimit.onchange = () => cwfSetCapControls('workDay', singleLimit.checked, document.getElementById('workDayMaxJobs')?.value, document.getElementById('workDayMaxUnits')?.value);
-  const bulkLimit = document.getElementById('bulkDayLimitEnabled');
-  if (bulkLimit) bulkLimit.onchange = () => cwfSetCapControls('bulkDay', bulkLimit.checked, document.getElementById('bulkDayMaxJobs')?.value, document.getElementById('bulkDayMaxUnits')?.value);
-  cwfSetCapControls('bulkDay', false, null, null);
+  const singleJobLimit = document.getElementById('workDayJobLimitEnabled');
+  const singleUnitLimit = document.getElementById('workDayUnitLimitEnabled');
+  const refreshSingleLimits = () => cwfSetCapControls('workDay', singleJobLimit?.checked === true, document.getElementById('workDayMaxJobs')?.value, singleUnitLimit?.checked === true, document.getElementById('workDayMaxUnits')?.value);
+  if (singleJobLimit) singleJobLimit.onchange = refreshSingleLimits;
+  if (singleUnitLimit) singleUnitLimit.onchange = refreshSingleLimits;
+  const bulkJobLimit = document.getElementById('bulkDayJobLimitEnabled');
+  const bulkUnitLimit = document.getElementById('bulkDayUnitLimitEnabled');
+  const refreshBulkLimits = () => cwfSetCapControls('bulkDay', bulkJobLimit?.checked === true, document.getElementById('bulkDayMaxJobs')?.value, bulkUnitLimit?.checked === true, document.getElementById('bulkDayMaxUnits')?.value);
+  if (bulkJobLimit) bulkJobLimit.onchange = refreshBulkLimits;
+  if (bulkUnitLimit) bulkUnitLimit.onchange = refreshBulkLimits;
+  cwfSetCapControls('bulkDay', false, null, false, null);
   document.getElementById('workCalendarRetryBtn').onclick = () => loadCwfAdvanceWorkCalendarMonthSafe();
   return wrap;
 }
@@ -6028,18 +6080,18 @@ function selectWorkCalendarDate(iso, rerender=true){
     summary.innerHTML = `<div class="cwf-detail-grid">
       <div><span>สถานะ</span><b>${statusText}</b></div>
       <div><span>เวลา</span><b>${it.can_accept_advance_job ? `${it.start_time || '09:00'}-${it.end_time || '18:00'}` : '-'}</b></div>
-      <div><span>งานสูงสุด</span><b>${it.can_accept_advance_job ? cwfCapLabel(it.max_jobs_per_day) : '-'}</b></div>
-      <div><span>เครื่องสูงสุด</span><b>${it.can_accept_advance_job ? cwfCapLabel(it.max_units_per_day) : '-'}</b></div>
+      <div><span>งานสูงสุด</span><b>${cwfJobCapLabel(it)}</b></div>
+      <div><span>เครื่องสูงสุด</span><b>${cwfUnitCapLabel(it)}</b></div>
       <div class="cwf-detail-note"><span>หมายเหตุ</span><b>${it.note ? String(it.note) : 'ไม่มี'}</b></div>
     </div>${locked ? '<div style="margin-top:8px;color:#64748b;font-weight:850">วันนี้ล็อกไว้เพราะมีงานที่ได้รับมอบหมายแล้ว</div>' : ''}`;
   }
   const set = (id,val) => { const el=document.getElementById(id); if(el) el.value=val ?? ''; };
-  set('workDayStart', it.start_time || '09:00'); set('workDayEnd', it.end_time || '18:00'); set('workDayMaxJobs', cwfNullableCap(it.max_jobs_per_day) ?? 1); set('workDayMaxUnits', cwfNullableCap(it.max_units_per_day) ?? 5); set('workDayNote', it.note || '');
-  cwfSetCapControls('workDay', cwfCapsLimited(it), it.max_jobs_per_day, it.max_units_per_day);
+  set('workDayStart', it.start_time || '09:00'); set('workDayEnd', it.end_time || '18:00'); set('workDayMaxJobs', cwfNullableCap(it.raw_max_jobs_per_day ?? it.max_jobs_per_day) ?? 4); set('workDayMaxUnits', cwfNullableCap(it.raw_max_units_per_day ?? it.max_units_per_day) ?? 5); set('workDayNote', it.note || '');
+  cwfSetCapControls('workDay', cwfJobCapLimited(it), it.raw_max_jobs_per_day ?? it.max_jobs_per_day, cwfUnitCapLimited(it), it.raw_max_units_per_day ?? it.max_units_per_day);
   const editPanel = document.getElementById('singleEditPanel'); if(editPanel) editPanel.style.display = 'none';
   const openBtn = document.getElementById('singleOpenDayBtn'); if(openBtn) openBtn.disabled = locked || it.can_accept_advance_job;
   const closeBtn = document.getElementById('singleCloseDayBtn'); if(closeBtn) closeBtn.disabled = locked || !it.can_accept_advance_job;
-  const editBtn = document.getElementById('editSelectedDayBtn'); if(editBtn) editBtn.disabled = false;
+  const editBtn = document.getElementById('editSelectedDayBtn'); if(editBtn) editBtn.disabled = locked;
 }
 async function saveCalendarDays(days, label='บันทึก'){
   const clean = days.filter(Boolean).slice(0,62);
@@ -6056,7 +6108,8 @@ async function saveCalendarDays(days, label='บันทึก'){
   return data;
 }
 function buildDayPayload(iso, isAdvance, opts={}){
-  const limitEnabled = opts.limit_enabled === true || opts.limitEnabled === true;
+  const jobLimitEnabled = opts.job_limit_enabled === true || opts.jobLimitEnabled === true || opts.limit_enabled === true || opts.limitEnabled === true;
+  const unitLimitEnabled = opts.unit_limit_enabled === true || opts.unitLimitEnabled === true || opts.limit_enabled === true || opts.limitEnabled === true;
   return {
     work_date: iso,
     day_status: isAdvance ? 'advance_only' : 'unavailable',
@@ -6064,8 +6117,8 @@ function buildDayPayload(iso, isAdvance, opts={}){
     can_accept_urgent_job: false,
     start_time: isAdvance ? (opts.start_time || '09:00') : '09:00',
     end_time: isAdvance ? (opts.end_time || '18:00') : '18:00',
-    max_jobs_per_day: isAdvance && limitEnabled ? cwfNullableCap(opts.max_jobs_per_day) : null,
-    max_units_per_day: isAdvance && limitEnabled ? cwfNullableCap(opts.max_units_per_day) : null,
+    max_jobs_per_day: isAdvance && jobLimitEnabled ? cwfNullableCap(opts.max_jobs_per_day) : null,
+    max_units_per_day: isAdvance && unitLimitEnabled ? cwfNullableCap(opts.max_units_per_day) : null,
     note: opts.note || ''
   };
 }
@@ -6109,16 +6162,19 @@ async function setSelectedDayAdvance(isAdvance){
 function showSingleEditPanel(){
   const iso = __cwfWorkCalendarState.selectedDate;
   if(!iso) return;
+  if(cwfIsLockedDay(iso)){ cwfLockedPopup(iso); return; }
   const p = document.getElementById('singleEditPanel'); if(p) p.style.display = 'grid';
 }
 async function saveSelectedDayCustom(){
   const iso = __cwfWorkCalendarState.selectedDate;
   if(!iso) return;
+  if(cwfIsLockedDay(iso)){ cwfLockedPopup(iso); return; }
   const get = (id, fallback='') => document.getElementById(id)?.value || fallback;
   const body = buildDayPayload(iso, true, {
     start_time: get('workDayStart','09:00'), end_time: get('workDayEnd','18:00'),
-    limit_enabled: document.getElementById('workDayLimitEnabled')?.checked === true,
-    max_jobs_per_day: Number(get('workDayMaxJobs','1')), max_units_per_day: Number(get('workDayMaxUnits','5')),
+    job_limit_enabled: document.getElementById('workDayJobLimitEnabled')?.checked === true,
+    unit_limit_enabled: document.getElementById('workDayUnitLimitEnabled')?.checked === true,
+    max_jobs_per_day: Number(get('workDayMaxJobs','4')), max_units_per_day: Number(get('workDayMaxUnits','5')),
     note: get('workDayNote','')
   });
   try{
@@ -6159,20 +6215,14 @@ function selectWorkCalendarPreset(kind){
   if(skipped) cwfCalendarNotify(`เลือกแล้ว • ข้ามวันที่มีงาน ${skipped} วัน`);
 }
 async function saveBulkSelected(custom=false, isAdvance=true, extraOpts={}){
-  const dates = Array.from(__cwfWorkCalendarState.selectedDates).filter(iso=>!cwfIsLockedDay(iso) || extraOpts.forceUnlimited);
+  const dates = Array.from(__cwfWorkCalendarState.selectedDates).filter(iso=>!cwfIsLockedDay(iso));
   if(!dates.length){ cwfCalendarNotify('❌ ยังไม่ได้เลือกวันที่ หรือวันที่เลือกมีงานอยู่แล้วทั้งหมด', 'error'); return; }
-  const opts = extraOpts.forceUnlimited ? {
-    start_time: '09:00',
-    end_time: '18:00',
-    limit_enabled: false,
-    max_jobs_per_day: null,
-    max_units_per_day: null,
-    note: ''
-  } : custom ? {
+  const opts = custom ? {
     start_time: document.getElementById('bulkDayStart')?.value || '09:00',
     end_time: document.getElementById('bulkDayEnd')?.value || '18:00',
-    limit_enabled: document.getElementById('bulkDayLimitEnabled')?.checked === true,
-    max_jobs_per_day: Number(document.getElementById('bulkDayMaxJobs')?.value || 1),
+    job_limit_enabled: document.getElementById('bulkDayJobLimitEnabled')?.checked === true,
+    unit_limit_enabled: document.getElementById('bulkDayUnitLimitEnabled')?.checked === true,
+    max_jobs_per_day: Number(document.getElementById('bulkDayMaxJobs')?.value || 4),
     max_units_per_day: Number(document.getElementById('bulkDayMaxUnits')?.value || 5),
     note: document.getElementById('bulkDayNote')?.value || ''
   } : {};

--- a/cwf-pwa.js
+++ b/cwf-pwa.js
@@ -1,10 +1,11 @@
 (function(){
   'use strict';
-  var VERSION = 'close-panel-hard-clean-v4';
+  var VERSION = '20260622_legacy_cap_policy_tech_cache_v1';
+  try { window.__CWF_PWA_BUILD__ = VERSION; } catch (_) {}
   function register(){
     if (!('serviceWorker' in navigator)) return;
     window.addEventListener('load', function(){
-      navigator.serviceWorker.register('/sw.js?v=' + VERSION).then(function(reg){
+      navigator.serviceWorker.register('/sw.js?v=' + VERSION, { updateViaCache: 'none' }).then(function(reg){
         try {
           if (reg && reg.waiting) reg.waiting.postMessage({ type: 'SKIP_WAITING' });
           if (reg) {

--- a/index.js
+++ b/index.js
@@ -57,8 +57,8 @@ const {
   toIsoDate,
   normWorkDayPayload,
   countLockedAdvanceJobsForDate,
-  loadLockedAdvanceUsageForDate,
-  validateLockedDaySafeEdit,
+  resolveTechnicianCalendarCaps,
+  sourceForWorkDayPayload,
 } = require("./server/lib/technicianCalendar");
 const { upsertTechnicianProfile } = require("./server/services/technicianProfileUpsert");
 const createTechnicianCountSummaryReadOnlyRoutes = require("./server/routes/technicianCountSummaryReadOnly");
@@ -20147,11 +20147,12 @@ function normalizeCalendarRow(row, iso, jobCount=0){
   const can = row ? (row.can_accept_advance_job === true || ['advance_only','available_advance','working'].includes(String(row.day_status || ''))) : false;
   const start = can ? (row?.start_time || '09:00') : null;
   const end = can ? (row?.end_time || '18:00') : null;
-  const jobs = can ? (row?.max_jobs_per_day == null ? null : Number(row.max_jobs_per_day)) : null;
-  const units = can ? (row?.max_units_per_day == null ? null : Number(row.max_units_per_day)) : null;
+  const caps = resolveTechnicianCalendarCaps(row || {});
+  const jobs = can ? caps.raw_max_jobs : null;
+  const units = can ? caps.raw_max_units : null;
   const note = row?.note || null;
   const hasCustom = !!(
-    (can && (start !== '09:00' || end !== '18:00' || jobs !== null || units !== null)) ||
+    (can && (start !== '09:00' || end !== '18:00' || caps.cap_mode === 'technician_custom')) ||
     String(note || '').trim()
   );
   return {
@@ -20162,6 +20163,12 @@ function normalizeCalendarRow(row, iso, jobCount=0){
     end_time: end,
     max_jobs_per_day: jobs,
     max_units_per_day: units,
+    raw_max_jobs_per_day: caps.raw_max_jobs,
+    raw_max_units_per_day: caps.raw_max_units,
+    cap_mode: can ? caps.cap_mode : 'system_default',
+    effective_max_jobs_per_day: can ? caps.effective_max_jobs : null,
+    effective_max_units_per_day: can ? caps.effective_max_units : null,
+    is_legacy_system_default: can ? caps.is_legacy_system_default : false,
     note,
     has_assigned_job: Number(jobCount || 0) > 0,
     assigned_job_count: Number(jobCount || 0),
@@ -20173,7 +20180,7 @@ async function loadWorkCalendarV2Month(username, month){
   const fromIso = firstDayOfMonthIso(month);
   const toIso = endDayOfMonthIso(month);
   const [cal, jobs] = await Promise.all([
-    pool.query(`SELECT work_date::date AS work_date, day_status, can_accept_advance_job, start_time, end_time, max_jobs_per_day, max_units_per_day, note, updated_at
+    pool.query(`SELECT work_date::date AS work_date, day_status, can_accept_advance_job, start_time, end_time, max_jobs_per_day, max_units_per_day, note, source, updated_at
                 FROM public.technician_monthly_work_calendar
                 WHERE technician_username=$1 AND work_date BETWEEN $2::date AND $3::date
                 ORDER BY work_date ASC`, [username, fromIso, toIso]),
@@ -20206,10 +20213,11 @@ function cwfDateRange(fromIso, toIso){
 }
 async function upsertCalendarDay(clientOrPool, username, workDate, input){
   const p = normWorkDayPayload(input || {});
+  const source = sourceForWorkDayPayload(p);
   const r = await clientOrPool.query(`
     INSERT INTO public.technician_monthly_work_calendar
       (technician_username, work_date, day_status, can_accept_advance_job, can_accept_urgent_job, start_time, end_time, max_jobs_per_day, max_units_per_day, note, source, updated_by, updated_at)
-    VALUES($1,$2::date,$3,$4,$5,$6,$7,$8,$9,$10,'technician',$1,NOW())
+    VALUES($1,$2::date,$3,$4,$5,$6,$7,$8,$9,$10,$11,$1,NOW())
     ON CONFLICT(technician_username, work_date) DO UPDATE SET
       day_status=EXCLUDED.day_status,
       can_accept_advance_job=EXCLUDED.can_accept_advance_job,
@@ -20219,9 +20227,9 @@ async function upsertCalendarDay(clientOrPool, username, workDate, input){
       max_jobs_per_day=EXCLUDED.max_jobs_per_day,
       max_units_per_day=EXCLUDED.max_units_per_day,
       note=EXCLUDED.note,
-      source='technician', updated_by=$1, updated_at=NOW()
+      source=EXCLUDED.source, updated_by=$1, updated_at=NOW()
     RETURNING *
-  `, [username, workDate, p.day_status, p.can_accept_advance_job, p.can_accept_urgent_job, p.start_time, p.end_time, p.max_jobs_per_day, p.max_units_per_day, p.note]);
+  `, [username, workDate, p.day_status, p.can_accept_advance_job, p.can_accept_urgent_job, p.start_time, p.end_time, p.max_jobs_per_day, p.max_units_per_day, p.note, source]);
   return r.rows[0] || null;
 }
 async function ensureDailyReadinessRow(username){
@@ -20345,8 +20353,8 @@ app.post('/technicians/:username/work-calendar-v2/copy-previous-month', async (r
         can_accept_advance_job: !!source.can_accept_advance_job,
         start_time: source.start_time,
         end_time: source.end_time,
-        max_jobs_per_day: source.max_jobs_per_day,
-        max_units_per_day: source.max_units_per_day,
+        max_jobs_per_day: source.cap_mode === 'technician_custom' ? source.max_jobs_per_day : null,
+        max_units_per_day: source.cap_mode === 'technician_custom' ? source.max_units_per_day : null,
         note: source.note
       });
       saved++;
@@ -20376,8 +20384,7 @@ app.use(createTechnicianCalendarWriteRoutes({
   toIsoDate,
   normWorkDayPayload,
   countLockedAdvanceJobsForDate,
-  loadLockedAdvanceUsageForDate,
-  validateLockedDaySafeEdit,
+  sourceForWorkDayPayload,
 }));
 
 // Defect 4/6: technician self-service copy uses the session identity (req.effective.username)
@@ -20409,8 +20416,8 @@ app.post('/tech/work-calendar/copy-previous-month', requireTechnicianSession, as
         can_accept_advance_job: !!source.can_accept_advance_job,
         start_time: source.start_time,
         end_time: source.end_time,
-        max_jobs_per_day: source.max_jobs_per_day,
-        max_units_per_day: source.max_units_per_day,
+        max_jobs_per_day: source.cap_mode === 'technician_custom' ? source.max_jobs_per_day : null,
+        max_units_per_day: source.cap_mode === 'technician_custom' ? source.max_units_per_day : null,
         note: source.note
       });
       saved++;

--- a/server/lib/technicianCalendar.js
+++ b/server/lib/technicianCalendar.js
@@ -35,6 +35,11 @@ function normWorkDayPayload(input = {}){
   };
 }
 
+const SYSTEM_DEFAULT_MAX_JOBS_PER_DAY = 4;
+const SYSTEM_DEFAULT_MAX_UNITS_PER_DAY = null;
+const LEGACY_DEFAULT_MAX_JOBS_PER_DAY = 1;
+const LEGACY_DEFAULT_MAX_UNITS_PER_DAY = 5;
+
 function normalizeNullableCap(value, max){
   if (value === null || value === undefined || value === '') return null;
   const text = String(value).trim().toLowerCase();
@@ -42,6 +47,41 @@ function normalizeNullableCap(value, max){
   const n = Number(value);
   if (!Number.isFinite(n)) return null;
   return Math.max(1, Math.min(Number(max || 99), Math.floor(n)));
+}
+
+function nullableNumber(value){
+  if (value === null || value === undefined || value === '') return null;
+  const n = Number(value);
+  return Number.isFinite(n) ? n : null;
+}
+
+function resolveTechnicianCalendarCaps(row = {}){
+  const source = String(row?.source || '').trim().toLowerCase();
+  const rawMaxJobs = nullableNumber(row?.max_jobs_per_day);
+  const rawMaxUnits = nullableNumber(row?.max_units_per_day);
+  const hasRawCaps = rawMaxJobs !== null || rawMaxUnits !== null;
+  const isLegacySystemDefault = (
+    source === 'technician' &&
+    rawMaxJobs === LEGACY_DEFAULT_MAX_JOBS_PER_DAY &&
+    rawMaxUnits === LEGACY_DEFAULT_MAX_UNITS_PER_DAY
+  );
+  const isCustom = source === 'technician_custom' || (hasRawCaps && !isLegacySystemDefault && source !== 'technician_default');
+  const capMode = isCustom ? 'technician_custom' : (isLegacySystemDefault ? 'legacy_system_default' : 'system_default');
+  return {
+    cap_mode: capMode,
+    raw_max_jobs: rawMaxJobs,
+    raw_max_units: rawMaxUnits,
+    effective_max_jobs: isCustom ? (rawMaxJobs ?? SYSTEM_DEFAULT_MAX_JOBS_PER_DAY) : SYSTEM_DEFAULT_MAX_JOBS_PER_DAY,
+    effective_max_units: isCustom ? (rawMaxUnits ?? SYSTEM_DEFAULT_MAX_UNITS_PER_DAY) : SYSTEM_DEFAULT_MAX_UNITS_PER_DAY,
+    is_legacy_system_default: isLegacySystemDefault,
+  };
+}
+
+function sourceForWorkDayPayload(payload = {}){
+  if (payload.can_accept_advance_job !== true || payload.day_status !== 'advance_only') return 'technician_default';
+  return (payload.max_jobs_per_day != null || payload.max_units_per_day != null)
+    ? 'technician_custom'
+    : 'technician_default';
 }
 
 function hhmmToMin(value){
@@ -153,6 +193,10 @@ module.exports = {
   toIsoDate,
   normWorkDayPayload,
   normalizeNullableCap,
+  resolveTechnicianCalendarCaps,
+  sourceForWorkDayPayload,
+  SYSTEM_DEFAULT_MAX_JOBS_PER_DAY,
+  SYSTEM_DEFAULT_MAX_UNITS_PER_DAY,
   countLockedAdvanceJobsForDate,
   loadLockedAdvanceUsageForDate,
   validateLockedDaySafeEdit,

--- a/server/routes/technicianCalendarReadOnly.js
+++ b/server/routes/technicianCalendarReadOnly.js
@@ -9,6 +9,7 @@ module.exports = function createTechnicianCalendarReadOnlyRoutes(deps = {}) {
   const firstDayOfMonthIso = deps.firstDayOfMonthIso;
   const endDayOfMonthIso = deps.endDayOfMonthIso;
   const isStrictIsoDate = deps.isStrictIsoDate;
+  const resolveTechnicianCalendarCaps = deps.resolveTechnicianCalendarCaps || require("../lib/technicianCalendar").resolveTechnicianCalendarCaps;
 
   router.get('/tech/work-calendar', requireTechnicianSession, async (req, res) => {
     try {
@@ -35,10 +36,23 @@ module.exports = function createTechnicianCalendarReadOnlyRoutes(deps = {}) {
                       AND COALESCE(j.job_status,'') NOT IN ('cancelled','canceled')
                     GROUP BY 1`, [username, fromIso, toIso])
       ]);
+      const items = (cal.rows||[]).map(x=>{
+        const caps = resolveTechnicianCalendarCaps(x);
+        return {
+          ...x,
+          work_date: toIsoDate(x.work_date),
+          raw_max_jobs_per_day: caps.raw_max_jobs,
+          raw_max_units_per_day: caps.raw_max_units,
+          cap_mode: caps.cap_mode,
+          effective_max_jobs_per_day: caps.effective_max_jobs,
+          effective_max_units_per_day: caps.effective_max_units,
+          is_legacy_system_default: caps.is_legacy_system_default,
+        };
+      });
       res.json({ ok:true, username, month, from:fromIso, to:toIso,
         employment_type: prof.rows[0]?.employment_type || 'company',
         weekly_off_days: prof.rows[0]?.weekly_off_days || '',
-        items: (cal.rows||[]).map(x=>({ ...x, work_date: toIsoDate(x.work_date) })),
+        items,
         holidays: (hol.rows||[]).map(x=>({ ...x, holiday_date: toIsoDate(x.holiday_date) })),
         job_counts: (jobs.rows||[]).map(x=>({ work_date: toIsoDate(x.work_date), job_count: Number(x.job_count||0) }))
       });
@@ -141,6 +155,7 @@ module.exports = function createTechnicianCalendarReadOnlyRoutes(deps = {}) {
           c.end_time,
           c.max_jobs_per_day,
           c.max_units_per_day,
+          c.source,
           c.note,
           c.updated_at AS calendar_updated_at,
           m.matrix_json,
@@ -158,10 +173,11 @@ module.exports = function createTechnicianCalendarReadOnlyRoutes(deps = {}) {
         const can = !isUnset && row.can_accept_advance_job === true;
         const start = can ? (row.start_time || '09:00') : null;
         const end = can ? (row.end_time || '18:00') : null;
-        const jobs = can ? (row.max_jobs_per_day == null ? null : Number(row.max_jobs_per_day)) : null;
-        const units = can ? (row.max_units_per_day == null ? null : Number(row.max_units_per_day)) : null;
+        const caps = resolveTechnicianCalendarCaps(row);
+        const jobs = can ? caps.raw_max_jobs : null;
+        const units = can ? caps.raw_max_units : null;
         const note = row.note || null;
-        const hasCustom = !!((can && (start !== '09:00' || end !== '18:00' || jobs !== null || units !== null)) || String(note || '').trim());
+        const hasCustom = !!((can && (start !== '09:00' || end !== '18:00' || caps.cap_mode === 'technician_custom')) || String(note || '').trim());
         const zones = [row.home_service_zone_code, row.secondary_service_zone_code, row.preferred_zone, [row.home_province, row.home_district].filter(Boolean).join(' ')].filter(Boolean);
         return {
           username: row.username,
@@ -175,6 +191,12 @@ module.exports = function createTechnicianCalendarReadOnlyRoutes(deps = {}) {
           end_time: end,
           max_jobs_per_day: jobs,
           max_units_per_day: units,
+          raw_max_jobs_per_day: caps.raw_max_jobs,
+          raw_max_units_per_day: caps.raw_max_units,
+          cap_mode: can ? caps.cap_mode : 'system_default',
+          effective_max_jobs_per_day: can ? caps.effective_max_jobs : null,
+          effective_max_units_per_day: can ? caps.effective_max_units : null,
+          is_legacy_system_default: can ? caps.is_legacy_system_default : false,
           note,
           has_assigned_job: Number(row.assigned_job_count || 0) > 0,
           assigned_job_count: Number(row.assigned_job_count || 0),

--- a/server/routes/technicianCalendarWrite.js
+++ b/server/routes/technicianCalendarWrite.js
@@ -7,43 +7,19 @@ module.exports = function createTechnicianCalendarWriteRoutes(deps = {}) {
   const toIsoDate = deps.toIsoDate;
   const normWorkDayPayload = deps.normWorkDayPayload;
   const countLockedAdvanceJobsForDate = deps.countLockedAdvanceJobsForDate;
-  const loadLockedAdvanceUsageForDate = deps.loadLockedAdvanceUsageForDate;
-  const validateLockedDaySafeEdit = deps.validateLockedDaySafeEdit;
+  const sourceForWorkDayPayload = deps.sourceForWorkDayPayload || require("../lib/technicianCalendar").sourceForWorkDayPayload;
 
-  function lockedEditMessage(code) {
-    const map = {
-      LOCKED_DAY_CANNOT_CLOSE: "This day already has jobs and cannot be closed.",
-      LOCKED_DAY_INVALID_WINDOW: "Work window is invalid.",
-      LOCKED_DAY_START_CUTS_JOB: "Start time would cut an existing job.",
-      LOCKED_DAY_END_CUTS_JOB: "End time would cut an existing job.",
-      LOCKED_DAY_MAX_JOBS_BELOW_USAGE: "Max jobs is below the current assigned jobs.",
-      LOCKED_DAY_MAX_UNITS_BELOW_USAGE: "Max units is below the current assigned units.",
-    };
-    return map[code] || "This day already has jobs. Only capacity increases, unlimited caps, or wider hours are allowed.";
-  }
-
-  async function assertLockedEditAllowed(db, username, work_date, payload) {
+  async function assertUnlocked(db, username, work_date) {
     const lockedJobs = await countLockedAdvanceJobsForDate(db, username, work_date);
-    if (lockedJobs <= 0) return { lockedJobs, locked: false, allowed: true };
-    if (typeof loadLockedAdvanceUsageForDate !== "function" || typeof validateLockedDaySafeEdit !== "function") {
-      return { lockedJobs, locked: true, allowed: false, code: "LOCKED_DAY_SAFE_EDIT_UNAVAILABLE" };
-    }
-    const usage = await loadLockedAdvanceUsageForDate(db, username, work_date);
-    const check = validateLockedDaySafeEdit(payload, usage);
-    return {
-      lockedJobs,
-      locked: true,
-      allowed: check.ok === true,
-      code: check.code || null,
-      usage: check.usage || usage,
-    };
+    return { lockedJobs, locked: lockedJobs > 0, allowed: lockedJobs <= 0 };
   }
 
   async function upsertDay(db, username, work_date, p) {
+    const source = sourceForWorkDayPayload(p);
     return db.query(`
       INSERT INTO public.technician_monthly_work_calendar
         (technician_username, work_date, day_status, can_accept_advance_job, can_accept_urgent_job, start_time, end_time, max_jobs_per_day, max_units_per_day, note, source, updated_by, updated_at)
-      VALUES($1,$2::date,$3,$4,$5,$6,$7,$8,$9,$10,'technician',$1,NOW())
+      VALUES($1,$2::date,$3,$4,$5,$6,$7,$8,$9,$10,$11,$1,NOW())
       ON CONFLICT(technician_username, work_date) DO UPDATE SET
         day_status=EXCLUDED.day_status,
         can_accept_advance_job=EXCLUDED.can_accept_advance_job,
@@ -53,9 +29,9 @@ module.exports = function createTechnicianCalendarWriteRoutes(deps = {}) {
         max_jobs_per_day=EXCLUDED.max_jobs_per_day,
         max_units_per_day=EXCLUDED.max_units_per_day,
         note=EXCLUDED.note,
-        source='technician', updated_by=$1, updated_at=NOW()
+        source=EXCLUDED.source, updated_by=$1, updated_at=NOW()
       RETURNING *
-    `, [username, work_date, p.day_status, p.can_accept_advance_job, p.can_accept_urgent_job, p.start_time, p.end_time, p.max_jobs_per_day, p.max_units_per_day, p.note]);
+    `, [username, work_date, p.day_status, p.can_accept_advance_job, p.can_accept_urgent_job, p.start_time, p.end_time, p.max_jobs_per_day, p.max_units_per_day, p.note, source]);
   }
 
   router.put("/tech/work-calendar/day", requireTechnicianSession, async (req, res) => {
@@ -65,19 +41,18 @@ module.exports = function createTechnicianCalendarWriteRoutes(deps = {}) {
       if (!work_date) return res.status(400).json({ error: "work_date is required" });
 
       const p = normWorkDayPayload(req.body || {});
-      const locked = await assertLockedEditAllowed(pool, username, work_date, p);
-      if (locked.locked && !locked.allowed) {
+      const locked = await assertUnlocked(pool, username, work_date);
+      if (!locked.allowed) {
         return res.status(409).json({
-          error: lockedEditMessage(locked.code),
+          error: "This day already has jobs and cannot be edited.",
           locked: true,
-          code: locked.code,
+          code: "LOCKED_DAY_HAS_JOBS",
           job_count: locked.lockedJobs,
-          usage: locked.usage || null,
         });
       }
 
       const r = await upsertDay(pool, username, work_date, p);
-      res.json({ ok: true, locked: locked.locked, usage: locked.usage || null, item: r.rows[0] });
+      res.json({ ok: true, locked: false, item: r.rows[0] });
     } catch (e) {
       console.error("PUT /tech/work-calendar/day error:", e);
       res.status(500).json({ error: "Failed to save work calendar" });
@@ -100,10 +75,10 @@ module.exports = function createTechnicianCalendarWriteRoutes(deps = {}) {
         const work_date = toIsoDate(String(d.work_date || "").trim());
         if (!work_date) continue;
         const p = normWorkDayPayload(d);
-        const locked = await assertLockedEditAllowed(client, username, work_date, p);
-        if (locked.locked && !locked.allowed) {
+        const locked = await assertUnlocked(client, username, work_date);
+        if (!locked.allowed) {
           skippedLocked += 1;
-          locked_rejections.push({ work_date, code: locked.code, job_count: locked.lockedJobs });
+          locked_rejections.push({ work_date, code: "LOCKED_DAY_HAS_JOBS", job_count: locked.lockedJobs });
           continue;
         }
         await upsertDay(client, username, work_date, p);

--- a/server/services/public/customerAvailability.js
+++ b/server/services/public/customerAvailability.js
@@ -4,6 +4,7 @@ const {
   loadCustomerScheduledLoadMap,
   rankCustomerScheduledCandidates,
 } = require("./customerScheduledAssignment");
+const { resolveTechnicianCalendarCaps } = require("../../lib/technicianCalendar");
 
 const SLOT_STEP_MIN = 30;
 const DEFAULT_UI_START = "09:00";
@@ -212,7 +213,7 @@ async function loadAdvanceCalendarMap(db, date, usernames, lockRows = false) {
   if (!names.length) return new Map();
   const result = await db.query(
     `SELECT technician_username, work_date::date AS work_date, day_status, can_accept_advance_job,
-            start_time, end_time, max_jobs_per_day, max_units_per_day
+            start_time, end_time, max_jobs_per_day, max_units_per_day, source
        FROM public.technician_monthly_work_calendar
       WHERE technician_username = ANY($1::text[])
         AND work_date=$2::date
@@ -327,8 +328,9 @@ async function eligibleCustomerTechnicians(deps, options) {
       invalidWindow += 1;
       return false;
     }
-    const maxJobs = calendar.max_jobs_per_day == null ? null : Number(calendar.max_jobs_per_day);
-    const maxUnits = calendar.max_units_per_day == null ? null : Number(calendar.max_units_per_day);
+    const caps = resolveTechnicianCalendarCaps(calendar);
+    const maxJobs = caps.effective_max_jobs;
+    const maxUnits = caps.effective_max_units;
     const usage = usageMap.get(username) || { jobs_count: 0, units_count: 0 };
     if (Number.isFinite(maxJobs) && maxJobs >= 1 && usage.jobs_count >= maxJobs) {
       capacityFull += 1;
@@ -339,6 +341,7 @@ async function eligibleCustomerTechnicians(deps, options) {
       return false;
     }
     tech.advance_calendar = calendar;
+    tech.advance_calendar_caps = caps;
     tech.advance_usage = usage;
     return true;
   });
@@ -614,13 +617,24 @@ async function diagnoseTechnicianEligibility(deps, options) {
   const requestedUnits = serviceUnitCount(options);
   const usageMap = await loadDailyUsageMap(pool, date, [username], options.ignore_job_id);
   const usage = usageMap.get(username) || { jobs_count: 0, units_count: 0 };
-  const maxJobs = calendar.max_jobs_per_day == null ? null : Number(calendar.max_jobs_per_day);
-  const maxUnits = calendar.max_units_per_day == null ? null : Number(calendar.max_units_per_day);
+  const caps = resolveTechnicianCalendarCaps(calendar);
+  const maxJobs = caps.effective_max_jobs;
+  const maxUnits = caps.effective_max_units;
   let capacityOk = true;
   if (Number.isFinite(maxJobs) && maxJobs >= 1 && usage.jobs_count >= maxJobs) capacityOk = false;
   if (Number.isFinite(maxUnits) && maxUnits >= 1 && (usage.units_count + requestedUnits) > maxUnits) capacityOk = false;
   gates.capacity_ok = capacityOk;
-  gates.usage = { jobs_count: usage.jobs_count, units_count: usage.units_count, requested_units: requestedUnits, max_jobs_per_day: maxJobs, max_units_per_day: maxUnits };
+  gates.usage = {
+    jobs_count: usage.jobs_count,
+    units_count: usage.units_count,
+    requested_units: requestedUnits,
+    raw_max_jobs_per_day: caps.raw_max_jobs,
+    raw_max_units_per_day: caps.raw_max_units,
+    cap_mode: caps.cap_mode,
+    effective_max_jobs_per_day: maxJobs,
+    effective_max_units_per_day: maxUnits,
+    is_legacy_system_default: caps.is_legacy_system_default,
+  };
   if (!capacityOk) return { username, date, gates, reason: "CAPACITY_FULL" };
 
   // Collision: is there at least one startable interval inside the technician window today?

--- a/sw.js
+++ b/sw.js
@@ -1,300 +1,57 @@
-(function () {
-  "use strict";
+/* CWF root service worker: Tech App shell/cache refresh */
+const CWF_TECH_BUILD_ID = "20260622_legacy_cap_policy_tech_cache_v1";
+const CACHE_PREFIX = "cwf-root-tech-app-";
+const CACHE_NAME = `${CACHE_PREFIX}${CWF_TECH_BUILD_ID}`;
+const SHELL_ASSETS = [
+  `/tech.html?v=${CWF_TECH_BUILD_ID}`,
+  `/app.js?v=${CWF_TECH_BUILD_ID}`,
+  `/cwf-pwa.js?v=${CWF_TECH_BUILD_ID}`,
+  `/manifest.json?v=${CWF_TECH_BUILD_ID}`,
+];
 
-  const root = window.CWFCustomerAppV2 = window.CWFCustomerAppV2 || {};
-  const SCHEDULED_STORAGE_KEY = "cwf_customer_app_v2_scheduled_v1";
-  const SCHEDULED_STORAGE_TTL_MS = 7 * 24 * 60 * 60 * 1000;
+self.addEventListener("install", (event) => {
+  event.waitUntil(
+    caches.open(CACHE_NAME)
+      .then((cache) => cache.addAll(SHELL_ASSETS))
+      .catch(() => undefined)
+      .then(() => self.skipWaiting())
+  );
+});
 
-  function bangkokTodayYmd() {
-    try {
-      const parts = new Intl.DateTimeFormat("en-CA", {
-        timeZone: "Asia/Bangkok",
-        year: "numeric",
-        month: "2-digit",
-        day: "2-digit",
-      }).formatToParts(new Date());
-      const value = Object.fromEntries(parts.map((part) => [part.type, part.value]));
-      return `${value.year}-${value.month}-${value.day}`;
-    } catch (_) {
-      return new Date(Date.now() + (7 * 60 * 60 * 1000)).toISOString().slice(0, 10);
-    }
+self.addEventListener("activate", (event) => {
+  event.waitUntil(
+    caches.keys()
+      .then((keys) => Promise.all(keys
+        .filter((key) => (
+          (key.startsWith(CACHE_PREFIX) && key !== CACHE_NAME) ||
+          key === "close-panel-hard-clean-v4" ||
+          key.startsWith("cwf-tech-")
+        ))
+        .map((key) => caches.delete(key))))
+      .then(() => self.clients.claim())
+  );
+});
+
+self.addEventListener("message", (event) => {
+  if (event.data && event.data.type === "SKIP_WAITING") self.skipWaiting();
+});
+
+self.addEventListener("fetch", (event) => {
+  const request = event.request;
+  if (request.method !== "GET") return;
+  const url = new URL(request.url);
+  if (url.origin !== self.location.origin) return;
+  if (url.pathname.startsWith("/api/") || url.pathname.startsWith("/tech/work-calendar")) return;
+
+  if (request.mode === "navigate" || /\.(?:js|css|html|json)$/i.test(url.pathname)) {
+    event.respondWith(
+      fetch(request)
+        .then((response) => {
+          const copy = response.clone();
+          caches.open(CACHE_NAME).then((cache) => cache.put(request, copy)).catch(() => undefined);
+          return response;
+        })
+        .catch(() => caches.match(request).then((cached) => cached || caches.match(`/tech.html?v=${CWF_TECH_BUILD_ID}`)))
+    );
   }
-
-  function defaultScheduledDraft() {
-    const today = bangkokTodayYmd();
-    return {
-      service_kind: "clean",
-      job_type: "ล้าง",
-      ac_type: "ผนัง",
-      wash_variant: "ล้างธรรมดา",
-      repair_variant: "",
-      btu: "12000",
-      machine_count: 1,
-      date: today,
-      calendar_month: today.slice(0, 7),
-      tech_type: "company",
-      selectedSlot: null,
-      customer_name: "",
-      customer_phone: "",
-      address_text: "",
-      maps_url: "",
-      customer_note: "",
-      job_zone: "",
-    };
-  }
-
-
-  function defaultUrgentDraft() {
-    return {
-      customer_name: "",
-      customer_phone: "",
-      address_text: "",
-      maps_url: "",
-      service_kind: "clean",
-      job_type: "ล้าง",
-      ac_type: "ผนัง",
-      wash_variant: "ล้างธรรมดา",
-      repair_variant: "",
-      btu: "12000",
-      machine_count: 1,
-      symptom: "",
-      job_zone: "",
-    };
-  }
-
-  function safeSessionGet() {
-    try { return window.sessionStorage.getItem(SCHEDULED_STORAGE_KEY); }
-    catch (_) { return null; }
-  }
-
-  function safeSessionSet(value) {
-    try { window.sessionStorage.setItem(SCHEDULED_STORAGE_KEY, value); }
-    catch (_) { /* storage may be blocked; in-memory flow still works */ }
-  }
-
-  function safeSessionRemove() {
-    try { window.sessionStorage.removeItem(SCHEDULED_STORAGE_KEY); }
-    catch (_) { /* ignore */ }
-  }
-
-  const state = {
-    currentRoute: "home",
-    bookingMode: null,
-    guestMode: true,
-    selectedService: null,
-    customer: null,
-    authStatus: "idle",
-    authError: "",
-    authConfig: null,
-    catalog: { status: "idle", items: [], error: "" },
-    promotions: { status: "idle", items: [], error: "" },
-    zones: { status: "idle", items: [], error: "" },
-    homePricing: { status: "idle", items: {}, error: "" },
-    addressPrefill: { status: "idle", scopes: {}, error: "" },
-    profileAddressForm: { editing: false, status: "idle", error: "", success: "" },
-    scheduledWizard: {
-      step: 1,
-      maxStep: 4,
-      error: "",
-    },
-    scheduledPreview: {
-      pricing: { status: "idle", data: null, error: "" },
-      availability: { status: "idle", data: null, error: "", query_key: "", loaded_at: "" },
-    },
-    scheduledSubmit: {
-      status: "idle",
-      error: "",
-      result: null,
-    },
-    urgentFlow: {
-      step: "form",
-      error: "",
-    },
-    tracking: { status: "idle", data: null, error: "" },
-    draft: {
-      scheduled: defaultScheduledDraft(),
-      urgent: defaultUrgentDraft(),
-      tracking: {
-        trackingCode: "",
-      },
-    },
-    init() {
-      this.currentRoute = this.readRouteFromHash();
-      this.restoreScheduledDraft();
-    },
-    readRouteFromHash() {
-      const route = String(window.location.hash || "").replace(/^#\/?/, "").trim();
-      return route || "home";
-    },
-    setRoute(route) {
-      this.currentRoute = route || "home";
-    },
-    setBookingMode(mode) {
-      this.bookingMode = mode;
-    },
-    updateDraft(scope, patch) {
-      this.draft[scope] = {
-        ...(this.draft[scope] || {}),
-        ...(patch || {}),
-      };
-      if (scope === "scheduled") this.persistScheduledDraft();
-    },
-    resetUrgentDraft() {
-      this.draft.urgent = defaultUrgentDraft();
-      this.urgentFlow = { step: "form", status: "idle", error: "", result: null };
-    },
-    resetScheduledDraft() {
-      this.draft.scheduled = defaultScheduledDraft();
-      this.scheduledWizard = { step: 1, maxStep: 4, error: "" };
-      this.scheduledPreview = {
-        pricing: { status: "idle", data: null, error: "" },
-        availability: { status: "idle", data: null, error: "", query_key: "", loaded_at: "" },
-      };
-      this.scheduledSubmit = { status: "idle", error: "", result: null };
-      safeSessionRemove();
-    },
-    persistScheduledDraft() {
-      const payload = {
-        version: 1,
-        saved_at: Date.now(),
-        step: Math.max(1, Math.min(4, Number(this.scheduledWizard?.step || 1))),
-        draft: this.draft.scheduled || defaultScheduledDraft(),
-      };
-      safeSessionSet(JSON.stringify(payload));
-    },
-    restoreScheduledDraft() {
-      const raw = safeSessionGet();
-      if (!raw) return false;
-      try {
-        const parsed = JSON.parse(raw);
-        if (!parsed || parsed.version !== 1 || !parsed.draft) return false;
-        if (!Number.isFinite(parsed.saved_at) || Date.now() - parsed.saved_at > SCHEDULED_STORAGE_TTL_MS) {
-          safeSessionRemove();
-          return false;
-        }
-        const defaults = defaultScheduledDraft();
-        const restored = { ...defaults, ...parsed.draft };
-        restored.service_kind = "clean";
-        restored.job_type = "ล้าง";
-        restored.repair_variant = "";
-        restored.machine_count = Math.max(1, Math.min(10, Number(restored.machine_count || 1)));
-        if (!restored.date || restored.date < bangkokTodayYmd()) {
-          restored.date = bangkokTodayYmd();
-          restored.selectedSlot = null;
-        }
-        restored.calendar_month = String(restored.calendar_month || restored.date.slice(0, 7));
-        this.draft.scheduled = restored;
-        this.scheduledWizard = {
-          ...this.scheduledWizard,
-          step: Math.max(1, Math.min(4, Number(parsed.step || 1))),
-          error: "",
-        };
-        return true;
-      } catch (_) {
-        safeSessionRemove();
-        return false;
-      }
-    },
-    setCollection(name, patch) {
-      this[name] = {
-        ...(this[name] || {}),
-        ...(patch || {}),
-      };
-    },
-    setHomePricing(patch) {
-      this.homePricing = {
-        ...(this.homePricing || {}),
-        ...(patch || {}),
-      };
-    },
-    setProfileAddressForm(patch) {
-      this.profileAddressForm = {
-        ...(this.profileAddressForm || {}),
-        ...(patch || {}),
-      };
-    },
-    savedAddress() {
-      const profile = this.customer && this.customer.logged_in ? (this.customer.profile || {}) : {};
-      return {
-        address: String(profile.address || "").trim(),
-        maps_url: String(profile.maps_url || "").trim(),
-      };
-    },
-    prefillSavedAddress(scope) {
-      const saved = this.savedAddress();
-      if (!saved.address && !saved.maps_url) return false;
-      const current = this.draft[scope] || {};
-      const patch = {};
-      if (!String(current.address_text || "").trim() && saved.address) patch.address_text = saved.address;
-      if (!String(current.maps_url || "").trim() && saved.maps_url) patch.maps_url = saved.maps_url;
-      if (!Object.keys(patch).length) return false;
-      this.updateDraft(scope, patch);
-      this.addressPrefill.scopes = {
-        ...(this.addressPrefill.scopes || {}),
-        [scope]: true,
-      };
-      return true;
-    },
-    async ensureSavedAddressPrefill(scope, onDone) {
-      if (this.prefillSavedAddress(scope)) return true;
-      if (this.customer || this.addressPrefill.status === "loading" || !root.api || !root.api.getCurrentCustomer) return false;
-      this.addressPrefill = { ...(this.addressPrefill || {}), status: "loading", error: "" };
-      try {
-        const customer = await root.api.getCurrentCustomer();
-        this.customer = customer;
-        this.guestMode = !customer || !customer.logged_in;
-        this.addressPrefill = { ...(this.addressPrefill || {}), status: "success", error: "" };
-        const changed = this.prefillSavedAddress(scope);
-        if (changed && typeof onDone === "function") onDone();
-        return changed;
-      } catch (error) {
-        this.addressPrefill = { ...(this.addressPrefill || {}), status: "error", error: error.message || "" };
-        return false;
-      }
-    },
-    updateCustomerProfile(patch) {
-      if (!this.customer) return;
-      this.customer = {
-        ...this.customer,
-        profile: {
-          ...(this.customer.profile || {}),
-          ...(patch || {}),
-        },
-      };
-    },
-    setScheduledWizard(patch) {
-      this.scheduledWizard = {
-        ...(this.scheduledWizard || {}),
-        ...(patch || {}),
-      };
-      this.scheduledWizard.step = Math.max(1, Math.min(4, Number(this.scheduledWizard.step || 1)));
-      this.persistScheduledDraft();
-    },
-    setScheduledPreview(name, patch) {
-      this.scheduledPreview[name] = {
-        ...(this.scheduledPreview[name] || {}),
-        ...(patch || {}),
-      };
-    },
-    setScheduledSubmit(patch) {
-      this.scheduledSubmit = {
-        ...(this.scheduledSubmit || {}),
-        ...(patch || {}),
-      };
-    },
-    setUrgentFlow(patch) {
-      this.urgentFlow = {
-        ...(this.urgentFlow || {}),
-        ...(patch || {}),
-      };
-    },
-    setTracking(patch) {
-      this.tracking = {
-        ...(this.tracking || {}),
-        ...(patch || {}),
-      };
-    },
-  };
-
-  root.state = state;
-})();
+});

--- a/tech.html
+++ b/tech.html
@@ -8,8 +8,10 @@
   <link rel="manifest" href="/manifest.json">
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <meta name="cwf-tech-build" content="20260622_legacy_cap_policy_tech_cache_v1">
   <title>หน้าช่าง - CWF</title>
   <link rel="stylesheet" href="style.css">
+  <script defer src="/cwf-pwa.js?v=20260622_legacy_cap_policy_tech_cache_v1"></script>
 
   <style>
     :root{
@@ -3431,7 +3433,7 @@
     }
   </style>
 
-<script src="app.js?v=20260621_draft_readonly_v1"></script>
+<script src="app.js?v=20260622_legacy_cap_policy_tech_cache_v1"></script>
   <script src="tech-onboarding.js?v=phase2a-fix-restore-onboarding-panel"></script>
   <script>
         function goEditProfile(){ location.href = '/edit-profile.html'; }

--- a/test/customerScheduledCapacityFairness.test.js
+++ b/test/customerScheduledCapacityFairness.test.js
@@ -4,7 +4,8 @@ const assert = require("node:assert/strict");
 const customerAvailability = require("../server/services/public/customerAvailability");
 const {
   normWorkDayPayload,
-  validateLockedDaySafeEdit,
+  resolveTechnicianCalendarCaps,
+  sourceForWorkDayPayload,
 } = require("../server/lib/technicianCalendar");
 const {
   rankCustomerScheduledCandidates,
@@ -53,6 +54,7 @@ function makeDeps({ calendar = {}, usage = {}, busyByTech = {} } = {}) {
             end_time: "18:00",
             max_jobs_per_day: calendar[technician_username]?.max_jobs_per_day ?? null,
             max_units_per_day: calendar[technician_username]?.max_units_per_day ?? null,
+            source: calendar[technician_username]?.source ?? null,
           })) };
         }
         if (text.includes("WITH assigned AS")) {
@@ -75,17 +77,34 @@ function makeDeps({ calendar = {}, usage = {}, busyByTech = {} } = {}) {
   };
 }
 
-test("default advance caps normalize to null, while explicit cap 1 survives", () => {
+test("cap policy resolves null/default, legacy 1/5, and custom 1/5 correctly", () => {
   const open = normWorkDayPayload({ can_accept_advance_job: true });
   assert.equal(open.max_jobs_per_day, null);
   assert.equal(open.max_units_per_day, null);
+  assert.equal(sourceForWorkDayPayload(open), "technician_default");
+  assert.deepEqual(resolveTechnicianCalendarCaps(open), {
+    cap_mode: "system_default",
+    raw_max_jobs: null,
+    raw_max_units: null,
+    effective_max_jobs: 4,
+    effective_max_units: null,
+    is_legacy_system_default: false,
+  });
 
   const capped = normWorkDayPayload({ can_accept_advance_job: true, max_jobs_per_day: 1, max_units_per_day: 1 });
   assert.equal(capped.max_jobs_per_day, 1);
   assert.equal(capped.max_units_per_day, 1);
+  assert.equal(sourceForWorkDayPayload(capped), "technician_custom");
+  assert.equal(resolveTechnicianCalendarCaps({ source: "technician", max_jobs_per_day: 1, max_units_per_day: 5 }).cap_mode, "legacy_system_default");
+  assert.equal(resolveTechnicianCalendarCaps({ source: "technician", max_jobs_per_day: 1, max_units_per_day: 5 }).effective_max_jobs, 4);
+  assert.equal(resolveTechnicianCalendarCaps({ source: "technician", max_jobs_per_day: 1, max_units_per_day: 5 }).effective_max_units, null);
+  const custom = resolveTechnicianCalendarCaps({ source: "technician_custom", max_jobs_per_day: 1, max_units_per_day: 5 });
+  assert.equal(custom.cap_mode, "technician_custom");
+  assert.equal(custom.effective_max_jobs, 1);
+  assert.equal(custom.effective_max_units, 5);
 });
 
-test("null caps do not close a day with existing usage; explicit caps still apply", async () => {
+test("system default allows up to four jobs, while explicit caps still apply", async () => {
   let result = await customerAvailability.computePublicCustomerSlots(makeDeps({
     calendar: { "tech-a": { max_jobs_per_day: null, max_units_per_day: null } },
     usage: { "tech-a": { jobs_count: 3, units_count: 9 } },
@@ -93,13 +112,25 @@ test("null caps do not close a day with existing usage; explicit caps still appl
   assert.ok(result.slots.length > 0);
 
   result = await customerAvailability.computePublicCustomerSlots(makeDeps({
-    calendar: { "tech-a": { max_jobs_per_day: 1, max_units_per_day: null } },
+    calendar: { "tech-a": { source: "technician", max_jobs_per_day: 1, max_units_per_day: 5 } },
+    usage: { "tech-a": { jobs_count: 1, units_count: 99 } },
+  }), CRITERIA);
+  assert.ok(result.slots.length > 0);
+
+  result = await customerAvailability.computePublicCustomerSlots(makeDeps({
+    calendar: { "tech-a": { max_jobs_per_day: null, max_units_per_day: null } },
+    usage: { "tech-a": { jobs_count: 4, units_count: 1 } },
+  }), CRITERIA);
+  assert.equal(result.reason_code, "CAPACITY_FULL");
+
+  result = await customerAvailability.computePublicCustomerSlots(makeDeps({
+    calendar: { "tech-a": { source: "technician_custom", max_jobs_per_day: 1, max_units_per_day: null } },
     usage: { "tech-a": { jobs_count: 1, units_count: 1 } },
   }), CRITERIA);
   assert.equal(result.reason_code, "CAPACITY_FULL");
 
   result = await customerAvailability.computePublicCustomerSlots(makeDeps({
-    calendar: { "tech-a": { max_jobs_per_day: null, max_units_per_day: 2 } },
+    calendar: { "tech-a": { source: "technician_custom", max_jobs_per_day: null, max_units_per_day: 2 } },
     usage: { "tech-a": { jobs_count: 0, units_count: 1 } },
   }), { ...CRITERIA, services: [{ ...CRITERIA.services[0], machine_count: 2 }] });
   assert.equal(result.reason_code, "CAPACITY_FULL");
@@ -132,14 +163,30 @@ test("duration controls slot visibility inside real gaps", async () => {
   assert.equal(twoHours.reason_code, "COLLISION_FULL");
 });
 
-test("locked-day safe validation allows unlimited/increase and rejects unsafe decreases", () => {
-  const usage = { jobs_count: 2, units_count: 4, earliest_start_min: 600, latest_end_min: 780 };
-  assert.equal(validateLockedDaySafeEdit({ day_status: "advance_only", can_accept_advance_job: true, start_time: "09:00", end_time: "18:00", max_jobs_per_day: null, max_units_per_day: null }, usage).ok, true);
-  assert.equal(validateLockedDaySafeEdit({ day_status: "advance_only", can_accept_advance_job: true, start_time: "09:00", end_time: "18:00", max_jobs_per_day: 3, max_units_per_day: 5 }, usage).ok, true);
-  assert.equal(validateLockedDaySafeEdit({ day_status: "unavailable", can_accept_advance_job: false }, usage).code, "LOCKED_DAY_CANNOT_CLOSE");
-  assert.equal(validateLockedDaySafeEdit({ day_status: "advance_only", can_accept_advance_job: true, start_time: "11:00", end_time: "18:00", max_jobs_per_day: null, max_units_per_day: null }, usage).code, "LOCKED_DAY_START_CUTS_JOB");
-  assert.equal(validateLockedDaySafeEdit({ day_status: "advance_only", can_accept_advance_job: true, start_time: "09:00", end_time: "12:00", max_jobs_per_day: null, max_units_per_day: null }, usage).code, "LOCKED_DAY_END_CUTS_JOB");
-  assert.equal(validateLockedDaySafeEdit({ day_status: "advance_only", can_accept_advance_job: true, start_time: "09:00", end_time: "18:00", max_jobs_per_day: 1, max_units_per_day: null }, usage).code, "LOCKED_DAY_MAX_JOBS_BELOW_USAGE");
+test("technician UI disables locked date editing and separates job/unit overrides", () => {
+  const fs = require("node:fs");
+  const path = require("node:path");
+  const app = fs.readFileSync(path.join(__dirname, "..", "app.js"), "utf8");
+  assert.match(app, /editBtn\.disabled = locked/);
+  assert.match(app, /workDayJobLimitEnabled/);
+  assert.match(app, /workDayUnitLimitEnabled/);
+  assert.match(app, /bulkDayJobLimitEnabled/);
+  assert.match(app, /bulkDayUnitLimitEnabled/);
+});
+
+test("calendar read API exposes trusted cap metadata while public slots stay anonymous", () => {
+  const fs = require("node:fs");
+  const path = require("node:path");
+  const readRoute = fs.readFileSync(path.join(__dirname, "..", "server/routes/technicianCalendarReadOnly.js"), "utf8");
+  const publicSvc = fs.readFileSync(path.join(__dirname, "..", "server/services/public/customerAvailability.js"), "utf8");
+  assert.match(readRoute, /resolveTechnicianCalendarCaps/);
+  assert.match(readRoute, /cap_mode/);
+  assert.match(readRoute, /effective_max_jobs_per_day/);
+  assert.match(readRoute, /effective_max_units_per_day/);
+  assert.match(publicSvc, /resolveTechnicianCalendarCaps/);
+  const slotPush = publicSvc.match(/slots\.push\(\{[\s\S]*?\n\s*\}\);/);
+  assert.ok(slotPush, "public slot push block exists");
+  assert.doesNotMatch(slotPush[0], /username|technician/i);
 });
 
 test("fair assignment ranking prioritizes projected minutes, older auto assignment, and non-username rotation", () => {

--- a/test/techCacheBuild.test.js
+++ b/test/techCacheBuild.test.js
@@ -1,0 +1,35 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+
+const root = path.join(__dirname, "..");
+const BUILD = "20260622_legacy_cap_policy_tech_cache_v1";
+
+function read(file) {
+  return fs.readFileSync(path.join(root, file), "utf8");
+}
+
+test("Tech App shell and cache files use the same production build id", () => {
+  const tech = read("tech.html");
+  const app = read("app.js");
+  const pwa = read("cwf-pwa.js");
+  const sw = read("sw.js");
+
+  assert.match(tech, new RegExp(`app\\.js\\?v=${BUILD}`));
+  assert.match(tech, new RegExp(`cwf-pwa\\.js\\?v=${BUILD}`));
+  assert.match(tech, new RegExp(`name="cwf-tech-build" content="${BUILD}"`));
+  assert.match(app, new RegExp(`__CWF_TECH_APP_VERSION__ = "${BUILD}"`));
+  assert.match(app, new RegExp(`/sw\\.js\\?v=${BUILD}`));
+  assert.match(pwa, new RegExp(`VERSION = '${BUILD}'`));
+  assert.match(sw, new RegExp(`CWF_TECH_BUILD_ID = "${BUILD}"`));
+});
+
+test("root service worker activates new cache and replaces stale Tech App caches", () => {
+  const sw = read("sw.js");
+  assert.match(sw, /self\.skipWaiting\(\)/);
+  assert.match(sw, /self\.clients\.claim\(\)/);
+  assert.match(sw, /CACHE_PREFIX = "cwf-root-tech-app-"/);
+  assert.match(sw, /key\.startsWith\(CACHE_PREFIX\) && key !== CACHE_NAME/);
+  assert.match(sw, /fetch\(request\)/);
+});

--- a/test/technicianCalendarWriteAndProfile.integration.test.js
+++ b/test/technicianCalendarWriteAndProfile.integration.test.js
@@ -9,8 +9,7 @@ const {
   toIsoDate,
   normWorkDayPayload,
   countLockedAdvanceJobsForDate,
-  loadLockedAdvanceUsageForDate,
-  validateLockedDaySafeEdit,
+  sourceForWorkDayPayload,
 } = require("../server/lib/technicianCalendar");
 const { upsertTechnicianProfile } = require("../server/services/technicianProfileUpsert");
 
@@ -109,8 +108,7 @@ test.before(async () => {
     toIsoDate,
     normWorkDayPayload,
     countLockedAdvanceJobsForDate,
-    loadLockedAdvanceUsageForDate,
-    validateLockedDaySafeEdit,
+    sourceForWorkDayPayload,
   }));
   app._setSessionUsername = (u) => { sessionUsername = u; };
 
@@ -173,11 +171,14 @@ dbTest("Blocker 2: single-day save via real route persists a real row keyed by r
   assert.equal(data.item.technician_username, "p1");
 
   const row = await pool.query(
-    `SELECT technician_username, work_date::text AS work_date, can_accept_advance_job FROM public.technician_monthly_work_calendar WHERE technician_username='p1'`
+    `SELECT technician_username, work_date::text AS work_date, can_accept_advance_job, source, max_jobs_per_day, max_units_per_day FROM public.technician_monthly_work_calendar WHERE technician_username='p1'`
   );
   assert.equal(row.rows.length, 1);
   assert.equal(row.rows[0].work_date, "2026-07-10");
   assert.equal(row.rows[0].can_accept_advance_job, true);
+  assert.equal(row.rows[0].source, "technician_custom");
+  assert.equal(row.rows[0].max_jobs_per_day, 3);
+  assert.equal(row.rows[0].max_units_per_day, 6);
 });
 
 dbTest("Blocker 2: username is sourced from req.effective.username, not client-supplied body", async () => {
@@ -192,9 +193,12 @@ dbTest("Blocker 2: username is sourced from req.effective.username, not client-s
   assert.equal(data.item.technician_username, "session-user");
 
   const row = await pool.query(
-    `SELECT technician_username FROM public.technician_monthly_work_calendar WHERE work_date='2026-07-11'`
+    `SELECT technician_username, source, max_jobs_per_day, max_units_per_day FROM public.technician_monthly_work_calendar WHERE work_date='2026-07-11'`
   );
   assert.equal(row.rows[0].technician_username, "session-user");
+  assert.equal(row.rows[0].source, "technician_default");
+  assert.equal(row.rows[0].max_jobs_per_day, null);
+  assert.equal(row.rows[0].max_units_per_day, null);
 });
 
 dbTest("Blocker 2: reading the month back after save shows the same saved date", async () => {
@@ -211,7 +215,7 @@ dbTest("Blocker 2: reading the month back after save shows the same saved date",
   assert.equal(monthRows.rows[0].can_accept_advance_job, true);
 });
 
-dbTest("locked day safe edit can increase capacity or switch to unlimited", async () => {
+dbTest("locked single-day edit is rejected with 409 and no row mutation", async () => {
   global.__cwfTestApp._setSessionUsername("p1");
   await pool.query(
     `INSERT INTO public.jobs (technician_username, appointment_datetime, job_status) VALUES ('p1', '2026-07-13 10:00:00+07', 'assigned')`
@@ -224,33 +228,34 @@ dbTest("locked day safe edit can increase capacity or switch to unlimited", asyn
     max_jobs_per_day: null,
     max_units_per_day: null,
   });
-  assert.equal(status, 200);
+  assert.equal(status, 409);
   assert.equal(data.locked, true);
-  const row = await pool.query(`SELECT max_jobs_per_day, max_units_per_day FROM public.technician_monthly_work_calendar WHERE work_date='2026-07-13'`);
-  assert.equal(row.rows.length, 1);
-  assert.equal(row.rows[0].max_jobs_per_day, null);
-  assert.equal(row.rows[0].max_units_per_day, null);
+  assert.equal(data.code, "LOCKED_DAY_HAS_JOBS");
+  const row = await pool.query(`SELECT 1 FROM public.technician_monthly_work_calendar WHERE work_date='2026-07-13'`);
+  assert.equal(row.rows.length, 0);
 });
 
-dbTest("locked day unsafe cap decrease is rejected with 409 and no row mutation", async () => {
+dbTest("locked bulk edit skips locked dates and saves only unlocked dates", async () => {
   global.__cwfTestApp._setSessionUsername("p1");
   const job = await pool.query(
     `INSERT INTO public.jobs (technician_username, appointment_datetime, job_status) VALUES ('p1', '2026-07-14 10:00:00+07', 'assigned') RETURNING job_id`
   );
   await pool.query(`INSERT INTO public.job_items (job_id, qty) VALUES ($1, 3)`, [job.rows[0].job_id]);
-  const { status, data } = await putJson("/tech/work-calendar/day", {
-    work_date: "2026-07-14",
-    can_accept_advance_job: true,
-    start_time: "09:00",
-    end_time: "18:00",
-    max_jobs_per_day: 1,
-    max_units_per_day: 2,
+  const { status, data } = await putJson("/tech/work-calendar/bulk", {
+    days: [
+      { work_date: "2026-07-14", can_accept_advance_job: true },
+      { work_date: "2026-07-15", can_accept_advance_job: true },
+    ],
   });
-  assert.equal(status, 409);
-  assert.equal(data.locked, true);
-  assert.equal(data.code, "LOCKED_DAY_MAX_UNITS_BELOW_USAGE");
-  const row = await pool.query(`SELECT 1 FROM public.technician_monthly_work_calendar WHERE work_date='2026-07-14'`);
-  assert.equal(row.rows.length, 0);
+  assert.equal(status, 200);
+  assert.equal(data.count, 1);
+  assert.equal(data.skipped_locked, 1);
+  assert.equal(data.locked_rejections[0].code, "LOCKED_DAY_HAS_JOBS");
+  const row = await pool.query(`SELECT work_date::text AS work_date, source, max_jobs_per_day, max_units_per_day FROM public.technician_monthly_work_calendar ORDER BY work_date`);
+  assert.deepEqual(row.rows.map((r) => r.work_date), ["2026-07-15"]);
+  assert.equal(row.rows[0].source, "technician_default");
+  assert.equal(row.rows[0].max_jobs_per_day, null);
+  assert.equal(row.rows[0].max_units_per_day, null);
 });
 
 // ============ Blocker 3: admin technician profile UPSERT INSERT path ============


### PR DESCRIPTION
## Summary
- Add a canonical technician calendar cap policy helper that treats null caps and legacy `source='technician'` `1/5` rows as system default `4 jobs / unlimited units`, while preserving `technician_custom` explicit caps.
- Apply the shared cap policy to Customer Scheduled availability, draft recheck, technician calendar read metadata, admin readiness diagnostics, and legacy inline calendar route wiring.
- Restore locked-day behavior so any date with assigned jobs rejects single-day edits and bulk skips locked dates.
- Split Tech Calendar job/unit cap overrides in the technician UI so each override stores independently and default saves persist `null/null` with `source='technician_default'`.
- Bump Tech App asset/build IDs and replace the root service worker with a real versioned cache-clearing worker for the Tech App shell.

## Validation
- `npm.cmd ci`
- `npm.cmd test` (144 pass, 7 skipped due local Postgres auth failure for user `postgres`; skipped DB tests are not counted as passed)
- `node --test test\\customerScheduledCapacityFairness.test.js`
- `node --test test\\techCacheBuild.test.js`
- `node --test test\\technicianCalendarWriteAndProfile.integration.test.js` (7 skipped locally due Postgres auth)
- `node --check` changed JS files
- `git diff --check`
- Startup smoke: `node -e "require('./index.js'); setTimeout(()=>process.exit(0), 1500)"`

## Notes
- No database migration and no production SQL/data update.
- No Admin Add, pricing, income, payout, payment, auth, LINE, or urgent-booking behavior changes.
- `index.js` was touched only for duplicated calendar route/wiring that would otherwise preserve old `source='technician'` write behavior.