### PR TITLE
feat(customer-app): add real catalog store and centered booking navigation

### DIFF
--- a/customer-app/assets/customer-app.css
+++ b/customer-app/assets/customer-app.css
@@ -2069,7 +2069,7 @@ p { margin: 0; }
   transform: translateX(-50%);
   z-index: 40;
   display: grid;
-  grid-template-columns: repeat(4, 1fr);
+  grid-template-columns: repeat(5, 1fr);
   align-items: stretch;
   gap: 2px;
   width: 100%;
@@ -2113,6 +2113,7 @@ p { margin: 0; }
   opacity: 0.85;
 }
 .nav-item[data-route="home"]::before { -webkit-mask-image: var(--ico-home); mask-image: var(--ico-home); }
+.nav-item[data-route="store"]::before { -webkit-mask-image: var(--ico-store); mask-image: var(--ico-store); }
 .nav-item[data-route="booking"]::before { -webkit-mask-image: var(--ico-book); mask-image: var(--ico-book); }
 .nav-item[data-route="tracking"]::before { -webkit-mask-image: var(--ico-track); mask-image: var(--ico-track); }
 .nav-item[data-route="profile"]::before { -webkit-mask-image: var(--ico-user); mask-image: var(--ico-user); }
@@ -2121,8 +2122,23 @@ p { margin: 0; }
 .nav-item.is-active::before { opacity: 1; }
 .nav-item.is-active span { font-weight: 800; }
 
+/* Centered booking action: visually prominent but kept inside the nav's
+   fixed height so it never overflows or covers page content. */
+.nav-item-primary {
+  background: linear-gradient(180deg, var(--blue), #0b4fae);
+  color: #fff;
+  border-radius: 14px;
+  margin: 2px;
+  box-shadow: 0 10px 18px -10px rgba(15, 77, 178, 0.55);
+}
+.nav-item-primary::before { width: 26px; height: 26px; opacity: 1; }
+.nav-item-primary span { font-weight: 800; }
+.nav-item-primary.is-active,
+.nav-item-primary.is-active::before { color: #fff; }
+
 :root {
   --ico-home: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='%23000' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M3 11l9-8 9 8'/%3E%3Cpath d='M5 10v10a1 1 0 0 0 1 1h4v-6h4v6h4a1 1 0 0 0 1-1V10'/%3E%3C/svg%3E");
+  --ico-store: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='%23000' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M3 9l1.2-5h15.6L21 9'/%3E%3Cpath d='M4 9v10a1 1 0 0 0 1 1h14a1 1 0 0 0 1-1V9'/%3E%3Cpath d='M9 21v-6h6v6'/%3E%3C/svg%3E");
   --ico-book: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='%23000' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Crect x='3' y='4' width='18' height='18' rx='3'/%3E%3Cpath d='M16 2v4M8 2v4M3 10h18'/%3E%3Cpath d='M9 15l2 2 4-4'/%3E%3C/svg%3E");
   --ico-track: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='%23000' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M12 21s-7-5.6-7-11a7 7 0 0 1 14 0c0 5.4-7 11-7 11z'/%3E%3Ccircle cx='12' cy='10' r='2.5'/%3E%3C/svg%3E");
   --ico-user: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='%23000' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Ccircle cx='12' cy='8' r='4'/%3E%3Cpath d='M4 21c0-4 4-6 8-6s8 2 8 6'/%3E%3C/svg%3E");
@@ -2502,8 +2518,12 @@ body {
   content: "หน้าแรก";
 }
 
+.bottom-nav [data-route="store"] span::after {
+  content: "ร้านค้า";
+}
+
 .bottom-nav [data-route="booking"] span::after {
-  content: "จองคิว";
+  content: "จอง";
 }
 
 .bottom-nav [data-route="tracking"] span::after {
@@ -2512,6 +2532,11 @@ body {
 
 .bottom-nav [data-route="profile"] span::after {
   content: "บัญชี";
+}
+
+@media (max-width: 360px) {
+  .bottom-nav .nav-item span::after { font-size: 0.68rem; }
+  .nav-item { padding: 6px 1px; }
 }
 
 .icon-pill [data-account-chip-label] {
@@ -3463,4 +3488,80 @@ body.has-contact-sheet { overflow: hidden; }
 .review-submit-actions .secondary-btn { min-height: 52px; }
 @media (max-width: 360px) {
   .review-submit-actions { grid-template-columns: 104px minmax(0, 1fr); }
+}
+
+/* ===================== Store (Phase 1) ===================== */
+.store-hero p { margin-top: 6px; }
+.store-filters {
+  display: grid;
+  grid-template-columns: minmax(0, 1.4fr) minmax(0, 1fr);
+  gap: 8px;
+  margin-bottom: 14px;
+}
+.store-search-input,
+.store-category-select {
+  width: 100%;
+  min-width: 0;
+  height: 44px;
+  padding: 0 12px;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--line);
+  background: #fff;
+  font-size: 14px;
+  color: var(--ink);
+}
+@media (max-width: 360px) {
+  .store-filters { grid-template-columns: 1fr; }
+}
+.store-grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 10px;
+}
+.store-card {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 14px;
+  border-radius: var(--radius);
+  border: 1px solid var(--line);
+  background: #fff;
+  min-width: 0;
+}
+.store-card-head {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  min-width: 0;
+}
+.store-card-head strong {
+  font-size: 15.5px;
+  overflow-wrap: anywhere;
+}
+.store-card-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  font-size: 12px;
+  color: var(--muted);
+}
+.store-card-meta span {
+  padding: 2px 8px;
+  border-radius: 999px;
+  background: var(--soft-blue, rgba(31, 123, 255, 0.1));
+}
+.store-card-price {
+  display: flex;
+  align-items: baseline;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+.store-card-actions {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 8px;
+  margin-top: 4px;
+}
+@media (max-width: 360px) {
+  .store-card-actions { grid-template-columns: 1fr; }
 }

--- a/customer-app/assets/customer-app.js
+++ b/customer-app/assets/customer-app.js
@@ -3,7 +3,7 @@
 
   const App = window.CWFCustomerAppV2;
   const BOOT_TIMEOUT_MS = 3500;
-  const BUILD_ID = "20260622_urgent_offer_flow_v1";
+  const BUILD_ID = "20260622_store_nav_phase1_v1";
 
   function withTimeout(promise, timeoutMs) {
     return Promise.race([
@@ -45,6 +45,7 @@
 
     App.router.register({
       home: App.ui.renderHome,
+      store: App.store.render,
       booking: App.ui.renderBookingMode,
       scheduled: App.bookingScheduled.render,
       urgent: App.bookingUrgent.render,

--- a/customer-app/index.html
+++ b/customer-app/index.html
@@ -9,10 +9,10 @@
   <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
   <meta name="apple-mobile-web-app-title" content="CWF Service">
   <title>CWF Customer Service</title>
-  <link rel="manifest" href="./manifest.webmanifest?v=20260622_urgent_offer_flow_v1">
+  <link rel="manifest" href="./manifest.webmanifest?v=20260622_store_nav_phase1_v1">
   <link rel="icon" type="image/png" sizes="192x192" href="./assets/icons/cwf-customer-192.png">
   <link rel="apple-touch-icon" sizes="180x180" href="./assets/icons/cwf-customer-180.png">
-  <link rel="stylesheet" href="./assets/customer-app.css?v=20260622_urgent_offer_flow_v1">
+  <link rel="stylesheet" href="./assets/customer-app.css?v=20260622_store_nav_phase1_v1">
 </head>
 <body class="is-app-booting">
   <div class="app-shell" data-app-shell>
@@ -43,25 +43,27 @@
 
     <nav class="bottom-nav" aria-label="เมนูแอปลูกค้า">
       <button type="button" data-route="home" class="nav-item is-active"><span>หน้าแรก</span></button>
-      <button type="button" data-route="booking" class="nav-item"><span>จองคิว</span></button>
+      <button type="button" data-route="store" class="nav-item"><span>ร้านค้า</span></button>
+      <button type="button" data-route="booking" class="nav-item nav-item-primary"><span>จอง</span></button>
       <button type="button" data-route="tracking" class="nav-item"><span>ติดตาม</span></button>
       <button type="button" data-route="profile" class="nav-item"><span>บัญชี</span></button>
     </nav>
   </div>
 
-  <script src="./modules/state.js?v=20260622_urgent_offer_flow_v1"></script>
-  <script src="./modules/utils.js?v=20260622_urgent_offer_flow_v1"></script>
-  <script src="./modules/api.js?v=20260622_urgent_offer_flow_v1"></script>
-  <script src="./modules/services.js?v=20260622_urgent_offer_flow_v1"></script>
-  <script src="./modules/ui.js?v=20260622_urgent_offer_flow_v1"></script>
-  <script src="./modules/auth.js?v=20260622_urgent_offer_flow_v1"></script>
-  <script src="./modules/pricing.js?v=20260622_urgent_offer_flow_v1"></script>
-  <script src="./modules/availability.js?v=20260622_urgent_offer_flow_v1"></script>
-  <script src="./modules/bookingScheduled.js?v=20260622_urgent_offer_flow_v1"></script>
-  <script src="./modules/bookingUrgent.js?v=20260622_urgent_offer_flow_v1"></script>
-  <script src="./modules/tracking.js?v=20260622_urgent_offer_flow_v1"></script>
-  <script src="./modules/profile.js?v=20260622_urgent_offer_flow_v1"></script>
-  <script src="./modules/router.js?v=20260622_urgent_offer_flow_v1"></script>
-  <script src="./assets/customer-app.js?v=20260622_urgent_offer_flow_v1"></script>
+  <script src="./modules/state.js?v=20260622_store_nav_phase1_v1"></script>
+  <script src="./modules/utils.js?v=20260622_store_nav_phase1_v1"></script>
+  <script src="./modules/api.js?v=20260622_store_nav_phase1_v1"></script>
+  <script src="./modules/services.js?v=20260622_store_nav_phase1_v1"></script>
+  <script src="./modules/ui.js?v=20260622_store_nav_phase1_v1"></script>
+  <script src="./modules/store.js?v=20260622_store_nav_phase1_v1"></script>
+  <script src="./modules/auth.js?v=20260622_store_nav_phase1_v1"></script>
+  <script src="./modules/pricing.js?v=20260622_store_nav_phase1_v1"></script>
+  <script src="./modules/availability.js?v=20260622_store_nav_phase1_v1"></script>
+  <script src="./modules/bookingScheduled.js?v=20260622_store_nav_phase1_v1"></script>
+  <script src="./modules/bookingUrgent.js?v=20260622_store_nav_phase1_v1"></script>
+  <script src="./modules/tracking.js?v=20260622_store_nav_phase1_v1"></script>
+  <script src="./modules/profile.js?v=20260622_store_nav_phase1_v1"></script>
+  <script src="./modules/router.js?v=20260622_store_nav_phase1_v1"></script>
+  <script src="./assets/customer-app.js?v=20260622_store_nav_phase1_v1"></script>
 </body>
 </html>

--- a/customer-app/manifest.webmanifest
+++ b/customer-app/manifest.webmanifest
@@ -2,7 +2,7 @@
   "name": "CWF Customer Service",
   "short_name": "CWF Service",
   "description": "แอปลูกค้า Coldwindflow สำหรับเลือกบริการ จองคิว และติดตามงาน",
-  "start_url": "/customer-app/index.html?v=20260622_urgent_offer_flow_v1#home",
+  "start_url": "/customer-app/index.html?v=20260622_store_nav_phase1_v1#home",
   "scope": "/customer-app/",
   "id": "/customer-app/",
   "display": "standalone",

--- a/customer-app/modules/store.js
+++ b/customer-app/modules/store.js
@@ -29,9 +29,10 @@
     const max = Number(item.btu_max);
     const hasMin = Number.isFinite(min) && min > 0;
     const hasMax = Number.isFinite(max) && max > 0;
-    if (hasMin && hasMax && min !== max) return `${min.toLocaleString("th-TH")}-${max.toLocaleString("th-TH")} BTU`;
-    if (hasMin) return `${min.toLocaleString("th-TH")} BTU`;
-    if (hasMax) return `${max.toLocaleString("th-TH")} BTU`;
+    if (hasMin && hasMax && min !== max) return `${min.toLocaleString("th-TH")}–${max.toLocaleString("th-TH")} BTU`;
+    if (hasMin && hasMax) return `${min.toLocaleString("th-TH")} BTU`;
+    if (hasMin) return `ตั้งแต่ ${min.toLocaleString("th-TH")} BTU`;
+    if (hasMax) return `ไม่เกิน ${max.toLocaleString("th-TH")} BTU`;
     return "";
   }
 
@@ -64,7 +65,7 @@
           ${unit ? `<span class="muted">/ ${root.utils.escapeHtml(unit)}</span>` : ""}
         </div>
         <div class="store-card-actions">
-          <button class="primary-btn" type="button" data-store-book="${root.utils.escapeHtml(id)}">จองบริการ</button>
+          <button class="primary-btn" type="button" data-store-book="${root.utils.escapeHtml(id)}">ไปหน้าจองบริการ</button>
           <button class="secondary-btn" type="button" data-store-contact="${root.utils.escapeHtml(id)}" data-store-contact-name="${root.utils.escapeHtml(name)}">สอบถามรายการนี้</button>
         </div>
       </article>
@@ -179,7 +180,7 @@
           <div class="hero store-hero">
             <div class="hero-badge">ร้านค้า CWF</div>
             <h2>เลือกบริการและอุปกรณ์</h2>
-            <p>รายการที่แสดงมาจากระบบจริงของ CWF ราคาที่เห็นเป็นราคาเริ่มต้น ระบบจะคำนวณราคาที่แน่นอนตอนจอง หรือติดต่อแอดมินเพื่อสอบถามรายการที่ยังไม่เปิดจองอัตโนมัติ</p>
+            <p>รายการที่แสดงมาจากระบบจริงของ CWF ราคาบนการ์ดเป็นราคาฐานหรือราคาเริ่มต้น สำหรับบริการที่รองรับสามารถไปยังหน้าจองได้ ส่วนรายการอื่นกรุณาติดต่อแอดมินเพื่อยืนยันรายละเอียดและราคา</p>
           </div>
           <div data-store-body>${renderBody()}</div>
           <div data-contact-sheet-mount></div>

--- a/customer-app/modules/store.js
+++ b/customer-app/modules/store.js
@@ -1,0 +1,194 @@
+(function () {
+  "use strict";
+
+  const root = window.CWFCustomerAppV2 = window.CWFCustomerAppV2 || {};
+
+  let filterState = { search: "", category: "" };
+
+  function categoriesFromItems(items) {
+    const set = new Set();
+    items.forEach((item) => {
+      const cat = String(item.item_category || "").trim();
+      if (cat) set.add(cat);
+    });
+    return Array.from(set).sort((a, b) => a.localeCompare(b, "th"));
+  }
+
+  function priceIsAsk(item) {
+    const price = Number(item.base_price);
+    return !Number.isFinite(price) || price <= 0;
+  }
+
+  function priceLabel(item) {
+    if (priceIsAsk(item)) return "สอบถามราคา";
+    return `ราคาเริ่มต้น ${root.utils.formatBaht(item.base_price)}`;
+  }
+
+  function btuRangeLabel(item) {
+    const min = Number(item.btu_min);
+    const max = Number(item.btu_max);
+    const hasMin = Number.isFinite(min) && min > 0;
+    const hasMax = Number.isFinite(max) && max > 0;
+    if (hasMin && hasMax && min !== max) return `${min.toLocaleString("th-TH")}-${max.toLocaleString("th-TH")} BTU`;
+    if (hasMin) return `${min.toLocaleString("th-TH")} BTU`;
+    if (hasMax) return `${max.toLocaleString("th-TH")} BTU`;
+    return "";
+  }
+
+  function applyFilters(items) {
+    const search = filterState.search.trim().toLowerCase();
+    const category = filterState.category;
+    return (items || []).filter((item) => {
+      if (category && String(item.item_category || "") !== category) return false;
+      if (search && !String(item.item_name || "").toLowerCase().includes(search)) return false;
+      return true;
+    });
+  }
+
+  function renderCard(item) {
+    const id = String(item.item_id || "");
+    const name = item.item_name || "-";
+    const category = item.item_category || "";
+    const unit = item.unit_label || "";
+    const btu = btuRangeLabel(item);
+    const meta = [item.job_category, item.ac_type, btu].filter(Boolean);
+    return `
+      <article class="store-card" data-store-item="${root.utils.escapeHtml(id)}">
+        <div class="store-card-head">
+          ${category ? `<span class="tag">${root.utils.escapeHtml(category)}</span>` : ""}
+          <strong>${root.utils.escapeHtml(name)}</strong>
+        </div>
+        ${meta.length ? `<div class="store-card-meta">${meta.map((m) => `<span>${root.utils.escapeHtml(m)}</span>`).join("")}</div>` : ""}
+        <div class="store-card-price">
+          <span class="price-text${priceIsAsk(item) ? " is-estimate" : ""}">${root.utils.escapeHtml(priceLabel(item))}</span>
+          ${unit ? `<span class="muted">/ ${root.utils.escapeHtml(unit)}</span>` : ""}
+        </div>
+        <div class="store-card-actions">
+          <button class="primary-btn" type="button" data-store-book="${root.utils.escapeHtml(id)}">จองบริการ</button>
+          <button class="secondary-btn" type="button" data-store-contact="${root.utils.escapeHtml(id)}" data-store-contact-name="${root.utils.escapeHtml(name)}">สอบถามรายการนี้</button>
+        </div>
+      </article>
+    `;
+  }
+
+  function renderGrid(items) {
+    const filtered = applyFilters(items);
+    if (!filtered.length) return root.utils.stateBox("", "ไม่พบรายการที่ตรงกับการค้นหา");
+    return `<div class="store-grid" data-store-grid>${filtered.map(renderCard).join("")}</div>`;
+  }
+
+  function renderBody() {
+    const bucket = root.state.catalog || { status: "idle", items: [], error: "" };
+    if (bucket.status === "idle" || bucket.status === "loading") {
+      return `<div class="content-skeleton" aria-label="กำลังโหลดรายการ"><span></span><span></span></div>`;
+    }
+    if (bucket.status === "error") {
+      return `
+        ${root.utils.stateBox("error", bucket.error || "โหลดข้อมูลไม่สำเร็จ")}
+        <button class="secondary-btn" type="button" data-store-retry>ลองใหม่</button>
+      `;
+    }
+    const items = bucket.items || [];
+    if (!items.length) {
+      return root.utils.stateBox("", "ยังไม่มีรายการที่เปิดให้ลูกค้าดูในขณะนี้ กรุณาติดต่อแอดมินเพื่อสอบถามบริการ");
+    }
+    const categories = categoriesFromItems(items);
+    return `
+      <div class="store-filters">
+        <input type="search" class="store-search-input" data-store-search placeholder="ค้นหาชื่อสินค้า/บริการ" aria-label="ค้นหาสินค้า" value="${root.utils.escapeHtml(filterState.search)}">
+        <select class="store-category-select" data-store-category aria-label="หมวดหมู่">
+          <option value="">ทั้งหมด</option>
+          ${categories.map((cat) => `<option value="${root.utils.escapeHtml(cat)}"${filterState.category === cat ? " selected" : ""}>${root.utils.escapeHtml(cat)}</option>`).join("")}
+        </select>
+      </div>
+      <div data-store-grid-mount>${renderGrid(items)}</div>
+    `;
+  }
+
+  function bindGridActions(container) {
+    container.querySelectorAll("[data-store-book]").forEach((button) => {
+      button.addEventListener("click", () => root.utils.routeTo("booking"));
+    });
+    container.querySelectorAll("[data-store-contact]").forEach((button) => {
+      button.addEventListener("click", () => {
+        const name = button.getAttribute("data-store-contact-name") || "รายการนี้";
+        root.ui.openContactSheet(container, { title: name });
+      });
+    });
+  }
+
+  function patchGrid(container) {
+    const mount = container.querySelector("[data-store-grid-mount]");
+    if (!mount) return;
+    mount.innerHTML = renderGrid(root.state.catalog.items || []);
+    bindGridActions(container);
+  }
+
+  function bindBody(container) {
+    const search = container.querySelector("[data-store-search]");
+    if (search) {
+      search.addEventListener("input", () => {
+        filterState.search = search.value || "";
+        patchGrid(container);
+      });
+    }
+    const category = container.querySelector("[data-store-category]");
+    if (category) {
+      category.addEventListener("change", () => {
+        filterState.category = category.value || "";
+        patchGrid(container);
+      });
+    }
+    const retry = container.querySelector("[data-store-retry]");
+    if (retry) {
+      retry.addEventListener("click", () => loadCatalog(container));
+    }
+    bindGridActions(container);
+  }
+
+  function patchBody(container) {
+    const mount = container.querySelector("[data-store-body]");
+    if (!mount) return;
+    mount.innerHTML = renderBody();
+    bindBody(container);
+  }
+
+  async function loadCatalog(container) {
+    root.state.setCollection("catalog", { status: "loading", items: [], error: "" });
+    patchBody(container);
+    try {
+      const data = await root.api.loadCatalogItems();
+      const items = root.utils.normalizeList(data, "items");
+      root.state.setCollection("catalog", { status: "success", items, error: "" });
+    } catch (error) {
+      root.state.setCollection("catalog", { status: "error", items: [], error: error?.message || "โหลดข้อมูลไม่สำเร็จ" });
+    }
+    patchBody(container);
+  }
+
+  function ensureLoaded(container) {
+    if (root.state.catalog.status !== "idle") return;
+    loadCatalog(container);
+  }
+
+  const store = {
+    render(container) {
+      filterState = { search: "", category: "" };
+      container.innerHTML = `
+        <section class="screen store-screen">
+          <div class="hero store-hero">
+            <div class="hero-badge">ร้านค้า CWF</div>
+            <h2>เลือกบริการและอุปกรณ์</h2>
+            <p>รายการที่แสดงมาจากระบบจริงของ CWF ราคาที่เห็นเป็นราคาเริ่มต้น ระบบจะคำนวณราคาที่แน่นอนตอนจอง หรือติดต่อแอดมินเพื่อสอบถามรายการที่ยังไม่เปิดจองอัตโนมัติ</p>
+          </div>
+          <div data-store-body>${renderBody()}</div>
+          <div data-contact-sheet-mount></div>
+        </section>
+      `;
+      bindBody(container);
+      ensureLoaded(container);
+    },
+  };
+
+  root.store = store;
+})();

--- a/customer-app/modules/ui.js
+++ b/customer-app/modules/ui.js
@@ -275,6 +275,7 @@
     prefetchHome: loadHomeData,
     patchHomeData,
     updateAccountChrome,
+    openContactSheet,
 
     renderHome(container) {
       container.innerHTML = `

--- a/customer-app/sw.js
+++ b/customer-app/sw.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const BUILD_ID = "20260622_urgent_offer_flow_v1";
+const BUILD_ID = "20260622_store_nav_phase1_v1";
 const CACHE_NAME = `cwf-customer-app-v2-${BUILD_ID}`;
 const APP_SHELL = [
   `./index.html?v=${BUILD_ID}`,
@@ -13,6 +13,7 @@ const APP_SHELL = [
   `./modules/api.js?v=${BUILD_ID}`,
   `./modules/services.js?v=${BUILD_ID}`,
   `./modules/ui.js?v=${BUILD_ID}`,
+  `./modules/store.js?v=${BUILD_ID}`,
   `./modules/auth.js?v=${BUILD_ID}`,
   `./modules/pricing.js?v=${BUILD_ID}`,
   `./modules/availability.js?v=${BUILD_ID}`,

--- a/test/customerAppRecovery.test.js
+++ b/test/customerAppRecovery.test.js
@@ -696,3 +696,50 @@ test("store search and category filters narrow already-loaded items without extr
 
   assert.equal(calls, 1);
 });
+
+test("store booking button routes to booking without implying the item is already added", async () => {
+  const context = makeContext();
+  const root = loadCustomerFrontend(context);
+  root.api.loadCatalogItems = async () => [
+    { item_id: 1, item_name: "ล้างแอร์ผนัง", item_category: "ล้างแอร์", base_price: 700, unit_label: "เครื่อง" },
+  ];
+
+  const container = new FakeMount();
+  root.store.render(container);
+  await new Promise((resolve) => setTimeout(resolve, 0));
+
+  const body = container.querySelector("[data-store-body]");
+  assert.match(body.innerHTML, /ไปหน้าจองบริการ/);
+  assert.doesNotMatch(body.innerHTML, />จองบริการ</);
+
+  assert.doesNotMatch(container.innerHTML, /ราคาที่แน่นอนตอนจอง/);
+  assert.doesNotMatch(container.innerHTML, /เพิ่มในรายการจอง/);
+  assert.doesNotMatch(container.innerHTML, /เพิ่มลงตะกร้า/);
+});
+
+test("store BTU label formats min/max/range/neither cases correctly", async () => {
+  const context = makeContext();
+  const root = loadCustomerFrontend(context);
+  root.api.loadCatalogItems = async () => [
+    { item_id: 1, item_name: "รุ่นช่วงบีทียู", item_category: "ล้างแอร์", base_price: 700, unit_label: "เครื่อง", btu_min: 9000, btu_max: 12000 },
+    { item_id: 2, item_name: "รุ่นบีทียูเท่ากัน", item_category: "ล้างแอร์", base_price: 700, unit_label: "เครื่อง", btu_min: 12000, btu_max: 12000 },
+    { item_id: 3, item_name: "รุ่นมีแค่ต่ำสุด", item_category: "ล้างแอร์", base_price: 700, unit_label: "เครื่อง", btu_min: 18000 },
+    { item_id: 4, item_name: "รุ่นมีแค่สูงสุด", item_category: "ล้างแอร์", base_price: 700, unit_label: "เครื่อง", btu_max: 12000 },
+    { item_id: 5, item_name: "รุ่นไม่มีบีทียู", item_category: "ล้างแอร์", base_price: 700, unit_label: "เครื่อง" },
+  ];
+
+  const container = new FakeMount();
+  root.store.render(container);
+  await new Promise((resolve) => setTimeout(resolve, 0));
+
+  const body = container.querySelector("[data-store-body]");
+  assert.match(body.innerHTML, /9,000–12,000 BTU/);
+  assert.match(body.innerHTML, /12,000 BTU/);
+  assert.match(body.innerHTML, /ตั้งแต่ 18,000 BTU/);
+  assert.match(body.innerHTML, /ไม่เกิน 12,000 BTU/);
+
+  const card5 = body.innerHTML.split("รุ่นไม่มีบีทียู")[1] || "";
+  const nextCardBoundary = card5.indexOf("</article>");
+  const card5Scope = nextCardBoundary >= 0 ? card5.slice(0, nextCardBoundary) : card5;
+  assert.doesNotMatch(card5Scope, /BTU/);
+});

--- a/test/customerAppRecovery.test.js
+++ b/test/customerAppRecovery.test.js
@@ -130,6 +130,79 @@ class WizardContainer {
   }
 }
 
+class FakeMount {
+  constructor() {
+    this._html = "";
+    this.mountCache = new Map();
+    this.singleCache = new Map();
+  }
+  set innerHTML(value) {
+    this._html = String(value || "");
+    this.mountCache.clear();
+    this.singleCache.clear();
+  }
+  get innerHTML() { return this._html; }
+  appendChild() {}
+  _findOwner(attr) {
+    if (this._html.includes(attr)) return this;
+    for (const child of this.mountCache.values()) {
+      const found = child._findOwner(attr);
+      if (found) return found;
+    }
+    return null;
+  }
+  static parseAttrs(tagHtml) {
+    const attrs = {};
+    [...tagHtml.matchAll(/([a-z-]+)="([^"]*)"/g)].forEach(([, k, v]) => { attrs[k] = v; });
+    return attrs;
+  }
+  querySelector(selector) {
+    const m = selector.match(/\[data-([a-z-]+)\]/);
+    if (!m) return null;
+    const attr = `data-${m[1]}`;
+    if (attr === "data-store-body" || attr === "data-store-grid-mount" || attr === "data-contact-sheet-mount") {
+      const owner = this._findOwner(attr);
+      if (!owner) return null;
+      if (!owner.mountCache.has(attr)) owner.mountCache.set(attr, new FakeMount());
+      return owner.mountCache.get(attr);
+    }
+    const owner = this._findOwner(attr);
+    if (!owner) return null;
+    if (owner.singleCache.has(attr)) return owner.singleCache.get(attr);
+    const tagMatch = owner._html.match(new RegExp(`<(input|select|button)[^>]*${attr}[^>]*>`));
+    if (!tagMatch) return null;
+    const attrs = FakeMount.parseAttrs(tagMatch[0]);
+    const el = tagMatch[1] === "button" ? new FakeButton(attrs) : new FakeInput(attrs);
+    owner.singleCache.set(attr, el);
+    return el;
+  }
+  querySelectorAll(selector) {
+    const m = selector.match(/\[data-([a-z-]+)\]/);
+    if (!m) return [];
+    const attr = `data-${m[1]}`;
+    const owner = this._findOwner(attr);
+    if (!owner) return [];
+    const results = [];
+    for (const match of owner._html.matchAll(new RegExp(`<button[^>]*${attr}="([^"]*)"[^>]*>`, "g"))) {
+      results.push(new FakeButton(FakeMount.parseAttrs(match[0])));
+    }
+    return results;
+  }
+}
+
+class FakeInput {
+  constructor(attrs = {}) {
+    this.attrs = attrs;
+    this.value = attrs.value || "";
+    this.listeners = {};
+  }
+  getAttribute(name) { return this.attrs[name] || ""; }
+  addEventListener(type, listener) { this.listeners[type] = listener; }
+  async dispatch(type) {
+    if (this.listeners[type]) await this.listeners[type]({});
+  }
+}
+
 function loadCustomerFrontend(context = makeContext()) {
   return load(context, [
     "customer-app/modules/utils.js",
@@ -137,6 +210,7 @@ function loadCustomerFrontend(context = makeContext()) {
     "customer-app/modules/api.js",
     "customer-app/modules/services.js",
     "customer-app/modules/ui.js",
+    "customer-app/modules/store.js",
     "customer-app/modules/auth.js",
     "customer-app/modules/availability.js",
     "customer-app/modules/bookingScheduled.js",
@@ -150,7 +224,7 @@ test("Customer App build id is consistent across shell and service worker", () =
   const sw = read("customer-app/sw.js");
   const app = read("customer-app/assets/customer-app.js");
   const manifest = read("customer-app/manifest.webmanifest");
-  const build = "20260622_urgent_offer_flow_v1";
+  const build = "20260622_store_nav_phase1_v1";
 
   assert.match(index, new RegExp(`customer-app\\.css\\?v=${build}`));
   assert.match(index, new RegExp(`bookingUrgent\\.js\\?v=${build}`));
@@ -161,6 +235,32 @@ test("Customer App build id is consistent across shell and service worker", () =
   assert.match(sw, /cwf-customer-app-v2-/);
   assert.match(app, /document\.readyState === "complete"/);
   assert.match(app, /window\.addEventListener\("load", registerServiceWorker/);
+});
+
+test("store module is loaded in index.html and precached in the service worker app shell", () => {
+  const index = read("customer-app/index.html");
+  const sw = read("customer-app/sw.js");
+  const build = "20260622_store_nav_phase1_v1";
+
+  assert.match(index, new RegExp(`modules/store\\.js\\?v=${build}`));
+  assert.match(sw, /`\.\/modules\/store\.js\?v=\$\{BUILD_ID\}`/);
+});
+
+test("bottom navigation has exactly 5 items in the required order with a centered primary booking action", () => {
+  const index = read("customer-app/index.html");
+  const navMatch = index.match(/<nav class="bottom-nav"[\s\S]*?<\/nav>/);
+  assert.ok(navMatch, "bottom-nav markup not found");
+  const navHtml = navMatch[0];
+  const routes = [...navHtml.matchAll(/data-route="([^"]+)"/g)].map((m) => m[1]);
+  assert.deepEqual(routes, ["home", "store", "booking", "tracking", "profile"]);
+  const bookingButtonMatch = navHtml.match(/<button[^>]*data-route="booking"[^>]*>/);
+  assert.ok(bookingButtonMatch, "booking nav button not found");
+  assert.match(bookingButtonMatch[0], /class="[^"]*nav-item-primary[^"]*"/);
+});
+
+test("store route is registered in the router setup", () => {
+  const app = read("customer-app/assets/customer-app.js");
+  assert.match(app, /store:\s*App\.store\.render/);
 });
 
 test("auth rendering separates logged-in account from provider login buttons", () => {
@@ -483,4 +583,116 @@ test("urgent request key is generated once, reused on resubmits, and cleared on 
     .then(() => {
       assert.equal(root.state.draft.urgent.urgent_request_key, "");
     });
+});
+
+test("store contains no hardcoded fake catalog items and only sources data from the real API", () => {
+  const storeSrc = read("customer-app/modules/store.js");
+  assert.match(storeSrc, /root\.api\.loadCatalogItems\(\)/);
+  assert.doesNotMatch(storeSrc, /item_name:\s*"/);
+  assert.doesNotMatch(storeSrc, /base_price:\s*\d/);
+});
+
+test("store loads real catalog items via root.api.loadCatalogItems and renders them", async () => {
+  const context = makeContext();
+  const root = loadCustomerFrontend(context);
+  let calls = 0;
+  root.api.loadCatalogItems = async () => {
+    calls += 1;
+    return [
+      { item_id: 1, item_name: "ล้างแอร์ผนัง 12000 BTU", item_category: "ล้างแอร์", base_price: 700, unit_label: "เครื่อง", job_category: "ล้าง", ac_type: "ผนัง", btu_min: 9000, btu_max: 12000 },
+      { item_id: 2, item_name: "ซ่อมแอร์ไม่เย็น", item_category: "ซ่อมแอร์", base_price: 0, unit_label: "งาน" },
+    ];
+  };
+
+  const container = new FakeMount();
+  root.store.render(container);
+  assert.equal(calls, 1);
+  await new Promise((resolve) => setTimeout(resolve, 0));
+
+  const body = container.querySelector("[data-store-body]");
+  assert.match(body.innerHTML, /ล้างแอร์ผนัง 12000 BTU/);
+  assert.match(body.innerHTML, /ราคาเริ่มต้น/);
+  assert.match(body.innerHTML, /สอบถามราคา/);
+});
+
+test("store renders an honest empty state instead of mock products when the API returns no items", async () => {
+  const context = makeContext();
+  const root = loadCustomerFrontend(context);
+  root.api.loadCatalogItems = async () => [];
+
+  const container = new FakeMount();
+  root.store.render(container);
+  await new Promise((resolve) => setTimeout(resolve, 0));
+
+  const body = container.querySelector("[data-store-body]");
+  assert.doesNotMatch(body.innerHTML, /store-card/);
+  assert.match(body.innerHTML, /ยังไม่มีรายการที่เปิดให้ลูกค้าดู/);
+});
+
+test("store renders an error state with a working retry button that re-fetches", async () => {
+  const context = makeContext();
+  const root = loadCustomerFrontend(context);
+  let calls = 0;
+  root.api.loadCatalogItems = async () => {
+    calls += 1;
+    if (calls === 1) throw new Error("โหลดข้อมูลไม่สำเร็จ");
+    return [{ item_id: 9, item_name: "ล้างแอร์สี่ทิศทาง", item_category: "ล้างแอร์", base_price: 1200, unit_label: "เครื่อง" }];
+  };
+
+  const container = new FakeMount();
+  root.store.render(container);
+  await new Promise((resolve) => setTimeout(resolve, 0));
+
+  let body = container.querySelector("[data-store-body]");
+  assert.match(body.innerHTML, /is-error/);
+  const retry = container.querySelector("[data-store-retry]");
+  assert.ok(retry, "retry button not found in error state");
+
+  await retry.click();
+  body = container.querySelector("[data-store-body]");
+  assert.equal(calls, 2);
+  assert.match(body.innerHTML, /ล้างแอร์สี่ทิศทาง/);
+});
+
+test("store search and category filters narrow already-loaded items without extra API calls", async () => {
+  const context = makeContext();
+  const root = loadCustomerFrontend(context);
+  let calls = 0;
+  root.api.loadCatalogItems = async () => {
+    calls += 1;
+    return [
+      { item_id: 1, item_name: "ล้างแอร์ผนัง", item_category: "ล้างแอร์", base_price: 700, unit_label: "เครื่อง" },
+      { item_id: 2, item_name: "ล้างแอร์เปลือย", item_category: "ล้างแอร์", base_price: 800, unit_label: "เครื่อง" },
+      { item_id: 3, item_name: "ซ่อมคอมเพรสเซอร์", item_category: "ซ่อมแอร์", base_price: 0, unit_label: "งาน" },
+    ];
+  };
+
+  const container = new FakeMount();
+  root.store.render(container);
+  await new Promise((resolve) => setTimeout(resolve, 0));
+
+  const search = container.querySelector("[data-store-search]");
+  assert.ok(search, "search input not found");
+  search.value = "เปลือย";
+  await search.dispatch("input");
+
+  let grid = container.querySelector("[data-store-grid-mount]");
+  assert.match(grid.innerHTML, /ล้างแอร์เปลือย/);
+  assert.doesNotMatch(grid.innerHTML, /ล้างแอร์ผนัง/);
+  assert.doesNotMatch(grid.innerHTML, /ซ่อมคอมเพรสเซอร์/);
+
+  search.value = "";
+  await search.dispatch("input");
+
+  const category = container.querySelector("[data-store-category]");
+  assert.ok(category, "category select not found");
+  category.value = "ซ่อมแอร์";
+  await category.dispatch("change");
+
+  grid = container.querySelector("[data-store-grid-mount]");
+  assert.match(grid.innerHTML, /ซ่อมคอมเพรสเซอร์/);
+  assert.doesNotMatch(grid.innerHTML, /ล้างแอร์ผนัง/);
+  assert.doesNotMatch(grid.innerHTML, /ล้างแอร์เปลือย/);
+
+  assert.equal(calls, 1);
 });

--- a/test/customerSameDayTiming.test.js
+++ b/test/customerSameDayTiming.test.js
@@ -160,7 +160,7 @@ test("customer app disables availability HTTP cache and refreshes same-day slots
 });
 
 test("customer app build and service worker cache IDs changed", () => {
-  const id = "20260622_urgent_offer_flow_v1";
+  const id = "20260622_store_nav_phase1_v1";
   for (const file of [
     "customer-app/index.html",
     "customer-app/sw.js",


### PR DESCRIPTION
## Summary
- Adds a new "Store" route (`customer-app/modules/store.js`) showing real catalog items from `GET /catalog/items?customer=1` (loading/empty/error states, client-side search + category filter, no mock data).
- Bottom navigation now has 5 items in the required order: หน้าแรก, ร้านค้า, จอง (centered, visually prominent), ติดตาม, บัญชี.
- Per-item CTAs: "ไปหน้าจองบริการ" → generic booking entry (does not pre-fill or map the item into a Booking Draft); "สอบถามรายการนี้" → existing LINE/phone contact sheet.
- Bumped synchronized Build ID to `20260622_store_nav_phase1_v1` across `index.html`, `customer-app.js`, `sw.js`, `manifest.webmanifest`; added `store.js` to the Service Worker app shell. `/catalog/` fetch behavior unchanged (already network-only).

## Correction Pass (latest commit `3ae189f`)
Addressed a ChatGPT review pass, scoped to exactly 3 files (`customer-app/modules/store.js`, `test/customerAppRecovery.test.js`, `test/customerSameDayTiming.test.js`):
- Fixed the previously-flagged stale Build ID sentinel in `test/customerSameDayTiming.test.js` (now `20260622_store_nav_phase1_v1`) — the "Scope Mismatch" noted below has been resolved and the full suite is green.
- Renamed the booking CTA from "จองบริการ" to "ไปหน้าจองบริการ" so customers don't think the item has been added to a booking.
- Reworded the Store hero copy to stop claiming every catalog item gets an exact price calculated at booking time (the Store doesn't pass the selected item into the Booking Flow); now says base/starting prices are shown on cards, supported services can proceed to booking, others require contacting admin.
- Rewrote BTU range formatting to remove ambiguity: range uses an en dash with comma separators (`9,000–12,000 BTU`), equal min/max collapses to a single value, min-only is prefixed `ตั้งแต่ `, max-only is prefixed `ไม่เกิน `, and neither renders nothing.
- Added/updated tests covering the new button label, absence of any "already added to booking" claim, and all BTU formatting cases (range, exact, min-only, max-only, neither).

## Test plan
- [x] `node --check customer-app/modules/store.js`
- [x] `node --test test/customerAppRecovery.test.js` — 25/25 passing
- [x] `node --test test/customerSameDayTiming.test.js` — 8/8 passing
- [x] `npm test` — 182 passing / 10 skipped / 0 failing (full suite green, no known issues remaining)
- [x] `git diff --check` — clean
- [ ] Manual browser QA at 320/360/390/430px — still **not** performed (no headless browser tooling available in this remote sandbox). This remains the primary outstanding risk before this PR can leave draft.

## Commits
- `3d729ad` — initial Store + nav implementation
- `3ae189f` — Correction Pass: messaging fixes + build regression test alignment

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01G8RDdFzW2bZKTwvsfaovwg)_