### PR TITLE
Fix urgent admin fallback, expiry finalization, and offer access

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,7 +1,7 @@
 
 
 // CWF Technician App Stable fix12: force real 20-row history page + cache-bust marker
-window.__CWF_TECH_APP_VERSION__ = "20260622_legacy_cap_policy_tech_cache_v1";
+window.__CWF_TECH_APP_VERSION__ = "20260622_urgent_offer_session_v1";
 try { console.info('[CWF_TECH_APP_VERSION]', window.__CWF_TECH_APP_VERSION__); } catch (_) {}
 
 // ✅ งานปัจจุบัน: งานล่วงหน้า (sub-tab)
@@ -1235,7 +1235,7 @@ function setPushUi(state, text) {
 
 async function ensureServiceWorkerForPush() {
   if (!('serviceWorker' in navigator)) throw new Error('เครื่องนี้ไม่รองรับ Service Worker');
-  const reg = await navigator.serviceWorker.register('/sw.js?v=20260622_legacy_cap_policy_tech_cache_v1', { updateViaCache: 'none' });
+  const reg = await navigator.serviceWorker.register('/sw.js?v=20260622_urgent_offer_session_v1', { updateViaCache: 'none' });
   try { await navigator.serviceWorker.ready; } catch (_) {}
   return reg;
 }
@@ -2971,7 +2971,7 @@ function loadOffers() {
   const duplicate = cwfTechShouldSkipDuplicate('offers');
   if (duplicate) return duplicate;
   __CWF_TECH_API_DEDUP__.offersInFlight = true;
-  const promise = fetch(`${API_BASE}/offers/tech/${username}`, { cache: "no-store" })
+  const promise = fetch(`${API_BASE}/offers/tech/me`, { credentials: "include", cache: "no-store" })
     .then((res) => res.json())
     .then((offers) => {
       const list = Array.isArray(offers) ? offers : [];
@@ -3107,7 +3107,7 @@ function submitTimeProposal(offerId, originalIso) {
   fetch(`${API_BASE}/offers/${offerId}/time-proposal`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ username, proposed_datetime: value, note: note?.value || "" }),
+    body: JSON.stringify({ proposed_datetime: value, note: note?.value || "" }),
   })
     .then(async (res) => {
       const data = await res.json().catch(() => ({}));
@@ -3208,7 +3208,7 @@ function acceptOffer(offerId) {
   fetch(`${API_BASE}/offers/${offerId}/accept`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ username }),
+    body: JSON.stringify({}),
   })
     .then(async (res) => {
       const data = await res.json().catch(() => ({}));
@@ -3231,7 +3231,7 @@ function declineOffer(offerId) {
   fetch(`${API_BASE}/offers/${offerId}/decline`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ username }),
+    body: JSON.stringify({}),
   })
     .then(async (res) => {
       const data = await res.json().catch(() => ({}));

--- a/cwf-pwa.js
+++ b/cwf-pwa.js
@@ -1,6 +1,6 @@
 (function(){
   'use strict';
-  var VERSION = '20260622_legacy_cap_policy_tech_cache_v1';
+  var VERSION = '20260622_urgent_offer_session_v1';
   try { window.__CWF_PWA_BUILD__ = VERSION; } catch (_) {}
   function register(){
     if (!('serviceWorker' in navigator)) return;

--- a/index.js
+++ b/index.js
@@ -28,6 +28,7 @@ const normalizerHelpers = require("./server/normalizers");
 const pricingHelpers = require("./server/pricing");
 const jobTiming = require("./server/services/jobTiming");
 const urgentPublicAdapter = require("./server/services/urgentPublicAdapter");
+const urgentFinalizer = require("./server/services/urgent/finalizer");
 const customerPricingHelpers = require("./server/customerPricing");
 const customerAuth = require("./server/customerAuth");
 const technicianIncomeHelpers = require("./server/technicianIncome");
@@ -14284,13 +14285,31 @@ console.log("[latlng_parse]", { ok: !!parsedAdminLL });
     if (urgentRequestKey && urgentDeterministicToken) {
       await client.query("SELECT pg_advisory_xact_lock(hashtext($1))", [urgentRequestKey]);
       const dupCheck = await client.query(
-        `SELECT booking_code, booking_token FROM public.jobs WHERE booking_token=$1 LIMIT 1`,
+        `SELECT j.job_id, j.booking_code, j.booking_token, COALESCE(j.job_status,'') AS job_status,
+                COUNT(o.offer_id)::int AS offers_count
+           FROM public.jobs j
+           LEFT JOIN public.job_offers o ON o.job_id=j.job_id
+          WHERE j.booking_token=$1
+          GROUP BY j.job_id, j.booking_code, j.booking_token, j.job_status
+          LIMIT 1`,
         [urgentDeterministicToken]
       );
       const dupRow = dupCheck.rows[0] || null;
       if (dupRow && dupRow.booking_code) {
         await client.query("COMMIT");
-        return res.json({ success: true, booking_code: dupRow.booking_code, token: dupRow.booking_token, duplicate: true });
+        const duplicatePayload = {
+          success: true,
+          booking_code: dupRow.booking_code,
+          token: dupRow.booking_token,
+          duplicate: true,
+          offers_count: Number(dupRow.offers_count || 0),
+        };
+        if (dupRow.job_status === "ไม่พบช่างรับงาน") {
+          duplicatePayload.phase = "admin_review";
+          duplicatePayload.admin_review = true;
+          duplicatePayload.message = "ส่งคำขอเข้าคิวแอดมินแล้ว";
+        }
+        return res.json(duplicatePayload);
       }
     }
 
@@ -14612,6 +14631,22 @@ if (coerceNumber(override_price, 0) > 0) {
       }
 
       if (!available.length) {
+        if (createdBySource === "customer" && bm === "urgent" && mode === "offer") {
+          await client.query(
+            `UPDATE public.jobs
+                SET job_status='ไม่พบช่างรับงาน',
+                    technician_username=NULL,
+                    technician_team=NULL,
+                    dispatch_mode='offer'
+              WHERE job_id=$1`,
+            [job_id]
+          );
+          console.warn("[admin_book_v2] customer_urgent_no_offer_targets", {
+            job_id,
+            booking_code,
+            service_zone_code: detectedZoneCode || null,
+          });
+        } else {
         const err = new Error('ยิงงานด่วนไม่สำเร็จ: ตอนนี้ไม่มีช่างที่เปิดรับงาน ว่างจริง และอยู่ในโซนนี้ ระบบจึงยังไม่ได้ส่งงานออกไปให้ช่างรับ');
         err.statusCode = 409;
         err.code = 'NO_URGENT_OFFER_TARGETS';
@@ -14624,6 +14659,7 @@ if (coerceNumber(override_price, 0) > 0) {
           zone_fallback_used,
         };
         throw err;
+        }
       }
 
       for (const u of available) {
@@ -14700,6 +14736,11 @@ if (coerceNumber(override_price, 0) > 0) {
       forced_assignment_zone_warning,
       offers_count: urgentPushTargets.length,
       allow_time_proposal: allowTimeProposal,
+      ...(createdBySource === "customer" && isUrgentOffer && urgentPushTargets.length === 0 ? {
+        phase: "admin_review",
+        admin_review: true,
+        message: "ส่งคำขอเข้าคิวแอดมินแล้ว",
+      } : {}),
     });
   } catch (e) {
     await client.query("ROLLBACK");
@@ -18380,42 +18421,41 @@ app.post('/tech/push_test', requireTechnicianSession, async (req, res) => {
   }
 });
 
-// ✅ Auto finalize urgent jobs when no one accepts
-// - Safe: ไม่กระทบงานปกติ / ไม่ล้มระบบ ถ้า query fail
+// Canonical urgent offer finalizer. Safe to call from existing tech/admin
+// mutation paths; startup runner below makes expiry autonomous.
 async function autoFinalizeUrgentJobs() {
   try {
-    await pool.query(
-      `
-      UPDATE public.jobs j
-      SET job_status = CASE
-        WHEN EXISTS (
-          SELECT 1 FROM public.job_offer_time_proposals p
-          WHERE p.job_id=j.job_id AND p.status='pending'
-        ) THEN 'รอพิจารณาเวลาใหม่'
-        ELSE 'ไม่พบช่างรับงาน'
-      END,
-      technician_username=NULL,
-      technician_team=NULL
-      WHERE COALESCE(j.booking_mode,'scheduled')='urgent'
-        AND j.technician_team IS NULL
-        AND j.technician_username IS NULL
-        AND j.canceled_at IS NULL
-        AND (j.job_status='รอช่างยืนยัน' OR j.job_status='pending_accept' OR j.job_status='รอพิจารณาเวลาใหม่')
-        AND EXISTS (
-          SELECT 1 FROM public.job_offers any_offer
-          WHERE any_offer.job_id=j.job_id
-        )
-        AND NOT EXISTS (
-          SELECT 1 FROM public.job_offers o
-          WHERE o.job_id=j.job_id
-            AND o.status='pending'
-            AND o.expires_at >= NOW()
-        )
-      `
-    );
+    return await urgentFinalizer.autoFinalizeUrgentJobs(pool);
   } catch (e) {
     console.warn('[autoFinalizeUrgentJobs] skip', e.message);
+    return { success: false, error: e.message };
   }
+}
+
+let urgentFinalizerRunnerInFlight = false;
+let urgentFinalizerRunnerTimer = null;
+
+function runUrgentFinalizerOnce(source = 'manual') {
+  if (urgentFinalizerRunnerInFlight) return Promise.resolve({ skipped: true, reason: 'in_flight' });
+  urgentFinalizerRunnerInFlight = true;
+  return urgentFinalizer.autoFinalizeUrgentJobs(pool)
+    .catch((e) => {
+      console.warn('[urgent_finalizer_runner] skip', { source, error: e.message });
+      return { success: false, error: e.message };
+    })
+    .finally(() => {
+      urgentFinalizerRunnerInFlight = false;
+    });
+}
+
+function startUrgentFinalizerRunner() {
+  if (urgentFinalizerRunnerTimer) return urgentFinalizerRunnerTimer;
+  runUrgentFinalizerOnce('startup').catch(() => {});
+  urgentFinalizerRunnerTimer = setInterval(() => {
+    runUrgentFinalizerOnce('interval').catch(() => {});
+  }, 45000);
+  if (typeof urgentFinalizerRunnerTimer.unref === 'function') urgentFinalizerRunnerTimer.unref();
+  return urgentFinalizerRunnerTimer;
 }
 
 app.post("/tech/income-summary-batch", requireTechnicianSession, async (req, res) => {
@@ -18548,67 +18588,108 @@ app.post("/api/super/technician-income-preview/backfill", requireSuperAdmin, asy
   }
 });
 
-app.get("/offers/tech/:username", async (req, res) => {
-  const { username } = req.params;
+async function loadPendingOffersForSessionTechnician(username) {
+  const aliases = await _getTechnicianVisibilityAliases(username);
+  const r = await pool.query(
+    `
+    SELECT
+      o.offer_id, o.job_id, o.status, o.offered_at, o.expires_at,
+      j.job_type, j.appointment_datetime,
+      j.address_text, j.maps_url, j.gps_latitude, j.gps_longitude,
+      j.job_price, j.job_status, j.booking_code, j.customer_note,
+      COALESCE(j.allow_time_proposal,FALSE) AS allow_time_proposal,
+      COALESCE(j.job_zone,'') AS job_zone,
+      COALESCE(sz.zone_label,'') AS job_zone_label,
+      COALESCE((
+        SELECT string_agg(COALESCE(ji.item_name,''), ', ' ORDER BY ji.job_item_id)
+        FROM public.job_items ji
+        WHERE ji.job_id = j.job_id
+      ), '') AS service_items_text
+    FROM public.job_offers o
+    JOIN public.jobs j ON j.job_id = o.job_id
+    LEFT JOIN public.service_zones sz ON sz.zone_code = j.service_zone_code
+    WHERE o.technician_username = ANY($1::text[])
+      AND o.status='pending'
+      AND o.expires_at >= NOW()
+    ORDER BY o.expires_at ASC
+    `,
+    [aliases]
+  );
 
-  const ready = await isTechReady(username);
-  if (!ready) return res.json([]);
-
-  try {
-    await pool.query(`
-      UPDATE public.job_offers
-      SET status='expired'
-      WHERE status='pending' AND expires_at < NOW()
-    `);
-
-    // ถ้า urgent ไม่มีใครรับแล้ว ให้ขึ้นสถานะลูกค้าแบบปลอดภัย
-    await autoFinalizeUrgentJobs();
-
-    const aliases = await _getTechnicianVisibilityAliases(username);
-    const r = await pool.query(
-      `
-      SELECT
-        o.offer_id, o.job_id, o.status, o.offered_at, o.expires_at,
-        j.job_type, j.appointment_datetime,
-        j.address_text, j.maps_url, j.gps_latitude, j.gps_longitude,
-        j.job_price, j.job_status, j.booking_code, j.customer_note,
-        COALESCE(j.allow_time_proposal,FALSE) AS allow_time_proposal,
-        COALESCE(j.job_zone,'') AS job_zone,
-        COALESCE(sz.zone_label,'') AS job_zone_label,
-        COALESCE((
-          SELECT string_agg(COALESCE(ji.item_name,''), ', ' ORDER BY ji.job_item_id)
-          FROM public.job_items ji
-          WHERE ji.job_id = j.job_id
-        ), '') AS service_items_text
-      FROM public.job_offers o
-      JOIN public.jobs j ON j.job_id = o.job_id
-      LEFT JOIN public.service_zones sz ON sz.zone_code = j.service_zone_code
-      WHERE o.technician_username = ANY($1::text[])
-        AND o.status='pending'
-        AND o.expires_at >= NOW()
-      ORDER BY o.expires_at ASC
-      `,
-      [aliases]
-    );
-
-    // Offered job cards read persisted display/preview rows only.
-    // Missing legacy rows stay pending instead of recalculating income during render.
-    const rows = [];
-    for (const row of (r.rows || [])) {
-      const base = { ...row, ..._techJobMoneyFallback(row, username, 'offered') };
-      try {
-        const money = await _buildTechnicianJobMoneySummary(row, username, { context: 'offered' });
-        if (money) Object.assign(base, money);
-      } catch (e) {
-        try { console.warn('[offers_income_preview] skip', { username, job_id: row.job_id, error: e.message }); } catch {}
-      }
-      rows.push(base);
+  const rows = [];
+  for (const row of (r.rows || [])) {
+    const base = { ...row, ..._techJobMoneyFallback(row, username, 'offered') };
+    try {
+      const money = await _buildTechnicianJobMoneySummary(row, username, { context: 'offered' });
+      if (money) Object.assign(base, money);
+    } catch (e) {
+      try { console.warn('[offers_income_preview] skip', { username, job_id: row.job_id, error: e.message }); } catch {}
     }
-    try { console.log('[CWF_TECH_JOBS_DEBUG] api offers with preview', { username, count: rows.length }); } catch {}
-    res.json(rows);
+    rows.push(base);
+  }
+  try { console.log('[CWF_TECH_JOBS_DEBUG] api offers with preview', { username, count: rows.length }); } catch {}
+  return rows;
+}
+
+async function assertRequestedTechnicianMatchesSession(requestedUsername, sessionUsername) {
+  const requested = String(requestedUsername || "").trim();
+  const session = String(sessionUsername || "").trim();
+  if (!session) {
+    const err = new Error("UNAUTHORIZED");
+    err.statusCode = 401;
+    throw err;
+  }
+  if (!requested || requested === "me") return true;
+  const aliases = await _getTechnicianVisibilityAliases(session);
+  const aliasSet = new Set((aliases || []).map((x) => String(x || "").trim().toLowerCase()).filter(Boolean));
+  if (!aliasSet.has(requested.toLowerCase())) {
+    const err = new Error("FORBIDDEN");
+    err.statusCode = 403;
+    throw err;
+  }
+  return true;
+}
+
+async function assertOfferOwnedBySessionTechnician(sessionUsername, offerTechnicianUsername) {
+  const session = String(sessionUsername || "").trim();
+  if (!session) {
+    const err = new Error("UNAUTHORIZED");
+    err.statusCode = 401;
+    throw err;
+  }
+  const aliases = await _getTechnicianVisibilityAliases(session);
+  const aliasSet = new Set((aliases || []).map((x) => String(x || "").trim().toLowerCase()).filter(Boolean));
+  const owner = String(offerTechnicianUsername || "").trim().toLowerCase();
+  if (!owner || !aliasSet.has(owner)) {
+    const err = new Error("FORBIDDEN");
+    err.statusCode = 403;
+    throw err;
+  }
+}
+
+app.get("/offers/tech/me", requireTechnicianSession, async (req, res) => {
+  const username = _authUsername(req);
+  if (!username) return res.status(401).json({ error: "UNAUTHORIZED" });
+  try {
+    const rows = await loadPendingOffersForSessionTechnician(username);
+    return res.json(rows);
   } catch (e) {
-    console.error(e);
-    res.status(500).json({ error: "โหลดข้อเสนองานไม่สำเร็จ" });
+    console.error("GET /offers/tech/me error:", e);
+    return res.status(500).json({ error: "โหลดข้อเสนองานไม่สำเร็จ" });
+  }
+});
+
+app.get("/offers/tech/:username", requireTechnicianSession, async (req, res) => {
+  const username = _authUsername(req);
+  try {
+    await assertRequestedTechnicianMatchesSession(req.params?.username, username);
+    const rows = await loadPendingOffersForSessionTechnician(username);
+    return res.json(rows);
+  } catch (e) {
+    const statusCode = Number(e?.statusCode || e?.status || 500);
+    if (statusCode === 401 || statusCode === 403) return res.status(statusCode).json({ error: e.message });
+    console.error("GET /offers/tech/:username error:", e);
+    return res.status(500).json({ error: "โหลดข้อเสนองานไม่สำเร็จ" });
   }
 });
 
@@ -18633,7 +18714,7 @@ app.post("/offers/:offer_id/accept", requireTechnicianSession, async (req, res) 
     const offer = offerR.rows[0];
     if (offer.status !== "pending") throw new Error("offer นี้ถูกตอบไปแล้ว");
     if (new Date(offer.expires_at) < new Date()) throw new Error("หมดเวลารับงานแล้ว");
-    if (!username || username !== offer.technician_username) throw new Error("username ไม่ตรงกับ offer");
+    await assertOfferOwnedBySessionTechnician(username, offer.technician_username);
 
     const jobR = await client.query(
       `SELECT job_id, technician_team FROM public.jobs WHERE job_id=$1 FOR UPDATE`,
@@ -18698,7 +18779,8 @@ app.post("/offers/:offer_id/accept", requireTechnicianSession, async (req, res) 
   } catch (e) {
     await client.query("ROLLBACK");
     console.error(e);
-    res.status(400).json({ error: e.message || "รับงานไม่สำเร็จ" });
+    const statusCode = Number(e?.statusCode || e?.status || 400);
+    res.status(statusCode >= 400 && statusCode < 600 ? statusCode : 400).json({ error: e.message || "รับงานไม่สำเร็จ" });
   } finally {
     client.release();
   }
@@ -18732,7 +18814,7 @@ app.post("/offers/:offer_id/time-proposal", requireTechnicianSession, async (req
     if (!offer) throw new Error("ไม่พบข้อเสนองานนี้");
     if (offer.status !== "pending") throw new Error("ข้อเสนองานนี้ถูกตอบไปแล้ว");
     if (new Date(offer.expires_at).getTime() < Date.now()) throw new Error("หมดเวลารับงานแล้ว");
-    if (!username || username !== offer.technician_username) throw new Error("บัญชีช่างไม่ตรงกับข้อเสนองาน");
+    await assertOfferOwnedBySessionTechnician(username, offer.technician_username);
 
     const jobR = await client.query(
       `SELECT job_id, appointment_datetime, COALESCE(duration_min,60) AS duration_min,
@@ -18773,7 +18855,8 @@ app.post("/offers/:offer_id/time-proposal", requireTechnicianSession, async (req
   } catch (e) {
     await client.query("ROLLBACK");
     console.error("POST /offers/:offer_id/time-proposal error:", e);
-    return res.status(400).json({ error: e.message || "ส่งเวลาใหม่ไม่สำเร็จ" });
+    const statusCode = Number(e?.statusCode || e?.status || 400);
+    return res.status(statusCode >= 400 && statusCode < 600 ? statusCode : 400).json({ error: e.message || "ส่งเวลาใหม่ไม่สำเร็จ" });
   } finally {
     client.release();
   }
@@ -18799,7 +18882,7 @@ app.post("/offers/:offer_id/decline", requireTechnicianSession, async (req, res)
 
     const offer = offerR.rows[0];
     if (offer.status !== "pending") throw new Error("offer นี้ถูกตอบไปแล้ว");
-    if (!username || username !== offer.technician_username) throw new Error("username ไม่ตรงกับ offer");
+    await assertOfferOwnedBySessionTechnician(username, offer.technician_username);
 
     if (new Date(offer.expires_at) < new Date()) {
       await client.query(`UPDATE public.job_offers SET status='expired', responded_at=NOW() WHERE offer_id=$1`, [offer_id]);
@@ -18845,7 +18928,8 @@ app.post("/offers/:offer_id/decline", requireTechnicianSession, async (req, res)
   } catch (e) {
     await client.query("ROLLBACK");
     console.error(e);
-    res.status(400).json({ error: e.message || "ไม่รับงานไม่สำเร็จ" });
+    const statusCode = Number(e?.statusCode || e?.status || 400);
+    res.status(statusCode >= 400 && statusCode < 600 ? statusCode : 400).json({ error: e.message || "ไม่รับงานไม่สำเร็จ" });
   } finally {
     client.release();
   }
@@ -25899,6 +25983,7 @@ function startServer() {
       https.createServer(options, app).listen(PORT, HOST, () => {
         console.log(`🔒 HTTPS CWF Server running`);
         console.log(`🔒 Local: https://localhost:${PORT}`);
+        startUrgentFinalizerRunner();
       });
       return;
     }
@@ -25908,6 +25993,7 @@ function startServer() {
 
   app.listen(PORT, HOST, () => {
     console.log(`🌐 HTTP CWF Server running at http://localhost:${PORT}`);
+    startUrgentFinalizerRunner();
   });
 }
 

--- a/server/services/urgent/finalizer.js
+++ b/server/services/urgent/finalizer.js
@@ -1,0 +1,99 @@
+"use strict";
+
+const FINALIZER_LOCK_KEY = "cwf_urgent_offer_finalizer_v1";
+const ADMIN_REVIEW_STATUS = "ไม่พบช่างรับงาน";
+const TIME_PROPOSAL_STATUS = "รอพิจารณาเวลาใหม่";
+
+async function autoFinalizeUrgentJobs(poolOrClient, options = {}) {
+  const externalClient = options.client || null;
+  const db = externalClient || poolOrClient;
+  if (!db || typeof db.query !== "function") {
+    throw new Error("urgent finalizer requires a pg pool or client");
+  }
+
+  const client = externalClient || (typeof db.connect === "function" ? await db.connect() : db);
+  let began = false;
+  try {
+    if (!externalClient) {
+      await client.query("BEGIN");
+      began = true;
+    }
+
+    const lockR = await client.query(
+      "SELECT pg_try_advisory_xact_lock(hashtext($1)) AS locked",
+      [FINALIZER_LOCK_KEY]
+    );
+    if (!lockR.rows?.[0]?.locked) {
+      if (began) await client.query("COMMIT");
+      return { success: true, skipped: true, reason: "locked", expired_offers: 0, finalized_jobs: 0 };
+    }
+
+    const expiredOffers = await client.query(
+      `
+      UPDATE public.job_offers
+         SET status='expired',
+             responded_at=COALESCE(responded_at,NOW())
+       WHERE status='pending'
+         AND expires_at < NOW()
+      `
+    );
+
+    const finalizedJobs = await client.query(
+      `
+      UPDATE public.jobs j
+         SET job_status=$1,
+             technician_username=NULL,
+             technician_team=NULL,
+             dispatch_mode='offer'
+       WHERE COALESCE(j.booking_mode,'')='urgent'
+         AND COALESCE(j.dispatch_mode,'')='offer'
+         AND NULLIF(TRIM(COALESCE(j.technician_username,'')),'') IS NULL
+         AND NULLIF(TRIM(COALESCE(j.technician_team,'')),'') IS NULL
+         AND j.canceled_at IS NULL
+         AND COALESCE(j.job_status,'') <> $1
+         AND COALESCE(j.job_status,'') <> $2
+         AND LOWER(COALESCE(j.job_status,'')) NOT IN ('cancel','canceled','cancelled','done','completed','closed','paid')
+         AND COALESCE(j.job_status,'') NOT IN ('ยกเลิก','เสร็จแล้ว','เสร็จสิ้น','ปิดงาน')
+         AND NOT EXISTS (
+           SELECT 1 FROM public.job_offers accepted_offer
+            WHERE accepted_offer.job_id=j.job_id
+              AND accepted_offer.status='accepted'
+         )
+         AND NOT EXISTS (
+           SELECT 1 FROM public.job_offers live_offer
+            WHERE live_offer.job_id=j.job_id
+              AND live_offer.status='pending'
+              AND live_offer.expires_at >= NOW()
+         )
+         AND NOT EXISTS (
+           SELECT 1 FROM public.job_offer_time_proposals proposal
+            WHERE proposal.job_id=j.job_id
+              AND proposal.status='pending'
+         )
+      `,
+      [ADMIN_REVIEW_STATUS, TIME_PROPOSAL_STATUS]
+    );
+
+    if (began) await client.query("COMMIT");
+    return {
+      success: true,
+      skipped: false,
+      expired_offers: expiredOffers.rowCount || 0,
+      finalized_jobs: finalizedJobs.rowCount || 0,
+    };
+  } catch (error) {
+    if (began) {
+      try { await client.query("ROLLBACK"); } catch (_) {}
+    }
+    throw error;
+  } finally {
+    if (!externalClient && typeof client.release === "function") client.release();
+  }
+}
+
+module.exports = {
+  ADMIN_REVIEW_STATUS,
+  FINALIZER_LOCK_KEY,
+  TIME_PROPOSAL_STATUS,
+  autoFinalizeUrgentJobs,
+};

--- a/sw.js
+++ b/sw.js
@@ -1,5 +1,5 @@
 /* CWF root service worker: Tech App shell/cache refresh */
-const CWF_TECH_BUILD_ID = "20260622_legacy_cap_policy_tech_cache_v1";
+const CWF_TECH_BUILD_ID = "20260622_urgent_offer_session_v1";
 const CACHE_PREFIX = "cwf-root-tech-app-";
 const CACHE_NAME = `${CACHE_PREFIX}${CWF_TECH_BUILD_ID}`;
 const SHELL_ASSETS = [

--- a/tech.html
+++ b/tech.html
@@ -8,10 +8,10 @@
   <link rel="manifest" href="/manifest.json">
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-  <meta name="cwf-tech-build" content="20260622_legacy_cap_policy_tech_cache_v1">
+  <meta name="cwf-tech-build" content="20260622_urgent_offer_session_v1">
   <title>หน้าช่าง - CWF</title>
   <link rel="stylesheet" href="style.css">
-  <script defer src="/cwf-pwa.js?v=20260622_legacy_cap_policy_tech_cache_v1"></script>
+  <script defer src="/cwf-pwa.js?v=20260622_urgent_offer_session_v1"></script>
 
   <style>
     :root{
@@ -3433,7 +3433,7 @@
     }
   </style>
 
-<script src="app.js?v=20260622_legacy_cap_policy_tech_cache_v1"></script>
+<script src="app.js?v=20260622_urgent_offer_session_v1"></script>
   <script src="tech-onboarding.js?v=phase2a-fix-restore-onboarding-panel"></script>
   <script>
         function goEditProfile(){ location.href = '/edit-profile.html'; }

--- a/test/techCacheBuild.test.js
+++ b/test/techCacheBuild.test.js
@@ -4,7 +4,7 @@ const fs = require("node:fs");
 const path = require("node:path");
 
 const root = path.join(__dirname, "..");
-const BUILD = "20260622_legacy_cap_policy_tech_cache_v1";
+const BUILD = "20260622_urgent_offer_session_v1";
 
 function read(file) {
   return fs.readFileSync(path.join(root, file), "utf8");

--- a/test/urgentFinalizer.integration.test.js
+++ b/test/urgentFinalizer.integration.test.js
@@ -1,0 +1,214 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const { Pool } = require("pg");
+
+const { autoFinalizeUrgentJobs, ADMIN_REVIEW_STATUS } = require("../server/services/urgent/finalizer");
+
+const PG_CONFIG = {
+  host: process.env.PGHOST || "127.0.0.1",
+  port: Number(process.env.PGPORT || 5432),
+  user: process.env.PGUSER || "postgres",
+  password: process.env.PGPASSWORD || "postgres",
+  database: process.env.PGDATABASE || "cwf_test",
+};
+
+let pool;
+let adminPool;
+let testDatabaseName = "";
+let dbUnavailableReason = "";
+
+test.before(async () => {
+  testDatabaseName = `cwf_urgent_${process.pid}_${Date.now()}`.toLowerCase();
+  adminPool = new Pool({ ...PG_CONFIG, database: process.env.PGMAINTENANCEDATABASE || "postgres" });
+  try {
+    await adminPool.query("SELECT 1");
+    await adminPool.query(`CREATE DATABASE ${testDatabaseName} ENCODING 'UTF8'`);
+  } catch (e) {
+    dbUnavailableReason = e.message || "Postgres test database is unavailable";
+    await adminPool.end().catch(() => {});
+    adminPool = null;
+    return;
+  }
+
+  pool = new Pool({ ...PG_CONFIG, database: testDatabaseName });
+
+  await pool.query(`
+    CREATE TABLE IF NOT EXISTS public.jobs (
+      job_id BIGSERIAL PRIMARY KEY,
+      booking_mode TEXT,
+      dispatch_mode TEXT,
+      technician_username TEXT,
+      technician_team TEXT,
+      appointment_datetime TIMESTAMPTZ,
+      job_status TEXT,
+      canceled_at TIMESTAMPTZ
+    )
+  `);
+  await pool.query(`ALTER TABLE public.jobs ADD COLUMN IF NOT EXISTS booking_mode TEXT`);
+  await pool.query(`ALTER TABLE public.jobs ADD COLUMN IF NOT EXISTS dispatch_mode TEXT`);
+  await pool.query(`ALTER TABLE public.jobs ADD COLUMN IF NOT EXISTS technician_username TEXT`);
+  await pool.query(`ALTER TABLE public.jobs ADD COLUMN IF NOT EXISTS technician_team TEXT`);
+  await pool.query(`ALTER TABLE public.jobs ADD COLUMN IF NOT EXISTS appointment_datetime TIMESTAMPTZ`);
+  await pool.query(`ALTER TABLE public.jobs ADD COLUMN IF NOT EXISTS job_status TEXT`);
+  await pool.query(`ALTER TABLE public.jobs ADD COLUMN IF NOT EXISTS canceled_at TIMESTAMPTZ`);
+  await pool.query(`
+    CREATE TABLE IF NOT EXISTS public.job_offers (
+      offer_id BIGSERIAL PRIMARY KEY,
+      job_id BIGINT NOT NULL,
+      technician_username TEXT NOT NULL,
+      status TEXT NOT NULL DEFAULT 'pending',
+      expires_at TIMESTAMPTZ,
+      responded_at TIMESTAMPTZ
+    )
+  `);
+  await pool.query(`ALTER TABLE public.job_offers ADD COLUMN IF NOT EXISTS job_id BIGINT`);
+  await pool.query(`ALTER TABLE public.job_offers ADD COLUMN IF NOT EXISTS technician_username TEXT`);
+  await pool.query(`ALTER TABLE public.job_offers ADD COLUMN IF NOT EXISTS status TEXT`);
+  await pool.query(`ALTER TABLE public.job_offers ADD COLUMN IF NOT EXISTS expires_at TIMESTAMPTZ`);
+  await pool.query(`ALTER TABLE public.job_offers ADD COLUMN IF NOT EXISTS responded_at TIMESTAMPTZ`);
+  await pool.query(`
+    CREATE TABLE IF NOT EXISTS public.job_offer_time_proposals (
+      proposal_id BIGSERIAL PRIMARY KEY,
+      offer_id BIGINT,
+      job_id BIGINT NOT NULL,
+      technician_username TEXT,
+      status TEXT NOT NULL DEFAULT 'pending',
+      proposed_datetime TIMESTAMPTZ
+    )
+  `);
+  await pool.query(`ALTER TABLE public.job_offer_time_proposals ADD COLUMN IF NOT EXISTS offer_id BIGINT`);
+  await pool.query(`ALTER TABLE public.job_offer_time_proposals ADD COLUMN IF NOT EXISTS job_id BIGINT`);
+  await pool.query(`ALTER TABLE public.job_offer_time_proposals ADD COLUMN IF NOT EXISTS technician_username TEXT`);
+  await pool.query(`ALTER TABLE public.job_offer_time_proposals ADD COLUMN IF NOT EXISTS status TEXT`);
+  await pool.query(`ALTER TABLE public.job_offer_time_proposals ADD COLUMN IF NOT EXISTS proposed_datetime TIMESTAMPTZ`);
+});
+
+test.after(async () => {
+  if (pool) await pool.end();
+  if (adminPool && testDatabaseName) {
+    await adminPool.query(`DROP DATABASE IF EXISTS ${testDatabaseName} WITH (FORCE)`).catch(() => {});
+    await adminPool.end().catch(() => {});
+  }
+});
+
+test.beforeEach(async (t) => {
+  if (dbUnavailableReason) {
+    t.skip(`Postgres integration database unavailable: ${dbUnavailableReason}`);
+    return;
+  }
+  await pool.query("DELETE FROM public.job_offer_time_proposals");
+  await pool.query("DELETE FROM public.job_offers");
+  await pool.query("DELETE FROM public.jobs");
+});
+
+function dbTest(name, fn) {
+  test(name, async (t) => {
+    if (dbUnavailableReason) return t.skip(`Postgres integration database unavailable: ${dbUnavailableReason}`);
+    return fn(t);
+  });
+}
+
+async function insertUrgentJob(status = "รอช่างยืนยัน", extra = {}) {
+  const r = await pool.query(
+    `INSERT INTO public.jobs (booking_mode, dispatch_mode, technician_username, technician_team, job_status, canceled_at)
+     VALUES ('urgent','offer',$1,$2,$3,$4)
+     RETURNING job_id`,
+    [
+      extra.technician_username || null,
+      extra.technician_team || null,
+      status,
+      extra.canceled_at || null,
+    ]
+  );
+  return Number(r.rows[0].job_id);
+}
+
+async function insertOffer(jobId, status, expiresSql, tech = "tech-a") {
+  const r = await pool.query(
+    `INSERT INTO public.job_offers (job_id, technician_username, status, expires_at)
+     VALUES ($1,$2,$3,${expiresSql})
+     RETURNING offer_id`,
+    [jobId, tech, status]
+  );
+  return Number(r.rows[0].offer_id);
+}
+
+dbTest("expired pending offer is marked expired and unassigned urgent job enters admin review", async () => {
+  const jobId = await insertUrgentJob();
+  const offerId = await insertOffer(jobId, "pending", "NOW() - INTERVAL '1 minute'");
+
+  const result = await autoFinalizeUrgentJobs(pool);
+  assert.equal(result.success, true);
+  assert.equal(result.expired_offers, 1);
+  assert.equal(result.finalized_jobs, 1);
+
+  const offer = await pool.query(`SELECT status, responded_at IS NOT NULL AS responded FROM public.job_offers WHERE offer_id=$1`, [offerId]);
+  assert.equal(offer.rows[0].status, "expired");
+  assert.equal(offer.rows[0].responded, true);
+
+  const job = await pool.query(`SELECT job_status FROM public.jobs WHERE job_id=$1`, [jobId]);
+  assert.equal(job.rows[0].job_status, ADMIN_REVIEW_STATUS);
+});
+
+dbTest("live offers, accepted offers, assigned jobs, time proposals, and terminal jobs are not overwritten", async () => {
+  const live = await insertUrgentJob();
+  await insertOffer(live, "pending", "NOW() + INTERVAL '5 minutes'");
+
+  const accepted = await insertUrgentJob();
+  await insertOffer(accepted, "accepted", "NOW() - INTERVAL '5 minutes'");
+
+  const assigned = await insertUrgentJob("รอช่างยืนยัน", { technician_username: "tech-a" });
+  await insertOffer(assigned, "pending", "NOW() - INTERVAL '5 minutes'");
+
+  const proposal = await insertUrgentJob();
+  const proposalOffer = await insertOffer(proposal, "pending", "NOW() - INTERVAL '5 minutes'");
+  await pool.query(
+    `INSERT INTO public.job_offer_time_proposals (offer_id, job_id, technician_username, status, proposed_datetime)
+     VALUES ($1,$2,'tech-a','pending',NOW() + INTERVAL '1 hour')`,
+    [proposalOffer, proposal]
+  );
+
+  const proposalStatus = await insertUrgentJob("รอพิจารณาเวลาใหม่");
+  await insertOffer(proposalStatus, "pending", "NOW() - INTERVAL '5 minutes'");
+
+  const cancelled = await insertUrgentJob("ยกเลิก");
+  await insertOffer(cancelled, "pending", "NOW() - INTERVAL '5 minutes'");
+
+  const completed = await insertUrgentJob("เสร็จแล้ว");
+  await insertOffer(completed, "pending", "NOW() - INTERVAL '5 minutes'");
+
+  await autoFinalizeUrgentJobs(pool);
+
+  const rows = await pool.query(`SELECT job_id, job_status FROM public.jobs ORDER BY job_id`);
+  const byId = new Map(rows.rows.map((r) => [Number(r.job_id), r.job_status]));
+  assert.equal(byId.get(live), "รอช่างยืนยัน");
+  assert.equal(byId.get(accepted), "รอช่างยืนยัน");
+  assert.equal(byId.get(assigned), "รอช่างยืนยัน");
+  assert.equal(byId.get(proposal), "รอช่างยืนยัน");
+  assert.equal(byId.get(proposalStatus), "รอพิจารณาเวลาใหม่");
+  assert.equal(byId.get(cancelled), "ยกเลิก");
+  assert.equal(byId.get(completed), "เสร็จแล้ว");
+});
+
+dbTest("finalizer is idempotent across repeated and concurrent runs", async () => {
+  const jobId = await insertUrgentJob();
+  await insertOffer(jobId, "pending", "NOW() - INTERVAL '10 minutes'");
+
+  const first = await autoFinalizeUrgentJobs(pool);
+  const second = await autoFinalizeUrgentJobs(pool);
+  assert.equal(first.finalized_jobs, 1);
+  assert.equal(second.finalized_jobs, 0);
+
+  const jobId2 = await insertUrgentJob();
+  await insertOffer(jobId2, "pending", "NOW() - INTERVAL '10 minutes'");
+  const concurrent = await Promise.all([
+    autoFinalizeUrgentJobs(pool),
+    autoFinalizeUrgentJobs(pool),
+    autoFinalizeUrgentJobs(pool),
+  ]);
+  const totalFinalized = concurrent.reduce((sum, r) => sum + Number(r.finalized_jobs || 0), 0);
+  assert.equal(totalFinalized, 1);
+
+  const jobs = await pool.query(`SELECT job_status FROM public.jobs WHERE job_id IN ($1,$2) ORDER BY job_id`, [jobId, jobId2]);
+  assert.deepEqual(jobs.rows.map((r) => r.job_status), [ADMIN_REVIEW_STATUS, ADMIN_REVIEW_STATUS]);
+});

--- a/test/urgentProductionHotfix.test.js
+++ b/test/urgentProductionHotfix.test.js
@@ -1,0 +1,89 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+
+const root = path.join(__dirname, "..");
+
+function read(file) {
+  return fs.readFileSync(path.join(root, file), "utf8");
+}
+
+function section(source, start, end) {
+  const i = source.indexOf(start);
+  assert.notEqual(i, -1, `missing start marker: ${start}`);
+  const j = source.indexOf(end, i + start.length);
+  assert.notEqual(j, -1, `missing end marker: ${end}`);
+  return source.slice(i, j);
+}
+
+test("customer urgent zero-target commits job/items into admin review without changing Admin Add contract", () => {
+  const index = read("index.js");
+  const handler = section(index, "async function handleAdminBookV2", "function getBangkokTodayYMD");
+
+  assert.match(handler, /createdBySource === "customer"/);
+  assert.match(handler, /req\.cwfBookSource === "customer"/);
+  assert.match(handler, /COUNT\(o\.offer_id\)::int AS offers_count/);
+  assert.match(handler, /duplicatePayload[\s\S]*offers_count: Number\(dupRow\.offers_count \|\| 0\)/);
+
+  const noTargets = section(handler, "if (!available.length)", "for (const u of available)");
+  assert.match(noTargets, /createdBySource === "customer" && bm === "urgent" && mode === "offer"/);
+  assert.match(noTargets, /SET job_status='ไม่พบช่างรับงาน'/);
+  assert.match(noTargets, /dispatch_mode='offer'/);
+  assert.match(noTargets, /throw err;/, "Admin Add zero-target path must still throw NO_URGENT_OFFER_TARGETS");
+
+  const response = section(handler, "return res.json({", "} catch (e)");
+  assert.match(response, /offers_count: urgentPushTargets\.length/);
+  assert.match(response, /phase: "admin_review"/);
+  assert.match(response, /admin_review: true/);
+});
+
+test("public urgent route remains adapter-only and public urgent status is read-only", () => {
+  const index = read("index.js");
+  const publicAdapter = section(index, "function handlePublicCustomerUrgentBook", "app.post(\"/public/book\"");
+  assert.match(publicAdapter, /req\.cwfBookSource = "customer"/);
+  assert.match(publicAdapter, /booking_mode: "urgent"/);
+  assert.match(publicAdapter, /dispatch_mode: "offer"/);
+  assert.match(publicAdapter, /return handleAdminBookV2\(req, res\)/);
+
+  const statusRoute = section(index, "app.get(\"/public/urgent-status\"", "app.get(\"/public/track\"");
+  assert.doesNotMatch(statusRoute, /\bUPDATE\b|\bINSERT\b|\bDELETE\b/i);
+  assert.match(statusRoute, /phase[\s\S]*"admin_review"/);
+  assert.match(statusRoute, /Cache-Control", "no-store/);
+});
+
+test("urgent finalizer is canonical, locked, periodic, and not driven by public status", () => {
+  const index = read("index.js");
+  const finalizer = read("server/services/urgent/finalizer.js");
+
+  assert.match(index, /urgentFinalizer\.autoFinalizeUrgentJobs\(pool\)/);
+  assert.match(finalizer, /pg_try_advisory_xact_lock\(hashtext\(\$1\)\)/);
+  assert.match(finalizer, /UPDATE public\.job_offers[\s\S]*status='expired'[\s\S]*expires_at < NOW\(\)/);
+  assert.match(finalizer, /NOT EXISTS \([\s\S]*accepted_offer[\s\S]*status='accepted'/);
+  assert.match(finalizer, /NOT EXISTS \([\s\S]*live_offer[\s\S]*status='pending'[\s\S]*expires_at >= NOW\(\)/);
+  assert.match(finalizer, /NOT EXISTS \([\s\S]*job_offer_time_proposals[\s\S]*status='pending'/);
+  assert.match(finalizer, /COALESCE\(j\.job_status,''\) <> \$2/);
+  assert.match(finalizer, /LOWER\(COALESCE\(j\.job_status,''\)\) NOT IN \('cancel','canceled','cancelled','done','completed','closed','paid'\)/);
+
+  assert.match(index, /let urgentFinalizerRunnerInFlight = false/);
+  assert.match(index, /setInterval\(\(\) => \{[\s\S]*runUrgentFinalizerOnce\('interval'\)[\s\S]*\}, 45000\)/);
+  assert.match(index, /urgentFinalizerRunnerTimer\.unref/);
+  assert.match(index, /startUrgentFinalizerRunner\(\)/);
+});
+
+test("technician offer reads and actions are bound to session identity", () => {
+  const index = read("index.js");
+  const app = read("app.js");
+
+  assert.match(index, /app\.get\("\/offers\/tech\/me", requireTechnicianSession/);
+  assert.match(index, /app\.get\("\/offers\/tech\/:username", requireTechnicianSession/);
+  assert.match(index, /const username = _authUsername\(req\)/);
+  assert.match(index, /assertRequestedTechnicianMatchesSession\(req\.params\?\.username, username\)/);
+  assert.match(index, /loadPendingOffersForSessionTechnician\(username\)/);
+  assert.match(index, /o\.technician_username = ANY\(\$1::text\[\]\)/);
+  assert.match(index, /assertOfferOwnedBySessionTechnician\(username, offer\.technician_username\)/);
+
+  assert.match(app, /\/offers\/tech\/me/);
+  assert.doesNotMatch(app, /offers\/tech\/\$\{username\}/);
+  assert.doesNotMatch(app, /JSON\.stringify\(\{ username[,}]/);
+});


### PR DESCRIPTION
## Summary
- Commit customer urgent zero-target requests into Admin Review using the existing `ไม่พบช่างรับงาน` status instead of rolling back after `NO_URGENT_OFFER_TARGETS`.
- Extract the urgent offer expiry finalizer into a canonical transaction/advisory-lock helper and run it after server startup every 45 seconds.
- Bind technician offer reads/actions to `requireTechnicianSession` and session-derived technician aliases, plus update the Tech App to read `/offers/tech/me` with a bumped cache build.

## Validation
- `npm ci`
- `node --check index.js app.js sw.js cwf-pwa.js server/services/urgent/finalizer.js test/urgentFinalizer.integration.test.js test/urgentProductionHotfix.test.js test/techCacheBuild.test.js`
- `git diff --check a95f0a3b1ed218fc13cbb0fd8eca19e97272f4d7...HEAD`
- Real PostgreSQL: temporary UTF-8 PostgreSQL 18 cluster on `127.0.0.1:55432`, `npm test` with `PGHOST=127.0.0.1 PGPORT=55432 PGUSER=postgres PGDATABASE=cwf_test` -> 182 pass, 0 fail, 0 skipped.

## Notes
- No migration, startup DDL, production SQL, or production data mutation.
- Admin Add urgent zero-target behavior remains the existing 409 `NO_URGENT_OFFER_TARGETS` path.