### PR TITLE
Fix same-day slot cutoff and separate service duration from travel buffer

### DIFF
--- a/customer-app/assets/customer-app.js
+++ b/customer-app/assets/customer-app.js
@@ -3,7 +3,7 @@
 
   const App = window.CWFCustomerAppV2;
   const BOOT_TIMEOUT_MS = 3500;
-  const BUILD_ID = "20260621_eligibility_techtype_v3";
+  const BUILD_ID = "20260622_same_day_timing_v1";
 
   function withTimeout(promise, timeoutMs) {
     return Promise.race([

--- a/customer-app/index.html
+++ b/customer-app/index.html
@@ -9,10 +9,10 @@
   <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
   <meta name="apple-mobile-web-app-title" content="CWF Service">
   <title>CWF Customer Service</title>
-  <link rel="manifest" href="./manifest.webmanifest?v=20260621_eligibility_techtype_v3">
+  <link rel="manifest" href="./manifest.webmanifest?v=20260622_same_day_timing_v1">
   <link rel="icon" type="image/png" sizes="192x192" href="./assets/icons/cwf-customer-192.png">
   <link rel="apple-touch-icon" sizes="180x180" href="./assets/icons/cwf-customer-180.png">
-  <link rel="stylesheet" href="./assets/customer-app.css?v=20260621_eligibility_techtype_v3">
+  <link rel="stylesheet" href="./assets/customer-app.css?v=20260622_same_day_timing_v1">
 </head>
 <body class="is-app-booting">
   <div class="app-shell" data-app-shell>
@@ -49,19 +49,19 @@
     </nav>
   </div>
 
-  <script src="./modules/state.js?v=20260621_eligibility_techtype_v3"></script>
-  <script src="./modules/utils.js?v=20260621_eligibility_techtype_v3"></script>
-  <script src="./modules/api.js?v=20260621_eligibility_techtype_v3"></script>
-  <script src="./modules/services.js?v=20260621_eligibility_techtype_v3"></script>
-  <script src="./modules/ui.js?v=20260621_eligibility_techtype_v3"></script>
-  <script src="./modules/auth.js?v=20260621_eligibility_techtype_v3"></script>
-  <script src="./modules/pricing.js?v=20260621_eligibility_techtype_v3"></script>
-  <script src="./modules/availability.js?v=20260621_eligibility_techtype_v3"></script>
-  <script src="./modules/bookingScheduled.js?v=20260621_eligibility_techtype_v3"></script>
-  <script src="./modules/bookingUrgent.js?v=20260621_eligibility_techtype_v3"></script>
-  <script src="./modules/tracking.js?v=20260621_eligibility_techtype_v3"></script>
-  <script src="./modules/profile.js?v=20260621_eligibility_techtype_v3"></script>
-  <script src="./modules/router.js?v=20260621_eligibility_techtype_v3"></script>
-  <script src="./assets/customer-app.js?v=20260621_eligibility_techtype_v3"></script>
+  <script src="./modules/state.js?v=20260622_same_day_timing_v1"></script>
+  <script src="./modules/utils.js?v=20260622_same_day_timing_v1"></script>
+  <script src="./modules/api.js?v=20260622_same_day_timing_v1"></script>
+  <script src="./modules/services.js?v=20260622_same_day_timing_v1"></script>
+  <script src="./modules/ui.js?v=20260622_same_day_timing_v1"></script>
+  <script src="./modules/auth.js?v=20260622_same_day_timing_v1"></script>
+  <script src="./modules/pricing.js?v=20260622_same_day_timing_v1"></script>
+  <script src="./modules/availability.js?v=20260622_same_day_timing_v1"></script>
+  <script src="./modules/bookingScheduled.js?v=20260622_same_day_timing_v1"></script>
+  <script src="./modules/bookingUrgent.js?v=20260622_same_day_timing_v1"></script>
+  <script src="./modules/tracking.js?v=20260622_same_day_timing_v1"></script>
+  <script src="./modules/profile.js?v=20260622_same_day_timing_v1"></script>
+  <script src="./modules/router.js?v=20260622_same_day_timing_v1"></script>
+  <script src="./assets/customer-app.js?v=20260622_same_day_timing_v1"></script>
 </body>
 </html>

--- a/customer-app/manifest.webmanifest
+++ b/customer-app/manifest.webmanifest
@@ -2,7 +2,7 @@
   "name": "CWF Customer Service",
   "short_name": "CWF Service",
   "description": "แอปลูกค้า Coldwindflow สำหรับเลือกบริการ จองคิว และติดตามงาน",
-  "start_url": "/customer-app/index.html?v=20260621_eligibility_techtype_v3#home",
+  "start_url": "/customer-app/index.html?v=20260622_same_day_timing_v1#home",
   "scope": "/customer-app/",
   "id": "/customer-app/",
   "display": "standalone",

--- a/customer-app/modules/api.js
+++ b/customer-app/modules/api.js
@@ -28,10 +28,11 @@
   }
 
   async function requestJson(path, options = {}) {
-    const { query, method = "GET", body } = options;
+    const { query, method = "GET", body, cache } = options;
     const response = await fetch(buildUrl(path, query), {
       method,
       credentials: "include",
+      cache: cache || "default",
       headers: body ? { "Content-Type": "application/json" } : undefined,
       body: body ? JSON.stringify(body) : undefined,
     });
@@ -82,11 +83,11 @@
     },
 
     async loadAvailability(query) {
-      return requestJson("/public/availability_v2", { query });
+      return requestJson("/public/availability_v2", { query, cache: "no-store" });
     },
 
     async loadAvailabilityCalendar(query) {
-      return requestJson("/public/availability_calendar_v2", { query });
+      return requestJson("/public/availability_calendar_v2", { query, cache: "no-store" });
     },
 
     async trackBooking(q) {

--- a/customer-app/modules/availability.js
+++ b/customer-app/modules/availability.js
@@ -34,6 +34,52 @@
     }
   }
 
+  function bangkokNowParts() {
+    try {
+      const parts = new Intl.DateTimeFormat("en-CA", {
+        timeZone: "Asia/Bangkok",
+        year: "numeric",
+        month: "2-digit",
+        day: "2-digit",
+        hour: "2-digit",
+        minute: "2-digit",
+        hour12: false,
+      }).formatToParts(new Date());
+      const value = Object.fromEntries(parts.map((part) => [part.type, part.value]));
+      return {
+        ymd: `${value.year}-${value.month}-${value.day}`,
+        hour: Number(value.hour || 0),
+        minute: Number(value.minute || 0),
+      };
+    } catch (_) {
+      const d = new Date(Date.now() + (7 * 60 * 60 * 1000));
+      return {
+        ymd: d.toISOString().slice(0, 10),
+        hour: d.getUTCHours(),
+        minute: d.getUTCMinutes(),
+      };
+    }
+  }
+
+  function ceilToStep(minute, stepMin) {
+    const step = Math.max(1, Number(stepMin || 30));
+    return Math.ceil(Number(minute || 0) / step) * step;
+  }
+
+  function currentSameDayBucket() {
+    const now = bangkokNowParts();
+    const minuteOfDay = (now.hour * 60) + now.minute;
+    return `${now.ymd}-${Math.floor(minuteOfDay / 5)}`;
+  }
+
+  function minimumStartForDate(date, responseMinimumStart, stepMin) {
+    const explicit = hhmmToMinutes(responseMinimumStart);
+    if (explicit != null && String(date || "").slice(0, 10) === bangkokTodayYmd()) return explicit;
+    const now = bangkokNowParts();
+    if (String(date || "").slice(0, 10) !== now.ymd) return null;
+    return ceilToStep((now.hour * 60) + now.minute, stepMin || 30);
+  }
+
   function publicAvailabilityQuery(draft, servicePayload, pricingData) {
     const d = draft || {};
     const payload = servicePayload || {};
@@ -57,6 +103,9 @@
     if (Array.isArray(payload.services) && payload.services.length) {
       query.services = JSON.stringify(payload.services);
     }
+    if (query.date && query.date === bangkokTodayYmd()) {
+      query._slot_bucket = currentSameDayBucket();
+    }
     return query;
   }
 
@@ -79,6 +128,9 @@
     if (Array.isArray(payload.services) && payload.services.length) {
       query.services = JSON.stringify(payload.services);
     }
+    if (query.month && query.month === bangkokTodayYmd().slice(0, 7)) {
+      query._slot_bucket = currentSameDayBucket();
+    }
     return query;
   }
 
@@ -95,6 +147,7 @@
       q.wash_variant,
       q.repair_variant,
       q.services,
+      q._slot_bucket,
     ].map((value) => String(value == null ? "" : value)).join("|");
   }
 
@@ -111,6 +164,7 @@
       q.wash_variant,
       q.repair_variant,
       q.services,
+      q._slot_bucket,
     ].map((value) => String(value == null ? "" : value)).join("|");
   }
 
@@ -138,6 +192,7 @@
     const durationMin = Math.max(15, Number(data.duration_min || fallbackDurationMin || 60));
     const stepMin = Math.max(5, Number(data.slot_step_min || 30));
     const date = String(data.date || "").trim();
+    const minimumStartMin = data.minimum_start ? minimumStartForDate(date, data.minimum_start, stepMin) : null;
     const unique = new Map();
 
     rawSlots.forEach((slot) => {
@@ -158,6 +213,7 @@
       }
 
       starts.forEach((minute) => {
+        if (minimumStartMin != null && minute < minimumStartMin) return;
         const start = minutesToHhmm(minute);
         const end = minutesToHhmm(minute + durationMin);
         if (!start || !end) return;
@@ -193,6 +249,8 @@
     hhmmToMinutes,
     minutesToHhmm,
     bangkokTodayYmd,
+    bangkokNowParts,
+    minimumStartForDate,
     publicAvailabilityQuery,
     publicCalendarQuery,
     queryKey,

--- a/customer-app/modules/bookingScheduled.js
+++ b/customer-app/modules/bookingScheduled.js
@@ -7,6 +7,9 @@
   let availabilityRequestSeq = 0;
   let calendarRequestSeq = 0;
   let recoveryInFlight = false;
+  let sameDayRefreshTimer = null;
+  let sameDayRefreshBound = false;
+  let latestContainer = null;
 
   function draft() {
     return root.state.draft.scheduled || {};
@@ -386,6 +389,53 @@
   function normalizedSlots() {
     const state = root.state.scheduledPreview.availability;
     return root.availability.normalizePublicSlots(state.data, root.state.scheduledPreview.pricing.data?.duration_min);
+  }
+
+  function isSelectedDateToday() {
+    return String(draft().date || "").slice(0, 10) === root.availability.bangkokTodayYmd();
+  }
+
+  function shouldRefreshSameDaySlots() {
+    return step() >= 2
+      && isSelectedDateToday()
+      && root.state.scheduledSubmit.status !== "success"
+      && Boolean(currentAvailabilityQuery());
+  }
+
+  async function refreshSameDaySlots(container) {
+    if (!container || !shouldRefreshSameDaySlots()) return;
+    await refreshAvailability(container, { preserveSelection: true });
+  }
+
+  function ensureSameDayRefresh(container) {
+    latestContainer = container || latestContainer;
+    if (sameDayRefreshTimer) {
+      const clearTimer = typeof window.clearInterval === "function"
+        ? window.clearInterval.bind(window)
+        : (typeof globalThis.clearInterval === "function" ? globalThis.clearInterval.bind(globalThis) : null);
+      if (clearTimer) clearTimer(sameDayRefreshTimer);
+      sameDayRefreshTimer = null;
+    }
+    if (shouldRefreshSameDaySlots()) {
+      const setTimer = typeof window.setInterval === "function"
+        ? window.setInterval.bind(window)
+        : (typeof globalThis.setInterval === "function" ? globalThis.setInterval.bind(globalThis) : null);
+      if (setTimer) {
+        sameDayRefreshTimer = setTimer(() => {
+          refreshSameDaySlots(latestContainer).catch(() => {});
+        }, 5 * 60 * 1000);
+      }
+    }
+    if (!sameDayRefreshBound) {
+      sameDayRefreshBound = true;
+      if (typeof document.addEventListener === "function") document.addEventListener("visibilitychange", () => {
+        if (document.visibilityState === "visible") refreshSameDaySlots(latestContainer).catch(() => {});
+      });
+      if (typeof window.addEventListener === "function") {
+        window.addEventListener("pageshow", () => refreshSameDaySlots(latestContainer).catch(() => {}));
+        window.addEventListener("focus", () => refreshSameDaySlots(latestContainer).catch(() => {}));
+      }
+    }
   }
 
   function renderCalendar() {
@@ -905,6 +955,7 @@
       </div>
     `;
     bind(container);
+    ensureSameDayRefresh(container);
   }
 
   function patchLine(lineId, patch, container) {

--- a/customer-app/sw.js
+++ b/customer-app/sw.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const BUILD_ID = "20260621_eligibility_techtype_v3";
+const BUILD_ID = "20260622_same_day_timing_v1";
 const CACHE_NAME = `cwf-customer-app-v2-${BUILD_ID}`;
 const APP_SHELL = [
   `./index.html?v=${BUILD_ID}`,

--- a/index.js
+++ b/index.js
@@ -26,6 +26,7 @@ const crypto = require("crypto");
 const fs = require("fs");
 const normalizerHelpers = require("./server/normalizers");
 const pricingHelpers = require("./server/pricing");
+const jobTiming = require("./server/services/jobTiming");
 const customerPricingHelpers = require("./server/customerPricing");
 const customerAuth = require("./server/customerAuth");
 const technicianIncomeHelpers = require("./server/technicianIncome");
@@ -116,7 +117,7 @@ if (WEB_PUSH_READY) {
   try { webpush.setVapidDetails(WEB_PUSH_SUBJECT, WEB_PUSH_PUBLIC_KEY, WEB_PUSH_PRIVATE_KEY); }
   catch (e) { console.warn("⚠️ web-push VAPID setup failed", e.message); }
 }
-const TRAVEL_BUFFER_MIN = Math.max(0, Number(process.env.TRAVEL_BUFFER_MIN || 30)); // นาที/งาน (Travel Buffer)
+const TRAVEL_BUFFER_MIN = jobTiming.TURNAROUND_BUFFER_MIN; // นาที/งาน (Travel Buffer)
 
 const SERVICE_ZONE_SEEDS = [
   { code: "A", name: "bangkok_east_core", label: "กรุงเทพตะวันออกแกนหลัก", group: "bangkok", color: "#0B4BB3", order: 10, districts: ["พระโขนง", "บางนา", "สวนหลวง", "ประเวศ", "บางกะปิ", "สะพานสูง", "ลาดกระบัง"] },
@@ -23209,25 +23210,7 @@ function minToHHMM(min) {
 }
 
 function getNowBangkokParts() {
-  const parts = new Intl.DateTimeFormat('en-CA', {
-    timeZone: 'Asia/Bangkok',
-    year: 'numeric',
-    month: '2-digit',
-    day: '2-digit',
-    hour: '2-digit',
-    minute: '2-digit',
-    hour12: false,
-  }).formatToParts(new Date());
-
-  const map = {};
-  for (const p of parts) {
-    if (p.type !== 'literal') map[p.type] = p.value;
-  }
-  return {
-    dateStr: `${map.year}-${map.month}-${map.day}`,
-    hour: Number(map.hour || 0),
-    minute: Number(map.minute || 0),
-  };
+  return jobTiming.getBangkokNow();
 }
 
 function getNowBangkokMin() {
@@ -23894,11 +23877,18 @@ function publicCustomerAvailabilityDeps(db = pool) {
   };
 }
 
+function setPublicAvailabilityNoStore(res) {
+  res.set("Cache-Control", "no-store, no-cache, must-revalidate, max-age=0");
+  res.set("Pragma", "no-cache");
+  res.set("Expires", "0");
+}
+
 app.post("/public/pricing_preview", async (req, res) => {
   try {
     const payload = req.body || {};
     // CWF Spec: pricing preview should match conservative schedule duration
-    const duration_min = computeDurationMinMulti(payload, { source: "pricing_preview", conservative: true });
+    const timing = jobTiming.computeJobTiming(payload, { source: "pricing_preview", conservative: true });
+    const duration_min = Number(timing.service_duration_min || 0);
     if (duration_min <= 0) return res.status(400).json({ error: "งานประเภทนี้ต้องให้แอดมินกำหนดเวลา (duration)" });
     const customerPrice = await customerPricingHelpers.resolveCustomerPricingMulti(payload, pool);
     const standard_price = Number(customerPrice.active_price ?? customerPrice.standard_price ?? 0);
@@ -23925,8 +23915,12 @@ app.post("/public/pricing_preview", async (req, res) => {
         total_after_discount,
       } : null,
       duration_min,
-      travel_buffer_min: TRAVEL_BUFFER_MIN,
-      effective_block_min: effectiveBlockMin(duration_min),
+      service_duration_min: duration_min,
+      travel_buffer_min: timing.turnaround_buffer_min,
+      turnaround_buffer_min: timing.turnaround_buffer_min,
+      effective_block_min: timing.occupied_duration_min,
+      occupied_duration_min: timing.occupied_duration_min,
+      timing_breakdown: timing.breakdown,
     });
   } catch (e) {
     console.error(e);
@@ -23939,6 +23933,7 @@ app.post("/public/pricing_preview", async (req, res) => {
 // 📅 Availability v2 (รายช่าง + แยก company/partner + ใช้ buffer)
 // =======================================
 app.get("/public/availability_v2", async (req, res) => {
+  setPublicAvailabilityNoStore(res);
   if (!ENABLE_AVAILABILITY_V2) return res.status(404).json({ error: "DISABLED" });
 
   const date = (req.query.date || new Date().toISOString().slice(0, 10)).toString();
@@ -24434,6 +24429,7 @@ app.get("/public/availability_v2", async (req, res) => {
 });
 
 app.get("/public/availability_calendar_v2", async (req, res) => {
+  setPublicAvailabilityNoStore(res);
   if (!ENABLE_AVAILABILITY_V2) return res.status(404).json({ error: "DISABLED" });
   const month = String(req.query.month || "").slice(0, 7);
   if (!/^\d{4}-\d{2}$/.test(month)) {
@@ -24713,6 +24709,28 @@ app.post("/public/book", async (req, res) => {
   // CWF Spec: conservative duration for schedule/collision
   const duration_min_v2 = computeDurationMinMulti(payloadV2, { source: "public_book", conservative: true });
   if (duration_min_v2 <= 0) return res.status(400).json({ error: "งานประเภทนี้ต้องให้แอดมินกำหนดเวลา (duration)" });
+  if (bm === "scheduled" && clientApp === "customer_app_v2") {
+    const startIsoForCutoff = normalizeAppointmentDatetime(appointment_datetime);
+    const requestedDate = String(startIsoForCutoff || "").slice(0, 10);
+    const requestedStart = String(startIsoForCutoff || "").slice(11, 16);
+    const requestedStartMin = toMin(requestedStart);
+    const nowParts = getNowBangkokParts();
+    const minStart = jobTiming.minimumStartForDate(requestedDate, {
+      ui_start_min: toMin("09:00"),
+      ui_end_min: toMin("18:00"),
+      slot_step_min: 30,
+      now_parts: nowParts,
+    });
+    if (requestedDate < nowParts.ymd || (minStart.is_today && requestedStartMin < minStart.minimum_start_min)) {
+      return res.status(409).json({
+        error: "SLOT_IN_PAST",
+        code: "SLOT_IN_PAST",
+        server_now: minStart.server_now,
+        timezone: minStart.timezone,
+        minimum_start: minStart.minimum_start,
+      });
+    }
+  }
   const customerPrice = await customerPricingHelpers.resolveCustomerPricingMulti(payloadV2, pool);
   const standard_price = Number(customerPrice.active_price ?? customerPrice.standard_price ?? 0);
 

--- a/server/pricing.js
+++ b/server/pricing.js
@@ -1,10 +1,11 @@
-"use strict";
+﻿"use strict";
 
 const {
   normalizeWashVariantLabel,
   normalizeServiceType,
   normalizeAcType,
 } = require("./normalizers");
+const jobTiming = require("./services/jobTiming");
 
 function coerceMachineCount(value) {
   const n = Number(value || 1);
@@ -33,45 +34,14 @@ function normalizeServiceLine(raw = {}, fallback = {}) {
 }
 
 function computeDurationMin(payload = {}, opts = {}) {
-  const src = opts.source || "unknown";
-  const job_type = normalizeServiceType(payload.job_type || payload.jobType || "");
-  const ac_type = normalizeAcType(payload.ac_type || payload.acType || "");
-  const wash_variant = normalizeWashVariantLabel(payload.wash_variant || payload.washVariant || "");
-  const repair_variant = String(payload.repair_variant || payload.repairVariant || "").trim();
-  const machine_count = coerceMachineCount(payload.machine_count || payload.machineCount || 1);
-  const admin_override = Number(payload.admin_override_duration_min || payload.adminOverrideDurationMin || 0);
-
-  let duration = 0;
-  const step = (first, next) => {
-    const n = machine_count;
-    if (n <= 1) return first;
-    return first + (n - 1) * next;
-  };
-
-  if (job_type === "ล้าง") {
-    if (ac_type === "ผนัง" || !ac_type) {
-      if (wash_variant === "ล้างพรีเมียม") duration = step(80, 50);
-      else if (wash_variant === "ล้างแขวนคอยล์") duration = step(120, 90);
-      else if (wash_variant === "ล้างแบบตัดล้าง") duration = step(180, 120);
-      else duration = step(60, 40);
-    } else {
-      duration = step(120, 90);
-    }
-  } else if (job_type === "ซ่อม") {
-    if (repair_variant === "ซ่อมเปลี่ยนอะไหล่") duration = admin_override > 0 ? admin_override : 0;
-    else duration = 60;
-  } else if (job_type === "ติดตั้ง") {
-    duration = admin_override > 0 ? admin_override : 0;
-  }
-
-  if (!Number.isFinite(duration) || duration <= 0) {
-    if (job_type === "ซ่อม" && repair_variant === "ซ่อมเปลี่ยนอะไหล่") return 0;
-    if (job_type === "ติดตั้ง") return 0;
-    duration = 60;
-  }
-
-  console.log("[computeDurationMin]", { src, job_type, ac_type, wash_variant, repair_variant, machine_count, duration });
-  return Math.round(duration);
+  const timingResult = jobTiming.computeServiceDurationMin(payload, opts);
+  console.log("[computeDurationMin]", {
+    src: opts.source || "unknown",
+    duration: timingResult.service_duration_min,
+    policy: timingResult.policy,
+    machine_count: timingResult.machine_count,
+  });
+  return Math.round(Number(timingResult.service_duration_min || 0));
 }
 
 function computeStandardPrice(payload = {}) {
@@ -122,45 +92,15 @@ function normalizeServicesFromPayload(payload = {}) {
 }
 
 function computeDurationMinMulti(payload = {}, opts = {}) {
-  const services = normalizeServicesFromPayload(payload);
-  if (!services) return computeDurationMin(payload, opts);
-
-  const conservative = opts && opts.conservative === true;
-  const parallel = !conservative && payload && (payload.parallel_by_tech === true || payload.parallel_by_tech === "true" || payload.parallel_by_tech === 1 || payload.parallel_by_tech === "1");
-  const byTech = new Map();
-  let total = 0;
-
-  for (const s of services) {
-    if (s.job_type === "ล้าง" && (s.ac_type === "ผนัง" || !s.ac_type) && !s.wash_variant) s.wash_variant = "ล้างธรรมดา";
-    const d = computeDurationMin(s, opts);
-    if (d <= 0) return 0;
-    total += d;
-
-    const mc = coerceMachineCount(s.machine_count || 1);
-    const allocations = s && (s.allocations || s.allocation || null);
-    if (allocations && typeof allocations === "object") {
-      const perMachine = d / mc;
-      for (const [tech, qty] of Object.entries(allocations)) {
-        const q = Math.max(0, Number(qty || 0));
-        if (!tech || q <= 0) continue;
-        byTech.set(tech, (byTech.get(tech) || 0) + perMachine * q);
-      }
-    } else {
-      const tech = (s.assigned_to || s.assigned_technician_username || "").toString().trim();
-      if (tech) byTech.set(tech, (byTech.get(tech) || 0) + d);
-    }
-  }
-
-  const distinctTech = byTech.size;
-  if (parallel && distinctTech >= 2) {
-    let mx = 0;
-    for (const v of byTech.values()) mx = Math.max(mx, Number(v || 0));
-    console.log("[computeDurationMinMulti]", { src: opts.source || "unknown", lines: services.length, parallel: true, distinctTech, max: mx, sum: total });
-    return Math.round(mx);
-  }
-
-  console.log("[computeDurationMinMulti]", { src: opts.source || "unknown", lines: services.length, parallel: false, conservative, total });
-  return Math.round(total);
+  const timingDuration = jobTiming.computeServiceDurationMinMulti(payload, opts);
+  const timingServices = normalizeServicesFromPayload(payload);
+  console.log("[computeDurationMinMulti]", {
+    src: opts.source || "unknown",
+    lines: timingServices ? timingServices.length : 1,
+    conservative: opts && opts.conservative === true,
+    total: timingDuration,
+  });
+  return Math.round(Number(timingDuration || 0));
 }
 
 function computeStandardPriceMulti(payload = {}) {

--- a/server/services/jobTiming.js
+++ b/server/services/jobTiming.js
@@ -1,0 +1,280 @@
+"use strict";
+
+const {
+  normalizeWashKey,
+  normalizeServiceType,
+  normalizeAcType,
+} = require("../normalizers");
+
+const TURNAROUND_BUFFER_MIN = Math.max(0, Number(process.env.TRAVEL_BUFFER_MIN || 30));
+const TIMEZONE = "Asia/Bangkok";
+const SLOT_STEP_MIN = 30;
+
+const JOB_WASH = normalizeServiceType("wash");
+const JOB_REPAIR = normalizeServiceType("repair");
+const JOB_INSTALL = normalizeServiceType("install");
+const AC_WALL = normalizeAcType("wall");
+
+function coerceMachineCount(value) {
+  const n = Number(value || 1);
+  return Math.max(1, Number.isFinite(n) ? Math.floor(n) : 1);
+}
+
+function steppedDuration(firstMin, additionalMin, machineCount) {
+  const count = coerceMachineCount(machineCount);
+  return count <= 1 ? firstMin : firstMin + ((count - 1) * additionalMin);
+}
+
+function normalizeServiceLine(raw = {}, fallback = {}) {
+  const job_type = normalizeServiceType(raw.job_type || raw.jobType || fallback.job_type || fallback.jobType || "");
+  const ac_type = normalizeAcType(raw.ac_type || raw.acType || fallback.ac_type || fallback.acType || "");
+  return {
+    job_type,
+    ac_type,
+    btu: Number(raw.btu || 0),
+    machine_count: coerceMachineCount(raw.machine_count || raw.machineCount || fallback.machine_count || fallback.machineCount || 1),
+    wash_variant: String(raw.wash_variant || raw.washVariant || fallback.wash_variant || fallback.washVariant || "").trim(),
+    repair_variant: String(raw.repair_variant || raw.repairVariant || fallback.repair_variant || fallback.repairVariant || "").trim(),
+    admin_override_duration_min: Number(raw.admin_override_duration_min || raw.adminOverrideDurationMin || fallback.admin_override_duration_min || fallback.adminOverrideDurationMin || 0),
+    assigned_to: (raw.assigned_to || raw.assigned_technician_username || null) ? String(raw.assigned_to || raw.assigned_technician_username).trim() : null,
+    assigned_technician_username: (raw.assigned_technician_username || raw.assigned_to || null) ? String(raw.assigned_technician_username || raw.assigned_to).trim() : null,
+    allocations: (() => {
+      const value = raw && (raw.allocations || raw.allocation || null);
+      return value && typeof value === "object" ? value : null;
+    })(),
+  };
+}
+
+function normalizeServicesFromPayload(payload = {}) {
+  const services = Array.isArray(payload.services) ? payload.services : null;
+  if (!services || !services.length) return null;
+  return services
+    .map((service) => normalizeServiceLine(service, payload))
+    .filter((service) => (
+      service.job_type
+      && service.ac_type
+      && Number.isFinite(service.btu)
+      && service.btu > 0
+      && Number.isFinite(service.machine_count)
+      && service.machine_count > 0
+    ));
+}
+
+function isPartsRepair(value) {
+  const text = String(value || "").toLowerCase();
+  return text.includes("part") || text.includes("อะไหล่") || text.includes("à¸­à¸°à¹„à¸«à¸¥à¹ˆ");
+}
+
+function computeServiceDurationMin(payload = {}, opts = {}) {
+  const src = opts.source || "unknown";
+  const line = normalizeServiceLine(payload);
+  const washKey = normalizeWashKey(line.wash_variant || "normal");
+  const repairVariant = line.repair_variant;
+  const count = coerceMachineCount(line.machine_count);
+  const adminOverride = Number(line.admin_override_duration_min || 0);
+
+  let duration = 0;
+  let policy = "fallback_60";
+
+  if (line.job_type === JOB_WASH) {
+    if (line.ac_type === AC_WALL || !line.ac_type) {
+      if (washKey === "premium") {
+        duration = steppedDuration(80, 50, count);
+        policy = "wash_wall_premium_first_80_add_50";
+      } else if (washKey === "coil") {
+        duration = steppedDuration(120, 90, count);
+        policy = "wash_wall_coil_first_120_add_90";
+      } else if (washKey === "overhaul") {
+        duration = steppedDuration(180, 120, count);
+        policy = "wash_wall_overhaul_first_180_add_120";
+      } else {
+        duration = steppedDuration(60, 30, count);
+        policy = "wash_wall_normal_first_60_add_30";
+      }
+    } else {
+      duration = steppedDuration(120, 90, count);
+      policy = "wash_non_wall_first_120_add_90";
+    }
+  } else if (line.job_type === JOB_REPAIR) {
+    if (isPartsRepair(repairVariant)) {
+      duration = adminOverride > 0 ? adminOverride : 0;
+      policy = "repair_parts_admin_override";
+    } else {
+      duration = 60;
+      policy = "repair_standard_60";
+    }
+  } else if (line.job_type === JOB_INSTALL) {
+    duration = adminOverride > 0 ? adminOverride : 0;
+    policy = "install_admin_override";
+  }
+
+  if (!Number.isFinite(duration) || duration <= 0) {
+    if (line.job_type === JOB_REPAIR && isPartsRepair(repairVariant)) return { service_duration_min: 0, policy, source: src };
+    if (line.job_type === JOB_INSTALL) return { service_duration_min: 0, policy, source: src };
+    duration = 60;
+  }
+
+  return {
+    service_duration_min: Math.round(duration),
+    policy,
+    source: src,
+    machine_count: count,
+  };
+}
+
+function computeServiceDurationMinMulti(payload = {}, opts = {}) {
+  const services = normalizeServicesFromPayload(payload);
+  if (!services) return computeServiceDurationMin(payload, opts).service_duration_min;
+
+  const conservative = opts && opts.conservative === true;
+  const parallel = !conservative && payload && (
+    payload.parallel_by_tech === true
+    || payload.parallel_by_tech === "true"
+    || payload.parallel_by_tech === 1
+    || payload.parallel_by_tech === "1"
+  );
+  const byTech = new Map();
+  let total = 0;
+
+  for (const service of services) {
+    const result = computeServiceDurationMin(service, opts);
+    const duration = Number(result.service_duration_min || 0);
+    if (duration <= 0) return 0;
+    total += duration;
+
+    const count = coerceMachineCount(service.machine_count || 1);
+    const allocations = service && (service.allocations || service.allocation || null);
+    if (allocations && typeof allocations === "object") {
+      const perMachine = duration / count;
+      for (const [tech, qty] of Object.entries(allocations)) {
+        const q = Math.max(0, Number(qty || 0));
+        if (!tech || q <= 0) continue;
+        byTech.set(tech, (byTech.get(tech) || 0) + (perMachine * q));
+      }
+    } else {
+      const tech = (service.assigned_to || service.assigned_technician_username || "").toString().trim();
+      if (tech) byTech.set(tech, (byTech.get(tech) || 0) + duration);
+    }
+  }
+
+  if (parallel && byTech.size >= 2) {
+    let max = 0;
+    for (const value of byTech.values()) max = Math.max(max, Number(value || 0));
+    return Math.round(max);
+  }
+  return Math.round(total);
+}
+
+function computeJobTiming(payload = {}, opts = {}) {
+  const serviceDuration = computeServiceDurationMinMulti(payload, opts);
+  const services = normalizeServicesFromPayload(payload) || [normalizeServiceLine(payload)];
+  const safeServices = services.map((service) => ({
+    job_type: service.job_type,
+    ac_type: service.ac_type,
+    btu: service.btu,
+    machine_count: service.machine_count,
+    wash_variant: service.wash_variant,
+    repair_variant: service.repair_variant,
+    admin_override_duration_min: service.admin_override_duration_min,
+  }));
+  return {
+    service_duration_min: serviceDuration,
+    turnaround_buffer_min: TURNAROUND_BUFFER_MIN,
+    occupied_duration_min: serviceDuration > 0 ? serviceDuration + TURNAROUND_BUFFER_MIN : 0,
+    breakdown: {
+      source: opts.source || "unknown",
+      buffer_policy: "once_per_job_after_service",
+      services: safeServices,
+    },
+  };
+}
+
+function getBangkokNow(date = new Date()) {
+  const parts = new Intl.DateTimeFormat("en-CA", {
+    timeZone: TIMEZONE,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: false,
+  }).formatToParts(date);
+  const map = {};
+  for (const part of parts) {
+    if (part.type !== "literal") map[part.type] = part.value;
+  }
+  const ymd = `${map.year}-${map.month}-${map.day}`;
+  const hour = Number(map.hour || 0);
+  const minute = Number(map.minute || 0);
+  return {
+    ymd,
+    dateStr: ymd,
+    Y: map.year,
+    M: map.month,
+    D: map.day,
+    hour,
+    minute,
+    hh: hour,
+    mm: minute,
+    iso: `${ymd}T${String(hour).padStart(2, "0")}:${String(minute).padStart(2, "0")}:00+07:00`,
+  };
+}
+
+function coerceBangkokNowParts(parts) {
+  if (!parts || typeof parts !== "object") return getBangkokNow();
+  const ymd = parts.ymd || parts.dateStr || (parts.Y && parts.M && parts.D ? `${parts.Y}-${parts.M}-${parts.D}` : null);
+  const hour = Number(parts.hour ?? parts.hh ?? 0);
+  const minute = Number(parts.minute ?? parts.mm ?? 0);
+  return {
+    ...parts,
+    ymd: ymd || getBangkokNow().ymd,
+    hour: Number.isFinite(hour) ? hour : 0,
+    minute: Number.isFinite(minute) ? minute : 0,
+  };
+}
+
+function ceilMinuteToStep(minute, stepMin = SLOT_STEP_MIN) {
+  const value = Number(minute || 0);
+  const step = Math.max(1, Number(stepMin || SLOT_STEP_MIN));
+  return Math.ceil(value / step) * step;
+}
+
+function minimumStartForDate(date, opts = {}) {
+  const uiStartMin = Number.isFinite(Number(opts.ui_start_min)) ? Number(opts.ui_start_min) : 0;
+  const uiEndMin = Number.isFinite(Number(opts.ui_end_min)) ? Number(opts.ui_end_min) : (24 * 60);
+  const stepMin = Number(opts.slot_step_min || SLOT_STEP_MIN);
+  const now = coerceBangkokNowParts(opts.now_parts || opts.nowParts || getBangkokNow());
+  const nowMin = (Number(now.hour || 0) * 60) + Number(now.minute || 0);
+  const isToday = String(date || "").slice(0, 10) === String(now.ymd || "").slice(0, 10);
+  const minimum = isToday ? Math.min(ceilMinuteToStep(nowMin, stepMin), uiEndMin) : uiStartMin;
+  return {
+    minimum_start_min: Math.max(uiStartMin, minimum),
+    minimum_start: minutesToHHMM(Math.max(uiStartMin, minimum)),
+    server_now: now.iso || `${now.ymd}T${String(now.hour).padStart(2, "0")}:${String(now.minute).padStart(2, "0")}:00+07:00`,
+    timezone: TIMEZONE,
+    is_today: isToday,
+  };
+}
+
+function minutesToHHMM(value) {
+  const total = Math.max(0, Math.round(Number(value || 0)));
+  const h = Math.floor(total / 60);
+  const m = total % 60;
+  return `${String(h).padStart(2, "0")}:${String(m).padStart(2, "0")}`;
+}
+
+module.exports = {
+  TIMEZONE,
+  SLOT_STEP_MIN,
+  TURNAROUND_BUFFER_MIN,
+  coerceMachineCount,
+  normalizeServiceLine,
+  normalizeServicesFromPayload,
+  computeServiceDurationMin,
+  computeServiceDurationMinMulti,
+  computeJobTiming,
+  getBangkokNow,
+  coerceBangkokNowParts,
+  ceilMinuteToStep,
+  minimumStartForDate,
+};

--- a/server/services/public/customerAvailability.js
+++ b/server/services/public/customerAvailability.js
@@ -5,6 +5,7 @@ const {
   rankCustomerScheduledCandidates,
 } = require("./customerScheduledAssignment");
 const { resolveTechnicianCalendarCaps } = require("../../lib/technicianCalendar");
+const jobTiming = require("../jobTiming");
 
 const SLOT_STEP_MIN = 30;
 const DEFAULT_UI_START = "09:00";
@@ -268,8 +269,25 @@ async function loadDailyUsageMap(db, date, usernames, ignoreJobId) {
 }
 
 function bangkokTodayYmd(nowParts) {
+  if (nowParts && nowParts.ymd) return String(nowParts.ymd).slice(0, 10);
+  if (nowParts && nowParts.dateStr) return String(nowParts.dateStr).slice(0, 10);
   if (nowParts && nowParts.Y && nowParts.M && nowParts.D) return `${nowParts.Y}-${nowParts.M}-${nowParts.D}`;
   return new Date(Date.now() + (7 * 60 * 60 * 1000)).toISOString().slice(0, 10);
+}
+
+function minimumStartForOptions(date, deps, uiStartMin, uiEndMin) {
+  let nowParts = null;
+  try {
+    nowParts = typeof deps.getNowBangkokParts === "function" ? deps.getNowBangkokParts() : jobTiming.getBangkokNow();
+  } catch (_) {
+    nowParts = jobTiming.getBangkokNow();
+  }
+  return jobTiming.minimumStartForDate(date, {
+    ui_start_min: uiStartMin,
+    ui_end_min: uiEndMin,
+    slot_step_min: SLOT_STEP_MIN,
+    now_parts: nowParts,
+  });
 }
 
 async function eligibleCustomerTechnicians(deps, options) {
@@ -379,16 +397,8 @@ async function computePublicCustomerSlots(deps, options) {
     events.get(key)[type].push(username);
   };
 
-  let startFloor = uiStartMin;
-  try {
-    const nowBkk = getNowBangkokParts();
-    if (date === bangkokTodayYmd(nowBkk)) {
-      const nowMin = (Number(nowBkk.hh || 0) * 60) + Number(nowBkk.mm || 0);
-      startFloor = Math.max(startFloor, Math.min(Math.ceil(nowMin / SLOT_STEP_MIN) * SLOT_STEP_MIN, uiEndMin));
-    }
-  } catch (_) {
-    startFloor = uiStartMin;
-  }
+  const cutoff = minimumStartForOptions(date, { getNowBangkokParts }, uiStartMin, uiEndMin);
+  const startFloor = cutoff.minimum_start_min;
 
   for (const tech of techs) {
     const cal = tech.advance_calendar || {};
@@ -401,7 +411,12 @@ async function computePublicCustomerSlots(deps, options) {
     sawWindow = true;
     const busyBlocks = await listBusyBlocksForTechOnDate(tech.username, date, null);
     for (const window of windows) {
-      const intervals = buildStartIntervalsByCollision(busyBlocks, window.startMin, window.endMin, durationMin);
+      const intervals = buildStartIntervalsByCollision(busyBlocks, window.startMin, window.endMin, durationMin)
+        .map((interval) => ({
+          startMin: interval.startMin,
+          endMin: Math.min(interval.endMin, window.endMin - durationMin),
+        }))
+        .filter((interval) => interval.endMin >= interval.startMin);
       if (intervals.length) sawStartInterval = true;
       for (const interval of intervals) {
         addEvent(interval.startMin, "add", tech.username);
@@ -431,7 +446,7 @@ async function computePublicCustomerSlots(deps, options) {
     for (let start = segmentStart; start <= lastStart; start += SLOT_STEP_MIN) {
       slots.push({
         start: minToHHMM(start),
-        end: minToHHMM(Math.min(uiEndMin, start + durationMin)),
+        end: minToHHMM(start + durationMin),
         available: true,
       });
     }
@@ -440,7 +455,14 @@ async function computePublicCustomerSlots(deps, options) {
   return {
     date,
     duration_min: durationMin,
+    service_duration_min: durationMin,
+    travel_buffer_min: jobTiming.TURNAROUND_BUFFER_MIN,
+    turnaround_buffer_min: jobTiming.TURNAROUND_BUFFER_MIN,
+    occupied_duration_min: durationMin + jobTiming.TURNAROUND_BUFFER_MIN,
     slot_step_min: SLOT_STEP_MIN,
+    server_now: cutoff.server_now,
+    timezone: cutoff.timezone,
+    minimum_start: cutoff.minimum_start,
     slots,
     ...(slots.length
       ? { availability_status: "available", reason_code: "AVAILABLE" }
@@ -467,6 +489,7 @@ function monthDays(month) {
 
 async function computeCalendarSummary(deps, options) {
   const month = String(options.month || "").slice(0, 7);
+  const cutoff = minimumStartForOptions(bangkokTodayYmd(typeof deps.getNowBangkokParts === "function" ? deps.getNowBangkokParts() : null), deps, 0, 24 * 60);
   const days = [];
   for (const date of monthDays(month)) {
     const diagnostic = makeDiagnostic();
@@ -480,7 +503,13 @@ async function computeCalendarSummary(deps, options) {
       first_available: first ? first.start : null,
     });
   }
-  return { month, days };
+  return {
+    month,
+    days,
+    server_now: cutoff.server_now,
+    timezone: cutoff.timezone,
+    minimum_start: cutoff.minimum_start,
+  };
 }
 
 async function hasAvailableStart(deps, options) {
@@ -497,6 +526,16 @@ async function reservePublicCustomerTechnician(deps, options) {
   if (!date || !start) {
     const error = new Error("CUSTOMER_SLOT_START_REQUIRED");
     error.status = 400;
+    throw error;
+  }
+  const cutoff = minimumStartForOptions(date, deps, deps.toMin(DEFAULT_UI_START), deps.toMin(DEFAULT_UI_END));
+  const startMinForCutoff = deps.toMin(start);
+  if (cutoff.is_today && Number.isFinite(startMinForCutoff) && startMinForCutoff < cutoff.minimum_start_min) {
+    const error = new Error("SLOT_IN_PAST");
+    error.status = 409;
+    error.code = "SLOT_IN_PAST";
+    error.server_now = cutoff.server_now;
+    error.minimum_start = cutoff.minimum_start;
     throw error;
   }
   const criteriaList = buildCriteriaList(options);

--- a/test/customerAppRecovery.test.js
+++ b/test/customerAppRecovery.test.js
@@ -135,7 +135,7 @@ test("Customer App build id is consistent across shell and service worker", () =
   const sw = read("customer-app/sw.js");
   const app = read("customer-app/assets/customer-app.js");
   const manifest = read("customer-app/manifest.webmanifest");
-  const build = "20260621_eligibility_techtype_v3";
+  const build = "20260622_same_day_timing_v1";
 
   assert.match(index, new RegExp(`customer-app\\.css\\?v=${build}`));
   assert.match(index, new RegExp(`bookingUrgent\\.js\\?v=${build}`));

--- a/test/customerSameDayTiming.test.js
+++ b/test/customerSameDayTiming.test.js
@@ -1,0 +1,173 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+
+const jobTiming = require("../server/services/jobTiming");
+const pricing = require("../server/pricing");
+const customerAvailability = require("../server/services/public/customerAvailability");
+
+const GOOD_MATRIX = { job_types: { wash: true }, ac_types: { wall: true }, wash_wall_variants: { normal: true } };
+const SERVICE = { job_type: "wash", ac_type: "wall", wash_variant: "normal", btu: 9000, machine_count: 1 };
+
+function toMin(value) {
+  const [h, m] = String(value).split(":").map(Number);
+  return h * 60 + m;
+}
+
+function minToHHMM(value) {
+  return `${String(Math.floor(value / 60)).padStart(2, "0")}:${String(value % 60).padStart(2, "0")}`;
+}
+
+function intervalsFromBusy(blocks, startMin, endMin, durationMin) {
+  const dur = Math.max(1, Number(durationMin || 0));
+  const busy = (blocks || []).slice().sort((a, b) => a.startMin - b.startMin);
+  const out = [];
+  let cursor = startMin;
+  for (const b of busy) {
+    const bs = Math.max(startMin, Number(b.startMin));
+    const be = Math.min(endMin, Number(b.busyEndMin ?? b.endMin));
+    if (bs - cursor >= dur) out.push({ startMin: cursor, endMin: bs - dur });
+    cursor = Math.max(cursor, be);
+  }
+  if (endMin - cursor >= dur) out.push({ startMin: cursor, endMin: endMin - dur });
+  return out;
+}
+
+function makeDeps({ nowParts, busyBlocks = [] } = {}) {
+  return {
+    pool: {
+      async query(sql, params = []) {
+        const text = String(sql);
+        if (text.includes("technician_service_matrix")) {
+          return { rows: [{ username: "tech-a", matrix_json: GOOD_MATRIX }] };
+        }
+        if (text.includes("technician_monthly_work_calendar")) {
+          return {
+            rows: [{
+              technician_username: "tech-a",
+              work_date: params[1],
+              day_status: "advance_only",
+              can_accept_advance_job: true,
+              start_time: "09:00",
+              end_time: "18:00",
+              max_jobs_per_day: null,
+              max_units_per_day: null,
+              source: "technician_default",
+            }],
+          };
+        }
+        if (text.includes("WITH assigned AS")) return { rows: [] };
+        return { rows: [] };
+      },
+    },
+    listTechniciansByType: async () => [{ username: "tech-a", customer_slot_visible: true }],
+    listBusyBlocksForTechOnDate: async () => busyBlocks,
+    buildStartIntervalsByCollision: intervalsFromBusy,
+    toMin,
+    minToHHMM,
+    getNowBangkokParts: () => nowParts,
+  };
+}
+
+test("canonical timing separates service duration and one turnaround buffer", () => {
+  assert.equal(jobTiming.computeServiceDurationMinMulti({ ...SERVICE, machine_count: 1 }, { conservative: true }), 60);
+  assert.equal(jobTiming.computeServiceDurationMinMulti({ ...SERVICE, machine_count: 2 }, { conservative: true }), 90);
+  assert.equal(jobTiming.computeServiceDurationMinMulti({ ...SERVICE, machine_count: 3 }, { conservative: true }), 120);
+
+  const timing = jobTiming.computeJobTiming({ ...SERVICE, machine_count: 2 }, { source: "test", conservative: true });
+  assert.equal(timing.service_duration_min, 90);
+  assert.equal(timing.turnaround_buffer_min, 30);
+  assert.equal(timing.occupied_duration_min, 120);
+  const anonymous = jobTiming.computeJobTiming({
+    services: [{ ...SERVICE, assigned_technician_username: "secret-tech" }],
+  }, { source: "test", conservative: true });
+  assert.doesNotMatch(JSON.stringify(anonymous.breakdown), /secret-tech/);
+});
+
+test("pricing and admin/public duration wrapper use the shared timing helper without adding buffer to price", () => {
+  assert.equal(pricing.computeDurationMinMulti({ ...SERVICE, machine_count: 2 }, { source: "pricing_preview", conservative: true }), 90);
+  assert.equal(pricing.computeStandardPriceMulti({ ...SERVICE, machine_count: 2 }), 1200);
+});
+
+test("same-day Bangkok cutoff removes starts before the rounded next 30-minute slot", async () => {
+  const base = { date: "2026-06-22", tech_type: "company", duration_min: 60, services: [SERVICE] };
+
+  let result = await customerAvailability.computePublicCustomerSlots(makeDeps({
+    nowParts: { dateStr: "2026-06-22", hour: 12, minute: 39 },
+  }), base);
+  assert.equal(result.minimum_start, "13:00");
+  assert.ok(result.slots.length > 0);
+  assert.ok(result.slots.every((slot) => slot.start >= "13:00"));
+
+  result = await customerAvailability.computePublicCustomerSlots(makeDeps({
+    nowParts: { dateStr: "2026-06-22", hour: 12, minute: 1 },
+  }), base);
+  assert.equal(result.minimum_start, "12:30");
+  assert.ok(result.slots.every((slot) => slot.start >= "12:30"));
+
+  result = await customerAvailability.computePublicCustomerSlots(makeDeps({
+    nowParts: { dateStr: "2026-06-22", hour: 12, minute: 30 },
+  }), base);
+  assert.equal(result.minimum_start, "12:30");
+  assert.ok(result.slots.some((slot) => slot.start === "12:30"));
+});
+
+test("future dates still show morning slots and two-unit service displays service end only", async () => {
+  const result = await customerAvailability.computePublicCustomerSlots(makeDeps({
+    nowParts: { dateStr: "2026-06-22", hour: 23, minute: 50 },
+  }), {
+    date: "2026-06-23",
+    tech_type: "company",
+    duration_min: 90,
+    services: [{ ...SERVICE, machine_count: 2 }],
+  });
+  assert.ok(result.slots.some((slot) => slot.start === "09:00"));
+  assert.ok(result.slots.some((slot) => slot.start === "16:30" && slot.end === "18:00"));
+  assert.ok(result.slots.every((slot) => slot.end !== "18:30"));
+});
+
+test("busy block with buffer blocks the next start until occupied end", async () => {
+  const result = await customerAvailability.computePublicCustomerSlots(makeDeps({
+    nowParts: { dateStr: "2026-06-22", hour: 8, minute: 0 },
+    busyBlocks: [{ startMin: toMin("16:30"), endMin: toMin("18:00"), busyEndMin: toMin("18:30") }],
+  }), {
+    date: "2026-06-23",
+    tech_type: "company",
+    duration_min: 60,
+    services: [SERVICE],
+  });
+  assert.ok(!result.slots.some((slot) => slot.start === "18:00"));
+});
+
+test("availability endpoints are no-store and expired submit returns SLOT_IN_PAST", () => {
+  const index = fs.readFileSync(path.join(__dirname, "..", "index.js"), "utf8");
+  assert.match(index, /Cache-Control", "no-store, no-cache, must-revalidate, max-age=0"/);
+  assert.match(index, /code: "SLOT_IN_PAST"/);
+  assert.match(index, /server_now/);
+  assert.match(index, /minimum_start/);
+});
+
+test("customer app disables availability HTTP cache and refreshes same-day slots", () => {
+  const api = fs.readFileSync(path.join(__dirname, "..", "customer-app/modules/api.js"), "utf8");
+  const availability = fs.readFileSync(path.join(__dirname, "..", "customer-app/modules/availability.js"), "utf8");
+  const scheduled = fs.readFileSync(path.join(__dirname, "..", "customer-app/modules/bookingScheduled.js"), "utf8");
+  assert.match(api, /cache: "no-store"/);
+  assert.match(availability, /_slot_bucket/);
+  assert.match(availability, /minimumStartForDate/);
+  assert.match(scheduled, /5 \* 60 \* 1000/);
+  assert.match(scheduled, /visibilitychange/);
+});
+
+test("customer app build and service worker cache IDs changed", () => {
+  const id = "20260622_same_day_timing_v1";
+  for (const file of [
+    "customer-app/index.html",
+    "customer-app/sw.js",
+    "customer-app/assets/customer-app.js",
+    "customer-app/manifest.webmanifest",
+  ]) {
+    const source = fs.readFileSync(path.join(__dirname, "..", file), "utf8");
+    assert.match(source, new RegExp(id));
+  }
+});


### PR DESCRIPTION
## Summary
- Add canonical job timing helper for service duration, single turnaround buffer, and occupied duration.
- Enforce Bangkok same-day minimum start in customer availability, calendar metadata, and scheduled submit revalidation with `SLOT_IN_PAST`.
- Separate customer-visible service end from internal buffer/collision blocking.
- Force no-store availability requests and bump Customer App build/cache ID.

## Verification
- `npm ci`
- `npm test` (152 passed, 7 DB integration tests skipped because local Postgres authentication failed)
- `node --check` on changed JS files
- `git diff --check`
- Startup smoke on `127.0.0.1:4319/customer-app/index.html` returned 200