### PR TITLE
Fix Customer urgent booking to reuse existing offer flow

### DIFF
--- a/customer-app/assets/customer-app.js
+++ b/customer-app/assets/customer-app.js
@@ -3,7 +3,7 @@
 
   const App = window.CWFCustomerAppV2;
   const BOOT_TIMEOUT_MS = 3500;
-  const BUILD_ID = "20260622_same_day_timing_v1";
+  const BUILD_ID = "20260622_urgent_offer_flow_v1";
 
   function withTimeout(promise, timeoutMs) {
     return Promise.race([

--- a/customer-app/index.html
+++ b/customer-app/index.html
@@ -9,10 +9,10 @@
   <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
   <meta name="apple-mobile-web-app-title" content="CWF Service">
   <title>CWF Customer Service</title>
-  <link rel="manifest" href="./manifest.webmanifest?v=20260622_same_day_timing_v1">
+  <link rel="manifest" href="./manifest.webmanifest?v=20260622_urgent_offer_flow_v1">
   <link rel="icon" type="image/png" sizes="192x192" href="./assets/icons/cwf-customer-192.png">
   <link rel="apple-touch-icon" sizes="180x180" href="./assets/icons/cwf-customer-180.png">
-  <link rel="stylesheet" href="./assets/customer-app.css?v=20260622_same_day_timing_v1">
+  <link rel="stylesheet" href="./assets/customer-app.css?v=20260622_urgent_offer_flow_v1">
 </head>
 <body class="is-app-booting">
   <div class="app-shell" data-app-shell>
@@ -49,19 +49,19 @@
     </nav>
   </div>
 
-  <script src="./modules/state.js?v=20260622_same_day_timing_v1"></script>
-  <script src="./modules/utils.js?v=20260622_same_day_timing_v1"></script>
-  <script src="./modules/api.js?v=20260622_same_day_timing_v1"></script>
-  <script src="./modules/services.js?v=20260622_same_day_timing_v1"></script>
-  <script src="./modules/ui.js?v=20260622_same_day_timing_v1"></script>
-  <script src="./modules/auth.js?v=20260622_same_day_timing_v1"></script>
-  <script src="./modules/pricing.js?v=20260622_same_day_timing_v1"></script>
-  <script src="./modules/availability.js?v=20260622_same_day_timing_v1"></script>
-  <script src="./modules/bookingScheduled.js?v=20260622_same_day_timing_v1"></script>
-  <script src="./modules/bookingUrgent.js?v=20260622_same_day_timing_v1"></script>
-  <script src="./modules/tracking.js?v=20260622_same_day_timing_v1"></script>
-  <script src="./modules/profile.js?v=20260622_same_day_timing_v1"></script>
-  <script src="./modules/router.js?v=20260622_same_day_timing_v1"></script>
-  <script src="./assets/customer-app.js?v=20260622_same_day_timing_v1"></script>
+  <script src="./modules/state.js?v=20260622_urgent_offer_flow_v1"></script>
+  <script src="./modules/utils.js?v=20260622_urgent_offer_flow_v1"></script>
+  <script src="./modules/api.js?v=20260622_urgent_offer_flow_v1"></script>
+  <script src="./modules/services.js?v=20260622_urgent_offer_flow_v1"></script>
+  <script src="./modules/ui.js?v=20260622_urgent_offer_flow_v1"></script>
+  <script src="./modules/auth.js?v=20260622_urgent_offer_flow_v1"></script>
+  <script src="./modules/pricing.js?v=20260622_urgent_offer_flow_v1"></script>
+  <script src="./modules/availability.js?v=20260622_urgent_offer_flow_v1"></script>
+  <script src="./modules/bookingScheduled.js?v=20260622_urgent_offer_flow_v1"></script>
+  <script src="./modules/bookingUrgent.js?v=20260622_urgent_offer_flow_v1"></script>
+  <script src="./modules/tracking.js?v=20260622_urgent_offer_flow_v1"></script>
+  <script src="./modules/profile.js?v=20260622_urgent_offer_flow_v1"></script>
+  <script src="./modules/router.js?v=20260622_urgent_offer_flow_v1"></script>
+  <script src="./assets/customer-app.js?v=20260622_urgent_offer_flow_v1"></script>
 </body>
 </html>

--- a/customer-app/manifest.webmanifest
+++ b/customer-app/manifest.webmanifest
@@ -2,7 +2,7 @@
   "name": "CWF Customer Service",
   "short_name": "CWF Service",
   "description": "แอปลูกค้า Coldwindflow สำหรับเลือกบริการ จองคิว และติดตามงาน",
-  "start_url": "/customer-app/index.html?v=20260622_same_day_timing_v1#home",
+  "start_url": "/customer-app/index.html?v=20260622_urgent_offer_flow_v1#home",
   "scope": "/customer-app/",
   "id": "/customer-app/",
   "display": "standalone",

--- a/customer-app/modules/api.js
+++ b/customer-app/modules/api.js
@@ -94,6 +94,10 @@
       return requestJson("/public/track", { query: { q } });
     },
 
+    async loadUrgentStatus(q) {
+      return requestJson("/public/urgent-status", { query: { q }, cache: "no-store" });
+    },
+
     async loadPromotions() {
       return requestJson("/promotions", { query: { customer: 1 } });
     },
@@ -121,6 +125,8 @@
       const body = {
         ...(payload || {}),
         booking_mode: "urgent",
+        dispatch_mode: "offer",
+        allow_time_proposal: true,
       };
       return requestJson("/public/book", {
         method: "POST",

--- a/customer-app/modules/bookingUrgent.js
+++ b/customer-app/modules/bookingUrgent.js
@@ -26,54 +26,8 @@
     return root.services.serviceLabel(service());
   }
 
-  function pad2(n) {
-    return String(n).padStart(2, "0");
-  }
-
-  function nextUrgentAppointmentIso() {
-    const parts = new Intl.DateTimeFormat("en-CA", {
-      timeZone: "Asia/Bangkok",
-      year: "numeric",
-      month: "2-digit",
-      day: "2-digit",
-      hour: "2-digit",
-      minute: "2-digit",
-      hour12: false,
-    }).formatToParts(new Date(Date.now() + 30 * 60 * 1000)).reduce((acc, part) => {
-      if (part.type !== "literal") acc[part.type] = part.value;
-      return acc;
-    }, {});
-    let year = Number(parts.year);
-    let month = Number(parts.month);
-    let day = Number(parts.day);
-    let hour = Number(parts.hour);
-    let minute = Math.ceil(Number(parts.minute || 0) / 30) * 30;
-    if (minute >= 60) {
-      hour += 1;
-      minute = 0;
-    }
-    if (hour < 9) {
-      hour = 9;
-      minute = 0;
-    } else if (hour >= 18) {
-      const next = new Date(Date.UTC(year, month - 1, day + 1, 2, 0, 0));
-      const nextParts = new Intl.DateTimeFormat("en-CA", {
-        timeZone: "Asia/Bangkok",
-        year: "numeric",
-        month: "2-digit",
-        day: "2-digit",
-      }).formatToParts(next).reduce((acc, part) => {
-        if (part.type !== "literal") acc[part.type] = part.value;
-        return acc;
-      }, {});
-      year = Number(nextParts.year);
-      month = Number(nextParts.month);
-      day = Number(nextParts.day);
-      hour = 9;
-      minute = 0;
-    }
-    return `${year}-${pad2(month)}-${pad2(day)}T${pad2(hour)}:${pad2(minute)}:00+07:00`;
-  }
+  let submitInFlight = false;
+  let pollTimer = null;
 
   function buildSubmitPayload() {
     const d = draft();
@@ -81,12 +35,13 @@
     return {
       customer_name: String(d.customer_name || "").trim(),
       customer_phone: String(d.customer_phone || "").trim(),
-      appointment_datetime: nextUrgentAppointmentIso(),
       address_text: String(d.address_text || "").trim(),
       maps_url: String(d.maps_url || "").trim(),
       job_zone: String(d.job_zone || "").trim(),
       customer_note: String(d.symptom || "").trim(),
       booking_mode: "urgent",
+      dispatch_mode: "offer",
+      allow_time_proposal: true,
       client_app: "customer_app_v2",
       job_type: s.job_type,
       ac_type: s.ac_type,
@@ -183,6 +138,22 @@
     if (s.job_type === "ซ่อม" && !s.repair_variant) errors.push("กรุณาเลือกประเภทงานซ่อม");
     if (!String(d.symptom || "").trim()) errors.push("กรุณาบอกอาการ/สิ่งที่ต้องการให้ช่างช่วย");
     return errors;
+  }
+
+  function trackingKeyFromResult(result) {
+    return result ? (result.token || result.booking_token || result.booking_code || "") : "";
+  }
+
+  function urgentStatusText(status, result) {
+    const phase = String(status?.phase || "").trim();
+    if (phase === "accepted") return "มีช่างรับงานแล้ว ระบบกำลังอัปเดตสถานะงานให้ติดตามต่อได้ทันที";
+    if (phase === "time_proposed") return "ช่างเสนอเวลาใหม่แล้ว แอดมินกำลังช่วยตรวจสอบและยืนยันกับลูกค้า";
+    if (phase === "admin_review") return "ยังไม่มีช่างรับในรอบข้อเสนอ แอดมินกำลังช่วยตรวจสอบคิวด่วน";
+    const expiresAt = status?.next_offer_expires_at || result?.next_offer_expires_at || null;
+    const end = expiresAt ? new Date(expiresAt).getTime() : 0;
+    const remain = end ? Math.max(0, Math.ceil((end - Date.now()) / 1000)) : 0;
+    const countdown = remain > 0 ? ` เหลือเวลารับงานประมาณ ${Math.floor(remain / 60)}:${String(remain % 60).padStart(2, "0")} นาที` : "";
+    return `ส่งคำขอคิวด่วนแล้ว กำลังรอช่างที่พร้อมรับงานกดรับ${countdown}`;
   }
 
   function hero() {
@@ -308,10 +279,11 @@
     const d = draft();
     const flow = root.state.urgentFlow || {};
     const result = flow.result || null;
-    const trackingKey = result ? (result.token || result.booking_code || "") : "";
+    const liveStatus = flow.liveStatus || null;
+    const trackingKey = trackingKeyFromResult(result);
     const offersCount = result ? Number(result.offers_count || 0) : 0;
     const offerEnabled = result ? result.urgent_offer_enabled !== false : true;
-    const waitingText = offerEnabled && offersCount > 0
+    let waitingText = offerEnabled && offersCount > 0
       ? "ส่งคำขอคิวด่วนแล้ว กำลังรอช่างพาร์ทเนอร์กดรับงาน ยังไม่ถือว่ายืนยันงานจนกว่าจะมีช่างรับหรือแอดมินยืนยัน"
       : "ส่งคำขอคิวด่วนแล้ว แอดมินกำลังช่วยตรวจสอบคิวด่วน ยังไม่ถือว่ายืนยันงานจนกว่าจะมีช่างรับหรือแอดมินยืนยัน";
     return `
@@ -333,7 +305,7 @@
             <span class="pulse-dot" aria-hidden="true"></span>
             <span>กำลังส่งคำขอหาช่างพาร์ทเนอร์ที่พร้อมรับงานในพื้นที่</span>
           </div>
-          <div class="notice is-urgent">${root.utils.escapeHtml(waitingText)}</div>
+          <div class="notice is-urgent" data-urgent-live-status>${root.utils.escapeHtml(urgentStatusText(liveStatus, result))}</div>
         </div>
       </section>
 
@@ -393,18 +365,47 @@
   }
 
   async function submitUrgent(container) {
+    if (submitInFlight || root.state.urgentFlow.status === "submitting") return;
+    submitInFlight = true;
     root.state.setUrgentFlow({ step: "review", status: "submitting", error: "", result: null });
     paint(container);
     try {
       const result = await root.api.submitUrgentRequest(buildSubmitPayload());
-      const trackingKey = result.token || result.booking_code || "";
+      const trackingKey = trackingKeyFromResult(result);
       if (trackingKey) root.state.updateDraft("tracking", { trackingCode: trackingKey });
       root.state.setUrgentFlow({ step: "waiting", status: "success", error: "", result });
+      submitInFlight = false;
       paint(container);
     } catch (error) {
+      submitInFlight = false;
       root.state.setUrgentFlow({ step: "review", status: "error", error: error.message || "ส่งคำขอคิวด่วนไม่สำเร็จ", result: null });
       paint(container);
     }
+  }
+
+  function stopPolling() {
+    if (pollTimer) {
+      clearInterval(pollTimer);
+      pollTimer = null;
+    }
+  }
+
+  async function pollUrgentStatus(container) {
+    const key = trackingKeyFromResult(root.state.urgentFlow?.result || null);
+    if (!key) return;
+    try {
+      const status = await root.api.loadUrgentStatus(key);
+      root.state.setUrgentFlow({ liveStatus: status, liveStatusError: "" });
+      if (root.state.currentRoute === "urgent" && root.state.urgentFlow.step === "waiting") paint(container);
+    } catch (error) {
+      root.state.setUrgentFlow({ liveStatusError: error.message || "โหลดสถานะคิวด่วนไม่สำเร็จ" });
+    }
+  }
+
+  function startPolling(container) {
+    if (pollTimer) return;
+    pollUrgentStatus(container);
+    pollTimer = setInterval(() => pollUrgentStatus(container), 10000);
   }
 
   function body() {
@@ -424,6 +425,8 @@
       </section>
     `;
     bind(container);
+    if (step === "waiting") startPolling(container);
+    else stopPolling();
   }
 
   function servicePatch(field, value) {
@@ -473,7 +476,8 @@
         } else if (action === "confirm") {
           await submitUrgent(container);
         } else if (action === "new-request") {
-          root.state.setUrgentFlow({ step: "form", status: "idle", error: "", result: null });
+          stopPolling();
+          root.state.setUrgentFlow({ step: "form", status: "idle", error: "", result: null, liveStatus: null, liveStatusError: "" });
           paint(container);
         } else if (action === "track-created") {
           const key = btn.getAttribute("data-tracking-key") || "";
@@ -492,7 +496,9 @@
       root.state.ensureSavedAddressPrefill("urgent", () => {
         if (root.state.currentRoute === "urgent") root.bookingUrgent.render(container);
       });
-      root.state.setUrgentFlow({ step: "form", status: "idle", error: "", result: null });
+      if (!root.state.urgentFlow || !root.state.urgentFlow.step) {
+        root.state.setUrgentFlow({ step: "form", status: "idle", error: "", result: null, liveStatus: null, liveStatusError: "" });
+      }
       paint(container);
     },
   };

--- a/customer-app/modules/bookingUrgent.js
+++ b/customer-app/modules/bookingUrgent.js
@@ -28,6 +28,20 @@
 
   let submitInFlight = false;
   let pollTimer = null;
+  let tickTimer = null;
+  let activeContainer = null;
+  let serverClockOffsetMs = 0;
+
+  // Reused across retries of the SAME request (network retry, double-tap,
+  // multi-tab) so the server can dedup; only cleared when the customer
+  // explicitly starts a genuinely new request ("new-request" action).
+  function ensureRequestKey() {
+    const d = draft();
+    if (d.urgent_request_key) return d.urgent_request_key;
+    const key = root.utils.randomKey();
+    root.state.updateDraft("urgent", { urgent_request_key: key });
+    return key;
+  }
 
   function buildSubmitPayload() {
     const d = draft();
@@ -43,6 +57,7 @@
       dispatch_mode: "offer",
       allow_time_proposal: true,
       client_app: "customer_app_v2",
+      urgent_request_key: ensureRequestKey(),
       job_type: s.job_type,
       ac_type: s.ac_type,
       btu: s.btu || 0,
@@ -144,14 +159,18 @@
     return result ? (result.token || result.booking_token || result.booking_code || "") : "";
   }
 
-  function urgentStatusText(status, result) {
+  function urgentStatusText(status) {
     const phase = String(status?.phase || "").trim();
+    if (status?.terminal) return "คำขอคิวด่วนนี้ปิดแล้ว กรุณาเริ่มคำขอใหม่หรือเปลี่ยนเป็นจองล่วงหน้า";
     if (phase === "accepted") return "มีช่างรับงานแล้ว ระบบกำลังอัปเดตสถานะงานให้ติดตามต่อได้ทันที";
     if (phase === "time_proposed") return "ช่างเสนอเวลาใหม่แล้ว แอดมินกำลังช่วยตรวจสอบและยืนยันกับลูกค้า";
     if (phase === "admin_review") return "ยังไม่มีช่างรับในรอบข้อเสนอ แอดมินกำลังช่วยตรวจสอบคิวด่วน";
-    const expiresAt = status?.next_offer_expires_at || result?.next_offer_expires_at || null;
+    const expiresAt = status?.next_offer_expires_at || null;
     const end = expiresAt ? new Date(expiresAt).getTime() : 0;
-    const remain = end ? Math.max(0, Math.ceil((end - Date.now()) / 1000)) : 0;
+    // Anchor the countdown to the server's clock (server_now), not the
+    // client's, so drift never produces a misleading countdown.
+    const nowOnServer = Date.now() + serverClockOffsetMs;
+    const remain = end ? Math.max(0, Math.ceil((end - nowOnServer) / 1000)) : 0;
     const countdown = remain > 0 ? ` เหลือเวลารับงานประมาณ ${Math.floor(remain / 60)}:${String(remain % 60).padStart(2, "0")} นาที` : "";
     return `ส่งคำขอคิวด่วนแล้ว กำลังรอช่างที่พร้อมรับงานกดรับ${countdown}`;
   }
@@ -305,7 +324,7 @@
             <span class="pulse-dot" aria-hidden="true"></span>
             <span>กำลังส่งคำขอหาช่างพาร์ทเนอร์ที่พร้อมรับงานในพื้นที่</span>
           </div>
-          <div class="notice is-urgent" data-urgent-live-status>${root.utils.escapeHtml(urgentStatusText(liveStatus, result))}</div>
+          <div class="notice is-urgent" data-urgent-live-status>${root.utils.escapeHtml(urgentStatusText(liveStatus))}</div>
         </div>
       </section>
 
@@ -390,22 +409,77 @@
     }
   }
 
+  function stopTick() {
+    if (tickTimer) {
+      clearInterval(tickTimer);
+      tickTimer = null;
+    }
+  }
+
+  function onWaitingScreen() {
+    return root.state.currentRoute === "urgent" && root.state.urgentFlow.step === "waiting";
+  }
+
+  // Updates only the live-status text node every second so the countdown
+  // moves smoothly without re-rendering (and re-binding) the whole screen.
+  function tickLiveStatus() {
+    if (!onWaitingScreen() || !activeContainer) return;
+    const node = activeContainer.querySelector("[data-urgent-live-status]");
+    if (!node) return;
+    node.textContent = urgentStatusText(root.state.urgentFlow?.liveStatus || null);
+  }
+
   async function pollUrgentStatus(container) {
     const key = trackingKeyFromResult(root.state.urgentFlow?.result || null);
     if (!key) return;
     try {
       const status = await root.api.loadUrgentStatus(key);
+      if (status && status.server_now) {
+        serverClockOffsetMs = new Date(status.server_now).getTime() - Date.now();
+      }
       root.state.setUrgentFlow({ liveStatus: status, liveStatusError: "" });
-      if (root.state.currentRoute === "urgent" && root.state.urgentFlow.step === "waiting") paint(container);
+      if (!onWaitingScreen()) return;
+      if (status && status.phase === "accepted") {
+        stopPolling();
+        stopTick();
+        const key2 = trackingKeyFromResult(root.state.urgentFlow?.result || null);
+        if (key2) root.state.updateDraft("tracking", { trackingCode: key2 });
+        root.utils.routeTo("tracking");
+        return;
+      }
+      if (status && status.terminal) {
+        stopPolling();
+        stopTick();
+      }
+      paint(container);
     } catch (error) {
       root.state.setUrgentFlow({ liveStatusError: error.message || "โหลดสถานะคิวด่วนไม่สำเร็จ" });
     }
   }
 
   function startPolling(container) {
-    if (pollTimer) return;
-    pollUrgentStatus(container);
-    pollTimer = setInterval(() => pollUrgentStatus(container), 10000);
+    activeContainer = container;
+    if (!pollTimer) {
+      pollUrgentStatus(container);
+      pollTimer = setInterval(() => pollUrgentStatus(container), 10000);
+    }
+    if (!tickTimer) {
+      tickTimer = setInterval(tickLiveStatus, 1000);
+    }
+  }
+
+  let visibilityBound = false;
+  function bindVisibilityRefresh() {
+    if (visibilityBound) return;
+    visibilityBound = true;
+    const refresh = () => {
+      if (document.visibilityState === "visible" && onWaitingScreen() && activeContainer) {
+        pollUrgentStatus(activeContainer);
+      }
+    };
+    document.addEventListener("visibilitychange", refresh);
+    window.addEventListener("focus", refresh);
+    window.addEventListener("pageshow", refresh);
   }
 
   function body() {
@@ -425,8 +499,13 @@
       </section>
     `;
     bind(container);
-    if (step === "waiting") startPolling(container);
-    else stopPolling();
+    const liveStatus = root.state.urgentFlow.liveStatus || null;
+    if (step === "waiting" && !(liveStatus && liveStatus.terminal)) {
+      startPolling(container);
+    } else {
+      stopPolling();
+      stopTick();
+    }
   }
 
   function servicePatch(field, value) {
@@ -477,6 +556,8 @@
           await submitUrgent(container);
         } else if (action === "new-request") {
           stopPolling();
+          stopTick();
+          root.state.updateDraft("urgent", { urgent_request_key: "" });
           root.state.setUrgentFlow({ step: "form", status: "idle", error: "", result: null, liveStatus: null, liveStatusError: "" });
           paint(container);
         } else if (action === "track-created") {
@@ -491,15 +572,22 @@
     });
   }
 
-  root.bookingUrgent = {
-    render(container) {
-      root.state.ensureSavedAddressPrefill("urgent", () => {
-        if (root.state.currentRoute === "urgent") root.bookingUrgent.render(container);
-      });
-      if (!root.state.urgentFlow || !root.state.urgentFlow.step) {
-        root.state.setUrgentFlow({ step: "form", status: "idle", error: "", result: null, liveStatus: null, liveStatusError: "" });
-      }
-      paint(container);
-    },
+  function render(container) {
+    root.state.ensureSavedAddressPrefill("urgent", () => {
+      if (root.state.currentRoute === "urgent") render(container);
+    });
+    if (!root.state.urgentFlow || !root.state.urgentFlow.step) {
+      root.state.setUrgentFlow({ step: "form", status: "idle", error: "", result: null, liveStatus: null, liveStatusError: "" });
+    }
+    bindVisibilityRefresh();
+    paint(container);
+  }
+
+  render.onLeave = () => {
+    stopPolling();
+    stopTick();
+    activeContainer = null;
   };
+
+  root.bookingUrgent = { render };
 })();

--- a/customer-app/modules/bookingUrgent.js
+++ b/customer-app/modules/bookingUrgent.js
@@ -294,6 +294,10 @@
     `;
   }
 
+  function isUrgentRequestTerminal(liveStatus) {
+    return !!(liveStatus && liveStatus.terminal === true);
+  }
+
   function renderWaiting() {
     const d = draft();
     const flow = root.state.urgentFlow || {};
@@ -302,6 +306,8 @@
     const trackingKey = trackingKeyFromResult(result);
     const offersCount = result ? Number(result.offers_count || 0) : 0;
     const offerEnabled = result ? result.urgent_offer_enabled !== false : true;
+    const isTerminal = isUrgentRequestTerminal(liveStatus);
+    const lockedAttr = isTerminal ? "" : 'disabled aria-disabled="true" title="ใช้ได้เมื่อคำขอคิวด่วนนี้ปิดแล้ว"';
     let waitingText = offerEnabled && offersCount > 0
       ? "ส่งคำขอคิวด่วนแล้ว กำลังรอช่างพาร์ทเนอร์กดรับงาน ยังไม่ถือว่ายืนยันงานจนกว่าจะมีช่างรับหรือแอดมินยืนยัน"
       : "ส่งคำขอคิวด่วนแล้ว แอดมินกำลังช่วยตรวจสอบคิวด่วน ยังไม่ถือว่ายืนยันงานจนกว่าจะมีช่างรับหรือแอดมินยืนยัน";
@@ -371,14 +377,16 @@
         </div>
         <div class="button-row">
           <button class="secondary-btn" type="button" disabled>ให้แอดมินช่วยจัดคิว</button>
-          <button class="secondary-btn" type="button" data-urgent-action="to-scheduled">เปลี่ยนเป็นจองล่วงหน้า</button>
+          <button class="secondary-btn" type="button" data-urgent-action="to-scheduled" ${lockedAttr}>เปลี่ยนเป็นจองล่วงหน้า</button>
         </div>
+        ${isTerminal ? "" : '<p class="muted">ปุ่มเปลี่ยนเป็นจองล่วงหน้าจะใช้ได้เมื่อคำขอคิวด่วนนี้ปิดแล้ว</p>'}
       </section>
 
       <div class="sticky-action">
         ${trackingKey ? `<button class="primary-btn" type="button" data-urgent-action="track-created" data-tracking-key="${root.utils.escapeHtml(trackingKey)}">ติดตามงานนี้</button>` : ""}
         <p class="muted">ยังไม่ถือว่ายืนยันงานจนกว่าจะมีช่างรับหรือแอดมินยืนยัน</p>
-        <button class="secondary-btn" type="button" data-urgent-action="new-request">เริ่มคำขอใหม่</button>
+        <button class="secondary-btn" type="button" data-urgent-action="new-request" ${lockedAttr}>เริ่มคำขอใหม่</button>
+        ${isTerminal ? "" : '<p class="muted">ปุ่มเริ่มคำขอใหม่จะใช้ได้เมื่อคำขอคิวด่วนนี้ปิดแล้ว</p>'}
       </div>
     `;
   }
@@ -555,6 +563,7 @@
         } else if (action === "confirm") {
           await submitUrgent(container);
         } else if (action === "new-request") {
+          if (root.state.urgentFlow.step === "waiting" && !isUrgentRequestTerminal(root.state.urgentFlow.liveStatus)) return;
           stopPolling();
           stopTick();
           root.state.updateDraft("urgent", { urgent_request_key: "" });
@@ -566,6 +575,7 @@
           root.state.setTracking({ status: "idle", data: null, error: "" });
           root.utils.routeTo("tracking");
         } else if (action === "to-scheduled") {
+          if (root.state.urgentFlow.step === "waiting" && !isUrgentRequestTerminal(root.state.urgentFlow.liveStatus)) return;
           root.utils.routeTo("scheduled");
         }
       });

--- a/customer-app/modules/router.js
+++ b/customer-app/modules/router.js
@@ -43,6 +43,10 @@
         history.replaceState(null, "", `#${route}`);
       }
       const routeChanged = this.lastRoute !== route;
+      if (routeChanged) {
+        const prevHandler = this.routes[this.lastRoute];
+        if (typeof prevHandler?.onLeave === "function") prevHandler.onLeave();
+      }
       this.lastRoute = route;
       root.state.setRoute(route);
       this.updateNav(route);

--- a/customer-app/modules/utils.js
+++ b/customer-app/modules/utils.js
@@ -16,6 +16,22 @@
     window.location.hash = `#${route || "home"}`;
   }
 
+  // Cryptographically random key for client-side idempotency (e.g. urgent
+  // booking request dedup). Falls back gracefully if crypto APIs are absent.
+  function randomKey() {
+    try {
+      if (window.crypto && typeof window.crypto.randomUUID === "function") {
+        return window.crypto.randomUUID().replace(/-/g, "");
+      }
+      if (window.crypto && typeof window.crypto.getRandomValues === "function") {
+        const arr = new Uint8Array(16);
+        window.crypto.getRandomValues(arr);
+        return Array.from(arr).map((b) => b.toString(16).padStart(2, "0")).join("");
+      }
+    } catch (_) { /* fall through to non-crypto fallback */ }
+    return `${Date.now().toString(16)}${Math.random().toString(16).slice(2)}${Math.random().toString(16).slice(2)}`;
+  }
+
   function formatBaht(value) {
     const n = Number(value || 0);
     if (!Number.isFinite(n) || n <= 0) return "-";
@@ -108,6 +124,7 @@
   root.utils = {
     escapeHtml,
     routeTo,
+    randomKey,
     formatBaht,
     formatDateTime,
     stepCards,

--- a/customer-app/sw.js
+++ b/customer-app/sw.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const BUILD_ID = "20260622_same_day_timing_v1";
+const BUILD_ID = "20260622_urgent_offer_flow_v1";
 const CACHE_NAME = `cwf-customer-app-v2-${BUILD_ID}`;
 const APP_SHELL = [
   `./index.html?v=${BUILD_ID}`,

--- a/index.js
+++ b/index.js
@@ -14159,6 +14159,8 @@ async function handleAdminBookV2(req, res) {
     String(allowTimeProposalRaw || "").trim().toLowerCase() === "true" ||
     String(allowTimeProposalRaw || "").trim() === "1"
   );
+  const createdBySource = req.cwfBookSource === "customer" ? "customer" : "admin";
+  const publicBookingToken = createdBySource === "customer" ? genToken(12) : null;
   const zoneDetected = await detectServiceZoneFromText({ address_text, job_zone, service_zone_code, maps_url });
   const detectedZoneCode = zoneDetected?.service_zone_code || null;
   const detectedZoneLabel = zoneDetected?.service_zone_label || null;
@@ -14418,7 +14420,7 @@ if (coerceNumber(override_price, 0) > 0) {
        booking_token, job_source, dispatch_mode, customer_note,
        maps_url, job_zone, duration_min, booking_mode, admin_override_duration_min,
        gps_latitude, gps_longitude, service_zone_code, service_zone_source, allow_time_proposal)
-      VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,NULL,'admin',$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21)
+      VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$22,$23,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21)
       RETURNING job_id
       `,
       [
@@ -14443,6 +14445,8 @@ if (coerceNumber(override_price, 0) > 0) {
         detectedZoneCode,
         detectedZoneSource,
         allowTimeProposal,
+        publicBookingToken,
+        createdBySource,
       ]
     );
 
@@ -14640,6 +14644,7 @@ if (coerceNumber(override_price, 0) > 0) {
       success: true,
       job_id,
       booking_code,
+      token: publicBookingToken,
       technician_username: isUrgentOffer ? null : selectedTech,
       tech_type: ttype,
       duration_min,
@@ -24646,6 +24651,35 @@ app.get("/public/availability", async (req, res) => {
   }
 });
 
+function defaultCustomerUrgentAppointmentIso() {
+  return dateToBangkokISO(new Date(Date.now() + 30 * 60 * 1000));
+}
+
+function isCustomerAppUrgentBook(body = {}) {
+  return String(body.booking_mode || "").trim().toLowerCase() === "urgent" &&
+    String(body.client_app || "").trim().toLowerCase() === "customer_app_v2";
+}
+
+function handlePublicCustomerUrgentBook(req, res) {
+  const body = req.body || {};
+  req.cwfBookSource = "customer";
+  req.body = {
+    ...body,
+    appointment_datetime: defaultCustomerUrgentAppointmentIso(),
+    booking_mode: "urgent",
+    dispatch_mode: "offer",
+    tech_type: "partner",
+    assign_mode: "auto",
+    technician_username: "",
+    team_members: [],
+    allow_time_proposal: true,
+    override_price: undefined,
+    override_duration_min: undefined,
+    promotion_id: undefined,
+  };
+  return handleAdminBookV2(req, res);
+}
+
 app.post("/public/book", async (req, res) => {
   // ✅ ลูกค้าจองคิว (ไม่บังคับกรอก lat/lng) + เลือกรายการบริการ/สินค้าได้
   // - โปรโมชั่น: ให้แอดมินเป็นคนใส่/ลบเท่านั้น (ฝั่งลูกค้าไม่รับ promo_id)
@@ -24670,6 +24704,10 @@ app.post("/public/book", async (req, res) => {
     repair_variant,
     services,
   } = req.body || {};
+
+  if (isCustomerAppUrgentBook(req.body || {})) {
+    return handlePublicCustomerUrgentBook(req, res);
+  }
 
   if (!customer_name || !job_type || !appointment_datetime || !address_text) {
     return res.status(400).json({ error: "กรอกข้อมูลไม่ครบ (ชื่อ/ประเภทงาน/วันนัด/ที่อยู่)" });
@@ -25168,6 +25206,81 @@ if (itemIdQty.length) {
     });
   } finally {
     client.release();
+  }
+});
+
+app.get("/public/urgent-status", async (req, res) => {
+  const q = String(req.query.q || req.query.token || req.query.booking_code || "").trim();
+  if (!q) return res.status(400).json({ error: "missing tracking code" });
+  try {
+    await pool.query(`
+      UPDATE public.job_offers
+      SET status='expired'
+      WHERE status='pending' AND expires_at < NOW()
+    `);
+    await autoFinalizeUrgentJobs();
+    const r = await pool.query(
+      `
+      SELECT job_id, booking_code, booking_token, job_status, booking_mode, dispatch_mode,
+             technician_username, technician_team, appointment_datetime,
+             COALESCE(allow_time_proposal,FALSE) AS allow_time_proposal
+      FROM public.jobs
+      WHERE booking_token=$1 OR booking_code=$1
+      LIMIT 1
+      `,
+      [q]
+    );
+    const job = r.rows[0];
+    if (!job) return res.status(404).json({ error: "not found" });
+    if (String(job.booking_mode || "").toLowerCase() !== "urgent") {
+      return res.status(400).json({ error: "not urgent booking" });
+    }
+    const offerR = await pool.query(
+      `
+      SELECT MIN(expires_at) FILTER (WHERE status='pending' AND expires_at >= NOW()) AS next_offer_expires_at,
+             BOOL_OR(status='pending' AND expires_at >= NOW()) AS has_pending_offer,
+             BOOL_OR(status='accepted') AS has_accepted_offer
+      FROM public.job_offers
+      WHERE job_id=$1
+      `,
+      [job.job_id]
+    );
+    const proposalR = await pool.query(
+      `
+      SELECT BOOL_OR(status='pending') AS has_pending_time_proposal
+      FROM public.job_offer_time_proposals
+      WHERE job_id=$1
+      `,
+      [job.job_id]
+    );
+    const offers = offerR.rows[0] || {};
+    const hasAccepted = Boolean(job.technician_username || job.technician_team || offers.has_accepted_offer);
+    const hasProposal = Boolean(proposalR.rows[0]?.has_pending_time_proposal) || String(job.job_status || "") === "รอพิจารณาเวลาใหม่";
+    const hasPending = Boolean(offers.has_pending_offer);
+    const phase = hasAccepted
+      ? "accepted"
+      : hasProposal
+        ? "time_proposed"
+        : hasPending
+          ? "waiting"
+          : "admin_review";
+    res.set("Cache-Control", "no-store");
+    return res.json({
+      success: true,
+      job_id: job.job_id,
+      booking_code: job.booking_code || null,
+      booking_mode: job.booking_mode || null,
+      dispatch_mode: job.dispatch_mode || null,
+      job_status: job.job_status || null,
+      phase,
+      appointment_datetime: job.appointment_datetime || null,
+      allow_time_proposal: Boolean(job.allow_time_proposal),
+      has_pending_offer: hasPending,
+      next_offer_expires_at: offers.next_offer_expires_at || null,
+    });
+  } catch (e) {
+    console.error("GET /public/urgent-status error:", e);
+    return res.status(500).json({ error: "urgent status failed" });
   }
 });
 

--- a/index.js
+++ b/index.js
@@ -11664,6 +11664,15 @@ try {
       `CREATE UNIQUE INDEX IF NOT EXISTS idx_jobs_booking_code_unique ON public.jobs(booking_code)`
     );
 
+    // Defense-in-depth for durable urgent-booking idempotency: booking_token
+    // is deterministically derived from urgent_request_key for customer
+    // urgent requests (see deriveUrgentBookingToken), so a unique index here
+    // guarantees at most one job per request key even if the advisory-lock
+    // dedup check in handleAdminBookV2 were ever bypassed or raced.
+    await pool.query(
+      `CREATE UNIQUE INDEX IF NOT EXISTS idx_jobs_booking_token_unique ON public.jobs(booking_token) WHERE booking_token IS NOT NULL`
+    );
+
     // backfill booking_code
     await pool.query(`
       UPDATE public.jobs
@@ -14161,7 +14170,19 @@ async function handleAdminBookV2(req, res) {
     String(allowTimeProposalRaw || "").trim() === "1"
   );
   const createdBySource = req.cwfBookSource === "customer" ? "customer" : "admin";
-  const publicBookingToken = createdBySource === "customer" ? genToken(12) : null;
+  // Customer-sourced urgent requests carry a client-generated
+  // urgent_request_key; deriving booking_token from it deterministically
+  // (instead of a random genToken) lets the dedup check below find a
+  // prior committed row for the exact same key, across restarts/instances.
+  const urgentRequestKey = (isUrgentOffer && createdBySource === "customer")
+    ? String(body.urgent_request_key || "").trim()
+    : "";
+  const urgentDeterministicToken = urgentRequestKey
+    ? urgentPublicAdapter.deriveUrgentBookingToken(urgentRequestKey)
+    : null;
+  const publicBookingToken = createdBySource === "customer"
+    ? (urgentDeterministicToken || genToken(12))
+    : null;
   const zoneDetected = await detectServiceZoneFromText({ address_text, job_zone, service_zone_code, maps_url });
   const detectedZoneCode = zoneDetected?.service_zone_code || null;
   const detectedZoneLabel = zoneDetected?.service_zone_label || null;
@@ -14260,6 +14281,28 @@ console.log("[latlng_parse]", { ok: !!parsedAdminLL });
   const client = await pool.connect();
   try {
     await client.query("BEGIN");
+
+    // Durable, cross-instance idempotency for customer-sourced urgent
+    // requests: an advisory lock scoped to this transaction serializes any
+    // concurrent/retried requests sharing the same urgent_request_key
+    // (across all app-server instances connected to this Postgres), and
+    // auto-releases on COMMIT/ROLLBACK so it can never be left held by a
+    // crashed process. If a job for this exact key already committed
+    // (found via the deterministic booking_token), short-circuit here and
+    // return that prior result instead of creating a second job/offer set.
+    if (urgentRequestKey && urgentDeterministicToken) {
+      await client.query("SELECT pg_advisory_xact_lock(hashtext($1))", [urgentRequestKey]);
+      const dupCheck = await client.query(
+        `SELECT booking_code, booking_token FROM public.jobs WHERE booking_token=$1 LIMIT 1`,
+        [urgentDeterministicToken]
+      );
+      const dupRow = dupCheck.rows[0] || null;
+      if (dupRow && dupRow.booking_code) {
+        await client.query("COMMIT");
+        return res.json({ success: true, booking_code: dupRow.booking_code, token: dupRow.booking_token, duplicate: true });
+      }
+    }
+
     await expireTechnicianAcceptStatuses(client);
 
     // promo
@@ -24652,8 +24695,6 @@ app.get("/public/availability", async (req, res) => {
   }
 });
 
-const customerUrgentIdempotency = new urgentPublicAdapter.UrgentIdempotencyStore();
-
 function isCustomerAppUrgentBook(body = {}) {
   return String(body.booking_mode || "").trim().toLowerCase() === "urgent" &&
     String(body.client_app || "").trim().toLowerCase() === "customer_app_v2";
@@ -24661,27 +24702,17 @@ function isCustomerAppUrgentBook(body = {}) {
 
 // Customer App V2 urgent requests are just another entry point into the
 // existing admin urgent offer engine (handleAdminBookV2): this adapter only
-// (a) strips the request down to a customer-safe allowlist, (b) computes a
-// rounded, business-hours-aware appointment time, and (c) deduplicates
-// retried/duplicate submits by client-generated urgent_request_key. It must
-// never branch into a separate dispatch/state machine.
+// (a) strips the request down to a customer-safe allowlist and (b) computes
+// a rounded, business-hours-aware appointment time. Deduplication of
+// retried/duplicate submits sharing the same client-generated
+// urgent_request_key is handled durably inside handleAdminBookV2's existing
+// transaction (advisory lock + deterministic booking_token lookup), not
+// here, so it survives process restarts and works across instances.
 function handlePublicCustomerUrgentBook(req, res) {
   const incoming = urgentPublicAdapter.sanitizeCustomerUrgentBody(req.body || {});
   const requestKey = incoming.urgent_request_key;
   if (!requestKey || requestKey.length < 16) {
     return res.status(400).json({ error: "MISSING_REQUEST_KEY", code: "MISSING_REQUEST_KEY" });
-  }
-
-  const cached = customerUrgentIdempotency.getCached(requestKey);
-  if (cached) {
-    return res.json({ success: true, booking_code: cached.booking_code, token: cached.token, duplicate: true });
-  }
-
-  const inFlight = customerUrgentIdempotency.getInFlight(requestKey);
-  if (inFlight) {
-    return inFlight
-      .then((result) => res.json({ success: true, booking_code: result.booking_code, token: result.token, duplicate: true }))
-      .catch(() => res.status(409).json({ error: "DUPLICATE_REQUEST_IN_PROGRESS", code: "DUPLICATE_REQUEST_IN_PROGRESS" }));
   }
 
   req.cwfBookSource = "customer";
@@ -24695,15 +24726,6 @@ function handlePublicCustomerUrgentBook(req, res) {
     technician_username: "",
     team_members: [],
     allow_time_proposal: true,
-  };
-
-  const settle = customerUrgentIdempotency.beginInFlight(requestKey);
-  const originalJson = res.json.bind(res);
-  res.json = (payload) => {
-    const ok = res.statusCode < 400 && payload && payload.success && payload.booking_code;
-    if (ok) settle.resolve({ booking_code: payload.booking_code, token: payload.token || null });
-    else settle.reject(new Error("urgent booking failed"));
-    return originalJson(payload);
   };
 
   return handleAdminBookV2(req, res);

--- a/index.js
+++ b/index.js
@@ -27,6 +27,7 @@ const fs = require("fs");
 const normalizerHelpers = require("./server/normalizers");
 const pricingHelpers = require("./server/pricing");
 const jobTiming = require("./server/services/jobTiming");
+const urgentPublicAdapter = require("./server/services/urgentPublicAdapter");
 const customerPricingHelpers = require("./server/customerPricing");
 const customerAuth = require("./server/customerAuth");
 const technicianIncomeHelpers = require("./server/technicianIncome");
@@ -24651,21 +24652,42 @@ app.get("/public/availability", async (req, res) => {
   }
 });
 
-function defaultCustomerUrgentAppointmentIso() {
-  return dateToBangkokISO(new Date(Date.now() + 30 * 60 * 1000));
-}
+const customerUrgentIdempotency = new urgentPublicAdapter.UrgentIdempotencyStore();
 
 function isCustomerAppUrgentBook(body = {}) {
   return String(body.booking_mode || "").trim().toLowerCase() === "urgent" &&
     String(body.client_app || "").trim().toLowerCase() === "customer_app_v2";
 }
 
+// Customer App V2 urgent requests are just another entry point into the
+// existing admin urgent offer engine (handleAdminBookV2): this adapter only
+// (a) strips the request down to a customer-safe allowlist, (b) computes a
+// rounded, business-hours-aware appointment time, and (c) deduplicates
+// retried/duplicate submits by client-generated urgent_request_key. It must
+// never branch into a separate dispatch/state machine.
 function handlePublicCustomerUrgentBook(req, res) {
-  const body = req.body || {};
+  const incoming = urgentPublicAdapter.sanitizeCustomerUrgentBody(req.body || {});
+  const requestKey = incoming.urgent_request_key;
+  if (!requestKey || requestKey.length < 16) {
+    return res.status(400).json({ error: "MISSING_REQUEST_KEY", code: "MISSING_REQUEST_KEY" });
+  }
+
+  const cached = customerUrgentIdempotency.getCached(requestKey);
+  if (cached) {
+    return res.json({ success: true, booking_code: cached.booking_code, token: cached.token, duplicate: true });
+  }
+
+  const inFlight = customerUrgentIdempotency.getInFlight(requestKey);
+  if (inFlight) {
+    return inFlight
+      .then((result) => res.json({ success: true, booking_code: result.booking_code, token: result.token, duplicate: true }))
+      .catch(() => res.status(409).json({ error: "DUPLICATE_REQUEST_IN_PROGRESS", code: "DUPLICATE_REQUEST_IN_PROGRESS" }));
+  }
+
   req.cwfBookSource = "customer";
   req.body = {
-    ...body,
-    appointment_datetime: defaultCustomerUrgentAppointmentIso(),
+    ...incoming,
+    appointment_datetime: urgentPublicAdapter.computeCustomerUrgentAppointmentIso(),
     booking_mode: "urgent",
     dispatch_mode: "offer",
     tech_type: "partner",
@@ -24673,10 +24695,17 @@ function handlePublicCustomerUrgentBook(req, res) {
     technician_username: "",
     team_members: [],
     allow_time_proposal: true,
-    override_price: undefined,
-    override_duration_min: undefined,
-    promotion_id: undefined,
   };
+
+  const settle = customerUrgentIdempotency.beginInFlight(requestKey);
+  const originalJson = res.json.bind(res);
+  res.json = (payload) => {
+    const ok = res.statusCode < 400 && payload && payload.success && payload.booking_code;
+    if (ok) settle.resolve({ booking_code: payload.booking_code, token: payload.token || null });
+    else settle.reject(new Error("urgent booking failed"));
+    return originalJson(payload);
+  };
+
   return handleAdminBookV2(req, res);
 }
 
@@ -25209,20 +25238,21 @@ if (itemIdQty.length) {
   }
 });
 
+// 100% read-only status lookup for the Customer App Waiting Room. Must never
+// mutate job_offers/jobs and must never leak job_id, technician identity,
+// offer counts, or admin/zone internals -- the response shape below is the
+// full contract.
 app.get("/public/urgent-status", async (req, res) => {
-  const q = String(req.query.q || req.query.token || req.query.booking_code || "").trim();
+  res.set("Cache-Control", "no-store, no-cache, must-revalidate, max-age=0");
+  res.set("Pragma", "no-cache");
+  res.set("Expires", "0");
+  const q = String(req.query.token || req.query.q || req.query.booking_code || "").trim();
   if (!q) return res.status(400).json({ error: "missing tracking code" });
   try {
-    await pool.query(`
-      UPDATE public.job_offers
-      SET status='expired'
-      WHERE status='pending' AND expires_at < NOW()
-    `);
-    await autoFinalizeUrgentJobs();
     const r = await pool.query(
       `
-      SELECT job_id, booking_code, booking_token, job_status, booking_mode, dispatch_mode,
-             technician_username, technician_team, appointment_datetime,
+      SELECT job_id, booking_code, booking_token, job_status, booking_mode,
+             technician_username, technician_team,
              COALESCE(allow_time_proposal,FALSE) AS allow_time_proposal
       FROM public.jobs
       WHERE booking_token=$1 OR booking_code=$1
@@ -25257,6 +25287,7 @@ app.get("/public/urgent-status", async (req, res) => {
     const hasAccepted = Boolean(job.technician_username || job.technician_team || offers.has_accepted_offer);
     const hasProposal = Boolean(proposalR.rows[0]?.has_pending_time_proposal) || String(job.job_status || "") === "รอพิจารณาเวลาใหม่";
     const hasPending = Boolean(offers.has_pending_offer);
+    const terminal = ["เสร็จแล้ว", "ยกเลิก"].includes(String(job.job_status || ""));
     const phase = hasAccepted
       ? "accepted"
       : hasProposal
@@ -25264,19 +25295,15 @@ app.get("/public/urgent-status", async (req, res) => {
         : hasPending
           ? "waiting"
           : "admin_review";
-    res.set("Cache-Control", "no-store");
     return res.json({
       success: true,
-      job_id: job.job_id,
       booking_code: job.booking_code || null,
-      booking_mode: job.booking_mode || null,
-      dispatch_mode: job.dispatch_mode || null,
-      job_status: job.job_status || null,
       phase,
-      appointment_datetime: job.appointment_datetime || null,
-      allow_time_proposal: Boolean(job.allow_time_proposal),
-      has_pending_offer: hasPending,
+      confirmed: hasAccepted,
+      terminal,
+      server_now: jobTiming.getBangkokNow().iso,
       next_offer_expires_at: offers.next_offer_expires_at || null,
+      allow_time_proposal: Boolean(job.allow_time_proposal),
     });
   } catch (e) {
     console.error("GET /public/urgent-status error:", e);

--- a/index.js
+++ b/index.js
@@ -11664,15 +11664,6 @@ try {
       `CREATE UNIQUE INDEX IF NOT EXISTS idx_jobs_booking_code_unique ON public.jobs(booking_code)`
     );
 
-    // Defense-in-depth for durable urgent-booking idempotency: booking_token
-    // is deterministically derived from urgent_request_key for customer
-    // urgent requests (see deriveUrgentBookingToken), so a unique index here
-    // guarantees at most one job per request key even if the advisory-lock
-    // dedup check in handleAdminBookV2 were ever bypassed or raced.
-    await pool.query(
-      `CREATE UNIQUE INDEX IF NOT EXISTS idx_jobs_booking_token_unique ON public.jobs(booking_token) WHERE booking_token IS NOT NULL`
-    );
-
     // backfill booking_code
     await pool.query(`
       UPDATE public.jobs

--- a/server/services/urgentPublicAdapter.js
+++ b/server/services/urgentPublicAdapter.js
@@ -1,0 +1,153 @@
+"use strict";
+
+const jobTiming = require("./jobTiming");
+
+const URGENT_LEAD_TIME_MIN = 30;
+const UI_START_MIN = 9 * 60; // 09:00, matches the Admin Add locked business window
+const UI_END_MIN = 18 * 60; // 18:00
+const IDEMPOTENCY_TTL_MS = 10 * 60 * 1000;
+
+function coerceNumber(value, fallback = 0) {
+  const n = Number(value);
+  return Number.isFinite(n) ? n : fallback;
+}
+
+function sanitizeCustomerServiceLine(raw) {
+  const item = raw && typeof raw === "object" ? raw : {};
+  return {
+    job_type: String(item.job_type || "").trim(),
+    ac_type: String(item.ac_type || "").trim(),
+    btu: coerceNumber(item.btu, 0),
+    machine_count: Math.max(1, coerceNumber(item.machine_count, 1)),
+    wash_variant: String(item.wash_variant || "").trim(),
+    repair_variant: String(item.repair_variant || "").trim(),
+  };
+}
+
+// Strict allowlist: only customer-safe fields are allowed to cross into the
+// existing admin urgent offer engine (handleAdminBookV2). Anything not listed
+// here -- override_price, override_duration_min, promotion_id,
+// service_zone_code, technician_username, team_members, etc. -- is dropped,
+// so a customer-sourced request can never reach admin-only behavior or force
+// a zone override. Zone is always re-derived from address_text/job_zone/maps_url
+// by the existing detectServiceZoneFromText logic inside handleAdminBookV2.
+function sanitizeCustomerUrgentBody(body) {
+  const src = body && typeof body === "object" ? body : {};
+  const services = Array.isArray(src.services) && src.services.length
+    ? src.services.slice(0, 10).map(sanitizeCustomerServiceLine)
+    : null;
+  return {
+    customer_name: String(src.customer_name || "").trim(),
+    customer_phone: String(src.customer_phone || "").trim(),
+    address_text: String(src.address_text || "").trim(),
+    maps_url: String(src.maps_url || "").trim(),
+    job_zone: String(src.job_zone || "").trim(),
+    customer_note: String(src.customer_note || "").trim(),
+    job_type: String(src.job_type || "").trim(),
+    ac_type: String(src.ac_type || "").trim(),
+    btu: coerceNumber(src.btu, 0),
+    machine_count: Math.max(1, coerceNumber(src.machine_count, 1)),
+    wash_variant: String(src.wash_variant || "").trim(),
+    repair_variant: String(src.repair_variant || "").trim(),
+    services,
+    client_app: "customer_app_v2",
+    urgent_request_key: String(src.urgent_request_key || "").trim(),
+  };
+}
+
+function addDaysToYmd(ymd, days) {
+  const d = new Date(`${String(ymd)}T00:00:00Z`);
+  d.setUTCDate(d.getUTCDate() + Number(days || 0));
+  return d.toISOString().slice(0, 10);
+}
+
+// Server-side, Asia/Bangkok, business-hours-aware urgent appointment
+// timestamp: now + lead time, rounded UP to the nearest slot step, clamped
+// to the 09:00-18:00 window (rolling to next day's open if past close).
+// Reuses jobTiming's canonical Bangkok-now/step-rounding helpers instead of
+// duplicating that formula; only the "roll to next business day" extension
+// (specific to this urgent lead-time use case) lives here.
+function computeCustomerUrgentAppointmentIso(now = jobTiming.getBangkokNow()) {
+  const nowMin = (Number(now.hour || 0) * 60) + Number(now.minute || 0);
+  const rounded = jobTiming.ceilMinuteToStep(nowMin + URGENT_LEAD_TIME_MIN, jobTiming.SLOT_STEP_MIN);
+  let targetDate = now.ymd;
+  let targetMin;
+  if (rounded <= UI_END_MIN) {
+    targetMin = Math.max(UI_START_MIN, rounded);
+  } else {
+    targetDate = addDaysToYmd(now.ymd, 1);
+    targetMin = UI_START_MIN;
+  }
+  const hh = String(Math.floor(targetMin / 60)).padStart(2, "0");
+  const mm = String(targetMin % 60).padStart(2, "0");
+  return `${targetDate}T${hh}:${mm}:00+07:00`;
+}
+
+// ---------------------------------------------------------------------------
+// Best-effort, single-process idempotency for retried/duplicate urgent
+// requests that share the same client-generated urgent_request_key.
+//
+// SCOPE MISMATCH (reported, not silently worked around): a durable,
+// cross-instance/cross-restart guarantee needs a unique column to lock on
+// (e.g. on public.jobs or public.job_offers), which is a schema change. Per
+// the explicit instruction not to create a migration in this round, this
+// layer is in-memory only: it dedups retries / double-taps / multi-tab
+// submits landing on the same Node process, but does NOT survive a process
+// restart and does NOT protect against two different server instances
+// racing on the same key. That guarantee needs an owner-approved migration.
+// ---------------------------------------------------------------------------
+class UrgentIdempotencyStore {
+  constructor(ttlMs = IDEMPOTENCY_TTL_MS) {
+    this.ttlMs = ttlMs;
+    this.cache = new Map();
+    this.inFlight = new Map();
+  }
+
+  prune() {
+    const cutoff = Date.now() - this.ttlMs;
+    for (const [key, entry] of this.cache.entries()) {
+      if (entry.ts < cutoff) this.cache.delete(key);
+    }
+  }
+
+  getCached(key) {
+    this.prune();
+    return key ? this.cache.get(key) || null : null;
+  }
+
+  getInFlight(key) {
+    return key ? this.inFlight.get(key) || null : null;
+  }
+
+  beginInFlight(key) {
+    let resolveFn;
+    let rejectFn;
+    const promise = new Promise((resolve, reject) => {
+      resolveFn = resolve;
+      rejectFn = reject;
+    });
+    promise.catch(() => {}); // avoid an unhandled rejection when a solo (non-duplicate) request fails
+    this.inFlight.set(key, promise);
+    return {
+      resolve: (result) => {
+        this.inFlight.delete(key);
+        this.cache.set(key, { ...result, ts: Date.now() });
+        resolveFn(result);
+      },
+      reject: (err) => {
+        this.inFlight.delete(key);
+        rejectFn(err);
+      },
+    };
+  }
+}
+
+module.exports = {
+  URGENT_LEAD_TIME_MIN,
+  UI_START_MIN,
+  UI_END_MIN,
+  sanitizeCustomerServiceLine,
+  sanitizeCustomerUrgentBody,
+  computeCustomerUrgentAppointmentIso,
+  UrgentIdempotencyStore,
+};

--- a/server/services/urgentPublicAdapter.js
+++ b/server/services/urgentPublicAdapter.js
@@ -1,11 +1,11 @@
 "use strict";
 
+const crypto = require("crypto");
 const jobTiming = require("./jobTiming");
 
 const URGENT_LEAD_TIME_MIN = 30;
 const UI_START_MIN = 9 * 60; // 09:00, matches the Admin Add locked business window
 const UI_END_MIN = 18 * 60; // 18:00
-const IDEMPOTENCY_TTL_MS = 10 * 60 * 1000;
 
 function coerceNumber(value, fallback = 0) {
   const n = Number(value);
@@ -84,62 +84,27 @@ function computeCustomerUrgentAppointmentIso(now = jobTiming.getBangkokNow()) {
 }
 
 // ---------------------------------------------------------------------------
-// Best-effort, single-process idempotency for retried/duplicate urgent
-// requests that share the same client-generated urgent_request_key.
+// Durable, DB-backed idempotency for retried/duplicate urgent requests that
+// share the same client-generated urgent_request_key.
 //
-// SCOPE MISMATCH (reported, not silently worked around): a durable,
-// cross-instance/cross-restart guarantee needs a unique column to lock on
-// (e.g. on public.jobs or public.job_offers), which is a schema change. Per
-// the explicit instruction not to create a migration in this round, this
-// layer is in-memory only: it dedups retries / double-taps / multi-tab
-// submits landing on the same Node process, but does NOT survive a process
-// restart and does NOT protect against two different server instances
-// racing on the same key. That guarantee needs an owner-approved migration.
+// Rather than an in-memory cache (which does not survive a process restart
+// and does not protect against two server instances racing on the same
+// key), the request key is hashed into a deterministic booking_token. The
+// caller (handleAdminBookV2) takes a Postgres advisory lock keyed on the
+// raw request key inside its existing per-request transaction, then looks
+// up an existing public.jobs row by this deterministic token before
+// inserting a new one. Because the lock is transaction-scoped
+// (pg_advisory_xact_lock) it auto-releases on COMMIT/ROLLBACK -- including
+// on a crashed connection -- and is visible to every connection on the same
+// Postgres instance, so restarts, multiple app-server instances, and
+// concurrent requests all converge on a single committed job/offer set
+// without requiring a new table or a separate migration: booking_token
+// already exists on public.jobs.
 // ---------------------------------------------------------------------------
-class UrgentIdempotencyStore {
-  constructor(ttlMs = IDEMPOTENCY_TTL_MS) {
-    this.ttlMs = ttlMs;
-    this.cache = new Map();
-    this.inFlight = new Map();
-  }
-
-  prune() {
-    const cutoff = Date.now() - this.ttlMs;
-    for (const [key, entry] of this.cache.entries()) {
-      if (entry.ts < cutoff) this.cache.delete(key);
-    }
-  }
-
-  getCached(key) {
-    this.prune();
-    return key ? this.cache.get(key) || null : null;
-  }
-
-  getInFlight(key) {
-    return key ? this.inFlight.get(key) || null : null;
-  }
-
-  beginInFlight(key) {
-    let resolveFn;
-    let rejectFn;
-    const promise = new Promise((resolve, reject) => {
-      resolveFn = resolve;
-      rejectFn = reject;
-    });
-    promise.catch(() => {}); // avoid an unhandled rejection when a solo (non-duplicate) request fails
-    this.inFlight.set(key, promise);
-    return {
-      resolve: (result) => {
-        this.inFlight.delete(key);
-        this.cache.set(key, { ...result, ts: Date.now() });
-        resolveFn(result);
-      },
-      reject: (err) => {
-        this.inFlight.delete(key);
-        rejectFn(err);
-      },
-    };
-  }
+function deriveUrgentBookingToken(requestKey) {
+  const key = String(requestKey || "").trim();
+  if (!key) return null;
+  return crypto.createHash("sha256").update(`urgent_v1:${key}`).digest("hex").slice(0, 24);
 }
 
 module.exports = {
@@ -149,5 +114,5 @@ module.exports = {
   sanitizeCustomerServiceLine,
   sanitizeCustomerUrgentBody,
   computeCustomerUrgentAppointmentIso,
-  UrgentIdempotencyStore,
+  deriveUrgentBookingToken,
 };

--- a/test/customerAppRecovery.test.js
+++ b/test/customerAppRecovery.test.js
@@ -462,9 +462,23 @@ test("urgent request key is generated once, reused on resubmits, and cleared on 
       assert.equal(root.state.draft.urgent.urgent_request_key, firstKey);
 
       root.bookingUrgent.render.onLeave();
+
+      // While the request is still non-terminal (waiting/time_proposed/
+      // admin_review), "new-request" must be a no-op: the key must survive.
       return container.querySelectorAll("[data-urgent-action]")
         .find((button) => button.getAttribute("data-urgent-action") === "new-request")
-        .click();
+        .click()
+        .then(() => {
+          assert.equal(root.state.draft.urgent.urgent_request_key, firstKey);
+
+          // Only once the live status is genuinely terminal does the
+          // "new-request" action clear the key and reset the flow.
+          root.state.setUrgentFlow({ liveStatus: { terminal: true, phase: "closed" } });
+          root.bookingUrgent.render(container);
+          return container.querySelectorAll("[data-urgent-action]")
+            .find((button) => button.getAttribute("data-urgent-action") === "new-request")
+            .click();
+        });
     })
     .then(() => {
       assert.equal(root.state.draft.urgent.urgent_request_key, "");

--- a/test/customerAppRecovery.test.js
+++ b/test/customerAppRecovery.test.js
@@ -135,7 +135,7 @@ test("Customer App build id is consistent across shell and service worker", () =
   const sw = read("customer-app/sw.js");
   const app = read("customer-app/assets/customer-app.js");
   const manifest = read("customer-app/manifest.webmanifest");
-  const build = "20260622_same_day_timing_v1";
+  const build = "20260622_urgent_offer_flow_v1";
 
   assert.match(index, new RegExp(`customer-app\\.css\\?v=${build}`));
   assert.match(index, new RegExp(`bookingUrgent\\.js\\?v=${build}`));
@@ -336,4 +336,34 @@ test("urgent route is registered and renders distinct urgent screen", () => {
   root.bookingUrgent.render(container);
   assert.match(container.innerHTML, /data-urgent-step="form"/);
   assert.match(container.innerHTML, /คิวด่วน/);
+});
+
+test("customer urgent booking reuses existing offer flow without client fake appointment", () => {
+  const urgent = read("customer-app/modules/bookingUrgent.js");
+  const api = read("customer-app/modules/api.js");
+  const server = read("index.js");
+
+  assert.doesNotMatch(urgent, /nextUrgentAppointmentIso/);
+  assert.doesNotMatch(urgent, /appointment_datetime:\s*nextUrgentAppointmentIso/);
+  assert.match(urgent, /allow_time_proposal:\s*true/);
+  assert.match(api, /dispatch_mode:\s*"offer"/);
+  assert.match(api, /allow_time_proposal:\s*true/);
+  assert.match(server, /function handlePublicCustomerUrgentBook/);
+  assert.match(server, /return handleAdminBookV2\(req,\s*res\)/);
+  assert.match(server, /req\.cwfBookSource = "customer"/);
+});
+
+test("customer urgent waiting room polls anonymous existing offer status", () => {
+  const urgent = read("customer-app/modules/bookingUrgent.js");
+  const api = read("customer-app/modules/api.js");
+  const server = read("index.js");
+
+  assert.match(api, /loadUrgentStatus/);
+  assert.match(urgent, /pollUrgentStatus/);
+  assert.match(urgent, /data-urgent-live-status/);
+  assert.match(server, /app\.get\("\/public\/urgent-status"/);
+  const statusRoute = server.slice(server.indexOf('app.get("/public/urgent-status"'), server.indexOf('app.get("/public/track"'));
+  assert.match(statusRoute, /next_offer_expires_at/);
+  assert.match(statusRoute, /phase/);
+  assert.doesNotMatch(statusRoute, /tech_name|full_name|matrix_json|technician_count/);
 });

--- a/test/customerAppRecovery.test.js
+++ b/test/customerAppRecovery.test.js
@@ -39,6 +39,14 @@ function makeContext() {
     console,
     setTimeout,
     clearTimeout,
+    // Unref'd so a timer left running by a module under test (e.g. a
+    // forgotten cleanup call) never keeps the test process alive.
+    setInterval(...args) {
+      const timer = setInterval(...args);
+      if (typeof timer.unref === "function") timer.unref();
+      return timer;
+    },
+    clearInterval,
     requestAnimationFrame(fn) { return fn(); },
     fetch: async () => ({ ok: true, text: async () => "{}" }),
   };
@@ -105,12 +113,19 @@ class WizardContainer {
     [...this._innerHTML.matchAll(/data-action="([^"]+)"/g)].forEach((match) => this.buttons.push(new FakeButton({ "data-action": match[1] })));
     [...this._innerHTML.matchAll(/data-scheduled-choice="([^"]+)"[^>]*data-choice-value="([^"]+)"/g)]
       .forEach((match) => this.buttons.push(new FakeButton({ "data-scheduled-choice": match[1], "data-choice-value": match[2] })));
+    [...this._innerHTML.matchAll(/data-urgent-action="([^"]+)"/g)].forEach((match) => this.buttons.push(new FakeButton({ "data-urgent-action": match[1] })));
   }
   get innerHTML() { return this._innerHTML; }
   scrollIntoView() {}
+  querySelector(selector) {
+    if (selector === "[data-urgent-live-status]") return null;
+    return null;
+  }
   querySelectorAll(selector) {
     if (selector === "[data-action]") return this.buttons.filter((button) => button.hasAttribute("data-action"));
     if (selector === "[data-scheduled-choice]") return this.buttons.filter((button) => button.hasAttribute("data-scheduled-choice"));
+    if (selector === "[data-urgent-action]") return this.buttons.filter((button) => button.hasAttribute("data-urgent-action"));
+    if (selector === "[data-urgent-field]" || selector === "[data-urgent-choice]") return [];
     return [];
   }
 }
@@ -366,4 +381,92 @@ test("customer urgent waiting room polls anonymous existing offer status", () =>
   assert.match(statusRoute, /next_offer_expires_at/);
   assert.match(statusRoute, /phase/);
   assert.doesNotMatch(statusRoute, /tech_name|full_name|matrix_json|technician_count/);
+});
+
+test("urgent waiting room navigates to tracking once the live status reports an accepted offer", async () => {
+  const context = makeContext();
+  const root = loadCustomerFrontend(context);
+  const routeCalls = [];
+  root.utils.routeTo = (route) => { routeCalls.push(route); root.state.setRoute(route); };
+  root.state.setRoute("urgent");
+  root.state.setUrgentFlow({
+    step: "waiting", status: "success", error: "",
+    result: { booking_code: "BK1", token: "TOK1", offers_count: 1 },
+    liveStatus: null, liveStatusError: "",
+  });
+  root.api.loadUrgentStatus = async () => ({
+    success: true, booking_code: "BK1", phase: "accepted", confirmed: true, terminal: false,
+    server_now: "2026-06-22T10:00:00+07:00", next_offer_expires_at: null, allow_time_proposal: true,
+  });
+
+  const container = new WizardContainer(root);
+  root.bookingUrgent.render(container);
+  await new Promise((resolve) => setTimeout(resolve, 0));
+
+  assert.deepEqual(routeCalls, ["tracking"]);
+  assert.equal(root.state.draft.tracking.trackingCode, "TOK1");
+  root.bookingUrgent.render.onLeave();
+});
+
+test("urgent waiting room shows the terminal message and stops polling without navigating", async () => {
+  const context = makeContext();
+  const root = loadCustomerFrontend(context);
+  const routeCalls = [];
+  root.utils.routeTo = (route) => { routeCalls.push(route); root.state.setRoute(route); };
+  root.state.setRoute("urgent");
+  root.state.setUrgentFlow({
+    step: "waiting", status: "success", error: "",
+    result: { booking_code: "BK2", token: "TOK2", offers_count: 1 },
+    liveStatus: null, liveStatusError: "",
+  });
+  let calls = 0;
+  root.api.loadUrgentStatus = async () => {
+    calls += 1;
+    return {
+      success: true, booking_code: "BK2", phase: "admin_review", confirmed: false, terminal: true,
+      server_now: "2026-06-22T10:00:00+07:00", next_offer_expires_at: null, allow_time_proposal: true,
+    };
+  };
+
+  const container = new WizardContainer(root);
+  root.bookingUrgent.render(container);
+  await new Promise((resolve) => setTimeout(resolve, 0));
+
+  assert.deepEqual(routeCalls, []);
+  assert.equal(root.state.urgentFlow.liveStatus.terminal, true);
+  assert.match(container.innerHTML, /คำขอคิวด่วนนี้ปิดแล้ว/);
+  assert.equal(calls, 1);
+  root.bookingUrgent.render.onLeave();
+});
+
+test("urgent request key is generated once, reused on resubmits, and cleared on a genuinely new request", () => {
+  const context = makeContext();
+  const root = loadCustomerFrontend(context);
+  root.state.updateDraft("urgent", {
+    customer_name: "Somchai", customer_phone: "0812345678", address_text: "123 Rd", symptom: "ไม่เย็น",
+  });
+  const container = new WizardContainer(root);
+  root.bookingUrgent.render(container);
+
+  let capturedPayload = null;
+  root.api.submitUrgentRequest = async (payload) => { capturedPayload = payload; return { success: true, booking_code: "BK3", token: "TOK3" }; };
+
+  root.state.setUrgentFlow({ step: "review" });
+  root.bookingUrgent.render(container);
+  return container.querySelectorAll("[data-urgent-action]")
+    .find((button) => button.getAttribute("data-urgent-action") === "confirm").click()
+    .then(() => {
+      assert.ok(capturedPayload.urgent_request_key);
+      assert.equal(capturedPayload.urgent_request_key.length >= 16, true);
+      const firstKey = capturedPayload.urgent_request_key;
+      assert.equal(root.state.draft.urgent.urgent_request_key, firstKey);
+
+      root.bookingUrgent.render.onLeave();
+      return container.querySelectorAll("[data-urgent-action]")
+        .find((button) => button.getAttribute("data-urgent-action") === "new-request")
+        .click();
+    })
+    .then(() => {
+      assert.equal(root.state.draft.urgent.urgent_request_key, "");
+    });
 });

--- a/test/customerSameDayTiming.test.js
+++ b/test/customerSameDayTiming.test.js
@@ -160,7 +160,7 @@ test("customer app disables availability HTTP cache and refreshes same-day slots
 });
 
 test("customer app build and service worker cache IDs changed", () => {
-  const id = "20260622_same_day_timing_v1";
+  const id = "20260622_urgent_offer_flow_v1";
   for (const file of [
     "customer-app/index.html",
     "customer-app/sw.js",

--- a/test/urgentPublicAdapter.test.js
+++ b/test/urgentPublicAdapter.test.js
@@ -1,0 +1,138 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const urgentPublicAdapter = require("../server/services/urgentPublicAdapter");
+
+test("sanitizeCustomerUrgentBody drops admin-only fields and keeps customer-safe ones", () => {
+  const out = urgentPublicAdapter.sanitizeCustomerUrgentBody({
+    customer_name: "  Somchai  ",
+    customer_phone: "0812345678",
+    address_text: "123 Test Rd",
+    maps_url: "https://maps.app.goo.gl/x",
+    job_zone: "north",
+    customer_note: "leaking",
+    job_type: "ล้าง",
+    ac_type: "ผนัง",
+    btu: "12000",
+    machine_count: "2",
+    wash_variant: "ล้างธรรมดา",
+    repair_variant: "",
+    services: [{ job_type: "ล้าง", ac_type: "ผนัง", btu: "9000", machine_count: "1" }],
+    // admin-only / dangerous passthrough fields that MUST be dropped
+    override_price: 1,
+    override_duration_min: 999,
+    promotion_id: 5,
+    service_zone_code: "ZONE_OVERRIDE",
+    technician_username: "tech1",
+    team_members: ["tech1", "tech2"],
+    job_id: 123,
+    job_status: "เสร็จแล้ว",
+  });
+
+  assert.equal(out.customer_name, "Somchai");
+  assert.equal(out.customer_phone, "0812345678");
+  assert.equal(out.btu, 12000);
+  assert.equal(out.machine_count, 2);
+  assert.equal(out.client_app, "customer_app_v2");
+  assert.deepEqual(Object.keys(out).sort(), [
+    "ac_type", "address_text", "btu", "client_app", "customer_name", "customer_note",
+    "customer_phone", "job_type", "job_zone", "machine_count", "maps_url",
+    "repair_variant", "services", "urgent_request_key", "wash_variant",
+  ].sort());
+  assert.equal(out.service_zone_code, undefined);
+  assert.equal(out.override_price, undefined);
+  assert.equal(out.override_duration_min, undefined);
+  assert.equal(out.promotion_id, undefined);
+  assert.equal(out.technician_username, undefined);
+  assert.equal(out.team_members, undefined);
+  assert.equal(out.job_id, undefined);
+  assert.equal(out.job_status, undefined);
+});
+
+test("sanitizeCustomerUrgentBody sanitizes nested service lines the same way", () => {
+  const out = urgentPublicAdapter.sanitizeCustomerUrgentBody({
+    services: [
+      { job_type: "ล้าง", ac_type: "ผนัง", btu: "9000", machine_count: "3", service_zone_code: "X", override_price: 1 },
+    ],
+  });
+  assert.equal(out.services.length, 1);
+  assert.deepEqual(Object.keys(out.services[0]).sort(), ["ac_type", "btu", "job_type", "machine_count", "repair_variant", "wash_variant"].sort());
+  assert.equal(out.services[0].machine_count, 3);
+});
+
+test("sanitizeCustomerUrgentBody caps services list at 10 entries", () => {
+  const services = Array.from({ length: 15 }, () => ({ job_type: "ล้าง" }));
+  const out = urgentPublicAdapter.sanitizeCustomerUrgentBody({ services });
+  assert.equal(out.services.length, 10);
+});
+
+test("computeCustomerUrgentAppointmentIso rounds up to the next slot step within business hours", () => {
+  const iso = urgentPublicAdapter.computeCustomerUrgentAppointmentIso({ ymd: "2026-06-22", hour: 10, minute: 5 });
+  // 10:05 + 30min lead = 10:35, ceil to 30-step => 11:00
+  assert.equal(iso, "2026-06-22T11:00:00+07:00");
+});
+
+test("computeCustomerUrgentAppointmentIso clamps to opening time when lead time lands before 09:00", () => {
+  const iso = urgentPublicAdapter.computeCustomerUrgentAppointmentIso({ ymd: "2026-06-22", hour: 8, minute: 10 });
+  assert.equal(iso, "2026-06-22T09:00:00+07:00");
+});
+
+test("computeCustomerUrgentAppointmentIso rolls over to next day's opening when lead time lands after 18:00", () => {
+  const iso = urgentPublicAdapter.computeCustomerUrgentAppointmentIso({ ymd: "2026-06-22", hour: 17, minute: 45 });
+  // 17:45 + 30min lead = 18:15, past UI_END_MIN(18:00) => roll to next day 09:00
+  assert.equal(iso, "2026-06-23T09:00:00+07:00");
+});
+
+test("computeCustomerUrgentAppointmentIso rolls month/year boundaries correctly", () => {
+  const iso = urgentPublicAdapter.computeCustomerUrgentAppointmentIso({ ymd: "2026-12-31", hour: 17, minute: 50 });
+  assert.equal(iso, "2027-01-01T09:00:00+07:00");
+});
+
+test("UrgentIdempotencyStore caches a settled result and replays it for the same key", () => {
+  const store = new urgentPublicAdapter.UrgentIdempotencyStore();
+  assert.equal(store.getCached("key1"), null);
+  const settle = store.beginInFlight("key1");
+  assert.equal(store.getInFlight("key1") !== null, true);
+  settle.resolve({ booking_code: "B1", token: "T1" });
+  assert.equal(store.getInFlight("key1"), null);
+  const cached = store.getCached("key1");
+  assert.equal(cached.booking_code, "B1");
+  assert.equal(cached.token, "T1");
+});
+
+test("UrgentIdempotencyStore exposes the in-flight promise so concurrent duplicates can await the same result", async () => {
+  const store = new urgentPublicAdapter.UrgentIdempotencyStore();
+  const settle = store.beginInFlight("key2");
+  const inFlight = store.getInFlight("key2");
+  assert.ok(inFlight);
+  settle.resolve({ booking_code: "B2", token: "T2" });
+  const result = await inFlight;
+  assert.equal(result.booking_code, "B2");
+});
+
+test("UrgentIdempotencyStore does not cache a rejected in-flight request", async () => {
+  const store = new urgentPublicAdapter.UrgentIdempotencyStore();
+  const settle = store.beginInFlight("key3");
+  const inFlight = store.getInFlight("key3");
+  settle.reject(new Error("boom"));
+  await assert.rejects(inFlight);
+  assert.equal(store.getCached("key3"), null);
+  assert.equal(store.getInFlight("key3"), null);
+});
+
+test("UrgentIdempotencyStore keeps different keys independent", () => {
+  const store = new urgentPublicAdapter.UrgentIdempotencyStore();
+  store.beginInFlight("a").resolve({ booking_code: "A" });
+  assert.equal(store.getCached("a").booking_code, "A");
+  assert.equal(store.getCached("b"), null);
+});
+
+test("UrgentIdempotencyStore prunes entries older than the TTL", () => {
+  const store = new urgentPublicAdapter.UrgentIdempotencyStore(1);
+  store.beginInFlight("old").resolve({ booking_code: "OLD" });
+  assert.equal(store.getCached("old").booking_code, "OLD");
+  return new Promise((resolve) => setTimeout(() => {
+    assert.equal(store.getCached("old"), null);
+    resolve();
+  }, 20));
+});

--- a/test/urgentPublicAdapter.test.js
+++ b/test/urgentPublicAdapter.test.js
@@ -88,51 +88,28 @@ test("computeCustomerUrgentAppointmentIso rolls month/year boundaries correctly"
   assert.equal(iso, "2027-01-01T09:00:00+07:00");
 });
 
-test("UrgentIdempotencyStore caches a settled result and replays it for the same key", () => {
-  const store = new urgentPublicAdapter.UrgentIdempotencyStore();
-  assert.equal(store.getCached("key1"), null);
-  const settle = store.beginInFlight("key1");
-  assert.equal(store.getInFlight("key1") !== null, true);
-  settle.resolve({ booking_code: "B1", token: "T1" });
-  assert.equal(store.getInFlight("key1"), null);
-  const cached = store.getCached("key1");
-  assert.equal(cached.booking_code, "B1");
-  assert.equal(cached.token, "T1");
+test("deriveUrgentBookingToken is deterministic for the same request key", () => {
+  const a = urgentPublicAdapter.deriveUrgentBookingToken("same-key-123");
+  const b = urgentPublicAdapter.deriveUrgentBookingToken("same-key-123");
+  assert.equal(a, b);
+  assert.equal(typeof a, "string");
+  assert.equal(a.length, 24);
 });
 
-test("UrgentIdempotencyStore exposes the in-flight promise so concurrent duplicates can await the same result", async () => {
-  const store = new urgentPublicAdapter.UrgentIdempotencyStore();
-  const settle = store.beginInFlight("key2");
-  const inFlight = store.getInFlight("key2");
-  assert.ok(inFlight);
-  settle.resolve({ booking_code: "B2", token: "T2" });
-  const result = await inFlight;
-  assert.equal(result.booking_code, "B2");
+test("deriveUrgentBookingToken differs for different request keys", () => {
+  const a = urgentPublicAdapter.deriveUrgentBookingToken("key-one");
+  const b = urgentPublicAdapter.deriveUrgentBookingToken("key-two");
+  assert.notEqual(a, b);
 });
 
-test("UrgentIdempotencyStore does not cache a rejected in-flight request", async () => {
-  const store = new urgentPublicAdapter.UrgentIdempotencyStore();
-  const settle = store.beginInFlight("key3");
-  const inFlight = store.getInFlight("key3");
-  settle.reject(new Error("boom"));
-  await assert.rejects(inFlight);
-  assert.equal(store.getCached("key3"), null);
-  assert.equal(store.getInFlight("key3"), null);
+test("deriveUrgentBookingToken returns null for an empty or missing key", () => {
+  assert.equal(urgentPublicAdapter.deriveUrgentBookingToken(""), null);
+  assert.equal(urgentPublicAdapter.deriveUrgentBookingToken(undefined), null);
+  assert.equal(urgentPublicAdapter.deriveUrgentBookingToken(null), null);
 });
 
-test("UrgentIdempotencyStore keeps different keys independent", () => {
-  const store = new urgentPublicAdapter.UrgentIdempotencyStore();
-  store.beginInFlight("a").resolve({ booking_code: "A" });
-  assert.equal(store.getCached("a").booking_code, "A");
-  assert.equal(store.getCached("b"), null);
-});
-
-test("UrgentIdempotencyStore prunes entries older than the TTL", () => {
-  const store = new urgentPublicAdapter.UrgentIdempotencyStore(1);
-  store.beginInFlight("old").resolve({ booking_code: "OLD" });
-  assert.equal(store.getCached("old").booking_code, "OLD");
-  return new Promise((resolve) => setTimeout(() => {
-    assert.equal(store.getCached("old"), null);
-    resolve();
-  }, 20));
+test("deriveUrgentBookingToken trims whitespace before hashing", () => {
+  const a = urgentPublicAdapter.deriveUrgentBookingToken("  padded-key  ");
+  const b = urgentPublicAdapter.deriveUrgentBookingToken("padded-key");
+  assert.equal(a, b);
 });


### PR DESCRIPTION
## Trace of existing Admin Add urgent flow
- Admin Add submits urgent mode to `/admin/book_v2`.
- `handleAdminBookV2` normalizes urgent as `booking_mode='urgent'` and `dispatch_mode='offer'`.
- The existing handler resolves pricing/duration, service zone, ready technicians, zone ranking, collision checks, and writes `jobs` plus `job_offers` with expiry.
- Technician app polls `/offers/tech/:username`, which only returns pending unexpired offers for authenticated ready technicians.
- Technician accepts through `/offers/:offer_id/accept`, which locks the offer/job, rechecks collision, first-accept-wins by expiring other pending offers, and assigns `technician_username`/`technician_team`.
- Technician proposes a new time through `/offers/:offer_id/time-proposal` when `allow_time_proposal` is true.
- Technician declines through `/offers/:offer_id/decline`; no decline reason is added.

## Summary
- Route Customer App urgent submissions into the existing `handleAdminBookV2` urgent offer path instead of using the duplicate public urgent offer block.
- Preserve `booking_mode='urgent'`, `dispatch_mode='offer'`, partner tech targeting, existing ready-toggle, zone, collision, offer expiry, first-accept-wins, and time-proposal behavior.
- Default Customer App urgent requests to `allow_time_proposal=true`.
- Remove client-generated urgent appointment time; the server assigns the urgent request timestamp before entering the existing offer flow.
- Add anonymous `/public/urgent-status` for Customer App Waiting Room polling/countdown without exposing technician identity.
- Prevent duplicate urgent submit and preserve Waiting Room across rerenders.
- Bump Customer App cache/build IDs.

## Tests
- `node --check index.js`
- `node --check customer-app/modules/api.js`
- `node --check customer-app/modules/bookingUrgent.js`
- `node --check customer-app/assets/customer-app.js`
- `node --check customer-app/sw.js`
- `node --test test/customerAppRecovery.test.js --test-reporter=spec` => 12/12 passed
- `npm.cmd test` => 154 passed, 7 skipped because local Postgres integration DB auth was unavailable
- `git diff --check` => passed

## Safety
- No new offer tables.
- No second urgent state machine.
- No automatic technician selection for urgent before technician acceptance.
- No decline reasons.
- No Admin Add urgent rewrite.
- Public status response does not include technician name, username, ID, matrix, or counts.