### PR TITLE
feat(admin): add Phase 2A admin service catalog manager

### DIFF
--- a/admin-store-catalog.html
+++ b/admin-store-catalog.html
@@ -136,7 +136,7 @@
     </div>
   </div>
 
-  <script src="/admin-v2-common.js?v=20260428_allpages_ui1"></script>
+  <script src="/admin-v2-common.js?v=20260622_admin_menu_catalog_entry"></script>
   <script src="/admin-store-catalog.js?v=20260622_admin_catalog_phase2a_v1"></script>
 </body>
 </html>

--- a/admin-store-catalog.html
+++ b/admin-store-catalog.html
@@ -1,0 +1,142 @@
+<!DOCTYPE html>
+<html lang="th">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <title>Admin • รายการบริการในร้านค้า</title>
+  <link rel="stylesheet" href="/style.css"/>
+</head>
+<body>
+  <div class="topbar">
+    <div><b>🗂️ รายการบริการในร้านค้า (Admin)</b></div>
+  </div>
+
+  <div class="container">
+    <div class="card" id="catalog_form_card">
+      <div style="display:flex;justify-content:space-between;align-items:center;gap:10px;flex-wrap:wrap;">
+        <div>
+          <b id="catalog_form_title">เพิ่มรายการบริการ</b>
+          <div class="muted2 mini">ควบคุมรายการที่จะแสดงในร้านค้าของแอปลูกค้า บันทึกแล้วมีผลทันทีผ่าน API จริง</div>
+        </div>
+        <button id="btnNewItem" class="secondary" type="button">+ เพิ่มรายการใหม่</button>
+      </div>
+
+      <div class="grid2" style="margin-top:12px">
+        <div>
+          <label>ชื่อรายการ *</label>
+          <input id="item_name" placeholder="เช่น ล้างแอร์ผนัง">
+        </div>
+        <div>
+          <label>หมวดหมู่</label>
+          <input id="item_category" placeholder="เช่น ล้างแอร์">
+        </div>
+      </div>
+
+      <div class="grid2" style="margin-top:10px">
+        <div>
+          <label>ราคาฐาน/ราคาเริ่มต้น (บาท)</label>
+          <input id="base_price" type="number" step="1" min="0" placeholder="ว่าง = สอบถามราคา">
+        </div>
+        <div>
+          <label>หน่วย</label>
+          <input id="unit_label" placeholder="เช่น เครื่อง, งาน">
+        </div>
+      </div>
+
+      <div class="grid2" style="margin-top:10px">
+        <div>
+          <label>ประเภทงาน</label>
+          <input id="job_category" placeholder="เช่น ล้าง, ซ่อม, ติดตั้ง">
+        </div>
+        <div>
+          <label>ประเภทแอร์</label>
+          <input id="ac_type" placeholder="เช่น ผนัง, สี่ทิศทาง, แขวน">
+        </div>
+      </div>
+
+      <div class="grid2" style="margin-top:10px">
+        <div>
+          <label>BTU ต่ำสุด</label>
+          <input id="btu_min" type="number" step="1" min="1" placeholder="ว่าง = ไม่จำกัด">
+        </div>
+        <div>
+          <label>BTU สูงสุด</label>
+          <input id="btu_max" type="number" step="1" min="1" placeholder="ว่าง = ไม่จำกัด">
+        </div>
+      </div>
+
+      <div class="grid2" style="margin-top:10px">
+        <div>
+          <label>สถานะการใช้งาน</label>
+          <select id="is_active">
+            <option value="1">เปิดใช้งาน</option>
+            <option value="0">ปิดใช้งาน</option>
+          </select>
+        </div>
+        <div>
+          <label>แสดงให้ลูกค้าเห็น</label>
+          <select id="is_customer_visible">
+            <option value="0">ไม่แสดง</option>
+            <option value="1">แสดง</option>
+          </select>
+        </div>
+      </div>
+
+      <div id="catalog_visible_hint" class="muted2 mini" style="margin-top:8px;display:none;color:#15803d;">
+        ✅ รายการนี้จะแสดงในร้านค้าลูกค้า
+      </div>
+
+      <div id="catalog_form_error" class="muted2 mini" style="margin-top:8px;display:none;color:#b91c1c;"></div>
+
+      <div style="display:flex;gap:8px;flex-wrap:wrap;margin-top:12px">
+        <button id="btnSaveItem" class="primary" type="button">บันทึกรายการ</button>
+        <button id="btnCancelEdit" class="secondary" type="button" style="display:none;">ยกเลิกการแก้ไข</button>
+      </div>
+    </div>
+
+    <div class="card" style="margin-top:12px">
+      <div style="display:flex;justify-content:space-between;align-items:center;gap:10px;flex-wrap:wrap;">
+        <b>รายการทั้งหมด</b>
+        <button id="btnReloadCatalog" class="secondary" type="button">รีเฟรช</button>
+      </div>
+
+      <div class="grid2" style="margin-top:10px">
+        <div>
+          <label>ค้นหาชื่อ</label>
+          <input id="catalog_search" placeholder="ค้นหาชื่อรายการ">
+        </div>
+        <div>
+          <label>สถานะ</label>
+          <select id="catalog_filter_active">
+            <option value="">ทั้งหมด</option>
+            <option value="1">เปิดใช้งาน</option>
+            <option value="0">ปิดใช้งาน</option>
+          </select>
+        </div>
+      </div>
+      <div class="grid2" style="margin-top:10px">
+        <div>
+          <label>แสดงให้ลูกค้าเห็น</label>
+          <select id="catalog_filter_visible">
+            <option value="">ทั้งหมด</option>
+            <option value="1">แสดง</option>
+            <option value="0">ไม่แสดง</option>
+          </select>
+        </div>
+        <div></div>
+      </div>
+
+      <div id="catalog_list" style="margin-top:10px">กำลังโหลดรายการ...</div>
+    </div>
+
+    <div class="card" style="margin-top:12px">
+      <b>👀 ดูตัวอย่างร้านค้าลูกค้า (Read-only Preview)</b>
+      <div class="muted2 mini" style="margin-top:4px">แสดงเฉพาะรายการที่ "เปิดใช้งาน" และ "แสดงให้ลูกค้าเห็น" พร้อมกัน ตามข้อมูลจริงที่โหลดมาด้านบน</div>
+      <div id="catalog_preview" style="margin-top:10px"></div>
+    </div>
+  </div>
+
+  <script src="/admin-v2-common.js?v=20260428_allpages_ui1"></script>
+  <script src="/admin-store-catalog.js?v=20260622_admin_catalog_phase2a_v1"></script>
+</body>
+</html>

--- a/admin-store-catalog.js
+++ b/admin-store-catalog.js
@@ -1,0 +1,268 @@
+let catalogItems = [];
+let editingItemId = null;
+let isSaving = false;
+
+function escapeHtml(value) {
+  return String(value == null ? "" : value)
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+function fmtCatalogPrice(item) {
+  const price = Number(item.base_price);
+  if (!Number.isFinite(price) || price <= 0) return "สอบถามราคา";
+  return `ราคาเริ่มต้น ${price.toLocaleString("th-TH")} บาท`;
+}
+
+function fmtBtuRange(item) {
+  const min = Number(item.btu_min);
+  const max = Number(item.btu_max);
+  const hasMin = Number.isFinite(min) && min > 0;
+  const hasMax = Number.isFinite(max) && max > 0;
+  if (hasMin && hasMax && min !== max) return `${min.toLocaleString("th-TH")}–${max.toLocaleString("th-TH")} BTU`;
+  if (hasMin && hasMax) return `${min.toLocaleString("th-TH")} BTU`;
+  if (hasMin) return `ตั้งแต่ ${min.toLocaleString("th-TH")} BTU`;
+  if (hasMax) return `ไม่เกิน ${max.toLocaleString("th-TH")} BTU`;
+  return "";
+}
+
+function resetCatalogForm() {
+  editingItemId = null;
+  el("item_name").value = "";
+  el("item_category").value = "";
+  el("base_price").value = "";
+  el("unit_label").value = "";
+  el("job_category").value = "";
+  el("ac_type").value = "";
+  el("btu_min").value = "";
+  el("btu_max").value = "";
+  el("is_active").value = "1";
+  el("is_customer_visible").value = "0";
+  el("catalog_form_title").textContent = "เพิ่มรายการบริการ";
+  el("btnSaveItem").textContent = "บันทึกรายการ";
+  el("btnCancelEdit").style.display = "none";
+  hideCatalogFormError();
+  updateCatalogVisibleHint();
+}
+
+function hideCatalogFormError() {
+  const box = el("catalog_form_error");
+  box.style.display = "none";
+  box.textContent = "";
+}
+
+function showCatalogFormError(message) {
+  const box = el("catalog_form_error");
+  box.textContent = message;
+  box.style.display = "block";
+}
+
+function updateCatalogVisibleHint() {
+  const active = el("is_active").value === "1";
+  const visible = el("is_customer_visible").value === "1";
+  el("catalog_visible_hint").style.display = (active && visible) ? "block" : "none";
+}
+
+function catalogFormPayload() {
+  const trimmedOrEmpty = (id) => (el(id).value || "").trim();
+  return {
+    item_name: trimmedOrEmpty("item_name"),
+    item_category: trimmedOrEmpty("item_category"),
+    base_price: trimmedOrEmpty("base_price"),
+    unit_label: trimmedOrEmpty("unit_label"),
+    job_category: trimmedOrEmpty("job_category"),
+    ac_type: trimmedOrEmpty("ac_type"),
+    btu_min: trimmedOrEmpty("btu_min"),
+    btu_max: trimmedOrEmpty("btu_max"),
+    is_active: el("is_active").value === "1",
+    is_customer_visible: el("is_customer_visible").value === "1",
+  };
+}
+
+function validateCatalogFormPayload(payload) {
+  if (!payload.item_name) return "กรุณากรอกชื่อรายการ";
+  if (payload.base_price !== "" && (!Number.isFinite(Number(payload.base_price)) || Number(payload.base_price) < 0)) {
+    return "ราคาต้องเป็นตัวเลขตั้งแต่ 0 ขึ้นไป";
+  }
+  if (payload.btu_min !== "" && (!Number.isFinite(Number(payload.btu_min)) || Number(payload.btu_min) <= 0)) {
+    return "btu_min ต้องเป็นค่าว่างหรือจำนวนบวก";
+  }
+  if (payload.btu_max !== "" && (!Number.isFinite(Number(payload.btu_max)) || Number(payload.btu_max) <= 0)) {
+    return "btu_max ต้องเป็นค่าว่างหรือจำนวนบวก";
+  }
+  if (payload.btu_min !== "" && payload.btu_max !== "" && Number(payload.btu_min) > Number(payload.btu_max)) {
+    return "btu_min ต้องไม่มากกว่า btu_max";
+  }
+  return "";
+}
+
+function editCatalogItem(itemId) {
+  const item = catalogItems.find((x) => Number(x.item_id) === Number(itemId));
+  if (!item) return;
+  editingItemId = Number(itemId);
+  el("item_name").value = item.item_name || "";
+  el("item_category").value = item.item_category || "";
+  el("base_price").value = Number(item.base_price) > 0 ? Number(item.base_price) : "";
+  el("unit_label").value = item.unit_label || "";
+  el("job_category").value = item.job_category || "";
+  el("ac_type").value = item.ac_type || "";
+  el("btu_min").value = item.btu_min || "";
+  el("btu_max").value = item.btu_max || "";
+  el("is_active").value = item.is_active ? "1" : "0";
+  el("is_customer_visible").value = item.is_customer_visible ? "1" : "0";
+  el("catalog_form_title").textContent = `แก้ไขรายการ #${item.item_id}`;
+  el("btnSaveItem").textContent = "บันทึกการแก้ไข";
+  el("btnCancelEdit").style.display = "block";
+  hideCatalogFormError();
+  updateCatalogVisibleHint();
+  window.scrollTo({ top: 0, behavior: "smooth" });
+}
+
+async function saveCatalogItem() {
+  if (isSaving) return;
+  hideCatalogFormError();
+
+  const payload = catalogFormPayload();
+  const validationError = validateCatalogFormPayload(payload);
+  if (validationError) {
+    showCatalogFormError(validationError);
+    return;
+  }
+
+  isSaving = true;
+  el("btnSaveItem").disabled = true;
+  try {
+    if (editingItemId) {
+      await apiFetch(`/admin/catalog/items/${editingItemId}`, { method: "PATCH", body: JSON.stringify(payload) });
+      showToast("บันทึกการแก้ไขแล้ว", "success");
+    } else {
+      await apiFetch("/admin/catalog/items", { method: "POST", body: JSON.stringify(payload) });
+      showToast("เพิ่มรายการแล้ว", "success");
+    }
+    resetCatalogForm();
+    await loadCatalogItems();
+  } catch (e) {
+    showCatalogFormError(e.message || "บันทึกรายการไม่สำเร็จ");
+  } finally {
+    isSaving = false;
+    el("btnSaveItem").disabled = false;
+  }
+}
+
+async function toggleCatalogField(itemId, field, nextValue, item) {
+  if (field === "is_active" && nextValue === false && item.is_active && item.is_customer_visible) {
+    const confirmed = confirm("รายการนี้กำลังแสดงให้ลูกค้าเห็นอยู่ ต้องการปิดใช้งานหรือไม่?");
+    if (!confirmed) return;
+  }
+  try {
+    await apiFetch(`/admin/catalog/items/${itemId}`, { method: "PATCH", body: JSON.stringify({ [field]: nextValue }) });
+    await loadCatalogItems();
+  } catch (e) {
+    showToast(e.message || "อัปเดตรายการไม่สำเร็จ", "error");
+  }
+}
+
+function catalogItemMatchesFilters(item) {
+  const search = (el("catalog_search").value || "").trim().toLowerCase();
+  const activeFilter = el("catalog_filter_active").value;
+  const visibleFilter = el("catalog_filter_visible").value;
+
+  if (search && !String(item.item_name || "").toLowerCase().includes(search)) return false;
+  if (activeFilter !== "" && Boolean(item.is_active) !== (activeFilter === "1")) return false;
+  if (visibleFilter !== "" && Boolean(item.is_customer_visible) !== (visibleFilter === "1")) return false;
+  return true;
+}
+
+function catalogItemRow(item) {
+  const active = !!item.is_active;
+  const visible = !!item.is_customer_visible;
+  const btu = fmtBtuRange(item);
+  const meta = [item.job_category, item.ac_type, btu].filter(Boolean).join(" • ");
+  return `
+  <div class="svc-row" style="align-items:flex-start">
+    <div class="svc-main" style="flex:1">
+      <div class="svc-title"><b>${escapeHtml(item.item_name)}</b> <span class="muted2 mini">#${escapeHtml(item.item_id)}</span></div>
+      <div class="muted2 mini">${escapeHtml(item.item_category || "-")} • ${escapeHtml(fmtCatalogPrice(item))}${item.unit_label ? ` / ${escapeHtml(item.unit_label)}` : ""}</div>
+      ${meta ? `<div class="muted2 mini">${escapeHtml(meta)}</div>` : ""}
+      <div class="muted2 mini">สถานะ: <b>${active ? "เปิดใช้งาน" : "ปิดใช้งาน"}</b> • แสดงลูกค้า: <b>${visible ? "แสดง" : "ไม่แสดง"}</b></div>
+    </div>
+    <div style="display:flex;gap:8px;flex-wrap:wrap;justify-content:flex-end">
+      <button class="secondary btn-small" data-act="edit" data-id="${item.item_id}">แก้ไข</button>
+      <button class="secondary btn-small" data-act="toggle-active" data-id="${item.item_id}">${active ? "ปิดใช้งาน" : "เปิดใช้งาน"}</button>
+      <button class="secondary btn-small" data-act="toggle-visible" data-id="${item.item_id}">${visible ? "ซ่อนจากลูกค้า" : "แสดงให้ลูกค้า"}</button>
+    </div>
+  </div>`;
+}
+
+function renderCatalogList() {
+  const box = el("catalog_list");
+  const filtered = catalogItems.filter(catalogItemMatchesFilters);
+  box.innerHTML = filtered.length
+    ? filtered.map(catalogItemRow).join("")
+    : `<div class="muted2">ไม่พบรายการที่ตรงกับการค้นหา/ตัวกรอง</div>`;
+}
+
+function renderCatalogPreview() {
+  const box = el("catalog_preview");
+  const visibleItems = catalogItems.filter((item) => item.is_active && item.is_customer_visible);
+  if (!visibleItems.length) {
+    box.innerHTML = `<div class="muted2">ยังไม่มีรายการที่จะแสดงในร้านค้าลูกค้าในขณะนี้</div>`;
+    return;
+  }
+  box.innerHTML = visibleItems.map((item) => {
+    const btu = fmtBtuRange(item);
+    return `
+    <div class="svc-row" style="align-items:flex-start">
+      <div class="svc-main" style="flex:1">
+        <div class="svc-title"><b>${escapeHtml(item.item_name)}</b></div>
+        <div class="muted2 mini">${escapeHtml(item.item_category || "-")} • ${escapeHtml(fmtCatalogPrice(item))}${item.unit_label ? ` / ${escapeHtml(item.unit_label)}` : ""}</div>
+        ${btu || item.ac_type ? `<div class="muted2 mini">${escapeHtml([item.ac_type, btu].filter(Boolean).join(" • "))}</div>` : ""}
+        <div class="muted2 mini">จะแสดงใน Store: <b style="color:#15803d">ใช่</b></div>
+      </div>
+    </div>`;
+  }).join("");
+}
+
+async function loadCatalogItems() {
+  const box = el("catalog_list");
+  box.innerHTML = "กำลังโหลดรายการ...";
+  try {
+    const items = await apiFetch("/admin/catalog/items");
+    catalogItems = Array.isArray(items) ? items : [];
+    renderCatalogList();
+    renderCatalogPreview();
+  } catch (e) {
+    box.innerHTML = `<div class="muted2">โหลดรายการไม่สำเร็จ: ${escapeHtml(e.message || "")}</div>`;
+  }
+}
+
+function bindCatalogListActions() {
+  el("catalog_list").addEventListener("click", (event) => {
+    const button = event.target.closest("[data-act]");
+    if (!button) return;
+    const id = Number(button.getAttribute("data-id"));
+    const item = catalogItems.find((x) => Number(x.item_id) === id);
+    if (!item) return;
+    const act = button.getAttribute("data-act");
+    if (act === "edit") editCatalogItem(id);
+    else if (act === "toggle-active") toggleCatalogField(id, "is_active", !item.is_active, item);
+    else if (act === "toggle-visible") toggleCatalogField(id, "is_customer_visible", !item.is_customer_visible, item);
+  });
+}
+
+document.addEventListener("DOMContentLoaded", () => {
+  resetCatalogForm();
+  bindCatalogListActions();
+  el("btnSaveItem").addEventListener("click", saveCatalogItem);
+  el("btnCancelEdit").addEventListener("click", resetCatalogForm);
+  el("btnNewItem").addEventListener("click", resetCatalogForm);
+  el("btnReloadCatalog").addEventListener("click", loadCatalogItems);
+  el("is_active").addEventListener("change", updateCatalogVisibleHint);
+  el("is_customer_visible").addEventListener("change", updateCatalogVisibleHint);
+  el("catalog_search").addEventListener("input", renderCatalogList);
+  el("catalog_filter_active").addEventListener("change", renderCatalogList);
+  el("catalog_filter_visible").addEventListener("change", renderCatalogList);
+  loadCatalogItems();
+});

--- a/admin-v2-common.js
+++ b/admin-v2-common.js
@@ -485,6 +485,7 @@ function injectAdminMenu(){
             <div class="cwf-link" data-href="/admin-history-v2.html">🧾 ประวัติงาน <small>History</small></div>
             <div class="cwf-link" data-href="/admin-review-v2.html">✅ อนุมัติงาน/รีวิว <small>Approvals</small></div>
             <div class="cwf-link" data-href="/admin-promotions-v2.html">🏷️ โปรโมชั่น/ราคา <small>Promotions</small></div>
+            <div class="cwf-link" data-href="/admin-store-catalog.html">🗂️ รายการบริการในร้านค้า <small>Store Catalog</small></div>
             <div class="cwf-link" data-href="/admin-job-view-v2.html">🔎 ดูงาน <small>Job View</small></div>
           </div>
         </div>

--- a/docs/ADMIN_SERVICE_CATALOG_PHASE2A_HANDOFF.md
+++ b/docs/ADMIN_SERVICE_CATALOG_PHASE2A_HANDOFF.md
@@ -53,6 +53,49 @@ git diff --check                                -> clean
 ## Remaining risks / what Phase 2B should pick up
 
 - **Browser QA not performed** for `admin-store-catalog.html` at any breakpoint — no headless browser tooling is available in this sandbox. The mobile-usable CSS follows the same classes already used by `admin-promotions-v2.html`, but visual verification in a real browser (320/360/390/430px and desktop) is still outstanding.
-- The pre-existing unauthenticated `POST /catalog/items` legacy route in `index.js` was deliberately left as-is (out of scope for this phase) — worth flagging to whoever owns Auth/Production routes, since it currently allows creating catalog rows without any admin session.
 - No server-side search/pagination was added to `GET /admin/catalog/items` — fine for the current catalog size, but if the catalog grows large this endpoint should add filtering/pagination in a later phase.
 - Phase 2B (Air Conditioner Product Phase) was explicitly not started, per scope.
+
+## Correction Pass (post Phase 2A, same branch/PR)
+
+Applied on top of commit `e815ede22ba4cbe5d40e7256fae762eda4502156`, fixing three production blockers identified in review. No new branch, no Phase 2B, no merge.
+
+### Correction 1 — Strict boolean validation
+
+`normalizeBoolean()` in `server/routes/catalog/items.js` previously silently fell back to a default for any unrecognized value (e.g. `"is_active": "มั่ว"` would silently become `true`). It now returns `{ ok, value }` / `{ ok: false, error }` and is wired into `validateMergedCatalogItem`, so an unrecognized value is rejected with `400` and never reaches `INSERT`/`UPDATE`.
+
+Accepted forms: real `true`/`false`, numbers `1`/`0`, and strings `"true"`/`"false"`/`"1"`/`"0"`/`"yes"`/`"no"`/`"on"`/`"off"` (case-insensitive, trimmed). The `"yes"/"no"/"on"/"off"` forms are kept for backward compatibility and are explicitly covered by a test. Empty string is now **rejected** rather than silently treated as `false`. Fields omitted from the request body are unaffected — `mergeCatalogItemPayload` already only substitutes the existing/default value when the client didn't send the key, so the strict check only runs against what the client actually sent.
+
+### Correction 2 — Legacy write route caller audit and auth fix
+
+Searched the repo for every consumer of `/catalog/items`:
+- `POST /catalog/items` declaration: only one, in `index.js` (the legacy route itself).
+- Client callers of `/catalog/items`: `customer-app/modules/api.js:110` (`requestJson("/catalog/items", { query: { customer: 1 } })`) and `admin-add-v2.js:1459` (`apiFetch("/catalog/items")`) — **both are `GET` requests**, neither posts to this route.
+- No fetch/XHR call to `POST /catalog/items` was found anywhere in the repo (admin pages, customer app, or scripts).
+
+Conclusion: no public/internal caller depends on the route being unauthenticated. Per the explicit authorization in this correction pass to change this route's auth behavior, `index.js`'s `app.post("/catalog/items", async (req, res) => {` was changed to `app.post("/catalog/items", requireAdminSession, async (req, res) => {` — middleware only, no change to path, request body contract, SQL, or response shape. The route was not moved or removed.
+
+### Correction 3 — Admin menu entry
+
+Added one link to the shared drawer markup in `admin-v2-common.js`, in the "หน้า Admin ทั้งหมด" group right after the existing Promotions link (same group as other catalog/pricing-adjacent admin pages): `🗂️ รายการบริการในร้านค้า` → `/admin-store-catalog.html`. Same `cwf-link` / `data-href` convention as every other entry; no redesign, no reordering of unrelated items, link appears exactly once.
+
+**Cache/version finding**: `admin-v2-common.js` is referenced with a static `?v=` cache-busting query string from 13 admin HTML pages. Bumping that query string is required for browsers with a cached copy to pick up the new menu link, but only `admin-store-catalog.html` is in this correction pass's authorized file list — the other 12 admin pages (`admin-dashboard-v2.html`, `admin-promotions-v2.html`, etc.) are out of scope and were **not** touched. `admin-store-catalog.html`'s own `?v=` was bumped (`20260428_allpages_ui1` → `20260622_admin_menu_catalog_entry`) since that file is authorized. The other 12 pages will continue serving their previously-cached `admin-v2-common.js` (missing the new menu link) until their own `?v=` is bumped in a separate, properly-scoped pass — flagged here as a known follow-up, not silently dropped.
+
+### Tests added in this pass
+
+`test/catalogItemsRoutes.test.js` (+10 tests, 26 total): invalid `is_active`/`is_customer_visible` rejected with no DB write, real booleans accepted, `"1"`/`"0"` accepted, `"yes"/"no"/"on"/"off"` backward-compat accepted, PATCH omitting booleans preserves existing values, static assertions that the legacy route now has `requireAdminSession`, that no unauthenticated declaration of it remains, and that the public `GET /catalog/items` route is not wrapped in admin auth.
+
+`test/adminStoreCatalogUi.test.js` (new, 5 tests): the shared menu contains the `/admin-store-catalog.html` link with the correct Thai label, the link appears exactly once, and `admin-store-catalog.html` still loads both `admin-v2-common.js` and its own `admin-store-catalog.js`.
+
+### Correction-pass test results
+
+```
+node --check server/routes/catalog/items.js     -> OK
+node --check admin-store-catalog.js             -> OK
+node --check admin-v2-common.js                 -> OK
+node --test test/catalogItemsRoutes.test.js     -> 26/26 pass
+node --test test/adminStoreCatalogUi.test.js    -> 5/5 pass
+node --test test/customerAppRecovery.test.js    -> 25/25 pass (unchanged, regression check)
+npm test                                        -> 213 pass / 10 skipped / 0 fail
+git diff --check                                -> clean
+```

--- a/docs/ADMIN_SERVICE_CATALOG_PHASE2A_HANDOFF.md
+++ b/docs/ADMIN_SERVICE_CATALOG_PHASE2A_HANDOFF.md
@@ -1,0 +1,58 @@
+# Admin Service Catalog Manager — Phase 2A Handoff
+
+## Scope
+
+Admin-only CRUD tool for `public.catalog_items`, the same table the Customer App Store reads from. No database migration, no schema change, no seeded/mock data, no Air Conditioner Product Phase work.
+
+## Existing contract confirmed before changes (read-only verification)
+
+1. **Route factory mounting**: `server/routes/catalog/items.js` exports `createCatalogItemRoutes(deps)`, mounted in `index.js` via `app.use(createCatalogItemRoutes({ pool }))` at the `📦 CATALOG` section (originally line ~12959).
+2. **Admin middleware**: the real middleware is `requireAdminSession` (defined in `index.js`, function declaration around line 1471). It is already injected into other route factories the same way (e.g. `createAdminAiOfficeControlCenterRoutes({ pool, requireAdminSession })`), and all `/admin/*` paths are additionally guarded globally via `app.use("/admin", requireAdminSession)` (line ~4399), which runs before the catalog routes are mounted.
+3. **Existing write route**: `index.js` already had an **unauthenticated** `app.post("/catalog/items", ...)` (legacy, restricted to `item_category` enum `service`/`product`, no validation of `job_category`/`ac_type`/BTU/visibility). It was left untouched — modifying or removing it was outside the authorized scope for this phase and touches "Auth behavior", which is forbidden. It is noted here as a pre-existing condition, not introduced by this work.
+4. **Columns actually used**: `item_id, item_name, item_category, base_price, unit_label, is_active, job_category, ac_type, btu_min, btu_max, is_customer_visible` — confirmed from the existing public `SELECT` in `server/routes/catalog/items.js`. No other columns assumed.
+5. **Constraints**: none enforced in SQL beyond what the existing public route already relied on (`is_active`, `is_customer_visible` as booleans). No CHECK constraints were discovered in-repo (no migration file defines `catalog_items`, so the table predates this repo's migration history).
+
+No scope mismatch was found — the existing structure supports this phase safely without any schema change.
+
+## What was built
+
+- **`server/routes/catalog/items.js`** (existing file, edited):
+  - Public `GET /catalog/items` is **unchanged byte-for-byte** in behavior (same WHERE clause construction, same filters, same response shape).
+  - Added three new admin endpoints, all requiring the injected `requireAdminSession` middleware:
+    - `GET /admin/catalog/items` — returns all rows (active + inactive), no filtering server-side (search/status filtering is done client-side in the admin UI).
+    - `POST /admin/catalog/items` — creates a new row. Defaults: `is_active=true`, `is_customer_visible=false` (a new item is never silently customer-visible).
+    - `PATCH /admin/catalog/items/:itemId` — partial update. Fetches the existing row, merges only the fields present in the request body onto it, validates the merged result, then writes all columns back (this guarantees fields the client didn't send are never changed, without building dynamic SQL column lists from client input).
+  - The route factory now **requires** `deps.requireAdminSession` to be a function and throws at construction time if it's missing — this makes it impossible to accidentally mount the admin routes without real auth.
+  - Validation (`validateMergedCatalogItem`): name required, price optional but must be `>= 0` if given, BTU fields optional positive numbers, `btu_min <= btu_max` when both present, booleans normalized safely from string/boolean/number input. Error responses return a short Thai message only — never SQL text or stack traces (errors are logged server-side via `console.error`, matching the existing pattern in this file).
+  - Hard delete is never used; deactivation is `PATCH { is_active: false }`.
+  - All SQL is parameterized (`$1, $2, ...`); no client input is ever used to build a column name or table name.
+
+- **`index.js`** (one-line change only): `app.use(createCatalogItemRoutes({ pool }))` → `app.use(createCatalogItemRoutes({ pool, requireAdminSession }))`, the minimum change needed to wire the real admin middleware into the route factory.
+
+- **`admin-store-catalog.html`** (new): admin page following the existing `admin-promotions-v2.html` convention (same `/style.css`, same `/admin-v2-common.js` shared script for `apiFetch`/`el`/`showToast`, same `.card`/`.svc-row`/button class conventions). Contains: create/edit form, search box, Active/Inactive filter, Customer-Visible/Hidden filter, item list with per-row Edit / Toggle Active / Toggle Visible buttons, and a read-only Store Preview section.
+
+- **`admin-store-catalog.js`** (new): all client logic — loads from `/admin/catalog/items` via the shared `apiFetch` helper (which already attaches the admin session cookie/token), client-side search/filter, form validation mirroring the server, a double-submit guard (`isSaving` flag + disabling the save button while a request is in flight), a `confirm()` prompt before deactivating an item that is currently both active and customer-visible, and a live hint ("✅ รายการนี้จะแสดงในร้านค้าลูกค้า") shown whenever the form's Active + Customer-Visible selects are both "on". The Store Preview section only lists items where `is_active && is_customer_visible`, computed from the same data just loaded from the real API — no separate/mock data source.
+
+- **`test/catalogItemsRoutes.test.js`** (new): 16 tests using an in-memory fake `pool` (same style as `test/customerAuth.test.js`) plus a real `express` + `http` server per test (no mocked HTTP layer). Covers public filtering behavior, admin auth rejection/acceptance, create/update validation (including `btu_min > btu_max`), partial-update field preservation, deactivate-via-update (not delete), and a SQL-injection attempt that is asserted to never appear in the literal SQL text sent to `pool.query` (only ever passed as a bound parameter). Also asserts the exact `index.js` wiring line via source-text match.
+
+## Not touched (forbidden / out of scope)
+
+Database schema, migrations, seed/production data, Air Conditioner product tables, payment, auth behavior (beyond the one DI wire-up), pricing calculation, booking, availability, urgent flow, tracking, technician app, customer app runtime/UI, promotions, production configuration. The Customer App Store (`customer-app/modules/store.js`) was read for reference only and was not modified in this phase.
+
+## Tests run
+
+```
+node --check server/routes/catalog/items.js     -> OK
+node --check admin-store-catalog.js             -> OK
+node --test test/catalogItemsRoutes.test.js     -> 16/16 pass
+node --test test/customerAppRecovery.test.js    -> 25/25 pass (unchanged, regression check)
+npm test                                        -> 198 pass / 10 skipped / 0 fail
+git diff --check                                -> clean
+```
+
+## Remaining risks / what Phase 2B should pick up
+
+- **Browser QA not performed** for `admin-store-catalog.html` at any breakpoint — no headless browser tooling is available in this sandbox. The mobile-usable CSS follows the same classes already used by `admin-promotions-v2.html`, but visual verification in a real browser (320/360/390/430px and desktop) is still outstanding.
+- The pre-existing unauthenticated `POST /catalog/items` legacy route in `index.js` was deliberately left as-is (out of scope for this phase) — worth flagging to whoever owns Auth/Production routes, since it currently allows creating catalog rows without any admin session.
+- No server-side search/pagination was added to `GET /admin/catalog/items` — fine for the current catalog size, but if the catalog grows large this endpoint should add filtering/pagination in a later phase.
+- Phase 2B (Air Conditioner Product Phase) was explicitly not started, per scope.

--- a/index.js
+++ b/index.js
@@ -12956,7 +12956,7 @@ app.use(createTechnicianDirectoryRoutes({ pool }));
 // =======================================
 // 📦 CATALOG
 // =======================================
-app.use(createCatalogItemRoutes({ pool }));
+app.use(createCatalogItemRoutes({ pool, requireAdminSession }));
 
 
 app.post("/catalog/items", async (req, res) => {

--- a/index.js
+++ b/index.js
@@ -12959,7 +12959,7 @@ app.use(createTechnicianDirectoryRoutes({ pool }));
 app.use(createCatalogItemRoutes({ pool, requireAdminSession }));
 
 
-app.post("/catalog/items", async (req, res) => {
+app.post("/catalog/items", requireAdminSession, async (req, res) => {
   const { item_name, item_category, base_price, unit_label } = req.body || {};
   if (!item_name) return res.status(400).json({ error: "กรอกชื่อรายการ" });
 

--- a/server/routes/catalog/items.js
+++ b/server/routes/catalog/items.js
@@ -1,10 +1,17 @@
-function normalizeBoolean(value, fallback) {
-  if (typeof value === "boolean") return value;
-  if (value === undefined || value === null) return fallback;
-  const s = String(value).trim().toLowerCase();
-  if (s === "1" || s === "true" || s === "yes" || s === "on") return true;
-  if (s === "0" || s === "false" || s === "no" || s === "off" || s === "") return false;
-  return fallback;
+function normalizeBoolean(value, fieldLabel) {
+  if (typeof value === "boolean") return { ok: true, value };
+  if (typeof value === "number") {
+    if (value === 1) return { ok: true, value: true };
+    if (value === 0) return { ok: true, value: false };
+    return { ok: false, error: `${fieldLabel} ไม่ถูกต้อง` };
+  }
+  if (typeof value === "string") {
+    const s = value.trim().toLowerCase();
+    if (s === "true" || s === "1" || s === "yes" || s === "on") return { ok: true, value: true };
+    if (s === "false" || s === "0" || s === "no" || s === "off") return { ok: true, value: false };
+    return { ok: false, error: `${fieldLabel} ไม่ถูกต้อง` };
+  }
+  return { ok: false, error: `${fieldLabel} ไม่ถูกต้อง` };
 }
 
 function parseOptionalPositiveNumber(value, fieldLabel) {
@@ -59,8 +66,13 @@ function validateMergedCatalogItem(merged) {
     errors.push("btu_min ต้องไม่มากกว่า btu_max");
   }
 
-  const is_active = normalizeBoolean(merged.is_active, true);
-  const is_customer_visible = normalizeBoolean(merged.is_customer_visible, false);
+  const isActiveResult = normalizeBoolean(merged.is_active, "is_active");
+  if (!isActiveResult.ok) errors.push(isActiveResult.error);
+  const isVisibleResult = normalizeBoolean(merged.is_customer_visible, "is_customer_visible");
+  if (!isVisibleResult.ok) errors.push(isVisibleResult.error);
+
+  const is_active = isActiveResult.ok ? isActiveResult.value : null;
+  const is_customer_visible = isVisibleResult.ok ? isVisibleResult.value : null;
 
   if (errors.length) return { ok: false, errors };
   return {

--- a/server/routes/catalog/items.js
+++ b/server/routes/catalog/items.js
@@ -1,7 +1,82 @@
+function normalizeBoolean(value, fallback) {
+  if (typeof value === "boolean") return value;
+  if (value === undefined || value === null) return fallback;
+  const s = String(value).trim().toLowerCase();
+  if (s === "1" || s === "true" || s === "yes" || s === "on") return true;
+  if (s === "0" || s === "false" || s === "no" || s === "off" || s === "") return false;
+  return fallback;
+}
+
+function parseOptionalPositiveNumber(value, fieldLabel) {
+  if (value === undefined || value === null || value === "") return { ok: true, value: null };
+  const n = Number(value);
+  if (!Number.isFinite(n) || n <= 0) return { ok: false, error: `${fieldLabel} ต้องเป็นค่าว่างหรือจำนวนบวก` };
+  return { ok: true, value: n };
+}
+
+const CATALOG_ITEM_FIELDS = [
+  "item_name", "item_category", "base_price", "unit_label",
+  "job_category", "ac_type", "btu_min", "btu_max",
+  "is_active", "is_customer_visible",
+];
+
+function mergeCatalogItemPayload(existing, body) {
+  const merged = {};
+  CATALOG_ITEM_FIELDS.forEach((key) => {
+    merged[key] = Object.prototype.hasOwnProperty.call(body, key) ? body[key] : existing[key];
+  });
+  return merged;
+}
+
+function validateMergedCatalogItem(merged) {
+  const errors = [];
+
+  const item_name = String(merged.item_name || "").trim();
+  if (!item_name) errors.push("กรุณากรอกชื่อรายการ");
+
+  const item_category = String(merged.item_category || "").trim();
+  const unit_label = String(merged.unit_label || "").trim();
+  const job_category = String(merged.job_category || "").trim();
+  const ac_type = String(merged.ac_type || "").trim();
+
+  let base_price = 0;
+  if (merged.base_price === null || merged.base_price === undefined || merged.base_price === "") {
+    base_price = 0;
+  } else {
+    const n = Number(merged.base_price);
+    if (!Number.isFinite(n) || n < 0) errors.push("ราคาต้องเป็นตัวเลขตั้งแต่ 0 ขึ้นไป");
+    else base_price = n;
+  }
+
+  const btuMinResult = parseOptionalPositiveNumber(merged.btu_min, "btu_min");
+  if (!btuMinResult.ok) errors.push(btuMinResult.error);
+  const btuMaxResult = parseOptionalPositiveNumber(merged.btu_max, "btu_max");
+  if (!btuMaxResult.ok) errors.push(btuMaxResult.error);
+
+  const btu_min = btuMinResult.ok ? btuMinResult.value : null;
+  const btu_max = btuMaxResult.ok ? btuMaxResult.value : null;
+  if (btu_min !== null && btu_max !== null && btu_min > btu_max) {
+    errors.push("btu_min ต้องไม่มากกว่า btu_max");
+  }
+
+  const is_active = normalizeBoolean(merged.is_active, true);
+  const is_customer_visible = normalizeBoolean(merged.is_customer_visible, false);
+
+  if (errors.length) return { ok: false, errors };
+  return {
+    ok: true,
+    value: { item_name, item_category, base_price, unit_label, job_category, ac_type, btu_min, btu_max, is_active, is_customer_visible },
+  };
+}
+
 module.exports = function createCatalogItemRoutes(deps = {}) {
   const express = require("express");
   const router = express.Router();
   const pool = deps.pool || require("../../db/pool");
+  const requireAdminSession = deps.requireAdminSession;
+  if (typeof requireAdminSession !== "function") {
+    throw new Error("createCatalogItemRoutes requires a requireAdminSession middleware function");
+  }
 
   router.get("/catalog/items", async (req, res) => {
     try {
@@ -36,6 +111,93 @@ module.exports = function createCatalogItemRoutes(deps = {}) {
     } catch (e) {
       console.error(e);
       res.status(500).json({ error: "โหลดรายการสินค้า/บริการไม่สำเร็จ" });
+    }
+  });
+
+  router.get("/admin/catalog/items", requireAdminSession, async (req, res) => {
+    try {
+      const r = await pool.query(
+        `
+        SELECT item_id, item_name, item_category, base_price, unit_label, is_active,
+               job_category, ac_type, btu_min, btu_max, is_customer_visible
+        FROM public.catalog_items
+        ORDER BY item_category, item_name
+        `
+      );
+      res.json(r.rows);
+    } catch (e) {
+      console.error(e);
+      res.status(500).json({ error: "โหลดรายการสินค้า/บริการไม่สำเร็จ" });
+    }
+  });
+
+  router.post("/admin/catalog/items", requireAdminSession, async (req, res) => {
+    try {
+      const defaults = {
+        item_name: "", item_category: "", base_price: 0, unit_label: "",
+        job_category: "", ac_type: "", btu_min: null, btu_max: null,
+        is_active: true, is_customer_visible: false,
+      };
+      const merged = mergeCatalogItemPayload(defaults, req.body || {});
+      const result = validateMergedCatalogItem(merged);
+      if (!result.ok) return res.status(400).json({ error: result.errors.join(", ") });
+
+      const v = result.value;
+      const r = await pool.query(
+        `
+        INSERT INTO public.catalog_items
+          (item_name, item_category, base_price, unit_label, job_category, ac_type, btu_min, btu_max, is_active, is_customer_visible)
+        VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10)
+        RETURNING item_id, item_name, item_category, base_price, unit_label, is_active,
+                  job_category, ac_type, btu_min, btu_max, is_customer_visible
+        `,
+        [v.item_name, v.item_category, v.base_price, v.unit_label, v.job_category, v.ac_type, v.btu_min, v.btu_max, v.is_active, v.is_customer_visible]
+      );
+      res.status(201).json(r.rows[0]);
+    } catch (e) {
+      console.error(e);
+      res.status(500).json({ error: "เพิ่มรายการไม่สำเร็จ" });
+    }
+  });
+
+  router.patch("/admin/catalog/items/:itemId", requireAdminSession, async (req, res) => {
+    try {
+      const itemId = String(req.params.itemId || "").trim();
+      if (!/^\d+$/.test(itemId)) return res.status(400).json({ error: "item_id ไม่ถูกต้อง" });
+
+      const existingResult = await pool.query(
+        `
+        SELECT item_id, item_name, item_category, base_price, unit_label, is_active,
+               job_category, ac_type, btu_min, btu_max, is_customer_visible
+        FROM public.catalog_items
+        WHERE item_id = $1
+        `,
+        [itemId]
+      );
+      const existing = existingResult.rows[0];
+      if (!existing) return res.status(404).json({ error: "ไม่พบรายการนี้" });
+
+      const merged = mergeCatalogItemPayload(existing, req.body || {});
+      const result = validateMergedCatalogItem(merged);
+      if (!result.ok) return res.status(400).json({ error: result.errors.join(", ") });
+
+      const v = result.value;
+      const r = await pool.query(
+        `
+        UPDATE public.catalog_items
+        SET item_name=$1, item_category=$2, base_price=$3, unit_label=$4,
+            job_category=$5, ac_type=$6, btu_min=$7, btu_max=$8,
+            is_active=$9, is_customer_visible=$10
+        WHERE item_id = $11
+        RETURNING item_id, item_name, item_category, base_price, unit_label, is_active,
+                  job_category, ac_type, btu_min, btu_max, is_customer_visible
+        `,
+        [v.item_name, v.item_category, v.base_price, v.unit_label, v.job_category, v.ac_type, v.btu_min, v.btu_max, v.is_active, v.is_customer_visible, itemId]
+      );
+      res.json(r.rows[0]);
+    } catch (e) {
+      console.error(e);
+      res.status(500).json({ error: "แก้ไขรายการไม่สำเร็จ" });
     }
   });
 

--- a/test/adminStoreCatalogUi.test.js
+++ b/test/adminStoreCatalogUi.test.js
@@ -1,0 +1,28 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+
+const commonJsSource = fs.readFileSync(path.join(__dirname, "..", "admin-v2-common.js"), "utf8");
+const catalogHtmlSource = fs.readFileSync(path.join(__dirname, "..", "admin-store-catalog.html"), "utf8");
+
+test("shared admin menu includes a link to /admin-store-catalog.html", () => {
+  assert.match(commonJsSource, /data-href="\/admin-store-catalog\.html"/);
+});
+
+test("shared admin menu catalog link has the expected Thai label", () => {
+  assert.match(commonJsSource, /data-href="\/admin-store-catalog\.html">[^<]*รายการบริการในร้านค้า/);
+});
+
+test("the /admin-store-catalog.html menu link appears exactly once", () => {
+  const matches = commonJsSource.match(/data-href="\/admin-store-catalog\.html"/g) || [];
+  assert.equal(matches.length, 1);
+});
+
+test("admin-store-catalog.html still loads the shared admin-v2-common.js script", () => {
+  assert.match(catalogHtmlSource, /<script src="\/admin-v2-common\.js\?v=[^"]+"><\/script>/);
+});
+
+test("admin-store-catalog.html loads its own admin-store-catalog.js script", () => {
+  assert.match(catalogHtmlSource, /<script src="\/admin-store-catalog\.js\?v=[^"]+"><\/script>/);
+});

--- a/test/catalogItemsRoutes.test.js
+++ b/test/catalogItemsRoutes.test.js
@@ -1,0 +1,285 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const http = require("node:http");
+const express = require("express");
+
+const createCatalogItemRoutes = require("../server/routes/catalog/items");
+
+function makePool(initialItems = []) {
+  const state = { items: initialItems.map((x) => ({ ...x })), queries: [] };
+  let nextId = 1 + state.items.reduce((max, x) => Math.max(max, Number(x.item_id) || 0), 0);
+  return {
+    state,
+    async query(sql, params = []) {
+      state.queries.push({ sql, params });
+
+      if (/INSERT INTO public\.catalog_items/.test(sql)) {
+        const [item_name, item_category, base_price, unit_label, job_category, ac_type, btu_min, btu_max, is_active, is_customer_visible] = params;
+        const row = { item_id: nextId++, item_name, item_category, base_price, unit_label, job_category, ac_type, btu_min, btu_max, is_active, is_customer_visible };
+        state.items.push(row);
+        return { rows: [row] };
+      }
+
+      if (/UPDATE public\.catalog_items/.test(sql)) {
+        const [item_name, item_category, base_price, unit_label, job_category, ac_type, btu_min, btu_max, is_active, is_customer_visible, item_id] = params;
+        const row = state.items.find((x) => String(x.item_id) === String(item_id));
+        if (!row) return { rows: [] };
+        Object.assign(row, { item_name, item_category, base_price, unit_label, job_category, ac_type, btu_min, btu_max, is_active, is_customer_visible });
+        return { rows: [row] };
+      }
+
+      if (/FROM public\.catalog_items\s*WHERE item_id = \$1/.test(sql)) {
+        const row = state.items.find((x) => String(x.item_id) === String(params[0]));
+        return { rows: row ? [row] : [] };
+      }
+
+      if (/FROM public\.catalog_items\s*ORDER BY item_category, item_name\s*$/.test(sql)) {
+        return { rows: state.items.slice() };
+      }
+
+      if (/FROM public\.catalog_items\s*WHERE/.test(sql)) {
+        let rows = state.items.filter((x) => x.is_active === true);
+        if (/is_customer_visible = TRUE/.test(sql)) rows = rows.filter((x) => x.is_customer_visible === true);
+        return { rows };
+      }
+
+      return { rows: [] };
+    },
+  };
+}
+
+function allowAdmin(req, res, next) { next(); }
+function denyAdmin(req, res) { res.status(401).json({ error: "UNAUTHORIZED" }); }
+
+async function withServer(router, fn) {
+  const app = express();
+  app.use(express.json());
+  app.use(router);
+  const server = http.createServer(app);
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  try {
+    return await fn(`http://127.0.0.1:${server.address().port}`);
+  } finally {
+    await new Promise((resolve) => server.close(resolve));
+  }
+}
+
+function sampleItems() {
+  return [
+    { item_id: 1, item_name: "ล้างแอร์ผนัง", item_category: "ล้างแอร์", base_price: 700, unit_label: "เครื่อง", job_category: "ล้าง", ac_type: "ผนัง", btu_min: 9000, btu_max: 12000, is_active: true, is_customer_visible: true },
+    { item_id: 2, item_name: "ซ่อมแอร์ไม่เย็น", item_category: "ซ่อมแอร์", base_price: 0, unit_label: "งาน", job_category: "ซ่อม", ac_type: null, btu_min: null, btu_max: null, is_active: true, is_customer_visible: false },
+    { item_id: 3, item_name: "ล้างแอร์สี่ทิศทาง (ปิดใช้งาน)", item_category: "ล้างแอร์", base_price: 900, unit_label: "เครื่อง", job_category: "ล้าง", ac_type: "สี่ทิศทาง", btu_min: 18000, btu_max: null, is_active: false, is_customer_visible: true },
+  ];
+}
+
+test("createCatalogItemRoutes throws without a requireAdminSession dependency", () => {
+  assert.throws(() => createCatalogItemRoutes({ pool: makePool() }), /requireAdminSession/);
+});
+
+test("public GET /catalog/items still filters is_active=true", async () => {
+  const pool = makePool(sampleItems());
+  const router = createCatalogItemRoutes({ pool, requireAdminSession: allowAdmin });
+  await withServer(router, async (base) => {
+    const res = await fetch(`${base}/catalog/items`);
+    const body = await res.json();
+    assert.equal(res.status, 200);
+    assert.ok(body.every((x) => x.is_active === true));
+    assert.equal(body.some((x) => x.item_id === 3), false);
+  });
+});
+
+test("public GET /catalog/items?customer=1 still filters is_customer_visible=true", async () => {
+  const pool = makePool(sampleItems());
+  const router = createCatalogItemRoutes({ pool, requireAdminSession: allowAdmin });
+  await withServer(router, async (base) => {
+    const res = await fetch(`${base}/catalog/items?customer=1`);
+    const body = await res.json();
+    assert.equal(res.status, 200);
+    assert.ok(body.every((x) => x.is_customer_visible === true));
+    assert.equal(body.some((x) => x.item_id === 2), false);
+    assert.equal(body.some((x) => x.item_id === 3), false);
+  });
+});
+
+test("public API does not expose hidden or inactive items", async () => {
+  const pool = makePool(sampleItems());
+  const router = createCatalogItemRoutes({ pool, requireAdminSession: allowAdmin });
+  await withServer(router, async (base) => {
+    const res = await fetch(`${base}/catalog/items?customer=1`);
+    const body = await res.json();
+    const names = body.map((x) => x.item_name);
+    assert.equal(names.includes("ซ่อมแอร์ไม่เย็น"), false);
+    assert.equal(names.includes("ล้างแอร์สี่ทิศทาง (ปิดใช้งาน)"), false);
+  });
+});
+
+test("admin GET is rejected when unauthorized", async () => {
+  const pool = makePool(sampleItems());
+  const router = createCatalogItemRoutes({ pool, requireAdminSession: denyAdmin });
+  await withServer(router, async (base) => {
+    const res = await fetch(`${base}/admin/catalog/items`);
+    assert.equal(res.status, 401);
+    assert.equal(pool.state.queries.length, 0);
+  });
+});
+
+test("admin GET, when authorized, returns both active and inactive items", async () => {
+  const pool = makePool(sampleItems());
+  const router = createCatalogItemRoutes({ pool, requireAdminSession: allowAdmin });
+  await withServer(router, async (base) => {
+    const res = await fetch(`${base}/admin/catalog/items`);
+    const body = await res.json();
+    assert.equal(res.status, 200);
+    assert.equal(body.length, 3);
+    assert.ok(body.some((x) => x.is_active === false));
+    assert.ok(body.some((x) => x.is_active === true));
+  });
+});
+
+test("admin POST create validation rejects an empty name", async () => {
+  const pool = makePool(sampleItems());
+  const router = createCatalogItemRoutes({ pool, requireAdminSession: allowAdmin });
+  await withServer(router, async (base) => {
+    const res = await fetch(`${base}/admin/catalog/items`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ item_name: "   ", base_price: 100 }),
+    });
+    assert.equal(res.status, 400);
+    const body = await res.json();
+    assert.match(body.error, /ชื่อ/);
+  });
+});
+
+test("admin POST create validation rejects a negative price", async () => {
+  const pool = makePool(sampleItems());
+  const router = createCatalogItemRoutes({ pool, requireAdminSession: allowAdmin });
+  await withServer(router, async (base) => {
+    const res = await fetch(`${base}/admin/catalog/items`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ item_name: "ทดสอบ", base_price: -1 }),
+    });
+    assert.equal(res.status, 400);
+  });
+});
+
+test("admin POST create rejects btu_min > btu_max", async () => {
+  const pool = makePool(sampleItems());
+  const router = createCatalogItemRoutes({ pool, requireAdminSession: allowAdmin });
+  await withServer(router, async (base) => {
+    const res = await fetch(`${base}/admin/catalog/items`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ item_name: "ทดสอบ BTU", btu_min: 24000, btu_max: 9000 }),
+    });
+    assert.equal(res.status, 400);
+    const body = await res.json();
+    assert.match(body.error, /btu_min/);
+  });
+});
+
+test("admin POST create succeeds with valid payload and defaults is_customer_visible to false", async () => {
+  const pool = makePool(sampleItems());
+  const router = createCatalogItemRoutes({ pool, requireAdminSession: allowAdmin });
+  await withServer(router, async (base) => {
+    const res = await fetch(`${base}/admin/catalog/items`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ item_name: "ติดตั้งแอร์ใหม่", item_category: "ติดตั้ง", base_price: 1500, unit_label: "เครื่อง" }),
+    });
+    assert.equal(res.status, 201);
+    const body = await res.json();
+    assert.equal(body.item_name, "ติดตั้งแอร์ใหม่");
+    assert.equal(body.is_active, true);
+    assert.equal(body.is_customer_visible, false);
+  });
+});
+
+test("admin PATCH update validation rejects an unknown item_id", async () => {
+  const pool = makePool(sampleItems());
+  const router = createCatalogItemRoutes({ pool, requireAdminSession: allowAdmin });
+  await withServer(router, async (base) => {
+    const res = await fetch(`${base}/admin/catalog/items/9999`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ item_name: "ไม่มีจริง" }),
+    });
+    assert.equal(res.status, 404);
+  });
+});
+
+test("admin PATCH update rejects btu_min > btu_max against the merged record", async () => {
+  const pool = makePool(sampleItems());
+  const router = createCatalogItemRoutes({ pool, requireAdminSession: allowAdmin });
+  await withServer(router, async (base) => {
+    const res = await fetch(`${base}/admin/catalog/items/1`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ btu_min: 99999 }),
+    });
+    assert.equal(res.status, 400);
+  });
+});
+
+test("admin PATCH update only changes fields explicitly sent by the client", async () => {
+  const pool = makePool(sampleItems());
+  const router = createCatalogItemRoutes({ pool, requireAdminSession: allowAdmin });
+  await withServer(router, async (base) => {
+    const res = await fetch(`${base}/admin/catalog/items/1`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ is_customer_visible: false }),
+    });
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.equal(body.is_customer_visible, false);
+    assert.equal(body.item_name, "ล้างแอร์ผนัง");
+    assert.equal(Number(body.base_price), 700);
+    assert.equal(body.is_active, true);
+  });
+});
+
+test("deactivate uses UPDATE (is_active=false), never DELETE", async () => {
+  const pool = makePool(sampleItems());
+  const router = createCatalogItemRoutes({ pool, requireAdminSession: allowAdmin });
+  await withServer(router, async (base) => {
+    const res = await fetch(`${base}/admin/catalog/items/1`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ is_active: false }),
+    });
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.equal(body.is_active, false);
+    assert.equal(pool.state.items.find((x) => x.item_id === 1).is_active, false);
+    assert.equal(pool.state.items.length, 3);
+    assert.equal(pool.state.queries.some((q) => /DELETE/i.test(q.sql)), false);
+  });
+});
+
+test("SQL injection attempts cannot change query structure", async () => {
+  const pool = makePool(sampleItems());
+  const router = createCatalogItemRoutes({ pool, requireAdminSession: allowAdmin });
+  const malicious = "Robert'); DROP TABLE public.catalog_items;--";
+  await withServer(router, async (base) => {
+    const res = await fetch(`${base}/admin/catalog/items`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ item_name: malicious, base_price: 10 }),
+    });
+    assert.equal(res.status, 201);
+    const insertQuery = pool.state.queries.find((q) => /INSERT INTO public\.catalog_items/.test(q.sql));
+    assert.ok(insertQuery);
+    assert.equal(insertQuery.sql.includes(malicious), false);
+    assert.ok(insertQuery.params.includes(malicious));
+    assert.equal(pool.state.items.some((x) => x.item_id === 3), true);
+  });
+});
+
+test("index.js passes the real requireAdminSession middleware into createCatalogItemRoutes", () => {
+  const source = fs.readFileSync(path.join(__dirname, "..", "index.js"), "utf8");
+  assert.match(source, /app\.use\(createCatalogItemRoutes\(\{\s*pool,\s*requireAdminSession\s*\}\)\)/);
+});

--- a/test/catalogItemsRoutes.test.js
+++ b/test/catalogItemsRoutes.test.js
@@ -283,3 +283,129 @@ test("index.js passes the real requireAdminSession middleware into createCatalog
   const source = fs.readFileSync(path.join(__dirname, "..", "index.js"), "utf8");
   assert.match(source, /app\.use\(createCatalogItemRoutes\(\{\s*pool,\s*requireAdminSession\s*\}\)\)/);
 });
+
+test("admin POST rejects an invalid is_active value and never writes to the DB", async () => {
+  const pool = makePool(sampleItems());
+  const router = createCatalogItemRoutes({ pool, requireAdminSession: allowAdmin });
+  await withServer(router, async (base) => {
+    const res = await fetch(`${base}/admin/catalog/items`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ item_name: "ทดสอบ", is_active: "มั่ว" }),
+    });
+    assert.equal(res.status, 400);
+    const body = await res.json();
+    assert.match(body.error, /is_active/);
+    assert.equal(pool.state.queries.some((q) => /INSERT INTO public\.catalog_items/.test(q.sql)), false);
+  });
+});
+
+test("admin POST rejects an invalid is_customer_visible value (out-of-range number) and never writes to the DB", async () => {
+  const pool = makePool(sampleItems());
+  const router = createCatalogItemRoutes({ pool, requireAdminSession: allowAdmin });
+  await withServer(router, async (base) => {
+    const res = await fetch(`${base}/admin/catalog/items`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ item_name: "ทดสอบ", is_customer_visible: 2 }),
+    });
+    assert.equal(res.status, 400);
+    const body = await res.json();
+    assert.match(body.error, /is_customer_visible/);
+    assert.equal(pool.state.queries.some((q) => /INSERT INTO public\.catalog_items/.test(q.sql)), false);
+  });
+});
+
+test("admin PATCH rejects an invalid boolean and never writes to the DB", async () => {
+  const pool = makePool(sampleItems());
+  const router = createCatalogItemRoutes({ pool, requireAdminSession: allowAdmin });
+  await withServer(router, async (base) => {
+    const res = await fetch(`${base}/admin/catalog/items/1`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ is_active: "มั่ว" }),
+    });
+    assert.equal(res.status, 400);
+    assert.equal(pool.state.queries.some((q) => /UPDATE public\.catalog_items/.test(q.sql)), false);
+    assert.equal(pool.state.items.find((x) => x.item_id === 1).is_active, true);
+  });
+});
+
+test("admin POST accepts real booleans for is_active/is_customer_visible", async () => {
+  const pool = makePool(sampleItems());
+  const router = createCatalogItemRoutes({ pool, requireAdminSession: allowAdmin });
+  await withServer(router, async (base) => {
+    const res = await fetch(`${base}/admin/catalog/items`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ item_name: "ทดสอบ", is_active: true, is_customer_visible: true }),
+    });
+    assert.equal(res.status, 201);
+    const body = await res.json();
+    assert.equal(body.is_active, true);
+    assert.equal(body.is_customer_visible, true);
+  });
+});
+
+test("admin POST accepts the supported \"1\"/\"0\" string forms for booleans", async () => {
+  const pool = makePool(sampleItems());
+  const router = createCatalogItemRoutes({ pool, requireAdminSession: allowAdmin });
+  await withServer(router, async (base) => {
+    const res = await fetch(`${base}/admin/catalog/items`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ item_name: "ทดสอบ", is_active: "0", is_customer_visible: "1" }),
+    });
+    assert.equal(res.status, 201);
+    const body = await res.json();
+    assert.equal(body.is_active, false);
+    assert.equal(body.is_customer_visible, true);
+  });
+});
+
+test("admin POST accepts the backward-compatible \"yes\"/\"no\"/\"on\"/\"off\" string forms for booleans", async () => {
+  const pool = makePool(sampleItems());
+  const router = createCatalogItemRoutes({ pool, requireAdminSession: allowAdmin });
+  await withServer(router, async (base) => {
+    const res = await fetch(`${base}/admin/catalog/items`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ item_name: "ทดสอบ", is_active: "off", is_customer_visible: "yes" }),
+    });
+    assert.equal(res.status, 201);
+    const body = await res.json();
+    assert.equal(body.is_active, false);
+    assert.equal(body.is_customer_visible, true);
+  });
+});
+
+test("admin PATCH that does not send boolean fields preserves their existing values", async () => {
+  const pool = makePool(sampleItems());
+  const router = createCatalogItemRoutes({ pool, requireAdminSession: allowAdmin });
+  await withServer(router, async (base) => {
+    const res = await fetch(`${base}/admin/catalog/items/1`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ item_name: "ล้างแอร์ผนัง (แก้ชื่อ)" }),
+    });
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.equal(body.is_active, true);
+    assert.equal(body.is_customer_visible, true);
+  });
+});
+
+test("legacy POST /catalog/items in index.js requires requireAdminSession", () => {
+  const source = fs.readFileSync(path.join(__dirname, "..", "index.js"), "utf8");
+  assert.match(source, /app\.post\("\/catalog\/items",\s*requireAdminSession,\s*async/);
+});
+
+test("no unauthenticated catalog write route declaration remains in index.js", () => {
+  const source = fs.readFileSync(path.join(__dirname, "..", "index.js"), "utf8");
+  assert.doesNotMatch(source, /app\.post\("\/catalog\/items",\s*async/);
+});
+
+test("public GET /catalog/items in index.js is not wrapped in requireAdminSession", () => {
+  const source = fs.readFileSync(path.join(__dirname, "..", "index.js"), "utf8");
+  assert.doesNotMatch(source, /app\.use\(createCatalogItemRoutes\(\{\s*pool,\s*requireAdminSession\s*\}\)\),\s*requireAdminSession/);
+});


### PR DESCRIPTION
## Summary
- Adds protected admin endpoints to the existing `server/routes/catalog/items.js` route factory: `GET/POST/PATCH /admin/catalog/items[/:itemId]`, all gated by the real `requireAdminSession` middleware injected through dependency injection.
- Keeps the existing public `GET /catalog/items` behavior unchanged: `is_active=true`, and `customer=1` additionally requires `is_customer_visible=true`.
- Adds `admin-store-catalog.html` + `admin-store-catalog.js` for real catalog management: list/search/filter, create/edit, active/visible toggles, validation, confirmation before deactivating visible items, double-submit guard, and read-only Store Preview.
- Adds one shared Admin menu entry: `รายการบริการในร้านค้า` → `/admin-store-catalog.html`.
- No migration, schema change, mock data, seed data, payment, booking, pricing, availability, urgent flow, tracking, technician-app, or customer-app runtime changes.

## Security correction pass
Latest commit: `5d03d09d533d69c16fa7d0d6ff7d18769be2dbc2`

- Boolean validation is strict: supported booleans/0/1/string equivalents pass; unknown values return `400` and do not execute INSERT/UPDATE.
- Legacy `POST /catalog/items` is now protected by `requireAdminSession` without changing its path, body contract, SQL, or response behavior.
- Repository caller audit found only GET callers (`customer-app/modules/api.js` and `admin-add-v2.js`); no unauthenticated POST caller was found.
- `admin-v2-common.js` now contains exactly one link to `/admin-store-catalog.html`.
- `admin-store-catalog.html` uses a bumped `admin-v2-common.js` cache version. The other existing Admin pages retain their current cache version and may require refresh before the new shared-menu entry appears.

## Changed files
- `server/routes/catalog/items.js`
- `index.js`
- `admin-v2-common.js`
- `admin-store-catalog.html`
- `admin-store-catalog.js`
- `test/catalogItemsRoutes.test.js`
- `test/adminStoreCatalogUi.test.js`
- `docs/ADMIN_SERVICE_CATALOG_PHASE2A_HANDOFF.md`

## Test plan
- [x] `node --check server/routes/catalog/items.js`
- [x] `node --check admin-store-catalog.js`
- [x] `node --check admin-v2-common.js`
- [x] `node --test test/catalogItemsRoutes.test.js` — 26/26 passing
- [x] `node --test test/adminStoreCatalogUi.test.js` — 5/5 passing
- [x] `node --test test/customerAppRecovery.test.js` — 25/25 passing
- [x] `npm test` — 213 passing / 10 pre-existing skipped / 0 failing
- [x] `git diff --check` — clean
- [ ] Manual browser QA of `admin-store-catalog.html` at 320/360/390/430px + desktop — not performed in the implementation sandbox.

## Remaining risks
- Focused browser QA and production smoke test are still required.
- Twelve existing Admin pages may use a cached older `admin-v2-common.js` until refresh/cache expiry; the new Catalog page itself uses the bumped version.
- Phase 2B Air Product Catalog has not started.

🤖 Implemented by Claude Code under CWF AI Command Center scope control.