### PR TITLE
CWF Store: HOT/SALE/GOLD recommended badges + verified customer reviews

### DIFF
--- a/admin-store-catalog.css
+++ b/admin-store-catalog.css
@@ -61,7 +61,18 @@
 .asc-badge-bookable{ background:#e0f2fe; color:#0369a1; }
 .asc-badge-contact{ background:#f1f5f9; color:#475569; }
 .asc-badge-featured{ background:#fde68a; color:#92400e; }
+.asc-badge-hot{ background:linear-gradient(135deg, #ff5f3d, #e0211f); color:#fff; }
 .asc-badge-primary{ background:#dcfce7; color:#15803d; position:absolute; top:4px; left:4px; }
+.asc-badge-pending{ background:#fef3c7; color:#92400e; }
+.asc-badge-approved{ background:#dcfce7; color:#15803d; }
+.asc-badge-rejected{ background:#fee2e2; color:#b91c1c; }
+.asc-badge-hidden{ background:#f1f5f9; color:#475569; }
+
+.asc-review-card{ align-items:flex-start; flex-direction:column; }
+.asc-review-card .asc-item-main{ width:100%; }
+.asc-review-stars{ font-size:14px; color:#f5b700; margin-top:4px; }
+.asc-review-comment{ font-size:13px; color:#1f2937; margin-top:4px; white-space:pre-wrap; overflow-wrap:anywhere; }
+.asc-review-actions{ display:flex; gap:6px; flex-wrap:wrap; margin-top:8px; width:100%; }
 
 .asc-gallery-grid{
   display:grid;

--- a/admin-store-catalog.html
+++ b/admin-store-catalog.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
   <title>Admin • รายการบริการในร้านค้า</title>
   <link rel="stylesheet" href="/style.css"/>
-  <link rel="stylesheet" href="/admin-store-catalog.css?v=20260623_catalog_marketplace_v2"/>
+  <link rel="stylesheet" href="/admin-store-catalog.css?v=20260624_catalog_hot_sale_reviews"/>
 </head>
 <body>
   <div class="topbar">
@@ -47,9 +47,28 @@
       <div class="muted2 mini" style="margin-top:4px">แสดงเฉพาะรายการที่ "เปิดใช้งาน" และ "แสดงให้ลูกค้าเห็น" พร้อมกัน ตามข้อมูลจริงที่โหลดมาด้านบน</div>
       <div id="catalog_preview" style="margin-top:10px"></div>
     </div>
+
+    <div class="card asc-reviews-card" style="margin-top:12px">
+      <b>⭐ ตรวจสอบรีวิวลูกค้า (Moderation)</b>
+      <div class="muted2 mini" style="margin-top:4px">อนุมัติ/ปฏิเสธ/ซ่อนรีวิวจริงจากลูกค้า มีผลต่อค่าเฉลี่ยและจำนวนรีวิวที่แสดงในร้านค้าทันที</div>
+      <div class="asc-toolbar-row" style="margin-top:10px">
+        <select id="review_filter_status" class="asc-filter">
+          <option value="">ทุกสถานะ</option>
+          <option value="pending">รออนุมัติ</option>
+          <option value="approved">อนุมัติแล้ว</option>
+          <option value="rejected">ปฏิเสธแล้ว</option>
+          <option value="hidden">ซ่อนอยู่</option>
+        </select>
+        <select id="review_filter_item" class="asc-filter">
+          <option value="">ทุกรายการ</option>
+        </select>
+        <button id="btnReloadReviews" class="secondary btn-small" type="button">รีเฟรช</button>
+      </div>
+      <div id="review_list" class="asc-card-list" style="margin-top:10px">กำลังโหลดรีวิว...</div>
+    </div>
   </div>
 
   <script src="/admin-v2-common.js?v=20260622_admin_menu_catalog_entry"></script>
-  <script src="/admin-store-catalog.js?v=20260623_catalog_marketplace_v2"></script>
+  <script src="/admin-store-catalog.js?v=20260624_catalog_hot_sale_reviews"></script>
 </body>
 </html>

--- a/admin-store-catalog.js
+++ b/admin-store-catalog.js
@@ -186,11 +186,19 @@ function ensureCatalogModal() {
               </select>
             </div>
           </div>
-          <div class="asc-field"><label>รายการแนะนำ (Featured) *</label>
-            <select id="cm_is_featured">
-              <option value="0">ไม่แนะนำ</option>
-              <option value="1">แนะนำ</option>
-            </select>
+          <div class="asc-grid2">
+            <div class="asc-field"><label>รายการแนะนำ (Featured) *</label>
+              <select id="cm_is_featured">
+                <option value="0">ไม่แนะนำ</option>
+                <option value="1">แนะนำ</option>
+              </select>
+            </div>
+            <div class="asc-field"><label>ป้าย HOT *</label>
+              <select id="cm_is_hot">
+                <option value="0">ไม่ใช่ HOT</option>
+                <option value="1">เป็น HOT</option>
+              </select>
+            </div>
           </div>
         </div>
 
@@ -316,6 +324,7 @@ function resetCatalogModalFields() {
   el("cm_booking_btu").value = "";
   el("cm_booking_wash_variant").value = "";
   el("cm_is_featured").value = "0";
+  el("cm_is_hot").value = "0";
   el("cm_short_description").value = "";
   el("cm_long_description").value = "";
   el("cm_highlights").value = "";
@@ -382,6 +391,7 @@ function openCatalogModalForEdit(itemId) {
   el("cm_booking_btu").value = item.booking_btu || "";
   el("cm_booking_wash_variant").value = item.booking_wash_variant || "";
   el("cm_is_featured").value = item.is_featured ? "1" : "0";
+  el("cm_is_hot").value = item.is_hot ? "1" : "0";
   el("cm_short_description").value = item.short_description || "";
   el("cm_long_description").value = item.long_description || "";
   el("cm_highlights").value = Array.isArray(item.highlights) ? item.highlights.join("\n") : "";
@@ -421,6 +431,7 @@ function catalogModalPayload() {
     booking_btu: trimmedOrEmpty("cm_booking_btu"),
     booking_wash_variant: trimmedOrEmpty("cm_booking_wash_variant"),
     is_featured: el("cm_is_featured").value === "1",
+    is_hot: el("cm_is_hot").value === "1",
     short_description: trimmedOrEmpty("cm_short_description"),
     long_description: trimmedOrEmpty("cm_long_description"),
     highlights: (el("cm_highlights").value || "").split("\n").map((line) => line.trim()).filter(Boolean),
@@ -970,6 +981,7 @@ function catalogItemCard(item) {
         ${hasPromo ? `<span class="asc-badge asc-badge-promo">${escapeHtml(item.campaign_name || "โปรโมชัน")}</span>` : ""}
         ${item.booking_mode === "bookable" ? `<span class="asc-badge asc-badge-bookable">จองออนไลน์ได้</span>` : `<span class="asc-badge asc-badge-contact">ติดต่อแอดมิน</span>`}
         ${item.is_featured ? `<span class="asc-badge asc-badge-featured">แนะนำ</span>` : ""}
+        ${item.is_hot ? `<span class="asc-badge asc-badge-hot">HOT</span>` : ""}
       </div>
     </div>
     <div class="asc-item-actions">
@@ -1027,6 +1039,123 @@ function bindCatalogListActions() {
   });
 }
 
+/* ---------- Review moderation ---------- */
+
+let reviewItems = [];
+let reviewActionPending = null;
+
+function reviewStatusLabel(status) {
+  if (status === "approved") return "อนุมัติแล้ว";
+  if (status === "rejected") return "ปฏิเสธแล้ว";
+  if (status === "hidden") return "ซ่อนอยู่";
+  return "รออนุมัติ";
+}
+
+function fmtDateTime(value) {
+  if (!value) return "-";
+  const d = new Date(value);
+  if (Number.isNaN(d.getTime())) return String(value);
+  return d.toLocaleString("th-TH", { year: "numeric", month: "2-digit", day: "2-digit", hour: "2-digit", minute: "2-digit" });
+}
+
+function reviewStarsHtml(rating) {
+  const n = Math.max(0, Math.min(5, Number(rating) || 0));
+  return Array.from({ length: 5 }, (_, i) => (i < n ? "★" : "☆")).join("");
+}
+
+function reviewActionButtons(review) {
+  const buttons = [];
+  if (review.moderation_status !== "approved") buttons.push(`<button class="secondary btn-small" type="button" data-ract="approved" data-review-id="${review.review_id}">อนุมัติ</button>`);
+  if (review.moderation_status !== "rejected") buttons.push(`<button class="secondary btn-small" type="button" data-ract="rejected" data-review-id="${review.review_id}">ปฏิเสธ</button>`);
+  if (review.moderation_status !== "hidden") buttons.push(`<button class="secondary btn-small" type="button" data-ract="hidden" data-review-id="${review.review_id}">ซ่อน</button>`);
+  if (review.moderation_status === "hidden" || review.moderation_status === "rejected") {
+    buttons.push(`<button class="secondary btn-small" type="button" data-ract="pending" data-review-id="${review.review_id}">คืนเป็นรออนุมัติ</button>`);
+  }
+  return buttons.join("");
+}
+
+function reviewCardHtml(review) {
+  return `
+  <div class="asc-item-card asc-review-card" data-review-id="${review.review_id}">
+    <div class="asc-item-main">
+      <div class="asc-item-title">${escapeHtml(review.item_name || "-")} <span class="asc-badge asc-badge-${review.moderation_status}">${reviewStatusLabel(review.moderation_status)}</span></div>
+      <div class="asc-item-meta">${escapeHtml(review.customer_identity || "ลูกค้า")} • งาน #${escapeHtml(String(review.completed_job_id || "-"))} • ${fmtDateTime(review.created_at)}</div>
+      <div class="asc-review-stars">${reviewStarsHtml(review.rating)}</div>
+      ${review.comment ? `<div class="asc-review-comment">${escapeHtml(review.comment)}</div>` : `<div class="muted2 mini">ไม่มีความเห็นเพิ่มเติม</div>`}
+      ${review.moderated_by ? `<div class="muted2 mini">ตรวจสอบล่าสุดโดย ${escapeHtml(review.moderated_by)} เมื่อ ${fmtDateTime(review.moderated_at)}</div>` : ""}
+    </div>
+    <div class="asc-item-actions asc-review-actions">${reviewActionButtons(review)}</div>
+  </div>`;
+}
+
+function renderReviewItemFilterOptions() {
+  const select = el("review_filter_item");
+  const current = select.value;
+  const seen = new Map();
+  reviewItems.forEach((r) => { if (!seen.has(r.item_id)) seen.set(r.item_id, r.item_name); });
+  select.innerHTML = `<option value="">ทุกรายการ</option>${Array.from(seen.entries()).map(([id, name]) => `<option value="${id}">${escapeHtml(name)}</option>`).join("")}`;
+  select.value = current;
+}
+
+function renderReviewList() {
+  const box = el("review_list");
+  const statusFilter = el("review_filter_status").value;
+  const itemFilter = el("review_filter_item").value;
+  const filtered = reviewItems.filter((r) => {
+    if (statusFilter && r.moderation_status !== statusFilter) return false;
+    if (itemFilter && String(r.item_id) !== String(itemFilter)) return false;
+    return true;
+  });
+  if (!filtered.length) {
+    box.innerHTML = `<div class="asc-empty">ไม่พบรีวิวที่ตรงกับตัวกรอง</div>`;
+    return;
+  }
+  box.innerHTML = filtered.map(reviewCardHtml).join("");
+}
+
+async function loadReviews() {
+  const box = el("review_list");
+  box.innerHTML = `<div class="asc-loading">กำลังโหลดรีวิว...</div>`;
+  try {
+    reviewItems = await apiFetch("/admin/catalog/reviews");
+    renderReviewItemFilterOptions();
+    renderReviewList();
+  } catch (e) {
+    box.innerHTML = `<div class="asc-error">โหลดรีวิวไม่สำเร็จ: ${escapeHtml(e.message || "")}</div>`;
+  }
+}
+
+async function setReviewModerationStatus(reviewId, nextStatus) {
+  if (reviewActionPending) return;
+  const review = reviewItems.find((r) => Number(r.review_id) === Number(reviewId));
+  if (!review) return;
+  const confirmLabels = { approved: "อนุมัติ", rejected: "ปฏิเสธ", hidden: "ซ่อน", pending: "คืนเป็นรออนุมัติ" };
+  const confirmed = confirm(`ต้องการ${confirmLabels[nextStatus] || nextStatus}รีวิวนี้หรือไม่?`);
+  if (!confirmed) return;
+  reviewActionPending = reviewId;
+  try {
+    const updated = await apiFetch(`/admin/catalog/reviews/${reviewId}`, {
+      method: "PATCH",
+      body: JSON.stringify({ moderation_status: nextStatus }),
+    });
+    Object.assign(review, updated);
+    renderReviewList();
+    showToast("อัปเดตสถานะรีวิวแล้ว", "success");
+  } catch (e) {
+    showToast(e.message || "อัปเดตสถานะรีวิวไม่สำเร็จ", "error");
+  } finally {
+    reviewActionPending = null;
+  }
+}
+
+function bindReviewListActions() {
+  el("review_list").addEventListener("click", (event) => {
+    const button = event.target.closest("[data-ract]");
+    if (!button) return;
+    setReviewModerationStatus(Number(button.getAttribute("data-review-id")), button.getAttribute("data-ract"));
+  });
+}
+
 document.addEventListener("DOMContentLoaded", () => {
   bindCatalogListActions();
   el("btnNewItem").addEventListener("click", openCatalogModalForNew);
@@ -1035,4 +1164,10 @@ document.addEventListener("DOMContentLoaded", () => {
   el("catalog_filter_active").addEventListener("change", renderCatalogList);
   el("catalog_filter_visible").addEventListener("change", renderCatalogList);
   loadCatalogItems();
+
+  bindReviewListActions();
+  el("btnReloadReviews").addEventListener("click", loadReviews);
+  el("review_filter_status").addEventListener("change", renderReviewList);
+  el("review_filter_item").addEventListener("change", renderReviewList);
+  loadReviews();
 });

--- a/customer-app/assets/customer-app.css
+++ b/customer-app/assets/customer-app.css
@@ -3569,7 +3569,7 @@ body.has-contact-sheet { overflow: hidden; }
 /* Image bleeds edge-to-edge; padding applies only to the text/price/CTA region below it. */
 .store-card-badges,
 .store-card-head,
-.store-standard-badge,
+.store-rating-badge,
 .store-card-price,
 .store-card-actions {
   padding-left: 10px;
@@ -3663,19 +3663,79 @@ body.has-contact-sheet { overflow: hidden; }
   position: absolute;
   top: 8px;
   right: 0;
-  z-index: 3;
-  background: linear-gradient(135deg, #1f7bff, #0f4fb8);
-  color: #fff;
+  z-index: 4;
+  background: linear-gradient(135deg, #ffe066, #f5b700 55%, #e0a300);
+  background-size: 200% 100%;
+  color: #4a3300;
   font-size: 10.5px;
   font-weight: 800;
   letter-spacing: 0.2px;
   padding: 4px 10px 4px 12px;
   border-radius: 999px 0 0 999px;
-  border-top: 1px solid rgba(255, 214, 92, 0.9);
-  border-bottom: 1px solid rgba(255, 214, 92, 0.9);
-  box-shadow: 0 3px 8px rgba(15, 79, 184, 0.45), inset 0 0 0 1px rgba(255, 255, 255, 0.15);
+  border-top: 1px solid rgba(255, 255, 255, 0.7);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.7);
+  box-shadow: 0 3px 8px rgba(224, 163, 0, 0.5), inset 0 0 0 1px rgba(255, 255, 255, 0.25);
   line-height: 1.4;
   pointer-events: none;
+  animation: store-gold-shimmer 2.4s linear infinite;
+}
+@media (prefers-reduced-motion: reduce) {
+  .store-featured-ribbon { animation: none; }
+}
+@keyframes store-gold-shimmer {
+  0% { background-position: 0% 0; }
+  100% { background-position: 200% 0; }
+}
+
+/* HOT badge: top-left, eye-catching flame/pulse, never blocks dots/ribbon/sale badge. */
+.store-hot-badge {
+  position: absolute;
+  top: 8px;
+  left: 8px;
+  z-index: 4;
+  background: linear-gradient(135deg, #ff5f3d, #e0211f);
+  color: #fff;
+  font-size: 10.5px;
+  font-weight: 800;
+  letter-spacing: 0.4px;
+  padding: 4px 9px;
+  border-radius: 999px;
+  box-shadow: 0 3px 8px rgba(224, 33, 31, 0.5);
+  pointer-events: none;
+  animation: store-hot-pulse 1.4s ease-in-out infinite;
+}
+@media (prefers-reduced-motion: reduce) {
+  .store-hot-badge { animation: none; }
+}
+@keyframes store-hot-pulse {
+  0%, 100% { transform: scale(1); box-shadow: 0 3px 8px rgba(224, 33, 31, 0.5); }
+  50% { transform: scale(1.08); box-shadow: 0 3px 12px rgba(224, 33, 31, 0.75); }
+}
+
+/* SALE badge: derived only from an active, non-expired, genuinely-discounted promo. */
+.store-sale-badge {
+  position: absolute;
+  bottom: 24px;
+  left: 8px;
+  z-index: 4;
+  background: linear-gradient(120deg, #ff2d78, #a21caf);
+  background-size: 220% 100%;
+  color: #fff;
+  font-size: 10px;
+  font-weight: 800;
+  letter-spacing: 0.3px;
+  padding: 3px 8px;
+  border-radius: 999px;
+  box-shadow: 0 3px 8px rgba(162, 28, 175, 0.45);
+  pointer-events: none;
+  animation: store-sale-sweep 2.2s linear infinite;
+}
+@media (prefers-reduced-motion: reduce) {
+  .store-sale-badge { animation: none; }
+}
+@keyframes store-sale-sweep {
+  0% { background-position: 0% 0; }
+  100% { background-position: 220% 0; }
 }
 
 .store-card-badges {
@@ -3695,7 +3755,7 @@ body.has-contact-sheet { overflow: hidden; }
 .store-badge-bookable { background: #dcfce7; color: #166534; }
 .store-badge-contact { background: #e0f2fe; color: #075985; }
 
-.store-standard-badge {
+.store-rating-badge {
   display: inline-flex;
   align-items: center;
   gap: 4px;
@@ -3703,12 +3763,17 @@ body.has-contact-sheet { overflow: hidden; }
   font-weight: 600;
   color: #92660a;
   margin-top: 2px;
+  background: none;
+  border: none;
+  padding: 2px 0;
+  cursor: pointer;
+  text-align: left;
 }
-.store-standard-stars { display: inline-flex; gap: 1px; line-height: 1; }
-.store-standard-star { position: relative; color: #e5e7eb; font-size: 11px; }
-.store-standard-star.is-filled { color: #f5b700; }
-.store-standard-star.is-half { color: #e5e7eb; }
-.store-standard-star.is-half::before {
+.store-rating-stars { display: inline-flex; gap: 1px; line-height: 1; }
+.store-rating-star { position: relative; color: #e5e7eb; font-size: 11px; }
+.store-rating-star.is-filled { color: #f5b700; }
+.store-rating-star.is-half { color: #e5e7eb; }
+.store-rating-star.is-half::before {
   content: "★";
   position: absolute;
   left: 0;
@@ -3717,9 +3782,9 @@ body.has-contact-sheet { overflow: hidden; }
   overflow: hidden;
   color: #f5b700;
 }
-.store-standard-label { color: #92660a; }
-.store-standard-value { color: #92660a; font-weight: 700; }
-.store-standard-count { color: #92660a; font-weight: 500; }
+.store-rating-label { color: #92660a; }
+.store-rating-value { color: #92660a; font-weight: 700; }
+.store-rating-count { color: #92660a; font-weight: 500; }
 
 .store-card-price {
   display: flex;
@@ -3855,4 +3920,116 @@ body.has-contact-sheet { overflow: hidden; }
     padding: 0;
     margin-top: 18px;
   }
+}
+
+/* ===================== Store Reviews (verified customer reviews) ===================== */
+.store-reviews-section { scroll-margin-top: 16px; }
+.store-reviews-summary {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 6px;
+  font-size: 13.5px;
+  margin-bottom: 10px;
+}
+.store-reviews-summary .store-rating-label { color: var(--ink); font-weight: 700; }
+.store-reviews-summary .store-rating-stars { font-size: 14px; }
+.store-reviews-summary .store-rating-star { font-size: 14px; }
+.store-reviews-summary .store-rating-value { color: var(--ink); font-weight: 700; }
+.store-reviews-summary .store-rating-count { color: var(--muted); font-weight: 500; }
+
+.store-reviews-empty { color: var(--muted); font-size: 13.5px; }
+.store-reviews-list {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  margin-bottom: 10px;
+}
+.store-review-item {
+  border: 1px solid var(--line);
+  border-radius: var(--radius-sm);
+  padding: 10px 12px;
+}
+.store-review-item-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  margin-bottom: 4px;
+}
+.store-review-item-name { font-size: 12.5px; font-weight: 700; color: var(--ink); }
+.store-review-item-stars { font-size: 12px; }
+.store-review-item-comment { font-size: 13px; color: var(--ink); white-space: pre-wrap; overflow-wrap: anywhere; margin-bottom: 4px; }
+.store-review-item-date { font-size: 11px; color: var(--muted); }
+.store-reviews-load-more { width: 100%; margin-bottom: 12px; }
+
+.store-review-star { color: #e5e7eb; }
+.store-review-star.is-filled { color: #f5b700; }
+
+.store-review-write-gate {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  font-size: 13px;
+  color: var(--muted);
+}
+.store-review-ineligible { font-size: 13px; color: var(--muted); }
+
+.store-review-form {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-sm);
+  padding: 12px;
+}
+.store-review-form h4 { font-size: 14px; margin: 0; }
+.store-review-field {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  font-size: 12.5px;
+  font-weight: 600;
+  color: var(--ink);
+}
+.store-review-field select,
+.store-review-field textarea {
+  font: inherit;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-sm);
+  padding: 8px 10px;
+  resize: vertical;
+  min-height: 64px;
+}
+.store-review-stars-input,
+.store-review-stars-display {
+  display: inline-flex;
+  gap: 4px;
+}
+.store-review-star-btn {
+  background: none;
+  border: none;
+  font-size: 24px;
+  line-height: 1;
+  color: #e5e7eb;
+  cursor: pointer;
+  padding: 2px;
+  min-width: 32px;
+  min-height: 32px;
+}
+.store-review-star-btn.is-filled { color: #f5b700; }
+.store-review-form-actions {
+  display: flex;
+  gap: 8px;
+}
+.store-review-form-actions .primary-btn,
+.store-review-form-actions .secondary-btn { flex: 1; min-height: 42px; }
+.store-review-preview-comment {
+  font-size: 13px;
+  color: var(--ink);
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+  background: var(--soft-blue, #eef2f7);
+  border-radius: var(--radius-sm);
+  padding: 8px 10px;
 }

--- a/customer-app/assets/customer-app.js
+++ b/customer-app/assets/customer-app.js
@@ -3,7 +3,7 @@
 
   const App = window.CWFCustomerAppV2;
   const BOOT_TIMEOUT_MS = 3500;
-  const BUILD_ID = "20260623_store_marketplace_final";
+  const BUILD_ID = "20260624_store_hot_sale_verified_reviews";
 
   function withTimeout(promise, timeoutMs) {
     return Promise.race([

--- a/customer-app/index.html
+++ b/customer-app/index.html
@@ -9,10 +9,10 @@
   <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
   <meta name="apple-mobile-web-app-title" content="CWF Service">
   <title>CWF Customer Service</title>
-  <link rel="manifest" href="./manifest.webmanifest?v=20260623_store_marketplace_final">
+  <link rel="manifest" href="./manifest.webmanifest?v=20260624_store_hot_sale_verified_reviews">
   <link rel="icon" type="image/png" sizes="192x192" href="./assets/icons/cwf-customer-192.png">
   <link rel="apple-touch-icon" sizes="180x180" href="./assets/icons/cwf-customer-180.png">
-  <link rel="stylesheet" href="./assets/customer-app.css?v=20260623_store_marketplace_final">
+  <link rel="stylesheet" href="./assets/customer-app.css?v=20260624_store_hot_sale_verified_reviews">
 </head>
 <body class="is-app-booting">
   <div class="app-shell" data-app-shell>
@@ -50,20 +50,20 @@
     </nav>
   </div>
 
-  <script src="./modules/state.js?v=20260623_store_marketplace_final"></script>
-  <script src="./modules/utils.js?v=20260623_store_marketplace_final"></script>
-  <script src="./modules/api.js?v=20260623_store_marketplace_final"></script>
-  <script src="./modules/services.js?v=20260623_store_marketplace_final"></script>
-  <script src="./modules/ui.js?v=20260623_store_marketplace_final"></script>
-  <script src="./modules/store.js?v=20260623_store_marketplace_final"></script>
-  <script src="./modules/auth.js?v=20260623_store_marketplace_final"></script>
-  <script src="./modules/pricing.js?v=20260623_store_marketplace_final"></script>
-  <script src="./modules/availability.js?v=20260623_store_marketplace_final"></script>
-  <script src="./modules/bookingScheduled.js?v=20260623_store_marketplace_final"></script>
-  <script src="./modules/bookingUrgent.js?v=20260623_store_marketplace_final"></script>
-  <script src="./modules/tracking.js?v=20260623_store_marketplace_final"></script>
-  <script src="./modules/profile.js?v=20260623_store_marketplace_final"></script>
-  <script src="./modules/router.js?v=20260623_store_marketplace_final"></script>
-  <script src="./assets/customer-app.js?v=20260623_store_marketplace_final"></script>
+  <script src="./modules/state.js?v=20260624_store_hot_sale_verified_reviews"></script>
+  <script src="./modules/utils.js?v=20260624_store_hot_sale_verified_reviews"></script>
+  <script src="./modules/api.js?v=20260624_store_hot_sale_verified_reviews"></script>
+  <script src="./modules/services.js?v=20260624_store_hot_sale_verified_reviews"></script>
+  <script src="./modules/ui.js?v=20260624_store_hot_sale_verified_reviews"></script>
+  <script src="./modules/store.js?v=20260624_store_hot_sale_verified_reviews"></script>
+  <script src="./modules/auth.js?v=20260624_store_hot_sale_verified_reviews"></script>
+  <script src="./modules/pricing.js?v=20260624_store_hot_sale_verified_reviews"></script>
+  <script src="./modules/availability.js?v=20260624_store_hot_sale_verified_reviews"></script>
+  <script src="./modules/bookingScheduled.js?v=20260624_store_hot_sale_verified_reviews"></script>
+  <script src="./modules/bookingUrgent.js?v=20260624_store_hot_sale_verified_reviews"></script>
+  <script src="./modules/tracking.js?v=20260624_store_hot_sale_verified_reviews"></script>
+  <script src="./modules/profile.js?v=20260624_store_hot_sale_verified_reviews"></script>
+  <script src="./modules/router.js?v=20260624_store_hot_sale_verified_reviews"></script>
+  <script src="./assets/customer-app.js?v=20260624_store_hot_sale_verified_reviews"></script>
 </body>
 </html>

--- a/customer-app/manifest.webmanifest
+++ b/customer-app/manifest.webmanifest
@@ -2,7 +2,7 @@
   "name": "CWF Customer Service",
   "short_name": "CWF Service",
   "description": "แอปลูกค้า Coldwindflow สำหรับเลือกบริการ จองคิว และติดตามงาน",
-  "start_url": "/customer-app/index.html?v=20260623_store_marketplace_final#home",
+  "start_url": "/customer-app/index.html?v=20260624_store_hot_sale_verified_reviews#home",
   "scope": "/customer-app/",
   "id": "/customer-app/",
   "display": "standalone",

--- a/customer-app/modules/api.js
+++ b/customer-app/modules/api.js
@@ -137,6 +137,26 @@
         body,
       });
     },
+
+    async loadCatalogItemReviews(itemId, { limit, offset } = {}) {
+      return requestJson(`/catalog/items/${encodeURIComponent(itemId)}/reviews`, {
+        query: { limit, offset },
+        cache: "no-store",
+      });
+    },
+
+    async loadReviewEligibility(itemId) {
+      return requestJson(`/catalog/items/${encodeURIComponent(itemId)}/reviews/eligibility`, {
+        cache: "no-store",
+      });
+    },
+
+    async submitCatalogItemReview(itemId, payload) {
+      return requestJson(`/catalog/items/${encodeURIComponent(itemId)}/reviews`, {
+        method: "POST",
+        body: payload,
+      });
+    },
   };
 
   root.api = api;

--- a/customer-app/modules/bookingScheduled.js
+++ b/customer-app/modules/bookingScheduled.js
@@ -708,6 +708,10 @@
 
   function buildSubmitPayload() {
     const d = draft();
+    const services = root.services.normalizeServiceLines(d);
+    const catalogItemId = services.length === 1 && Number.isFinite(Number(d.catalog_item_id)) && Number(d.catalog_item_id) > 0
+      ? Number(d.catalog_item_id)
+      : null;
     return {
       customer_name: String(d.customer_name || "").trim(),
       customer_phone: String(d.customer_phone || "").trim(),
@@ -720,6 +724,7 @@
       job_zone: String(d.job_zone || "").trim(),
       service_kind: "clean",
       allow_time_proposal: d.allow_time_proposal === true,
+      catalog_item_id: catalogItemId,
       ...payloadFromDraft(),
     };
   }

--- a/customer-app/modules/services.js
+++ b/customer-app/modules/services.js
@@ -223,6 +223,7 @@
   function applyCommerceDraft(scope, item) {
     if (!item || item.action === "contact" || !item.draft) return false;
     const line = normalizeServiceLine(item.draft);
+    const catalogItemId = Number.isFinite(Number(item.id)) && Number(item.id) > 0 ? Number(item.id) : null;
     root.state.updateDraft(scope, {
       service_kind: "clean",
       job_type: "ล้าง",
@@ -232,6 +233,7 @@
       wash_variant: line.wash_variant,
       services: [line],
       selectedSlot: null,
+      catalog_item_id: catalogItemId,
     });
     root.state.selectedService = { id: item.id || item.title || "", route: scope };
     if (scope === "scheduled") {

--- a/customer-app/modules/store.js
+++ b/customer-app/modules/store.js
@@ -39,10 +39,6 @@
     return Number.isFinite(normal) && Number.isFinite(sale) && sale < normal;
   }
 
-  function promoBadgeText(item) {
-    return item.campaign_name || item.price_label || "โปร";
-  }
-
   // The legacy catalog table constrains item_category to "service"/"product"
   // in storage; that generic token carries no useful information for the
   // customer, so it is hidden entirely rather than shown as a translated tag.
@@ -97,19 +93,39 @@
     return `<span class="store-featured-ribbon">CWF แนะนำ</span>`;
   }
 
-  // Future-rating-prop-ready: once a real review system exists, items carry
-  // rating_average (1-5, may be fractional) and review_count (>0). rating_value
-  // is legacy and is never read here — it must not become a second contract.
-  // Until rating_average/review_count are both present and valid there is no
-  // real data, so we fail safe to a full 5-star badge with no review count
-  // rather than fabricate one.
-  function standardRatingInfo(item) {
+  function renderHotBadge(item) {
+    if (!item.is_hot) return "";
+    return `<span class="store-hot-badge" aria-label="สินค้า HOT">HOT</span>`;
+  }
+
+  function salePercentOff(item) {
+    const normal = Number(item.normal_price);
+    const sale = Number(item.active_price);
+    if (!Number.isFinite(normal) || normal <= 0 || !Number.isFinite(sale) || sale >= normal) return null;
+    const pct = Math.round(((normal - sale) / normal) * 100);
+    return pct > 0 ? pct : null;
+  }
+
+  function renderSaleBadge(item) {
+    if (!hasPromo(item)) return "";
+    const pct = salePercentOff(item);
+    const text = pct ? `SALE -${pct}%` : "SALE";
+    return `<span class="store-sale-badge" aria-label="ลดราคา">${root.utils.escapeHtml(text)}</span>`;
+  }
+
+  // Real review aggregates only. item.rating_average/review_count come straight
+  // from the backend's catalog_item_reviews aggregation (approved reviews only —
+  // see attachCatalogRatings() in server/routes/catalog/items.js). There is no
+  // fallback/legacy rating field read here: until a real approved review exists,
+  // this must render an honest "no reviews yet" state (empty stars, count 0) —
+  // never a fabricated full-star score.
+  function realRatingInfo(item) {
     const avg = Number(item && item.rating_average);
     const count = Number(item && item.review_count);
     if (Number.isFinite(avg) && avg >= 1 && avg <= 5 && Number.isFinite(count) && count > 0) {
-      return { value: avg, count };
+      return { value: avg, count, hasReviews: true };
     }
-    return { value: 5, count: 0 };
+    return { value: 0, count: 0, hasReviews: false };
   }
 
   function formatRatingAverage(value) {
@@ -117,27 +133,39 @@
     return rounded % 1 === 0 ? String(rounded) : rounded.toFixed(1);
   }
 
-  function renderStandardBadge(item) {
-    const { value, count } = standardRatingInfo(item);
-    const hasRealReviews = count > 0;
+  function renderRatingBadge(item) {
+    const { value, count, hasReviews } = realRatingInfo(item);
     const full = Math.floor(value);
     const hasHalf = full < 5 && value - full >= 0.5;
     const stars = Array.from({ length: 5 }, (_, i) => {
-      const cls = i < full ? " is-filled" : i === full && hasHalf ? " is-half" : "";
-      return `<span class="store-standard-star${cls}" aria-hidden="true">★</span>`;
+      const filled = hasReviews && i < full;
+      const half = hasReviews && i === full && hasHalf;
+      const cls = filled ? " is-filled" : half ? " is-half" : "";
+      return `<span class="store-rating-star${cls}" aria-hidden="true">${filled || half ? "★" : "☆"}</span>`;
     }).join("");
-    if (!hasRealReviews) {
-      return `<div class="store-standard-badge" title="มาตรฐาน CWF"><span class="store-standard-stars">${stars}</span><span class="store-standard-label">มาตรฐาน CWF</span></div>`;
-    }
-    const valueLabel = `<span class="store-standard-value">${formatRatingAverage(value)}</span>`;
-    const countLabel = `<span class="store-standard-count">(${count} รีวิว)</span>`;
-    return `<div class="store-standard-badge store-standard-badge-real" title="คะแนนรีวิวจริง"><span class="store-standard-stars">${stars}</span>${valueLabel}${countLabel}</div>`;
+    const id = String(item.item_id || "");
+    const valueLabel = hasReviews ? `<span class="store-rating-value">${formatRatingAverage(value)}</span>` : "";
+    const countLabel = `<span class="store-rating-count">(${count})</span>`;
+    return `
+      <button type="button" class="store-rating-badge" data-store-rating="${root.utils.escapeHtml(id)}" title="ดูรีวิวจากลูกค้า">
+        <span class="store-rating-label">รีวิว</span>
+        <span class="store-rating-stars">${stars}</span>
+        ${valueLabel}${countLabel}
+      </button>
+    `;
   }
 
   function renderCardGallery(item, name) {
     const images = itemGalleryImages(item);
     if (!images.length) {
-      return `<div class="store-card-gallery"><div class="store-card-image-placeholder" aria-hidden="true">ไม่มีรูปภาพ</div></div>`;
+      return `
+        <div class="store-card-gallery">
+          ${renderHotBadge(item)}
+          ${renderFeaturedRibbon(item)}
+          <div class="store-card-image-placeholder" aria-hidden="true">ไม่มีรูปภาพ</div>
+          ${renderSaleBadge(item)}
+        </div>
+      `;
     }
     const autoplay = images.length > 1 && item.is_autoplay_enabled === true;
     const dots = images.length > 1
@@ -145,8 +173,10 @@
       : "";
     return `
       <div class="store-card-gallery"${autoplay ? ' data-store-autoplay="1"' : ""}>
+        ${renderHotBadge(item)}
         ${renderFeaturedRibbon(item)}
         <div class="store-card-slides" data-store-slides>${renderGallerySlides(images, name, "store-card-slide")}</div>
+        ${renderSaleBadge(item)}
         ${dots}
       </div>
     `;
@@ -154,7 +184,6 @@
 
   function renderBadges(item) {
     const badges = [];
-    if (hasPromo(item)) badges.push(`<span class="store-badge store-badge-promo">${root.utils.escapeHtml(promoBadgeText(item))}</span>`);
     if (isBookable(item)) badges.push(`<span class="store-badge store-badge-bookable">จองได้</span>`);
     else badges.push(`<span class="store-badge store-badge-contact">ติดต่อแอดมิน</span>`);
     return badges.length ? `<div class="store-card-badges">${badges.join("")}</div>` : "";
@@ -178,7 +207,7 @@
           <strong>${root.utils.escapeHtml(name)}</strong>
           ${meta.length ? `<div class="store-card-meta">${meta.map((m) => `<span>${root.utils.escapeHtml(m)}</span>`).join("")}</div>` : ""}
         </div>
-        ${renderStandardBadge(item)}
+        ${renderRatingBadge(item)}
         <div class="store-card-price">
           <span class="price-text${priceIsAsk(item) ? " is-estimate" : ""}">${root.utils.escapeHtml(priceLabel(item))}</span>
           ${promo ? `<span class="price-strike">${root.utils.escapeHtml(root.utils.formatBaht(item.normal_price))}</span>` : ""}
@@ -374,6 +403,13 @@
         root.ui.openContactSheet(container, { title: name });
       });
     });
+    container.querySelectorAll("[data-store-rating]").forEach((button) => {
+      button.addEventListener("click", (event) => {
+        event.stopPropagation && event.stopPropagation();
+        const id = button.getAttribute("data-store-rating");
+        goToDetail(id);
+      });
+    });
     bindGallerySliders(container);
   }
 
@@ -452,7 +488,14 @@
   function renderDetailGallery(item, name) {
     const images = itemGalleryImages(item);
     if (!images.length) {
-      return `<div class="store-detail-gallery"><div class="store-card-image-placeholder" aria-hidden="true">ไม่มีรูปภาพ</div></div>`;
+      return `
+        <div class="store-detail-gallery">
+          ${renderHotBadge(item)}
+          ${renderFeaturedRibbon(item)}
+          <div class="store-card-image-placeholder" aria-hidden="true">ไม่มีรูปภาพ</div>
+          ${renderSaleBadge(item)}
+        </div>
+      `;
     }
     const autoplay = images.length > 1 && item.is_autoplay_enabled === true;
     const dots = images.length > 1
@@ -460,11 +503,287 @@
       : "";
     return `
       <div class="store-detail-gallery"${autoplay ? ' data-store-autoplay="1"' : ""}>
+        ${renderHotBadge(item)}
         ${renderFeaturedRibbon(item)}
         <div class="store-detail-slides" data-store-detail-slides>${renderGallerySlides(images, name, "store-detail-slide")}</div>
+        ${renderSaleBadge(item)}
         ${dots}
       </div>
     `;
+  }
+
+  // ---------- Verified Customer Reviews (Product Detail) ----------
+
+  const REVIEWS_PAGE_SIZE = 10;
+
+  let reviewsState = { itemId: null, status: "idle", reviews: [], total: 0, ratingAverage: null, reviewCount: 0, offset: 0 };
+  let writeReviewState = {
+    open: false,
+    eligibilityStatus: "idle", // idle | loading | success | error
+    eligible: false,
+    eligibleJobs: [],
+    jobId: null,
+    rating: 0,
+    comment: "",
+    step: "form", // form | preview
+    submitting: false,
+    error: "",
+    success: false,
+  };
+
+  function resetReviewsState(itemId) {
+    reviewsState = { itemId, status: "idle", reviews: [], total: 0, ratingAverage: null, reviewCount: 0, offset: 0 };
+    writeReviewState = {
+      open: false, eligibilityStatus: "idle", eligible: false, eligibleJobs: [],
+      jobId: null, rating: 0, comment: "", step: "form", submitting: false, error: "", success: false,
+    };
+  }
+
+  function patchReviewsSection(container, item) {
+    const mount = container.querySelector("[data-store-reviews-section]");
+    if (!mount) return;
+    mount.innerHTML = renderReviewsSectionBody(item);
+    bindReviewsSection(container, item);
+  }
+
+  async function loadReviewsList(container, item, { append } = {}) {
+    const itemId = item.item_id;
+    reviewsState.status = append ? reviewsState.status : "loading";
+    if (!append) patchReviewsSection(container, item);
+    try {
+      const offset = append ? reviewsState.offset : 0;
+      const data = await root.api.loadCatalogItemReviews(itemId, { limit: REVIEWS_PAGE_SIZE, offset });
+      const incoming = root.utils.normalizeList(data, "reviews");
+      reviewsState = {
+        itemId,
+        status: "success",
+        reviews: append ? reviewsState.reviews.concat(incoming) : incoming,
+        total: Number(data?.total || 0),
+        ratingAverage: data?.rating_average == null ? null : Number(data.rating_average),
+        reviewCount: Number(data?.review_count || 0),
+        offset: offset + incoming.length,
+      };
+    } catch (error) {
+      reviewsState.status = "error";
+      reviewsState.error = error?.message || "โหลดรีวิวไม่สำเร็จ";
+    }
+    patchReviewsSection(container, item);
+  }
+
+  async function loadEligibility(container, item) {
+    if (!root.state.customer?.logged_in) return;
+    writeReviewState.eligibilityStatus = "loading";
+    try {
+      const data = await root.api.loadReviewEligibility(item.item_id);
+      writeReviewState.eligibilityStatus = "success";
+      writeReviewState.eligible = Boolean(data?.eligible);
+      writeReviewState.eligibleJobs = root.utils.normalizeList(data, "eligible_jobs");
+      writeReviewState.jobId = writeReviewState.eligibleJobs[0]?.job_id || null;
+    } catch (error) {
+      writeReviewState.eligibilityStatus = "error";
+      writeReviewState.eligible = false;
+    }
+    patchReviewsSection(container, item);
+  }
+
+  function renderReviewStars(currentRating, interactive) {
+    return Array.from({ length: 5 }, (_, i) => {
+      const n = i + 1;
+      const filled = n <= currentRating;
+      if (!interactive) return `<span class="store-review-star${filled ? " is-filled" : ""}" aria-hidden="true">${filled ? "★" : "☆"}</span>`;
+      return `<button type="button" class="store-review-star-btn${filled ? " is-filled" : ""}" data-review-star="${n}" aria-label="${n} ดาว">${filled ? "★" : "☆"}</button>`;
+    }).join("");
+  }
+
+  function renderWriteReviewPanel(item) {
+    if (!root.state.customer?.logged_in) {
+      return `
+        <div class="store-review-write-gate">
+          <p>เข้าสู่ระบบเพื่อเขียนรีวิวสำหรับงานที่คุณใช้บริการจริง</p>
+          <button type="button" class="secondary-btn" data-store-review-login>เข้าสู่ระบบ</button>
+        </div>
+      `;
+    }
+    if (writeReviewState.eligibilityStatus === "loading" || writeReviewState.eligibilityStatus === "idle") {
+      return `<div class="content-skeleton" aria-label="กำลังตรวจสอบสิทธิ์รีวิว"><span></span></div>`;
+    }
+    if (!writeReviewState.eligible) {
+      return `<p class="store-review-ineligible">คุณยังไม่มีงานที่เสร็จสมบูรณ์สำหรับสินค้า/บริการนี้ที่สามารถรีวิวได้ในขณะนี้</p>`;
+    }
+    if (writeReviewState.success) {
+      return root.utils.stateBox("success", "ส่งรีวิวแล้ว รอแอดมินตรวจสอบ");
+    }
+    if (!writeReviewState.open) {
+      return `<button type="button" class="secondary-btn" data-store-review-open>เขียนรีวิว</button>`;
+    }
+
+    const jobPicker = writeReviewState.eligibleJobs.length > 1 ? `
+      <label class="store-review-field">
+        <span>เลือกงานที่ต้องการรีวิว</span>
+        <select data-store-review-job>
+          ${writeReviewState.eligibleJobs.map((j) => `<option value="${root.utils.escapeHtml(j.job_id)}"${String(j.job_id) === String(writeReviewState.jobId) ? " selected" : ""}>${root.utils.escapeHtml(String(j.appointment_datetime || "").slice(0, 16).replace("T", " "))}</option>`).join("")}
+        </select>
+      </label>
+    ` : "";
+
+    if (writeReviewState.step === "preview") {
+      return `
+        <div class="store-review-form store-review-preview">
+          <h4>ตรวจสอบรีวิวก่อนส่ง</h4>
+          <div class="store-review-stars-display">${renderReviewStars(writeReviewState.rating, false)}</div>
+          <p class="store-review-preview-comment">${root.utils.escapeHtml(writeReviewState.comment || "(ไม่มีความเห็นเพิ่มเติม)")}</p>
+          ${writeReviewState.error ? root.utils.stateBox("error", writeReviewState.error) : ""}
+          <div class="store-review-form-actions">
+            <button type="button" class="secondary-btn" data-store-review-back ${writeReviewState.submitting ? "disabled" : ""}>กลับไปแก้ไข</button>
+            <button type="button" class="primary-btn" data-store-review-confirm ${writeReviewState.submitting ? "disabled" : ""}>${writeReviewState.submitting ? "กำลังส่ง..." : "ยืนยันส่งรีวิว"}</button>
+          </div>
+        </div>
+      `;
+    }
+
+    return `
+      <div class="store-review-form">
+        <h4>เขียนรีวิว</h4>
+        ${jobPicker}
+        <label class="store-review-field">
+          <span>ให้คะแนน</span>
+          <div class="store-review-stars-input" data-store-review-stars>${renderReviewStars(writeReviewState.rating, true)}</div>
+        </label>
+        <label class="store-review-field">
+          <span>ความเห็น (ไม่บังคับ)</span>
+          <textarea data-store-review-comment maxlength="500" placeholder="บอกเล่าประสบการณ์ใช้บริการของคุณ">${root.utils.escapeHtml(writeReviewState.comment)}</textarea>
+        </label>
+        ${writeReviewState.error ? root.utils.stateBox("error", writeReviewState.error) : ""}
+        <div class="store-review-form-actions">
+          <button type="button" class="secondary-btn" data-store-review-cancel>ยกเลิก</button>
+          <button type="button" class="primary-btn" data-store-review-next>ตรวจสอบรีวิว</button>
+        </div>
+      </div>
+    `;
+  }
+
+  function renderReviewsList() {
+    if (reviewsState.status === "loading" && !reviewsState.reviews.length) {
+      return `<div class="content-skeleton" aria-label="กำลังโหลดรีวิว"><span></span><span></span></div>`;
+    }
+    if (reviewsState.status === "error") {
+      return root.utils.stateBox("error", reviewsState.error || "โหลดรีวิวไม่สำเร็จ");
+    }
+    if (!reviewsState.reviews.length) {
+      return `<p class="store-reviews-empty">ยังไม่มีรีวิวสำหรับสินค้า/บริการนี้</p>`;
+    }
+    const items = reviewsState.reviews.map((r) => `
+      <div class="store-review-item">
+        <div class="store-review-item-head">
+          <span class="store-review-item-name">${root.utils.escapeHtml(r.display_name || "ลูกค้า")}</span>
+          <span class="store-review-item-stars">${renderReviewStars(Number(r.rating || 0), false)}</span>
+        </div>
+        ${r.comment ? `<p class="store-review-item-comment">${root.utils.escapeHtml(r.comment)}</p>` : ""}
+        <span class="store-review-item-date">${root.utils.escapeHtml(String(r.created_at || "").slice(0, 10))}</span>
+      </div>
+    `).join("");
+    const hasMore = reviewsState.reviews.length < reviewsState.total;
+    return `
+      <div class="store-reviews-list">${items}</div>
+      ${hasMore ? `<button type="button" class="secondary-btn store-reviews-load-more" data-store-reviews-more>โหลดรีวิวเพิ่ม</button>` : ""}
+    `;
+  }
+
+  function renderReviewsSectionBody(item) {
+    const avg = reviewsState.ratingAverage;
+    const count = reviewsState.reviewCount;
+    const hasReviews = Number.isFinite(avg) && avg >= 1 && count > 0;
+    return `
+      <h3>รีวิวจากลูกค้า</h3>
+      <div class="store-reviews-summary">
+        <span class="store-rating-label">รีวิว</span>
+        <span class="store-rating-stars">${renderReviewStars(hasReviews ? Math.round(avg) : 0, false)}</span>
+        ${hasReviews ? `<span class="store-rating-value">${formatRatingAverage(avg)}</span>` : ""}
+        <span class="store-rating-count">(${count})</span>
+      </div>
+      <div class="store-reviews-list-mount">${renderReviewsList()}</div>
+      <div class="store-review-write-mount">${renderWriteReviewPanel(item)}</div>
+    `;
+  }
+
+  function bindReviewsSection(container, item) {
+    const section = container.querySelector("[data-store-reviews-section]");
+    if (!section) return;
+
+    const moreButton = section.querySelector("[data-store-reviews-more]");
+    if (moreButton) moreButton.addEventListener("click", () => loadReviewsList(container, item, { append: true }));
+
+    const loginButton = section.querySelector("[data-store-review-login]");
+    if (loginButton) loginButton.addEventListener("click", () => root.utils.routeTo("profile"));
+
+    const openButton = section.querySelector("[data-store-review-open]");
+    if (openButton) openButton.addEventListener("click", () => {
+      writeReviewState.open = true;
+      patchReviewsSection(container, item);
+    });
+
+    const cancelButton = section.querySelector("[data-store-review-cancel]");
+    if (cancelButton) cancelButton.addEventListener("click", () => {
+      writeReviewState.open = false;
+      writeReviewState.rating = 0;
+      writeReviewState.comment = "";
+      writeReviewState.error = "";
+      patchReviewsSection(container, item);
+    });
+
+    const jobSelect = section.querySelector("[data-store-review-job]");
+    if (jobSelect) jobSelect.addEventListener("change", () => { writeReviewState.jobId = jobSelect.value; });
+
+    section.querySelectorAll("[data-review-star]").forEach((button) => {
+      button.addEventListener("click", () => {
+        writeReviewState.rating = Number(button.getAttribute("data-review-star") || 0);
+        patchReviewsSection(container, item);
+      });
+    });
+
+    const commentInput = section.querySelector("[data-store-review-comment]");
+    if (commentInput) commentInput.addEventListener("input", () => { writeReviewState.comment = commentInput.value; });
+
+    const nextButton = section.querySelector("[data-store-review-next]");
+    if (nextButton) nextButton.addEventListener("click", () => {
+      if (!writeReviewState.rating) {
+        writeReviewState.error = "กรุณาให้คะแนน 1-5 ดาว";
+        patchReviewsSection(container, item);
+        return;
+      }
+      writeReviewState.error = "";
+      writeReviewState.step = "preview";
+      patchReviewsSection(container, item);
+    });
+
+    const backButton = section.querySelector("[data-store-review-back]");
+    if (backButton) backButton.addEventListener("click", () => {
+      writeReviewState.step = "form";
+      patchReviewsSection(container, item);
+    });
+
+    const confirmButton = section.querySelector("[data-store-review-confirm]");
+    if (confirmButton) confirmButton.addEventListener("click", async () => {
+      if (writeReviewState.submitting) return;
+      writeReviewState.submitting = true;
+      writeReviewState.error = "";
+      patchReviewsSection(container, item);
+      try {
+        await root.api.submitCatalogItemReview(item.item_id, {
+          job_id: writeReviewState.jobId,
+          rating: writeReviewState.rating,
+          comment: writeReviewState.comment,
+        });
+        writeReviewState.submitting = false;
+        writeReviewState.open = false;
+        writeReviewState.success = true;
+        patchReviewsSection(container, item);
+      } catch (error) {
+        writeReviewState.submitting = false;
+        writeReviewState.error = error?.message || "ส่งรีวิวไม่สำเร็จ";
+        patchReviewsSection(container, item);
+      }
+    });
   }
 
   function renderDetailContent(item) {
@@ -482,7 +801,7 @@
         ${category ? `<span class="tag">${root.utils.escapeHtml(category)}</span>` : ""}
         <h2>${root.utils.escapeHtml(name)}</h2>
       </div>
-      ${renderStandardBadge(item)}
+      ${renderRatingBadge(item)}
       <div class="store-detail-price">
         <span class="price-text${priceIsAsk(item) ? " is-estimate" : ""}">${root.utils.escapeHtml(priceLabel(item))}</span>
         ${promo ? `<span class="price-strike">${root.utils.escapeHtml(root.utils.formatBaht(item.normal_price))}</span>` : ""}
@@ -509,6 +828,9 @@
           <p>${root.utils.escapeHtml(item.service_conditions)}</p>
         </div>
       ` : ""}
+      <div class="store-detail-section store-reviews-section" data-store-reviews-section>
+        ${renderReviewsSectionBody(item)}
+      </div>
       <div class="store-detail-cta-bar">
         ${bookable
           ? `<button class="primary-btn" type="button" data-store-detail-book>จองคิว</button>`
@@ -591,6 +913,14 @@
         root.ui.openContactSheet(container, { title: item?.item_name || "รายการนี้" });
       });
     }
+    container.querySelectorAll("[data-store-rating]").forEach((button) => {
+      button.addEventListener("click", () => {
+        const section = container.querySelector("[data-store-reviews-section]");
+        if (section) section.scrollIntoView({ behavior: "smooth", block: "start" });
+      });
+    });
+    const item = root.state.storeDetail?.data;
+    if (item) bindReviewsSection(container, item);
     bindDetailGallery(container);
   }
 
@@ -602,6 +932,7 @@
   }
 
   async function loadDetail(container, itemId) {
+    resetReviewsState(itemId);
     if (!itemId) {
       root.state.setStoreDetail({ status: "error", itemId: "", data: null, error: "ไม่พบรายการนี้" });
       patchDetailBody(container);
@@ -612,6 +943,10 @@
     try {
       const data = await root.api.loadCatalogItem(itemId);
       root.state.setStoreDetail({ status: "success", itemId, data, error: "" });
+      patchDetailBody(container);
+      loadReviewsList(container, data);
+      loadEligibility(container, data);
+      return;
     } catch (error) {
       const message = error?.status === 404 ? "ไม่พบรายการนี้" : (error?.message || "โหลดข้อมูลไม่สำเร็จ");
       root.state.setStoreDetail({ status: "error", itemId, data: null, error: message });

--- a/customer-app/sw.js
+++ b/customer-app/sw.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const BUILD_ID = "20260623_store_marketplace_final";
+const BUILD_ID = "20260624_store_hot_sale_verified_reviews";
 const CACHE_NAME = `cwf-customer-app-v2-${BUILD_ID}`;
 const APP_SHELL = [
   `./index.html?v=${BUILD_ID}`,

--- a/index.js
+++ b/index.js
@@ -41,6 +41,7 @@ const { createTechnicianJobMoneyHelpers } = require("./server/technicianJobMoney
 const createSystemRoutes = require("./server/routes/system");
 const createTechnicianDirectoryRoutes = require("./server/routes/users/technicians");
 const createCatalogItemRoutes = require("./server/routes/catalog/items");
+const createCatalogReviewRoutes = require("./server/routes/catalog/reviews");
 const createServiceZoneRoutes = require("./server/routes/serviceZones");
 const createPageRoutes = require("./server/routes/pages");
 const createDocumentRoutes = require("./server/routes/docs");
@@ -12957,6 +12958,7 @@ app.use(createTechnicianDirectoryRoutes({ pool }));
 // 📦 CATALOG
 // =======================================
 app.use(createCatalogItemRoutes({ pool, requireAdminSession }));
+app.use(createCatalogReviewRoutes({ pool, requireCustomerJwt, requireAdminSession }));
 
 
 app.post("/catalog/items", requireAdminSession, async (req, res) => {
@@ -24806,6 +24808,26 @@ function handlePublicCustomerUrgentBook(req, res) {
   return handleAdminBookV2(req, res);
 }
 
+// ✅ Fail-safe capability check: jobs.catalog_item_id / jobs.customer_sub are
+// additive columns from a migration that may not have run yet. Never assume
+// they exist — insert NULL/omit them until the schema is confirmed ready.
+let jobsCatalogLinkSchemaReadyCache = false;
+async function isJobsCatalogLinkSchemaReady() {
+  if (jobsCatalogLinkSchemaReadyCache) return true;
+  try {
+    const r = await pool.query(
+      `SELECT COUNT(*)::int AS cnt FROM information_schema.columns
+        WHERE table_schema = 'public' AND table_name = 'jobs'
+          AND column_name IN ('catalog_item_id', 'customer_sub')`
+    );
+    const ready = Number(r.rows?.[0]?.cnt || 0) === 2;
+    if (ready) jobsCatalogLinkSchemaReadyCache = true;
+    return ready;
+  } catch (_) {
+    return false;
+  }
+}
+
 app.post("/public/book", async (req, res) => {
   // ✅ ลูกค้าจองคิว (ไม่บังคับกรอก lat/lng) + เลือกรายการบริการ/สินค้าได้
   // - โปรโมชั่น: ให้แอดมินเป็นคนใส่/ลบเท่านั้น (ฝั่งลูกค้าไม่รับ promo_id)
@@ -24829,6 +24851,7 @@ app.post("/public/book", async (req, res) => {
     wash_variant,
     repair_variant,
     services,
+    catalog_item_id, // optional: links this booking to the Store catalog item it was booked for
   } = req.body || {};
 
   if (isCustomerAppUrgentBook(req.body || {})) {
@@ -24838,6 +24861,25 @@ app.post("/public/book", async (req, res) => {
   if (!customer_name || !job_type || !appointment_datetime || !address_text) {
     return res.status(400).json({ error: "กรอกข้อมูลไม่ครบ (ชื่อ/ประเภทงาน/วันนัด/ที่อยู่)" });
   }
+
+  // ✅ Soft customer identity: never required, never trusted blindly elsewhere —
+  // this is only a best-effort linkage so a logged-in customer can later prove
+  // ownership of *this* job for review eligibility. Booking proceeds for guests too.
+  let customerSubForJob = null;
+  try {
+    const jwtSecretForBook = getJwtSecret();
+    const cwfToken = parseCookieValue(req, "cwf_token");
+    if (jwtSecretForBook && cwfToken) {
+      const customerPayload = jwtVerify(cwfToken, jwtSecretForBook);
+      if (customerPayload && customerPayload.sub) {
+        customerSubForJob = String(customerPayload.sub);
+      }
+    }
+  } catch (_) {
+    customerSubForJob = null;
+  }
+  const catalogItemIdForJob = Number(catalog_item_id);
+  const safeCatalogItemIdForJob = Number.isFinite(catalogItemIdForJob) && catalogItemIdForJob > 0 ? catalogItemIdForJob : null;
 
   // ✅ sanitize items (ไม่เชื่อราคา/ชื่อจากฝั่งลูกค้า)
   const safeItemsIn = Array.isArray(items) ? items : [];
@@ -25170,34 +25212,46 @@ if (itemIdQty.length) {
     // - urgent (ยิงงานด่วน)      => offer  (ไป flow offer)
     const dispatchMode = (bm === 'urgent') ? 'offer' : 'normal';
 
+    const catalogLinkReady = await isJobsCatalogLinkSchemaReady();
+    const jobInsertColumns = [
+      "customer_name", "customer_phone", "job_type", "appointment_datetime", "job_price",
+      "address_text", "technician_team", "technician_username", "job_status",
+      "booking_token", "job_source", "dispatch_mode", "customer_note",
+      "maps_url", "job_zone", "duration_min", "booking_mode", "allow_time_proposal",
+    ];
+    const jobInsertValuesSql = ["$1", "$2", "$3", "$4", "$5", "$6", "NULL", "$16", "$11", "$7", "'customer'", "$14", "$8", "$9", "$10", "$12", "$13", "$15"];
+    const jobInsertParams = [
+      String(customer_name).trim(),
+      (customer_phone || "").toString().trim(),
+      String(job_type).trim(),
+      appointment_datetime,
+      Number(base_total || 0),
+      String(address_text).trim(),
+      token,
+      (customer_note || "").toString(),
+      (maps_url || "").toString(),
+      (job_zone || "").toString(),
+      bm === 'urgent' ? (urgentOfferEnabled ? 'รอช่างยืนยัน' : 'ไม่พบช่างรับงาน') : 'รอตรวจสอบ',
+      duration_min_v2,
+      (bm === 'urgent' ? 'urgent' : 'scheduled'),
+      dispatchMode,
+      allowTimeProposal,
+      draftReservationTech ? draftReservationTech.username : null,
+    ];
+    if (catalogLinkReady) {
+      jobInsertColumns.push("catalog_item_id", "customer_sub");
+      jobInsertParams.push(safeCatalogItemIdForJob, customerSubForJob);
+      jobInsertValuesSql.push(`$${jobInsertParams.length - 1}`, `$${jobInsertParams.length}`);
+    }
+
     const r = await client.query(
       `
       INSERT INTO public.jobs
-      (customer_name, customer_phone, job_type, appointment_datetime, job_price,
-       address_text, technician_team, technician_username, job_status,
-       booking_token, job_source, dispatch_mode, customer_note,
-       maps_url, job_zone, duration_min, booking_mode, allow_time_proposal)
-      VALUES ($1,$2,$3,$4,$5,$6,NULL,$16,$11,$7,'customer',$14,$8,$9,$10,$12,$13,$15)
+      (${jobInsertColumns.join(", ")})
+      VALUES (${jobInsertValuesSql.join(",")})
       RETURNING job_id, booking_token
       `,
-      [
-        String(customer_name).trim(),
-        (customer_phone || "").toString().trim(),
-        String(job_type).trim(),
-        appointment_datetime,
-        Number(base_total || 0),
-        String(address_text).trim(),
-        token,
-        (customer_note || "").toString(),
-        (maps_url || "").toString(),
-        (job_zone || "").toString(),
-        bm === 'urgent' ? (urgentOfferEnabled ? 'รอช่างยืนยัน' : 'ไม่พบช่างรับงาน') : 'รอตรวจสอบ',
-        duration_min_v2,
-        (bm === 'urgent' ? 'urgent' : 'scheduled'),
-        dispatchMode,
-        allowTimeProposal,
-        draftReservationTech ? draftReservationTech.username : null,
-      ]
+      jobInsertParams
     );
 
     // attach promo to job (if any)

--- a/migrations/20260623_catalog_store_hot_sale_reviews.sql
+++ b/migrations/20260623_catalog_store_hot_sale_reviews.sql
@@ -1,0 +1,155 @@
+-- Catalog Store HOT badge + verified customer reviews.
+-- Additive only:
+--   - catalog_items.is_hot (admin-controlled HOT badge toggle)
+--   - jobs.catalog_item_id (links a Store-originated booking to the catalog
+--     item it was booked for; NULL for every existing/legacy job, and never
+--     backfilled/guessed)
+--   - jobs.customer_sub (links a Store-originated booking to the logged-in
+--     customer identity (LINE sub) that placed it, when one was present at
+--     booking time; NULL for every existing/legacy job and for guest bookings)
+--   - public.catalog_item_reviews (new table; one verified review per
+--     completed job)
+-- No existing data is touched. Apply during a planned deployment window.
+-- Do not run against production until reviewed.
+
+BEGIN;
+
+ALTER TABLE public.catalog_items
+  ADD COLUMN IF NOT EXISTS is_hot BOOLEAN NOT NULL DEFAULT FALSE;
+
+ALTER TABLE public.jobs
+  ADD COLUMN IF NOT EXISTS catalog_item_id BIGINT NULL;
+
+ALTER TABLE public.jobs
+  ADD COLUMN IF NOT EXISTS customer_sub TEXT NULL;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint con
+    JOIN pg_class rel ON rel.oid = con.conrelid
+    JOIN pg_namespace nsp ON nsp.oid = rel.relnamespace
+    WHERE nsp.nspname = 'public'
+      AND rel.relname = 'jobs'
+      AND con.contype = 'f'
+      AND con.conname = 'jobs_catalog_item_id_fkey'
+  ) THEN
+    ALTER TABLE public.jobs
+      ADD CONSTRAINT jobs_catalog_item_id_fkey
+      FOREIGN KEY (catalog_item_id)
+      REFERENCES public.catalog_items(item_id)
+      ON DELETE SET NULL;
+  END IF;
+END
+$$;
+
+CREATE INDEX IF NOT EXISTS idx_jobs_catalog_item_id
+  ON public.jobs(catalog_item_id)
+  WHERE catalog_item_id IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_jobs_customer_sub
+  ON public.jobs(customer_sub)
+  WHERE customer_sub IS NOT NULL;
+
+CREATE TABLE IF NOT EXISTS public.catalog_item_reviews (
+  review_id BIGSERIAL PRIMARY KEY,
+  item_id BIGINT NOT NULL,
+  completed_job_id BIGINT NOT NULL,
+  customer_identity TEXT NOT NULL,
+  rating INTEGER NOT NULL,
+  comment TEXT,
+  moderation_status TEXT NOT NULL DEFAULT 'pending',
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  moderated_at TIMESTAMPTZ,
+  moderated_by TEXT
+);
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint con
+    JOIN pg_class rel ON rel.oid = con.conrelid
+    JOIN pg_namespace nsp ON nsp.oid = rel.relnamespace
+    WHERE nsp.nspname = 'public' AND rel.relname = 'catalog_item_reviews'
+      AND con.contype = 'c' AND con.conname = 'catalog_item_reviews_rating_check'
+  ) THEN
+    ALTER TABLE public.catalog_item_reviews
+      ADD CONSTRAINT catalog_item_reviews_rating_check
+      CHECK (rating BETWEEN 1 AND 5);
+  END IF;
+END
+$$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint con
+    JOIN pg_class rel ON rel.oid = con.conrelid
+    JOIN pg_namespace nsp ON nsp.oid = rel.relnamespace
+    WHERE nsp.nspname = 'public' AND rel.relname = 'catalog_item_reviews'
+      AND con.contype = 'c' AND con.conname = 'catalog_item_reviews_status_check'
+  ) THEN
+    ALTER TABLE public.catalog_item_reviews
+      ADD CONSTRAINT catalog_item_reviews_status_check
+      CHECK (moderation_status IN ('pending', 'approved', 'rejected', 'hidden'));
+  END IF;
+END
+$$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint con
+    JOIN pg_class rel ON rel.oid = con.conrelid
+    JOIN pg_namespace nsp ON nsp.oid = rel.relnamespace
+    WHERE nsp.nspname = 'public' AND rel.relname = 'catalog_item_reviews'
+      AND con.contype = 'f' AND con.conname = 'catalog_item_reviews_item_id_fkey'
+  ) THEN
+    ALTER TABLE public.catalog_item_reviews
+      ADD CONSTRAINT catalog_item_reviews_item_id_fkey
+      FOREIGN KEY (item_id) REFERENCES public.catalog_items(item_id) ON DELETE CASCADE;
+  END IF;
+END
+$$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint con
+    JOIN pg_class rel ON rel.oid = con.conrelid
+    JOIN pg_namespace nsp ON nsp.oid = rel.relnamespace
+    WHERE nsp.nspname = 'public' AND rel.relname = 'catalog_item_reviews'
+      AND con.contype = 'f' AND con.conname = 'catalog_item_reviews_job_id_fkey'
+  ) THEN
+    ALTER TABLE public.catalog_item_reviews
+      ADD CONSTRAINT catalog_item_reviews_job_id_fkey
+      FOREIGN KEY (completed_job_id) REFERENCES public.jobs(job_id) ON DELETE CASCADE;
+  END IF;
+END
+$$;
+
+-- Exactly one review per completed job, enforced at the database level.
+CREATE UNIQUE INDEX IF NOT EXISTS uq_catalog_item_reviews_job
+  ON public.catalog_item_reviews(completed_job_id);
+
+CREATE INDEX IF NOT EXISTS idx_catalog_item_reviews_item_status
+  ON public.catalog_item_reviews(item_id, moderation_status);
+
+CREATE INDEX IF NOT EXISTS idx_catalog_item_reviews_created_at
+  ON public.catalog_item_reviews(created_at DESC);
+
+COMMIT;
+
+-- Rollback plan:
+-- DROP INDEX IF EXISTS public.idx_catalog_item_reviews_created_at;
+-- DROP INDEX IF EXISTS public.idx_catalog_item_reviews_item_status;
+-- DROP INDEX IF EXISTS public.uq_catalog_item_reviews_job;
+-- DROP TABLE IF EXISTS public.catalog_item_reviews;
+-- DROP INDEX IF EXISTS public.idx_jobs_customer_sub;
+-- DROP INDEX IF EXISTS public.idx_jobs_catalog_item_id;
+-- ALTER TABLE public.jobs DROP CONSTRAINT IF EXISTS jobs_catalog_item_id_fkey;
+-- ALTER TABLE public.jobs DROP COLUMN IF EXISTS customer_sub;
+-- ALTER TABLE public.jobs DROP COLUMN IF EXISTS catalog_item_id;
+-- ALTER TABLE public.catalog_items DROP COLUMN IF EXISTS is_hot;

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "migrate:catalog-store-media-pricing": "node scripts/run-catalog-store-media-pricing-migration.js",
     "migrate:catalog-marketplace-v2": "node scripts/run-catalog-marketplace-v2-migration.js",
     "migrate:catalog-autoplay": "node scripts/run-catalog-autoplay-migration.js",
+    "migrate:catalog-hot-sale-reviews": "node scripts/run-catalog-store-hot-sale-reviews-migration.js",
     "test": "node --test test/*.test.js"
   },
   "dependencies": {

--- a/scripts/run-catalog-store-hot-sale-reviews-migration.js
+++ b/scripts/run-catalog-store-hot-sale-reviews-migration.js
@@ -1,0 +1,217 @@
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+const { Client } = require("pg");
+
+const MIGRATION_RELATIVE_PATH = "migrations/20260623_catalog_store_hot_sale_reviews.sql";
+const ADVISORY_LOCK_KEY = "202606230066";
+
+function clean(value) {
+  return String(value == null ? "" : value).trim();
+}
+
+function safeErrorMessage(error) {
+  const msg = clean(error && error.message ? error.message : error) || "unknown error";
+  return msg
+    .replace(/postgres(?:ql)?:\/\/[^\s"'<>]+/gi, "[REDACTED_DATABASE_URL]")
+    .replace(/(password|passwd|pwd|secret|token)=([^&\s]+)/gi, "$1=[REDACTED]");
+}
+
+function resolveMigrationPath(repoRoot = path.resolve(__dirname, "..")) {
+  const root = path.resolve(repoRoot);
+  const migrationPath = path.resolve(root, MIGRATION_RELATIVE_PATH);
+  const expected = path.resolve(root, "migrations", "20260623_catalog_store_hot_sale_reviews.sql");
+  if (migrationPath !== expected || !migrationPath.startsWith(root + path.sep)) {
+    throw new Error("migration path rejected");
+  }
+  return migrationPath;
+}
+
+function readMigrationSql(repoRoot) {
+  return fs.readFileSync(resolveMigrationPath(repoRoot), "utf8");
+}
+
+// See run-catalog-marketplace-v2-migration.js for the rationale: the runner owns
+// the transaction boundary itself so a verifySchema() failure still triggers a
+// real ROLLBACK, while the file itself keeps its own BEGIN/COMMIT so it stays
+// directly pasteable into pgAdmin.
+function stripOuterTransactionWrapper(sql) {
+  return sql
+    .replace(/^[ \t]*BEGIN[ \t]*;[ \t]*$/m, "")
+    .replace(/^[ \t]*COMMIT[ \t]*;[ \t]*$/m, "");
+}
+
+function createClientConfig(env = process.env) {
+  const databaseUrl = clean(env.DATABASE_URL);
+  if (!databaseUrl) throw new Error("DATABASE_URL is required");
+  return {
+    connectionString: databaseUrl,
+    options: "-c timezone=Asia/Bangkok",
+    ssl: { rejectUnauthorized: false },
+  };
+}
+
+async function verifySchema(client) {
+  const catalogColumns = await client.query(`
+    SELECT column_name, data_type
+    FROM information_schema.columns
+    WHERE table_schema = 'public' AND table_name = 'catalog_items' AND column_name = 'is_hot'
+  `);
+  if (catalogColumns.rows?.[0]?.data_type !== "boolean") {
+    throw new Error("catalog_items.is_hot missing after migration");
+  }
+
+  const jobsColumns = await client.query(`
+    SELECT column_name, data_type
+    FROM information_schema.columns
+    WHERE table_schema = 'public' AND table_name = 'jobs'
+      AND column_name IN ('catalog_item_id', 'customer_sub')
+  `);
+  const jobsColumnTypes = new Map((jobsColumns.rows || []).map((row) => [row.column_name, row.data_type]));
+  if (jobsColumnTypes.get("catalog_item_id") !== "bigint") {
+    throw new Error("jobs.catalog_item_id missing after migration");
+  }
+  if (jobsColumnTypes.get("customer_sub") !== "text") {
+    throw new Error("jobs.customer_sub missing after migration");
+  }
+
+  const reviewsTable = await client.query("SELECT to_regclass('public.catalog_item_reviews') AS reg");
+  if (!reviewsTable.rows?.[0]?.reg) throw new Error("catalog_item_reviews table missing after migration");
+
+  const reviewsColumns = await client.query(`
+    SELECT column_name, data_type
+    FROM information_schema.columns
+    WHERE table_schema = 'public' AND table_name = 'catalog_item_reviews'
+  `);
+  const reviewsColumnTypes = new Map((reviewsColumns.rows || []).map((row) => [row.column_name, row.data_type]));
+  const requiredReviewColumns = {
+    review_id: "bigint",
+    item_id: "bigint",
+    completed_job_id: "bigint",
+    customer_identity: "text",
+    rating: "integer",
+    comment: "text",
+    moderation_status: "text",
+    created_at: "timestamp with time zone",
+    updated_at: "timestamp with time zone",
+    moderated_at: "timestamp with time zone",
+    moderated_by: "text",
+  };
+  Object.entries(requiredReviewColumns).forEach(([column, type]) => {
+    if (reviewsColumnTypes.get(column) !== type) {
+      throw new Error(`catalog_item_reviews.${column} missing after migration`);
+    }
+  });
+
+  const indexes = await client.query(`
+    SELECT indexname FROM pg_indexes
+    WHERE schemaname = 'public' AND tablename = 'catalog_item_reviews'
+  `);
+  const indexNames = new Set((indexes.rows || []).map((row) => row.indexname));
+  ["uq_catalog_item_reviews_job", "idx_catalog_item_reviews_item_status", "idx_catalog_item_reviews_created_at"].forEach((name) => {
+    if (!indexNames.has(name)) throw new Error(`${name} missing after migration`);
+  });
+
+  const constraints = await client.query(`
+    SELECT con.conname AS constraint_name, con.contype AS constraint_type
+    FROM pg_constraint con
+    JOIN pg_class rel ON rel.oid = con.conrelid
+    JOIN pg_namespace nsp ON nsp.oid = rel.relnamespace
+    WHERE nsp.nspname = 'public' AND rel.relname IN ('catalog_item_reviews', 'jobs')
+  `);
+  const constraintNames = new Set((constraints.rows || []).map((row) => row.constraint_name));
+  [
+    "catalog_item_reviews_rating_check",
+    "catalog_item_reviews_status_check",
+    "catalog_item_reviews_item_id_fkey",
+    "catalog_item_reviews_job_id_fkey",
+    "jobs_catalog_item_id_fkey",
+  ].forEach((name) => {
+    if (!constraintNames.has(name)) throw new Error(`${name} missing after migration`);
+  });
+}
+
+async function runMigration(options = {}) {
+  const env = options.env || process.env;
+  const logger = options.logger || console;
+  const repoRoot = options.repoRoot || path.resolve(__dirname, "..");
+  const clientFactory = options.clientFactory || ((config) => new Client(config));
+  const config = createClientConfig(env);
+  const sql = readMigrationSql(repoRoot);
+  const body = stripOuterTransactionWrapper(sql);
+  const client = clientFactory(config);
+  let locked = false;
+  let inTransaction = false;
+  let originalError = null;
+
+  logger.log("CATALOG_STORE_HOT_SALE_REVIEWS_MIGRATION_START");
+  try {
+    await client.connect();
+    await client.query("SELECT pg_advisory_lock($1::bigint)", [ADVISORY_LOCK_KEY]);
+    locked = true;
+
+    await client.query("BEGIN");
+    inTransaction = true;
+    await client.query(body);
+    await verifySchema(client);
+    await client.query("COMMIT");
+    inTransaction = false;
+    logger.log("CATALOG_STORE_HOT_SALE_REVIEWS_MIGRATION_OK");
+  } catch (error) {
+    originalError = error;
+    throw error;
+  } finally {
+    let cleanupError = null;
+    if (inTransaction) {
+      try {
+        await client.query("ROLLBACK");
+      } catch (error) {
+        cleanupError = cleanupError || error;
+      }
+    }
+    if (locked) {
+      try {
+        await client.query("SELECT pg_advisory_unlock($1::bigint)", [ADVISORY_LOCK_KEY]);
+      } catch (error) {
+        cleanupError = cleanupError || error;
+      }
+    }
+    try {
+      await client.end();
+    } catch (error) {
+      cleanupError = cleanupError || error;
+    }
+    if (!originalError && cleanupError) throw cleanupError;
+  }
+}
+
+async function runCli(options = {}) {
+  const logger = options.logger || console;
+  try {
+    await runMigration(options);
+    return 0;
+  } catch (error) {
+    logger.error(`CATALOG_STORE_HOT_SALE_REVIEWS_MIGRATION_FAILED: ${safeErrorMessage(error)}`);
+    return 1;
+  }
+}
+
+if (require.main === module) {
+  runCli().then((code) => {
+    process.exitCode = code;
+  });
+}
+
+module.exports = {
+  ADVISORY_LOCK_KEY,
+  MIGRATION_RELATIVE_PATH,
+  createClientConfig,
+  readMigrationSql,
+  resolveMigrationPath,
+  runCli,
+  runMigration,
+  safeErrorMessage,
+  stripOuterTransactionWrapper,
+  verifySchema,
+};

--- a/server/routes/catalog/items.js
+++ b/server/routes/catalog/items.js
@@ -61,6 +61,11 @@ const CATALOG_MARKETPLACE_FIELDS = [
   "booking_wash_variant", "is_featured", "is_autoplay_enabled",
 ];
 
+// HOT badge field (migrations/20260623_catalog_store_hot_sale_reviews.sql). Kept as
+// its own whitelist, mirroring CATALOG_MARKETPLACE_FIELDS, since it ships in a later
+// migration and needs its own independent schema-readiness gate.
+const CATALOG_HOT_FIELDS = ["is_hot"];
+
 const BOOKING_MODES = new Set(["bookable", "contact_admin"]);
 
 // Allowed values must match the Customer App's canonical lists exactly
@@ -80,7 +85,21 @@ function mergeCatalogItemPayload(existing, body) {
   CATALOG_MARKETPLACE_FIELDS.forEach((key) => {
     merged[key] = Object.prototype.hasOwnProperty.call(body, key) ? body[key] : existing[key];
   });
+  CATALOG_HOT_FIELDS.forEach((key) => {
+    merged[key] = Object.prototype.hasOwnProperty.call(body, key) ? body[key] : existing[key];
+  });
   return merged;
+}
+
+function validateHotField(merged) {
+  const isHotResult = normalizeBoolean(
+    Object.prototype.hasOwnProperty.call(merged, "is_hot") && merged.is_hot !== undefined && merged.is_hot !== null && merged.is_hot !== ""
+      ? merged.is_hot
+      : false,
+    "is_hot"
+  );
+  if (!isHotResult.ok) return { ok: false, errors: [isHotResult.error] };
+  return { ok: true, value: { is_hot: isHotResult.value } };
 }
 
 function parseOptionalText(value, fieldLabel, maxLen) {
@@ -361,10 +380,29 @@ const CATALOG_SELECT_MARKETPLACE_AUTOPLAY = `
   LEFT JOIN public.customer_service_price_rules pr ON pr.rule_id = ci.price_rule_id
 `;
 
-// Four-tier capability-driven SELECT: legacy (day one) -> +media/pricing -> +marketplace v2
-// -> +autoplay. Building from flags (rather than hand-written constants per combination)
-// keeps later tiers from drifting out of sync with earlier ones as all evolve.
-function buildCatalogSelect({ pricingReady, marketplaceReady, autoplayReady }) {
+// Adds the additive is_hot badge column (migrations/20260623_catalog_store_hot_sale_reviews.sql)
+// on top of CATALOG_SELECT_MARKETPLACE_AUTOPLAY. Kept as its own tier so is_hot is only ever
+// read/written once its own migration has actually run, regardless of autoplay's state.
+const CATALOG_SELECT_FULL = `
+  SELECT ci.item_id, ci.item_name, ci.item_category, ci.base_price, ci.unit_label, ci.is_active,
+         ci.job_category, ci.ac_type, ci.btu_min, ci.btu_max, ci.is_customer_visible,
+         ci.image_url, ci.image_public_id, ci.price_rule_id,
+         ci.short_description, ci.long_description, ci.highlights, ci.service_conditions,
+         ci.booking_mode, ci.booking_service_key, ci.booking_ac_type, ci.booking_btu,
+         ci.booking_wash_variant, ci.is_featured, ci.is_autoplay_enabled, ci.is_hot,
+         pr.normal_price AS rule_normal_price, pr.active_price AS rule_active_price,
+         pr.campaign_name AS rule_campaign_name, pr.is_active AS rule_is_active,
+         pr.effective_from AS rule_effective_from, pr.effective_to AS rule_effective_to,
+         pr.wash_variant AS rule_wash_variant, pr.label AS rule_label, pr.priority AS rule_priority
+  FROM public.catalog_items ci
+  LEFT JOIN public.customer_service_price_rules pr ON pr.rule_id = ci.price_rule_id
+`;
+
+// Five-tier capability-driven SELECT: legacy (day one) -> +media/pricing -> +marketplace v2
+// -> +autoplay -> +hot badge. Building from flags (rather than hand-written constants per
+// combination) keeps later tiers from drifting out of sync with earlier ones as all evolve.
+function buildCatalogSelect({ pricingReady, marketplaceReady, autoplayReady, hotReady }) {
+  if (marketplaceReady && autoplayReady && hotReady) return CATALOG_SELECT_FULL;
   if (marketplaceReady && autoplayReady) return CATALOG_SELECT_MARKETPLACE_AUTOPLAY;
   if (marketplaceReady) return CATALOG_SELECT_MARKETPLACE;
   if (pricingReady) return CATALOG_SELECT_WITH_PRICING;
@@ -390,6 +428,34 @@ async function attachCatalogImages(pool, rows, marketplaceReady) {
     byItem.get(imgRow.item_id).push(imgRow);
   });
   rows.forEach((row) => { row.images = byItem.get(row.item_id) || []; });
+  return rows;
+}
+
+// Attaches real review aggregates (approved reviews only) to each row in a single
+// grouped query, so the Store list never N+1s one rating query per item. Mirrors
+// attachCatalogImages's idiom. When the reviews schema hasn't been migrated yet
+// (or there are zero approved reviews), rows get rating_average=null/review_count=0
+// — never a fabricated default — so the renderer must show the honest "no reviews
+// yet" state.
+async function attachCatalogRatings(pool, rows, reviewsReady) {
+  if (!reviewsReady || !rows.length) {
+    rows.forEach((row) => { row.rating_average = null; row.review_count = 0; });
+    return rows;
+  }
+  const ids = rows.map((row) => row.item_id);
+  const r = await pool.query(
+    `SELECT item_id, AVG(rating)::numeric AS rating_average, COUNT(*)::int AS review_count
+       FROM public.catalog_item_reviews
+      WHERE item_id = ANY($1::bigint[]) AND moderation_status = 'approved'
+      GROUP BY item_id`,
+    [ids]
+  );
+  const byItem = new Map(r.rows.map((row) => [Number(row.item_id), row]));
+  rows.forEach((row) => {
+    const agg = byItem.get(Number(row.item_id));
+    row.rating_average = agg ? Number(agg.rating_average) : null;
+    row.review_count = agg ? Number(agg.review_count) : 0;
+  });
   return rows;
 }
 
@@ -506,6 +572,13 @@ function serializeCatalogRow(row) {
     // migration has actually run, and a pre-migration item must never be silently
     // treated as autoplay-enabled.
     is_autoplay_enabled: row.is_autoplay_enabled === undefined ? false : Boolean(row.is_autoplay_enabled),
+    // Fail-safe disabled, same idiom: a pre-migration item is never silently HOT.
+    is_hot: Boolean(row.is_hot),
+    // Real review aggregates only (approved reviews); attachCatalogRatings() sets
+    // these to rating_average=null/review_count=0 when there are no real reviews
+    // yet — the renderer must treat that as "no reviews", never a fabricated score.
+    rating_average: row.rating_average == null ? null : Number(row.rating_average),
+    review_count: Number(row.review_count || 0),
   };
 }
 
@@ -672,12 +745,42 @@ module.exports = function createCatalogItemRoutes(deps = {}) {
     return ready;
   }
 
+  // Mirrors the same capability-check idiom for the additive HOT badge column
+  // (migrations/20260623_catalog_store_hot_sale_reviews.sql).
+  let hotSchemaReadyCache = false;
+  async function isHotSchemaReady(db) {
+    if (hotSchemaReadyCache) return true;
+    const r = await db.query(`
+      SELECT COUNT(*)::int AS cnt
+      FROM information_schema.columns
+      WHERE table_schema = 'public' AND table_name = 'catalog_items'
+        AND column_name = 'is_hot'
+    `);
+    const ready = Number(r.rows?.[0]?.cnt || 0) === 1;
+    if (ready) hotSchemaReadyCache = true;
+    return ready;
+  }
+
+  // Same migration adds public.catalog_item_reviews; gated independently since a
+  // deployment could in principle have is_hot but not yet have run far enough for
+  // the table (both ship in the same file, but this stays defensive/explicit).
+  let reviewsSchemaReadyCache = false;
+  async function isReviewsSchemaReady(db) {
+    if (reviewsSchemaReadyCache) return true;
+    const r = await db.query(`SELECT to_regclass('public.catalog_item_reviews') AS reg`);
+    const ready = Boolean(r.rows?.[0]?.reg);
+    if (ready) reviewsSchemaReadyCache = true;
+    return ready;
+  }
+
   router.get("/catalog/items", async (req, res) => {
     try {
       const pricingReady = await isMediaPricingSchemaReady(pool);
       const marketplaceReady = await isMarketplaceSchemaReady(pool);
       const autoplayReady = await isAutoplaySchemaReady(pool);
-      const select = buildCatalogSelect({ pricingReady, marketplaceReady, autoplayReady });
+      const hotReady = await isHotSchemaReady(pool);
+      const reviewsReady = await isReviewsSchemaReady(pool);
+      const select = buildCatalogSelect({ pricingReady, marketplaceReady, autoplayReady, hotReady });
       const customer = String(req.query.customer || "").trim() === "1";
       const job_category = (req.query.job_category || "").toString().trim();
       const ac_type = (req.query.ac_type || "").toString().trim();
@@ -702,6 +805,7 @@ module.exports = function createCatalogItemRoutes(deps = {}) {
         params
       );
       await attachCatalogImages(pool, r.rows, marketplaceReady);
+      await attachCatalogRatings(pool, r.rows, reviewsReady);
       res.json(r.rows.map(serializeCatalogRow));
     } catch (e) {
       console.error(e);
@@ -717,7 +821,9 @@ module.exports = function createCatalogItemRoutes(deps = {}) {
       const pricingReady = await isMediaPricingSchemaReady(pool);
       const marketplaceReady = await isMarketplaceSchemaReady(pool);
       const autoplayReady = await isAutoplaySchemaReady(pool);
-      const select = buildCatalogSelect({ pricingReady, marketplaceReady, autoplayReady });
+      const hotReady = await isHotSchemaReady(pool);
+      const reviewsReady = await isReviewsSchemaReady(pool);
+      const select = buildCatalogSelect({ pricingReady, marketplaceReady, autoplayReady, hotReady });
 
       const r = await pool.query(
         `${select} WHERE ci.item_id = $1 AND ci.is_active = TRUE AND ci.is_customer_visible = TRUE`,
@@ -726,6 +832,7 @@ module.exports = function createCatalogItemRoutes(deps = {}) {
       const row = r.rows[0];
       if (!row) return res.status(404).json({ error: "ไม่พบรายการนี้" });
       await attachCatalogImages(pool, [row], marketplaceReady);
+      await attachCatalogRatings(pool, [row], reviewsReady);
       res.json(serializeCatalogDetailRow(row));
     } catch (e) {
       console.error(e);
@@ -738,9 +845,12 @@ module.exports = function createCatalogItemRoutes(deps = {}) {
       const pricingReady = await isMediaPricingSchemaReady(pool);
       const marketplaceReady = await isMarketplaceSchemaReady(pool);
       const autoplayReady = await isAutoplaySchemaReady(pool);
-      const select = buildCatalogSelect({ pricingReady, marketplaceReady, autoplayReady });
+      const hotReady = await isHotSchemaReady(pool);
+      const reviewsReady = await isReviewsSchemaReady(pool);
+      const select = buildCatalogSelect({ pricingReady, marketplaceReady, autoplayReady, hotReady });
       const r = await pool.query(`${select} ORDER BY ci.item_category, ci.item_name`);
       await attachCatalogImages(pool, r.rows, marketplaceReady);
+      await attachCatalogRatings(pool, r.rows, reviewsReady);
       res.json(r.rows.map(serializeAdminCatalogRow));
     } catch (e) {
       console.error(e);
@@ -761,28 +871,51 @@ module.exports = function createCatalogItemRoutes(deps = {}) {
     const marketplaceResult = validateMarketplaceFields(merged);
     if (!marketplaceResult.ok) return res.status(400).json({ error: marketplaceResult.errors.join(", ") });
 
+    const hotResult = validateHotField(merged);
+    if (!hotResult.ok) return res.status(400).json({ error: hotResult.errors.join(", ") });
+
     const hasPricingKey = req.body && Object.prototype.hasOwnProperty.call(req.body, "pricing");
     const pricingResult = hasPricingKey ? validatePricingInput(req.body.pricing) : { ok: true, value: undefined };
     if (!pricingResult.ok) return res.status(400).json({ error: pricingResult.errors.join(", ") });
 
     const hasMarketplaceKey = CATALOG_MARKETPLACE_FIELDS.some((key) => Object.prototype.hasOwnProperty.call(req.body || {}, key));
+    const hasHotKey = CATALOG_HOT_FIELDS.some((key) => Object.prototype.hasOwnProperty.call(req.body || {}, key));
     const schemaReady = await isMediaPricingSchemaReady(pool);
     const marketplaceReady = await isMarketplaceSchemaReady(pool);
     const autoplayReady = await isAutoplaySchemaReady(pool);
+    const hotReady = await isHotSchemaReady(pool);
     if (pricingResult.value && !schemaReady) {
       return res.status(503).json({ error: "ระบบราคาโปรโมชันยังไม่พร้อมใช้งาน (ยังไม่ได้รัน migration)" });
     }
     if (hasMarketplaceKey && !marketplaceReady) {
       return res.status(503).json({ error: "ระบบ Marketplace ยังไม่พร้อมใช้งาน (ยังไม่ได้รัน migration)" });
     }
+    if (hasHotKey && !hotReady) {
+      return res.status(503).json({ error: "ระบบ HOT badge ยังไม่พร้อมใช้งาน (ยังไม่ได้รัน migration)" });
+    }
 
     const v = result.value;
     const mv = marketplaceResult.value;
+    const hv = hotResult.value;
     const client = await pool.connect();
     try {
       await client.query("BEGIN");
       let insertRes;
-      if (marketplaceReady && autoplayReady) {
+      if (marketplaceReady && autoplayReady && hotReady) {
+        insertRes = await client.query(
+          `INSERT INTO public.catalog_items
+             (item_name, item_category, base_price, unit_label, job_category, ac_type, btu_min, btu_max, is_active, is_customer_visible,
+              short_description, long_description, highlights, service_conditions,
+              booking_mode, booking_service_key, booking_ac_type, booking_btu, booking_wash_variant, is_featured, is_autoplay_enabled, is_hot)
+           VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21,$22)
+           RETURNING item_id`,
+          [
+            v.item_name, v.item_category, v.base_price, v.unit_label, v.job_category, v.ac_type, v.btu_min, v.btu_max, v.is_active, v.is_customer_visible,
+            mv.short_description, mv.long_description, mv.highlights ? JSON.stringify(mv.highlights) : null, mv.service_conditions,
+            mv.booking_mode, mv.booking_service_key, mv.booking_ac_type, mv.booking_btu, mv.booking_wash_variant, mv.is_featured, mv.is_autoplay_enabled, hv.is_hot,
+          ]
+        );
+      } else if (marketplaceReady && autoplayReady) {
         insertRes = await client.query(
           `INSERT INTO public.catalog_items
              (item_name, item_category, base_price, unit_label, job_category, ac_type, btu_min, btu_max, is_active, is_customer_visible,
@@ -833,9 +966,10 @@ module.exports = function createCatalogItemRoutes(deps = {}) {
 
       await client.query("COMMIT");
 
-      const select = buildCatalogSelect({ pricingReady: schemaReady, marketplaceReady, autoplayReady });
+      const select = buildCatalogSelect({ pricingReady: schemaReady, marketplaceReady, autoplayReady, hotReady });
       const final = await client.query(`${select} WHERE ci.item_id = $1`, [itemId]);
       await attachCatalogImages(client, final.rows, marketplaceReady);
+      await attachCatalogRatings(client, final.rows, await isReviewsSchemaReady(client));
       res.status(201).json(serializeAdminCatalogRow(final.rows[0]));
     } catch (e) {
       await client.query("ROLLBACK").catch(() => {});
@@ -853,7 +987,8 @@ module.exports = function createCatalogItemRoutes(deps = {}) {
     const schemaReady = await isMediaPricingSchemaReady(pool);
     const marketplaceReady = await isMarketplaceSchemaReady(pool);
     const autoplayReady = await isAutoplaySchemaReady(pool);
-    const select = buildCatalogSelect({ pricingReady: schemaReady, marketplaceReady, autoplayReady });
+    const hotReady = await isHotSchemaReady(pool);
+    const select = buildCatalogSelect({ pricingReady: schemaReady, marketplaceReady, autoplayReady, hotReady });
     const existingResult = await pool.query(`${select} WHERE ci.item_id = $1`, [itemId]);
     const existing = existingResult.rows[0];
     if (!existing) return res.status(404).json({ error: "ไม่พบรายการนี้" });
@@ -864,6 +999,9 @@ module.exports = function createCatalogItemRoutes(deps = {}) {
 
     const marketplaceResult = validateMarketplaceFields(merged);
     if (!marketplaceResult.ok) return res.status(400).json({ error: marketplaceResult.errors.join(", ") });
+
+    const hotResult = validateHotField(merged);
+    if (!hotResult.ok) return res.status(400).json({ error: hotResult.errors.join(", ") });
 
     const hasPricingKey = req.body && Object.prototype.hasOwnProperty.call(req.body, "pricing");
     const pricingResult = hasPricingKey ? validatePricingInput(req.body.pricing) : { ok: true, value: undefined };
@@ -877,12 +1015,35 @@ module.exports = function createCatalogItemRoutes(deps = {}) {
       return res.status(503).json({ error: "ระบบ Marketplace ยังไม่พร้อมใช้งาน (ยังไม่ได้รัน migration)" });
     }
 
+    const hasHotKey = CATALOG_HOT_FIELDS.some((key) => Object.prototype.hasOwnProperty.call(req.body || {}, key));
+    if (hasHotKey && !hotReady) {
+      return res.status(503).json({ error: "ระบบ HOT badge ยังไม่พร้อมใช้งาน (ยังไม่ได้รัน migration)" });
+    }
+
     const v = result.value;
     const mv = marketplaceResult.value;
+    const hv = hotResult.value;
     const client = await pool.connect();
     try {
       await client.query("BEGIN");
-      if (marketplaceReady && autoplayReady) {
+      if (marketplaceReady && autoplayReady && hotReady) {
+        await client.query(
+          `UPDATE public.catalog_items
+              SET item_name=$1, item_category=$2, base_price=$3, unit_label=$4,
+                  job_category=$5, ac_type=$6, btu_min=$7, btu_max=$8,
+                  is_active=$9, is_customer_visible=$10,
+                  short_description=$11, long_description=$12, highlights=$13, service_conditions=$14,
+                  booking_mode=$15, booking_service_key=$16, booking_ac_type=$17, booking_btu=$18,
+                  booking_wash_variant=$19, is_featured=$20, is_autoplay_enabled=$21, is_hot=$22
+            WHERE item_id = $23`,
+          [
+            v.item_name, v.item_category, v.base_price, v.unit_label, v.job_category, v.ac_type, v.btu_min, v.btu_max, v.is_active, v.is_customer_visible,
+            mv.short_description, mv.long_description, mv.highlights ? JSON.stringify(mv.highlights) : null, mv.service_conditions,
+            mv.booking_mode, mv.booking_service_key, mv.booking_ac_type, mv.booking_btu, mv.booking_wash_variant, mv.is_featured, mv.is_autoplay_enabled, hv.is_hot,
+            itemId,
+          ]
+        );
+      } else if (marketplaceReady && autoplayReady) {
         await client.query(
           `UPDATE public.catalog_items
               SET item_name=$1, item_category=$2, base_price=$3, unit_label=$4,
@@ -947,6 +1108,7 @@ module.exports = function createCatalogItemRoutes(deps = {}) {
 
       const final = await client.query(`${select} WHERE ci.item_id = $1`, [itemId]);
       await attachCatalogImages(client, final.rows, marketplaceReady);
+      await attachCatalogRatings(client, final.rows, await isReviewsSchemaReady(client));
       res.json(serializeAdminCatalogRow(final.rows[0]));
     } catch (e) {
       await client.query("ROLLBACK").catch(() => {});
@@ -1080,7 +1242,8 @@ module.exports = function createCatalogItemRoutes(deps = {}) {
 
         const marketplaceReady = await isMarketplaceSchemaReady(pool);
         const autoplayReady = await isAutoplaySchemaReady(pool);
-        const select = buildCatalogSelect({ pricingReady: true, marketplaceReady, autoplayReady });
+        const hotReady = await isHotSchemaReady(pool);
+        const select = buildCatalogSelect({ pricingReady: true, marketplaceReady, autoplayReady, hotReady });
         const final = await pool.query(`${select} WHERE ci.item_id = $1`, [itemId]);
         await attachCatalogImages(pool, final.rows, marketplaceReady);
         res.json(serializeAdminCatalogRow(final.rows[0]));
@@ -1130,7 +1293,8 @@ module.exports = function createCatalogItemRoutes(deps = {}) {
 
       const marketplaceReady = await isMarketplaceSchemaReady(pool);
       const autoplayReady = await isAutoplaySchemaReady(pool);
-      const select = buildCatalogSelect({ pricingReady: true, marketplaceReady, autoplayReady });
+      const hotReady = await isHotSchemaReady(pool);
+      const select = buildCatalogSelect({ pricingReady: true, marketplaceReady, autoplayReady, hotReady });
       const final = await pool.query(`${select} WHERE ci.item_id = $1`, [itemId]);
       await attachCatalogImages(pool, final.rows, marketplaceReady);
       res.json(serializeAdminCatalogRow(final.rows[0]));
@@ -1439,3 +1603,5 @@ module.exports.validatePricingInput = validatePricingInput;
 module.exports.validateMarketplaceFields = validateMarketplaceFields;
 module.exports.buildCatalogSelect = buildCatalogSelect;
 module.exports.MAX_CATALOG_IMAGES_PER_ITEM = MAX_CATALOG_IMAGES_PER_ITEM;
+module.exports.validateHotField = validateHotField;
+module.exports.attachCatalogRatings = attachCatalogRatings;

--- a/server/routes/catalog/reviews.js
+++ b/server/routes/catalog/reviews.js
@@ -14,6 +14,33 @@ const MAX_COMMENT_LENGTH = 500;
 const REVIEW_PUBLIC_PAGE_SIZE = 10;
 const REVIEW_PUBLIC_PAGE_SIZE_MAX = 50;
 
+// Minimal in-memory fixed-window limiter (mirrors the in-memory Map +
+// sweep-expired pattern already used by server/customerAuth.js's OAuth
+// state store). Scoped to this module only — not a new auth system, just a
+// per-process request throttle so review submission can't be hammered.
+function createFixedWindowLimiter({ windowMs, maxRequests, now = () => Date.now() }) {
+  const hits = new Map();
+  function sweepExpired(currentNow) {
+    for (const [key, entry] of hits.entries()) {
+      if (currentNow - entry.windowStart >= windowMs) hits.delete(key);
+    }
+  }
+  return {
+    consume(key) {
+      const currentNow = now();
+      sweepExpired(currentNow);
+      let entry = hits.get(key);
+      if (!entry || currentNow - entry.windowStart >= windowMs) {
+        entry = { count: 0, windowStart: currentNow };
+      }
+      entry.count += 1;
+      hits.set(key, entry);
+      return entry.count <= maxRequests;
+    },
+    _hits: hits,
+  };
+}
+
 function maskCustomerDisplayName(name) {
   const trimmed = String(name || "").trim();
   if (!trimmed) return "คุณลูกค้า";
@@ -52,6 +79,20 @@ module.exports = function createCatalogReviewRoutes(deps = {}) {
     throw new Error("createCatalogReviewRoutes requires a requireAdminSession middleware function");
   }
 
+  // Two independent buckets: per-customer (the genuine identity) and per-IP
+  // (defense-in-depth against one account hammering from many IPs is not the
+  // concern here — this guards against scripted abuse hitting the endpoint
+  // regardless of how many accounts it cycles through). Only the POST
+  // submission route consumes these; GET /reviews stays unrestricted.
+  const reviewSubmitCustomerLimiter = deps.reviewSubmitCustomerLimiter || createFixedWindowLimiter({
+    windowMs: deps.reviewSubmitCustomerLimitWindowMs || 10 * 60 * 1000,
+    maxRequests: deps.reviewSubmitCustomerLimitMax || 5,
+  });
+  const reviewSubmitIpLimiter = deps.reviewSubmitIpLimiter || createFixedWindowLimiter({
+    windowMs: deps.reviewSubmitIpLimitWindowMs || 10 * 60 * 1000,
+    maxRequests: deps.reviewSubmitIpLimitMax || 20,
+  });
+
   let reviewsSchemaReadyCache = false;
   async function isReviewsSchemaReady(db) {
     if (reviewsSchemaReadyCache) return true;
@@ -78,8 +119,13 @@ module.exports = function createCatalogReviewRoutes(deps = {}) {
   // for this item — the source of truth for both "is eligible at all" and
   // "which job should this review be attached to". Never trusts client input
   // for ownership: the job row itself must carry this customer's sub.
-  async function findEligibleJobsForReview(customerSub, itemId) {
-    const r = await pool.query(
+  //
+  // `db` is either the module pool (read-only eligibility check, no lock
+  // needed) or a transaction client (submission path, where forUpdate=true
+  // locks the matching job rows for the duration of the transaction so two
+  // concurrent submissions for the same job can't both see it as eligible).
+  async function findEligibleJobsForReview(db, customerSub, itemId, { forUpdate = false } = {}) {
+    const r = await db.query(
       `SELECT j.job_id, j.appointment_datetime
          FROM public.jobs j
         WHERE j.customer_sub = $1
@@ -88,7 +134,7 @@ module.exports = function createCatalogReviewRoutes(deps = {}) {
           AND NOT EXISTS (
             SELECT 1 FROM public.catalog_item_reviews r WHERE r.completed_job_id = j.job_id
           )
-        ORDER BY j.appointment_datetime DESC`,
+        ORDER BY j.appointment_datetime DESC${forUpdate ? "\n        FOR UPDATE OF j" : ""}`,
       [customerSub, itemId, Array.from(DONE_JOB_STATUSES)]
     );
     return r.rows;
@@ -159,7 +205,7 @@ module.exports = function createCatalogReviewRoutes(deps = {}) {
       const itemR = await pool.query(`SELECT item_id FROM public.catalog_items WHERE item_id = $1`, [itemId]);
       if (!itemR.rows.length) return res.json({ eligible: false, eligible_jobs: [] });
 
-      const jobs = await findEligibleJobsForReview(customerSub, itemId);
+      const jobs = await findEligibleJobsForReview(pool, customerSub, itemId);
       res.json({
         eligible: jobs.length > 0,
         eligible_jobs: jobs.map((j) => ({ job_id: Number(j.job_id), appointment_datetime: j.appointment_datetime })),
@@ -189,27 +235,46 @@ module.exports = function createCatalogReviewRoutes(deps = {}) {
       const customerSub = String(req.customer?.sub || "");
       if (!customerSub) return res.status(401).json({ error: "กรุณาเข้าสู่ระบบ" });
 
+      // Rate-limit before doing any DB work. Both buckets are always
+      // consumed (even on a non-eligible request) so the limit can't be
+      // bypassed by retrying with a different job_id.
+      const ip = String(req.ip || req.connection?.remoteAddress || "unknown");
+      const withinCustomerLimit = reviewSubmitCustomerLimiter.consume(`cust:${customerSub}`);
+      const withinIpLimit = reviewSubmitIpLimiter.consume(`ip:${ip}`);
+      if (!withinCustomerLimit || !withinIpLimit) {
+        return res.status(429).json({ error: "คุณส่งรีวิวบ่อยเกินไป กรุณาลองใหม่ในอีกสักครู่" });
+      }
+
       const validated = validateRatingAndComment(req.body || {});
       if (!validated.ok) return res.status(400).json({ error: validated.error });
 
       const requestedJobId = Number(req.body?.job_id);
-      const eligibleJobs = await findEligibleJobsForReview(customerSub, itemId);
-      const matchedJob = Number.isFinite(requestedJobId)
-        ? eligibleJobs.find((j) => Number(j.job_id) === requestedJobId)
-        : eligibleJobs[0];
-
-      if (!matchedJob) {
-        return res.status(403).json({ error: "คุณยังไม่มีงานที่เสร็จสมบูรณ์สำหรับสินค้า/บริการนี้ หรือเคยรีวิวงานนี้ไปแล้ว" });
-      }
 
       await client.query("BEGIN");
-      // customer_identity stores only the customer's own display name as it appeared
-      // at submission time (used solely to derive the public masked label, e.g.
-      // "คุณ ส***") — never the LINE sub, phone, or email. Ownership/eligibility is
-      // already fully re-verified above from jobs.customer_sub, not from this column.
-      const customerIdentity = String(req.customer?.name || "").trim() || "ลูกค้า";
       let insertResult;
+      let matchedJob;
       try {
+        // Re-verify everything inside the transaction, with the candidate
+        // job rows locked (FOR UPDATE) so a concurrent submission for the
+        // same job can't also see it as eligible before either commits:
+        // ownership (customer_sub), catalog linkage (catalog_item_id),
+        // genuine completion (job_status), and not-already-reviewed
+        // (NOT EXISTS against catalog_item_reviews) are all re-checked here,
+        // not trusted from any earlier read or from client input.
+        const eligibleJobs = await findEligibleJobsForReview(client, customerSub, itemId, { forUpdate: true });
+        matchedJob = Number.isFinite(requestedJobId)
+          ? eligibleJobs.find((j) => Number(j.job_id) === requestedJobId)
+          : eligibleJobs[0];
+
+        if (!matchedJob) {
+          await client.query("ROLLBACK");
+          return res.status(403).json({ error: "คุณยังไม่มีงานที่เสร็จสมบูรณ์สำหรับสินค้า/บริการนี้ หรือเคยรีวิวงานนี้ไปแล้ว" });
+        }
+
+        // customer_identity stores only the customer's own display name as it
+        // appeared at submission time (used solely to derive the public masked
+        // label, e.g. "คุณ ส***") — never the LINE sub, phone, or email.
+        const customerIdentity = String(req.customer?.name || "").trim() || "ลูกค้า";
         insertResult = await client.query(
           `INSERT INTO public.catalog_item_reviews
              (item_id, completed_job_id, customer_identity, rating, comment, moderation_status)
@@ -325,3 +390,4 @@ module.exports.MAX_COMMENT_LENGTH = MAX_COMMENT_LENGTH;
 module.exports.maskCustomerDisplayName = maskCustomerDisplayName;
 module.exports.validateRatingAndComment = validateRatingAndComment;
 module.exports.DONE_JOB_STATUSES = DONE_JOB_STATUSES;
+module.exports.createFixedWindowLimiter = createFixedWindowLimiter;

--- a/server/routes/catalog/reviews.js
+++ b/server/routes/catalog/reviews.js
@@ -1,0 +1,327 @@
+// Verified customer reviews for Store catalog items
+// (migrations/20260623_catalog_store_hot_sale_reviews.sql).
+//
+// Eligibility to submit a review is never trusted from the client: every
+// request re-derives "did this customer really complete this job for this
+// catalog item, and have they not already reviewed it" from the database
+// itself (jobs + catalog_item_reviews), using the same job-status vocabulary
+// the rest of the app already treats as "completed" (mirrors index.js's
+// STATUS_BUCKETS.done — kept here as a local copy since index.js does not
+// export it; if that set changes there, update this one too).
+const DONE_JOB_STATUSES = new Set(["เสร็จแล้ว", "เสร็จสิ้น", "ปิดงาน", "completed", "done"]);
+
+const MAX_COMMENT_LENGTH = 500;
+const REVIEW_PUBLIC_PAGE_SIZE = 10;
+const REVIEW_PUBLIC_PAGE_SIZE_MAX = 50;
+
+function maskCustomerDisplayName(name) {
+  const trimmed = String(name || "").trim();
+  if (!trimmed) return "คุณลูกค้า";
+  const first = trimmed[0];
+  return `คุณ ${first}${"*".repeat(Math.max(1, Math.min(trimmed.length - 1, 4)))}`;
+}
+
+function validateRatingAndComment(body) {
+  const rating = Number(body?.rating);
+  if (!Number.isInteger(rating) || rating < 1 || rating > 5) {
+    return { ok: false, error: "กรุณาให้คะแนน 1-5 ดาว" };
+  }
+  let comment = body?.comment;
+  if (comment === undefined || comment === null) {
+    comment = null;
+  } else {
+    comment = String(comment).trim();
+    if (comment.length > MAX_COMMENT_LENGTH) {
+      return { ok: false, error: `ความเห็นต้องไม่เกิน ${MAX_COMMENT_LENGTH} ตัวอักษร` };
+    }
+    if (!comment) comment = null;
+  }
+  return { ok: true, value: { rating, comment } };
+}
+
+module.exports = function createCatalogReviewRoutes(deps = {}) {
+  const express = require("express");
+  const router = express.Router();
+  const pool = deps.pool || require("../../db/pool");
+  const requireCustomerJwt = deps.requireCustomerJwt;
+  if (typeof requireCustomerJwt !== "function") {
+    throw new Error("createCatalogReviewRoutes requires a requireCustomerJwt middleware function");
+  }
+  const requireAdminSession = deps.requireAdminSession;
+  if (typeof requireAdminSession !== "function") {
+    throw new Error("createCatalogReviewRoutes requires a requireAdminSession middleware function");
+  }
+
+  let reviewsSchemaReadyCache = false;
+  async function isReviewsSchemaReady(db) {
+    if (reviewsSchemaReadyCache) return true;
+    const r = await db.query(`SELECT to_regclass('public.catalog_item_reviews') AS reg`);
+    const ready = Boolean(r.rows?.[0]?.reg);
+    if (ready) reviewsSchemaReadyCache = true;
+    return ready;
+  }
+
+  let jobsCatalogLinkSchemaReadyCache = false;
+  async function isJobsCatalogLinkSchemaReady(db) {
+    if (jobsCatalogLinkSchemaReadyCache) return true;
+    const r = await db.query(`
+      SELECT COUNT(*)::int AS cnt FROM information_schema.columns
+       WHERE table_schema = 'public' AND table_name = 'jobs'
+         AND column_name IN ('catalog_item_id', 'customer_sub')
+    `);
+    const ready = Number(r.rows?.[0]?.cnt || 0) === 2;
+    if (ready) jobsCatalogLinkSchemaReadyCache = true;
+    return ready;
+  }
+
+  // Returns the customer's completed, catalog-linked, not-yet-reviewed jobs
+  // for this item — the source of truth for both "is eligible at all" and
+  // "which job should this review be attached to". Never trusts client input
+  // for ownership: the job row itself must carry this customer's sub.
+  async function findEligibleJobsForReview(customerSub, itemId) {
+    const r = await pool.query(
+      `SELECT j.job_id, j.appointment_datetime
+         FROM public.jobs j
+        WHERE j.customer_sub = $1
+          AND j.catalog_item_id = $2
+          AND j.job_status = ANY($3::text[])
+          AND NOT EXISTS (
+            SELECT 1 FROM public.catalog_item_reviews r WHERE r.completed_job_id = j.job_id
+          )
+        ORDER BY j.appointment_datetime DESC`,
+      [customerSub, itemId, Array.from(DONE_JOB_STATUSES)]
+    );
+    return r.rows;
+  }
+
+  // GET /catalog/items/:itemId/reviews — public, paginated, approved-only.
+  router.get("/catalog/items/:itemId/reviews", async (req, res) => {
+    try {
+      const itemId = Number(req.params.itemId);
+      if (!Number.isFinite(itemId) || itemId <= 0) {
+        return res.status(400).json({ error: "item_id ไม่ถูกต้อง" });
+      }
+      const reviewsReady = await isReviewsSchemaReady(pool);
+      if (!reviewsReady) return res.json({ reviews: [], total: 0, rating_average: null, review_count: 0 });
+
+      const pageSize = Math.min(REVIEW_PUBLIC_PAGE_SIZE_MAX, Math.max(1, Number(req.query.limit) || REVIEW_PUBLIC_PAGE_SIZE));
+      const offset = Math.max(0, Number(req.query.offset) || 0);
+
+      const aggR = await pool.query(
+        `SELECT AVG(rating)::numeric AS rating_average, COUNT(*)::int AS review_count
+           FROM public.catalog_item_reviews WHERE item_id = $1 AND moderation_status = 'approved'`,
+        [itemId]
+      );
+      const ratingAverage = aggR.rows?.[0]?.rating_average == null ? null : Number(aggR.rows[0].rating_average);
+      const reviewCount = Number(aggR.rows?.[0]?.review_count || 0);
+
+      const listR = await pool.query(
+        `SELECT review_id, rating, comment, created_at, customer_identity
+           FROM public.catalog_item_reviews
+          WHERE item_id = $1 AND moderation_status = 'approved'
+          ORDER BY created_at DESC
+          LIMIT $2 OFFSET $3`,
+        [itemId, pageSize, offset]
+      );
+
+      // Public payload never exposes phone/email/internal customer ID/job ID/booking code/moderation data.
+      const reviews = listR.rows.map((row) => ({
+        review_id: Number(row.review_id),
+        rating: Number(row.rating),
+        comment: row.comment || "",
+        display_name: maskCustomerDisplayName(row.customer_identity),
+        created_at: row.created_at,
+      }));
+
+      res.json({ reviews, total: reviewCount, rating_average: ratingAverage, review_count: reviewCount });
+    } catch (e) {
+      console.error(e);
+      res.status(500).json({ error: "โหลดรีวิวไม่สำเร็จ" });
+    }
+  });
+
+  // GET /catalog/items/:itemId/reviews/eligibility — requires customer session.
+  // Tells the UI honestly whether a "เขียนรีวิว" button/form may be shown.
+  router.get("/catalog/items/:itemId/reviews/eligibility", requireCustomerJwt, async (req, res) => {
+    try {
+      const itemId = Number(req.params.itemId);
+      if (!Number.isFinite(itemId) || itemId <= 0) {
+        return res.status(400).json({ error: "item_id ไม่ถูกต้อง" });
+      }
+      const linkReady = await isJobsCatalogLinkSchemaReady(pool);
+      const reviewsReady = await isReviewsSchemaReady(pool);
+      if (!linkReady || !reviewsReady) {
+        return res.json({ eligible: false, eligible_jobs: [] });
+      }
+      const customerSub = String(req.customer?.sub || "");
+      if (!customerSub) return res.json({ eligible: false, eligible_jobs: [] });
+
+      const itemR = await pool.query(`SELECT item_id FROM public.catalog_items WHERE item_id = $1`, [itemId]);
+      if (!itemR.rows.length) return res.json({ eligible: false, eligible_jobs: [] });
+
+      const jobs = await findEligibleJobsForReview(customerSub, itemId);
+      res.json({
+        eligible: jobs.length > 0,
+        eligible_jobs: jobs.map((j) => ({ job_id: Number(j.job_id), appointment_datetime: j.appointment_datetime })),
+      });
+    } catch (e) {
+      console.error(e);
+      res.status(500).json({ error: "ตรวจสอบสิทธิ์รีวิวไม่สำเร็จ" });
+    }
+  });
+
+  // POST /catalog/items/:itemId/reviews — requires customer session. Re-verifies
+  // every eligibility condition server-side; never trusts a client-supplied job_id
+  // beyond confirming it's one of *this* customer's own genuinely eligible jobs.
+  router.post("/catalog/items/:itemId/reviews", requireCustomerJwt, async (req, res) => {
+    const client = await pool.connect();
+    try {
+      const itemId = Number(req.params.itemId);
+      if (!Number.isFinite(itemId) || itemId <= 0) {
+        return res.status(400).json({ error: "item_id ไม่ถูกต้อง" });
+      }
+      const linkReady = await isJobsCatalogLinkSchemaReady(pool);
+      const reviewsReady = await isReviewsSchemaReady(pool);
+      if (!linkReady || !reviewsReady) {
+        return res.status(503).json({ error: "ระบบรีวิวยังไม่พร้อมใช้งาน (ยังไม่ได้รัน migration)" });
+      }
+
+      const customerSub = String(req.customer?.sub || "");
+      if (!customerSub) return res.status(401).json({ error: "กรุณาเข้าสู่ระบบ" });
+
+      const validated = validateRatingAndComment(req.body || {});
+      if (!validated.ok) return res.status(400).json({ error: validated.error });
+
+      const requestedJobId = Number(req.body?.job_id);
+      const eligibleJobs = await findEligibleJobsForReview(customerSub, itemId);
+      const matchedJob = Number.isFinite(requestedJobId)
+        ? eligibleJobs.find((j) => Number(j.job_id) === requestedJobId)
+        : eligibleJobs[0];
+
+      if (!matchedJob) {
+        return res.status(403).json({ error: "คุณยังไม่มีงานที่เสร็จสมบูรณ์สำหรับสินค้า/บริการนี้ หรือเคยรีวิวงานนี้ไปแล้ว" });
+      }
+
+      await client.query("BEGIN");
+      // customer_identity stores only the customer's own display name as it appeared
+      // at submission time (used solely to derive the public masked label, e.g.
+      // "คุณ ส***") — never the LINE sub, phone, or email. Ownership/eligibility is
+      // already fully re-verified above from jobs.customer_sub, not from this column.
+      const customerIdentity = String(req.customer?.name || "").trim() || "ลูกค้า";
+      let insertResult;
+      try {
+        insertResult = await client.query(
+          `INSERT INTO public.catalog_item_reviews
+             (item_id, completed_job_id, customer_identity, rating, comment, moderation_status)
+           VALUES ($1, $2, $3, $4, $5, 'pending')
+           RETURNING review_id, created_at`,
+          [itemId, matchedJob.job_id, customerIdentity, validated.value.rating, validated.value.comment]
+        );
+      } catch (insertError) {
+        await client.query("ROLLBACK");
+        if (insertError && insertError.code === "23505") {
+          return res.status(409).json({ error: "งานนี้ถูกใช้รีวิวไปแล้ว" });
+        }
+        throw insertError;
+      }
+      await client.query("COMMIT");
+
+      console.log("[catalog_review_submit]", { item_id: itemId, job_id: matchedJob.job_id, review_id: insertResult.rows[0].review_id });
+      res.status(201).json({
+        review_id: Number(insertResult.rows[0].review_id),
+        moderation_status: "pending",
+        created_at: insertResult.rows[0].created_at,
+      });
+    } catch (e) {
+      try { await client.query("ROLLBACK"); } catch (_) {}
+      console.error(e);
+      res.status(500).json({ error: "ส่งรีวิวไม่สำเร็จ" });
+    } finally {
+      client.release();
+    }
+  });
+
+  // ---- Admin moderation ----
+
+  router.get("/admin/catalog/reviews", requireAdminSession, async (req, res) => {
+    try {
+      const reviewsReady = await isReviewsSchemaReady(pool);
+      if (!reviewsReady) return res.json([]);
+
+      const status = String(req.query.status || "").trim();
+      const itemId = Number(req.query.item_id);
+      const where = [];
+      const params = [];
+      let p = 1;
+      if (status) { params.push(status); where.push(`r.moderation_status = $${p++}`); }
+      if (Number.isFinite(itemId) && itemId > 0) { params.push(itemId); where.push(`r.item_id = $${p++}`); }
+
+      const r = await pool.query(
+        `SELECT r.review_id, r.item_id, ci.item_name, r.completed_job_id, r.customer_identity,
+                r.rating, r.comment, r.moderation_status, r.created_at, r.updated_at,
+                r.moderated_at, r.moderated_by
+           FROM public.catalog_item_reviews r
+           JOIN public.catalog_items ci ON ci.item_id = r.item_id
+           ${where.length ? `WHERE ${where.join(" AND ")}` : ""}
+          ORDER BY r.created_at DESC
+          LIMIT 200`,
+        params
+      );
+      res.json(r.rows.map((row) => ({
+        review_id: Number(row.review_id),
+        item_id: Number(row.item_id),
+        item_name: row.item_name,
+        completed_job_id: Number(row.completed_job_id),
+        customer_identity: row.customer_identity,
+        rating: Number(row.rating),
+        comment: row.comment || "",
+        moderation_status: row.moderation_status,
+        created_at: row.created_at,
+        updated_at: row.updated_at,
+        moderated_at: row.moderated_at,
+        moderated_by: row.moderated_by,
+      })));
+    } catch (e) {
+      console.error(e);
+      res.status(500).json({ error: "โหลดรายการรีวิวไม่สำเร็จ" });
+    }
+  });
+
+  router.patch("/admin/catalog/reviews/:reviewId", requireAdminSession, async (req, res) => {
+    try {
+      const reviewsReady = await isReviewsSchemaReady(pool);
+      if (!reviewsReady) return res.status(503).json({ error: "ระบบรีวิวยังไม่พร้อมใช้งาน" });
+
+      const reviewId = Number(req.params.reviewId);
+      if (!Number.isFinite(reviewId) || reviewId <= 0) {
+        return res.status(400).json({ error: "review_id ไม่ถูกต้อง" });
+      }
+      const nextStatus = String(req.body?.moderation_status || "").trim();
+      const allowed = new Set(["pending", "approved", "rejected", "hidden"]);
+      if (!allowed.has(nextStatus)) {
+        return res.status(400).json({ error: "สถานะไม่ถูกต้อง" });
+      }
+      const moderatedBy = String(req.actor?.username || req.auth?.username || "admin");
+
+      const r = await pool.query(
+        `UPDATE public.catalog_item_reviews
+            SET moderation_status = $1, moderated_at = NOW(), moderated_by = $2, updated_at = NOW()
+          WHERE review_id = $3
+          RETURNING review_id, moderation_status, moderated_at, moderated_by`,
+        [nextStatus, moderatedBy, reviewId]
+      );
+      if (!r.rows.length) return res.status(404).json({ error: "ไม่พบรีวิว" });
+      res.json(r.rows[0]);
+    } catch (e) {
+      console.error(e);
+      res.status(500).json({ error: "อัปเดตสถานะรีวิวไม่สำเร็จ" });
+    }
+  });
+
+  return router;
+};
+
+module.exports.MAX_COMMENT_LENGTH = MAX_COMMENT_LENGTH;
+module.exports.maskCustomerDisplayName = maskCustomerDisplayName;
+module.exports.validateRatingAndComment = validateRatingAndComment;
+module.exports.DONE_JOB_STATUSES = DONE_JOB_STATUSES;

--- a/test/adminStoreCatalogUi.test.js
+++ b/test/adminStoreCatalogUi.test.js
@@ -367,9 +367,9 @@ test("gallery delete and set-primary actions ask for confirmation only on delete
   assert.match(catalogJsSource, /async function onGalleryDelete\(imageId\) \{[\s\S]*?confirm\(.*ลบรูปภาพ/);
 });
 
-test("admin-store-catalog.html script and stylesheet references were bumped to the marketplace v2 build id", () => {
-  assert.match(catalogHtmlSource, /admin-store-catalog\.css\?v=20260623_catalog_marketplace_v2/);
-  assert.match(catalogHtmlSource, /admin-store-catalog\.js\?v=20260623_catalog_marketplace_v2/);
+test("admin-store-catalog.html script and stylesheet references were bumped to the hot/sale/reviews build id", () => {
+  assert.match(catalogHtmlSource, /admin-store-catalog\.css\?v=20260624_catalog_hot_sale_reviews/);
+  assert.match(catalogHtmlSource, /admin-store-catalog\.js\?v=20260624_catalog_hot_sale_reviews/);
 });
 
 test("admin-store-catalog.css defines gallery grid and badge styles for the marketplace UI", () => {
@@ -508,4 +508,67 @@ test("confirmDeleteCatalogItem calls the real DELETE endpoint and surfaces a Clo
   assert.match(body, /apiFetch\(`\/admin\/catalog\/items\/\$\{itemId\}`, \{ method: "DELETE" \}\)/);
   assert.match(body, /if \(result && result\.warning\) showToast\(result\.warning, "error"\);/);
   assert.match(body, /else showToast\("ลบรายการแล้ว", "success"\);/);
+});
+
+// ---------- HOT badge admin toggle ----------
+
+test("modal includes an is_hot toggle alongside is_featured under section 6, with reset and edit-populate wiring", () => {
+  assert.match(catalogJsSource, /6\) การแสดงผล[\s\S]*?id="cm_is_featured"[\s\S]{0,400}id="cm_is_hot"/);
+  assert.match(catalogJsSource, /el\("cm_is_hot"\)\.value = "0";/);
+  assert.match(catalogJsSource, /el\("cm_is_hot"\)\.value = item\.is_hot \? "1" : "0";/);
+});
+
+test("catalogModalPayload includes is_hot as a boolean derived from the select", () => {
+  assert.match(catalogJsSource, /is_hot: el\("cm_is_hot"\)\.value === "1",/);
+});
+
+test("catalog item cards show a HOT badge only when is_hot is true", () => {
+  assert.match(catalogJsSource, /item\.is_hot \? `<span class="asc-badge asc-badge-hot">HOT<\/span>` : ""/);
+});
+
+// ---------- Review moderation panel ----------
+
+test("admin page has a review moderation card with status/item filters and a reload button", () => {
+  const catalogHtmlSource = fs.readFileSync(path.join(__dirname, "..", "admin-store-catalog.html"), "utf8");
+  assert.match(catalogHtmlSource, /id="review_filter_status"/);
+  assert.match(catalogHtmlSource, /id="review_filter_item"/);
+  assert.match(catalogHtmlSource, /id="btnReloadReviews"/);
+  assert.match(catalogHtmlSource, /id="review_list"/);
+});
+
+test("loadReviews fetches the admin moderation endpoint and renderReviewList applies status/item filters", () => {
+  assert.match(catalogJsSource, /async function loadReviews\(\)[\s\S]*?apiFetch\("\/admin\/catalog\/reviews"\)/);
+  assert.match(catalogJsSource, /function renderReviewList\(\)/);
+  assert.match(catalogJsSource, /el\("review_filter_status"\)\.value/);
+  assert.match(catalogJsSource, /el\("review_filter_item"\)\.value/);
+});
+
+test("setReviewModerationStatus confirms before acting, PATCHes the review, and updates state without a full reload", () => {
+  const fnMatch = catalogJsSource.match(/async function setReviewModerationStatus\(reviewId, nextStatus\)[\s\S]*?\n}\n/);
+  assert.ok(fnMatch, "setReviewModerationStatus function not found");
+  const body = fnMatch[0];
+  assert.match(body, /confirm\(/);
+  assert.match(body, /apiFetch\(`\/admin\/catalog\/reviews\/\$\{reviewId\}`, \{\s*method: "PATCH",\s*body: JSON\.stringify\(\{ moderation_status: nextStatus \}\),\s*\}\)/);
+  assert.match(body, /Object\.assign\(review, updated\)/);
+  assert.match(body, /showToast\(/);
+});
+
+test("review action buttons never expose customer phone/email/internal IDs beyond completed_job_id and a display identity", () => {
+  const fnMatch = catalogJsSource.match(/function reviewCardHtml\(review\)[\s\S]*?\n}\n/);
+  assert.ok(fnMatch, "reviewCardHtml function not found");
+  const body = fnMatch[0];
+  assert.doesNotMatch(body, /\bphone\b/i);
+  assert.doesNotMatch(body, /\bemail\b/i);
+  assert.match(body, /review\.customer_identity/);
+  assert.match(body, /review\.completed_job_id/);
+});
+
+test("review action buttons support approve/reject/hide/restore-to-pending depending on current status", () => {
+  const fnMatch = catalogJsSource.match(/function reviewActionButtons\(review\)[\s\S]*?\n}\n/);
+  assert.ok(fnMatch, "reviewActionButtons function not found");
+  const body = fnMatch[0];
+  assert.match(body, /"approved"/);
+  assert.match(body, /"rejected"/);
+  assert.match(body, /"hidden"/);
+  assert.match(body, /"pending"/);
 });

--- a/test/catalogReviewRoutes.test.js
+++ b/test/catalogReviewRoutes.test.js
@@ -1,0 +1,444 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const http = require("node:http");
+const express = require("express");
+
+const createCatalogReviewRoutes = require("../server/routes/catalog/reviews");
+
+const DONE_STATUS = "เสร็จแล้ว";
+
+function makePool({ schemaReady = true, items = [], jobs = [], reviews = [] } = {}) {
+  const state = {
+    items: items.map((x) => ({ ...x })),
+    jobs: jobs.map((x) => ({ ...x })),
+    reviews: reviews.map((x) => ({ ...x })),
+  };
+  let nextReviewId = 1 + state.reviews.reduce((max, r) => Math.max(max, Number(r.review_id) || 0), 0);
+
+  async function query(sql, params = []) {
+    const s = String(sql);
+
+    if (s.includes("to_regclass('public.catalog_item_reviews')")) {
+      return { rows: [{ reg: schemaReady ? "public.catalog_item_reviews" : null }] };
+    }
+    if (s.includes("information_schema.columns") && s.includes("catalog_item_id', 'customer_sub")) {
+      return { rows: [{ cnt: schemaReady ? 2 : 0 }] };
+    }
+
+    if (/^\s*BEGIN\s*$/i.test(s.trim())) return { rows: [] };
+    if (/^\s*COMMIT\s*$/i.test(s.trim())) return { rows: [] };
+    if (/^\s*ROLLBACK\s*$/i.test(s.trim())) return { rows: [] };
+
+    if (s.includes("SELECT j.job_id, j.appointment_datetime")) {
+      const [customerSub, itemId, statuses] = params;
+      const reviewed = new Set(state.reviews.map((r) => Number(r.completed_job_id)));
+      const rows = state.jobs
+        .filter((j) =>
+          String(j.customer_sub) === String(customerSub) &&
+          Number(j.catalog_item_id) === Number(itemId) &&
+          statuses.includes(j.job_status) &&
+          !reviewed.has(Number(j.job_id))
+        )
+        .sort((a, b) => new Date(b.appointment_datetime) - new Date(a.appointment_datetime));
+      return { rows };
+    }
+
+    if (s.includes("SELECT item_id FROM public.catalog_items WHERE item_id")) {
+      const [itemId] = params;
+      const found = state.items.find((it) => Number(it.item_id) === Number(itemId));
+      return { rows: found ? [{ item_id: found.item_id }] : [] };
+    }
+
+    if (s.includes("INSERT INTO public.catalog_item_reviews")) {
+      const [itemId, jobId, customerIdentity, rating, comment] = params;
+      if (state.racyDuplicateJobIds?.has(Number(jobId)) || state.reviews.some((r) => Number(r.completed_job_id) === Number(jobId))) {
+        const err = new Error("duplicate key value violates unique constraint");
+        err.code = "23505";
+        throw err;
+      }
+      const row = {
+        review_id: nextReviewId++,
+        item_id: Number(itemId),
+        completed_job_id: Number(jobId),
+        customer_identity: customerIdentity,
+        rating: Number(rating),
+        comment,
+        moderation_status: "pending",
+        created_at: new Date().toISOString(),
+        updated_at: new Date().toISOString(),
+        moderated_at: null,
+        moderated_by: null,
+      };
+      state.reviews.push(row);
+      return { rows: [{ review_id: row.review_id, created_at: row.created_at }] };
+    }
+
+    if (s.includes("SELECT AVG(rating)::numeric AS rating_average")) {
+      const [itemId] = params;
+      const approved = state.reviews.filter((r) => Number(r.item_id) === Number(itemId) && r.moderation_status === "approved");
+      const avg = approved.length ? approved.reduce((sum, r) => sum + Number(r.rating), 0) / approved.length : null;
+      return { rows: [{ rating_average: avg, review_count: approved.length }] };
+    }
+
+    if (s.includes("SELECT review_id, rating, comment, created_at, customer_identity")) {
+      const [itemId, limit, offset] = params;
+      const approved = state.reviews
+        .filter((r) => Number(r.item_id) === Number(itemId) && r.moderation_status === "approved")
+        .sort((a, b) => new Date(b.created_at) - new Date(a.created_at))
+        .slice(offset, offset + limit);
+      return { rows: approved };
+    }
+
+    if (s.includes("FROM public.catalog_item_reviews r") && s.includes("JOIN public.catalog_items ci")) {
+      let rows = state.reviews.map((r) => ({
+        ...r,
+        item_name: (state.items.find((it) => Number(it.item_id) === Number(r.item_id)) || {}).item_name || "?",
+      }));
+      let idx = 0;
+      if (s.includes("r.moderation_status = $")) {
+        idx += 1;
+        rows = rows.filter((r) => r.moderation_status === params[idx - 1]);
+      }
+      if (s.includes("r.item_id = $")) {
+        idx += 1;
+        rows = rows.filter((r) => Number(r.item_id) === Number(params[idx - 1]));
+      }
+      return { rows };
+    }
+
+    if (s.includes("UPDATE public.catalog_item_reviews")) {
+      const [nextStatus, moderatedBy, reviewId] = params;
+      const row = state.reviews.find((r) => Number(r.review_id) === Number(reviewId));
+      if (!row) return { rows: [] };
+      row.moderation_status = nextStatus;
+      row.moderated_by = moderatedBy;
+      row.moderated_at = new Date().toISOString();
+      return { rows: [{ review_id: row.review_id, moderation_status: row.moderation_status, moderated_at: row.moderated_at, moderated_by: row.moderated_by }] };
+    }
+
+    throw new Error(`unhandled query in fake pool: ${s.slice(0, 120)}`);
+  }
+
+  return {
+    query,
+    state,
+    async connect() {
+      return {
+        query,
+        release() {},
+      };
+    },
+  };
+}
+
+function requireCustomerJwtFor(sub, name) {
+  return (req, res, next) => {
+    if (!sub) return res.status(401).json({ error: "UNAUTHORIZED" });
+    req.customer = { sub, name };
+    next();
+  };
+}
+function allowAdmin(req, res, next) { req.actor = { username: "admin1" }; next(); }
+function denyAdmin(req, res) { res.status(401).json({ error: "UNAUTHORIZED" }); }
+
+async function withServer(router, fn) {
+  const app = express();
+  app.use(express.json());
+  app.use(router);
+  const server = http.createServer(app);
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  try {
+    return await fn(`http://127.0.0.1:${server.address().port}`);
+  } finally {
+    await new Promise((resolve) => server.close(resolve));
+  }
+}
+
+test("createCatalogReviewRoutes throws without requireCustomerJwt or requireAdminSession", () => {
+  assert.throws(() => createCatalogReviewRoutes({ pool: makePool(), requireAdminSession: allowAdmin }), /requireCustomerJwt/);
+  assert.throws(() => createCatalogReviewRoutes({ pool: makePool(), requireCustomerJwt: requireCustomerJwtFor("s1") }), /requireAdminSession/);
+});
+
+test("public reviews list is approved-only and never exposes job_id, customer_sub, or moderation fields", async () => {
+  const pool = makePool({
+    items: [{ item_id: 1, item_name: "ล้างแอร์ผนัง" }],
+    reviews: [
+      { review_id: 1, item_id: 1, completed_job_id: 101, customer_identity: "สมชาย", rating: 5, comment: "ดีมาก", moderation_status: "approved", created_at: "2026-06-01T00:00:00Z" },
+      { review_id: 2, item_id: 1, completed_job_id: 102, customer_identity: "สมหญิง", rating: 4, comment: "พอใจ", moderation_status: "pending", created_at: "2026-06-02T00:00:00Z" },
+      { review_id: 3, item_id: 1, completed_job_id: 103, customer_identity: "แอบดู", rating: 1, comment: "แย่", moderation_status: "rejected", created_at: "2026-06-03T00:00:00Z" },
+    ],
+  });
+  const router = createCatalogReviewRoutes({ pool, requireCustomerJwt: requireCustomerJwtFor(null), requireAdminSession: denyAdmin });
+
+  await withServer(router, async (base) => {
+    const res = await fetch(`${base}/catalog/items/1/reviews`);
+    const body = await res.json();
+    assert.equal(res.status, 200);
+    assert.equal(body.review_count, 1);
+    assert.equal(body.rating_average, 5);
+    assert.equal(body.reviews.length, 1);
+    assert.equal(body.reviews[0].rating, 5);
+    assert.match(body.reviews[0].display_name, /^คุณ /);
+    assert.ok(!("completed_job_id" in body.reviews[0]));
+    assert.ok(!("customer_identity" in body.reviews[0]));
+    assert.ok(!("moderation_status" in body.reviews[0]));
+    assert.ok(!JSON.stringify(body).includes("สมชาย"));
+  });
+});
+
+test("public reviews list is honest-empty before the reviews schema migration has run", async () => {
+  const pool = makePool({ schemaReady: false });
+  const router = createCatalogReviewRoutes({ pool, requireCustomerJwt: requireCustomerJwtFor(null), requireAdminSession: denyAdmin });
+  await withServer(router, async (base) => {
+    const res = await fetch(`${base}/catalog/items/1/reviews`);
+    const body = await res.json();
+    assert.equal(res.status, 200);
+    assert.deepEqual(body, { reviews: [], total: 0, rating_average: null, review_count: 0 });
+  });
+});
+
+test("eligibility requires a genuine session and is false with no eligible completed job", async () => {
+  const pool = makePool({
+    items: [{ item_id: 1, item_name: "ล้างแอร์ผนัง" }],
+    jobs: [{ job_id: 10, customer_sub: "sub-1", catalog_item_id: 1, job_status: "รอตรวจสอบ", appointment_datetime: "2026-06-01T00:00:00Z" }],
+  });
+  const routerNoAuth = createCatalogReviewRoutes({ pool, requireCustomerJwt: requireCustomerJwtFor(null), requireAdminSession: denyAdmin });
+  await withServer(routerNoAuth, async (base) => {
+    const res = await fetch(`${base}/catalog/items/1/reviews/eligibility`);
+    assert.equal(res.status, 401);
+  });
+
+  const router = createCatalogReviewRoutes({ pool, requireCustomerJwt: requireCustomerJwtFor("sub-1", "ลูกค้า A"), requireAdminSession: denyAdmin });
+  await withServer(router, async (base) => {
+    const res = await fetch(`${base}/catalog/items/1/reviews/eligibility`);
+    const body = await res.json();
+    assert.equal(res.status, 200);
+    assert.equal(body.eligible, false);
+    assert.deepEqual(body.eligible_jobs, []);
+  });
+});
+
+test("eligibility is true only for a genuinely completed job linked to this item and owned by this customer", async () => {
+  const pool = makePool({
+    items: [{ item_id: 1, item_name: "ล้างแอร์ผนัง" }],
+    jobs: [
+      { job_id: 10, customer_sub: "sub-1", catalog_item_id: 1, job_status: DONE_STATUS, appointment_datetime: "2026-06-01T00:00:00Z" },
+      { job_id: 11, customer_sub: "sub-2", catalog_item_id: 1, job_status: DONE_STATUS, appointment_datetime: "2026-06-01T00:00:00Z" },
+      { job_id: 12, customer_sub: "sub-1", catalog_item_id: 2, job_status: DONE_STATUS, appointment_datetime: "2026-06-01T00:00:00Z" },
+      { job_id: 13, customer_sub: "sub-1", catalog_item_id: 1, job_status: "รอตรวจสอบ", appointment_datetime: "2026-06-01T00:00:00Z" },
+    ],
+  });
+  const router = createCatalogReviewRoutes({ pool, requireCustomerJwt: requireCustomerJwtFor("sub-1", "ลูกค้า A"), requireAdminSession: denyAdmin });
+  await withServer(router, async (base) => {
+    const res = await fetch(`${base}/catalog/items/1/reviews/eligibility`);
+    const body = await res.json();
+    assert.equal(body.eligible, true);
+    assert.deepEqual(body.eligible_jobs.map((j) => j.job_id), [10]);
+  });
+});
+
+test("a job already reviewed is never eligible again", async () => {
+  const pool = makePool({
+    items: [{ item_id: 1, item_name: "ล้างแอร์ผนัง" }],
+    jobs: [{ job_id: 10, customer_sub: "sub-1", catalog_item_id: 1, job_status: DONE_STATUS, appointment_datetime: "2026-06-01T00:00:00Z" }],
+    reviews: [{ review_id: 1, item_id: 1, completed_job_id: 10, customer_identity: "x", rating: 5, comment: null, moderation_status: "approved", created_at: "2026-06-02T00:00:00Z" }],
+  });
+  const router = createCatalogReviewRoutes({ pool, requireCustomerJwt: requireCustomerJwtFor("sub-1", "ลูกค้า A"), requireAdminSession: denyAdmin });
+  await withServer(router, async (base) => {
+    const res = await fetch(`${base}/catalog/items/1/reviews/eligibility`);
+    const body = await res.json();
+    assert.equal(body.eligible, false);
+  });
+});
+
+test("submitting a review never trusts a client-supplied job_id belonging to another customer", async () => {
+  const pool = makePool({
+    items: [{ item_id: 1, item_name: "ล้างแอร์ผนัง" }],
+    jobs: [
+      { job_id: 10, customer_sub: "sub-1", catalog_item_id: 1, job_status: DONE_STATUS, appointment_datetime: "2026-06-01T00:00:00Z" },
+      { job_id: 99, customer_sub: "sub-2", catalog_item_id: 1, job_status: DONE_STATUS, appointment_datetime: "2026-06-01T00:00:00Z" },
+    ],
+  });
+  const router = createCatalogReviewRoutes({ pool, requireCustomerJwt: requireCustomerJwtFor("sub-1", "ลูกค้า A"), requireAdminSession: denyAdmin });
+  await withServer(router, async (base) => {
+    const res = await fetch(`${base}/catalog/items/1/reviews`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ rating: 5, comment: "ดี", job_id: 99 }),
+    });
+    assert.equal(res.status, 403);
+    assert.equal(pool.state.reviews.length, 0);
+  });
+});
+
+test("submitting a review with no eligible job at all is rejected even if the client claims a job_id", async () => {
+  const pool = makePool({ items: [{ item_id: 1, item_name: "ล้างแอร์ผนัง" }], jobs: [] });
+  const router = createCatalogReviewRoutes({ pool, requireCustomerJwt: requireCustomerJwtFor("sub-1", "ลูกค้า A"), requireAdminSession: denyAdmin });
+  await withServer(router, async (base) => {
+    const res = await fetch(`${base}/catalog/items/1/reviews`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ rating: 5, job_id: 999 }),
+    });
+    assert.equal(res.status, 403);
+  });
+});
+
+test("a valid review submission is created as pending and is attached to the real eligible job", async () => {
+  const pool = makePool({
+    items: [{ item_id: 1, item_name: "ล้างแอร์ผนัง" }],
+    jobs: [{ job_id: 10, customer_sub: "sub-1", catalog_item_id: 1, job_status: DONE_STATUS, appointment_datetime: "2026-06-01T00:00:00Z" }],
+  });
+  const router = createCatalogReviewRoutes({ pool, requireCustomerJwt: requireCustomerJwtFor("sub-1", "ลูกค้า A"), requireAdminSession: denyAdmin });
+  await withServer(router, async (base) => {
+    const res = await fetch(`${base}/catalog/items/1/reviews`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ rating: 5, comment: "ดีมาก" }),
+    });
+    const body = await res.json();
+    assert.equal(res.status, 201);
+    assert.equal(body.moderation_status, "pending");
+    assert.equal(pool.state.reviews.length, 1);
+    assert.equal(pool.state.reviews[0].completed_job_id, 10);
+    assert.equal(pool.state.reviews[0].moderation_status, "pending");
+  });
+});
+
+test("a duplicate review on the same job is rejected and never inserts a second row", async () => {
+  const pool = makePool({
+    items: [{ item_id: 1, item_name: "ล้างแอร์ผนัง" }],
+    jobs: [
+      { job_id: 10, customer_sub: "sub-1", catalog_item_id: 1, job_status: DONE_STATUS, appointment_datetime: "2026-06-01T00:00:00Z" },
+      { job_id: 20, customer_sub: "sub-1", catalog_item_id: 1, job_status: DONE_STATUS, appointment_datetime: "2026-06-02T00:00:00Z" },
+    ],
+    reviews: [{ review_id: 1, item_id: 1, completed_job_id: 10, customer_identity: "x", rating: 4, comment: null, moderation_status: "approved", created_at: "2026-06-03T00:00:00Z" }],
+  });
+  const router = createCatalogReviewRoutes({ pool, requireCustomerJwt: requireCustomerJwtFor("sub-1", "ลูกค้า A"), requireAdminSession: denyAdmin });
+  await withServer(router, async (base) => {
+    const res = await fetch(`${base}/catalog/items/1/reviews`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ rating: 5, job_id: 10 }),
+    });
+    assert.equal(res.status, 403);
+    assert.equal(pool.state.reviews.length, 1);
+  });
+});
+
+test("a concurrent duplicate review caught only by the DB unique constraint returns 409, not a 500", async () => {
+  const pool = makePool({
+    items: [{ item_id: 1, item_name: "ล้างแอร์ผนัง" }],
+    jobs: [{ job_id: 10, customer_sub: "sub-1", catalog_item_id: 1, job_status: DONE_STATUS, appointment_datetime: "2026-06-01T00:00:00Z" }],
+  });
+  const router = createCatalogReviewRoutes({ pool, requireCustomerJwt: requireCustomerJwtFor("sub-1", "ลูกค้า A"), requireAdminSession: denyAdmin });
+  await withServer(router, async (base) => {
+    // The job is still "eligible" by this request's own read, but another
+    // request's INSERT lands first and trips the DB unique constraint.
+    pool.state.racyDuplicateJobIds = new Set([10]);
+    const res = await fetch(`${base}/catalog/items/1/reviews`, {
+      method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify({ rating: 5, job_id: 10 }),
+    });
+    assert.equal(res.status, 409);
+    assert.equal(pool.state.reviews.length, 0);
+  });
+});
+
+test("rating must be an integer 1-5 and comment is capped at 500 characters", async () => {
+  const pool = makePool({
+    items: [{ item_id: 1, item_name: "ล้างแอร์ผนัง" }],
+    jobs: [{ job_id: 10, customer_sub: "sub-1", catalog_item_id: 1, job_status: DONE_STATUS, appointment_datetime: "2026-06-01T00:00:00Z" }],
+  });
+  const router = createCatalogReviewRoutes({ pool, requireCustomerJwt: requireCustomerJwtFor("sub-1", "ลูกค้า A"), requireAdminSession: denyAdmin });
+  await withServer(router, async (base) => {
+    const badRating = await fetch(`${base}/catalog/items/1/reviews`, {
+      method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify({ rating: 6 }),
+    });
+    assert.equal(badRating.status, 400);
+
+    const tooLong = await fetch(`${base}/catalog/items/1/reviews`, {
+      method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify({ rating: 5, comment: "a".repeat(501) }),
+    });
+    assert.equal(tooLong.status, 400);
+    assert.equal(pool.state.reviews.length, 0);
+  });
+});
+
+test("admin moderation list and filters require requireAdminSession and never leak unrelated reviews", async () => {
+  const pool = makePool({
+    items: [{ item_id: 1, item_name: "ล้างแอร์ผนัง" }, { item_id: 2, item_name: "ซ่อมแอร์" }],
+    reviews: [
+      { review_id: 1, item_id: 1, completed_job_id: 10, customer_identity: "A", rating: 5, comment: "ดี", moderation_status: "pending", created_at: "2026-06-01T00:00:00Z" },
+      { review_id: 2, item_id: 2, completed_job_id: 11, customer_identity: "B", rating: 3, comment: "โอเค", moderation_status: "approved", created_at: "2026-06-02T00:00:00Z" },
+    ],
+  });
+
+  const routerDenied = createCatalogReviewRoutes({ pool, requireCustomerJwt: requireCustomerJwtFor(null), requireAdminSession: denyAdmin });
+  await withServer(routerDenied, async (base) => {
+    const res = await fetch(`${base}/admin/catalog/reviews`);
+    assert.equal(res.status, 401);
+  });
+
+  const router = createCatalogReviewRoutes({ pool, requireCustomerJwt: requireCustomerJwtFor(null), requireAdminSession: allowAdmin });
+  await withServer(router, async (base) => {
+    const all = await (await fetch(`${base}/admin/catalog/reviews`)).json();
+    assert.equal(all.length, 2);
+
+    const pendingOnly = await (await fetch(`${base}/admin/catalog/reviews?status=pending`)).json();
+    assert.equal(pendingOnly.length, 1);
+    assert.equal(pendingOnly[0].review_id, 1);
+
+    const itemOnly = await (await fetch(`${base}/admin/catalog/reviews?item_id=2`)).json();
+    assert.equal(itemOnly.length, 1);
+    assert.equal(itemOnly[0].item_id, 2);
+  });
+});
+
+test("admin can approve, reject, hide, and restore-to-pending with an audit trail; invalid status/id are rejected", async () => {
+  const pool = makePool({
+    items: [{ item_id: 1, item_name: "ล้างแอร์ผนัง" }],
+    reviews: [{ review_id: 1, item_id: 1, completed_job_id: 10, customer_identity: "A", rating: 5, comment: "ดี", moderation_status: "pending", created_at: "2026-06-01T00:00:00Z" }],
+  });
+  const router = createCatalogReviewRoutes({ pool, requireCustomerJwt: requireCustomerJwtFor(null), requireAdminSession: allowAdmin });
+  await withServer(router, async (base) => {
+    const badStatus = await fetch(`${base}/admin/catalog/reviews/1`, {
+      method: "PATCH", headers: { "content-type": "application/json" }, body: JSON.stringify({ moderation_status: "garbage" }),
+    });
+    assert.equal(badStatus.status, 400);
+
+    const notFound = await fetch(`${base}/admin/catalog/reviews/999`, {
+      method: "PATCH", headers: { "content-type": "application/json" }, body: JSON.stringify({ moderation_status: "approved" }),
+    });
+    assert.equal(notFound.status, 404);
+
+    const approve = await fetch(`${base}/admin/catalog/reviews/1`, {
+      method: "PATCH", headers: { "content-type": "application/json" }, body: JSON.stringify({ moderation_status: "approved" }),
+    });
+    const approveBody = await approve.json();
+    assert.equal(approve.status, 200);
+    assert.equal(approveBody.moderation_status, "approved");
+    assert.equal(approveBody.moderated_by, "admin1");
+    assert.ok(approveBody.moderated_at);
+
+    const hide = await fetch(`${base}/admin/catalog/reviews/1`, {
+      method: "PATCH", headers: { "content-type": "application/json" }, body: JSON.stringify({ moderation_status: "hidden" }),
+    });
+    assert.equal((await hide.json()).moderation_status, "hidden");
+
+    const restore = await fetch(`${base}/admin/catalog/reviews/1`, {
+      method: "PATCH", headers: { "content-type": "application/json" }, body: JSON.stringify({ moderation_status: "pending" }),
+    });
+    assert.equal((await restore.json()).moderation_status, "pending");
+  });
+});
+
+test("submitting a review before the migration has run returns 503 instead of a fake success", async () => {
+  const pool = makePool({ schemaReady: false });
+  const router = createCatalogReviewRoutes({ pool, requireCustomerJwt: requireCustomerJwtFor("sub-1", "ลูกค้า A"), requireAdminSession: denyAdmin });
+  await withServer(router, async (base) => {
+    const res = await fetch(`${base}/catalog/items/1/reviews`, {
+      method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify({ rating: 5 }),
+    });
+    assert.equal(res.status, 503);
+  });
+});

--- a/test/catalogReviewRoutes.test.js
+++ b/test/catalogReviewRoutes.test.js
@@ -432,6 +432,116 @@ test("admin can approve, reject, hide, and restore-to-pending with an audit trai
   });
 });
 
+test("review submission is wrapped in a single transaction: BEGIN before the eligibility re-check, COMMIT only after a successful INSERT", async () => {
+  const pool = makePool({
+    items: [{ item_id: 1, item_name: "ล้างแอร์ผนัง" }],
+    jobs: [{ job_id: 10, customer_sub: "sub-1", catalog_item_id: 1, job_status: DONE_STATUS, appointment_datetime: "2026-06-01T00:00:00Z" }],
+  });
+  const calls = [];
+  const baseConnect = pool.connect.bind(pool);
+  pool.connect = async () => {
+    const real = await baseConnect();
+    return {
+      query: (sql, params) => { calls.push(String(sql).trim()); return real.query(sql, params); },
+      release: real.release,
+    };
+  };
+  const router = createCatalogReviewRoutes({ pool, requireCustomerJwt: requireCustomerJwtFor("sub-1", "ลูกค้า A"), requireAdminSession: denyAdmin });
+  await withServer(router, async (base) => {
+    const res = await fetch(`${base}/catalog/items/1/reviews`, {
+      method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify({ rating: 5 }),
+    });
+    assert.equal(res.status, 201);
+  });
+  const beginIdx = calls.findIndex((c) => /^BEGIN$/i.test(c));
+  const eligibilityIdx = calls.findIndex((c) => c.includes("SELECT j.job_id, j.appointment_datetime"));
+  const insertIdx = calls.findIndex((c) => c.includes("INSERT INTO public.catalog_item_reviews"));
+  const commitIdx = calls.findIndex((c) => /^COMMIT$/i.test(c));
+  assert.ok(beginIdx !== -1 && eligibilityIdx !== -1 && insertIdx !== -1 && commitIdx !== -1, calls.join(" | "));
+  assert.ok(beginIdx < eligibilityIdx, "BEGIN must come before the eligibility re-check");
+  assert.ok(eligibilityIdx < insertIdx, "eligibility re-check must happen before INSERT");
+  assert.ok(insertIdx < commitIdx, "INSERT must happen before COMMIT");
+  assert.match(calls[eligibilityIdx], /FOR UPDATE OF j/);
+});
+
+test("an ineligible submission rolls back the transaction instead of leaving it open", async () => {
+  const pool = makePool({ items: [{ item_id: 1, item_name: "ล้างแอร์ผนัง" }], jobs: [] });
+  const calls = [];
+  const baseConnect = pool.connect.bind(pool);
+  pool.connect = async () => {
+    const real = await baseConnect();
+    return {
+      query: (sql, params) => { calls.push(String(sql).trim()); return real.query(sql, params); },
+      release: real.release,
+    };
+  };
+  const router = createCatalogReviewRoutes({ pool, requireCustomerJwt: requireCustomerJwtFor("sub-1", "ลูกค้า A"), requireAdminSession: denyAdmin });
+  await withServer(router, async (base) => {
+    const res = await fetch(`${base}/catalog/items/1/reviews`, {
+      method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify({ rating: 5 }),
+    });
+    assert.equal(res.status, 403);
+  });
+  assert.ok(calls.some((c) => /^ROLLBACK$/i.test(c)));
+  assert.ok(!calls.some((c) => /^COMMIT$/i.test(c)));
+});
+
+test("review submission is rate-limited per customer without affecting public GET reviews", async () => {
+  const pool = makePool({
+    items: [{ item_id: 1, item_name: "ล้างแอร์ผนัง" }],
+    jobs: [],
+    reviews: [
+      { review_id: 1, item_id: 1, completed_job_id: 1, customer_identity: "x", rating: 5, comment: null, moderation_status: "approved", created_at: "2026-06-01T00:00:00Z" },
+    ],
+  });
+  const router = createCatalogReviewRoutes({
+    pool,
+    requireCustomerJwt: requireCustomerJwtFor("sub-1", "ลูกค้า A"),
+    requireAdminSession: denyAdmin,
+    reviewSubmitCustomerLimitMax: 2,
+    reviewSubmitCustomerLimitWindowMs: 60_000,
+    reviewSubmitIpLimitMax: 1000,
+  });
+  await withServer(router, async (base) => {
+    const post = () => fetch(`${base}/catalog/items/1/reviews`, {
+      method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify({ rating: 5 }),
+    });
+    const first = await post();
+    const second = await post();
+    const third = await post();
+    assert.equal(first.status, 403); // no eligible job, but counts toward the limit
+    assert.equal(second.status, 403);
+    assert.equal(third.status, 429);
+    const thirdBody = await third.json();
+    assert.match(thirdBody.error, /บ่อยเกินไป/);
+
+    // GET public reviews must be unaffected by the submission rate limit.
+    const getRes = await fetch(`${base}/catalog/items/1/reviews`);
+    assert.equal(getRes.status, 200);
+  });
+});
+
+test("review submission rate limit is tracked separately per IP bucket", async () => {
+  const pool = makePool({ items: [{ item_id: 1, item_name: "ล้างแอร์ผนัง" }], jobs: [] });
+  const router = createCatalogReviewRoutes({
+    pool,
+    requireCustomerJwt: requireCustomerJwtFor("sub-1", "ลูกค้า A"),
+    requireAdminSession: denyAdmin,
+    reviewSubmitCustomerLimitMax: 1000,
+    reviewSubmitIpLimitMax: 1,
+    reviewSubmitIpLimitWindowMs: 60_000,
+  });
+  await withServer(router, async (base) => {
+    const post = () => fetch(`${base}/catalog/items/1/reviews`, {
+      method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify({ rating: 5 }),
+    });
+    const first = await post();
+    const second = await post();
+    assert.equal(first.status, 403);
+    assert.equal(second.status, 429);
+  });
+});
+
 test("submitting a review before the migration has run returns 503 instead of a fake success", async () => {
   const pool = makePool({ schemaReady: false });
   const router = createCatalogReviewRoutes({ pool, requireCustomerJwt: requireCustomerJwtFor("sub-1", "ลูกค้า A"), requireAdminSession: denyAdmin });

--- a/test/customerAppRecovery.test.js
+++ b/test/customerAppRecovery.test.js
@@ -228,7 +228,7 @@ test("Customer App build id is consistent across shell and service worker", () =
   const sw = read("customer-app/sw.js");
   const app = read("customer-app/assets/customer-app.js");
   const manifest = read("customer-app/manifest.webmanifest");
-  const build = "20260623_store_marketplace_final";
+  const build = "20260624_store_hot_sale_verified_reviews";
 
   assert.match(index, new RegExp(`customer-app\\.css\\?v=${build}`));
   assert.match(index, new RegExp(`bookingUrgent\\.js\\?v=${build}`));
@@ -244,7 +244,7 @@ test("Customer App build id is consistent across shell and service worker", () =
 test("store module is loaded in index.html and precached in the service worker app shell", () => {
   const index = read("customer-app/index.html");
   const sw = read("customer-app/sw.js");
-  const build = "20260623_store_marketplace_final";
+  const build = "20260624_store_hot_sale_verified_reviews";
 
   assert.match(index, new RegExp(`modules/store\\.js\\?v=${build}`));
   assert.match(sw, /`\.\/modules\/store\.js\?v=\$\{BUILD_ID\}`/);
@@ -792,7 +792,7 @@ test("store card and product detail render product name before the rating badge,
   await new Promise((resolve) => setTimeout(resolve, 0));
   const body = container.querySelector("[data-store-body]");
   const nameIndex = body.innerHTML.indexOf("ล้างแอร์ผนัง");
-  const ratingIndex = body.innerHTML.indexOf("store-standard-badge");
+  const ratingIndex = body.innerHTML.indexOf("store-rating-badge");
   const priceIndex = body.innerHTML.indexOf("store-card-price");
   assert.ok(nameIndex > -1 && ratingIndex > -1 && priceIndex > -1);
   assert.ok(nameIndex < ratingIndex);
@@ -803,7 +803,7 @@ test("store card and product detail render product name before the rating badge,
   await new Promise((resolve) => setTimeout(resolve, 0));
   const detailBody = container.querySelector("[data-store-detail-body]");
   const detailNameIndex = detailBody.innerHTML.indexOf("ล้างแอร์ผนัง");
-  const detailRatingIndex = detailBody.innerHTML.indexOf("store-standard-badge");
+  const detailRatingIndex = detailBody.innerHTML.indexOf("store-rating-badge");
   const detailPriceIndex = detailBody.innerHTML.indexOf("store-detail-price");
   assert.ok(detailNameIndex > -1 && detailRatingIndex > -1 && detailPriceIndex > -1);
   assert.ok(detailNameIndex < detailRatingIndex);
@@ -920,7 +920,7 @@ test("store shows the real sale price prominently with the normal price struck t
   const body = container.querySelector("[data-store-body]");
   assert.match(body.innerHTML, /class="price-text[^"]*">500/);
   assert.match(body.innerHTML, /class="price-strike">700/);
-  assert.match(body.innerHTML, /class="store-badge store-badge-promo">โปรดูแลแอร์รับหน้าฝน/);
+  assert.match(body.innerHTML, /class="store-sale-badge"[^>]*>SALE -29%/);
 });
 
 test("store falls back to base_price when there is no active price rule", async () => {
@@ -976,7 +976,7 @@ test("store card shows a multi-image slider with dot indicators when an item has
   assert.equal((body.innerHTML.match(/class="store-card-dot is-active"/g) || []).length, 1);
 });
 
-test("store card shows the CWF featured ribbon only for featured items, and a five-star standard-service badge for every item", async () => {
+test("store card shows the CWF featured ribbon only for featured items, and an honest rating badge for every item", async () => {
   const context = makeContext();
   const root = loadCustomerFrontend(context);
   root.api.loadCatalogItems = async () => [
@@ -992,12 +992,15 @@ test("store card shows the CWF featured ribbon only for featured items, and a fi
   assert.equal((body.innerHTML.match(/store-featured-ribbon/g) || []).length, 1);
   assert.match(body.innerHTML, /CWF แนะนำ/);
   assert.doesNotMatch(body.innerHTML, /store-badge-featured/);
-  assert.equal((body.innerHTML.match(/store-standard-badge/g) || []).length, 2);
-  assert.equal((body.innerHTML.match(/store-standard-label">มาตรฐาน CWF/g) || []).length, 2);
-  assert.equal((body.innerHTML.match(/store-standard-star is-filled/g) || []).length, 10);
+  assert.equal((body.innerHTML.match(/store-rating-badge/g) || []).length, 2);
+  assert.equal((body.innerHTML.match(/store-rating-label">รีวิว/g) || []).length, 2);
+  assert.doesNotMatch(body.innerHTML, /มาตรฐาน CWF/);
+  // neither item has real reviews yet, so both must render honest empty stars and a (0) count
+  assert.equal((body.innerHTML.match(/store-rating-star is-filled/g) || []).length, 0);
+  assert.equal((body.innerHTML.match(/store-rating-count">\(0\)<\/span>/g) || []).length, 2);
 });
 
-test("standard-service badge renders real rating_average/review_count with half stars and a visible count, but falls back to a fake-review-free 5-star badge when there is no real data", async () => {
+test("rating badge renders real rating_average/review_count with half stars and a visible count, but falls back to an honest zero-review badge when there is no real data", async () => {
   const context = makeContext();
   const root = loadCustomerFrontend(context);
   root.api.loadCatalogItems = async () => [
@@ -1010,14 +1013,14 @@ test("standard-service badge renders real rating_average/review_count with half 
   await new Promise((resolve) => setTimeout(resolve, 0));
 
   const body = container.querySelector("[data-store-body]");
-  assert.match(body.innerHTML, /store-standard-star is-half/);
-  assert.match(body.innerHTML, /store-standard-value">4\.5<\/span>/);
-  assert.match(body.innerHTML, /store-standard-count">\(12 รีวิว\)<\/span>/);
-  assert.equal((body.innerHTML.match(/store-standard-count/g) || []).length, 1);
-  assert.equal((body.innerHTML.match(/store-standard-star is-filled/g) || []).length, 4 + 5);
+  assert.match(body.innerHTML, /store-rating-star is-half/);
+  assert.match(body.innerHTML, /store-rating-value">4\.5<\/span>/);
+  assert.match(body.innerHTML, /store-rating-count">\(12\)<\/span>/);
+  assert.match(body.innerHTML, /store-rating-count">\(0\)<\/span>/);
+  assert.equal((body.innerHTML.match(/store-rating-star is-filled/g) || []).length, 4);
 });
 
-test("standard-service badge star fill logic only shows a half star once the fractional part reaches 0.5; below that it rounds down to full/empty stars only", async () => {
+test("rating badge star fill logic only shows a half star once the fractional part reaches 0.5; below that it rounds down to full/empty stars only", async () => {
   const context = makeContext();
   const root = loadCustomerFrontend(context);
   root.api.loadCatalogItems = async () => [
@@ -1029,13 +1032,13 @@ test("standard-service badge star fill logic only shows a half star once the fra
   await new Promise((resolve) => setTimeout(resolve, 0));
 
   const body = container.querySelector("[data-store-body]");
-  assert.match(body.innerHTML, /store-standard-value">4\.2<\/span>/);
-  assert.match(body.innerHTML, /store-standard-count">\(6 รีวิว\)<\/span>/);
-  assert.doesNotMatch(body.innerHTML, /store-standard-star is-half/);
-  assert.equal((body.innerHTML.match(/store-standard-star is-filled/g) || []).length, 4);
+  assert.match(body.innerHTML, /store-rating-value">4\.2<\/span>/);
+  assert.match(body.innerHTML, /store-rating-count">\(6\)<\/span>/);
+  assert.doesNotMatch(body.innerHTML, /store-rating-star is-half/);
+  assert.equal((body.innerHTML.match(/store-rating-star is-filled/g) || []).length, 4);
 });
 
-test("standard-service badge ignores legacy rating_value and fails safe to the no-fake-review CWF badge on invalid/null rating_average or review_count", async () => {
+test("rating badge ignores legacy rating_value and fails safe to the no-fake-review honest badge on invalid/null rating_average or review_count", async () => {
   const context = makeContext();
   const root = loadCustomerFrontend(context);
   root.api.loadCatalogItems = async () => [
@@ -1052,15 +1055,15 @@ test("standard-service badge ignores legacy rating_value and fails safe to the n
   await new Promise((resolve) => setTimeout(resolve, 0));
 
   const body = container.querySelector("[data-store-body]");
-  // every item must fail safe to the plain 5-star "มาตรฐาน CWF" badge with zero visible review counts
-  assert.equal((body.innerHTML.match(/store-standard-badge/g) || []).length, 5);
-  assert.equal((body.innerHTML.match(/store-standard-label">มาตรฐาน CWF/g) || []).length, 5);
-  assert.equal((body.innerHTML.match(/store-standard-star is-filled/g) || []).length, 25);
-  assert.doesNotMatch(body.innerHTML, /store-standard-count/);
-  assert.doesNotMatch(body.innerHTML, /store-standard-star is-half/);
+  // every item must fail safe to the honest zero-star, zero-count badge -- never a fabricated average
+  assert.equal((body.innerHTML.match(/store-rating-badge/g) || []).length, 5);
+  assert.equal((body.innerHTML.match(/store-rating-count">\(0\)<\/span>/g) || []).length, 5);
+  assert.equal((body.innerHTML.match(/store-rating-star is-filled/g) || []).length, 0);
+  assert.doesNotMatch(body.innerHTML, /store-rating-star is-half/);
+  assert.doesNotMatch(body.innerHTML, /store-rating-value/);
 });
 
-test("standard-service badge never displays a numeric average, a zero-review count, or the phrase \"คะแนนลูกค้า\" anywhere in its markup", async () => {
+test("rating badge never displays a fabricated 5.0 average or the phrase \"มาตรฐาน CWF\"/\"คะแนนลูกค้า\" anywhere in its markup", async () => {
   const context = makeContext();
   const root = loadCustomerFrontend(context);
   root.api.loadCatalogItems = async () => [
@@ -1072,14 +1075,15 @@ test("standard-service badge never displays a numeric average, a zero-review cou
   await new Promise((resolve) => setTimeout(resolve, 0));
 
   const body = container.querySelector("[data-store-body]");
-  const badgeMatch = body.innerHTML.match(/<div class="store-standard-badge"[\s\S]*?<\/div>/);
-  assert.ok(badgeMatch, "standard badge markup not found");
+  const badgeMatch = body.innerHTML.match(/<button type="button" class="store-rating-badge"[\s\S]*?<\/button>/);
+  assert.ok(badgeMatch, "rating badge markup not found");
   assert.doesNotMatch(badgeMatch[0], /5\.0/);
-  assert.doesNotMatch(badgeMatch[0], /0 รีวิว/);
+  assert.doesNotMatch(badgeMatch[0], /มาตรฐาน CWF/);
   assert.doesNotMatch(badgeMatch[0], /คะแนนลูกค้า/);
+  assert.match(badgeMatch[0], /รีวิว/);
 });
 
-test("product detail page uses the exact same renderStandardBadge output as the store card for both real and absent rating data", async () => {
+test("product detail page uses the exact same renderRatingBadge output as the store card for both real and absent rating data", async () => {
   const context = makeContext();
   const root = loadCustomerFrontend(context);
   root.api.loadCatalogItem = async () => ({
@@ -1093,10 +1097,10 @@ test("product detail page uses the exact same renderStandardBadge output as the 
   await new Promise((resolve) => setTimeout(resolve, 0));
 
   const body = container.querySelector("[data-store-detail-body]");
-  assert.match(body.innerHTML, /store-standard-star is-half/);
-  assert.match(body.innerHTML, /store-standard-value">3\.5<\/span>/);
-  assert.match(body.innerHTML, /store-standard-count">\(8 รีวิว\)<\/span>/);
-  assert.equal((body.innerHTML.match(/store-standard-star is-filled/g) || []).length, 3);
+  assert.match(body.innerHTML, /store-rating-star is-half/);
+  assert.match(body.innerHTML, /store-rating-value">3\.5<\/span>/);
+  assert.match(body.innerHTML, /store-rating-count">\(8\)<\/span>/);
+  assert.equal((body.innerHTML.match(/store-rating-star is-filled/g) || []).length, 3);
 });
 
 test("store card and product detail gallery flag autoplay only for multi-image items with is_autoplay_enabled true", async () => {

--- a/test/customerMultiServiceCalendar.test.js
+++ b/test/customerMultiServiceCalendar.test.js
@@ -30,15 +30,15 @@ test("public availability and public booking share the customer availability hel
   assert.match(booking, /customerAvailability\.hasAvailableStart/);
   assert.match(booking, /customerAvailability\.reservePublicCustomerTechnician/);
   assert.match(booking, /technician_username/);
-  assert.match(booking, /job_status='รอตรวจสอบ'|VALUES \([\s\S]*'รอตรวจสอบ'/);
+  assert.match(booking, /'รอตรวจสอบ'/);
 });
 
 test("public book validates and persists allow_time_proposal as a jobs column", () => {
   const booking = section('app.post("/public/book"', 'app.get("/public/track"');
   assert.match(booking, /allow_time_proposal/);
   assert.match(booking, /allowTimeProposal == null/);
-  assert.match(booking, /booking_mode, allow_time_proposal\)/);
-  assert.match(booking, /\$13,\$15\)/);
+  assert.match(booking, /"booking_mode", "allow_time_proposal"/);
+  assert.match(booking, /allowTimeProposal,/);
   assert.match(booking, /allowTimeProposal/);
   assert.doesNotMatch(booking, /customer_note\s*[:=][\s\S]{0,200}allowTimeProposal/);
 });

--- a/test/customerSameDayTiming.test.js
+++ b/test/customerSameDayTiming.test.js
@@ -160,7 +160,7 @@ test("customer app disables availability HTTP cache and refreshes same-day slots
 });
 
 test("customer app build and service worker cache IDs changed", () => {
-  const id = "20260623_store_marketplace_final";
+  const id = "20260624_store_hot_sale_verified_reviews";
   for (const file of [
     "customer-app/index.html",
     "customer-app/sw.js",


### PR DESCRIPTION
## Status: WAITING FOR VISUAL QA

This is a server-side remote execution environment with no browser, Playwright, Puppeteer, or Chromium available. The mandatory 320/390/430px (and 360/1280px) screenshot QA pass described below has **not** been performed and must be done before merge.

## Branch / commit

- Branch: `feature/store-hot-sale-verified-reviews`
- HEAD commit: `26ba96d` (follow-up to `37c7ca6`)
- Base: `main` @ `7e94c64d91b40dc4fbb649f69dd2de993fff22f2`

## Summary

Implements HOT / SALE / "CWF แนะนำ" (gold) badges on the customer Store, plus a verified-customer-review system (submission, eligibility, and admin moderation), per the locked spec. No payment, technician workflow, tracking, or auth-core logic was touched.

### Badges (Phase A)
- **HOT**: new `catalog_items.is_hot BOOLEAN NOT NULL DEFAULT FALSE`, admin-toggleable. Red-orange gradient/pulse badge, top-left, never obscures other badges or rating dots.
- **SALE**: derived purely from the existing pricing resolver (`normal_price` vs `active_price` / `has_active_promotion`) — **no new column**. Only rendered when a promo is genuinely active and sale price < normal price. Red/pink shine-sweep, bottom-left.
- **"CWF แนะนำ"**: reuses existing `is_featured`; changed from blue to gold/yellow with dark text, top-right, shimmer — most visually prominent badge, never duplicated.
- All animations respect `prefers-reduced-motion: reduce` (stop motion, keep color/shadow).
- Fixed a real bug: `renderCardGallery`/`renderDetailGallery` in `customer-app/modules/store.js` silently dropped all three badges for items with no images — now fixed for both Card and Detail.

### Reviews (Phases B–E)
- Rating display always starts with "รีวิว"; zero-review state is honest (e.g. `รีวิว ☆☆☆☆☆ (0)`), never a fake/standard badge — "มาตรฐาน CWF" text removed entirely.
- `server/routes/catalog/reviews.js`:
  - `GET` public review list per item — APPROVED-only, no PII (no phone/email/internal customer id).
  - `GET` eligibility check + `POST` submission — re-verifies eligibility **server-side** every request, now **inside a single DB transaction**: `BEGIN` happens before the eligibility re-check, the candidate job row(s) are read with `SELECT ... FOR UPDATE OF j` so a concurrent submission for the same job can't also see it as eligible before either commits, and ownership/`catalog_item_id`/completed-status/not-already-reviewed are all re-checked against that locked read — never trusted from any earlier read or from client input. Ineligible → rollback + `403`. DB unique-constraint race → rollback + `409`. Any other failure → rollback + `500`.
  - **Rate limiting**: POST submission only (GET public list is unaffected) is throttled by an in-memory fixed-window limiter, keyed separately per customer and per IP (defaults: 5/10min per customer, 20/10min per IP; both configurable via constructor deps for testing). No new auth/identity system — reuses the existing `requireCustomerJwt` cookie-JWT session.
  - Admin endpoints: list/filter by item/status, approve/reject/hide/restore, with `moderated_at`/`moderated_by` audit fields.
- Customer Detail page gets a "รีวิวจากลูกค้า" section (average, count, list, load-more, empty state) and a "เขียนรีวิว" flow (select eligible job → rate → comment → preview → confirm → "ส่งรีวิวแล้ว รอแอดมินตรวจสอบ"); ineligible customers see an honest message, never a fake form.
- Admin Store Catalog UI gains a review moderation panel (list/filter, approve/reject/hide/restore with confirm-before-action and double-submit protection).

## Database migration

File: `migrations/20260623_catalog_store_hot_sale_reviews.sql` — **additive only, not run against production.**

Adds `catalog_items.is_hot`, `jobs.catalog_item_id` (nullable FK, no backfill of historical jobs), and the `catalog_item_reviews` table with FKs, a unique constraint on `completed_job_id`, and supporting indexes. Idempotent (`IF NOT EXISTS` guards), transactional, advisory-locked, pgAdmin-pasteable.

**Production run command:** `node scripts/run-catalog-store-hot-sale-reviews-migration.js`

**Post-migration verify query:**
```sql
SELECT column_name FROM information_schema.columns WHERE table_name='catalog_items' AND column_name='is_hot';
SELECT column_name FROM information_schema.columns WHERE table_name='jobs' AND column_name='catalog_item_id';
SELECT to_regclass('public.catalog_item_reviews');
```

**Rollback**: drop the added columns/table — documented in the migration file header; safe because nothing else depends on them yet.

## Eligibility / concurrency design (security-relevant)

Eligibility is never trusted from the client. Every list/submit request re-derives the customer's eligible job set from `jobs` filtered by `customer_sub = req.customer.sub AND catalog_item_id = :item_id AND job_status IN (done-statuses) AND NOT EXISTS (already-reviewed)`. On submission, this re-derivation now happens **inside the transaction with `FOR UPDATE`**, closing the race window between "check eligible" and "insert review" that existed before. Reuses the existing `requireCustomerJwt` cookie-JWT middleware — no new customer identity system.

## API summary

- `GET /public/catalog/items/:item_id/reviews` — public, paginated, APPROVED-only, PII-free.
- `GET /public/catalog/items/:item_id/review-eligibility` — customer session required.
- `POST /public/catalog/items/:item_id/reviews` — customer session required, server-verified eligibility (transactional + `FOR UPDATE`), rate-limited per customer and per IP.
- `GET /admin/catalog/reviews` — admin session required, filter by item/status.
- `PATCH /admin/catalog/reviews/:review_id` — admin session required, moderation status transitions.

## Tests

- `npm test`: **487 passed, 0 failed, 11 skipped** (pre-existing, DB-dependent, unrelated to this change).
- `node --check` clean on all touched/new files.
- `git diff --check` clean.
- `test/catalogReviewRoutes.test.js`: 19 tests (was 15) — added transaction-ordering tests (BEGIN before the FOR-UPDATE eligibility re-check, INSERT before COMMIT, rollback-on-ineligible) and rate-limit tests for both the per-customer and per-IP buckets, plus confirmation that GET public reviews is unaffected by the submission rate limit.

## QA screenshots

Not captured — no browser, Playwright, Puppeteer, or Chromium available in this execution environment. **Marking draft "WAITING FOR VISUAL QA"**. Required before merge, at minimum 320/390/430px (plus 360/1280px): Store grid with HOT+SALE+gold badges overlapping without collision, `รีวิว ☆☆☆☆☆ (0)` empty state, Product Detail reviews section, customer submit-review flow, pending-review state, admin moderation panel, `prefers-reduced-motion` state, no horizontal overflow, bottom navigation not covering CTAs.

## Risks

- Migration is additive and untested against production data volume; recommend running during low traffic and verifying the schema-check output before relying on it.
- `jobs.catalog_item_id` is null for all historical jobs by design (no backfill) — reviews are only possible going forward from jobs created after catalog linkage is wired into the booking flow.
- In-memory rate limiter is per-process; if the app ever runs multiple processes/instances without a shared store, the effective limit is per-instance, not global. Acceptable for the current deployment topology; flagged for awareness.

## Confirmations

- [x] No changes to Payment, Technician workflow, Tracking, or Auth core logic.
- [x] No production migration run; no production data modified.
- [x] Reuses existing `requireCustomerJwt` identity system — no new customer identity system created.
- [x] No new branch, no new PR — all work on `feature/store-hot-sale-verified-reviews` / PR #90.
- [x] Not merged.
