### PR TITLE
Hotfix: safe-cast job_units.btu and fail-open booking_count aggregation

### DIFF
--- a/server/lib/historicalServiceResolver.js
+++ b/server/lib/historicalServiceResolver.js
@@ -25,6 +25,22 @@ function jobTypeToServiceType(jobType) {
   return JOB_TYPE_TO_SERVICE_TYPE[String(jobType || "").trim()] || null;
 }
 
+// public.job_units.btu is TEXT on some deployments (legacy rows), while
+// catalog_items.btu_min/btu_max are INTEGER. A bare comparison between the
+// two ("integer <= text") throws 42883 "operator does not exist" and kills
+// the whole query. This SQL expression safely casts to numeric only when
+// the trimmed, comma-stripped text is a plain decimal; anything else
+// (NULL, "", "ไม่ระบุ", "N/A", ...) becomes SQL NULL instead of erroring, so
+// callers can simply require "<expr> IS NOT NULL" before matching on it.
+// Centralized here so the bulk and single-job queries can't drift apart.
+function btuValueSql(column) {
+  return `(CASE
+       WHEN REPLACE(BTRIM(COALESCE(${column}::text, '')), ',', '') ~ '^[0-9]+(\\.[0-9]+)?$'
+       THEN REPLACE(BTRIM(${column}::text), ',', '')::numeric
+       ELSE NULL
+     END)`;
+}
+
 // jobs.catalog_item_id (and customer_sub) ship in the same earlier migration
 // this resolver builds on; guard against querying a column that doesn't
 // exist yet on a deployment where that migration hasn't run.
@@ -58,7 +74,7 @@ async function bulkResolveHistoricalItemMatches(db, itemIds) {
   const excludedParams = EXCLUDED_BOOKING_JOB_STATUSES.map((_, i) => `$${i + 2}`).join(", ");
   const r = await db.query(
     `WITH active_units AS (
-       SELECT ju.unit_id, ju.job_id, ju.ac_type, ju.btu, j.job_type
+       SELECT ju.unit_id, ju.job_id, ju.ac_type, ${btuValueSql("ju.btu")} AS btu_value, j.job_type
          FROM public.job_units ju
          JOIN public.jobs j ON j.job_id = ju.job_id
         WHERE j.catalog_item_id IS NULL
@@ -77,8 +93,9 @@ async function bulkResolveHistoricalItemMatches(db, itemIds) {
               ON ci.item_id = ANY($1::bigint[])
              AND ci.job_category = au.job_type
              AND ci.ac_type = au.ac_type
-             AND (ci.btu_min IS NULL OR ci.btu_min <= au.btu)
-             AND (ci.btu_max IS NULL OR ci.btu_max >= au.btu)
+             AND au.btu_value IS NOT NULL
+             AND (ci.btu_min IS NULL OR ci.btu_min <= au.btu_value)
+             AND (ci.btu_max IS NULL OR ci.btu_max >= au.btu_value)
      ),
      job_item_matched_units AS (
        SELECT job_id, item_id, COUNT(DISTINCT unit_id)::int AS matched_units,
@@ -140,17 +157,22 @@ async function resolveHistoricalServiceTarget(db, jobId) {
   let unambiguousItemId = null;
   if (totalUnits > 0) {
     const unitR = await db.query(
-      `WITH unit_matches AS (
-         SELECT ju.unit_id, ci.item_id,
-                COUNT(*) OVER (PARTITION BY ju.unit_id) AS match_count
+      `WITH active_units AS (
+         SELECT ju.unit_id, ju.ac_type, ${btuValueSql("ju.btu")} AS btu_value
            FROM public.job_units ju
-           JOIN public.catalog_items ci
-                ON ci.job_category = $2
-               AND ci.ac_type = ju.ac_type
-               AND (ci.btu_min IS NULL OR ci.btu_min <= ju.btu)
-               AND (ci.btu_max IS NULL OR ci.btu_max >= ju.btu)
           WHERE ju.job_id = $1
             AND LOWER(COALESCE(NULLIF(ju.status, ''), 'pending')) NOT IN ('cancelled', 'removed', 'deleted', 'void', 'inactive')
+       ),
+       unit_matches AS (
+         SELECT au.unit_id, ci.item_id,
+                COUNT(*) OVER (PARTITION BY au.unit_id) AS match_count
+           FROM active_units au
+           JOIN public.catalog_items ci
+                ON ci.job_category = $2
+               AND ci.ac_type = au.ac_type
+               AND au.btu_value IS NOT NULL
+               AND (ci.btu_min IS NULL OR ci.btu_min <= au.btu_value)
+               AND (ci.btu_max IS NULL OR ci.btu_max >= au.btu_value)
        )
        SELECT item_id, COUNT(DISTINCT unit_id)::int AS matched_units
          FROM unit_matches
@@ -181,6 +203,7 @@ module.exports = {
   EXCLUDED_BOOKING_JOB_STATUSES,
   JOB_TYPE_TO_SERVICE_TYPE,
   jobTypeToServiceType,
+  btuValueSql,
   bulkResolveHistoricalItemMatches,
   resolveHistoricalServiceTarget,
 };

--- a/server/routes/catalog/items.js
+++ b/server/routes/catalog/items.js
@@ -517,25 +517,35 @@ async function attachBookingCounts(pool, rows, jobsCatalogLinkReady) {
   if (!jobsCatalogLinkReady || !rows.length) return rows;
 
   const ids = rows.map((row) => Number(row.item_id));
-  const byItem = new Map();
 
-  const direct = await pool.query(
-    `SELECT catalog_item_id AS item_id, COUNT(DISTINCT job_id)::int AS cnt
-       FROM public.jobs
-      WHERE catalog_item_id = ANY($1::bigint[])
-        AND COALESCE(job_status, '') NOT IN (${EXCLUDED_BOOKING_JOB_STATUSES.map((_, i) => `$${i + 2}`).join(", ")})
-        AND canceled_at IS NULL
-      GROUP BY catalog_item_id`,
-    [ids, ...EXCLUDED_BOOKING_JOB_STATUSES]
-  );
-  direct.rows.forEach((r) => byItem.set(Number(r.item_id), Number(r.cnt)));
+  // booking_count is supplementary enrichment, not core catalog data: a
+  // failure here (e.g. a legacy BTU value the resolver can't normalize)
+  // must never take down the whole Store listing. Fail open to 0 and let
+  // the catalog response continue with status 200; only the main catalog
+  // query above is allowed to surface as a real error.
+  try {
+    const byItem = new Map();
 
-  const historical = await bulkResolveHistoricalItemMatches(pool, ids);
-  historical.forEach((cnt, id) => {
-    byItem.set(id, (byItem.get(id) || 0) + cnt);
-  });
+    const direct = await pool.query(
+      `SELECT catalog_item_id AS item_id, COUNT(DISTINCT job_id)::int AS cnt
+         FROM public.jobs
+        WHERE catalog_item_id = ANY($1::bigint[])
+          AND COALESCE(job_status, '') NOT IN (${EXCLUDED_BOOKING_JOB_STATUSES.map((_, i) => `$${i + 2}`).join(", ")})
+          AND canceled_at IS NULL
+        GROUP BY catalog_item_id`,
+      [ids, ...EXCLUDED_BOOKING_JOB_STATUSES]
+    );
+    direct.rows.forEach((r) => byItem.set(Number(r.item_id), Number(r.cnt)));
 
-  rows.forEach((row) => { row.booking_count = byItem.get(Number(row.item_id)) || 0; });
+    const historical = await bulkResolveHistoricalItemMatches(pool, ids);
+    historical.forEach((cnt, id) => {
+      byItem.set(id, (byItem.get(id) || 0) + cnt);
+    });
+
+    rows.forEach((row) => { row.booking_count = byItem.get(Number(row.item_id)) || 0; });
+  } catch (e) {
+    console.warn("[catalog_booking_count] aggregation failed", e && e.code ? { code: e.code } : undefined);
+  }
   return rows;
 }
 

--- a/test/catalogItemsRoutes.test.js
+++ b/test/catalogItemsRoutes.test.js
@@ -7,7 +7,7 @@ const express = require("express");
 
 const createCatalogItemRoutes = require("../server/routes/catalog/items");
 
-function makePool(initialItems = [], initialRules = [], { schemaReady = true, marketplaceReady = false, autoplayReady = false, jobsCatalogLinkReady = false, jobs = [], jobUnits = [] } = {}) {
+function makePool(initialItems = [], initialRules = [], { schemaReady = true, marketplaceReady = false, autoplayReady = false, jobsCatalogLinkReady = false, jobs = [], jobUnits = [], forceBookingCountError = false } = {}) {
   const state = {
     items: initialItems.map((x) => ({
       image_url: null, image_public_id: null, price_rule_id: null,
@@ -92,6 +92,7 @@ function makePool(initialItems = [], initialRules = [], { schemaReady = true, ma
     // Job-level consistency: a job only counts toward an item when EVERY one
     // of its active units unambiguously matches that same single item.
     if (s.includes("WITH active_units AS") && s.includes("JOIN public.jobs j")) {
+      if (forceBookingCountError) throw new Error("simulated historical resolver failure");
       const [itemIds] = params;
       const excludedStatuses = ["ยกเลิก", "cancelled", "canceled", "ไม่พบช่างรับงาน"];
       const byItem = new Map();
@@ -105,12 +106,14 @@ function makePool(initialItems = [], initialRules = [], { schemaReady = true, ma
         const matchedItemIds = new Set();
         let allUnitsUnambiguous = true;
         for (const unit of units) {
-          const matches = state.items.filter((it) =>
+          const btuText = String(unit.btu == null ? "" : unit.btu).trim().replace(/,/g, "");
+          const btuValue = /^[0-9]+(\.[0-9]+)?$/.test(btuText) ? Number(btuText) : null;
+          const matches = btuValue == null ? [] : state.items.filter((it) =>
             itemIds.map(Number).includes(Number(it.item_id)) &&
             it.job_category === job.job_type &&
             it.ac_type === unit.ac_type &&
-            (it.btu_min == null || it.btu_min <= unit.btu) &&
-            (it.btu_max == null || it.btu_max >= unit.btu)
+            (it.btu_min == null || it.btu_min <= btuValue) &&
+            (it.btu_max == null || it.btu_max >= btuValue)
           );
           if (matches.length !== 1) { allUnitsUnambiguous = false; break; }
           matchedItemIds.add(Number(matches[0].item_id));
@@ -537,6 +540,63 @@ test("public API does not expose hidden or inactive items", async () => {
     const names = body.map((x) => x.item_name);
     assert.equal(names.includes("ซ่อมแอร์ไม่เย็น"), false);
     assert.equal(names.includes("ล้างแอร์สี่ทิศทาง (ปิดใช้งาน)"), false);
+  });
+});
+
+// --- booking_count fail-open (production fix: a booking-count aggregation
+// failure -- e.g. a legacy text-format BTU value the historical resolver
+// can't normalize -- must never take down the Store listing). ---
+
+test("public GET /catalog/items still returns 200 with the full item list when historical booking-count aggregation throws", async () => {
+  const pool = makePool(sampleItems(), [], { jobsCatalogLinkReady: true, forceBookingCountError: true });
+  const router = createCatalogItemRoutes({ pool, requireAdminSession: allowAdmin });
+  await withServer(router, async (base) => {
+    const res = await fetch(`${base}/catalog/items?customer=1`);
+    const body = await res.json();
+    assert.equal(res.status, 200);
+    assert.equal(body.length, 1); // sampleItems() filtered by the ?customer=1 contract (is_active && is_customer_visible)
+    assert.ok(body.every((x) => x.item_id != null && x.item_name));
+  });
+});
+
+test("booking_count falls back to 0 for every item when historical booking-count aggregation throws", async () => {
+  const pool = makePool(sampleItems(), [], { jobsCatalogLinkReady: true, forceBookingCountError: true });
+  const router = createCatalogItemRoutes({ pool, requireAdminSession: allowAdmin });
+  await withServer(router, async (base) => {
+    const res = await fetch(`${base}/catalog/items?customer=1`);
+    const body = await res.json();
+    assert.equal(res.status, 200);
+    assert.ok(body.every((x) => x.booking_count === 0));
+  });
+});
+
+test("other catalog fields (price, rating, etc.) are not lost when booking-count aggregation fails open", async () => {
+  const pool = makePool(sampleItems(), [], { jobsCatalogLinkReady: true, forceBookingCountError: true });
+  const router = createCatalogItemRoutes({ pool, requireAdminSession: allowAdmin });
+  await withServer(router, async (base) => {
+    const res = await fetch(`${base}/catalog/items?customer=1`);
+    const body = await res.json();
+    assert.equal(res.status, 200);
+    const item1 = body.find((x) => x.item_id === 1);
+    assert.ok(item1);
+    assert.equal(item1.base_price, 700);
+    assert.equal(item1.item_category, "ล้างแอร์");
+  });
+});
+
+test("booking-count fail-open does not swallow a genuine failure in the main catalog query itself", async () => {
+  const pool = makePool(sampleItems(), [], { jobsCatalogLinkReady: true });
+  const originalQuery = pool.query;
+  pool.query = async (sql, params) => {
+    if (String(sql).includes("FROM public.catalog_items") && String(sql).includes("WHERE") && !String(sql).includes("information_schema")) {
+      throw new Error("simulated main catalog query failure");
+    }
+    return originalQuery(sql, params);
+  };
+  const router = createCatalogItemRoutes({ pool, requireAdminSession: allowAdmin });
+  await withServer(router, async (base) => {
+    const res = await fetch(`${base}/catalog/items?customer=1`);
+    assert.equal(res.status, 500);
   });
 });
 

--- a/test/historicalServiceResolver.test.js
+++ b/test/historicalServiceResolver.test.js
@@ -21,15 +21,24 @@ function makeDb({ linkReady = true, jobs = [], jobUnits = [], items = [] } = {})
       !["cancelled", "removed", "deleted", "void", "inactive"].includes(String(u.status || "pending").toLowerCase()));
   }
 
+  // Mirrors btuValueSql: only a plain (optionally comma-grouped) decimal
+  // string normalizes to a number; anything else (NULL, "", "ไม่ระบุ", ...)
+  // becomes null, same as the SQL CASE expression evaluating to SQL NULL.
+  function normalizeBtu(btu) {
+    const text = String(btu == null ? "" : btu).trim().replace(/,/g, "");
+    return /^[0-9]+(\.[0-9]+)?$/.test(text) ? Number(text) : null;
+  }
+
   function unitMatchesForJob(jobId, jobType, candidateItemIds = null) {
     const units = activeUnitsForJob(jobId);
     return units.map((u) => {
-      const matches = items.filter((it) =>
+      const btuValue = normalizeBtu(u.btu);
+      const matches = btuValue == null ? [] : items.filter((it) =>
         (candidateItemIds == null || candidateItemIds.includes(Number(it.item_id))) &&
         it.job_category === jobType &&
         it.ac_type === u.ac_type &&
-        (it.btu_min == null || it.btu_min <= u.btu) &&
-        (it.btu_max == null || it.btu_max >= u.btu)
+        (it.btu_min == null || it.btu_min <= btuValue) &&
+        (it.btu_max == null || it.btu_max >= btuValue)
       );
       return { unit_id: u.unit_id, matches };
     });
@@ -43,7 +52,7 @@ function makeDb({ linkReady = true, jobs = [], jobUnits = [], items = [] } = {})
     }
 
     // bulkResolveHistoricalItemMatches (distinct bulk CTE chain: active_units -> job_unit_totals -> unit_matches -> job_item_matched_units -> job_item_candidates).
-    if (s.includes("WITH active_units AS")) {
+    if (s.includes("WITH active_units AS") && s.includes("job_unit_totals")) {
       const [itemIds] = params;
       const candidates = itemIds.map(Number);
       const byItem = new Map();
@@ -83,7 +92,7 @@ function makeDb({ linkReady = true, jobs = [], jobUnits = [], items = [] } = {})
     }
 
     // resolveHistoricalServiceTarget: per-item matched-unit grouping.
-    if (s.includes("WITH unit_matches AS") && s.includes("WHERE ju.job_id = $1")) {
+    if (s.includes("WITH active_units AS") && s.includes("WHERE ju.job_id = $1")) {
       const [jobId, jobType] = params;
       const matchedUnitsByItem = new Map();
       for (const { matches } of unitMatchesForJob(jobId, jobType)) {
@@ -307,4 +316,75 @@ test("resolveHistoricalServiceTarget never resolves item scope when two units un
   const db = makeDb({ items, jobs, jobUnits });
   const result = await resolveHistoricalServiceTarget(db, 13);
   assert.deepEqual(result, { scope: "service_type", itemId: null, serviceType: "ซ่อมแอร์" });
+});
+
+// --- BTU text-format safety (production fix: job_units.btu is TEXT on some
+// deployments; a bare comparison against catalog_items' INTEGER btu_min/
+// btu_max throws 42883 "operator does not exist: integer <= text"). ---
+
+test("resolveHistoricalServiceTarget matches a comma-grouped BTU string (\"12,000\")", async () => {
+  const items = [{ item_id: 5, job_category: "ซ่อม", ac_type: "wall", btu_min: 9000, btu_max: 15000 }];
+  const jobs = [{ job_id: 20, job_type: "ซ่อม", catalog_item_id: null }];
+  const jobUnits = [{ unit_id: 1, job_id: 20, ac_type: "wall", btu: "12,000", status: "active" }];
+  const db = makeDb({ items, jobs, jobUnits });
+  const result = await resolveHistoricalServiceTarget(db, 20);
+  assert.deepEqual(result, { scope: "item", itemId: 5, serviceType: null });
+});
+
+test("resolveHistoricalServiceTarget matches a plain BTU string (\"12000\")", async () => {
+  const items = [{ item_id: 5, job_category: "ซ่อม", ac_type: "wall", btu_min: 9000, btu_max: 15000 }];
+  const jobs = [{ job_id: 21, job_type: "ซ่อม", catalog_item_id: null }];
+  const jobUnits = [{ unit_id: 1, job_id: 21, ac_type: "wall", btu: "12000", status: "active" }];
+  const db = makeDb({ items, jobs, jobUnits });
+  const result = await resolveHistoricalServiceTarget(db, 21);
+  assert.deepEqual(result, { scope: "item", itemId: 5, serviceType: null });
+});
+
+test("resolveHistoricalServiceTarget matches a decimal BTU string (\"12000.0\")", async () => {
+  const items = [{ item_id: 5, job_category: "ซ่อม", ac_type: "wall", btu_min: 9000, btu_max: 15000 }];
+  const jobs = [{ job_id: 22, job_type: "ซ่อม", catalog_item_id: null }];
+  const jobUnits = [{ unit_id: 1, job_id: 22, ac_type: "wall", btu: "12000.0", status: "active" }];
+  const db = makeDb({ items, jobs, jobUnits });
+  const result = await resolveHistoricalServiceTarget(db, 22);
+  assert.deepEqual(result, { scope: "item", itemId: 5, serviceType: null });
+});
+
+test("resolveHistoricalServiceTarget never throws and never matches an item for an empty BTU string", async () => {
+  const items = [{ item_id: 5, job_category: "ซ่อม", ac_type: "wall", btu_min: 9000, btu_max: 15000 }];
+  const jobs = [{ job_id: 23, job_type: "ซ่อม", catalog_item_id: null }];
+  const jobUnits = [{ unit_id: 1, job_id: 23, ac_type: "wall", btu: "", status: "active" }];
+  const db = makeDb({ items, jobs, jobUnits });
+  const result = await resolveHistoricalServiceTarget(db, 23);
+  assert.deepEqual(result, { scope: "service_type", itemId: null, serviceType: "ซ่อมแอร์" });
+});
+
+test("resolveHistoricalServiceTarget never throws and never matches an item for a non-numeric BTU value (\"ไม่ระบุ\")", async () => {
+  const items = [{ item_id: 5, job_category: "ซ่อม", ac_type: "wall", btu_min: 9000, btu_max: 15000 }];
+  const jobs = [{ job_id: 24, job_type: "ซ่อม", catalog_item_id: null }];
+  const jobUnits = [{ unit_id: 1, job_id: 24, ac_type: "wall", btu: "ไม่ระบุ", status: "active" }];
+  const db = makeDb({ items, jobs, jobUnits });
+  const result = await resolveHistoricalServiceTarget(db, 24);
+  assert.deepEqual(result, { scope: "service_type", itemId: null, serviceType: "ซ่อมแอร์" });
+});
+
+test("resolveHistoricalServiceTarget falls back to service_type when one of two units has an unparseable BTU (job-level consistency still enforced)", async () => {
+  const items = [{ item_id: 5, job_category: "ซ่อม", ac_type: "wall", btu_min: 9000, btu_max: 15000 }];
+  const jobs = [{ job_id: 25, job_type: "ซ่อม", catalog_item_id: null }];
+  const jobUnits = [
+    { unit_id: 1, job_id: 25, ac_type: "wall", btu: "12000", status: "active" }, // matches item 5
+    { unit_id: 2, job_id: 25, ac_type: "wall", btu: "N/A", status: "active" }, // unparseable, still an active unit, matches nothing
+  ];
+  const db = makeDb({ items, jobs, jobUnits });
+  const result = await resolveHistoricalServiceTarget(db, 25);
+  assert.deepEqual(result, { scope: "service_type", itemId: null, serviceType: "ซ่อมแอร์" });
+});
+
+test("bulkResolveHistoricalItemMatches never throws and never counts a job when its unit has a text-format/unparseable BTU value", async () => {
+  const items = [{ item_id: 1, job_category: "ล้าง", ac_type: "wall", btu_min: 9000, btu_max: 12000 }];
+  const jobs = [{ job_id: 400, job_type: "ล้าง", catalog_item_id: null, job_status: "เสร็จแล้ว", canceled_at: null }];
+  const jobUnits = [{ unit_id: 1, job_id: 400, ac_type: "wall", btu: "ไม่ระบุ", status: "active" }];
+  const db = makeDb({ items, jobs, jobUnits });
+
+  const byItem = await bulkResolveHistoricalItemMatches(db, [1]);
+  assert.equal(byItem.get(1), undefined);
 });


### PR DESCRIPTION
## Summary
- Production was throwing `42883 operator does not exist: integer <= text` because `job_units.btu` is TEXT on some deployments while `catalog_items.btu_min`/`btu_max` are INTEGER, killing `/catalog/items` entirely.
- Added a centralized `btuValueSql()` SQL fragment (server/lib/historicalServiceResolver.js) that safely normalizes BTU text to numeric via a regex-gated CASE expression, evaluating to SQL NULL for any unparseable value instead of erroring. Wired into both the bulk (`bulkResolveHistoricalItemMatches`) and single-job (`resolveHistoricalServiceTarget`) queries so they can't drift apart. A unit with an unparseable BTU still counts toward "every active unit" but can never match an item — its job falls back to `service_type`/`overall` scope instead of erroring. Never casts directly to integer, never guesses an item, never mutates existing data.
- Wrapped `attachBookingCounts()`'s aggregation (server/routes/catalog/items.js) in its own try/catch so a failure there (BTU-related or otherwise) never takes down the Store listing: `booking_count` falls back to 0 and the response still returns 200. Logs only `[catalog_booking_count] aggregation failed` plus an error code, never customer data. The main catalog query's own error handling is untouched — a genuine failure there still surfaces as before.

## No schema/migration/deploy changes
This PR touches only application code and tests. No DB schema changes, no migrations, no production data changes.

## Test plan
- [x] `node --check server/lib/historicalServiceResolver.js`
- [x] `node --check server/routes/catalog/items.js`
- [x] `npm test` — 550 pass, 0 fail, 11 skipped
- [x] `git diff --check` — clean
- [x] New tests: BTU `"12000"`, `"12,000"`, `"12000.0"` match; empty string and `"ไม่ระบุ"` don't throw/match; multi-unit job with one unparseable BTU falls back to service_type; bulk aggregation never throws on text-format BTU
- [x] New tests: `/catalog/items` still returns 200 with full item list when historical booking-count aggregation throws; `booking_count` falls back to 0 for all items; price/category/other catalog fields are not lost; a genuine failure in the main catalog query itself is NOT swallowed (still 500)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>


---
_Generated by [Claude Code](https://claude.ai/code/session_01G8RDdFzW2bZKTwvsfaovwg)_