### PR TITLE
Catalog Store polish: ribbon, standard badge, autoplay, gallery max-4, real delete

### DIFF
--- a/admin-store-catalog.css
+++ b/admin-store-catalog.css
@@ -154,6 +154,11 @@
 .asc-accordion-summary::before{ content:"▸ "; }
 .asc-accordion[open] > .asc-accordion-summary::before{ content:"▾ "; }
 .asc-accordion > .asc-warning{ margin-top:8px; }
+.asc-booking-advanced{ margin-top:8px; }
+.asc-booking-advanced > .asc-field{ margin-top:8px; }
+.asc-gallery-count{ margin-bottom:6px; }
+.asc-gallery-overlimit{ margin-bottom:8px; }
+.asc-gallery-thumb-error-text{ font-size:10px; }
 .asc-modal-error{ color:#b91c1c; font-size:12px; margin-top:6px; display:none; }
 .asc-loading, .asc-empty, .asc-error{ padding:14px; text-align:center; color:#64748b; font-size:13px; }
 .asc-error{ color:#b91c1c; }

--- a/admin-store-catalog.css
+++ b/admin-store-catalog.css
@@ -92,6 +92,19 @@
   font-size:11px;
   padding:3px 6px;
 }
+.asc-gallery-thumb-pending{ opacity:.85; }
+.asc-gallery-thumb-status{
+  margin-top:4px;
+  text-align:center;
+  font-size:11px;
+  border-radius:6px;
+  padding:2px 4px;
+  background:#f1f5f9;
+  color:#475569;
+}
+.asc-gallery-thumb-status-uploading{ background:#e0f2fe; color:#0369a1; }
+.asc-gallery-thumb-status-done{ background:#dcfce7; color:#15803d; }
+.asc-gallery-thumb-status-error{ background:#fee2e2; color:#b91c1c; }
 
 .asc-item-actions{
   display:flex;
@@ -135,6 +148,12 @@
 .asc-image-preview{
   width:88px; height:88px; border-radius:10px; object-fit:cover; background:#f1f5f9;
 }
+.asc-accordion{ cursor:default; }
+.asc-accordion-summary{ cursor:pointer; list-style:none; }
+.asc-accordion-summary::-webkit-details-marker{ display:none; }
+.asc-accordion-summary::before{ content:"▸ "; }
+.asc-accordion[open] > .asc-accordion-summary::before{ content:"▾ "; }
+.asc-accordion > .asc-warning{ margin-top:8px; }
 .asc-modal-error{ color:#b91c1c; font-size:12px; margin-top:6px; display:none; }
 .asc-loading, .asc-empty, .asc-error{ padding:14px; text-align:center; color:#64748b; font-size:13px; }
 .asc-error{ color:#b91c1c; }

--- a/admin-store-catalog.js
+++ b/admin-store-catalog.js
@@ -601,34 +601,46 @@ async function onGalleryImagePicked(event) {
 }
 
 async function onGalleryDelete(imageId) {
-  if (!editingItemId) return;
+  if (!editingItemId || galleryUploading) return;
   const confirmed = confirm("ต้องการลบรูปภาพนี้หรือไม่?");
   if (!confirmed) return;
+  galleryUploading = true;
+  renderGalleryManager();
   try {
     await apiFetch(`/admin/catalog/items/${editingItemId}/images/${imageId}`, { method: "DELETE" });
     await loadGalleryImages(editingItemId);
   } catch (e) {
     showToast(e.message || "ลบรูปภาพไม่สำเร็จ", "error");
+  } finally {
+    galleryUploading = false;
+    renderGalleryManager();
   }
 }
 
 async function onGallerySetPrimary(imageId) {
-  if (!editingItemId) return;
+  if (!editingItemId || galleryUploading) return;
+  galleryUploading = true;
+  renderGalleryManager();
   try {
     await apiFetch(`/admin/catalog/items/${editingItemId}/images/${imageId}/primary`, { method: "POST" });
     await loadGalleryImages(editingItemId);
   } catch (e) {
     showToast(e.message || "ตั้งรูปหลักไม่สำเร็จ", "error");
+  } finally {
+    galleryUploading = false;
+    renderGalleryManager();
   }
 }
 
 async function onGalleryReorder(imageId, direction) {
-  if (!editingItemId) return;
+  if (!editingItemId || galleryUploading) return;
   const index = galleryImages.findIndex((img) => Number(img.image_id) === Number(imageId));
   const swapWith = direction === "up" ? index - 1 : index + 1;
   if (index < 0 || swapWith < 0 || swapWith >= galleryImages.length) return;
   const ids = galleryImages.map((img) => img.image_id);
   [ids[index], ids[swapWith]] = [ids[swapWith], ids[index]];
+  galleryUploading = true;
+  renderGalleryManager();
   try {
     await apiFetch(`/admin/catalog/items/${editingItemId}/images/reorder`, {
       method: "POST",
@@ -637,6 +649,9 @@ async function onGalleryReorder(imageId, direction) {
     await loadGalleryImages(editingItemId);
   } catch (e) {
     showToast(e.message || "จัดเรียงรูปภาพไม่สำเร็จ", "error");
+  } finally {
+    galleryUploading = false;
+    renderGalleryManager();
   }
 }
 

--- a/admin-store-catalog.js
+++ b/admin-store-catalog.js
@@ -8,6 +8,7 @@ let galleryImages = [];
 let galleryLoading = false;
 let galleryUploading = false;
 let galleryUploadQueue = [];
+let galleryPickNotice = "";
 let deleteModalItemId = null;
 const BOOKING_MODES = ["bookable", "contact_admin"];
 // Must mirror the backend's MAX_CATALOG_IMAGES_PER_ITEM (server/routes/catalog/items.js)
@@ -132,27 +133,32 @@ function ensureCatalogModal() {
           </div>
           <div id="cm_booking_fields" style="display:none;">
             <div class="asc-grid2">
-              <div class="asc-field"><label>Service Key (ข้อมูลอ้างอิง ไม่ใช่เงื่อนไขการจอง)</label><input id="cm_booking_service_key" placeholder="เช่น wash_wall"></div>
               <div class="asc-field"><label>ประเภทแอร์สำหรับจอง *</label>
                 <select id="cm_booking_ac_type">
                   <option value="">— เลือกประเภทแอร์ —</option>
                   ${BOOKING_AC_TYPES.map((v) => `<option value="${escapeHtml(v)}">${escapeHtml(v)}</option>`).join("")}
                 </select>
               </div>
-            </div>
-            <div class="asc-grid2">
               <div class="asc-field"><label>BTU สำหรับจอง *</label>
                 <select id="cm_booking_btu">
                   <option value="">— เลือก BTU —</option>
                   ${BOOKING_BTU_OPTIONS.map((v) => `<option value="${v}">${v.toLocaleString("th-TH")}</option>`).join("")}
                 </select>
               </div>
+            </div>
+            <div class="asc-grid2">
               <div class="asc-field" id="cm_booking_wash_variant_field"><label>รูปแบบการล้างสำหรับจอง * (สำหรับแอร์ผนัง)</label>
                 <select id="cm_booking_wash_variant">
                   <option value="">— เลือกรูปแบบการล้าง —</option>
                   ${BOOKING_WASH_VARIANTS.map((v) => `<option value="${escapeHtml(v)}">${escapeHtml(v)}</option>`).join("")}
                 </select>
               </div>
+              <div></div>
+            </div>
+            <details class="asc-booking-advanced">
+              <summary class="asc-accordion-summary">ตั้งค่าเพิ่มเติม (Advanced)</summary>
+              <div class="asc-field"><label>Service Key (ข้อมูลอ้างอิง ไม่ใช่เงื่อนไขการจอง)</label><input id="cm_booking_service_key" placeholder="เช่น wash_wall"></div>
+            </details>
             </div>
           </div>
         </div>
@@ -319,6 +325,7 @@ function resetCatalogModalFields() {
   galleryImages = [];
   galleryUploading = false;
   galleryUploadQueue = [];
+  galleryPickNotice = "";
   renderGalleryManager();
   hideCatalogModalError();
 }
@@ -386,6 +393,10 @@ function openCatalogModalForEdit(itemId) {
 }
 
 function closeCatalogModal() {
+  if (galleryUploading) {
+    showToast("กำลังอัปโหลดรูปภาพ กรุณารอให้เสร็จก่อนปิดหน้านี้", "error");
+    return;
+  }
   const backdrop = el("catalog_modal_backdrop");
   if (backdrop) backdrop.classList.add("hidden");
 }
@@ -546,11 +557,24 @@ function galleryStatusLabel(status) {
 }
 
 function galleryQueueThumbHtml(queued) {
+  const label = galleryStatusLabel(queued.status);
+  const statusText = queued.status === "error" && queued.error ? `${label}: ${escapeHtml(queued.error)}` : escapeHtml(label);
+  const actions = queued.status === "error"
+    ? `<div class="asc-gallery-thumb-actions">
+         <button class="secondary btn-small" type="button" data-qact="retry" data-queue-id="${escapeHtml(queued.localId)}">ลองใหม่</button>
+         <button class="secondary btn-small" type="button" data-qact="remove" data-queue-id="${escapeHtml(queued.localId)}">เอาออก</button>
+       </div>`
+    : "";
   return `
   <div class="asc-gallery-thumb asc-gallery-thumb-pending" data-queue-id="${escapeHtml(queued.localId)}">
     <img src="${escapeHtml(queued.localUrl)}" alt="${escapeHtml(queued.name)}" loading="lazy">
-    <div class="asc-gallery-thumb-status asc-gallery-thumb-status-${queued.status}">${escapeHtml(galleryStatusLabel(queued.status))}</div>
+    <div class="asc-gallery-thumb-status asc-gallery-thumb-status-${queued.status}">${statusText}</div>
+    ${actions}
   </div>`;
+}
+
+function galleryActiveCount() {
+  return galleryImages.length + galleryUploadQueue.filter((q) => q.status !== "error").length;
 }
 
 function renderGalleryManager() {
@@ -568,11 +592,15 @@ function renderGalleryManager() {
   const grid = existingThumbs || queueThumbs
     ? `<div class="asc-gallery-grid">${existingThumbs}${queueThumbs}</div>`
     : `<div class="asc-empty">ยังไม่มีรูปภาพในแกลเลอรี</div>`;
-  const remaining = Math.max(0, MAX_GALLERY_IMAGES - galleryImages.length);
+  const activeCount = galleryActiveCount();
+  const remaining = Math.max(0, MAX_GALLERY_IMAGES - activeCount);
+  const countLine = `<div class="muted2 mini asc-gallery-count">มีอยู่ ${activeCount} / ${MAX_GALLERY_IMAGES} รูป</div>`;
+  const noticeLine = galleryPickNotice ? `<div class="asc-warning asc-gallery-overlimit">${escapeHtml(galleryPickNotice)}</div>` : "";
   let inputArea;
   if (galleryUploading) {
-    const doneCount = galleryUploadQueue.filter((q) => q.status === "done" || q.status === "error").length;
-    inputArea = `<div class="asc-loading">กำลังอัปโหลด ${doneCount}/${galleryUploadQueue.length} รูป</div>`;
+    const inFlightCount = galleryUploadQueue.filter((q) => q.status === "pending" || q.status === "uploading").length;
+    const settledCount = galleryUploadQueue.filter((q) => q.status === "done" || q.status === "error").length;
+    inputArea = `<div class="asc-loading">กำลังเพิ่มอีก ${inFlightCount} รูป (เสร็จแล้ว ${settledCount}/${galleryUploadQueue.length})</div>`;
   } else if (remaining > 0) {
     inputArea = `<div class="asc-field" style="margin-top:8px;">
           <input id="cm_gallery_input" type="file" accept="image/jpeg,image/png,image/webp" multiple>
@@ -581,7 +609,7 @@ function renderGalleryManager() {
   } else {
     inputArea = `<div class="muted2 mini" style="margin-top:8px;">มีรูปภาพครบ ${MAX_GALLERY_IMAGES} รูปแล้ว ลบรูปเดิมก่อนเพิ่มรูปใหม่</div>`;
   }
-  body.innerHTML = `${grid}${inputArea}`;
+  body.innerHTML = `${countLine}${noticeLine}${grid}${inputArea}`;
   const input = el("cm_gallery_input");
   if (input) input.addEventListener("change", onGalleryImagePicked);
 }
@@ -602,27 +630,43 @@ async function loadGalleryImages(itemId) {
 
 async function onGalleryImagePicked(event) {
   const files = event.target.files ? Array.from(event.target.files) : [];
-  if (!files.length || !editingItemId) return;
-  const remaining = Math.max(0, MAX_GALLERY_IMAGES - galleryImages.length);
-  const toUpload = files.slice(0, remaining);
-  if (files.length > toUpload.length) {
-    showToast(`เลือกได้สูงสุด ${MAX_GALLERY_IMAGES} รูปต่อรายการ อัปโหลดเฉพาะ ${toUpload.length} รูปแรก`, "error");
-  }
-  if (!toUpload.length) return;
+  event.target.value = "";
+  if (!files.length || !editingItemId || galleryUploading) return;
 
-  galleryUploadQueue = toUpload.map((file, i) => ({
+  const activeBefore = galleryActiveCount();
+  const remaining = Math.max(0, MAX_GALLERY_IMAGES - activeBefore);
+  const toUpload = files.slice(0, remaining);
+
+  if (!toUpload.length) {
+    galleryPickNotice = `เลือกแล้ว ${files.length} รูป แต่มีอยู่ครบ ${MAX_GALLERY_IMAGES} / ${MAX_GALLERY_IMAGES} รูปแล้ว ไม่สามารถเพิ่มรูปที่เลือกได้ กรุณาลบรูปเดิมก่อน`;
+    renderGalleryManager();
+    return;
+  }
+
+  galleryPickNotice = `เลือกแล้ว ${files.length} รูป มีอยู่ ${activeBefore} / ${MAX_GALLERY_IMAGES} รูป กำลังเพิ่มอีก ${toUpload.length} รูป`;
+  if (files.length > toUpload.length) {
+    galleryPickNotice += ` (เลือกมาเกินจำนวนที่ว่าง จะอัปโหลดเฉพาะ: ${toUpload.map((f) => f.name || "รูปภาพ").join(", ")})`;
+  }
+
+  const newlyQueued = toUpload.map((file, i) => ({
     localId: `q${Date.now()}_${i}`,
     file,
     name: file.name || "รูปภาพ",
     localUrl: URL.createObjectURL(file),
     status: "pending",
+    error: "",
   }));
+  galleryUploadQueue = galleryUploadQueue.concat(newlyQueued);
+  await runGalleryUploadQueue(newlyQueued);
+}
+
+async function runGalleryUploadQueue(itemsToRun) {
   galleryUploading = true;
   renderGalleryManager();
 
-  const failures = [];
-  for (const queued of galleryUploadQueue) {
+  for (const queued of itemsToRun) {
     queued.status = "uploading";
+    queued.error = "";
     renderGalleryManager();
     try {
       const formData = new FormData();
@@ -631,16 +675,38 @@ async function onGalleryImagePicked(event) {
       queued.status = "done";
     } catch (e) {
       queued.status = "error";
-      failures.push(queued.name);
+      queued.error = e.message || "อัปโหลดไม่สำเร็จ";
     }
     renderGalleryManager();
   }
 
   galleryUploading = false;
-  for (const queued of galleryUploadQueue) URL.revokeObjectURL(queued.localUrl);
-  galleryUploadQueue = [];
-  await loadGalleryImages(editingItemId);
-  if (failures.length) showToast(`อัปโหลดไม่สำเร็จ: ${failures.join(", ")}`, "error");
+  const doneItems = galleryUploadQueue.filter((q) => q.status === "done");
+  for (const queued of doneItems) URL.revokeObjectURL(queued.localUrl);
+  galleryUploadQueue = galleryUploadQueue.filter((q) => q.status !== "done");
+  if (doneItems.length) await loadGalleryImages(editingItemId);
+  if (!galleryUploadQueue.length) galleryPickNotice = "";
+  renderGalleryManager();
+
+  const failures = itemsToRun.filter((q) => q.status === "error");
+  if (failures.length) showToast(`อัปโหลดไม่สำเร็จ: ${failures.map((q) => q.name).join(", ")}`, "error");
+}
+
+async function onGalleryRetry(localId) {
+  if (galleryUploading) return;
+  const queued = galleryUploadQueue.find((q) => q.localId === localId);
+  if (!queued) return;
+  await runGalleryUploadQueue([queued]);
+}
+
+function onGalleryDismissFailed(localId) {
+  if (galleryUploading) return;
+  const queued = galleryUploadQueue.find((q) => q.localId === localId);
+  if (!queued) return;
+  URL.revokeObjectURL(queued.localUrl);
+  galleryUploadQueue = galleryUploadQueue.filter((q) => q.localId !== localId);
+  if (!galleryUploadQueue.length) galleryPickNotice = "";
+  renderGalleryManager();
 }
 
 async function onGalleryDelete(imageId) {
@@ -701,13 +767,21 @@ async function onGalleryReorder(imageId, direction) {
 function bindGalleryActions() {
   el("cm_gallery_body").addEventListener("click", (event) => {
     const button = event.target.closest("[data-gact]");
-    if (!button) return;
-    const imageId = Number(button.getAttribute("data-image-id"));
-    const act = button.getAttribute("data-gact");
-    if (act === "delete") onGalleryDelete(imageId);
-    else if (act === "primary") onGallerySetPrimary(imageId);
-    else if (act === "up") onGalleryReorder(imageId, "up");
-    else if (act === "down") onGalleryReorder(imageId, "down");
+    if (button) {
+      const imageId = Number(button.getAttribute("data-image-id"));
+      const act = button.getAttribute("data-gact");
+      if (act === "delete") onGalleryDelete(imageId);
+      else if (act === "primary") onGallerySetPrimary(imageId);
+      else if (act === "up") onGalleryReorder(imageId, "up");
+      else if (act === "down") onGalleryReorder(imageId, "down");
+      return;
+    }
+    const qbutton = event.target.closest("[data-qact]");
+    if (!qbutton) return;
+    const localId = qbutton.getAttribute("data-queue-id");
+    const qact = qbutton.getAttribute("data-qact");
+    if (qact === "retry") onGalleryRetry(localId);
+    else if (qact === "remove") onGalleryDismissFailed(localId);
   });
 }
 

--- a/admin-store-catalog.js
+++ b/admin-store-catalog.js
@@ -7,6 +7,7 @@ let moreSheetItemId = null;
 let galleryImages = [];
 let galleryLoading = false;
 let galleryUploading = false;
+let galleryUploadQueue = [];
 let deleteModalItemId = null;
 const BOOKING_MODES = ["bookable", "contact_admin"];
 // Must mirror the backend's MAX_CATALOG_IMAGES_PER_ITEM (server/routes/catalog/items.js)
@@ -63,28 +64,16 @@ function ensureCatalogModal() {
       <div class="cwf-modal-body">
 
         <div class="asc-section">
-          <div class="asc-section-title">1) ข้อมูลบริการ</div>
+          <div class="asc-section-title">1) ข้อมูลหลัก</div>
           <div class="asc-field"><label>ชื่อรายการ *</label><input id="cm_item_name" placeholder="เช่น ล้างแอร์ผนัง"></div>
           <div class="asc-grid2">
             <div class="asc-field"><label>หมวดหมู่ *</label><input id="cm_item_category" placeholder="เช่น ล้างแอร์"></div>
             <div class="asc-field"><label>หน่วย *</label><input id="cm_unit_label" placeholder="เช่น เครื่อง, งาน"></div>
           </div>
-          <div class="asc-grid2">
-            <div class="asc-field"><label>ประเภทงาน *</label><input id="cm_job_category" placeholder="เช่น ล้าง, ซ่อม"></div>
-            <div class="asc-field"><label>ประเภทแอร์ *</label><input id="cm_ac_type" placeholder="เช่น ผนัง, แขวน"></div>
-          </div>
-          <div class="asc-grid2">
-            <div class="asc-field"><label>ลักษณะการล้าง *</label><input id="cm_wash_variant" placeholder="เช่น ล้างน้ำ, ล้างน้ำยา"></div>
-            <div></div>
-          </div>
-          <div class="asc-grid2">
-            <div class="asc-field"><label>BTU ต่ำสุด *</label><input id="cm_btu_min" type="number" step="1" min="1" placeholder="ว่าง = ไม่จำกัด"></div>
-            <div class="asc-field"><label>BTU สูงสุด *</label><input id="cm_btu_max" type="number" step="1" min="1" placeholder="ว่าง = ไม่จำกัด"></div>
-          </div>
         </div>
 
         <div class="asc-section">
-          <div class="asc-section-title">2) รูปบริการ</div>
+          <div class="asc-section-title">2) รูปภาพสินค้า</div>
           <div class="asc-image-preview-row">
             <img id="cm_image_preview" class="asc-image-preview" src="" alt="" style="display:none;">
             <div id="cm_image_placeholder" class="asc-item-thumb asc-placeholder">ไม่มีรูป</div>
@@ -100,11 +89,16 @@ function ensureCatalogModal() {
               <option value="0">ไม่เลื่อนอัตโนมัติ</option>
             </select>
           </div>
+          <div id="cm_gallery_section">
+            <div class="asc-section-title" style="margin-top:14px;">รูปภาพเพิ่มเติม (แกลเลอรี)</div>
+            <div id="cm_gallery_body"></div>
+          </div>
         </div>
 
         <div class="asc-section">
           <div class="asc-section-title">3) ราคาและโปรโมชั่น</div>
           <div class="asc-warning">${escapeHtml(PRICING_WARNING_TEXT)}</div>
+          <div class="asc-field"><label>ราคาฐาน (Base Price) *</label><input id="cm_base_price" type="number" step="1" min="0" placeholder="ใช้เมื่อยังไม่มีราคาโปรโมชัน"></div>
           <div class="asc-grid2">
             <div class="asc-field"><label>ราคาปกติ (บาท) *</label><input id="cm_normal_price" type="number" step="1" min="0"></div>
             <div class="asc-field"><label>ราคาขายจริง (บาท) *</label><input id="cm_active_price" type="number" step="1" min="0"></div>
@@ -129,30 +123,7 @@ function ensureCatalogModal() {
         </div>
 
         <div class="asc-section">
-          <div class="asc-section-title">4) การแสดงผล</div>
-          <div class="asc-grid2">
-            <div class="asc-field"><label>สถานะการใช้งาน *</label>
-              <select id="cm_is_active">
-                <option value="1">เปิดใช้งาน</option>
-                <option value="0">ปิดใช้งาน</option>
-              </select>
-            </div>
-            <div class="asc-field"><label>แสดงให้ลูกค้าเห็น *</label>
-              <select id="cm_is_customer_visible">
-                <option value="0">ไม่แสดง</option>
-                <option value="1">แสดง</option>
-              </select>
-            </div>
-          </div>
-        </div>
-
-        <div class="asc-section">
-          <div class="asc-section-title">5) ขั้นสูง</div>
-          <div class="asc-field"><label>ราคาฐาน (Base Price) *</label><input id="cm_base_price" type="number" step="1" min="0" placeholder="ใช้เมื่อยังไม่มีราคาโปรโมชัน"></div>
-        </div>
-
-        <div class="asc-section">
-          <div class="asc-section-title">6) ข้อมูลตลาด (Marketplace)</div>
+          <div class="asc-section-title">4) การจอง</div>
           <div class="asc-field"><label>การจอง *</label>
             <select id="cm_booking_mode">
               <option value="contact_admin">ติดต่อแอดมิน (ไม่จองออนไลน์)</option>
@@ -184,22 +155,56 @@ function ensureCatalogModal() {
               </div>
             </div>
           </div>
-          <div class="asc-field"><label>รายการแนะนำ (Featured) *</label>
-            <select id="cm_is_featured">
-              <option value="0">ไม่แนะนำ</option>
-              <option value="1">แนะนำ</option>
-            </select>
-          </div>
+        </div>
+
+        <div class="asc-section">
+          <div class="asc-section-title">5) รายละเอียด</div>
           <div class="asc-field"><label>คำอธิบายสั้น</label><textarea id="cm_short_description" rows="2" maxlength="300" placeholder="แสดงบนการ์ดร้านค้า"></textarea></div>
           <div class="asc-field"><label>คำอธิบายแบบเต็ม</label><textarea id="cm_long_description" rows="4" placeholder="แสดงในหน้ารายละเอียดสินค้า"></textarea></div>
           <div class="asc-field"><label>จุดเด่น (1 บรรทัดต่อ 1 รายการ)</label><textarea id="cm_highlights" rows="3" placeholder="เช่น&#10;ฟรีน้ำยา&#10;รับประกัน 30 วัน"></textarea></div>
           <div class="asc-field"><label>เงื่อนไขการให้บริการ</label><textarea id="cm_service_conditions" rows="3"></textarea></div>
         </div>
 
-        <div class="asc-section" id="cm_gallery_section">
-          <div class="asc-section-title">7) รูปภาพหลายรูป (แกลเลอรี)</div>
-          <div id="cm_gallery_body"></div>
+        <div class="asc-section">
+          <div class="asc-section-title">6) การแสดงผล</div>
+          <div class="asc-grid2">
+            <div class="asc-field"><label>สถานะการใช้งาน *</label>
+              <select id="cm_is_active">
+                <option value="1">เปิดใช้งาน</option>
+                <option value="0">ปิดใช้งาน</option>
+              </select>
+            </div>
+            <div class="asc-field"><label>แสดงให้ลูกค้าเห็น *</label>
+              <select id="cm_is_customer_visible">
+                <option value="0">ไม่แสดง</option>
+                <option value="1">แสดง</option>
+              </select>
+            </div>
+          </div>
+          <div class="asc-field"><label>รายการแนะนำ (Featured) *</label>
+            <select id="cm_is_featured">
+              <option value="0">ไม่แนะนำ</option>
+              <option value="1">แนะนำ</option>
+            </select>
+          </div>
         </div>
+
+        <details class="asc-section asc-accordion">
+          <summary class="asc-section-title asc-accordion-summary">7) ข้อมูลจับคู่ระบบราคา (กดเพื่อแก้ไข)</summary>
+          <div class="asc-warning">การแก้ไขค่าด้านล่างนี้จะเปลี่ยนการจับคู่กับระบบราคาอัตโนมัติ (customer_service_price_rules) โปรดมั่นใจก่อนแก้ไข</div>
+          <div class="asc-grid2">
+            <div class="asc-field"><label>ประเภทงาน *</label><input id="cm_job_category" placeholder="เช่น ล้าง, ซ่อม"></div>
+            <div class="asc-field"><label>ประเภทแอร์ *</label><input id="cm_ac_type" placeholder="เช่น ผนัง, แขวน"></div>
+          </div>
+          <div class="asc-grid2">
+            <div class="asc-field"><label>ลักษณะการล้าง *</label><input id="cm_wash_variant" placeholder="เช่น ล้างน้ำ, ล้างน้ำยา"></div>
+            <div></div>
+          </div>
+          <div class="asc-grid2">
+            <div class="asc-field"><label>BTU ต่ำสุด *</label><input id="cm_btu_min" type="number" step="1" min="1" placeholder="ว่าง = ไม่จำกัด"></div>
+            <div class="asc-field"><label>BTU สูงสุด *</label><input id="cm_btu_max" type="number" step="1" min="1" placeholder="ว่าง = ไม่จำกัด"></div>
+          </div>
+        </details>
 
         <div id="catalog_modal_error" class="asc-modal-error"></div>
       </div>
@@ -313,6 +318,7 @@ function resetCatalogModalFields() {
   updateBookingFieldsVisibility();
   galleryImages = [];
   galleryUploading = false;
+  galleryUploadQueue = [];
   renderGalleryManager();
   hideCatalogModalError();
 }
@@ -532,6 +538,21 @@ function galleryThumbHtml(image, index, total) {
   </div>`;
 }
 
+function galleryStatusLabel(status) {
+  if (status === "uploading") return "กำลังอัปโหลด...";
+  if (status === "done") return "สำเร็จ";
+  if (status === "error") return "ล้มเหลว";
+  return "รออัปโหลด";
+}
+
+function galleryQueueThumbHtml(queued) {
+  return `
+  <div class="asc-gallery-thumb asc-gallery-thumb-pending" data-queue-id="${escapeHtml(queued.localId)}">
+    <img src="${escapeHtml(queued.localUrl)}" alt="${escapeHtml(queued.name)}" loading="lazy">
+    <div class="asc-gallery-thumb-status asc-gallery-thumb-status-${queued.status}">${escapeHtml(galleryStatusLabel(queued.status))}</div>
+  </div>`;
+}
+
 function renderGalleryManager() {
   const body = el("cm_gallery_body");
   if (!editingItemId) {
@@ -542,18 +563,24 @@ function renderGalleryManager() {
     body.innerHTML = `<div class="asc-loading">กำลังโหลดรูปภาพ...</div>`;
     return;
   }
-  const grid = galleryImages.length
-    ? `<div class="asc-gallery-grid">${galleryImages.map((img, i) => galleryThumbHtml(img, i, galleryImages.length)).join("")}</div>`
+  const existingThumbs = galleryImages.map((img, i) => galleryThumbHtml(img, i, galleryImages.length)).join("");
+  const queueThumbs = galleryUploadQueue.map(galleryQueueThumbHtml).join("");
+  const grid = existingThumbs || queueThumbs
+    ? `<div class="asc-gallery-grid">${existingThumbs}${queueThumbs}</div>`
     : `<div class="asc-empty">ยังไม่มีรูปภาพในแกลเลอรี</div>`;
   const remaining = Math.max(0, MAX_GALLERY_IMAGES - galleryImages.length);
-  const inputArea = galleryUploading
-    ? `<div class="asc-loading">กำลังอัปโหลดรูปภาพ...</div>`
-    : remaining > 0
-      ? `<div class="asc-field" style="margin-top:8px;">
+  let inputArea;
+  if (galleryUploading) {
+    const doneCount = galleryUploadQueue.filter((q) => q.status === "done" || q.status === "error").length;
+    inputArea = `<div class="asc-loading">กำลังอัปโหลด ${doneCount}/${galleryUploadQueue.length} รูป</div>`;
+  } else if (remaining > 0) {
+    inputArea = `<div class="asc-field" style="margin-top:8px;">
           <input id="cm_gallery_input" type="file" accept="image/jpeg,image/png,image/webp" multiple>
           <div class="muted2 mini">JPEG/PNG/WEBP ไม่เกิน 5MB ต่อรูป (เพิ่มได้อีก ${remaining} จาก ${MAX_GALLERY_IMAGES} รูป)</div>
-        </div>`
-      : `<div class="muted2 mini" style="margin-top:8px;">มีรูปภาพครบ ${MAX_GALLERY_IMAGES} รูปแล้ว ลบรูปเดิมก่อนเพิ่มรูปใหม่</div>`;
+        </div>`;
+  } else {
+    inputArea = `<div class="muted2 mini" style="margin-top:8px;">มีรูปภาพครบ ${MAX_GALLERY_IMAGES} รูปแล้ว ลบรูปเดิมก่อนเพิ่มรูปใหม่</div>`;
+  }
   body.innerHTML = `${grid}${inputArea}`;
   const input = el("cm_gallery_input");
   if (input) input.addEventListener("change", onGalleryImagePicked);
@@ -583,19 +610,35 @@ async function onGalleryImagePicked(event) {
   }
   if (!toUpload.length) return;
 
+  galleryUploadQueue = toUpload.map((file, i) => ({
+    localId: `q${Date.now()}_${i}`,
+    file,
+    name: file.name || "รูปภาพ",
+    localUrl: URL.createObjectURL(file),
+    status: "pending",
+  }));
   galleryUploading = true;
   renderGalleryManager();
+
   const failures = [];
-  for (const file of toUpload) {
+  for (const queued of galleryUploadQueue) {
+    queued.status = "uploading";
+    renderGalleryManager();
     try {
       const formData = new FormData();
-      formData.append("image", file);
+      formData.append("image", queued.file);
       await apiFetch(`/admin/catalog/items/${editingItemId}/images`, { method: "POST", body: formData });
+      queued.status = "done";
     } catch (e) {
-      failures.push(file.name || "รูปภาพ");
+      queued.status = "error";
+      failures.push(queued.name);
     }
+    renderGalleryManager();
   }
+
   galleryUploading = false;
+  for (const queued of galleryUploadQueue) URL.revokeObjectURL(queued.localUrl);
+  galleryUploadQueue = [];
   await loadGalleryImages(editingItemId);
   if (failures.length) showToast(`อัปโหลดไม่สำเร็จ: ${failures.join(", ")}`, "error");
 }

--- a/admin-store-catalog.js
+++ b/admin-store-catalog.js
@@ -6,7 +6,11 @@ let pendingImageRemoved = false;
 let moreSheetItemId = null;
 let galleryImages = [];
 let galleryLoading = false;
+let galleryUploading = false;
+let deleteModalItemId = null;
 const BOOKING_MODES = ["bookable", "contact_admin"];
+// Must mirror the backend's MAX_CATALOG_IMAGES_PER_ITEM (server/routes/catalog/items.js)
+const MAX_GALLERY_IMAGES = 4;
 
 // Must mirror the Customer App's canonical lists exactly
 // (customer-app/modules/services.js: acTypes/btuOptions/washVariants) and the
@@ -89,6 +93,12 @@ function ensureCatalogModal() {
               <div class="muted2 mini">JPEG/PNG/WEBP ไม่เกิน 5MB</div>
               <button id="cm_image_delete" class="secondary btn-small" type="button" style="display:none;margin-top:6px;">ลบรูปภาพ</button>
             </div>
+          </div>
+          <div class="asc-field"><label>เลื่อนรูปภาพอัตโนมัติ (Autoplay) *</label>
+            <select id="cm_is_autoplay_enabled">
+              <option value="1">เลื่อนอัตโนมัติ</option>
+              <option value="0">ไม่เลื่อนอัตโนมัติ</option>
+            </select>
           </div>
         </div>
 
@@ -286,6 +296,7 @@ function resetCatalogModalFields() {
   el("cm_is_customer_visible").value = "0";
   el("cm_base_price").value = "";
   el("cm_image_input").value = "";
+  el("cm_is_autoplay_enabled").value = "1";
   pendingImageFile = null;
   pendingImageRemoved = false;
   setCatalogImagePreview(null);
@@ -301,6 +312,7 @@ function resetCatalogModalFields() {
   el("cm_service_conditions").value = "";
   updateBookingFieldsVisibility();
   galleryImages = [];
+  galleryUploading = false;
   renderGalleryManager();
   hideCatalogModalError();
 }
@@ -350,6 +362,7 @@ function openCatalogModalForEdit(itemId) {
   el("cm_is_active").value = item.is_active ? "1" : "0";
   el("cm_is_customer_visible").value = item.is_customer_visible ? "1" : "0";
   el("cm_base_price").value = Number(item.base_price) > 0 ? Number(item.base_price) : "";
+  el("cm_is_autoplay_enabled").value = item.is_autoplay_enabled === false ? "0" : "1";
   if (item.image_url) setCatalogImagePreview(item.image_url);
   el("cm_booking_mode").value = BOOKING_MODES.includes(item.booking_mode) ? item.booking_mode : "contact_admin";
   el("cm_booking_service_key").value = item.booking_service_key || "";
@@ -383,6 +396,7 @@ function catalogModalPayload() {
     btu_min: trimmedOrEmpty("cm_btu_min"),
     btu_max: trimmedOrEmpty("cm_btu_max"),
     base_price: trimmedOrEmpty("cm_base_price"),
+    is_autoplay_enabled: el("cm_is_autoplay_enabled").value === "1",
     is_active: el("cm_is_active").value === "1",
     is_customer_visible: el("cm_is_customer_visible").value === "1",
     booking_mode: el("cm_booking_mode").value,
@@ -531,12 +545,16 @@ function renderGalleryManager() {
   const grid = galleryImages.length
     ? `<div class="asc-gallery-grid">${galleryImages.map((img, i) => galleryThumbHtml(img, i, galleryImages.length)).join("")}</div>`
     : `<div class="asc-empty">ยังไม่มีรูปภาพในแกลเลอรี</div>`;
-  body.innerHTML = `
-    ${grid}
-    <div class="asc-field" style="margin-top:8px;">
-      <input id="cm_gallery_input" type="file" accept="image/jpeg,image/png,image/webp">
-      <div class="muted2 mini">JPEG/PNG/WEBP ไม่เกิน 5MB ต่อรูป</div>
-    </div>`;
+  const remaining = Math.max(0, MAX_GALLERY_IMAGES - galleryImages.length);
+  const inputArea = galleryUploading
+    ? `<div class="asc-loading">กำลังอัปโหลดรูปภาพ...</div>`
+    : remaining > 0
+      ? `<div class="asc-field" style="margin-top:8px;">
+          <input id="cm_gallery_input" type="file" accept="image/jpeg,image/png,image/webp" multiple>
+          <div class="muted2 mini">JPEG/PNG/WEBP ไม่เกิน 5MB ต่อรูป (เพิ่มได้อีก ${remaining} จาก ${MAX_GALLERY_IMAGES} รูป)</div>
+        </div>`
+      : `<div class="muted2 mini" style="margin-top:8px;">มีรูปภาพครบ ${MAX_GALLERY_IMAGES} รูปแล้ว ลบรูปเดิมก่อนเพิ่มรูปใหม่</div>`;
+  body.innerHTML = `${grid}${inputArea}`;
   const input = el("cm_gallery_input");
   if (input) input.addEventListener("change", onGalleryImagePicked);
 }
@@ -556,16 +574,30 @@ async function loadGalleryImages(itemId) {
 }
 
 async function onGalleryImagePicked(event) {
-  const file = event.target.files && event.target.files[0];
-  if (!file || !editingItemId) return;
-  try {
-    const formData = new FormData();
-    formData.append("image", file);
-    await apiFetch(`/admin/catalog/items/${editingItemId}/images`, { method: "POST", body: formData });
-    await loadGalleryImages(editingItemId);
-  } catch (e) {
-    showToast(e.message || "อัปโหลดรูปภาพไม่สำเร็จ", "error");
+  const files = event.target.files ? Array.from(event.target.files) : [];
+  if (!files.length || !editingItemId) return;
+  const remaining = Math.max(0, MAX_GALLERY_IMAGES - galleryImages.length);
+  const toUpload = files.slice(0, remaining);
+  if (files.length > toUpload.length) {
+    showToast(`เลือกได้สูงสุด ${MAX_GALLERY_IMAGES} รูปต่อรายการ อัปโหลดเฉพาะ ${toUpload.length} รูปแรก`, "error");
   }
+  if (!toUpload.length) return;
+
+  galleryUploading = true;
+  renderGalleryManager();
+  const failures = [];
+  for (const file of toUpload) {
+    try {
+      const formData = new FormData();
+      formData.append("image", file);
+      await apiFetch(`/admin/catalog/items/${editingItemId}/images`, { method: "POST", body: formData });
+    } catch (e) {
+      failures.push(file.name || "รูปภาพ");
+    }
+  }
+  galleryUploading = false;
+  await loadGalleryImages(editingItemId);
+  if (failures.length) showToast(`อัปโหลดไม่สำเร็จ: ${failures.join(", ")}`, "error");
 }
 
 async function onGalleryDelete(imageId) {
@@ -631,6 +663,7 @@ function ensureMoreSheet() {
     <div class="asc-more-sheet">
       <button class="secondary" data-act="toggle-active" type="button">เปิด/ปิดใช้งาน</button>
       <button class="secondary" data-act="toggle-visible" type="button">แสดง/ซ่อนจากลูกค้า</button>
+      <button class="danger" data-act="delete" type="button">ลบรายการนี้</button>
       <button class="secondary" data-act="close" type="button">ปิด</button>
     </div>
   </div>`;
@@ -644,6 +677,7 @@ function ensureMoreSheet() {
     if (act === "close" || !item) { closeMoreSheet(); return; }
     if (act === "toggle-active") toggleCatalogField(item.item_id, "is_active", !item.is_active, item);
     if (act === "toggle-visible") toggleCatalogField(item.item_id, "is_customer_visible", !item.is_customer_visible, item);
+    if (act === "delete") { closeMoreSheet(); openDeleteModal(item.item_id); return; }
     closeMoreSheet();
   });
 }
@@ -657,6 +691,86 @@ function openMoreSheet(itemId) {
 function closeMoreSheet() {
   const backdrop = el("asc_more_sheet_backdrop");
   if (backdrop) backdrop.classList.add("hidden");
+}
+
+/* ---------- Delete confirmation modal ---------- */
+
+function ensureDeleteModal() {
+  if (el("asc_delete_modal_backdrop")) return;
+  const wrap = document.createElement("div");
+  wrap.innerHTML = `
+  <div id="asc_delete_modal_backdrop" class="cwf-modal-backdrop hidden">
+    <div class="cwf-modal">
+      <div class="cwf-modal-head">
+        <div class="cwf-modal-title">ลบรายการนี้</div>
+        <button id="asc_delete_modal_close" class="cwf-modal-close" type="button">×</button>
+      </div>
+      <div class="cwf-modal-body">
+        <div class="asc-warning">การลบจะลบรายการและรูปภาพทั้งหมดอย่างถาวร ไม่สามารถย้อนกลับได้ (งานเก่าและราคาที่เคยจองไว้จะไม่ถูกแก้ไข)</div>
+        <div id="asc_delete_modal_visible_warning" class="asc-warning" style="display:none;">รายการนี้กำลังแสดงให้ลูกค้าเห็นอยู่ในขณะนี้</div>
+        <div class="asc-field">
+          <label>พิมพ์ชื่อรายการ "<span id="asc_delete_modal_item_name"></span>" เพื่อยืนยัน</label>
+          <input id="asc_delete_modal_confirm_input" placeholder="พิมพ์ชื่อรายการให้ตรงกัน">
+        </div>
+        <div id="asc_delete_modal_error" class="asc-modal-error"></div>
+      </div>
+      <div class="cwf-modal-foot">
+        <button id="asc_delete_modal_cancel" class="secondary" type="button">ยกเลิก</button>
+        <button id="asc_delete_modal_confirm" class="danger" type="button" disabled>ลบรายการ</button>
+      </div>
+    </div>
+  </div>`;
+  document.body.appendChild(wrap.firstElementChild);
+
+  el("asc_delete_modal_close").addEventListener("click", closeDeleteModal);
+  el("asc_delete_modal_cancel").addEventListener("click", closeDeleteModal);
+  el("asc_delete_modal_confirm").addEventListener("click", confirmDeleteCatalogItem);
+  el("asc_delete_modal_confirm_input").addEventListener("input", updateDeleteConfirmButtonState);
+}
+
+function updateDeleteConfirmButtonState() {
+  const item = catalogItems.find((x) => Number(x.item_id) === Number(deleteModalItemId));
+  const typed = (el("asc_delete_modal_confirm_input").value || "").trim();
+  el("asc_delete_modal_confirm").disabled = !item || typed !== item.item_name;
+}
+
+function openDeleteModal(itemId) {
+  const item = catalogItems.find((x) => Number(x.item_id) === Number(itemId));
+  if (!item) return;
+  ensureDeleteModal();
+  deleteModalItemId = item.item_id;
+  el("asc_delete_modal_item_name").textContent = item.item_name || "";
+  el("asc_delete_modal_confirm_input").value = "";
+  el("asc_delete_modal_error").textContent = "";
+  el("asc_delete_modal_error").style.display = "none";
+  el("asc_delete_modal_visible_warning").style.display = item.is_active && item.is_customer_visible ? "block" : "none";
+  updateDeleteConfirmButtonState();
+  el("asc_delete_modal_backdrop").classList.remove("hidden");
+}
+
+function closeDeleteModal() {
+  const backdrop = el("asc_delete_modal_backdrop");
+  if (backdrop) backdrop.classList.add("hidden");
+  deleteModalItemId = null;
+}
+
+async function confirmDeleteCatalogItem() {
+  if (!deleteModalItemId) return;
+  const itemId = deleteModalItemId;
+  const confirmButton = el("asc_delete_modal_confirm");
+  confirmButton.disabled = true;
+  try {
+    const result = await apiFetch(`/admin/catalog/items/${itemId}`, { method: "DELETE" });
+    closeDeleteModal();
+    await loadCatalogItems();
+    if (result && result.warning) showToast(result.warning, "error");
+    else showToast("ลบรายการแล้ว", "success");
+  } catch (e) {
+    const box = el("asc_delete_modal_error");
+    box.textContent = e.message || "ลบรายการไม่สำเร็จ";
+    box.style.display = "block";
+    updateDeleteConfirmButtonState();
+  }
 }
 
 /* ---------- List / cards ---------- */

--- a/admin-store-catalog.js
+++ b/admin-store-catalog.js
@@ -159,7 +159,6 @@ function ensureCatalogModal() {
               <summary class="asc-accordion-summary">ตั้งค่าเพิ่มเติม (Advanced)</summary>
               <div class="asc-field"><label>Service Key (ข้อมูลอ้างอิง ไม่ใช่เงื่อนไขการจอง)</label><input id="cm_booking_service_key" placeholder="เช่น wash_wall"></div>
             </details>
-            </div>
           </div>
         </div>
 

--- a/customer-app/assets/customer-app.css
+++ b/customer-app/assets/customer-app.css
@@ -3628,6 +3628,21 @@ body.has-contact-sheet { overflow: hidden; }
   color: var(--muted);
 }
 
+.store-featured-ribbon {
+  position: absolute;
+  top: 8px;
+  right: 0;
+  z-index: 2;
+  background: linear-gradient(135deg, var(--accent, #1f7bff), #0f4fb8);
+  color: #fff;
+  font-size: 10.5px;
+  font-weight: 700;
+  padding: 4px 10px 4px 12px;
+  border-radius: 999px 0 0 999px;
+  box-shadow: 0 2px 6px rgba(15, 79, 184, 0.35);
+  line-height: 1.4;
+}
+
 .store-card-badges {
   display: flex;
   flex-wrap: wrap;
@@ -3642,10 +3657,22 @@ body.has-contact-sheet { overflow: hidden; }
   line-height: 1.4;
 }
 .store-badge-promo { background: #fef3c7; color: #92400e; }
-.store-badge-featured { background: #ede9fe; color: #5b21b6; }
 .store-badge-bookable { background: #dcfce7; color: #166534; }
 .store-badge-contact { background: #e0f2fe; color: #075985; }
-.store-card-badge { /* legacy alias kept for any cached markup */ }
+
+.store-standard-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 10.5px;
+  font-weight: 600;
+  color: #92660a;
+  margin-top: 2px;
+}
+.store-standard-stars { display: inline-flex; gap: 1px; line-height: 1; }
+.store-standard-star { color: #e5e7eb; font-size: 11px; }
+.store-standard-star.is-filled { color: #f5b700; }
+.store-standard-label { color: #92660a; }
 
 .store-card-price {
   display: flex;

--- a/customer-app/assets/customer-app.css
+++ b/customer-app/assets/customer-app.css
@@ -3670,9 +3670,20 @@ body.has-contact-sheet { overflow: hidden; }
   margin-top: 2px;
 }
 .store-standard-stars { display: inline-flex; gap: 1px; line-height: 1; }
-.store-standard-star { color: #e5e7eb; font-size: 11px; }
+.store-standard-star { position: relative; color: #e5e7eb; font-size: 11px; }
 .store-standard-star.is-filled { color: #f5b700; }
+.store-standard-star.is-half { color: #e5e7eb; }
+.store-standard-star.is-half::before {
+  content: "★";
+  position: absolute;
+  left: 0;
+  top: 0;
+  width: 50%;
+  overflow: hidden;
+  color: #f5b700;
+}
 .store-standard-label { color: #92660a; }
+.store-standard-count { color: #92660a; font-weight: 500; }
 
 .store-card-price {
   display: flex;

--- a/customer-app/assets/customer-app.css
+++ b/customer-app/assets/customer-app.css
@@ -3683,6 +3683,7 @@ body.has-contact-sheet { overflow: hidden; }
   color: #f5b700;
 }
 .store-standard-label { color: #92660a; }
+.store-standard-value { color: #92660a; font-weight: 700; }
 .store-standard-count { color: #92660a; font-weight: 500; }
 
 .store-card-price {

--- a/customer-app/modules/store.js
+++ b/customer-app/modules/store.js
@@ -82,16 +82,36 @@
     `).join("");
   }
 
+  function renderFeaturedRibbon(item) {
+    if (!item.is_featured) return "";
+    return `<span class="store-featured-ribbon">CWF แนะนำ</span>`;
+  }
+
+  function standardRatingValue(item) {
+    const raw = Number(item && item.rating_value);
+    return Number.isFinite(raw) && raw >= 1 && raw <= 5 ? raw : 5;
+  }
+
+  function renderStandardBadge(item) {
+    const rounded = Math.round(standardRatingValue(item));
+    const stars = Array.from({ length: 5 }, (_, i) =>
+      `<span class="store-standard-star${i < rounded ? " is-filled" : ""}" aria-hidden="true">★</span>`
+    ).join("");
+    return `<div class="store-standard-badge" title="มาตรฐานบริการ CWF"><span class="store-standard-stars">${stars}</span><span class="store-standard-label">มาตรฐานบริการ CWF</span></div>`;
+  }
+
   function renderCardGallery(item, name) {
     const images = itemGalleryImages(item);
     if (!images.length) {
       return `<div class="store-card-gallery"><div class="store-card-image-placeholder" aria-hidden="true">ไม่มีรูปภาพ</div></div>`;
     }
+    const autoplay = images.length > 1 && item.is_autoplay_enabled === true;
     const dots = images.length > 1
       ? `<div class="store-card-dots" data-store-dots>${images.map((_, i) => `<span class="store-card-dot${i === 0 ? " is-active" : ""}"></span>`).join("")}</div>`
       : "";
     return `
-      <div class="store-card-gallery">
+      <div class="store-card-gallery"${autoplay ? ' data-store-autoplay="1"' : ""}>
+        ${renderFeaturedRibbon(item)}
         <div class="store-card-slides" data-store-slides>${renderGallerySlides(images, name, "store-card-slide")}</div>
         ${dots}
       </div>
@@ -101,7 +121,6 @@
   function renderBadges(item) {
     const badges = [];
     if (hasPromo(item)) badges.push(`<span class="store-badge store-badge-promo">${root.utils.escapeHtml(promoBadgeText(item))}</span>`);
-    if (item.is_featured) badges.push(`<span class="store-badge store-badge-featured">แนะนำ</span>`);
     if (isBookable(item)) badges.push(`<span class="store-badge store-badge-bookable">จองได้ทันที</span>`);
     else badges.push(`<span class="store-badge store-badge-contact">ติดต่อแอดมิน</span>`);
     return badges.length ? `<div class="store-card-badges">${badges.join("")}</div>` : "";
@@ -120,6 +139,7 @@
       <article class="store-card" data-store-item="${root.utils.escapeHtml(id)}" tabindex="0" role="button" aria-label="ดูรายละเอียด ${root.utils.escapeHtml(name)}">
         ${renderCardGallery(item, name)}
         ${renderBadges(item)}
+        ${renderStandardBadge(item)}
         <div class="store-card-head">
           ${category ? `<span class="tag">${root.utils.escapeHtml(category)}</span>` : ""}
           <strong>${root.utils.escapeHtml(name)}</strong>
@@ -173,15 +193,103 @@
     `;
   }
 
+  const AUTOPLAY_INTERVAL_MS = 4500;
+  const AUTOPLAY_RESUME_DELAY_MS = 4500;
+
+  function prefersReducedMotion() {
+    try {
+      return typeof window.matchMedia === "function" && window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+    } catch (_error) {
+      return false;
+    }
+  }
+
+  // Returns a cleanup function, or null if autoplay could not be attached
+  // (reduced-motion preference, or the slides element lacks scrollTo support
+  // in this environment).
+  function attachAutoplay(slides, dots) {
+    if (prefersReducedMotion() || typeof slides.scrollTo !== "function") return null;
+    const count = dots.length;
+    if (count < 2) return null;
+    let timer = null;
+    let paused = false;
+    let visible = false;
+    let resumeTimer = null;
+
+    function stop() {
+      if (timer) { clearInterval(timer); timer = null; }
+    }
+    function start() {
+      if (timer || paused || !visible) return;
+      timer = setInterval(() => {
+        const width = Math.max(1, slides.clientWidth);
+        const current = Math.round(slides.scrollLeft / width);
+        const next = current >= count - 1 ? 0 : current + 1;
+        slides.scrollTo({ left: next * width, behavior: "smooth" });
+      }, AUTOPLAY_INTERVAL_MS);
+    }
+    function pauseForInteraction() {
+      paused = true;
+      stop();
+      if (resumeTimer) clearTimeout(resumeTimer);
+      resumeTimer = setTimeout(() => { paused = false; start(); }, AUTOPLAY_RESUME_DELAY_MS);
+    }
+    slides.addEventListener("touchstart", pauseForInteraction, { passive: true });
+    slides.addEventListener("pointerdown", pauseForInteraction, { passive: true });
+
+    function onVisibilityChange() {
+      if (document.hidden) stop();
+      else start();
+    }
+    document.addEventListener("visibilitychange", onVisibilityChange);
+
+    let observer = null;
+    if (typeof IntersectionObserver === "function") {
+      observer = new IntersectionObserver((entries) => {
+        entries.forEach((entry) => {
+          visible = entry.isIntersecting;
+          if (visible) start();
+          else stop();
+        });
+      }, { threshold: 0.5 });
+      observer.observe(slides);
+    } else {
+      visible = true;
+      start();
+    }
+
+    return function cleanup() {
+      stop();
+      if (resumeTimer) clearTimeout(resumeTimer);
+      document.removeEventListener("visibilitychange", onVisibilityChange);
+      if (observer) observer.disconnect();
+      slides.removeEventListener("touchstart", pauseForInteraction);
+      slides.removeEventListener("pointerdown", pauseForInteraction);
+    };
+  }
+
+  let cardAutoplayCleanups = [];
+
+  function clearCardAutoplay() {
+    cardAutoplayCleanups.forEach((cleanup) => cleanup());
+    cardAutoplayCleanups = [];
+  }
+
   function bindGallerySliders(scope) {
+    clearCardAutoplay();
     scope.querySelectorAll("[data-store-slides]").forEach((slides) => {
       const gallery = slides.closest(".store-card-gallery");
       const dots = gallery ? gallery.querySelectorAll(".store-card-dot") : [];
-      if (!dots.length) return;
-      slides.addEventListener("scroll", () => {
-        const index = Math.round(slides.scrollLeft / Math.max(1, slides.clientWidth));
-        dots.forEach((dot, i) => dot.classList.toggle("is-active", i === index));
-      }, { passive: true });
+      if (dots.length) {
+        slides.addEventListener("scroll", () => {
+          const index = Math.round(slides.scrollLeft / Math.max(1, slides.clientWidth));
+          dots.forEach((dot, i) => dot.classList.toggle("is-active", i === index));
+        }, { passive: true });
+      }
+      if (gallery && gallery.getAttribute("data-store-autoplay") === "1") {
+        const cleanup = attachAutoplay(slides, dots);
+        if (cleanup) cardAutoplayCleanups.push(cleanup);
+      }
     });
   }
 
@@ -304,11 +412,13 @@
     if (!images.length) {
       return `<div class="store-detail-gallery"><div class="store-card-image-placeholder" aria-hidden="true">ไม่มีรูปภาพ</div></div>`;
     }
+    const autoplay = images.length > 1 && item.is_autoplay_enabled === true;
     const dots = images.length > 1
       ? `<div class="store-detail-dots" data-store-detail-dots>${images.map((_, i) => `<span class="store-detail-dot${i === 0 ? " is-active" : ""}"></span>`).join("")}</div>`
       : "";
     return `
-      <div class="store-detail-gallery">
+      <div class="store-detail-gallery"${autoplay ? ' data-store-autoplay="1"' : ""}>
+        ${renderFeaturedRibbon(item)}
         <div class="store-detail-slides" data-store-detail-slides>${renderGallerySlides(images, name, "store-detail-slide")}</div>
         ${dots}
       </div>
@@ -326,6 +436,7 @@
       <button class="store-detail-back" type="button" data-store-detail-back>${root.utils.icon("pin", 16)}กลับไปหน้าร้านค้า</button>
       ${renderDetailGallery(item, name)}
       ${renderBadges(item)}
+      ${renderStandardBadge(item)}
       <div class="store-detail-head">
         ${category ? `<span class="tag">${root.utils.escapeHtml(category)}</span>` : ""}
         <h2>${root.utils.escapeHtml(name)}</h2>
@@ -388,7 +499,17 @@
     return renderDetailContent(bucket.data);
   }
 
+  let detailAutoplayCleanup = null;
+
+  function clearDetailAutoplay() {
+    if (detailAutoplayCleanup) {
+      detailAutoplayCleanup();
+      detailAutoplayCleanup = null;
+    }
+  }
+
   function bindDetailGallery(container) {
+    clearDetailAutoplay();
     const slides = container.querySelector("[data-store-detail-slides]");
     const dotsWrap = container.querySelector("[data-store-detail-dots]");
     if (!slides || !dotsWrap) return;
@@ -397,6 +518,10 @@
       const index = Math.round(slides.scrollLeft / Math.max(1, slides.clientWidth));
       dots.forEach((dot, i) => dot.classList.toggle("is-active", i === index));
     }, { passive: true });
+    const gallery = slides.closest(".store-detail-gallery");
+    if (gallery && gallery.getAttribute("data-store-autoplay") === "1") {
+      detailAutoplayCleanup = attachAutoplay(slides, dots);
+    }
   }
 
   function bindDetailBody(container) {
@@ -481,6 +606,13 @@
         loadDetail(container, itemId);
       }
     },
+  };
+
+  store.render.onLeave = () => {
+    clearCardAutoplay();
+  };
+  store.renderDetail.onLeave = () => {
+    clearDetailAutoplay();
   };
 
   root.store = store;

--- a/customer-app/modules/store.js
+++ b/customer-app/modules/store.js
@@ -87,17 +87,31 @@
     return `<span class="store-featured-ribbon">CWF แนะนำ</span>`;
   }
 
-  function standardRatingValue(item) {
-    const raw = Number(item && item.rating_value);
-    return Number.isFinite(raw) && raw >= 1 && raw <= 5 ? raw : 5;
+  // Future-rating-prop-ready: once a real review system exists, items carry
+  // rating_average (1-5, may be fractional) and review_count (>0). Until then
+  // there is no real data, so we show a full 5-star badge with no review
+  // count rather than fabricate one.
+  function standardRatingInfo(item) {
+    const avg = Number(item && item.rating_average);
+    const count = Number(item && item.review_count);
+    if (Number.isFinite(avg) && avg >= 1 && avg <= 5 && Number.isFinite(count) && count > 0) {
+      return { value: avg, count };
+    }
+    const legacy = Number(item && item.rating_value);
+    const value = Number.isFinite(legacy) && legacy >= 1 && legacy <= 5 ? legacy : 5;
+    return { value, count: 0 };
   }
 
   function renderStandardBadge(item) {
-    const rounded = Math.round(standardRatingValue(item));
-    const stars = Array.from({ length: 5 }, (_, i) =>
-      `<span class="store-standard-star${i < rounded ? " is-filled" : ""}" aria-hidden="true">★</span>`
-    ).join("");
-    return `<div class="store-standard-badge" title="มาตรฐานบริการ CWF"><span class="store-standard-stars">${stars}</span><span class="store-standard-label">มาตรฐานบริการ CWF</span></div>`;
+    const { value, count } = standardRatingInfo(item);
+    const full = Math.floor(value);
+    const hasHalf = full < 5 && value - full >= 0.5;
+    const stars = Array.from({ length: 5 }, (_, i) => {
+      const cls = i < full ? " is-filled" : i === full && hasHalf ? " is-half" : "";
+      return `<span class="store-standard-star${cls}" aria-hidden="true">★</span>`;
+    }).join("");
+    const countLabel = count > 0 ? `<span class="store-standard-count">(${count})</span>` : "";
+    return `<div class="store-standard-badge" title="มาตรฐานบริการ CWF"><span class="store-standard-stars">${stars}</span><span class="store-standard-label">มาตรฐานบริการ CWF</span>${countLabel}</div>`;
   }
 
   function renderCardGallery(item, name) {

--- a/customer-app/modules/store.js
+++ b/customer-app/modules/store.js
@@ -102,16 +102,26 @@
     return { value: 5, count: 0 };
   }
 
+  function formatRatingAverage(value) {
+    const rounded = Math.round(value * 10) / 10;
+    return rounded % 1 === 0 ? String(rounded) : rounded.toFixed(1);
+  }
+
   function renderStandardBadge(item) {
     const { value, count } = standardRatingInfo(item);
+    const hasRealReviews = count > 0;
     const full = Math.floor(value);
     const hasHalf = full < 5 && value - full >= 0.5;
     const stars = Array.from({ length: 5 }, (_, i) => {
       const cls = i < full ? " is-filled" : i === full && hasHalf ? " is-half" : "";
       return `<span class="store-standard-star${cls}" aria-hidden="true">★</span>`;
     }).join("");
-    const countLabel = count > 0 ? `<span class="store-standard-count">(${count})</span>` : "";
-    return `<div class="store-standard-badge" title="มาตรฐานบริการ CWF"><span class="store-standard-stars">${stars}</span><span class="store-standard-label">มาตรฐานบริการ CWF</span>${countLabel}</div>`;
+    if (!hasRealReviews) {
+      return `<div class="store-standard-badge" title="มาตรฐานบริการ CWF"><span class="store-standard-stars">${stars}</span><span class="store-standard-label">มาตรฐานบริการ CWF</span></div>`;
+    }
+    const valueLabel = `<span class="store-standard-value">${formatRatingAverage(value)}</span>`;
+    const countLabel = `<span class="store-standard-count">(${count} รีวิว)</span>`;
+    return `<div class="store-standard-badge store-standard-badge-real" title="คะแนนรีวิวจริง"><span class="store-standard-stars">${stars}</span>${valueLabel}${countLabel}</div>`;
   }
 
   function renderCardGallery(item, name) {

--- a/customer-app/modules/store.js
+++ b/customer-app/modules/store.js
@@ -88,18 +88,18 @@
   }
 
   // Future-rating-prop-ready: once a real review system exists, items carry
-  // rating_average (1-5, may be fractional) and review_count (>0). Until then
-  // there is no real data, so we show a full 5-star badge with no review
-  // count rather than fabricate one.
+  // rating_average (1-5, may be fractional) and review_count (>0). rating_value
+  // is legacy and is never read here — it must not become a second contract.
+  // Until rating_average/review_count are both present and valid there is no
+  // real data, so we fail safe to a full 5-star badge with no review count
+  // rather than fabricate one.
   function standardRatingInfo(item) {
     const avg = Number(item && item.rating_average);
     const count = Number(item && item.review_count);
     if (Number.isFinite(avg) && avg >= 1 && avg <= 5 && Number.isFinite(count) && count > 0) {
       return { value: avg, count };
     }
-    const legacy = Number(item && item.rating_value);
-    const value = Number.isFinite(legacy) && legacy >= 1 && legacy <= 5 ? legacy : 5;
-    return { value, count: 0 };
+    return { value: 5, count: 0 };
   }
 
   function renderStandardBadge(item) {

--- a/migrations/20260623_catalog_store_autoplay.sql
+++ b/migrations/20260623_catalog_store_autoplay.sql
@@ -1,0 +1,16 @@
+-- Catalog Store Autoplay — adds a per-item toggle controlling whether the
+-- customer Store card / product detail image gallery auto-slides.
+-- Additive only: one new defaulted column on catalog_items. No existing
+-- data is touched.
+-- Apply during a planned deployment window. Do not run against production
+-- until reviewed.
+
+BEGIN;
+
+ALTER TABLE public.catalog_items
+  ADD COLUMN IF NOT EXISTS is_autoplay_enabled BOOLEAN NOT NULL DEFAULT TRUE;
+
+COMMIT;
+
+-- Rollback plan:
+-- ALTER TABLE public.catalog_items DROP COLUMN IF EXISTS is_autoplay_enabled;

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "migrate:customer-auth": "node scripts/run-customer-auth-migration.js",
     "migrate:catalog-store-media-pricing": "node scripts/run-catalog-store-media-pricing-migration.js",
     "migrate:catalog-marketplace-v2": "node scripts/run-catalog-marketplace-v2-migration.js",
+    "migrate:catalog-autoplay": "node scripts/run-catalog-autoplay-migration.js",
     "test": "node --test test/*.test.js"
   },
   "dependencies": {

--- a/scripts/run-catalog-autoplay-migration.js
+++ b/scripts/run-catalog-autoplay-migration.js
@@ -1,0 +1,158 @@
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+const { Client } = require("pg");
+
+const MIGRATION_RELATIVE_PATH = "migrations/20260623_catalog_store_autoplay.sql";
+const ADVISORY_LOCK_KEY = "202606230066";
+
+function clean(value) {
+  return String(value == null ? "" : value).trim();
+}
+
+function safeErrorMessage(error) {
+  const msg = clean(error && error.message ? error.message : error) || "unknown error";
+  return msg
+    .replace(/postgres(?:ql)?:\/\/[^\s"'<>]+/gi, "[REDACTED_DATABASE_URL]")
+    .replace(/(password|passwd|pwd|secret|token)=([^&\s]+)/gi, "$1=[REDACTED]");
+}
+
+function resolveMigrationPath(repoRoot = path.resolve(__dirname, "..")) {
+  const root = path.resolve(repoRoot);
+  const migrationPath = path.resolve(root, MIGRATION_RELATIVE_PATH);
+  const expected = path.resolve(root, "migrations", "20260623_catalog_store_autoplay.sql");
+  if (migrationPath !== expected || !migrationPath.startsWith(root + path.sep)) {
+    throw new Error("migration path rejected");
+  }
+  return migrationPath;
+}
+
+function readMigrationSql(repoRoot) {
+  return fs.readFileSync(resolveMigrationPath(repoRoot), "utf8");
+}
+
+// The migration file keeps its own top-level BEGIN/COMMIT so it can still be
+// pasted directly into pgAdmin and run standalone. When driven by this
+// runner, though, the runner must own the transaction boundary itself (so a
+// verifySchema() failure can still trigger a real ROLLBACK after the body
+// has executed) — so those two statements are stripped before the body is
+// executed under the runner's own BEGIN/COMMIT/ROLLBACK.
+function stripOuterTransactionWrapper(sql) {
+  return sql
+    .replace(/^[ \t]*BEGIN[ \t]*;[ \t]*$/m, "")
+    .replace(/^[ \t]*COMMIT[ \t]*;[ \t]*$/m, "");
+}
+
+function createClientConfig(env = process.env) {
+  const databaseUrl = clean(env.DATABASE_URL);
+  if (!databaseUrl) throw new Error("DATABASE_URL is required");
+  return {
+    connectionString: databaseUrl,
+    options: "-c timezone=Asia/Bangkok",
+    ssl: { rejectUnauthorized: false },
+  };
+}
+
+async function verifySchema(client) {
+  const columns = await client.query(`
+    SELECT column_name, data_type, is_nullable, column_default
+    FROM information_schema.columns
+    WHERE table_schema = 'public'
+      AND table_name = 'catalog_items'
+      AND column_name = 'is_autoplay_enabled'
+  `);
+  const row = columns.rows?.[0];
+  if (!row) throw new Error("catalog_items.is_autoplay_enabled missing after migration");
+  if (row.data_type !== "boolean") throw new Error("catalog_items.is_autoplay_enabled has unexpected type after migration");
+  if (row.is_nullable !== "NO") throw new Error("catalog_items.is_autoplay_enabled is unexpectedly nullable after migration");
+}
+
+async function runMigration(options = {}) {
+  const env = options.env || process.env;
+  const logger = options.logger || console;
+  const repoRoot = options.repoRoot || path.resolve(__dirname, "..");
+  const clientFactory = options.clientFactory || ((config) => new Client(config));
+  const config = createClientConfig(env);
+  const sql = readMigrationSql(repoRoot);
+  const body = stripOuterTransactionWrapper(sql);
+  const client = clientFactory(config);
+  let locked = false;
+  let inTransaction = false;
+  let originalError = null;
+
+  logger.log("CATALOG_AUTOPLAY_MIGRATION_START");
+  try {
+    await client.connect();
+    await client.query("SELECT pg_advisory_lock($1::bigint)", [ADVISORY_LOCK_KEY]);
+    locked = true;
+
+    // The runner owns BEGIN/verify/COMMIT itself (rather than trusting the
+    // migration file's own embedded BEGIN/COMMIT) so that a verifySchema()
+    // failure — discovered only after the migration body has run — still
+    // triggers a real ROLLBACK instead of leaving an already-committed,
+    // wrongly-verified schema change in place.
+    await client.query("BEGIN");
+    inTransaction = true;
+    await client.query(body);
+    await verifySchema(client);
+    await client.query("COMMIT");
+    inTransaction = false;
+    logger.log("CATALOG_AUTOPLAY_MIGRATION_OK");
+  } catch (error) {
+    originalError = error;
+    throw error;
+  } finally {
+    let cleanupError = null;
+    if (inTransaction) {
+      try {
+        await client.query("ROLLBACK");
+      } catch (error) {
+        cleanupError = cleanupError || error;
+      }
+    }
+    if (locked) {
+      try {
+        await client.query("SELECT pg_advisory_unlock($1::bigint)", [ADVISORY_LOCK_KEY]);
+      } catch (error) {
+        cleanupError = cleanupError || error;
+      }
+    }
+    try {
+      await client.end();
+    } catch (error) {
+      cleanupError = cleanupError || error;
+    }
+    if (!originalError && cleanupError) throw cleanupError;
+  }
+}
+
+async function runCli(options = {}) {
+  const logger = options.logger || console;
+  try {
+    await runMigration(options);
+    return 0;
+  } catch (error) {
+    logger.error(`CATALOG_AUTOPLAY_MIGRATION_FAILED: ${safeErrorMessage(error)}`);
+    return 1;
+  }
+}
+
+if (require.main === module) {
+  runCli().then((code) => {
+    process.exitCode = code;
+  });
+}
+
+module.exports = {
+  ADVISORY_LOCK_KEY,
+  MIGRATION_RELATIVE_PATH,
+  createClientConfig,
+  readMigrationSql,
+  resolveMigrationPath,
+  runCli,
+  runMigration,
+  safeErrorMessage,
+  stripOuterTransactionWrapper,
+  verifySchema,
+};

--- a/server/routes/catalog/items.js
+++ b/server/routes/catalog/items.js
@@ -1,6 +1,8 @@
 const { money, intOrNull, boolish } = require("../../customerPricing");
 const cloudinaryImageUpload = require("../../lib/cloudinaryImageUpload");
 
+const MAX_CATALOG_IMAGES_PER_ITEM = 4;
+
 function normalizeBoolean(value, fieldLabel) {
   if (typeof value === "boolean") return { ok: true, value };
   if (typeof value === "number") {
@@ -1053,7 +1055,12 @@ module.exports = function createCatalogItemRoutes(deps = {}) {
                FROM public.catalog_item_images WHERE item_id = $1`,
             [itemId]
           );
-          const isFirstImage = Number(countResult.rows[0].cnt) === 0;
+          const currentCount = Number(countResult.rows[0].cnt);
+          if (currentCount >= MAX_CATALOG_IMAGES_PER_ITEM) {
+            await client.query("ROLLBACK");
+            return res.status(409).json({ error: `รายการนี้มีรูปภาพครบ ${MAX_CATALOG_IMAGES_PER_ITEM} รูปแล้ว ไม่สามารถเพิ่มรูปได้อีก` });
+          }
+          const isFirstImage = currentCount === 0;
           const nextSortOrder = Number(countResult.rows[0].max_sort) + 1;
 
           uploaded = await uploadCatalogImage({
@@ -1268,3 +1275,4 @@ module.exports.serializeCatalogImage = serializeCatalogImage;
 module.exports.validatePricingInput = validatePricingInput;
 module.exports.validateMarketplaceFields = validateMarketplaceFields;
 module.exports.buildCatalogSelect = buildCatalogSelect;
+module.exports.MAX_CATALOG_IMAGES_PER_ITEM = MAX_CATALOG_IMAGES_PER_ITEM;

--- a/server/routes/catalog/items.js
+++ b/server/routes/catalog/items.js
@@ -867,6 +867,77 @@ module.exports = function createCatalogItemRoutes(deps = {}) {
     }
   });
 
+  router.delete("/admin/catalog/items/:itemId", requireAdminSession, async (req, res) => {
+    try {
+      const itemId = String(req.params.itemId || "").trim();
+      if (!/^\d+$/.test(itemId)) return res.status(400).json({ error: "item_id ไม่ถูกต้อง" });
+
+      const marketplaceReady = await isMarketplaceSchemaReady(pool);
+
+      const client = await pool.connect();
+      let existing;
+      let galleryImages = [];
+      try {
+        await client.query("BEGIN");
+
+        const existingResult = await client.query(
+          `SELECT item_id, image_public_id FROM public.catalog_items WHERE item_id = $1 FOR UPDATE`,
+          [itemId]
+        );
+        existing = existingResult.rows[0];
+        if (!existing) {
+          await client.query("ROLLBACK");
+          return res.status(404).json({ error: "ไม่พบรายการนี้" });
+        }
+
+        if (marketplaceReady) {
+          const galleryResult = await client.query(
+            `SELECT image_public_id FROM public.catalog_item_images WHERE item_id = $1 AND image_public_id IS NOT NULL`,
+            [itemId]
+          );
+          galleryImages = galleryResult.rows;
+        }
+
+        // Deleting the row is the source of truth for "this item is gone" — gallery
+        // rows are removed via the existing ON DELETE CASCADE FK, and the linked price
+        // rule (customer_service_price_rules) is intentionally never touched here so
+        // old jobs priced against it keep working. Cloudinary cleanup happens after
+        // commit, best-effort, and never re-creates the item if it fails.
+        await client.query(`DELETE FROM public.catalog_items WHERE item_id = $1`, [itemId]);
+
+        await client.query("COMMIT");
+      } catch (e) {
+        await client.query("ROLLBACK").catch(() => {});
+        throw e;
+      } finally {
+        client.release();
+      }
+
+      const publicIdsToClean = [];
+      if (existing.image_public_id) publicIdsToClean.push(existing.image_public_id);
+      for (const row of galleryImages) {
+        if (row.image_public_id) publicIdsToClean.push(row.image_public_id);
+      }
+
+      let cloudinaryWarning = null;
+      for (const publicId of publicIdsToClean) {
+        try {
+          await deleteCatalogImage(publicId);
+        } catch (cleanupError) {
+          console.error("cloudinary cleanup after item delete failed", safeImageErrorMessage(cleanupError));
+          cloudinaryWarning = "ลบสินค้าแล้ว แต่ล้างรูปบน Cloudinary บางรูปไม่สำเร็จ";
+        }
+      }
+
+      const response = { ok: true, item_id: Number(itemId) };
+      if (cloudinaryWarning) response.warning = cloudinaryWarning;
+      res.json(response);
+    } catch (e) {
+      console.error(e);
+      res.status(500).json({ error: "ลบรายการไม่สำเร็จ" });
+    }
+  });
+
   router.post(
     "/admin/catalog/items/:itemId/image",
     requireAdminSession,

--- a/server/routes/catalog/items.js
+++ b/server/routes/catalog/items.js
@@ -58,7 +58,7 @@ const CATALOG_ITEM_FIELDS = [
 const CATALOG_MARKETPLACE_FIELDS = [
   "short_description", "long_description", "highlights", "service_conditions",
   "booking_mode", "booking_service_key", "booking_ac_type", "booking_btu",
-  "booking_wash_variant", "is_featured",
+  "booking_wash_variant", "is_featured", "is_autoplay_enabled",
 ];
 
 const BOOKING_MODES = new Set(["bookable", "contact_admin"]);
@@ -149,6 +149,14 @@ function validateMarketplaceFields(merged) {
   );
   if (!isFeaturedResult.ok) errors.push(isFeaturedResult.error);
 
+  const isAutoplayEnabledResult = normalizeBoolean(
+    Object.prototype.hasOwnProperty.call(merged, "is_autoplay_enabled") && merged.is_autoplay_enabled !== undefined && merged.is_autoplay_enabled !== null && merged.is_autoplay_enabled !== ""
+      ? merged.is_autoplay_enabled
+      : true,
+    "is_autoplay_enabled"
+  );
+  if (!isAutoplayEnabledResult.ok) errors.push(isAutoplayEnabledResult.error);
+
   // booking_service_key is metadata only — the customer app doesn't consume it
   // for prefill yet, so it must never be treated as sufficient on its own. A
   // bookable item must carry a real, supported ac_type + btu (and, for wall
@@ -184,6 +192,7 @@ function validateMarketplaceFields(merged) {
       booking_wash_variant: bookingWashVariantResult.value,
       booking_btu: bookingBtuResult.value !== null ? Math.round(bookingBtuResult.value) : null,
       is_featured: isFeaturedResult.value,
+      is_autoplay_enabled: isAutoplayEnabledResult.value,
     },
   };
 }
@@ -333,10 +342,30 @@ const CATALOG_SELECT_MARKETPLACE = `
   LEFT JOIN public.customer_service_price_rules pr ON pr.rule_id = ci.price_rule_id
 `;
 
-// Three-tier capability-driven SELECT: legacy (day one) -> +media/pricing -> +marketplace v2.
-// Building from flags (rather than three independently-hand-written constants) keeps the
-// marketplace tier from drifting out of sync with the pricing tier as both evolve.
-function buildCatalogSelect({ pricingReady, marketplaceReady }) {
+// Adds the additive auto-slide column (migrations/<date>_catalog_store_autoplay.sql) on top
+// of CATALOG_SELECT_MARKETPLACE. Kept as its own tier (rather than folded permanently into
+// CATALOG_SELECT_MARKETPLACE) so the column is only ever referenced once its own migration
+// has actually run, independent of when marketplace v2 itself ran.
+const CATALOG_SELECT_MARKETPLACE_AUTOPLAY = `
+  SELECT ci.item_id, ci.item_name, ci.item_category, ci.base_price, ci.unit_label, ci.is_active,
+         ci.job_category, ci.ac_type, ci.btu_min, ci.btu_max, ci.is_customer_visible,
+         ci.image_url, ci.image_public_id, ci.price_rule_id,
+         ci.short_description, ci.long_description, ci.highlights, ci.service_conditions,
+         ci.booking_mode, ci.booking_service_key, ci.booking_ac_type, ci.booking_btu,
+         ci.booking_wash_variant, ci.is_featured, ci.is_autoplay_enabled,
+         pr.normal_price AS rule_normal_price, pr.active_price AS rule_active_price,
+         pr.campaign_name AS rule_campaign_name, pr.is_active AS rule_is_active,
+         pr.effective_from AS rule_effective_from, pr.effective_to AS rule_effective_to,
+         pr.wash_variant AS rule_wash_variant, pr.label AS rule_label, pr.priority AS rule_priority
+  FROM public.catalog_items ci
+  LEFT JOIN public.customer_service_price_rules pr ON pr.rule_id = ci.price_rule_id
+`;
+
+// Four-tier capability-driven SELECT: legacy (day one) -> +media/pricing -> +marketplace v2
+// -> +autoplay. Building from flags (rather than hand-written constants per combination)
+// keeps later tiers from drifting out of sync with earlier ones as all evolve.
+function buildCatalogSelect({ pricingReady, marketplaceReady, autoplayReady }) {
+  if (marketplaceReady && autoplayReady) return CATALOG_SELECT_MARKETPLACE_AUTOPLAY;
   if (marketplaceReady) return CATALOG_SELECT_MARKETPLACE;
   if (pricingReady) return CATALOG_SELECT_WITH_PRICING;
   return CATALOG_SELECT_LEGACY;
@@ -473,6 +502,10 @@ function serializeCatalogRow(row) {
     booking_btu: row.booking_mode === "bookable" ? (row.booking_btu || null) : null,
     booking_wash_variant: row.booking_mode === "bookable" ? (row.booking_wash_variant || null) : null,
     is_featured: Boolean(row.is_featured),
+    // Fail-safe disabled: row.is_autoplay_enabled is undefined until the autoplay
+    // migration has actually run, and a pre-migration item must never be silently
+    // treated as autoplay-enabled.
+    is_autoplay_enabled: row.is_autoplay_enabled === undefined ? false : Boolean(row.is_autoplay_enabled),
   };
 }
 
@@ -621,11 +654,30 @@ module.exports = function createCatalogItemRoutes(deps = {}) {
     return ready;
   }
 
+  // Mirrors the same capability-check idiom for the additive auto-slide column
+  // (migrations/<date>_catalog_store_autoplay.sql). Kept independent of
+  // isMarketplaceSchemaReady so is_autoplay_enabled is only ever read/written once
+  // its own migration has actually run, regardless of marketplace v2's state.
+  let autoplaySchemaReadyCache = false;
+  async function isAutoplaySchemaReady(db) {
+    if (autoplaySchemaReadyCache) return true;
+    const r = await db.query(`
+      SELECT COUNT(*)::int AS cnt
+      FROM information_schema.columns
+      WHERE table_schema = 'public' AND table_name = 'catalog_items'
+        AND column_name = 'is_autoplay_enabled'
+    `);
+    const ready = Number(r.rows?.[0]?.cnt || 0) === 1;
+    if (ready) autoplaySchemaReadyCache = true;
+    return ready;
+  }
+
   router.get("/catalog/items", async (req, res) => {
     try {
       const pricingReady = await isMediaPricingSchemaReady(pool);
       const marketplaceReady = await isMarketplaceSchemaReady(pool);
-      const select = buildCatalogSelect({ pricingReady, marketplaceReady });
+      const autoplayReady = await isAutoplaySchemaReady(pool);
+      const select = buildCatalogSelect({ pricingReady, marketplaceReady, autoplayReady });
       const customer = String(req.query.customer || "").trim() === "1";
       const job_category = (req.query.job_category || "").toString().trim();
       const ac_type = (req.query.ac_type || "").toString().trim();
@@ -664,7 +716,8 @@ module.exports = function createCatalogItemRoutes(deps = {}) {
 
       const pricingReady = await isMediaPricingSchemaReady(pool);
       const marketplaceReady = await isMarketplaceSchemaReady(pool);
-      const select = buildCatalogSelect({ pricingReady, marketplaceReady });
+      const autoplayReady = await isAutoplaySchemaReady(pool);
+      const select = buildCatalogSelect({ pricingReady, marketplaceReady, autoplayReady });
 
       const r = await pool.query(
         `${select} WHERE ci.item_id = $1 AND ci.is_active = TRUE AND ci.is_customer_visible = TRUE`,
@@ -684,7 +737,8 @@ module.exports = function createCatalogItemRoutes(deps = {}) {
     try {
       const pricingReady = await isMediaPricingSchemaReady(pool);
       const marketplaceReady = await isMarketplaceSchemaReady(pool);
-      const select = buildCatalogSelect({ pricingReady, marketplaceReady });
+      const autoplayReady = await isAutoplaySchemaReady(pool);
+      const select = buildCatalogSelect({ pricingReady, marketplaceReady, autoplayReady });
       const r = await pool.query(`${select} ORDER BY ci.item_category, ci.item_name`);
       await attachCatalogImages(pool, r.rows, marketplaceReady);
       res.json(r.rows.map(serializeAdminCatalogRow));
@@ -714,6 +768,7 @@ module.exports = function createCatalogItemRoutes(deps = {}) {
     const hasMarketplaceKey = CATALOG_MARKETPLACE_FIELDS.some((key) => Object.prototype.hasOwnProperty.call(req.body || {}, key));
     const schemaReady = await isMediaPricingSchemaReady(pool);
     const marketplaceReady = await isMarketplaceSchemaReady(pool);
+    const autoplayReady = await isAutoplaySchemaReady(pool);
     if (pricingResult.value && !schemaReady) {
       return res.status(503).json({ error: "ระบบราคาโปรโมชันยังไม่พร้อมใช้งาน (ยังไม่ได้รัน migration)" });
     }
@@ -726,8 +781,23 @@ module.exports = function createCatalogItemRoutes(deps = {}) {
     const client = await pool.connect();
     try {
       await client.query("BEGIN");
-      const insertRes = marketplaceReady
-        ? await client.query(
+      let insertRes;
+      if (marketplaceReady && autoplayReady) {
+        insertRes = await client.query(
+          `INSERT INTO public.catalog_items
+             (item_name, item_category, base_price, unit_label, job_category, ac_type, btu_min, btu_max, is_active, is_customer_visible,
+              short_description, long_description, highlights, service_conditions,
+              booking_mode, booking_service_key, booking_ac_type, booking_btu, booking_wash_variant, is_featured, is_autoplay_enabled)
+           VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21)
+           RETURNING item_id`,
+          [
+            v.item_name, v.item_category, v.base_price, v.unit_label, v.job_category, v.ac_type, v.btu_min, v.btu_max, v.is_active, v.is_customer_visible,
+            mv.short_description, mv.long_description, mv.highlights ? JSON.stringify(mv.highlights) : null, mv.service_conditions,
+            mv.booking_mode, mv.booking_service_key, mv.booking_ac_type, mv.booking_btu, mv.booking_wash_variant, mv.is_featured, mv.is_autoplay_enabled,
+          ]
+        );
+      } else if (marketplaceReady) {
+        insertRes = await client.query(
           `INSERT INTO public.catalog_items
              (item_name, item_category, base_price, unit_label, job_category, ac_type, btu_min, btu_max, is_active, is_customer_visible,
               short_description, long_description, highlights, service_conditions,
@@ -739,14 +809,16 @@ module.exports = function createCatalogItemRoutes(deps = {}) {
             mv.short_description, mv.long_description, mv.highlights ? JSON.stringify(mv.highlights) : null, mv.service_conditions,
             mv.booking_mode, mv.booking_service_key, mv.booking_ac_type, mv.booking_btu, mv.booking_wash_variant, mv.is_featured,
           ]
-        )
-        : await client.query(
+        );
+      } else {
+        insertRes = await client.query(
           `INSERT INTO public.catalog_items
              (item_name, item_category, base_price, unit_label, job_category, ac_type, btu_min, btu_max, is_active, is_customer_visible)
            VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10)
            RETURNING item_id`,
           [v.item_name, v.item_category, v.base_price, v.unit_label, v.job_category, v.ac_type, v.btu_min, v.btu_max, v.is_active, v.is_customer_visible]
         );
+      }
       const itemId = insertRes.rows[0].item_id;
 
       if (pricingResult.value) {
@@ -761,7 +833,7 @@ module.exports = function createCatalogItemRoutes(deps = {}) {
 
       await client.query("COMMIT");
 
-      const select = buildCatalogSelect({ pricingReady: schemaReady, marketplaceReady });
+      const select = buildCatalogSelect({ pricingReady: schemaReady, marketplaceReady, autoplayReady });
       const final = await client.query(`${select} WHERE ci.item_id = $1`, [itemId]);
       await attachCatalogImages(client, final.rows, marketplaceReady);
       res.status(201).json(serializeAdminCatalogRow(final.rows[0]));
@@ -780,7 +852,8 @@ module.exports = function createCatalogItemRoutes(deps = {}) {
 
     const schemaReady = await isMediaPricingSchemaReady(pool);
     const marketplaceReady = await isMarketplaceSchemaReady(pool);
-    const select = buildCatalogSelect({ pricingReady: schemaReady, marketplaceReady });
+    const autoplayReady = await isAutoplaySchemaReady(pool);
+    const select = buildCatalogSelect({ pricingReady: schemaReady, marketplaceReady, autoplayReady });
     const existingResult = await pool.query(`${select} WHERE ci.item_id = $1`, [itemId]);
     const existing = existingResult.rows[0];
     if (!existing) return res.status(404).json({ error: "ไม่พบรายการนี้" });
@@ -809,7 +882,24 @@ module.exports = function createCatalogItemRoutes(deps = {}) {
     const client = await pool.connect();
     try {
       await client.query("BEGIN");
-      if (marketplaceReady) {
+      if (marketplaceReady && autoplayReady) {
+        await client.query(
+          `UPDATE public.catalog_items
+              SET item_name=$1, item_category=$2, base_price=$3, unit_label=$4,
+                  job_category=$5, ac_type=$6, btu_min=$7, btu_max=$8,
+                  is_active=$9, is_customer_visible=$10,
+                  short_description=$11, long_description=$12, highlights=$13, service_conditions=$14,
+                  booking_mode=$15, booking_service_key=$16, booking_ac_type=$17, booking_btu=$18,
+                  booking_wash_variant=$19, is_featured=$20, is_autoplay_enabled=$21
+            WHERE item_id = $22`,
+          [
+            v.item_name, v.item_category, v.base_price, v.unit_label, v.job_category, v.ac_type, v.btu_min, v.btu_max, v.is_active, v.is_customer_visible,
+            mv.short_description, mv.long_description, mv.highlights ? JSON.stringify(mv.highlights) : null, mv.service_conditions,
+            mv.booking_mode, mv.booking_service_key, mv.booking_ac_type, mv.booking_btu, mv.booking_wash_variant, mv.is_featured, mv.is_autoplay_enabled,
+            itemId,
+          ]
+        );
+      } else if (marketplaceReady) {
         await client.query(
           `UPDATE public.catalog_items
               SET item_name=$1, item_category=$2, base_price=$3, unit_label=$4,
@@ -989,7 +1079,8 @@ module.exports = function createCatalogItemRoutes(deps = {}) {
         }
 
         const marketplaceReady = await isMarketplaceSchemaReady(pool);
-        const select = buildCatalogSelect({ pricingReady: true, marketplaceReady });
+        const autoplayReady = await isAutoplaySchemaReady(pool);
+        const select = buildCatalogSelect({ pricingReady: true, marketplaceReady, autoplayReady });
         const final = await pool.query(`${select} WHERE ci.item_id = $1`, [itemId]);
         await attachCatalogImages(pool, final.rows, marketplaceReady);
         res.json(serializeAdminCatalogRow(final.rows[0]));
@@ -1038,7 +1129,8 @@ module.exports = function createCatalogItemRoutes(deps = {}) {
       }
 
       const marketplaceReady = await isMarketplaceSchemaReady(pool);
-      const select = buildCatalogSelect({ pricingReady: true, marketplaceReady });
+      const autoplayReady = await isAutoplaySchemaReady(pool);
+      const select = buildCatalogSelect({ pricingReady: true, marketplaceReady, autoplayReady });
       const final = await pool.query(`${select} WHERE ci.item_id = $1`, [itemId]);
       await attachCatalogImages(pool, final.rows, marketplaceReady);
       res.json(serializeAdminCatalogRow(final.rows[0]));

--- a/test/adminStoreCatalogUi.test.js
+++ b/test/adminStoreCatalogUi.test.js
@@ -8,6 +8,44 @@ const catalogHtmlSource = fs.readFileSync(path.join(__dirname, "..", "admin-stor
 const catalogJsSource = fs.readFileSync(path.join(__dirname, "..", "admin-store-catalog.js"), "utf8");
 const catalogCssSource = fs.readFileSync(path.join(__dirname, "..", "admin-store-catalog.css"), "utf8");
 
+const VOID_TAGS = new Set(["area", "base", "br", "col", "embed", "hr", "img", "input", "link", "meta", "param", "source", "track", "wbr"]);
+
+function extractCatalogModalHtml() {
+  const m = catalogJsSource.match(/wrap\.innerHTML = `([\s\S]*?)`;\n  document\.body\.appendChild/);
+  if (!m) throw new Error("could not find ensureCatalogModal's wrap.innerHTML template");
+  return m[1];
+}
+
+// Walks the modal's HTML template as a real tag stack (not just text matching), so a
+// stray/missing closing tag is caught even when it doesn't disturb any single regex window.
+function buildTagDepthTrace(html) {
+  const tagRe = /<(\/?)([a-zA-Z][a-zA-Z0-9]*)\b([^>]*?)(\/?)>/g;
+  const stack = [];
+  const trace = [];
+  let match;
+  while ((match = tagRe.exec(html))) {
+    const [, closing, name, attrs, selfClose] = match;
+    const lower = name.toLowerCase();
+    if (closing) {
+      const top = stack[stack.length - 1];
+      if (!top || top.name !== lower) {
+        throw new Error(`mismatched closing tag </${lower}> at offset ${match.index}; stack top was ${top ? top.name : "(empty)"}`);
+      }
+      stack.pop();
+      continue;
+    }
+    const idMatch = attrs.match(/id="([^"]+)"/);
+    const classMatch = attrs.match(/class="([^"]+)"/);
+    const entry = { name: lower, id: idMatch ? idMatch[1] : null, classes: classMatch ? classMatch[1].split(/\s+/) : [], depth: stack.length };
+    trace.push(entry);
+    if (!selfClose && !VOID_TAGS.has(lower)) stack.push(entry);
+  }
+  if (stack.length) {
+    throw new Error(`unclosed tag(s) remain on stack: ${stack.map((s) => s.name + (s.id ? "#" + s.id : "")).join(", ")}`);
+  }
+  return trace;
+}
+
 test("shared admin menu includes a link to /admin-store-catalog.html", () => {
   assert.match(commonJsSource, /data-href="\/admin-store-catalog\.html"/);
 });
@@ -212,6 +250,42 @@ test("booking section shows only booking_mode/ac_type/btu/wash_variant prominent
   // service_key must not also appear outside of the collapsed subsection
   const outsideDetails = section.replace(detailsMatch[0], "");
   assert.doesNotMatch(outsideDetails, /id="cm_booking_service_key"/);
+});
+
+test("the catalog modal's HTML template is a fully-balanced tag tree (catches stray/missing closing tags that text-window regexes can miss), and sections 5/6/7 plus the error box stay direct children of .cwf-modal-body", () => {
+  const html = extractCatalogModalHtml();
+  // buildTagDepthTrace throws on any mismatched/unclosed tag, which is itself the
+  // regression check for the malformed-markup bug (an extra </div> after the booking
+  // Advanced <details> used to close cm_booking_fields and the booking asc-section twice).
+  const trace = buildTagDepthTrace(html);
+
+  const modalBody = trace.find((e) => e.name === "div" && e.classes.includes("cwf-modal-body"));
+  assert.ok(modalBody, ".cwf-modal-body not found");
+  const bodyDepth = modalBody.depth + 1; // depth of elements that are direct children of .cwf-modal-body
+
+  const bookingFields = trace.find((e) => e.id === "cm_booking_fields");
+  assert.ok(bookingFields, "cm_booking_fields not found");
+  // cm_booking_fields must sit inside exactly one asc-section wrapper, i.e. one level
+  // deeper than the direct children of .cwf-modal-body, not two levels deeper (which is
+  // what the extra stray </div> used to produce by closing the section's wrapper early).
+  assert.equal(bookingFields.depth, bodyDepth + 1, "cm_booking_fields is not nested exactly one level inside its asc-section");
+
+  const detailsAdvanced = trace.find((e) => e.name === "details" && e.classes.includes("asc-booking-advanced"));
+  assert.ok(detailsAdvanced, "booking advanced <details> not found");
+  assert.equal(detailsAdvanced.depth, bookingFields.depth + 1, "booking advanced <details> is not nested directly inside cm_booking_fields");
+
+  for (const id of ["cm_short_description", "cm_is_active", "cm_job_category"]) {
+    const found = trace.find((e) => e.id === id);
+    assert.ok(found, `${id} not found in modal template`);
+  }
+
+  const errorBox = trace.find((e) => e.id === "catalog_modal_error");
+  assert.ok(errorBox, "catalog_modal_error not found");
+  assert.equal(errorBox.depth, bodyDepth, "catalog_modal_error must be a direct child of .cwf-modal-body");
+
+  const section7 = trace.find((e) => e.name === "details" && e.classes.includes("asc-accordion") && e.classes.includes("asc-section"));
+  assert.ok(section7, "section 7 (price-rule-matching accordion) not found");
+  assert.equal(section7.depth, bodyDepth, "section 7 must be a direct child of .cwf-modal-body");
 });
 
 test("booking detail fields are wrapped in a container that toggles visibility based on booking_mode", () => {

--- a/test/adminStoreCatalogUi.test.js
+++ b/test/adminStoreCatalogUi.test.js
@@ -158,6 +158,34 @@ test("catalogModalPayload sends pricing.pricing_is_active, not pricing.is_active
   assert.doesNotMatch(catalogJsSource, /pricing\.is_active\b/);
 });
 
+test("the 7-section reorganization does not change which element id backs each field: every id read in catalogModalPayload is also written in openCatalogModalForEdit, so reordering sections never drops a value on open+save", () => {
+  const payloadMatch = catalogJsSource.match(/function catalogModalPayload\(\)[\s\S]*?\n}\n/);
+  const editMatch = catalogJsSource.match(/function openCatalogModalForEdit\(itemId\)[\s\S]*?\n}\n/);
+  assert.ok(payloadMatch, "catalogModalPayload function not found");
+  assert.ok(editMatch, "openCatalogModalForEdit function not found");
+  const payloadIds = [...payloadMatch[0].matchAll(/el\("(cm_[a-z_]+)"\)/g)].map((m) => m[1]);
+  const editIds = [...editMatch[0].matchAll(/el\("(cm_[a-z_]+)"\)\.value =/g)].map((m) => m[1]);
+  const missing = payloadIds.filter((id) => !editIds.includes(id));
+  assert.deepEqual(missing, [], `fields read by catalogModalPayload but never populated in openCatalogModalForEdit: ${missing.join(", ")}`);
+});
+
+test("no two distinct DOM elements in the modal share the same id (no duplicate inputs writing into the same field)", () => {
+  const ids = [...catalogJsSource.matchAll(/id="(cm_[a-z_]+)"/g)].map((m) => m[1]);
+  const counts = {};
+  for (const id of ids) counts[id] = (counts[id] || 0) + 1;
+  const duplicates = Object.entries(counts).filter(([, n]) => n > 1).map(([id]) => id);
+  assert.deepEqual(duplicates, [], `duplicate field ids found: ${duplicates.join(", ")}`);
+});
+
+test("hidden/collapsed fields (price-rule-matching accordion, booking advanced subsection) are populated on edit just like visible fields, so collapsing them never clears stored values", () => {
+  const editMatch = catalogJsSource.match(/function openCatalogModalForEdit\(itemId\)[\s\S]*?\n}\n/);
+  assert.ok(editMatch, "openCatalogModalForEdit function not found");
+  const body = editMatch[0];
+  for (const id of ["cm_job_category", "cm_ac_type", "cm_wash_variant", "cm_btu_min", "cm_btu_max", "cm_booking_service_key"]) {
+    assert.match(body, new RegExp(`el\\("${id}"\\)\\.value = `), `${id} is not populated in openCatalogModalForEdit`);
+  }
+});
+
 // ---------- Marketplace v2: admin UI ----------
 
 test("modal includes booking_mode and is_featured under their own sections, plus description fields under รายละเอียด", () => {
@@ -171,6 +199,19 @@ test("modal includes booking_mode and is_featured under their own sections, plus
   assert.match(catalogJsSource, /id="cm_long_description"/);
   assert.match(catalogJsSource, /id="cm_highlights"/);
   assert.match(catalogJsSource, /id="cm_service_conditions"/);
+});
+
+test("booking section shows only booking_mode/ac_type/btu/wash_variant prominently; service_key is tucked into a collapsed Advanced subsection", () => {
+  const sectionMatch = catalogJsSource.match(/4\) การจอง[\s\S]*?<\/div>\n\n        <div class="asc-section">\n          <div class="asc-section-title">5\)/);
+  assert.ok(sectionMatch, "booking section not found");
+  const section = sectionMatch[0];
+  const detailsMatch = section.match(/<details class="asc-booking-advanced">[\s\S]*?<\/details>/);
+  assert.ok(detailsMatch, "booking advanced <details> not found");
+  assert.doesNotMatch(detailsMatch[0], /<details[^>]* open/);
+  assert.match(detailsMatch[0], /id="cm_booking_service_key"/);
+  // service_key must not also appear outside of the collapsed subsection
+  const outsideDetails = section.replace(detailsMatch[0], "");
+  assert.doesNotMatch(outsideDetails, /id="cm_booking_service_key"/);
 });
 
 test("booking detail fields are wrapped in a container that toggles visibility based on booking_mode", () => {
@@ -277,38 +318,84 @@ test("gallery file input supports selecting multiple files and enforces a max of
   assert.match(catalogJsSource, /<input id="cm_gallery_input" type="file" accept="[^"]+" multiple>/);
 });
 
-test("onGalleryImagePicked uploads multiple files sequentially via a per-file status queue, truncates over the remaining slot count, and hides the input while uploading", () => {
+test("onGalleryImagePicked builds a per-file status queue, blocks picking while already uploading, and clearly reports over-limit truncation instead of staying silent", () => {
   const fnMatch = catalogJsSource.match(/async function onGalleryImagePicked\(event\)[\s\S]*?\n}\n/);
   assert.ok(fnMatch, "onGalleryImagePicked function not found");
   const body = fnMatch[0];
   assert.match(body, /Array\.from\(event\.target\.files\)/);
-  assert.match(body, /const remaining = Math\.max\(0, MAX_GALLERY_IMAGES - galleryImages\.length\);/);
+  assert.match(body, /if \(!files\.length \|\| !editingItemId \|\| galleryUploading\) return;/);
+  assert.match(body, /const activeBefore = galleryActiveCount\(\);/);
+  assert.match(body, /const remaining = Math\.max\(0, MAX_GALLERY_IMAGES - activeBefore\);/);
   assert.match(body, /files\.slice\(0, remaining\)/);
-  assert.match(body, /galleryUploading = true;/);
-  assert.match(body, /galleryUploading = false;/);
-  assert.match(body, /galleryUploadQueue = toUpload\.map\(/);
+  assert.match(body, /if \(!toUpload\.length\) \{/);
+  assert.match(body, /galleryPickNotice = `เลือกแล้ว \$\{files\.length\} รูป/);
+  assert.match(body, /if \(files\.length > toUpload\.length\) \{/);
+  assert.match(body, /เลือกมาเกินจำนวนที่ว่าง จะอัปโหลดเฉพาะ/);
   assert.match(body, /status: "pending",/);
-  assert.match(body, /for \(const queued of galleryUploadQueue\)/);
+  assert.match(body, /await runGalleryUploadQueue\(newlyQueued\);/);
+});
+
+test("runGalleryUploadQueue uploads sequentially with per-file status transitions, reloads the gallery, keeps failed items for retry, and never re-uploads a succeeded file", () => {
+  const fnMatch = catalogJsSource.match(/async function runGalleryUploadQueue\(itemsToRun\)[\s\S]*?\n}\n/);
+  assert.ok(fnMatch, "runGalleryUploadQueue function not found");
+  const body = fnMatch[0];
+  assert.match(body, /galleryUploading = true;/);
+  assert.match(body, /for \(const queued of itemsToRun\)/);
   assert.match(body, /queued\.status = "uploading";/);
   assert.match(body, /queued\.status = "done";/);
   assert.match(body, /queued\.status = "error";/);
-  assert.match(body, /URL\.revokeObjectURL\(queued\.localUrl\);/);
-
-  const renderMatch = catalogJsSource.match(/function renderGalleryManager\(\)[\s\S]*?\n}\n/);
-  assert.ok(renderMatch, "renderGalleryManager function not found");
-  assert.match(renderMatch[0], /if \(galleryUploading\) \{/);
-  assert.match(renderMatch[0], /<input id="cm_gallery_input"/);
+  assert.match(body, /galleryUploading = false;/);
+  // succeeded items are removed from the queue so a later retry pass can never re-upload them
+  assert.match(body, /const doneItems = galleryUploadQueue\.filter\(\(q\) => q\.status === "done"\);/);
+  assert.match(body, /galleryUploadQueue = galleryUploadQueue\.filter\(\(q\) => q\.status !== "done"\);/);
+  assert.match(body, /await loadGalleryImages\(editingItemId\);/);
 });
 
-test("the gallery upload queue shows a per-file pending/uploading/done/error status and an x/N upload progress count", () => {
+test("a single failed upload can be retried without touching files that already succeeded, and can be dismissed without retrying", () => {
+  assert.match(catalogJsSource, /async function onGalleryRetry\(localId\)/);
+  const retryMatch = catalogJsSource.match(/async function onGalleryRetry\(localId\)[\s\S]*?\n}\n/);
+  assert.ok(retryMatch, "onGalleryRetry function not found");
+  assert.match(retryMatch[0], /if \(galleryUploading\) return;/);
+  assert.match(retryMatch[0], /await runGalleryUploadQueue\(\[queued\]\);/);
+
+  assert.match(catalogJsSource, /function onGalleryDismissFailed\(localId\)/);
+  const dismissMatch = catalogJsSource.match(/function onGalleryDismissFailed\(localId\)[\s\S]*?\n}\n/);
+  assert.ok(dismissMatch, "onGalleryDismissFailed function not found");
+  assert.match(dismissMatch[0], /URL\.revokeObjectURL\(queued\.localUrl\);/);
+  assert.match(dismissMatch[0], /galleryUploadQueue = galleryUploadQueue\.filter\(\(q\) => q\.localId !== localId\);/);
+});
+
+test("the gallery upload queue shows a per-file pending/uploading/done/error status with a retry/remove action on failure, and a live in-progress count", () => {
   assert.match(catalogJsSource, /function galleryStatusLabel\(status\)/);
   assert.match(catalogJsSource, /if \(status === "uploading"\) return "กำลังอัปโหลด\.\.\.";/);
   assert.match(catalogJsSource, /if \(status === "done"\) return "สำเร็จ";/);
   assert.match(catalogJsSource, /if \(status === "error"\) return "ล้มเหลว";/);
   assert.match(catalogJsSource, /function galleryQueueThumbHtml\(queued\)/);
-  assert.match(catalogJsSource, /asc-gallery-thumb-status-\$\{queued\.status\}/);
+  const thumbMatch = catalogJsSource.match(/function galleryQueueThumbHtml\(queued\)[\s\S]*?\n}\n/);
+  assert.ok(thumbMatch, "galleryQueueThumbHtml function not found");
+  assert.match(thumbMatch[0], /asc-gallery-thumb-status-\$\{queued\.status\}/);
+  assert.match(thumbMatch[0], /data-qact="retry"/);
+  assert.match(thumbMatch[0], /data-qact="remove"/);
+
   const renderMatch = catalogJsSource.match(/function renderGalleryManager\(\)[\s\S]*?\n}\n/);
-  assert.match(renderMatch[0], /กำลังอัปโหลด \$\{doneCount\}\/\$\{galleryUploadQueue\.length\} รูป/);
+  assert.ok(renderMatch, "renderGalleryManager function not found");
+  assert.match(renderMatch[0], /มีอยู่ \$\{activeCount\} \/ \$\{MAX_GALLERY_IMAGES\} รูป/);
+  assert.match(renderMatch[0], /กำลังเพิ่มอีก \$\{inFlightCount\} รูป \(เสร็จแล้ว \$\{settledCount\}\/\$\{galleryUploadQueue\.length\}\)/);
+});
+
+test("bindGalleryActions wires retry/remove buttons (data-qact) in addition to the existing image actions (data-gact)", () => {
+  const fnMatch = catalogJsSource.match(/function bindGalleryActions\(\)[\s\S]*?\n}\n/);
+  assert.ok(fnMatch, "bindGalleryActions function not found");
+  assert.match(fnMatch[0], /qact === "retry"\) onGalleryRetry\(localId\);/);
+  assert.match(fnMatch[0], /qact === "remove"\) onGalleryDismissFailed\(localId\);/);
+});
+
+test("closeCatalogModal refuses to close while a gallery upload is in flight instead of silently discarding it", () => {
+  const fnMatch = catalogJsSource.match(/function closeCatalogModal\(\)[\s\S]*?\n}\n/);
+  assert.ok(fnMatch, "closeCatalogModal function not found");
+  assert.match(fnMatch[0], /if \(galleryUploading\) \{/);
+  assert.match(fnMatch[0], /กำลังอัปโหลดรูปภาพ กรุณารอให้เสร็จก่อนปิดหน้านี้/);
+  assert.match(fnMatch[0], /return;/);
 });
 
 test("the more-sheet has a delete option that opens the delete confirmation modal", () => {

--- a/test/adminStoreCatalogUi.test.js
+++ b/test/adminStoreCatalogUi.test.js
@@ -247,3 +247,59 @@ test("admin-store-catalog.css defines gallery grid and badge styles for the mark
   assert.match(catalogCssSource, /\.asc-badge-bookable\{/);
   assert.match(catalogCssSource, /\.asc-badge-featured\{/);
 });
+
+// ---------- Autoplay toggle, multi-image upload queue, delete confirmation ----------
+
+test("modal includes an is_autoplay_enabled select defaulting to enabled, wired into reset/edit/payload", () => {
+  assert.match(catalogJsSource, /<select id="cm_is_autoplay_enabled">/);
+  assert.match(catalogJsSource, /el\("cm_is_autoplay_enabled"\)\.value = "1";/);
+  assert.match(catalogJsSource, /el\("cm_is_autoplay_enabled"\)\.value = item\.is_autoplay_enabled === false \? "0" : "1";/);
+  assert.match(catalogJsSource, /is_autoplay_enabled: el\("cm_is_autoplay_enabled"\)\.value === "1",/);
+});
+
+test("gallery file input supports selecting multiple files and enforces a max of MAX_GALLERY_IMAGES", () => {
+  assert.match(catalogJsSource, /const MAX_GALLERY_IMAGES = 4;/);
+  assert.match(catalogJsSource, /<input id="cm_gallery_input" type="file" accept="[^"]+" multiple>/);
+});
+
+test("onGalleryImagePicked uploads multiple files sequentially, truncates over the remaining slot count, and hides the input while uploading", () => {
+  const fnMatch = catalogJsSource.match(/async function onGalleryImagePicked\(event\)[\s\S]*?\n}\n/);
+  assert.ok(fnMatch, "onGalleryImagePicked function not found");
+  const body = fnMatch[0];
+  assert.match(body, /Array\.from\(event\.target\.files\)/);
+  assert.match(body, /const remaining = Math\.max\(0, MAX_GALLERY_IMAGES - galleryImages\.length\);/);
+  assert.match(body, /files\.slice\(0, remaining\)/);
+  assert.match(body, /galleryUploading = true;/);
+  assert.match(body, /galleryUploading = false;/);
+  assert.match(body, /for \(const file of toUpload\)/);
+
+  const renderMatch = catalogJsSource.match(/function renderGalleryManager\(\)[\s\S]*?\n}\n/);
+  assert.ok(renderMatch, "renderGalleryManager function not found");
+  assert.match(renderMatch[0], /const inputArea = galleryUploading/);
+});
+
+test("the more-sheet has a delete option that opens the delete confirmation modal", () => {
+  assert.match(catalogJsSource, /<button class="danger" data-act="delete" type="button">ลบรายการนี้<\/button>/);
+  assert.match(catalogJsSource, /if \(act === "delete"\) \{ closeMoreSheet\(\); openDeleteModal\(item\.item_id\); return; \}/);
+});
+
+test("delete confirmation modal requires typing the exact item_name before the confirm button is enabled", () => {
+  assert.match(catalogJsSource, /function updateDeleteConfirmButtonState\(\)/);
+  assert.match(catalogJsSource, /typed !== item\.item_name/);
+  assert.match(catalogJsSource, /id="asc_delete_modal_confirm" class="danger" type="button" disabled>/);
+});
+
+test("delete confirmation modal warns extra when the item is currently active and visible to customers", () => {
+  const fnMatch = catalogJsSource.match(/function openDeleteModal\(itemId\)[\s\S]*?\n}\n/);
+  assert.ok(fnMatch, "openDeleteModal function not found");
+  assert.match(fnMatch[0], /item\.is_active && item\.is_customer_visible \? "block" : "none"/);
+});
+
+test("confirmDeleteCatalogItem calls the real DELETE endpoint and surfaces a Cloudinary cleanup warning distinctly from plain success", () => {
+  const fnMatch = catalogJsSource.match(/async function confirmDeleteCatalogItem\(\)[\s\S]*?\n}\n/);
+  assert.ok(fnMatch, "confirmDeleteCatalogItem function not found");
+  const body = fnMatch[0];
+  assert.match(body, /apiFetch\(`\/admin\/catalog\/items\/\$\{itemId\}`, \{ method: "DELETE" \}\)/);
+  assert.match(body, /if \(result && result\.warning\) showToast\(result\.warning, "error"\);/);
+  assert.match(body, /else showToast\("ลบรายการแล้ว", "success"\);/);
+});

--- a/test/adminStoreCatalogUi.test.js
+++ b/test/adminStoreCatalogUi.test.js
@@ -48,13 +48,29 @@ test("main page contains header, add-button, search, filter, card list and store
   assert.match(catalogHtmlSource, /id="catalog_preview"/);
 });
 
-test("admin-store-catalog.js builds a modal/bottom-sheet with 5 sections", () => {
+test("admin-store-catalog.js builds a modal/bottom-sheet with 7 non-redundant sections, with price-rule-matching fields collapsed into an accordion", () => {
   assert.match(catalogJsSource, /cwf-modal-backdrop/);
-  assert.match(catalogJsSource, /1\) ข้อมูลบริการ/);
-  assert.match(catalogJsSource, /2\) รูปบริการ/);
+  assert.match(catalogJsSource, /1\) ข้อมูลหลัก/);
+  assert.match(catalogJsSource, /2\) รูปภาพสินค้า/);
   assert.match(catalogJsSource, /3\) ราคาและโปรโมชั่น/);
-  assert.match(catalogJsSource, /4\) การแสดงผล/);
-  assert.match(catalogJsSource, /5\) ขั้นสูง/);
+  assert.match(catalogJsSource, /4\) การจอง/);
+  assert.match(catalogJsSource, /5\) รายละเอียด/);
+  assert.match(catalogJsSource, /6\) การแสดงผล/);
+  assert.match(catalogJsSource, /7\) ข้อมูลจับคู่ระบบราคา/);
+  // legacy cover image and the multi-image gallery must be merged into one section, not split
+  assert.match(catalogJsSource, /2\) รูปภาพสินค้า[\s\S]*?id="cm_image_input"[\s\S]*?id="cm_gallery_section"/);
+  // base_price must live with pricing, not under a separate "advanced" section
+  assert.doesNotMatch(catalogJsSource, /ขั้นสูง/);
+  assert.match(catalogJsSource, /3\) ราคาและโปรโมชั่น[\s\S]*?id="cm_base_price"/);
+  // price-rule-matching fields must be collapsed by default (native <details>, no "open" attribute)
+  const accordionMatch = catalogJsSource.match(/<details class="asc-section asc-accordion">[\s\S]*?<\/details>/);
+  assert.ok(accordionMatch, "price-rule-matching accordion not found");
+  assert.doesNotMatch(accordionMatch[0], /<details[^>]* open/);
+  assert.match(accordionMatch[0], /id="cm_job_category"/);
+  assert.match(accordionMatch[0], /id="cm_ac_type"/);
+  assert.match(accordionMatch[0], /id="cm_wash_variant"/);
+  assert.match(accordionMatch[0], /id="cm_btu_min"/);
+  assert.match(accordionMatch[0], /id="cm_btu_max"/);
 });
 
 test("modal contains normal_price and active_price fields", () => {
@@ -144,15 +160,14 @@ test("catalogModalPayload sends pricing.pricing_is_active, not pricing.is_active
 
 // ---------- Marketplace v2: admin UI ----------
 
-test("modal includes a marketplace section with booking_mode, is_featured, and description fields", () => {
-  assert.match(catalogJsSource, /6\) ข้อมูลตลาด \(Marketplace\)/);
-  assert.match(catalogJsSource, /id="cm_booking_mode"/);
+test("modal includes booking_mode and is_featured under their own sections, plus description fields under รายละเอียด", () => {
+  assert.match(catalogJsSource, /4\) การจอง[\s\S]*?id="cm_booking_mode"/);
   assert.match(catalogJsSource, /id="cm_booking_service_key"/);
   assert.match(catalogJsSource, /id="cm_booking_ac_type"/);
   assert.match(catalogJsSource, /id="cm_booking_btu"/);
   assert.match(catalogJsSource, /id="cm_booking_wash_variant"/);
-  assert.match(catalogJsSource, /id="cm_is_featured"/);
-  assert.match(catalogJsSource, /id="cm_short_description"/);
+  assert.match(catalogJsSource, /6\) การแสดงผล[\s\S]*?id="cm_is_featured"/);
+  assert.match(catalogJsSource, /5\) รายละเอียด[\s\S]*?id="cm_short_description"/);
   assert.match(catalogJsSource, /id="cm_long_description"/);
   assert.match(catalogJsSource, /id="cm_highlights"/);
   assert.match(catalogJsSource, /id="cm_service_conditions"/);
@@ -262,7 +277,7 @@ test("gallery file input supports selecting multiple files and enforces a max of
   assert.match(catalogJsSource, /<input id="cm_gallery_input" type="file" accept="[^"]+" multiple>/);
 });
 
-test("onGalleryImagePicked uploads multiple files sequentially, truncates over the remaining slot count, and hides the input while uploading", () => {
+test("onGalleryImagePicked uploads multiple files sequentially via a per-file status queue, truncates over the remaining slot count, and hides the input while uploading", () => {
   const fnMatch = catalogJsSource.match(/async function onGalleryImagePicked\(event\)[\s\S]*?\n}\n/);
   assert.ok(fnMatch, "onGalleryImagePicked function not found");
   const body = fnMatch[0];
@@ -271,11 +286,29 @@ test("onGalleryImagePicked uploads multiple files sequentially, truncates over t
   assert.match(body, /files\.slice\(0, remaining\)/);
   assert.match(body, /galleryUploading = true;/);
   assert.match(body, /galleryUploading = false;/);
-  assert.match(body, /for \(const file of toUpload\)/);
+  assert.match(body, /galleryUploadQueue = toUpload\.map\(/);
+  assert.match(body, /status: "pending",/);
+  assert.match(body, /for \(const queued of galleryUploadQueue\)/);
+  assert.match(body, /queued\.status = "uploading";/);
+  assert.match(body, /queued\.status = "done";/);
+  assert.match(body, /queued\.status = "error";/);
+  assert.match(body, /URL\.revokeObjectURL\(queued\.localUrl\);/);
 
   const renderMatch = catalogJsSource.match(/function renderGalleryManager\(\)[\s\S]*?\n}\n/);
   assert.ok(renderMatch, "renderGalleryManager function not found");
-  assert.match(renderMatch[0], /const inputArea = galleryUploading/);
+  assert.match(renderMatch[0], /if \(galleryUploading\) \{/);
+  assert.match(renderMatch[0], /<input id="cm_gallery_input"/);
+});
+
+test("the gallery upload queue shows a per-file pending/uploading/done/error status and an x/N upload progress count", () => {
+  assert.match(catalogJsSource, /function galleryStatusLabel\(status\)/);
+  assert.match(catalogJsSource, /if \(status === "uploading"\) return "กำลังอัปโหลด\.\.\.";/);
+  assert.match(catalogJsSource, /if \(status === "done"\) return "สำเร็จ";/);
+  assert.match(catalogJsSource, /if \(status === "error"\) return "ล้มเหลว";/);
+  assert.match(catalogJsSource, /function galleryQueueThumbHtml\(queued\)/);
+  assert.match(catalogJsSource, /asc-gallery-thumb-status-\$\{queued\.status\}/);
+  const renderMatch = catalogJsSource.match(/function renderGalleryManager\(\)[\s\S]*?\n}\n/);
+  assert.match(renderMatch[0], /กำลังอัปโหลด \$\{doneCount\}\/\$\{galleryUploadQueue\.length\} รูป/);
 });
 
 test("the more-sheet has a delete option that opens the delete confirmation modal", () => {

--- a/test/adminStoreCatalogUi.test.js
+++ b/test/adminStoreCatalogUi.test.js
@@ -295,6 +295,18 @@ test("delete confirmation modal warns extra when the item is currently active an
   assert.match(fnMatch[0], /item\.is_active && item\.is_customer_visible \? "block" : "none"/);
 });
 
+test("gallery delete/set-primary/reorder actions guard against double-clicks while a gallery action is in flight", () => {
+  const deleteFn = catalogJsSource.match(/async function onGalleryDelete\(imageId\)[\s\S]*?\n}\n/);
+  const primaryFn = catalogJsSource.match(/async function onGallerySetPrimary\(imageId\)[\s\S]*?\n}\n/);
+  const reorderFn = catalogJsSource.match(/async function onGalleryReorder\(imageId, direction\)[\s\S]*?\n}\n/);
+  assert.ok(deleteFn && primaryFn && reorderFn, "gallery action functions not found");
+  for (const fn of [deleteFn[0], primaryFn[0], reorderFn[0]]) {
+    assert.match(fn, /galleryUploading\) return;/);
+    assert.match(fn, /galleryUploading = true;/);
+    assert.match(fn, /finally \{\s*\n\s*galleryUploading = false;/);
+  }
+});
+
 test("confirmDeleteCatalogItem calls the real DELETE endpoint and surfaces a Cloudinary cleanup warning distinctly from plain success", () => {
   const fnMatch = catalogJsSource.match(/async function confirmDeleteCatalogItem\(\)[\s\S]*?\n}\n/);
   assert.ok(fnMatch, "confirmDeleteCatalogItem function not found");

--- a/test/catalogAutoplayMigration.test.js
+++ b/test/catalogAutoplayMigration.test.js
@@ -1,0 +1,256 @@
+"use strict";
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("fs");
+const path = require("path");
+const runner = require("../scripts/run-catalog-autoplay-migration");
+
+const REPO_ROOT = path.resolve(__dirname, "..");
+const DATABASE_URL = "postgres://user:super-secret-password@db.example.invalid:5432/cwf";
+
+class FakeClient {
+  constructor(options = {}) {
+    this.options = options;
+    this.connected = false;
+    this.ended = false;
+    this.queries = [];
+    this.aborted = false;
+  }
+
+  async connect() {
+    this.connected = true;
+    if (this.options.failConnect) throw new Error(this.options.failConnect);
+  }
+
+  async query(sql, params) {
+    this.queries.push({ sql, params });
+    const s = String(sql);
+    if (this.aborted && sql !== "ROLLBACK") throw new Error("current transaction is aborted");
+    if (sql === "ROLLBACK") {
+      if (this.options.failRollback) throw new Error(this.options.failRollback);
+      this.aborted = false;
+      return { rows: [] };
+    }
+    if (s.includes("pg_advisory_unlock") && this.options.failUnlock) throw new Error(this.options.failUnlock);
+    if (this.options.failSql && s.includes("ALTER TABLE public.catalog_items")) {
+      this.aborted = true;
+      throw new Error(this.options.failSql);
+    }
+    if (s.includes("column_name = 'is_autoplay_enabled'") && s.includes("information_schema.columns")) {
+      if (this.options.missingColumn) return { rows: [] };
+      return {
+        rows: [
+          {
+            column_name: "is_autoplay_enabled",
+            data_type: this.options.wrongType ? "text" : "boolean",
+            is_nullable: this.options.nullable ? "YES" : "NO",
+            column_default: "true",
+          },
+        ],
+      };
+    }
+    return { rows: [] };
+  }
+
+  async end() {
+    this.ended = true;
+    if (this.options.failEnd) throw new Error(this.options.failEnd);
+  }
+}
+
+function makeLogger() {
+  const lines = [];
+  return {
+    lines,
+    log(message) { lines.push(String(message)); },
+    error(message) { lines.push(String(message)); },
+  };
+}
+
+test("autoplay migration runner fails safely when DATABASE_URL is missing", async () => {
+  let created = false;
+  const logger = makeLogger();
+  const code = await runner.runCli({
+    env: {},
+    repoRoot: REPO_ROOT,
+    logger,
+    clientFactory() {
+      created = true;
+      return new FakeClient();
+    },
+  });
+  assert.equal(code, 1);
+  assert.equal(created, false);
+  assert.match(logger.lines.join("\n"), /CATALOG_AUTOPLAY_MIGRATION_FAILED: DATABASE_URL is required/);
+});
+
+test("autoplay migration runner executes the exact merged SQL file and verifies schema", async () => {
+  let client;
+  const logger = makeLogger();
+  await runner.runMigration({
+    env: { DATABASE_URL },
+    repoRoot: REPO_ROOT,
+    logger,
+    clientFactory(config) {
+      assert.equal(config.connectionString, DATABASE_URL);
+      client = new FakeClient();
+      return client;
+    },
+  });
+  const migrationSql = fs.readFileSync(path.join(REPO_ROOT, runner.MIGRATION_RELATIVE_PATH), "utf8");
+  assert.equal(client.queries[0].sql, "SELECT pg_advisory_lock($1::bigint)");
+  assert.deepEqual(client.queries[0].params, [runner.ADVISORY_LOCK_KEY]);
+  assert.equal(client.queries[1].sql, "BEGIN");
+  assert.equal(client.queries[2].sql, runner.stripOuterTransactionWrapper(migrationSql));
+  assert.ok(client.queries.some((q) => q.sql === "COMMIT"));
+  assert.equal(client.queries.at(-1).sql, "SELECT pg_advisory_unlock($1::bigint)");
+  assert.equal(client.ended, true);
+  assert.deepEqual(logger.lines, ["CATALOG_AUTOPLAY_MIGRATION_START", "CATALOG_AUTOPLAY_MIGRATION_OK"]);
+});
+
+test("autoplay migration runner rolls back before unlock on SQL failure, preserving original error", async () => {
+  let client;
+  const logger = makeLogger();
+  const code = await runner.runCli({
+    env: { DATABASE_URL },
+    repoRoot: REPO_ROOT,
+    logger,
+    clientFactory() {
+      client = new FakeClient({ failSql: "migration boom" });
+      return client;
+    },
+  });
+  assert.equal(code, 1);
+  assert.equal(client.ended, true);
+  assert.equal(client.queries.at(-2).sql, "ROLLBACK");
+  assert.equal(client.queries.at(-1).sql, "SELECT pg_advisory_unlock($1::bigint)");
+  assert.match(logger.lines.join("\n"), /CATALOG_AUTOPLAY_MIGRATION_FAILED: migration boom/);
+});
+
+test("autoplay migration runner cleanup errors never mask the original failure or leak secrets", async () => {
+  let client;
+  const logger = makeLogger();
+  const code = await runner.runCli({
+    env: { DATABASE_URL },
+    repoRoot: REPO_ROOT,
+    logger,
+    clientFactory() {
+      client = new FakeClient({
+        failSql: "migration boom",
+        failRollback: "rollback boom",
+        failUnlock: "unlock boom",
+        failEnd: "end boom",
+      });
+      return client;
+    },
+  });
+  assert.equal(code, 1);
+  assert.equal(client.ended, true);
+  const output = logger.lines.join("\n");
+  assert.match(output, /CATALOG_AUTOPLAY_MIGRATION_FAILED: migration boom/);
+  assert.doesNotMatch(output, /rollback boom/);
+  assert.doesNotMatch(output, /unlock boom/);
+  assert.doesNotMatch(output, /end boom/);
+});
+
+test("autoplay migration runner fails non-zero when is_autoplay_enabled column is missing", async () => {
+  const logger = makeLogger();
+  const code = await runner.runCli({
+    env: { DATABASE_URL },
+    repoRoot: REPO_ROOT,
+    logger,
+    clientFactory() { return new FakeClient({ missingColumn: true }); },
+  });
+  assert.equal(code, 1);
+  assert.match(logger.lines.join("\n"), /catalog_items\.is_autoplay_enabled missing after migration/);
+});
+
+test("autoplay migration runner rolls back (not commits) when post-body schema verification fails", async () => {
+  let client;
+  const logger = makeLogger();
+  const code = await runner.runCli({
+    env: { DATABASE_URL },
+    repoRoot: REPO_ROOT,
+    logger,
+    clientFactory() {
+      client = new FakeClient({ missingColumn: true });
+      return client;
+    },
+  });
+  assert.equal(code, 1);
+  const sqls = client.queries.map((q) => q.sql);
+  assert.ok(sqls.includes("BEGIN"));
+  const migrationSql = fs.readFileSync(path.join(REPO_ROOT, runner.MIGRATION_RELATIVE_PATH), "utf8");
+  assert.ok(sqls.some((sql) => sql === runner.stripOuterTransactionWrapper(migrationSql)));
+  assert.ok(!sqls.includes("COMMIT"), "a failed verification must never reach COMMIT");
+  const rollbackIndex = sqls.lastIndexOf("ROLLBACK");
+  const unlockIndex = sqls.findIndex((sql) => String(sql).includes("pg_advisory_unlock"));
+  assert.ok(rollbackIndex !== -1, "ROLLBACK must be issued when verification fails");
+  assert.ok(rollbackIndex < unlockIndex, "ROLLBACK must happen before the advisory unlock");
+  assert.equal(client.ended, true);
+});
+
+test("autoplay migration runner fails non-zero when is_autoplay_enabled has the wrong type", async () => {
+  const logger = makeLogger();
+  const code = await runner.runCli({
+    env: { DATABASE_URL },
+    repoRoot: REPO_ROOT,
+    logger,
+    clientFactory() { return new FakeClient({ wrongType: true }); },
+  });
+  assert.equal(code, 1);
+  assert.match(logger.lines.join("\n"), /catalog_items\.is_autoplay_enabled has unexpected type/);
+});
+
+test("autoplay migration runner fails non-zero when is_autoplay_enabled is unexpectedly nullable", async () => {
+  const logger = makeLogger();
+  const code = await runner.runCli({
+    env: { DATABASE_URL },
+    repoRoot: REPO_ROOT,
+    logger,
+    clientFactory() { return new FakeClient({ nullable: true }); },
+  });
+  assert.equal(code, 1);
+  assert.match(logger.lines.join("\n"), /catalog_items\.is_autoplay_enabled is unexpectedly nullable/);
+});
+
+test("autoplay migration runner does not print database secrets", async () => {
+  const logger = makeLogger();
+  const code = await runner.runCli({
+    env: { DATABASE_URL },
+    repoRoot: REPO_ROOT,
+    logger,
+    clientFactory() { return new FakeClient({ failConnect: `cannot connect ${DATABASE_URL}` }); },
+  });
+  const output = logger.lines.join("\n");
+  assert.equal(code, 1);
+  assert.doesNotMatch(output, /super-secret-password/);
+  assert.match(output, /\[REDACTED_DATABASE_URL\]/);
+});
+
+test("autoplay migration SQL is additive only: no DELETE/TRUNCATE/DROP TABLE/DROP COLUMN", () => {
+  const migrationSql = fs.readFileSync(path.join(REPO_ROOT, runner.MIGRATION_RELATIVE_PATH), "utf8");
+  const executable = migrationSql
+    .split("\n")
+    .filter((line) => !line.trim().startsWith("--"))
+    .join("\n");
+  assert.doesNotMatch(executable, /\bDELETE\s+FROM\b/i);
+  assert.doesNotMatch(executable, /\bTRUNCATE\b/i);
+  assert.doesNotMatch(executable, /\bDROP\s+TABLE\b/i);
+  assert.doesNotMatch(executable, /\bDROP\s+COLUMN\b/i);
+});
+
+test("autoplay migration SQL uses IF NOT EXISTS / idempotent guards", () => {
+  const migrationSql = fs.readFileSync(path.join(REPO_ROOT, runner.MIGRATION_RELATIVE_PATH), "utf8");
+  assert.match(migrationSql, /ADD COLUMN IF NOT EXISTS is_autoplay_enabled BOOLEAN NOT NULL DEFAULT TRUE/);
+});
+
+test("autoplay migration runner uses an advisory lock distinct from other migration runners", () => {
+  const mediaPricingRunner = require("../scripts/run-catalog-store-media-pricing-migration");
+  const customerAuthRunner = require("../scripts/run-customer-auth-migration");
+  const marketplaceV2Runner = require("../scripts/run-catalog-marketplace-v2-migration");
+  assert.notEqual(runner.ADVISORY_LOCK_KEY, mediaPricingRunner.ADVISORY_LOCK_KEY);
+  assert.notEqual(runner.ADVISORY_LOCK_KEY, customerAuthRunner.ADVISORY_LOCK_KEY);
+  assert.notEqual(runner.ADVISORY_LOCK_KEY, marketplaceV2Runner.ADVISORY_LOCK_KEY);
+});

--- a/test/catalogItemsRoutes.test.js
+++ b/test/catalogItemsRoutes.test.js
@@ -7,7 +7,7 @@ const express = require("express");
 
 const createCatalogItemRoutes = require("../server/routes/catalog/items");
 
-function makePool(initialItems = [], initialRules = [], { schemaReady = true, marketplaceReady = false } = {}) {
+function makePool(initialItems = [], initialRules = [], { schemaReady = true, marketplaceReady = false, autoplayReady = false } = {}) {
   const state = {
     items: initialItems.map((x) => ({
       image_url: null, image_public_id: null, price_rule_id: null,
@@ -28,7 +28,7 @@ function makePool(initialItems = [], initialRules = [], { schemaReady = true, ma
 
   function joinedRow(item) {
     const rule = item.price_rule_id ? state.rules.find((r) => String(r.rule_id) === String(item.price_rule_id)) : null;
-    return {
+    const row = {
       ...item,
       rule_normal_price: rule ? rule.normal_price : null,
       rule_active_price: rule ? rule.active_price : null,
@@ -40,6 +40,10 @@ function makePool(initialItems = [], initialRules = [], { schemaReady = true, ma
       rule_label: rule ? rule.label : null,
       rule_priority: rule ? rule.priority : null,
     };
+    // Mirrors a real SELECT: is_autoplay_enabled is only a real, readable column once its
+    // own migration has run, regardless of what the in-memory fixture happens to hold.
+    if (!autoplayReady) delete row.is_autoplay_enabled;
+    return row;
   }
 
   function imagesForItem(itemId) {
@@ -52,6 +56,9 @@ function makePool(initialItems = [], initialRules = [], { schemaReady = true, ma
     state.queries.push({ sql, params });
     const s = String(sql);
 
+    if (s.includes("information_schema.columns") && s.includes("catalog_items") && s.includes("is_autoplay_enabled")) {
+      return { rows: [{ cnt: autoplayReady ? 1 : 0 }] };
+    }
     if (s.includes("information_schema.columns") && s.includes("catalog_items") && s.includes("short_description")) {
       return { rows: [{ cnt: marketplaceReady ? 10 : 0 }] };
     }
@@ -64,6 +71,22 @@ function makePool(initialItems = [], initialRules = [], { schemaReady = true, ma
 
     if (/^\s*(BEGIN|COMMIT|ROLLBACK)\s*;?\s*$/i.test(s)) return { rows: [] };
     if (s.includes("ALTER TABLE") || s.includes("CREATE INDEX") || s.includes("ADD CONSTRAINT") || s.includes("DO $$")) return { rows: [] };
+
+    if (s.includes("INSERT INTO public.catalog_items") && s.includes("is_autoplay_enabled")) {
+      const [
+        item_name, item_category, base_price, unit_label, job_category, ac_type, btu_min, btu_max, is_active, is_customer_visible,
+        short_description, long_description, highlights, service_conditions,
+        booking_mode, booking_service_key, booking_ac_type, booking_btu, booking_wash_variant, is_featured, is_autoplay_enabled,
+      ] = params;
+      const row = {
+        item_id: nextItemId++, item_name, item_category, base_price, unit_label, job_category, ac_type, btu_min, btu_max,
+        is_active, is_customer_visible, image_url: null, image_public_id: null, price_rule_id: null,
+        short_description, long_description, highlights: highlights ? JSON.parse(highlights) : null, service_conditions,
+        booking_mode, booking_service_key, booking_ac_type, booking_btu, booking_wash_variant, is_featured, is_autoplay_enabled,
+      };
+      state.items.push(row);
+      return { rows: [{ item_id: row.item_id }] };
+    }
 
     if (s.includes("INSERT INTO public.catalog_items") && s.includes("booking_mode")) {
       const [
@@ -133,6 +156,24 @@ function makePool(initialItems = [], initialRules = [], { schemaReady = true, ma
       const [item_id] = params;
       const row = state.items.find((x) => String(x.item_id) === String(item_id));
       if (row) Object.assign(row, { image_url: null, image_public_id: null });
+      return { rows: [] };
+    }
+
+    if (s.includes("SET item_name=$1") && s.includes("is_autoplay_enabled=$21")) {
+      const [
+        item_name, item_category, base_price, unit_label, job_category, ac_type, btu_min, btu_max, is_active, is_customer_visible,
+        short_description, long_description, highlights, service_conditions,
+        booking_mode, booking_service_key, booking_ac_type, booking_btu, booking_wash_variant, is_featured, is_autoplay_enabled,
+        item_id,
+      ] = params;
+      const row = state.items.find((x) => String(x.item_id) === String(item_id));
+      if (row) {
+        Object.assign(row, {
+          item_name, item_category, base_price, unit_label, job_category, ac_type, btu_min, btu_max, is_active, is_customer_visible,
+          short_description, long_description, highlights: highlights ? JSON.parse(highlights) : null, service_conditions,
+          booking_mode, booking_service_key, booking_ac_type, booking_btu, booking_wash_variant, is_featured, is_autoplay_enabled,
+        });
+      }
       return { rows: [] };
     }
 
@@ -1870,6 +1911,110 @@ test("admin POST rejects a bookable item with only booking_service_key set", asy
     });
     assert.equal(res.status, 400);
     assert.equal(pool.state.items.length, 3);
+  });
+});
+
+// ---------- Auto-slide (is_autoplay_enabled) ----------
+
+test("validateMarketplaceFields defaults is_autoplay_enabled to true", () => {
+  const result = validateMarketplaceFields({});
+  assert.equal(result.ok, true);
+  assert.equal(result.value.is_autoplay_enabled, true);
+});
+
+test("validateMarketplaceFields rejects a non-boolean is_autoplay_enabled", () => {
+  const result = validateMarketplaceFields({ is_autoplay_enabled: "not-a-boolean" });
+  assert.equal(result.ok, false);
+  assert.ok(result.errors.some((e) => /is_autoplay_enabled/.test(e)));
+});
+
+test("public/detail/admin DTOs fail-safe is_autoplay_enabled to false before the autoplay migration has run", async () => {
+  const items = sampleItems();
+  items[0].is_autoplay_enabled = true; // even if the column somehow had a value pre-migration
+  const pool = makePool(items, [], { marketplaceReady: true, autoplayReady: false });
+  const router = createCatalogItemRoutes({ pool, requireAdminSession: allowAdmin });
+  await withServer(router, async (base) => {
+    const listRes = await fetch(`${base}/catalog/items?customer=1`);
+    const listBody = await listRes.json();
+    assert.equal(listBody.find((x) => x.item_id === 1).is_autoplay_enabled, false);
+
+    const adminRes = await fetch(`${base}/admin/catalog/items`);
+    const adminBody = await adminRes.json();
+    assert.equal(adminBody.find((x) => x.item_id === 1).is_autoplay_enabled, false);
+  });
+});
+
+test("admin POST creates an item with is_autoplay_enabled once the autoplay migration has run", async () => {
+  const pool = makePool(sampleItems(), [], { marketplaceReady: true, autoplayReady: true });
+  const router = createCatalogItemRoutes({ pool, requireAdminSession: allowAdmin });
+  await withServer(router, async (base) => {
+    const res = await fetch(`${base}/admin/catalog/items`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ item_name: "ทดสอบ autoplay", is_autoplay_enabled: false }),
+    });
+    assert.equal(res.status, 201);
+    const body = await res.json();
+    assert.equal(body.is_autoplay_enabled, false);
+  });
+});
+
+test("admin POST defaults is_autoplay_enabled to true when omitted, once the autoplay migration has run", async () => {
+  const pool = makePool(sampleItems(), [], { marketplaceReady: true, autoplayReady: true });
+  const router = createCatalogItemRoutes({ pool, requireAdminSession: allowAdmin });
+  await withServer(router, async (base) => {
+    const res = await fetch(`${base}/admin/catalog/items`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ item_name: "ทดสอบ autoplay default" }),
+    });
+    assert.equal(res.status, 201);
+    const body = await res.json();
+    assert.equal(body.is_autoplay_enabled, true);
+  });
+});
+
+test("admin PATCH round-trips is_autoplay_enabled and leaves it unchanged when not sent", async () => {
+  const items = sampleItems();
+  items[0].is_autoplay_enabled = false;
+  const pool = makePool(items, [], { marketplaceReady: true, autoplayReady: true });
+  const router = createCatalogItemRoutes({ pool, requireAdminSession: allowAdmin });
+  await withServer(router, async (base) => {
+    const res = await fetch(`${base}/admin/catalog/items/1`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ item_name: "ทดสอบ ไม่เปลี่ยน autoplay" }),
+    });
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.equal(body.is_autoplay_enabled, false);
+
+    const res2 = await fetch(`${base}/admin/catalog/items/1`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ is_autoplay_enabled: true }),
+    });
+    const body2 = await res2.json();
+    assert.equal(body2.is_autoplay_enabled, true);
+  });
+});
+
+test("opening an item for edit and saving without changes round-trips is_autoplay_enabled unchanged", async () => {
+  const items = sampleItems();
+  items[0].is_autoplay_enabled = false;
+  items[0].is_featured = true;
+  const pool = makePool(items, [], { marketplaceReady: true, autoplayReady: true });
+  const router = createCatalogItemRoutes({ pool, requireAdminSession: allowAdmin });
+  await withServer(router, async (base) => {
+    const res = await fetch(`${base}/admin/catalog/items/1`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({}),
+    });
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.equal(body.is_autoplay_enabled, false);
+    assert.equal(body.is_featured, true);
   });
 });
 

--- a/test/catalogItemsRoutes.test.js
+++ b/test/catalogItemsRoutes.test.js
@@ -171,6 +171,18 @@ function makePool(initialItems = [], initialRules = [], { schemaReady = true, ma
       return { rows: row ? [{ item_id: row.item_id }] : [] };
     }
 
+    if (s.includes("SELECT image_public_id FROM public.catalog_item_images WHERE item_id = $1 AND image_public_id IS NOT NULL")) {
+      const rows = imagesForItem(params[0]).filter((img) => img.image_public_id != null).map((img) => ({ image_public_id: img.image_public_id }));
+      return { rows };
+    }
+
+    if (s.includes("DELETE FROM public.catalog_items WHERE item_id = $1")) {
+      const [itemId] = params;
+      state.items = state.items.filter((x) => String(x.item_id) !== String(itemId));
+      state.images = state.images.filter((img) => String(img.item_id) !== String(itemId));
+      return { rows: [] };
+    }
+
     if (s.includes("FROM public.catalog_item_images") && s.includes("ANY($1::bigint[])")) {
       const ids = (params[0] || []).map(String);
       const rows = state.images
@@ -1526,6 +1538,127 @@ test("image upload SQL is parameterized: a hostile filename/public_id never appe
     assert.ok(updateQuery);
     assert.equal(updateQuery.sql.includes(hostilePublicId), false);
     assert.ok(updateQuery.params.includes(hostilePublicId));
+  });
+});
+
+// ---------- DELETE /admin/catalog/items/:itemId ----------
+
+test("DELETE admin catalog item removes the row and never touches customer_service_price_rules", async () => {
+  const items = sampleItems();
+  items[0].price_rule_id = 70;
+  const rules = [{ rule_id: 70, normal_price: 700, active_price: 550, campaign_name: "เดิม", is_active: true, effective_from: null, effective_to: null }];
+  const pool = makePool(items, rules);
+  const router = createCatalogItemRoutes({ pool, requireAdminSession: allowAdmin });
+  await withServer(router, async (base) => {
+    const res = await fetch(`${base}/admin/catalog/items/1`, { method: "DELETE" });
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.equal(body.ok, true);
+    assert.equal(pool.state.items.some((x) => x.item_id === 1), false);
+    assert.equal(pool.state.rules.length, 1);
+    assert.equal(pool.state.rules[0].rule_id, 70);
+    const deleteQuery = pool.state.queries.some((q) => /DELETE FROM public\.customer_service_price_rules/i.test(q.sql));
+    assert.equal(deleteQuery, false);
+  });
+});
+
+test("DELETE admin catalog item also removes its gallery images (cascade)", async () => {
+  const pool = makePool(sampleItems(), [], { marketplaceReady: true });
+  pool.state.images.push(
+    { image_id: 1, item_id: 1, image_url: "u1", image_public_id: "p1", alt_text: null, sort_order: 0, is_primary: true },
+    { image_id: 2, item_id: 1, image_url: "u2", image_public_id: "p2", alt_text: null, sort_order: 1, is_primary: false }
+  );
+  const router = createCatalogItemRoutes({ pool, requireAdminSession: allowAdmin });
+  await withServer(router, async (base) => {
+    const res = await fetch(`${base}/admin/catalog/items/1`, { method: "DELETE" });
+    assert.equal(res.status, 200);
+    assert.equal(pool.state.images.length, 0);
+  });
+});
+
+test("DELETE admin catalog item cleans up legacy and gallery Cloudinary assets", async () => {
+  const items = sampleItems();
+  items[0].image_public_id = "legacy-pub-id";
+  const pool = makePool(items, [], { marketplaceReady: true });
+  pool.state.images.push(
+    { image_id: 1, item_id: 1, image_url: "u1", image_public_id: "gallery-pub-1", alt_text: null, sort_order: 0, is_primary: true }
+  );
+  const cleanedUp = [];
+  const deleteCatalogImage = async (publicId) => { cleanedUp.push(publicId); return { ok: true }; };
+  const router = createCatalogItemRoutes({ pool, requireAdminSession: allowAdmin, deleteCatalogImage });
+  await withServer(router, async (base) => {
+    const res = await fetch(`${base}/admin/catalog/items/1`, { method: "DELETE" });
+    assert.equal(res.status, 200);
+    assert.deepEqual(cleanedUp.sort(), ["gallery-pub-1", "legacy-pub-id"]);
+  });
+});
+
+test("DELETE admin catalog item still reports success with a warning when Cloudinary cleanup fails", async () => {
+  const items = sampleItems();
+  items[0].image_public_id = "legacy-pub-id";
+  const pool = makePool(items);
+  const deleteCatalogImage = async () => { throw new Error("cloudinary down"); };
+  const router = createCatalogItemRoutes({ pool, requireAdminSession: allowAdmin, deleteCatalogImage });
+  await withServer(router, async (base) => {
+    const res = await fetch(`${base}/admin/catalog/items/1`, { method: "DELETE" });
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.equal(body.ok, true);
+    assert.match(body.warning, /Cloudinary/);
+    assert.equal(pool.state.items.some((x) => x.item_id === 1), false);
+  });
+});
+
+test("DELETE admin catalog item returns 404 for an unknown item and changes nothing", async () => {
+  const pool = makePool(sampleItems());
+  const router = createCatalogItemRoutes({ pool, requireAdminSession: allowAdmin });
+  await withServer(router, async (base) => {
+    const res = await fetch(`${base}/admin/catalog/items/999`, { method: "DELETE" });
+    assert.equal(res.status, 404);
+    assert.equal(pool.state.items.length, sampleItems().length);
+  });
+});
+
+test("DELETE admin catalog item returns 400 for a malformed item id", async () => {
+  const pool = makePool(sampleItems());
+  const router = createCatalogItemRoutes({ pool, requireAdminSession: allowAdmin });
+  await withServer(router, async (base) => {
+    const res = await fetch(`${base}/admin/catalog/items/abc`, { method: "DELETE" });
+    assert.equal(res.status, 400);
+  });
+});
+
+test("DELETE admin catalog item requires an admin session", async () => {
+  const pool = makePool(sampleItems());
+  const router = createCatalogItemRoutes({ pool, requireAdminSession: denyAdmin });
+  await withServer(router, async (base) => {
+    const res = await fetch(`${base}/admin/catalog/items/1`, { method: "DELETE" });
+    assert.equal(res.status, 401);
+    assert.equal(pool.state.items.length, sampleItems().length);
+  });
+});
+
+test("a repeated DELETE of an already-deleted item returns 404 instead of double-deleting", async () => {
+  const pool = makePool(sampleItems());
+  const router = createCatalogItemRoutes({ pool, requireAdminSession: allowAdmin });
+  await withServer(router, async (base) => {
+    const first = await fetch(`${base}/admin/catalog/items/1`, { method: "DELETE" });
+    assert.equal(first.status, 200);
+    const second = await fetch(`${base}/admin/catalog/items/1`, { method: "DELETE" });
+    assert.equal(second.status, 404);
+  });
+});
+
+test("DELETE admin catalog item responds successfully (no hang/deadlock) against a single-connection pool", async () => {
+  const pool = makePool(sampleItems());
+  const tracker = wrapAsSingleConnectionPool(pool);
+  const router = createCatalogItemRoutes({ pool, requireAdminSession: allowAdmin });
+  await withServer(router, async (base) => {
+    const res = await fetch(`${base}/admin/catalog/items/1`, { method: "DELETE" });
+    assert.equal(res.status, 200);
+    assert.deepEqual(tracker.poolQueryCallsWhileCheckedOut, []);
+    assert.equal(tracker.connectCalls, 1);
+    assert.equal(tracker.releaseCalls, 1);
   });
 });
 

--- a/test/catalogItemsRoutes.test.js
+++ b/test/catalogItemsRoutes.test.js
@@ -1974,6 +1974,54 @@ test("uploading a second gallery image is not primary and gets the next sort_ord
   });
 });
 
+test("uploading a 5th gallery image is rejected and never persisted", async () => {
+  const pool = makePool(sampleItems(), [], { marketplaceReady: true });
+  pool.state.images.push(
+    { image_id: 1, item_id: 1, image_url: "u1", image_public_id: "p1", alt_text: null, sort_order: 0, is_primary: true },
+    { image_id: 2, item_id: 1, image_url: "u2", image_public_id: "p2", alt_text: null, sort_order: 1, is_primary: false },
+    { image_id: 3, item_id: 1, image_url: "u3", image_public_id: "p3", alt_text: null, sort_order: 2, is_primary: false },
+    { image_id: 4, item_id: 1, image_url: "u4", image_public_id: "p4", alt_text: null, sort_order: 3, is_primary: false }
+  );
+  let uploadCalled = false;
+  const uploadCatalogImage = async () => { uploadCalled = true; return { url: "https://res.cloudinary.com/demo/g5.jpg", public_id: "g5" }; };
+  const router = createCatalogItemRoutes({ pool, requireAdminSession: allowAdmin, uploadCatalogImage });
+  await withServer(router, async (base) => {
+    const res = await fetch(`${base}/admin/catalog/items/1/images`, { method: "POST", body: multipartImageForm(JPEG_BYTES) });
+    assert.equal(res.status, 409);
+    const body = await res.json();
+    assert.match(body.error, /4 รูป/);
+    assert.equal(uploadCalled, false);
+    assert.equal(pool.state.images.length, 4);
+  });
+});
+
+test("concurrent gallery uploads at the cap never exceed 4 images for an item", async () => {
+  const pool = makePool(sampleItems(), [], { marketplaceReady: true });
+  wrapWithFakeRowLock(pool);
+  pool.state.images.push(
+    { image_id: 1, item_id: 1, image_url: "u1", image_public_id: "p1", alt_text: null, sort_order: 0, is_primary: true },
+    { image_id: 2, item_id: 1, image_url: "u2", image_public_id: "p2", alt_text: null, sort_order: 1, is_primary: false },
+    { image_id: 3, item_id: 1, image_url: "u3", image_public_id: "p3", alt_text: null, sort_order: 2, is_primary: false }
+  );
+  let n = 0;
+  const uploadCatalogImage = async () => {
+    n += 1;
+    await new Promise((resolve) => setTimeout(resolve, 5));
+    return { url: `https://res.cloudinary.com/demo/cap${n}.jpg`, public_id: `cap${n}` };
+  };
+  const router = createCatalogItemRoutes({ pool, requireAdminSession: allowAdmin, uploadCatalogImage });
+  await withServer(router, async (base) => {
+    const [res1, res2] = await Promise.all([
+      fetch(`${base}/admin/catalog/items/1/images`, { method: "POST", body: multipartImageForm(JPEG_BYTES) }),
+      fetch(`${base}/admin/catalog/items/1/images`, { method: "POST", body: multipartImageForm(PNG_BYTES, { mimetype: "image/png", filename: "x.png" }) }),
+    ]);
+    const statuses = [res1.status, res2.status].sort();
+    assert.deepEqual(statuses, [201, 409]);
+    const itemImages = pool.state.images.filter((img) => String(img.item_id) === "1");
+    assert.equal(itemImages.length, 4);
+  });
+});
+
 test("concurrent first-image uploads for the same item never produce two Primary images", async () => {
   const pool = makePool(sampleItems(), [], { marketplaceReady: true });
   wrapWithFakeRowLock(pool);

--- a/test/customerAppRecovery.test.js
+++ b/test/customerAppRecovery.test.js
@@ -916,9 +916,28 @@ test("standard-service badge renders real rating_average/review_count with half 
 
   const body = container.querySelector("[data-store-body]");
   assert.match(body.innerHTML, /store-standard-star is-half/);
-  assert.match(body.innerHTML, /store-standard-count">\(12\)<\/span>/);
+  assert.match(body.innerHTML, /store-standard-value">4\.5<\/span>/);
+  assert.match(body.innerHTML, /store-standard-count">\(12 รีวิว\)<\/span>/);
   assert.equal((body.innerHTML.match(/store-standard-count/g) || []).length, 1);
   assert.equal((body.innerHTML.match(/store-standard-star is-filled/g) || []).length, 4 + 5);
+});
+
+test("standard-service badge star fill logic only shows a half star once the fractional part reaches 0.5; below that it rounds down to full/empty stars only", async () => {
+  const context = makeContext();
+  const root = loadCustomerFrontend(context);
+  root.api.loadCatalogItems = async () => [
+    { item_id: 1, item_name: "4.2 ดาว", item_category: "ล้างแอร์", base_price: 700, unit_label: "เครื่อง", rating_average: 4.2, review_count: 6 },
+  ];
+
+  const container = new FakeMount();
+  root.store.render(container);
+  await new Promise((resolve) => setTimeout(resolve, 0));
+
+  const body = container.querySelector("[data-store-body]");
+  assert.match(body.innerHTML, /store-standard-value">4\.2<\/span>/);
+  assert.match(body.innerHTML, /store-standard-count">\(6 รีวิว\)<\/span>/);
+  assert.doesNotMatch(body.innerHTML, /store-standard-star is-half/);
+  assert.equal((body.innerHTML.match(/store-standard-star is-filled/g) || []).length, 4);
 });
 
 test("standard-service badge ignores legacy rating_value and fails safe to the no-fake-review CWF badge on invalid/null rating_average or review_count", async () => {
@@ -980,7 +999,8 @@ test("product detail page uses the exact same renderStandardBadge output as the 
 
   const body = container.querySelector("[data-store-detail-body]");
   assert.match(body.innerHTML, /store-standard-star is-half/);
-  assert.match(body.innerHTML, /store-standard-count">\(8\)<\/span>/);
+  assert.match(body.innerHTML, /store-standard-value">3\.5<\/span>/);
+  assert.match(body.innerHTML, /store-standard-count">\(8 รีวิว\)<\/span>/);
   assert.equal((body.innerHTML.match(/store-standard-star is-filled/g) || []).length, 3);
 });
 

--- a/test/customerAppRecovery.test.js
+++ b/test/customerAppRecovery.test.js
@@ -881,6 +881,84 @@ test("store card shows a multi-image slider with dot indicators when an item has
   assert.equal((body.innerHTML.match(/class="store-card-dot is-active"/g) || []).length, 1);
 });
 
+test("store card shows the CWF featured ribbon only for featured items, and a five-star standard-service badge for every item", async () => {
+  const context = makeContext();
+  const root = loadCustomerFrontend(context);
+  root.api.loadCatalogItems = async () => [
+    { item_id: 1, item_name: "รายการแนะนำ", item_category: "ล้างแอร์", base_price: 700, unit_label: "เครื่อง", is_featured: true, image_url: "https://res.cloudinary.com/demo/a.jpg" },
+    { item_id: 2, item_name: "รายการธรรมดา", item_category: "ล้างแอร์", base_price: 700, unit_label: "เครื่อง", is_featured: false, image_url: "https://res.cloudinary.com/demo/b.jpg" },
+  ];
+
+  const container = new FakeMount();
+  root.store.render(container);
+  await new Promise((resolve) => setTimeout(resolve, 0));
+
+  const body = container.querySelector("[data-store-body]");
+  assert.equal((body.innerHTML.match(/store-featured-ribbon/g) || []).length, 1);
+  assert.match(body.innerHTML, /CWF แนะนำ/);
+  assert.doesNotMatch(body.innerHTML, /store-badge-featured/);
+  assert.equal((body.innerHTML.match(/store-standard-badge/g) || []).length, 2);
+  assert.equal((body.innerHTML.match(/store-standard-label">มาตรฐานบริการ CWF/g) || []).length, 2);
+  assert.equal((body.innerHTML.match(/store-standard-star is-filled/g) || []).length, 10);
+});
+
+test("store card and product detail gallery flag autoplay only for multi-image items with is_autoplay_enabled true", async () => {
+  const context = makeContext();
+  const root = loadCustomerFrontend(context);
+  root.api.loadCatalogItems = async () => [
+    {
+      item_id: 1, item_name: "เปิดออโต้เลื่อน", item_category: "ล้างแอร์", base_price: 700, unit_label: "เครื่อง",
+      is_autoplay_enabled: true,
+      images: [
+        { image_id: 1, image_url: "https://res.cloudinary.com/demo/a.jpg", alt_text: null },
+        { image_id: 2, image_url: "https://res.cloudinary.com/demo/b.jpg", alt_text: null },
+      ],
+    },
+    {
+      item_id: 2, item_name: "ปิดออโต้เลื่อน", item_category: "ล้างแอร์", base_price: 700, unit_label: "เครื่อง",
+      is_autoplay_enabled: false,
+      images: [
+        { image_id: 3, image_url: "https://res.cloudinary.com/demo/c.jpg", alt_text: null },
+        { image_id: 4, image_url: "https://res.cloudinary.com/demo/d.jpg", alt_text: null },
+      ],
+    },
+    {
+      item_id: 3, item_name: "รูปเดียวเปิดออโต้", item_category: "ล้างแอร์", base_price: 700, unit_label: "เครื่อง",
+      is_autoplay_enabled: true,
+      image_url: "https://res.cloudinary.com/demo/e.jpg",
+    },
+  ];
+
+  const container = new FakeMount();
+  root.store.render(container);
+  await new Promise((resolve) => setTimeout(resolve, 0));
+
+  const body = container.querySelector("[data-store-body]");
+  assert.equal((body.innerHTML.match(/data-store-autoplay="1"/g) || []).length, 1);
+});
+
+test("product detail gallery flags autoplay for a multi-image bookable item with is_autoplay_enabled true", async () => {
+  const context = makeContext();
+  const root = loadCustomerFrontend(context);
+  root.state.setRoute("storeItem-9");
+  root.api.loadCatalogItem = async () => ({
+    item_id: 9, item_name: "รายละเอียดออโต้เลื่อน", item_category: "ล้างแอร์", base_price: 900, unit_label: "เครื่อง",
+    is_autoplay_enabled: true, is_featured: true,
+    images: [
+      { image_id: 1, image_url: "https://res.cloudinary.com/demo/a.jpg", alt_text: null },
+      { image_id: 2, image_url: "https://res.cloudinary.com/demo/b.jpg", alt_text: null },
+    ],
+  });
+
+  const container = new FakeMount();
+  root.store.renderDetail(container);
+  await new Promise((resolve) => setTimeout(resolve, 0));
+
+  const body = container.querySelector("[data-store-detail-body]");
+  assert.match(body.innerHTML, /data-store-autoplay="1"/);
+  assert.match(body.innerHTML, /store-featured-ribbon/);
+});
+
 test("storeItem dynamic route is registered and dispatches to the product detail handler with the numeric id", () => {
   const shell = read("customer-app/assets/customer-app.js");
   assert.match(shell, /storeItem:\s*App\.store\.renderDetail/);

--- a/test/customerAppRecovery.test.js
+++ b/test/customerAppRecovery.test.js
@@ -921,6 +921,69 @@ test("standard-service badge renders real rating_average/review_count with half 
   assert.equal((body.innerHTML.match(/store-standard-star is-filled/g) || []).length, 4 + 5);
 });
 
+test("standard-service badge ignores legacy rating_value and fails safe to the no-fake-review CWF badge on invalid/null rating_average or review_count", async () => {
+  const context = makeContext();
+  const root = loadCustomerFrontend(context);
+  root.api.loadCatalogItems = async () => [
+    // legacy field present but must never be read as the rating contract
+    { item_id: 1, item_name: "เคสเก่า rating_value", item_category: "ล้างแอร์", base_price: 700, unit_label: "เครื่อง", rating_value: 4 },
+    { item_id: 2, item_name: "rating_average ไม่ใช่ตัวเลข", item_category: "ล้างแอร์", base_price: 700, unit_label: "เครื่อง", rating_average: "abc", review_count: 5 },
+    { item_id: 3, item_name: "rating_average นอกช่วง", item_category: "ล้างแอร์", base_price: 700, unit_label: "เครื่อง", rating_average: 7, review_count: 3 },
+    { item_id: 4, item_name: "review_count เป็น 0", item_category: "ล้างแอร์", base_price: 700, unit_label: "เครื่อง", rating_average: 4.8, review_count: 0 },
+    { item_id: 5, item_name: "review_count เป็น null", item_category: "ล้างแอร์", base_price: 700, unit_label: "เครื่อง", rating_average: 4.8, review_count: null },
+  ];
+
+  const container = new FakeMount();
+  root.store.render(container);
+  await new Promise((resolve) => setTimeout(resolve, 0));
+
+  const body = container.querySelector("[data-store-body]");
+  // every item must fail safe to the plain 5-star "มาตรฐานบริการ CWF" badge with zero visible review counts
+  assert.equal((body.innerHTML.match(/store-standard-badge/g) || []).length, 5);
+  assert.equal((body.innerHTML.match(/store-standard-label">มาตรฐานบริการ CWF/g) || []).length, 5);
+  assert.equal((body.innerHTML.match(/store-standard-star is-filled/g) || []).length, 25);
+  assert.doesNotMatch(body.innerHTML, /store-standard-count/);
+  assert.doesNotMatch(body.innerHTML, /store-standard-star is-half/);
+});
+
+test("standard-service badge never displays a numeric average, a zero-review count, or the phrase \"คะแนนลูกค้า\" anywhere in its markup", async () => {
+  const context = makeContext();
+  const root = loadCustomerFrontend(context);
+  root.api.loadCatalogItems = async () => [
+    { item_id: 1, item_name: "ยังไม่มีรีวิว", item_category: "ล้างแอร์", base_price: 700, unit_label: "เครื่อง" },
+  ];
+
+  const container = new FakeMount();
+  root.store.render(container);
+  await new Promise((resolve) => setTimeout(resolve, 0));
+
+  const body = container.querySelector("[data-store-body]");
+  const badgeMatch = body.innerHTML.match(/<div class="store-standard-badge"[\s\S]*?<\/div>/);
+  assert.ok(badgeMatch, "standard badge markup not found");
+  assert.doesNotMatch(badgeMatch[0], /5\.0/);
+  assert.doesNotMatch(badgeMatch[0], /0 รีวิว/);
+  assert.doesNotMatch(badgeMatch[0], /คะแนนลูกค้า/);
+});
+
+test("product detail page uses the exact same renderStandardBadge output as the store card for both real and absent rating data", async () => {
+  const context = makeContext();
+  const root = loadCustomerFrontend(context);
+  root.api.loadCatalogItem = async () => ({
+    item_id: 9, item_name: "ล้างแอร์มีรีวิว", item_category: "ล้างแอร์", base_price: 900, unit_label: "เครื่อง",
+    rating_average: 3.5, review_count: 8,
+  });
+
+  const container = new FakeMount();
+  root.state.setRoute("storeItem-9");
+  root.store.renderDetail(container);
+  await new Promise((resolve) => setTimeout(resolve, 0));
+
+  const body = container.querySelector("[data-store-detail-body]");
+  assert.match(body.innerHTML, /store-standard-star is-half/);
+  assert.match(body.innerHTML, /store-standard-count">\(8\)<\/span>/);
+  assert.equal((body.innerHTML.match(/store-standard-star is-filled/g) || []).length, 3);
+});
+
 test("store card and product detail gallery flag autoplay only for multi-image items with is_autoplay_enabled true", async () => {
   const context = makeContext();
   const root = loadCustomerFrontend(context);

--- a/test/customerAppRecovery.test.js
+++ b/test/customerAppRecovery.test.js
@@ -902,6 +902,25 @@ test("store card shows the CWF featured ribbon only for featured items, and a fi
   assert.equal((body.innerHTML.match(/store-standard-star is-filled/g) || []).length, 10);
 });
 
+test("standard-service badge renders real rating_average/review_count with half stars and a visible count, but falls back to a fake-review-free 5-star badge when there is no real data", async () => {
+  const context = makeContext();
+  const root = loadCustomerFrontend(context);
+  root.api.loadCatalogItems = async () => [
+    { item_id: 1, item_name: "มีรีวิวจริง", item_category: "ล้างแอร์", base_price: 700, unit_label: "เครื่อง", rating_average: 4.5, review_count: 12 },
+    { item_id: 2, item_name: "ยังไม่มีรีวิว", item_category: "ล้างแอร์", base_price: 700, unit_label: "เครื่อง" },
+  ];
+
+  const container = new FakeMount();
+  root.store.render(container);
+  await new Promise((resolve) => setTimeout(resolve, 0));
+
+  const body = container.querySelector("[data-store-body]");
+  assert.match(body.innerHTML, /store-standard-star is-half/);
+  assert.match(body.innerHTML, /store-standard-count">\(12\)<\/span>/);
+  assert.equal((body.innerHTML.match(/store-standard-count/g) || []).length, 1);
+  assert.equal((body.innerHTML.match(/store-standard-star is-filled/g) || []).length, 4 + 5);
+});
+
 test("store card and product detail gallery flag autoplay only for multi-image items with is_autoplay_enabled true", async () => {
   const context = makeContext();
   const root = loadCustomerFrontend(context);


### PR DESCRIPTION
## Summary

Single draft PR covering all 7 originally requested items, plus three rounds of follow-up fixes from review comments. Branch created from latest `main`. No production migration run, no merge performed, no other PR/branch opened. All fixes applied on this same branch/PR per the reviews' explicit constraints.

Head SHA: `88f36ca`

### Original 7 items
1. **Featured ribbon** — `CWF แนะนำ` ribbon overlay (top-right, brand gradient, responsive) on Store cards/detail. `customer-app/modules/store.js`, `customer-app/assets/customer-app.css`.
2. **Multi-image upload, max 4** — backend hard limit enforced (`MAX_CATALOG_IMAGES_PER_ITEM = 4`, row-locked check). See review-fix round 2 below for the upgraded UX.
3. **Auto-slide on Store/Detail** — additive column `is_autoplay_enabled BOOLEAN NOT NULL DEFAULT TRUE` on `catalog_items`. Viewport-gated (`IntersectionObserver`), respects `prefers-reduced-motion`, pauses on touch/hidden-tab, cleans up via the router's `onLeave` hook. Admin can toggle it per item. Migration: `migrations/20260623_catalog_store_autoplay.sql`, runner: `scripts/run-catalog-autoplay-migration.js`, npm command: `migrate:catalog-autoplay`.
4. **"มาตรฐานบริการ CWF" badge** — see review-fix round 3 below for the completed real-rating-ready renderer.
5. **Real delete** — `DELETE /admin/catalog/items/:itemId` wired into the admin UI via a "ลบรายการนี้" action in the more-sheet → confirmation modal requiring the admin to type the exact item name, extra warning if the item is currently live/visible, surfaces any Cloudinary best-effort cleanup `warning` distinctly from plain success.
6. **Add/edit form structure** — see review-fix round 1 below; the original claim that the existing 7-section layout already satisfied this was incorrect and has been corrected.
7. **Related-system audit** — gallery delete/set-primary/reorder actions had no in-flight guard, allowing duplicate double-click submissions; fixed by reusing the `galleryUploading` flag to block re-entry around each action.

### Review-comment fixes — round 1
1. **Form reorganized into 7 genuinely non-redundant sections** (`admin-store-catalog.js: ensureCatalogModal()`): ข้อมูลหลัก / รูปภาพสินค้า (legacy cover image + multi-image gallery merged into one section) / ราคาและโปรโมชั่น (now includes `cm_base_price`, no more separate "ขั้นสูง") / การจอง / รายละเอียด / การแสดงผล / ข้อมูลจับคู่ระบบราคา — the catalog-item fields that are actually matched against `customer_service_price_rules` are collapsed by default inside a native `<details>` accordion with an explicit warning. All field element ids are unchanged, so existing reset/edit/payload logic round-trips every value exactly as before.
2. **Multi-image upload UX (first pass)**: per-file `pending → uploading → done|error` queue with local preview thumbnails and an "x/N" progress indicator, still sequential through the existing single-image upload endpoint — no new bulk-upload API.
3. **Future-review-ready badge renderer (first pass)**: `standardRatingInfo(item)` reads `rating_average`/`review_count` when valid; otherwise falls back to a plain 5-star badge.

### Review-comment fixes — round 2
1. **Booking section decluttered further**: `cm_booking_service_key` moved into a collapsed-by-default "ตั้งค่าเพิ่มเติม (Advanced)" `<details>` subsection.
2. **Multi-image upload UX (completed)**: append-only queue (never drops a prior failure on a new pick), persistent non-toast over-limit notice, per-file Retry/Remove on failure that never re-uploads already-succeeded files, gallery reload after the queue settles, and a close-while-uploading guard.
3. **Rating contract simplified**: removed the legacy `rating_value` fallback entirely; the only contract is `rating_average` (1–5) + `review_count` (>0).

### Review-comment fixes — round 3 (Final Code Review blockers)
1. **Fixed malformed booking modal markup**: `ensureCatalogModal()` had a stray extra `</div>` right after the booking Advanced `<details>` block, which double-closed `#cm_booking_fields` and the booking `.asc-section` and effectively skewed the nesting of everything after it. Removed the extra closing tag so `#cm_booking_fields` and the booking `.asc-section` each close exactly once, and confirmed sections 5/6/7 plus `#catalog_modal_error` remain direct children of `.cwf-modal-body`. No field ids or event handlers were touched. Added a new structural regression test (`test/adminStoreCatalogUi.test.js`) that walks the modal's HTML template as a real tag stack (not a text-window regex) and fails on any unbalanced or misnested tag — this test fails against the old markup and passes against the fix, so this class of bug can't silently regress again.
2. **Completed the real-rating display**: `renderStandardBadge()` in `customer-app/modules/store.js` now shows the actual average (rounded to at most 1 decimal place, e.g. `4.5`) and a `(N รีวิว)` count alongside full/half/empty stars whenever `rating_average` (1–5) and `review_count` (>0) are both valid. When there is no real data (or it's invalid/null/zero), the badge is unchanged from the prior round: exactly `★★★★★ มาตรฐานบริการ CWF`, with no `"5.0"`, no `"0 รีวิว"`, and no claim of `"คะแนนลูกค้า"` anywhere in that fallback markup. Store card and Product Detail continue to call the exact same `renderStandardBadge()` function, verified to produce identical output for both real and absent rating data. A small CSS rule (`.store-standard-value`) was added to `customer-app/assets/customer-app.css` to style the new numeric average text; no other styling was touched.

New tests added this round: the tag-stack structural regression test described above; a real-rating test asserting `4.5` + `(12 รีวิว)` render together with the correct half-star; a boundary test asserting `4.2` shows 4 full stars and no half star (fraction below 0.5 rounds down); the Card/Detail parity test was updated to assert the new value+count format.

## Forbidden areas — untouched (confirmed)
Payment, Auth core, Technician app/job flow, Tracking, and production data were not touched. No change to `customer_service_price_rules` data or schema. No schema change beyond the single additive `is_autoplay_enabled` column (already covered by round 1). No backend route, API contract, migration, or `package.json` change in round 3 — `server/routes/catalog/items.js` and `server/lib/cloudinaryImageUpload.js` were not touched. Upload queue behavior, autoplay, delete flow, booking behavior (other than the markup-nesting fix, which changes no field id/handler/behavior), pricing behavior, and the featured ribbon were left exactly as they were. No new branch, no new PR, no merge, no production migration was run by me in any round.

## Migration

```
npm run migrate:catalog-autoplay
```
Verify:
```sql
SELECT column_name, data_type, is_nullable, column_default
FROM information_schema.columns
WHERE table_schema = 'public' AND table_name = 'catalog_items' AND column_name = 'is_autoplay_enabled';
```
Expected: `is_autoplay_enabled | boolean | NO | true`

## Tests

`npm test` → 467 total, 456 passing, 11 pre-existing skips (DB-dependent), 0 failures. `node --check` passes on every modified JS file. `git diff --check` is clean.

## Browser QA

No browser is available in this sandbox. **Browser QA was NOT performed and is NOT claimed to have passed**, in this round or any previous round. Substituted with automated DOM/markup tests against rendered HTML strings (vm-based harness in `test/customerAppRecovery.test.js`) and source-regex/tag-tree-structural tests against the admin UI (`test/adminStoreCatalogUi.test.js`). No screenshots/video are attached since no browser rendered anything in this environment.

## Remaining risk / follow-up
- Real cross-browser/responsive (320/360/390/430/1280px) visual QA, including the accordion interactions, per-file upload previews/retry UI, and the new rating value/count layout, is still needed before this ships to production.
- The autoplay timer/IntersectionObserver code paths remain untestable in this Node-only sandbox; only render-time HTML attributes are verified automatically.
- `rating_average`/`review_count` have no real data source yet — the renderer is real-data-ready but every item currently falls back to the standard CWF badge by design until a real review system exists.


---
_Generated by [Claude Code](https://claude.ai/code/session_01G8RDdFzW2bZKTwvsfaovwg)_