### PR TITLE
Store marketplace polish: CTA wording, badges, autoplay jitter, CTA-bar/grid fixes

### DIFF
--- a/customer-app/assets/customer-app.css
+++ b/customer-app/assets/customer-app.css
@@ -3491,7 +3491,32 @@ body.has-contact-sheet { overflow: hidden; }
 }
 
 /* ===================== Store / Marketplace (Phase 2) ===================== */
-.store-hero p { margin-top: 6px; }
+/* Compact Store-only header; the shared .hero class stays untouched for other screens. */
+.store-compact-header {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 12px 14px;
+  margin-bottom: 12px;
+  border-radius: var(--radius);
+  background: linear-gradient(135deg, var(--accent, #1f7bff), #0f4fb8);
+  color: #fff;
+  min-height: 0;
+}
+.store-compact-header h2 {
+  margin: 0;
+  font-size: 15px;
+  line-height: 1.3;
+}
+.store-compact-badge {
+  flex: 0 0 auto;
+  font-size: 10.5px;
+  font-weight: 700;
+  padding: 3px 9px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.18);
+  white-space: nowrap;
+}
 .store-filters {
   display: grid;
   grid-template-columns: minmax(0, 1.4fr) minmax(0, 1fr);
@@ -3514,36 +3539,42 @@ body.has-contact-sheet { overflow: hidden; }
   .store-filters { grid-template-columns: 1fr; }
 }
 
-/* Mobile-first 2-column marketplace grid (Lazada/Shopee-style). */
+/* Mobile-first 2-column marketplace grid (Lazada/Shopee-style).
+   The app shell stays capped at max-width: 480px on every viewport (it's a
+   phone-sized column even on desktop), so the grid must not scale its
+   column count off viewport-width media queries -- the container never
+   actually grows past ~480px, and doing so squeezed cards into unreadable
+   slivers at wide viewports. Stay at 2 columns at every width. */
 .store-grid {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: 10px;
-}
-@media (min-width: 700px) {
-  .store-grid { grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 12px; }
-}
-@media (min-width: 1024px) {
-  .store-grid { grid-template-columns: repeat(4, minmax(0, 1fr)); }
-}
-@media (min-width: 1280px) {
-  .store-grid { grid-template-columns: repeat(5, minmax(0, 1fr)); gap: 14px; }
 }
 
 .store-card {
   display: flex;
   flex-direction: column;
   gap: 6px;
-  padding: 10px;
+  padding: 0 0 10px;
   border-radius: var(--radius);
   border: 1px solid var(--line);
   background: #fff;
   min-width: 0;
   cursor: pointer;
+  overflow: hidden;
   transition: transform 0.15s ease, box-shadow 0.15s ease;
 }
 .store-card:active { transform: scale(0.98); }
 .store-card:hover { box-shadow: 0 6px 18px rgba(15, 23, 42, 0.08); }
+/* Image bleeds edge-to-edge; padding applies only to the text/price/CTA region below it. */
+.store-card-badges,
+.store-card-head,
+.store-standard-badge,
+.store-card-price,
+.store-card-actions {
+  padding-left: 10px;
+  padding-right: 10px;
+}
 .store-card-head {
   display: flex;
   flex-direction: column;
@@ -3632,15 +3663,19 @@ body.has-contact-sheet { overflow: hidden; }
   position: absolute;
   top: 8px;
   right: 0;
-  z-index: 2;
-  background: linear-gradient(135deg, var(--accent, #1f7bff), #0f4fb8);
+  z-index: 3;
+  background: linear-gradient(135deg, #1f7bff, #0f4fb8);
   color: #fff;
   font-size: 10.5px;
-  font-weight: 700;
+  font-weight: 800;
+  letter-spacing: 0.2px;
   padding: 4px 10px 4px 12px;
   border-radius: 999px 0 0 999px;
-  box-shadow: 0 2px 6px rgba(15, 79, 184, 0.35);
+  border-top: 1px solid rgba(255, 214, 92, 0.9);
+  border-bottom: 1px solid rgba(255, 214, 92, 0.9);
+  box-shadow: 0 3px 8px rgba(15, 79, 184, 0.45), inset 0 0 0 1px rgba(255, 255, 255, 0.15);
   line-height: 1.4;
+  pointer-events: none;
 }
 
 .store-card-badges {
@@ -3714,7 +3749,7 @@ body.has-contact-sheet { overflow: hidden; }
 }
 
 /* ===================== Store Product Detail ===================== */
-.store-detail-screen { padding-bottom: 96px; }
+.store-detail-screen { padding-bottom: calc(var(--nav-h) + var(--safe-b) + 80px); }
 .store-detail-back {
   display: inline-flex;
   align-items: center;
@@ -3799,11 +3834,13 @@ body.has-contact-sheet { overflow: hidden; }
   position: fixed;
   left: 0;
   right: 0;
-  bottom: 0;
-  z-index: 30;
+  /* Sits above the bottom-nav (height var(--nav-h), z-index 40) so the CTA is
+     never visually hidden behind it. */
+  bottom: calc(var(--nav-h) + var(--safe-b));
+  z-index: 35;
   display: flex;
   gap: 8px;
-  padding: 10px 14px calc(10px + env(safe-area-inset-bottom, 0px));
+  padding: 10px 14px;
   background: #fff;
   border-top: 1px solid var(--line);
   box-shadow: 0 -6px 18px rgba(15, 23, 42, 0.06);

--- a/customer-app/assets/customer-app.js
+++ b/customer-app/assets/customer-app.js
@@ -3,7 +3,7 @@
 
   const App = window.CWFCustomerAppV2;
   const BOOT_TIMEOUT_MS = 3500;
-  const BUILD_ID = "20260623_catalog_marketplace_v2";
+  const BUILD_ID = "20260623_store_marketplace_final";
 
   function withTimeout(promise, timeoutMs) {
     return Promise.race([

--- a/customer-app/index.html
+++ b/customer-app/index.html
@@ -9,10 +9,10 @@
   <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
   <meta name="apple-mobile-web-app-title" content="CWF Service">
   <title>CWF Customer Service</title>
-  <link rel="manifest" href="./manifest.webmanifest?v=20260623_catalog_marketplace_v2">
+  <link rel="manifest" href="./manifest.webmanifest?v=20260623_store_marketplace_final">
   <link rel="icon" type="image/png" sizes="192x192" href="./assets/icons/cwf-customer-192.png">
   <link rel="apple-touch-icon" sizes="180x180" href="./assets/icons/cwf-customer-180.png">
-  <link rel="stylesheet" href="./assets/customer-app.css?v=20260623_catalog_marketplace_v2">
+  <link rel="stylesheet" href="./assets/customer-app.css?v=20260623_store_marketplace_final">
 </head>
 <body class="is-app-booting">
   <div class="app-shell" data-app-shell>
@@ -50,20 +50,20 @@
     </nav>
   </div>
 
-  <script src="./modules/state.js?v=20260623_catalog_marketplace_v2"></script>
-  <script src="./modules/utils.js?v=20260623_catalog_marketplace_v2"></script>
-  <script src="./modules/api.js?v=20260623_catalog_marketplace_v2"></script>
-  <script src="./modules/services.js?v=20260623_catalog_marketplace_v2"></script>
-  <script src="./modules/ui.js?v=20260623_catalog_marketplace_v2"></script>
-  <script src="./modules/store.js?v=20260623_catalog_marketplace_v2"></script>
-  <script src="./modules/auth.js?v=20260623_catalog_marketplace_v2"></script>
-  <script src="./modules/pricing.js?v=20260623_catalog_marketplace_v2"></script>
-  <script src="./modules/availability.js?v=20260623_catalog_marketplace_v2"></script>
-  <script src="./modules/bookingScheduled.js?v=20260623_catalog_marketplace_v2"></script>
-  <script src="./modules/bookingUrgent.js?v=20260623_catalog_marketplace_v2"></script>
-  <script src="./modules/tracking.js?v=20260623_catalog_marketplace_v2"></script>
-  <script src="./modules/profile.js?v=20260623_catalog_marketplace_v2"></script>
-  <script src="./modules/router.js?v=20260623_catalog_marketplace_v2"></script>
-  <script src="./assets/customer-app.js?v=20260623_catalog_marketplace_v2"></script>
+  <script src="./modules/state.js?v=20260623_store_marketplace_final"></script>
+  <script src="./modules/utils.js?v=20260623_store_marketplace_final"></script>
+  <script src="./modules/api.js?v=20260623_store_marketplace_final"></script>
+  <script src="./modules/services.js?v=20260623_store_marketplace_final"></script>
+  <script src="./modules/ui.js?v=20260623_store_marketplace_final"></script>
+  <script src="./modules/store.js?v=20260623_store_marketplace_final"></script>
+  <script src="./modules/auth.js?v=20260623_store_marketplace_final"></script>
+  <script src="./modules/pricing.js?v=20260623_store_marketplace_final"></script>
+  <script src="./modules/availability.js?v=20260623_store_marketplace_final"></script>
+  <script src="./modules/bookingScheduled.js?v=20260623_store_marketplace_final"></script>
+  <script src="./modules/bookingUrgent.js?v=20260623_store_marketplace_final"></script>
+  <script src="./modules/tracking.js?v=20260623_store_marketplace_final"></script>
+  <script src="./modules/profile.js?v=20260623_store_marketplace_final"></script>
+  <script src="./modules/router.js?v=20260623_store_marketplace_final"></script>
+  <script src="./assets/customer-app.js?v=20260623_store_marketplace_final"></script>
 </body>
 </html>

--- a/customer-app/manifest.webmanifest
+++ b/customer-app/manifest.webmanifest
@@ -2,7 +2,7 @@
   "name": "CWF Customer Service",
   "short_name": "CWF Service",
   "description": "แอปลูกค้า Coldwindflow สำหรับเลือกบริการ จองคิว และติดตามงาน",
-  "start_url": "/customer-app/index.html?v=20260623_catalog_marketplace_v2#home",
+  "start_url": "/customer-app/index.html?v=20260623_store_marketplace_final#home",
   "scope": "/customer-app/",
   "id": "/customer-app/",
   "display": "standalone",

--- a/customer-app/modules/store.js
+++ b/customer-app/modules/store.js
@@ -44,11 +44,12 @@
   }
 
   // The legacy catalog table constrains item_category to "service"/"product"
-  // in storage; that raw token must never reach the customer as a badge.
+  // in storage; that generic token carries no useful information for the
+  // customer, so it is hidden entirely rather than shown as a translated tag.
   function categoryLabel(cat) {
     const trimmed = String(cat || "").trim();
-    if (trimmed.toLowerCase() === "service") return "บริการ";
-    if (trimmed.toLowerCase() === "product") return "สินค้า";
+    if (trimmed.toLowerCase() === "service") return "";
+    if (trimmed.toLowerCase() === "product") return "";
     return trimmed;
   }
 

--- a/customer-app/modules/store.js
+++ b/customer-app/modules/store.js
@@ -40,7 +40,16 @@
   }
 
   function promoBadgeText(item) {
-    return item.campaign_name || item.price_label || "โปรโมชัน";
+    return item.campaign_name || item.price_label || "โปร";
+  }
+
+  // The legacy catalog table constrains item_category to "service"/"product"
+  // in storage; that raw token must never reach the customer as a badge.
+  function categoryLabel(cat) {
+    const trimmed = String(cat || "").trim();
+    if (trimmed.toLowerCase() === "service") return "บริการ";
+    if (trimmed.toLowerCase() === "product") return "สินค้า";
+    return trimmed;
   }
 
   function isBookable(item) {
@@ -117,7 +126,7 @@
       return `<span class="store-standard-star${cls}" aria-hidden="true">★</span>`;
     }).join("");
     if (!hasRealReviews) {
-      return `<div class="store-standard-badge" title="มาตรฐานบริการ CWF"><span class="store-standard-stars">${stars}</span><span class="store-standard-label">มาตรฐานบริการ CWF</span></div>`;
+      return `<div class="store-standard-badge" title="มาตรฐาน CWF"><span class="store-standard-stars">${stars}</span><span class="store-standard-label">มาตรฐาน CWF</span></div>`;
     }
     const valueLabel = `<span class="store-standard-value">${formatRatingAverage(value)}</span>`;
     const countLabel = `<span class="store-standard-count">(${count} รีวิว)</span>`;
@@ -145,7 +154,7 @@
   function renderBadges(item) {
     const badges = [];
     if (hasPromo(item)) badges.push(`<span class="store-badge store-badge-promo">${root.utils.escapeHtml(promoBadgeText(item))}</span>`);
-    if (isBookable(item)) badges.push(`<span class="store-badge store-badge-bookable">จองได้ทันที</span>`);
+    if (isBookable(item)) badges.push(`<span class="store-badge store-badge-bookable">จองได้</span>`);
     else badges.push(`<span class="store-badge store-badge-contact">ติดต่อแอดมิน</span>`);
     return badges.length ? `<div class="store-card-badges">${badges.join("")}</div>` : "";
   }
@@ -153,7 +162,7 @@
   function renderCard(item) {
     const id = String(item.item_id || "");
     const name = item.item_name || "-";
-    const category = item.item_category || "";
+    const category = categoryLabel(item.item_category);
     const unit = item.unit_label || "";
     const btu = btuRangeLabel(item);
     const meta = [item.job_category, item.ac_type, btu].filter(Boolean);
@@ -163,12 +172,12 @@
       <article class="store-card" data-store-item="${root.utils.escapeHtml(id)}" tabindex="0" role="button" aria-label="ดูรายละเอียด ${root.utils.escapeHtml(name)}">
         ${renderCardGallery(item, name)}
         ${renderBadges(item)}
-        ${renderStandardBadge(item)}
         <div class="store-card-head">
           ${category ? `<span class="tag">${root.utils.escapeHtml(category)}</span>` : ""}
           <strong>${root.utils.escapeHtml(name)}</strong>
+          ${meta.length ? `<div class="store-card-meta">${meta.map((m) => `<span>${root.utils.escapeHtml(m)}</span>`).join("")}</div>` : ""}
         </div>
-        ${meta.length ? `<div class="store-card-meta">${meta.map((m) => `<span>${root.utils.escapeHtml(m)}</span>`).join("")}</div>` : ""}
+        ${renderStandardBadge(item)}
         <div class="store-card-price">
           <span class="price-text${priceIsAsk(item) ? " is-estimate" : ""}">${root.utils.escapeHtml(priceLabel(item))}</span>
           ${promo ? `<span class="price-strike">${root.utils.escapeHtml(root.utils.formatBaht(item.normal_price))}</span>` : ""}
@@ -176,8 +185,8 @@
         </div>
         <div class="store-card-actions">
           ${bookable
-            ? `<button class="primary-btn" type="button" data-store-book="${root.utils.escapeHtml(id)}">จองบริการนี้</button>`
-            : `<button class="secondary-btn" type="button" data-store-contact="${root.utils.escapeHtml(id)}" data-store-contact-name="${root.utils.escapeHtml(name)}">สอบถามรายการนี้</button>`}
+            ? `<button class="primary-btn" type="button" data-store-book="${root.utils.escapeHtml(id)}">จองคิว</button>`
+            : `<button class="secondary-btn" type="button" data-store-contact="${root.utils.escapeHtml(id)}" data-store-contact-name="${root.utils.escapeHtml(name)}">สอบถามแอดมิน</button>`}
         </div>
       </article>
     `;
@@ -217,8 +226,9 @@
     `;
   }
 
-  const AUTOPLAY_INTERVAL_MS = 4500;
-  const AUTOPLAY_RESUME_DELAY_MS = 4500;
+  const AUTOPLAY_INTERVAL_MS = 3500;
+  const AUTOPLAY_RESUME_DELAY_MS = 5000;
+  const AUTOPLAY_JITTER_MS = 1200;
 
   function prefersReducedMotion() {
     try {
@@ -241,16 +251,23 @@
     let resumeTimer = null;
 
     function stop() {
-      if (timer) { clearInterval(timer); timer = null; }
+      if (timer) { clearTimeout(timer); timer = null; }
     }
+    // Uses a setTimeout chain (not setInterval) so a random jitter can be
+    // applied to the very first tick only; this keeps multiple visible
+    // cards from advancing in visual lock-step while still settling into
+    // the configured interval after the first transition.
     function start() {
       if (timer || paused || !visible) return;
-      timer = setInterval(() => {
+      function tick() {
         const width = Math.max(1, slides.clientWidth);
         const current = Math.round(slides.scrollLeft / width);
         const next = current >= count - 1 ? 0 : current + 1;
         slides.scrollTo({ left: next * width, behavior: "smooth" });
-      }, AUTOPLAY_INTERVAL_MS);
+        timer = setTimeout(tick, AUTOPLAY_INTERVAL_MS);
+      }
+      const jitter = Math.floor(Math.random() * AUTOPLAY_JITTER_MS);
+      timer = setTimeout(tick, AUTOPLAY_INTERVAL_MS + jitter);
     }
     function pauseForInteraction() {
       paused = true;
@@ -451,7 +468,7 @@
 
   function renderDetailContent(item) {
     const name = item.item_name || "-";
-    const category = item.item_category || "";
+    const category = categoryLabel(item.item_category);
     const unit = item.unit_label || "";
     const promo = hasPromo(item);
     const bookable = isBookable(item);
@@ -460,11 +477,11 @@
       <button class="store-detail-back" type="button" data-store-detail-back>${root.utils.icon("pin", 16)}กลับไปหน้าร้านค้า</button>
       ${renderDetailGallery(item, name)}
       ${renderBadges(item)}
-      ${renderStandardBadge(item)}
       <div class="store-detail-head">
         ${category ? `<span class="tag">${root.utils.escapeHtml(category)}</span>` : ""}
         <h2>${root.utils.escapeHtml(name)}</h2>
       </div>
+      ${renderStandardBadge(item)}
       <div class="store-detail-price">
         <span class="price-text${priceIsAsk(item) ? " is-estimate" : ""}">${root.utils.escapeHtml(priceLabel(item))}</span>
         ${promo ? `<span class="price-strike">${root.utils.escapeHtml(root.utils.formatBaht(item.normal_price))}</span>` : ""}
@@ -493,8 +510,8 @@
       ` : ""}
       <div class="store-detail-cta-bar">
         ${bookable
-          ? `<button class="primary-btn" type="button" data-store-detail-book>จองบริการนี้</button>`
-          : `<button class="primary-btn" type="button" data-store-detail-contact>สอบถามรายการนี้</button>`}
+          ? `<button class="primary-btn" type="button" data-store-detail-book>จองคิว</button>`
+          : `<button class="primary-btn" type="button" data-store-detail-contact>สอบถามแอดมิน</button>`}
       </div>
     `;
   }
@@ -606,10 +623,9 @@
       filterState = { search: "", category: "" };
       container.innerHTML = `
         <section class="screen store-screen">
-          <div class="hero store-hero">
-            <div class="hero-badge">ร้านค้า CWF</div>
+          <div class="store-compact-header">
+            <span class="store-compact-badge">ร้านค้า CWF</span>
             <h2>เลือกบริการและอุปกรณ์</h2>
-            <p>รายการที่แสดงมาจากระบบจริงของ CWF ราคาบนการ์ดเป็นราคาฐานหรือราคาเริ่มต้น สำหรับบริการที่รองรับสามารถไปยังหน้าจองได้ ส่วนรายการอื่นกรุณาติดต่อแอดมินเพื่อยืนยันรายละเอียดและราคา</p>
           </div>
           <div data-store-body>${renderBody()}</div>
           <div data-contact-sheet-mount></div>

--- a/customer-app/sw.js
+++ b/customer-app/sw.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const BUILD_ID = "20260623_catalog_marketplace_v2";
+const BUILD_ID = "20260623_store_marketplace_final";
 const CACHE_NAME = `cwf-customer-app-v2-${BUILD_ID}`;
 const APP_SHELL = [
   `./index.html?v=${BUILD_ID}`,

--- a/test/customerAppRecovery.test.js
+++ b/test/customerAppRecovery.test.js
@@ -228,7 +228,7 @@ test("Customer App build id is consistent across shell and service worker", () =
   const sw = read("customer-app/sw.js");
   const app = read("customer-app/assets/customer-app.js");
   const manifest = read("customer-app/manifest.webmanifest");
-  const build = "20260623_catalog_marketplace_v2";
+  const build = "20260623_store_marketplace_final";
 
   assert.match(index, new RegExp(`customer-app\\.css\\?v=${build}`));
   assert.match(index, new RegExp(`bookingUrgent\\.js\\?v=${build}`));
@@ -244,10 +244,18 @@ test("Customer App build id is consistent across shell and service worker", () =
 test("store module is loaded in index.html and precached in the service worker app shell", () => {
   const index = read("customer-app/index.html");
   const sw = read("customer-app/sw.js");
-  const build = "20260623_catalog_marketplace_v2";
+  const build = "20260623_store_marketplace_final";
 
   assert.match(index, new RegExp(`modules/store\\.js\\?v=${build}`));
   assert.match(sw, /`\.\/modules\/store\.js\?v=\$\{BUILD_ID\}`/);
+});
+
+test("store autoplay uses a ~3.5s interval, a ~5s resume delay after manual interaction, and a randomized first-tick jitter so cards do not advance in lock-step", () => {
+  const storeSrc = read("customer-app/modules/store.js");
+  assert.match(storeSrc, /const AUTOPLAY_INTERVAL_MS = 3500;/);
+  assert.match(storeSrc, /const AUTOPLAY_RESUME_DELAY_MS = 5000;/);
+  assert.match(storeSrc, /const AUTOPLAY_JITTER_MS = \d+;/);
+  assert.match(storeSrc, /Math\.random\(\) \* AUTOPLAY_JITTER_MS/);
 });
 
 test("bottom navigation has exactly 5 items in the required order with a centered primary booking action", () => {
@@ -739,6 +747,84 @@ test("store shows a real booking button only when the item's booking_mode is exp
   assert.match(body.innerHTML, /data-store-contact="2"/);
 });
 
+test("store card and product detail use the exact required CTA wording for bookable vs contact_admin items", async () => {
+  const context = makeContext();
+  const root = loadCustomerFrontend(context);
+  const items = [
+    { item_id: 1, item_name: "ล้างแอร์ผนัง", item_category: "ล้างแอร์", base_price: 700, unit_label: "เครื่อง", booking_mode: "bookable", booking_ac_type: "ผนัง", booking_btu: 12000 },
+    { item_id: 2, item_name: "ติดตั้งแอร์ใหม่", item_category: "ติดตั้ง", base_price: 0, unit_label: "งาน", booking_mode: "contact_admin" },
+  ];
+  root.api.loadCatalogItems = async () => items;
+  root.api.loadCatalogItem = async (id) => items.find((it) => String(it.item_id) === String(id));
+
+  const container = new FakeMount();
+  root.store.render(container);
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  const body = container.querySelector("[data-store-body]");
+  assert.match(body.innerHTML, /data-store-book="1"[^>]*>จองคิว</);
+  assert.match(body.innerHTML, /data-store-contact="2"[^>]*>สอบถามแอดมิน</);
+  assert.doesNotMatch(body.innerHTML, /จองบริการนี้/);
+  assert.doesNotMatch(body.innerHTML, /สอบถามรายการนี้/);
+
+  root.state.setRoute("storeItem-1");
+  root.store.renderDetail(container);
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  let detailBody = container.querySelector("[data-store-detail-body]");
+  assert.match(detailBody.innerHTML, /data-store-detail-book[^>]*>จองคิว</);
+
+  root.state.setRoute("storeItem-2");
+  root.store.renderDetail(container);
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  detailBody = container.querySelector("[data-store-detail-body]");
+  assert.match(detailBody.innerHTML, /data-store-detail-contact[^>]*>สอบถามแอดมิน</);
+  assert.doesNotMatch(detailBody.innerHTML, /จองคิว/);
+});
+
+test("store card and product detail render product name before the rating badge, and price right after the rating", async () => {
+  const context = makeContext();
+  const root = loadCustomerFrontend(context);
+  const item = { item_id: 1, item_name: "ล้างแอร์ผนัง", item_category: "ล้างแอร์", base_price: 700, unit_label: "เครื่อง" };
+  root.api.loadCatalogItems = async () => [item];
+  root.api.loadCatalogItem = async () => item;
+
+  const container = new FakeMount();
+  root.store.render(container);
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  const body = container.querySelector("[data-store-body]");
+  const nameIndex = body.innerHTML.indexOf("ล้างแอร์ผนัง");
+  const ratingIndex = body.innerHTML.indexOf("store-standard-badge");
+  const priceIndex = body.innerHTML.indexOf("store-card-price");
+  assert.ok(nameIndex > -1 && ratingIndex > -1 && priceIndex > -1);
+  assert.ok(nameIndex < ratingIndex);
+  assert.ok(ratingIndex < priceIndex);
+
+  root.state.setRoute("storeItem-1");
+  root.store.renderDetail(container);
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  const detailBody = container.querySelector("[data-store-detail-body]");
+  const detailNameIndex = detailBody.innerHTML.indexOf("ล้างแอร์ผนัง");
+  const detailRatingIndex = detailBody.innerHTML.indexOf("store-standard-badge");
+  const detailPriceIndex = detailBody.innerHTML.indexOf("store-detail-price");
+  assert.ok(detailNameIndex > -1 && detailRatingIndex > -1 && detailPriceIndex > -1);
+  assert.ok(detailNameIndex < detailRatingIndex);
+  assert.ok(detailRatingIndex < detailPriceIndex);
+});
+
+test("store hides/translates the generic literal 'service' item_category instead of showing it as a raw English badge", async () => {
+  const context = makeContext();
+  const root = loadCustomerFrontend(context);
+  root.api.loadCatalogItems = async () => [
+    { item_id: 1, item_name: "รายการทั่วไป", item_category: "service", base_price: 700, unit_label: "เครื่อง" },
+  ];
+
+  const container = new FakeMount();
+  root.store.render(container);
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  const body = container.querySelector("[data-store-body]");
+  assert.doesNotMatch(body.innerHTML, /class="tag">service</);
+  assert.match(body.innerHTML, /class="tag">บริการ</);
+});
+
 test("store BTU label formats min/max/range/neither cases correctly", async () => {
   const context = makeContext();
   const root = loadCustomerFrontend(context);
@@ -848,13 +934,17 @@ test("store falls back to base_price when there is no active price rule", async 
   assert.doesNotMatch(body.innerHTML, /สอบถามราคา/);
 });
 
-test("store grid uses a 2-column-first mobile layout that expands at larger breakpoints", () => {
+test("store grid stays 2-column at every viewport width since the app shell never widens past its mobile column", () => {
   const css = read("customer-app/assets/customer-app.css");
   const gridBlock = css.slice(css.indexOf(".store-grid {"), css.indexOf(".store-grid {") + 400);
   assert.match(gridBlock, /grid-template-columns:\s*repeat\(2,\s*minmax\(0,\s*1fr\)\)/);
-  assert.match(css, /@media \(min-width: 700px\)[\s\S]{0,80}repeat\(3,/);
-  assert.match(css, /@media \(min-width: 1024px\)[\s\S]{0,80}repeat\(4,/);
-  assert.match(css, /@media \(min-width: 1280px\)[\s\S]{0,80}repeat\(5,/);
+  // .app-shell caps at max-width: 480px on every viewport, so escalating
+  // .store-grid to 3/4/5 columns via viewport-width media queries squeezed
+  // cards into unreadable slivers at desktop widths -- there must be no
+  // such escalation.
+  assert.doesNotMatch(css, /\.store-grid\s*\{\s*grid-template-columns:\s*repeat\(3,/);
+  assert.doesNotMatch(css, /\.store-grid\s*\{\s*grid-template-columns:\s*repeat\(4,/);
+  assert.doesNotMatch(css, /\.store-grid\s*\{\s*grid-template-columns:\s*repeat\(5,/);
 });
 
 test("store card shows a multi-image slider with dot indicators when an item has several images", async () => {
@@ -898,7 +988,7 @@ test("store card shows the CWF featured ribbon only for featured items, and a fi
   assert.match(body.innerHTML, /CWF แนะนำ/);
   assert.doesNotMatch(body.innerHTML, /store-badge-featured/);
   assert.equal((body.innerHTML.match(/store-standard-badge/g) || []).length, 2);
-  assert.equal((body.innerHTML.match(/store-standard-label">มาตรฐานบริการ CWF/g) || []).length, 2);
+  assert.equal((body.innerHTML.match(/store-standard-label">มาตรฐาน CWF/g) || []).length, 2);
   assert.equal((body.innerHTML.match(/store-standard-star is-filled/g) || []).length, 10);
 });
 
@@ -957,9 +1047,9 @@ test("standard-service badge ignores legacy rating_value and fails safe to the n
   await new Promise((resolve) => setTimeout(resolve, 0));
 
   const body = container.querySelector("[data-store-body]");
-  // every item must fail safe to the plain 5-star "มาตรฐานบริการ CWF" badge with zero visible review counts
+  // every item must fail safe to the plain 5-star "มาตรฐาน CWF" badge with zero visible review counts
   assert.equal((body.innerHTML.match(/store-standard-badge/g) || []).length, 5);
-  assert.equal((body.innerHTML.match(/store-standard-label">มาตรฐานบริการ CWF/g) || []).length, 5);
+  assert.equal((body.innerHTML.match(/store-standard-label">มาตรฐาน CWF/g) || []).length, 5);
   assert.equal((body.innerHTML.match(/store-standard-star is-filled/g) || []).length, 25);
   assert.doesNotMatch(body.innerHTML, /store-standard-count/);
   assert.doesNotMatch(body.innerHTML, /store-standard-star is-half/);

--- a/test/customerAppRecovery.test.js
+++ b/test/customerAppRecovery.test.js
@@ -810,11 +810,13 @@ test("store card and product detail render product name before the rating badge,
   assert.ok(detailRatingIndex < detailPriceIndex);
 });
 
-test("store hides/translates the generic literal 'service' item_category instead of showing it as a raw English badge", async () => {
+test("store hides the generic literal 'service'/'product' item_category entirely instead of showing it as a category tag", async () => {
   const context = makeContext();
   const root = loadCustomerFrontend(context);
   root.api.loadCatalogItems = async () => [
     { item_id: 1, item_name: "รายการทั่วไป", item_category: "service", base_price: 700, unit_label: "เครื่อง" },
+    { item_id: 2, item_name: "สินค้าทั่วไป", item_category: "product", base_price: 700, unit_label: "ชิ้น" },
+    { item_id: 3, item_name: "ล้างแอร์ผนัง", item_category: "ล้างแอร์", base_price: 700, unit_label: "เครื่อง" },
   ];
 
   const container = new FakeMount();
@@ -822,7 +824,10 @@ test("store hides/translates the generic literal 'service' item_category instead
   await new Promise((resolve) => setTimeout(resolve, 0));
   const body = container.querySelector("[data-store-body]");
   assert.doesNotMatch(body.innerHTML, /class="tag">service</);
-  assert.match(body.innerHTML, /class="tag">บริการ</);
+  assert.doesNotMatch(body.innerHTML, /class="tag">product</);
+  assert.doesNotMatch(body.innerHTML, /class="tag">บริการ</);
+  assert.doesNotMatch(body.innerHTML, /class="tag">สินค้า</);
+  assert.match(body.innerHTML, /class="tag">ล้างแอร์</);
 });
 
 test("store BTU label formats min/max/range/neither cases correctly", async () => {

--- a/test/customerSameDayTiming.test.js
+++ b/test/customerSameDayTiming.test.js
@@ -160,7 +160,7 @@ test("customer app disables availability HTTP cache and refreshes same-day slots
 });
 
 test("customer app build and service worker cache IDs changed", () => {
-  const id = "20260623_catalog_marketplace_v2";
+  const id = "20260623_store_marketplace_final";
   for (const file of [
     "customer-app/index.html",
     "customer-app/sw.js",


### PR DESCRIPTION
## Summary

Branch: `feature/cwf-store-marketplace-final-completion`
Head SHA: `07e61801f4712a8622a728accf83b030a25b69dd`

Polishes the Customer App Store/Catalog marketplace UI within the existing scope (no DB/migration changes were needed). Scope strictly limited to Customer Store, Admin Catalog read-only audit, and tests — Payment, Auth core, Technician app, Tracking, Production data, and the DB schema were not touched.

### Final accepted changes
- Bookable items show `จองคิว`; contact-admin items show `สอบถามแอดมิน` on cards and Product Detail.
- Generic DB categories `service` / `product` are hidden entirely from the customer UI; real categories such as `ล้างแอร์` still render.
- Compact Store header and tighter card layout.
- `★★★★★ มาตรฐาน CWF` fallback with no fabricated score/count.
- Product name → rating → price order.
- Autoplay uses ~3.5s cadence, ~5s resume delay after manual interaction, and randomized first tick to avoid synchronized cards.
- Product Detail CTA bar is positioned above bottom navigation.
- Store grid remains readable inside the app shell at all tested widths.
- Customer App build/cache version bumped consistently.

### Tests
- `npm test` → 471 tests, 460 pass, 0 fail, 11 skipped.
- `node --check` clean.
- `git diff --check` clean.

### Browser QA
Playwright + Chromium verified at 320 / 360 / 390 / 430 / 1280px with mocked catalog data. No horizontal overflow observed. Autoplay advancement and Product Detail CTA visibility were visually checked.

### Confirmations
- No DB schema or migration changes.
- No production data touched.
- Payment, Auth core, Technician app/job flow, Tracking, and Review-table systems untouched.

### Remaining risk
Final smoke test against the live production API is still required after deploy.