### PR TITLE
fix(catalog): support legacy CLOUDINARY_NAME env

### DIFF
--- a/server/lib/cloudinaryImageUpload.js
+++ b/server/lib/cloudinaryImageUpload.js
@@ -24,7 +24,10 @@ function parseCloudinaryEnv(env = process.env) {
     if (parsed) return parsed;
   }
   return {
-    cloudName: String(env.CLOUDINARY_CLOUD_NAME || "").trim(),
+    // CLOUDINARY_NAME is the legacy var name already used by the technician
+    // photo system (cwf-revisit-tech-preload.js) — kept as a fallback so the
+    // catalog uploader works off the same Render env without any ENV changes.
+    cloudName: String(env.CLOUDINARY_CLOUD_NAME || env.CLOUDINARY_NAME || "").trim(),
     apiKey: String(env.CLOUDINARY_API_KEY || "").trim(),
     apiSecret: String(env.CLOUDINARY_API_SECRET || "").trim(),
   };

--- a/test/cloudinaryImageUpload.test.js
+++ b/test/cloudinaryImageUpload.test.js
@@ -30,6 +30,48 @@ test("discrete CLOUDINARY_CLOUD_NAME/CLOUDINARY_API_KEY/CLOUDINARY_API_SECRET en
   assert.equal(cloudinaryEnabled(env), true);
 });
 
+test("CLOUDINARY_NAME (the legacy technician-photo env var) is accepted as cloudName when CLOUDINARY_CLOUD_NAME is absent", () => {
+  const env = { CLOUDINARY_NAME: "legacy-cloud", CLOUDINARY_API_KEY: "key9", CLOUDINARY_API_SECRET: SECRET };
+  assert.deepEqual(parseCloudinaryEnv(env), { cloudName: "legacy-cloud", apiKey: "key9", apiSecret: SECRET });
+  assert.equal(cloudinaryEnabled(env), true);
+});
+
+test("when both CLOUDINARY_CLOUD_NAME and CLOUDINARY_NAME are set, CLOUDINARY_CLOUD_NAME wins", () => {
+  const env = {
+    CLOUDINARY_CLOUD_NAME: "preferred-cloud",
+    CLOUDINARY_NAME: "legacy-cloud",
+    CLOUDINARY_API_KEY: "key10",
+    CLOUDINARY_API_SECRET: SECRET,
+  };
+  assert.deepEqual(parseCloudinaryEnv(env), { cloudName: "preferred-cloud", apiKey: "key10", apiSecret: SECRET });
+});
+
+test("a valid CLOUDINARY_URL still wins over both CLOUDINARY_CLOUD_NAME and CLOUDINARY_NAME", () => {
+  const env = {
+    CLOUDINARY_URL: `cloudinary://urlkey:${SECRET}@url-cloud`,
+    CLOUDINARY_CLOUD_NAME: "ignored-cloud-name",
+    CLOUDINARY_NAME: "ignored-legacy-name",
+  };
+  assert.deepEqual(parseCloudinaryEnv(env), { cloudName: "url-cloud", apiKey: "urlkey", apiSecret: SECRET });
+});
+
+test("CLOUDINARY_NAME fallback never logs the configured secret to the console", () => {
+  const env = { CLOUDINARY_NAME: "legacy-cloud", CLOUDINARY_API_KEY: "key11", CLOUDINARY_API_SECRET: SECRET };
+  const originalLog = console.log;
+  const originalError = console.error;
+  const logged = [];
+  console.log = (...args) => logged.push(args.join(" "));
+  console.error = (...args) => logged.push(args.join(" "));
+  try {
+    parseCloudinaryEnv(env);
+    cloudinaryEnabled(env);
+  } finally {
+    console.log = originalLog;
+    console.error = originalError;
+  }
+  assert.equal(logged.some((line) => line.includes(SECRET)), false);
+});
+
 test("an incomplete CLOUDINARY_URL is rejected and falls back to (incomplete) discrete env, never partially configured", () => {
   const env = { CLOUDINARY_URL: "cloudinary://onlykey@cloud3" };
   const parsed = parseCloudinaryEnv(env);


### PR DESCRIPTION
## Root cause

Confirmed via direct code reading: the legacy technician-photo upload path (`cwf-revisit-tech-preload.js`) already falls back to `CLOUDINARY_NAME` when `CLOUDINARY_CLOUD_NAME` is absent:

```js
cloudName: process.env.CLOUDINARY_CLOUD_NAME || process.env.CLOUDINARY_NAME || '',
```

`server/lib/cloudinaryImageUpload.js` (used by the Service Catalog image uploader) did not have this fallback, so Catalog uploads fail in any environment where only `CLOUDINARY_NAME` is set (i.e. the existing Render env used by the technician-photo feature) — with no Render ENV change required to fix it.

## Fix

`parseCloudinaryEnv()` in `server/lib/cloudinaryImageUpload.js` now resolves `cloudName` with the same priority order as the technician-photo system:

1. `CLOUDINARY_URL` (if valid)
2. `CLOUDINARY_CLOUD_NAME`
3. `CLOUDINARY_NAME` (legacy fallback, new)

`CLOUDINARY_API_KEY` / `CLOUDINARY_API_SECRET` handling is unchanged. No changes to Cloudinary folder structure, signing algorithm, upload endpoint, file validation, image size limit, the catalog route, or the technician-photo system itself.

## Changed files (2, as authorized)
- `server/lib/cloudinaryImageUpload.js`
- `test/cloudinaryImageUpload.test.js`

## Tests added
- `CLOUDINARY_NAME` + key + secret → `cloudinaryEnabled()` is `true`
- `parseCloudinaryEnv()` returns `cloudName` sourced from `CLOUDINARY_NAME`
- `CLOUDINARY_CLOUD_NAME` wins when both `CLOUDINARY_CLOUD_NAME` and `CLOUDINARY_NAME` are set
- A valid `CLOUDINARY_URL` wins over both
- The `CLOUDINARY_NAME` fallback never logs the configured secret

## Verification
- `node --check server/lib/cloudinaryImageUpload.js` — pass
- `node --test test/cloudinaryImageUpload.test.js` — 16/16 pass
- `npm test` — 320 total, 309 pass, 11 skip, 0 fail
- `git diff --check` — clean

**This PR is a draft and must not be merged without explicit approval (ห้าม Merge).**


---
_Generated by [Claude Code](https://claude.ai/code/session_01G8RDdFzW2bZKTwvsfaovwg)_