### PR TITLE
Store/Product-Detail marketplace UX overhaul

### DIFF
--- a/customer-app/assets/customer-app.css
+++ b/customer-app/assets/customer-app.css
@@ -3754,22 +3754,30 @@ body.has-contact-sheet { overflow: hidden; }
 .store-badge-promo { background: #fef3c7; color: #92400e; }
 .store-badge-bookable { background: #dcfce7; color: #166534; }
 .store-badge-contact { background: #e0f2fe; color: #075985; }
+.store-badge-queue-today { background: #fee2e2; color: #b91c1c; }
 
+/* Note: padding is intentionally top/bottom only here -- this rule shares
+   specificity with the combined ".store-card-badges, .store-card-head, ..."
+   rule above that grants 10px horizontal padding on the card; a shorthand
+   `padding` here would zero that back out and cram the rating row against
+   the card's left edge. */
 .store-rating-badge {
   display: inline-flex;
   align-items: center;
-  gap: 4px;
+  gap: 6px;
   font-size: 10.5px;
   font-weight: 600;
   color: #92660a;
-  margin-top: 2px;
+  margin-top: 3px;
+  margin-bottom: 1px;
   background: none;
   border: none;
-  padding: 2px 0;
+  padding-top: 3px;
+  padding-bottom: 3px;
   cursor: pointer;
   text-align: left;
 }
-.store-rating-stars { display: inline-flex; gap: 1px; line-height: 1; }
+.store-rating-stars { display: inline-flex; gap: 2px; line-height: 1; }
 .store-rating-star { position: relative; color: #e5e7eb; font-size: 11px; }
 .store-rating-star.is-filled { color: #f5b700; }
 .store-rating-star.is-half { color: #e5e7eb; }
@@ -3782,9 +3790,9 @@ body.has-contact-sheet { overflow: hidden; }
   overflow: hidden;
   color: #f5b700;
 }
-.store-rating-label { color: #92660a; }
-.store-rating-value { color: #92660a; font-weight: 700; }
-.store-rating-count { color: #92660a; font-weight: 500; }
+.store-rating-label { color: #92660a; margin-right: 1px; }
+.store-rating-value { color: #92660a; font-weight: 700; margin-left: 2px; }
+.store-rating-count { color: #92660a; font-weight: 500; margin-left: 1px; }
 
 .store-booking-count {
   font-size: 10.5px;
@@ -3902,6 +3910,169 @@ body.has-contact-sheet { overflow: hidden; }
   gap: 6px;
   font-size: 13.5px;
 }
+
+.store-detail-summary { margin-top: 10px; }
+.store-detail-summary p {
+  font-size: 13.5px;
+  color: var(--ink);
+  line-height: 1.5;
+  display: -webkit-box;
+  -webkit-line-clamp: 4;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+/* BTU/spec variant selector (Shopee/Lazada-style segmented options). */
+.store-detail-variant-selector { margin-top: 14px; }
+.store-detail-variant-label {
+  display: block;
+  font-size: 12.5px;
+  font-weight: 700;
+  color: var(--ink);
+  margin-bottom: 6px;
+}
+.store-detail-variant-options {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+.store-detail-variant-option {
+  font: inherit;
+  font-size: 12.5px;
+  font-weight: 600;
+  padding: 8px 12px;
+  border-radius: 999px;
+  border: 1.5px solid var(--line);
+  background: #fff;
+  color: var(--ink);
+  cursor: pointer;
+  transition: border-color 0.15s ease, color 0.15s ease, background 0.15s ease;
+}
+.store-detail-variant-option.is-selected {
+  border-color: var(--accent, #1f7bff);
+  color: var(--accent, #1f7bff);
+  background: var(--soft-blue, rgba(31, 123, 255, 0.08));
+  font-weight: 700;
+}
+
+/* Related-products horizontal slider (same family, different wash method). */
+.store-detail-related { margin-top: 18px; }
+.store-detail-related h3 { font-size: 14.5px; margin-bottom: 8px; }
+.store-related-slider {
+  display: flex;
+  gap: 10px;
+  overflow-x: auto;
+  scroll-snap-type: x mandatory;
+  scrollbar-width: none;
+  padding-bottom: 2px;
+}
+.store-related-slider::-webkit-scrollbar { display: none; }
+.store-related-card {
+  flex: 0 0 130px;
+  scroll-snap-align: start;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 4px;
+  cursor: pointer;
+  background: none;
+  border: none;
+  padding: 0;
+  font: inherit;
+  text-align: left;
+  color: var(--ink);
+}
+.store-related-card-image-wrap {
+  width: 130px;
+  height: 130px;
+  border-radius: var(--radius-sm);
+  overflow: hidden;
+  background: var(--soft-blue, #eef2f7);
+}
+.store-related-card-image {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+.store-related-card strong {
+  font-size: 12px;
+  line-height: 1.3;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+.store-related-card .price-text { font-size: 12.5px; }
+
+/* Collapsible product-detail accordion (native <details>/<summary>; default
+   collapsed except where explicitly opened). */
+.store-detail-accordion-group {
+  margin-top: 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.store-detail-accordion {
+  border: 1px solid var(--line);
+  border-radius: var(--radius-sm);
+  padding: 0 12px;
+}
+.store-detail-accordion summary {
+  font-size: 14px;
+  font-weight: 700;
+  color: var(--ink);
+  padding: 12px 0;
+  cursor: pointer;
+  list-style: none;
+}
+.store-detail-accordion summary::-webkit-details-marker { display: none; }
+.store-detail-accordion summary::after {
+  content: "+";
+  float: right;
+  font-weight: 700;
+  color: var(--muted);
+}
+.store-detail-accordion[open] summary::after { content: "–"; }
+.store-detail-accordion-body { padding: 0 0 14px; }
+.store-detail-accordion-body p {
+  font-size: 13.5px;
+  color: var(--ink);
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
+/* 4-way wall-AC cleaning-method comparison: mobile-readable stacked cards. */
+.store-compare-grid {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+.store-compare-card {
+  border: 1px solid var(--line);
+  border-radius: var(--radius-sm);
+  padding: 10px 12px;
+  background: var(--soft-blue, #f8fafc);
+}
+.store-compare-card h4 { font-size: 13.5px; margin: 0 0 6px; color: var(--accent, #1f7bff); }
+.store-compare-card dl {
+  margin: 0;
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 4px 10px;
+}
+.store-compare-card dt {
+  font-size: 11.5px;
+  font-weight: 700;
+  color: var(--muted);
+  white-space: nowrap;
+}
+.store-compare-card dd {
+  margin: 0;
+  font-size: 12.5px;
+  color: var(--ink);
+  line-height: 1.4;
+}
+
 .store-detail-cta-bar {
   position: fixed;
   left: 0;

--- a/customer-app/assets/customer-app.css
+++ b/customer-app/assets/customer-app.css
@@ -4003,6 +4003,24 @@ body.has-contact-sheet { overflow: hidden; }
   overflow: hidden;
 }
 .store-related-card .price-text { font-size: 12.5px; }
+.store-related-card.is-current {
+  cursor: default;
+  position: relative;
+}
+.store-related-card.is-current .store-related-card-image-wrap {
+  outline: 2px solid var(--brand, #2f6fed);
+  outline-offset: 2px;
+}
+.store-related-card-badge {
+  align-self: flex-start;
+  background: var(--brand, #2f6fed);
+  color: #fff;
+  font-size: 10.5px;
+  font-weight: 600;
+  line-height: 1;
+  padding: 2px 6px;
+  border-radius: 999px;
+}
 
 /* Collapsible product-detail accordion (native <details>/<summary>; default
    collapsed except where explicitly opened). */

--- a/customer-app/modules/store.js
+++ b/customer-app/modules/store.js
@@ -116,24 +116,27 @@
     return (siblings || []).find((s) => String(s.item_id) === String(selectedVariantItemId)) || item;
   }
 
-  // Up to 4 same-family items, one representative per distinct wash variant,
-  // excluding this item's own variant group (those are BTU siblings, shown in
-  // the selector instead). Real catalog data only.
+  // Up to 4 same-family items, one representative per distinct wash variant
+  // (BTU siblings within one variant are not repeated -- those are shown in
+  // the BTU selector instead). Includes the item currently being viewed as
+  // the first card (marked is_current) so all real wash-method variants in
+  // the family are visible, not just the other three. Real catalog data only.
   function relatedFamilyItems(item, allItems) {
     if (!item || !item.job_category || !item.ac_type) return [];
     const fam = familyKey(item);
     const seenVariants = new Set([variantGroupKey(item)]);
-    const result = [];
+    const others = [];
     for (const it of allItems || []) {
       if (String(it.item_id) === String(item.item_id)) continue;
       if (familyKey(it) !== fam) continue;
       const vk = variantGroupKey(it);
       if (seenVariants.has(vk)) continue;
       seenVariants.add(vk);
-      result.push(it);
-      if (result.length >= 4) break;
+      others.push(it);
+      if (others.length >= 3) break;
     }
-    return result;
+    if (!others.length) return [];
+    return [{ ...item, is_current: true }, ...others];
   }
 
   function applyFilters(items) {
@@ -645,6 +648,16 @@
             const thumb = images.length
               ? `<img class="store-related-card-image" src="${root.utils.escapeHtml(images[0].image_url)}" alt="${root.utils.escapeHtml(images[0].alt_text || r.item_name || "")}" loading="lazy" onerror="this.style.visibility='hidden';">`
               : `<div class="store-card-image-placeholder" aria-hidden="true">ไม่มีรูปภาพ</div>`;
+            if (r.is_current) {
+              return `
+                <div class="store-related-card is-current" aria-current="true">
+                  <span class="store-related-card-badge">กำลังดู</span>
+                  <div class="store-related-card-image-wrap">${thumb}</div>
+                  <strong>${root.utils.escapeHtml(r.item_name || "-")}</strong>
+                  <span class="price-text${priceIsAsk(r) ? " is-estimate" : ""}">${root.utils.escapeHtml(priceLabel(r))}</span>
+                </div>
+              `;
+            }
             return `
               <button type="button" class="store-related-card" data-store-related-item="${root.utils.escapeHtml(String(r.item_id))}" aria-label="ดูรายละเอียด ${root.utils.escapeHtml(r.item_name || "")}">
                 <div class="store-related-card-image-wrap">${thumb}</div>
@@ -665,7 +678,7 @@
     {
       title: "ล้างปกติ",
       bestFor: "แอร์ที่ดูแลสม่ำเสมอ ไม่มีกลิ่นอับหรือคราบสะสมมาก",
-      thoroughness: "ล้างคอยล์เย็น แผ่นกรอง และถาดน้ำทิ้งจากภายนอกตัวเครื่อง",
+      thoroughness: "ล้างฟิลเตอร์ คอยล์เย็น คอยล์ร้อน และฉีดอัดท่อน้ำทิ้ง",
       advantages: "เร็ว ราคาประหยัด เหมาะกับการล้างตามรอบปกติ",
       depth: "ล้างจากภายนอกตัวเครื่อง ไม่ถอดชิ้นส่วนภายใน",
       dirtLevel: "เหมาะกับสิ่งสกปรกระดับน้อยถึงปานกลาง",
@@ -673,7 +686,7 @@
     {
       title: "ล้างพรีเมียม",
       bestFor: "แอร์ที่ใช้งานหนักหรือไม่ได้ล้างมานาน",
-      thoroughness: "ล้างลึกถึงคอยล์เย็น พัดลม พร้อมฟอกฆ่าเชื้อเพิ่มเติม",
+      thoroughness: "ล้างละเอียดคอยล์เย็น-คอยล์ร้อน ถอดรางน้ำทิ้งและโพรงกระรอกออกล้าง พร้อมฉีดอัดท่อน้ำทิ้ง",
       advantages: "ลดกลิ่นอับ ลดเชื้อแบคทีเรีย อากาศเย็นสะอาดขึ้น",
       depth: "เปิดฝาครอบและล้างชิ้นส่วนภายในมากกว่าล้างปกติ",
       dirtLevel: "เหมาะกับสิ่งสกปรกระดับปานกลางถึงมาก",
@@ -681,7 +694,7 @@
     {
       title: "แขวนคอยล์",
       bestFor: "แอร์ที่มีน้ำหยด ตันบ่อย หรือคอยล์สกปรกมาก",
-      thoroughness: "ถอดคอยล์เย็นออกมาล้างแบบแขวนนอกตัวเครื่อง",
+      thoroughness: "ถอดแผงไฟและถาดหลังออกมาทำความสะอาดอย่างละเอียด",
       advantages: "ล้างได้ทั่วถึงทุกซอกของคอยล์ แก้ปัญหาน้ำหยดได้ตรงจุด",
       depth: "ถอดชิ้นส่วนคอยล์ออกจากตัวเครื่องเพื่อล้าง",
       dirtLevel: "เหมาะกับสิ่งสกปรกระดับมากถึงมากที่สุด",
@@ -689,7 +702,7 @@
     {
       title: "ตัดล้างใหญ่",
       bestFor: "แอร์ที่ไม่เคยล้างใหญ่มานาน หรือมีปัญหาสะสมหลายจุด",
-      thoroughness: "ล้างและตรวจเช็คทุกชิ้นส่วนหลักของเครื่องอย่างละเอียด",
+      thoroughness: "ถอดล้างทั้งตัวเครื่อง ทำความสะอาดครบทุกระบบ โดยประเมินหน้างานก่อนเริ่มงาน",
       advantages: "ครอบคลุมที่สุด เหมาะกับการแก้ปัญหาสะสมระยะยาว",
       depth: "เปิดและถอดชิ้นส่วนภายในเกือบทั้งหมดเพื่อล้างลึกที่สุด",
       dirtLevel: "เหมาะกับสิ่งสกปรกสะสมมากที่สุด",

--- a/customer-app/modules/store.js
+++ b/customer-app/modules/store.js
@@ -65,6 +65,77 @@
     return "";
   }
 
+  // Shopee/Lazada-style variant-option wording ("18,000 BTU ขึ้นไป"), distinct
+  // from btuRangeLabel()'s wording used elsewhere on the card/detail page.
+  function variantBtuLabel(item) {
+    const min = Number(item.btu_min);
+    const max = Number(item.btu_max);
+    const hasMin = Number.isFinite(min) && min > 0;
+    const hasMax = Number.isFinite(max) && max > 0;
+    if (hasMin && hasMax && min !== max) return `${min.toLocaleString("th-TH")}–${max.toLocaleString("th-TH")} BTU`;
+    if (hasMin && hasMax) return `${min.toLocaleString("th-TH")} BTU`;
+    if (hasMin) return `${min.toLocaleString("th-TH")} BTU ขึ้นไป`;
+    if (hasMax) return `ไม่เกิน ${max.toLocaleString("th-TH")} BTU`;
+    return "ไม่ระบุ BTU";
+  }
+
+  // "Family" = same job_category + ac_type, spanning different wash methods
+  // (ล้างปกติ/ล้างพรีเมียม/แขวนคอยล์/ตัดล้างใหญ่) -- used for related-products.
+  // "Variant group" = family + the specific wash method, spanning different BTU
+  // bands of that one method -- used for the BTU/spec selector. Both keys are
+  // built only from real per-row catalog fields, never a fabricated mapping.
+  function familyKey(item) {
+    return `${item.job_category || ""}|${item.ac_type || ""}`;
+  }
+
+  function variantGroupKey(item) {
+    return `${item.job_category || ""}|${item.ac_type || ""}|${item.booking_wash_variant || ""}`;
+  }
+
+  // Siblings sharing this item's exact variant group (same method, different
+  // BTU). Only meaningful for bookable items with a real booking_wash_variant;
+  // otherwise there is nothing to group, so the item is its own only "sibling".
+  function variantSiblings(item, allItems) {
+    if (!item || item.booking_mode !== "bookable" || !item.booking_wash_variant) return [item];
+    const key = variantGroupKey(item);
+    const list = (allItems || []).filter((it) => it.booking_mode === "bookable" && variantGroupKey(it) === key);
+    if (!list.some((it) => String(it.item_id) === String(item.item_id))) list.push(item);
+    return list.slice().sort((a, b) => {
+      const aBtu = Number(a.btu_min) || Number(a.booking_btu) || 0;
+      const bBtu = Number(b.btu_min) || Number(b.booking_btu) || 0;
+      return aBtu - bBtu;
+    });
+  }
+
+  // The item the customer is currently viewing price/short-info for: either the
+  // originally loaded detail item, or whichever sibling they tapped in the BTU
+  // selector. Never a network re-fetch -- purely a client-side selection among
+  // already-known real catalog rows.
+  function currentVariantDisplayItem(item, siblings) {
+    if (!selectedVariantItemId || String(selectedVariantItemId) === String(item.item_id)) return item;
+    return (siblings || []).find((s) => String(s.item_id) === String(selectedVariantItemId)) || item;
+  }
+
+  // Up to 4 same-family items, one representative per distinct wash variant,
+  // excluding this item's own variant group (those are BTU siblings, shown in
+  // the selector instead). Real catalog data only.
+  function relatedFamilyItems(item, allItems) {
+    if (!item || !item.job_category || !item.ac_type) return [];
+    const fam = familyKey(item);
+    const seenVariants = new Set([variantGroupKey(item)]);
+    const result = [];
+    for (const it of allItems || []) {
+      if (String(it.item_id) === String(item.item_id)) continue;
+      if (familyKey(it) !== fam) continue;
+      const vk = variantGroupKey(it);
+      if (seenVariants.has(vk)) continue;
+      seenVariants.add(vk);
+      result.push(it);
+      if (result.length >= 4) break;
+    }
+    return result;
+  }
+
   function applyFilters(items) {
     const search = filterState.search.trim().toLowerCase();
     const category = filterState.category;
@@ -194,10 +265,16 @@
     `;
   }
 
+  // "มีคิววันนี้" only ever reflects item.has_queue_today, a real
+  // technician-eligibility check computed server-side (attachTodayQueueAvailability
+  // in server/routes/catalog/items.js) -- never guessed/hardcoded true for all
+  // items. Items without a queue today keep the existing "จองได้" wording.
   function renderBadges(item) {
     const badges = [];
-    if (isBookable(item)) badges.push(`<span class="store-badge store-badge-bookable">จองได้</span>`);
-    else badges.push(`<span class="store-badge store-badge-contact">ติดต่อแอดมิน</span>`);
+    if (isBookable(item)) {
+      if (item.has_queue_today === true) badges.push(`<span class="store-badge store-badge-queue-today">มีคิววันนี้</span>`);
+      else badges.push(`<span class="store-badge store-badge-bookable">จองได้</span>`);
+    } else badges.push(`<span class="store-badge store-badge-contact">ติดต่อแอดมิน</span>`);
     return badges.length ? `<div class="store-card-badges">${badges.join("")}</div>` : "";
   }
 
@@ -525,6 +602,119 @@
     `;
   }
 
+  // Currently selected BTU/spec sibling on the product detail page (per
+  // requirement #5). Reset whenever a new detail item is loaded.
+  let selectedVariantItemId = null;
+
+  function renderAccordionSection(title, bodyHtml, { open } = {}) {
+    if (!bodyHtml) return "";
+    return `
+      <details class="store-detail-accordion"${open ? " open" : ""}>
+        <summary>${root.utils.escapeHtml(title)}</summary>
+        <div class="store-detail-accordion-body">${bodyHtml}</div>
+      </details>
+    `;
+  }
+
+  function renderVariantSelector(item, siblings) {
+    if (!siblings || siblings.length < 2) return "";
+    const selectedId = selectedVariantItemId || item.item_id;
+    return `
+      <div class="store-detail-variant-selector" data-store-variant-selector>
+        <span class="store-detail-variant-label">เลือกขนาด BTU</span>
+        <div class="store-detail-variant-options">
+          ${siblings.map((s) => `
+            <button type="button" class="store-detail-variant-option${String(s.item_id) === String(selectedId) ? " is-selected" : ""}" data-store-variant-option="${root.utils.escapeHtml(String(s.item_id))}">
+              ${root.utils.escapeHtml(variantBtuLabel(s))}
+            </button>
+          `).join("")}
+        </div>
+      </div>
+    `;
+  }
+
+  function renderRelatedProducts(item, allItems) {
+    const related = relatedFamilyItems(item, allItems);
+    if (!related.length) return "";
+    return `
+      <div class="store-detail-related" data-store-related>
+        <h3>บริการที่เกี่ยวข้อง</h3>
+        <div class="store-related-slider">
+          ${related.map((r) => {
+            const images = itemGalleryImages(r);
+            const thumb = images.length
+              ? `<img class="store-related-card-image" src="${root.utils.escapeHtml(images[0].image_url)}" alt="${root.utils.escapeHtml(images[0].alt_text || r.item_name || "")}" loading="lazy" onerror="this.style.visibility='hidden';">`
+              : `<div class="store-card-image-placeholder" aria-hidden="true">ไม่มีรูปภาพ</div>`;
+            return `
+              <button type="button" class="store-related-card" data-store-related-item="${root.utils.escapeHtml(String(r.item_id))}" aria-label="ดูรายละเอียด ${root.utils.escapeHtml(r.item_name || "")}">
+                <div class="store-related-card-image-wrap">${thumb}</div>
+                <strong>${root.utils.escapeHtml(r.item_name || "-")}</strong>
+                <span class="price-text${priceIsAsk(r) ? " is-estimate" : ""}">${root.utils.escapeHtml(priceLabel(r))}</span>
+              </button>
+            `;
+          }).join("")}
+        </div>
+      </div>
+    `;
+  }
+
+  // Static, factual comparison content (not derived from per-item DB fields --
+  // these four wash methods are fixed domain concepts shared by every wall-AC
+  // wash item, not a guess about any specific catalog row's price/availability).
+  const WALL_AC_CLEANING_COMPARISON = [
+    {
+      title: "ล้างปกติ",
+      bestFor: "แอร์ที่ดูแลสม่ำเสมอ ไม่มีกลิ่นอับหรือคราบสะสมมาก",
+      thoroughness: "ล้างคอยล์เย็น แผ่นกรอง และถาดน้ำทิ้งจากภายนอกตัวเครื่อง",
+      advantages: "เร็ว ราคาประหยัด เหมาะกับการล้างตามรอบปกติ",
+      depth: "ล้างจากภายนอกตัวเครื่อง ไม่ถอดชิ้นส่วนภายใน",
+      dirtLevel: "เหมาะกับสิ่งสกปรกระดับน้อยถึงปานกลาง",
+    },
+    {
+      title: "ล้างพรีเมียม",
+      bestFor: "แอร์ที่ใช้งานหนักหรือไม่ได้ล้างมานาน",
+      thoroughness: "ล้างลึกถึงคอยล์เย็น พัดลม พร้อมฟอกฆ่าเชื้อเพิ่มเติม",
+      advantages: "ลดกลิ่นอับ ลดเชื้อแบคทีเรีย อากาศเย็นสะอาดขึ้น",
+      depth: "เปิดฝาครอบและล้างชิ้นส่วนภายในมากกว่าล้างปกติ",
+      dirtLevel: "เหมาะกับสิ่งสกปรกระดับปานกลางถึงมาก",
+    },
+    {
+      title: "แขวนคอยล์",
+      bestFor: "แอร์ที่มีน้ำหยด ตันบ่อย หรือคอยล์สกปรกมาก",
+      thoroughness: "ถอดคอยล์เย็นออกมาล้างแบบแขวนนอกตัวเครื่อง",
+      advantages: "ล้างได้ทั่วถึงทุกซอกของคอยล์ แก้ปัญหาน้ำหยดได้ตรงจุด",
+      depth: "ถอดชิ้นส่วนคอยล์ออกจากตัวเครื่องเพื่อล้าง",
+      dirtLevel: "เหมาะกับสิ่งสกปรกระดับมากถึงมากที่สุด",
+    },
+    {
+      title: "ตัดล้างใหญ่",
+      bestFor: "แอร์ที่ไม่เคยล้างใหญ่มานาน หรือมีปัญหาสะสมหลายจุด",
+      thoroughness: "ล้างและตรวจเช็คทุกชิ้นส่วนหลักของเครื่องอย่างละเอียด",
+      advantages: "ครอบคลุมที่สุด เหมาะกับการแก้ปัญหาสะสมระยะยาว",
+      depth: "เปิดและถอดชิ้นส่วนภายในเกือบทั้งหมดเพื่อล้างลึกที่สุด",
+      dirtLevel: "เหมาะกับสิ่งสกปรกสะสมมากที่สุด",
+    },
+  ];
+
+  function renderCleaningComparison() {
+    return `
+      <div class="store-compare-grid">
+        ${WALL_AC_CLEANING_COMPARISON.map((c) => `
+          <div class="store-compare-card">
+            <h4>${root.utils.escapeHtml(c.title)}</h4>
+            <dl>
+              <dt>เหมาะกับ</dt><dd>${root.utils.escapeHtml(c.bestFor)}</dd>
+              <dt>ความละเอียด</dt><dd>${root.utils.escapeHtml(c.thoroughness)}</dd>
+              <dt>ข้อดี</dt><dd>${root.utils.escapeHtml(c.advantages)}</dd>
+              <dt>ความลึกในการเข้าถึงเครื่อง</dt><dd>${root.utils.escapeHtml(c.depth)}</dd>
+              <dt>ระดับความสกปรกที่เหมาะสม</dt><dd>${root.utils.escapeHtml(c.dirtLevel)}</dd>
+            </dl>
+          </div>
+        `).join("")}
+      </div>
+    `;
+  }
+
   // ---------- Verified Customer Reviews (Product Detail) ----------
 
   const REVIEWS_PAGE_SIZE = 10;
@@ -802,10 +992,15 @@
   function renderDetailContent(item) {
     const name = item.item_name || "-";
     const category = categoryLabel(item.item_category);
-    const unit = item.unit_label || "";
-    const promo = hasPromo(item);
-    const bookable = isBookable(item);
     const highlights = Array.isArray(item.highlights) ? item.highlights : [];
+    const allItems = (root.state.catalog && root.state.catalog.items) || [];
+    const siblings = variantSiblings(item, allItems);
+    const displayItem = currentVariantDisplayItem(item, siblings);
+    const unit = displayItem.unit_label || "";
+    const promo = hasPromo(displayItem);
+    const bookable = isBookable(displayItem);
+    const showCompare = item.ac_type === "ผนัง" && item.job_category === "ล้าง";
+
     return `
       <button class="store-detail-back" type="button" data-store-detail-back>${root.utils.icon("pin", 16)}กลับไปหน้าร้านค้า</button>
       ${renderDetailGallery(item, name)}
@@ -816,32 +1011,29 @@
       </div>
       ${renderRatingBadge(item)}
       ${renderBookingCountLabel(item)}
-      <div class="store-detail-price">
-        <span class="price-text${priceIsAsk(item) ? " is-estimate" : ""}">${root.utils.escapeHtml(priceLabel(item))}</span>
-        ${promo ? `<span class="price-strike">${root.utils.escapeHtml(root.utils.formatBaht(item.normal_price))}</span>` : ""}
-        ${unit && !priceIsAsk(item) ? `<span class="muted">/ ${root.utils.escapeHtml(unit)}</span>` : ""}
+      <div class="store-detail-price" data-store-detail-price>
+        <span class="price-text${priceIsAsk(displayItem) ? " is-estimate" : ""}">${root.utils.escapeHtml(priceLabel(displayItem))}</span>
+        ${promo ? `<span class="price-strike">${root.utils.escapeHtml(root.utils.formatBaht(displayItem.normal_price))}</span>` : ""}
+        ${unit && !priceIsAsk(displayItem) ? `<span class="muted">/ ${root.utils.escapeHtml(unit)}</span>` : ""}
       </div>
-      ${item.short_description ? `<div class="store-detail-section"><p>${root.utils.escapeHtml(item.short_description)}</p></div>` : ""}
-      ${highlights.length ? `
-        <div class="store-detail-section">
-          <h3>จุดเด่นของบริการ</h3>
+      ${renderVariantSelector(item, siblings)}
+      ${displayItem.short_description ? `<div class="store-detail-section store-detail-summary"><p>${root.utils.escapeHtml(displayItem.short_description)}</p></div>` : ""}
+      ${renderRelatedProducts(item, allItems)}
+      <div class="store-detail-accordion-group">
+        ${renderAccordionSection("จุดเด่นของบริการ", highlights.length ? `
           <ul class="store-detail-highlights">
             ${highlights.map((h) => `<li>${root.utils.icon("sparkle", 16)}<span>${root.utils.escapeHtml(h)}</span></li>`).join("")}
           </ul>
-        </div>
-      ` : ""}
-      ${item.long_description ? `
-        <div class="store-detail-section">
-          <h3>รายละเอียดบริการ</h3>
-          <p>${root.utils.escapeHtml(item.long_description)}</p>
-        </div>
-      ` : ""}
-      ${item.service_conditions ? `
-        <div class="store-detail-section">
-          <h3>เงื่อนไขบริการ</h3>
-          <p>${root.utils.escapeHtml(item.service_conditions)}</p>
-        </div>
-      ` : ""}
+        ` : "")}
+        ${renderAccordionSection("รายละเอียดบริการ", item.long_description ? `<p>${root.utils.escapeHtml(item.long_description)}</p>` : "")}
+        ${renderAccordionSection("ประเภทแอร์ที่เหมาะสม", item.ac_type ? `
+          <ul class="store-detail-highlights">
+            <li>${root.utils.icon("sparkle", 16)}<span>${root.utils.escapeHtml(item.ac_type)}</span></li>
+          </ul>
+        ` : "")}
+        ${renderAccordionSection("เงื่อนไขบริการ", item.service_conditions ? `<p>${root.utils.escapeHtml(item.service_conditions)}</p>` : "")}
+        ${showCompare ? renderAccordionSection("เปรียบเทียบวิธีล้างแอร์ผนัง", renderCleaningComparison()) : ""}
+      </div>
       <div class="store-detail-section store-reviews-section" data-store-reviews-section>
         ${renderReviewsSectionBody(item)}
       </div>
@@ -912,9 +1104,12 @@
     if (bookButton) {
       bookButton.addEventListener("click", () => {
         const item = root.state.storeDetail?.data;
-        const draftItem = root.services.catalogItemToCommerceDraft(item);
+        if (!item) return;
+        const allItems = (root.state.catalog && root.state.catalog.items) || [];
+        const target = currentVariantDisplayItem(item, variantSiblings(item, allItems));
+        const draftItem = root.services.catalogItemToCommerceDraft(target);
         if (!draftItem || !root.services.applyCommerceDraft("scheduled", draftItem)) {
-          root.ui.openContactSheet(container, { title: item?.item_name || "รายการนี้" });
+          root.ui.openContactSheet(container, { title: target?.item_name || item?.item_name || "รายการนี้" });
           return;
         }
         root.utils.routeTo("scheduled");
@@ -933,6 +1128,15 @@
         if (section) section.scrollIntoView({ behavior: "smooth", block: "start" });
       });
     });
+    container.querySelectorAll("[data-store-variant-option]").forEach((button) => {
+      button.addEventListener("click", () => {
+        selectedVariantItemId = button.getAttribute("data-store-variant-option");
+        patchDetailBody(container);
+      });
+    });
+    container.querySelectorAll("[data-store-related-item]").forEach((card) => {
+      card.addEventListener("click", () => goToDetail(card.getAttribute("data-store-related-item")));
+    });
     const item = root.state.storeDetail?.data;
     if (item) bindReviewsSection(container, item);
     bindDetailGallery(container);
@@ -945,8 +1149,25 @@
     bindDetailBody(container);
   }
 
+  // Lets the detail page show related-products/variant-selector data sourced
+  // from the full catalog list even when the customer navigated straight to a
+  // detail URL without first visiting the Store list page.
+  async function ensureCatalogListLoaded() {
+    const bucket = root.state.catalog || { status: "idle", items: [] };
+    if (bucket.status === "success" && Array.isArray(bucket.items) && bucket.items.length) return bucket.items;
+    try {
+      const data = await root.api.loadCatalogItems();
+      const items = root.utils.normalizeList(data, "items");
+      root.state.setCollection("catalog", { status: "success", items, error: "" });
+      return items;
+    } catch (_error) {
+      return bucket.items || [];
+    }
+  }
+
   async function loadDetail(container, itemId) {
     resetReviewsState(itemId);
+    selectedVariantItemId = null;
     if (!itemId) {
       root.state.setStoreDetail({ status: "error", itemId: "", data: null, error: "ไม่พบรายการนี้" });
       patchDetailBody(container);
@@ -960,6 +1181,9 @@
       patchDetailBody(container);
       loadReviewsList(container, data);
       loadEligibility(container, data);
+      ensureCatalogListLoaded().then((items) => {
+        if (items.length && String(root.state.storeDetail?.itemId) === String(itemId)) patchDetailBody(container);
+      });
       return;
     } catch (error) {
       const message = error?.status === 404 ? "ไม่พบรายการนี้" : (error?.message || "โหลดข้อมูลไม่สำเร็จ");

--- a/index.js
+++ b/index.js
@@ -12957,7 +12957,14 @@ app.use(createTechnicianDirectoryRoutes({ pool }));
 // =======================================
 // 📦 CATALOG
 // =======================================
-app.use(createCatalogItemRoutes({ pool, requireAdminSession }));
+app.use(createCatalogItemRoutes({
+  pool,
+  requireAdminSession,
+  listBusyBlocksForTechOnDate,
+  buildStartIntervalsByCollision,
+  toMin,
+  minToHHMM,
+}));
 app.use(createCatalogReviewRoutes({ pool, requireCustomerJwt, requireAdminSession }));
 
 
@@ -23488,7 +23495,7 @@ function isTechOffOnDate(techRow, dateStr, offMap, opts = {}) {
   return weekly.has(dow);
 }
 
-async function listAssignedJobsForTechOnDate(username, dateStr, ignoreJobId) {
+async function listAssignedJobsForTechOnDate(username, dateStr, ignoreJobId, poolOverride) {
   // ✅ Timezone-robust filter (source of truth: Asia/Bangkok)
   // กรองด้วยช่วงเวลา [dayStart, dayEnd) แบบ Bangkok offset แล้ว cast เป็น timestamptz เสมอ
   // โดยเราได้บังคับ timezone ของ session ที่ db.js แล้ว (options: -c timezone=Asia/Bangkok)
@@ -23513,7 +23520,7 @@ async function listAssignedJobsForTechOnDate(username, dateStr, ignoreJobId) {
   // - งานเดียวกันอาจแบ่งรายการให้หลายช่าง (job_items.assigned_technician_username)
   // - duration_min ของ jobs เป็น “รวมใบงาน/หัวหน้าทีม” จึงห้ามเอาไปล็อกคิวทุกคน
   // ทางแก้: คืน assigned_items เฉพาะของช่างคนนั้น แล้วคำนวณ duration ต่อคน (per-tech) ตอนทำ availability/collision
-  const r = await pool.query(
+  const r = await (poolOverride || pool).query(
     `
     SELECT
       j.job_id,
@@ -23776,10 +23783,10 @@ async function listJobBlocksForTechOnDate(username, dateStr, ignoreJobId){
   return mergeMinIntervals(raw);
 }
 
-async function listBusyBlocksForTechOnDate(username, dateStr, ignoreJobId){
+async function listBusyBlocksForTechOnDate(username, dateStr, ignoreJobId, poolOverride){
   // Returns merged BUSY blocks (with conservative buffer) in Bangkok minutes:
   // [{job_id,startMin,busyEndMin,startIso,durationMin}]
-  const jobs = await listAssignedJobsForTechOnDate(username, dateStr, ignoreJobId);
+  const jobs = await listAssignedJobsForTechOnDate(username, dateStr, ignoreJobId, poolOverride);
   const raw = [];
   for(const j of (jobs||[])){
     const startDate = new Date(j.appointment_datetime);

--- a/index.js
+++ b/index.js
@@ -12957,14 +12957,7 @@ app.use(createTechnicianDirectoryRoutes({ pool }));
 // =======================================
 // 📦 CATALOG
 // =======================================
-app.use(createCatalogItemRoutes({
-  pool,
-  requireAdminSession,
-  listBusyBlocksForTechOnDate,
-  buildStartIntervalsByCollision,
-  toMin,
-  minToHHMM,
-}));
+app.use(createCatalogItemRoutes({ pool, requireAdminSession }));
 app.use(createCatalogReviewRoutes({ pool, requireCustomerJwt, requireAdminSession }));
 
 
@@ -23495,7 +23488,7 @@ function isTechOffOnDate(techRow, dateStr, offMap, opts = {}) {
   return weekly.has(dow);
 }
 
-async function listAssignedJobsForTechOnDate(username, dateStr, ignoreJobId, poolOverride) {
+async function listAssignedJobsForTechOnDate(username, dateStr, ignoreJobId) {
   // ✅ Timezone-robust filter (source of truth: Asia/Bangkok)
   // กรองด้วยช่วงเวลา [dayStart, dayEnd) แบบ Bangkok offset แล้ว cast เป็น timestamptz เสมอ
   // โดยเราได้บังคับ timezone ของ session ที่ db.js แล้ว (options: -c timezone=Asia/Bangkok)
@@ -23520,7 +23513,7 @@ async function listAssignedJobsForTechOnDate(username, dateStr, ignoreJobId, poo
   // - งานเดียวกันอาจแบ่งรายการให้หลายช่าง (job_items.assigned_technician_username)
   // - duration_min ของ jobs เป็น “รวมใบงาน/หัวหน้าทีม” จึงห้ามเอาไปล็อกคิวทุกคน
   // ทางแก้: คืน assigned_items เฉพาะของช่างคนนั้น แล้วคำนวณ duration ต่อคน (per-tech) ตอนทำ availability/collision
-  const r = await (poolOverride || pool).query(
+  const r = await pool.query(
     `
     SELECT
       j.job_id,
@@ -23783,10 +23776,10 @@ async function listJobBlocksForTechOnDate(username, dateStr, ignoreJobId){
   return mergeMinIntervals(raw);
 }
 
-async function listBusyBlocksForTechOnDate(username, dateStr, ignoreJobId, poolOverride){
+async function listBusyBlocksForTechOnDate(username, dateStr, ignoreJobId){
   // Returns merged BUSY blocks (with conservative buffer) in Bangkok minutes:
   // [{job_id,startMin,busyEndMin,startIso,durationMin}]
-  const jobs = await listAssignedJobsForTechOnDate(username, dateStr, ignoreJobId, poolOverride);
+  const jobs = await listAssignedJobsForTechOnDate(username, dateStr, ignoreJobId);
   const raw = [];
   for(const j of (jobs||[])){
     const startDate = new Date(j.appointment_datetime);

--- a/server/routes/catalog/items.js
+++ b/server/routes/catalog/items.js
@@ -1,7 +1,7 @@
 const { money, intOrNull, boolish } = require("../../customerPricing");
 const cloudinaryImageUpload = require("../../lib/cloudinaryImageUpload");
 const customerAvailability = require("../../services/public/customerAvailability");
-const { getBangkokNow, computeJobTiming } = require("../../services/jobTiming");
+const { getBangkokNow, computeJobTiming, minimumStartForDate } = require("../../services/jobTiming");
 
 const MAX_CATALOG_IMAGES_PER_ITEM = 4;
 
@@ -578,12 +578,22 @@ async function listTechniciansForQueueCheck(pool, techType, opts = {}) {
   return r.rows || [];
 }
 
+function queueCutoffToMin(hhmm) {
+  const m = /^(\d{2}):(\d{2})$/.exec(String(hhmm || ""));
+  if (!m) return NaN;
+  return Number(m[1]) * 60 + Number(m[2]);
+}
+
 // "มีคิววันนี้" is real today-availability, derived the same way the booking
 // flow itself decides eligibility (server/services/public/customerAvailability's
 // eligibleCustomerTechnicians: service-matrix match + today's advance-calendar
-// gate + remaining daily capacity) -- never a guess, never hardcoded. Scoped to
-// a single in-process cache per (job/ac/wash) combo so a Store list page with
-// many items only re-runs the eligibility check once per distinct service
+// gate + remaining daily capacity), PLUS a same-day cutoff check so a
+// technician whose work window for today has already ended never shows a
+// false "has queue today" badge. (Existing-job collision within the
+// remaining window is not checked here -- that's the real booking flow's
+// job at reservation time, not the Store badge's.) Scoped to a single
+// in-process cache per (job/ac/wash) combo so a Store list page with many
+// items only re-runs the eligibility check once per distinct service
 // combination, not once per item.
 const QUEUE_TODAY_CACHE_TTL_MS = 60_000;
 const queueTodayCache = new Map();
@@ -595,34 +605,32 @@ async function hasTechnicianQueueToday(pool, { jobCategory, acType, washVariant 
   const cached = queueTodayCache.get(cacheKey);
   if (cached && cached.expiresAt > Date.now()) return cached.value;
 
-  const { listBusyBlocksForTechOnDate, buildStartIntervalsByCollision, toMin, minToHHMM } = slotDeps;
-  if (!listBusyBlocksForTechOnDate || !buildStartIntervalsByCollision || !toMin || !minToHHMM) {
-    queueTodayCache.set(cacheKey, { value: false, expiresAt: Date.now() + QUEUE_TODAY_CACHE_TTL_MS });
-    return false;
-  }
-
   const deps = {
     pool,
     listTechniciansByType: (techType, opts) => listTechniciansForQueueCheck(pool, techType, opts),
-    listBusyBlocksForTechOnDate,
-    buildStartIntervalsByCollision,
-    toMin,
-    minToHHMM,
-    getNowBangkokParts,
   };
-  const durationMin = computeJobTiming(
-    { job_type: jobCategory, ac_type: acType, wash_variant: washVariant, machine_count: 1 },
-    { source: "catalog_queue_today" }
-  ).service_duration_min;
-  const result = await customerAvailability.computePublicCustomerSlots(deps, {
+  const eligible = await customerAvailability.eligibleCustomerTechnicians(deps, {
     date: today,
     tech_type: "company",
     job_type: jobCategory,
     ac_type: acType,
     wash_variant: washVariant || undefined,
-    duration_min: durationMin,
   });
-  const value = Array.isArray(result && result.slots) && result.slots.some((s) => s.available);
+
+  const durationMin = computeJobTiming(
+    { job_type: jobCategory, ac_type: acType, wash_variant: washVariant, machine_count: 1 },
+    { source: "catalog_queue_today" }
+  ).service_duration_min;
+  const cutoff = minimumStartForDate(today, {
+    ui_start_min: 0,
+    ui_end_min: 24 * 60,
+    now_parts: getNowBangkokParts(),
+  });
+  const cutoffMin = cutoff.minimum_start_min;
+  const value = (Array.isArray(eligible) ? eligible : []).some((tech) => {
+    const endMin = queueCutoffToMin(String((tech.advance_calendar || {}).end_time || "").slice(0, 5));
+    return Number.isFinite(endMin) && (endMin - cutoffMin) >= durationMin;
+  });
   queueTodayCache.set(cacheKey, { value, expiresAt: Date.now() + QUEUE_TODAY_CACHE_TTL_MS });
   return value;
 }
@@ -882,13 +890,7 @@ module.exports = function createCatalogItemRoutes(deps = {}) {
   if (typeof requireAdminSession !== "function") {
     throw new Error("createCatalogItemRoutes requires a requireAdminSession middleware function");
   }
-  const queueSlotDeps = {
-    listBusyBlocksForTechOnDate: deps.listBusyBlocksForTechOnDate,
-    buildStartIntervalsByCollision: deps.buildStartIntervalsByCollision,
-    toMin: deps.toMin,
-    minToHHMM: deps.minToHHMM,
-    getNowBangkokParts: deps.getNowBangkokParts,
-  };
+  const queueSlotDeps = deps.getNowBangkokParts ? { getNowBangkokParts: deps.getNowBangkokParts } : {};
   const uploadCatalogImage = deps.uploadCatalogImage || cloudinaryImageUpload.uploadCatalogImage;
   const deleteCatalogImage = deps.deleteCatalogImage || cloudinaryImageUpload.deleteCatalogImage;
   const upload = multer({

--- a/server/routes/catalog/items.js
+++ b/server/routes/catalog/items.js
@@ -1,7 +1,7 @@
 const { money, intOrNull, boolish } = require("../../customerPricing");
 const cloudinaryImageUpload = require("../../lib/cloudinaryImageUpload");
 const customerAvailability = require("../../services/public/customerAvailability");
-const { getBangkokNow } = require("../../services/jobTiming");
+const { getBangkokNow, computeJobTiming } = require("../../services/jobTiming");
 
 const MAX_CATALOG_IMAGES_PER_ITEM = 4;
 
@@ -588,24 +588,41 @@ async function listTechniciansForQueueCheck(pool, techType, opts = {}) {
 const QUEUE_TODAY_CACHE_TTL_MS = 60_000;
 const queueTodayCache = new Map();
 
-async function hasTechnicianQueueToday(pool, { jobCategory, acType, washVariant }) {
-  const today = getBangkokNow().ymd;
+async function hasTechnicianQueueToday(pool, { jobCategory, acType, washVariant }, slotDeps = {}) {
+  const getNowBangkokParts = slotDeps.getNowBangkokParts || getBangkokNow;
+  const today = getNowBangkokParts().ymd;
   const cacheKey = `${jobCategory}|${acType}|${washVariant || ""}|${today}`;
   const cached = queueTodayCache.get(cacheKey);
   if (cached && cached.expiresAt > Date.now()) return cached.value;
 
+  const { listBusyBlocksForTechOnDate, buildStartIntervalsByCollision, toMin, minToHHMM } = slotDeps;
+  if (!listBusyBlocksForTechOnDate || !buildStartIntervalsByCollision || !toMin || !minToHHMM) {
+    queueTodayCache.set(cacheKey, { value: false, expiresAt: Date.now() + QUEUE_TODAY_CACHE_TTL_MS });
+    return false;
+  }
+
   const deps = {
     pool,
     listTechniciansByType: (techType, opts) => listTechniciansForQueueCheck(pool, techType, opts),
+    listBusyBlocksForTechOnDate,
+    buildStartIntervalsByCollision,
+    toMin,
+    minToHHMM,
+    getNowBangkokParts,
   };
-  const eligible = await customerAvailability.eligibleCustomerTechnicians(deps, {
+  const durationMin = computeJobTiming(
+    { job_type: jobCategory, ac_type: acType, wash_variant: washVariant, machine_count: 1 },
+    { source: "catalog_queue_today" }
+  ).service_duration_min;
+  const result = await customerAvailability.computePublicCustomerSlots(deps, {
     date: today,
     tech_type: "company",
     job_type: jobCategory,
     ac_type: acType,
     wash_variant: washVariant || undefined,
+    duration_min: durationMin,
   });
-  const value = Array.isArray(eligible) && eligible.length > 0;
+  const value = Array.isArray(result && result.slots) && result.slots.some((s) => s.available);
   queueTodayCache.set(cacheKey, { value, expiresAt: Date.now() + QUEUE_TODAY_CACHE_TTL_MS });
   return value;
 }
@@ -615,7 +632,7 @@ async function hasTechnicianQueueToday(pool, { jobCategory, acType, washVariant 
 // fail-open contract as attachBookingCounts: a failure here (e.g. the
 // technician-matrix tables aren't ready yet) must never block the Store
 // from loading -- it just leaves has_queue_today=false for the affected rows.
-async function attachTodayQueueAvailability(pool, rows) {
+async function attachTodayQueueAvailability(pool, rows, slotDeps = {}) {
   rows.forEach((row) => { row.has_queue_today = false; });
   const bookableRows = rows.filter((row) => row.booking_mode === "bookable" && row.job_category && row.booking_ac_type);
   if (!bookableRows.length) return rows;
@@ -629,7 +646,7 @@ async function attachTodayQueueAvailability(pool, rows) {
         jobCategory: row.job_category,
         acType: row.booking_ac_type,
         washVariant: row.booking_wash_variant,
-      }));
+      }, slotDeps));
     }
     bookableRows.forEach((row) => {
       const key = `${row.job_category}|${row.booking_ac_type}|${row.booking_wash_variant || ""}`;
@@ -865,6 +882,13 @@ module.exports = function createCatalogItemRoutes(deps = {}) {
   if (typeof requireAdminSession !== "function") {
     throw new Error("createCatalogItemRoutes requires a requireAdminSession middleware function");
   }
+  const queueSlotDeps = {
+    listBusyBlocksForTechOnDate: deps.listBusyBlocksForTechOnDate,
+    buildStartIntervalsByCollision: deps.buildStartIntervalsByCollision,
+    toMin: deps.toMin,
+    minToHHMM: deps.minToHHMM,
+    getNowBangkokParts: deps.getNowBangkokParts,
+  };
   const uploadCatalogImage = deps.uploadCatalogImage || cloudinaryImageUpload.uploadCatalogImage;
   const deleteCatalogImage = deps.deleteCatalogImage || cloudinaryImageUpload.deleteCatalogImage;
   const upload = multer({
@@ -1012,7 +1036,7 @@ module.exports = function createCatalogItemRoutes(deps = {}) {
       await attachCatalogImages(pool, r.rows, marketplaceReady);
       await attachCatalogRatings(pool, r.rows, reviewsReady);
       await attachBookingCounts(pool, r.rows, jobsCatalogLinkReady);
-      await attachTodayQueueAvailability(pool, r.rows);
+      await attachTodayQueueAvailability(pool, r.rows, queueSlotDeps);
       res.json(r.rows.map(serializeCatalogRow));
     } catch (e) {
       console.error(e);
@@ -1042,7 +1066,7 @@ module.exports = function createCatalogItemRoutes(deps = {}) {
       await attachCatalogImages(pool, [row], marketplaceReady);
       await attachCatalogRatings(pool, [row], reviewsReady);
       await attachBookingCounts(pool, [row], jobsCatalogLinkReady);
-      await attachTodayQueueAvailability(pool, [row]);
+      await attachTodayQueueAvailability(pool, [row], queueSlotDeps);
       res.json(serializeCatalogDetailRow(row));
     } catch (e) {
       console.error(e);

--- a/server/routes/catalog/items.js
+++ b/server/routes/catalog/items.js
@@ -1,7 +1,7 @@
 const { money, intOrNull, boolish } = require("../../customerPricing");
 const cloudinaryImageUpload = require("../../lib/cloudinaryImageUpload");
 const customerAvailability = require("../../services/public/customerAvailability");
-const { getBangkokNow, computeJobTiming, minimumStartForDate } = require("../../services/jobTiming");
+const { getBangkokNow, computeJobTiming } = require("../../services/jobTiming");
 
 const MAX_CATALOG_IMAGES_PER_ITEM = 4;
 
@@ -578,22 +578,12 @@ async function listTechniciansForQueueCheck(pool, techType, opts = {}) {
   return r.rows || [];
 }
 
-function queueCutoffToMin(hhmm) {
-  const m = /^(\d{2}):(\d{2})$/.exec(String(hhmm || ""));
-  if (!m) return NaN;
-  return Number(m[1]) * 60 + Number(m[2]);
-}
-
 // "มีคิววันนี้" is real today-availability, derived the same way the booking
 // flow itself decides eligibility (server/services/public/customerAvailability's
 // eligibleCustomerTechnicians: service-matrix match + today's advance-calendar
-// gate + remaining daily capacity), PLUS a same-day cutoff check so a
-// technician whose work window for today has already ended never shows a
-// false "has queue today" badge. (Existing-job collision within the
-// remaining window is not checked here -- that's the real booking flow's
-// job at reservation time, not the Store badge's.) Scoped to a single
-// in-process cache per (job/ac/wash) combo so a Store list page with many
-// items only re-runs the eligibility check once per distinct service
+// gate + remaining daily capacity) -- never a guess, never hardcoded. Scoped to
+// a single in-process cache per (job/ac/wash) combo so a Store list page with
+// many items only re-runs the eligibility check once per distinct service
 // combination, not once per item.
 const QUEUE_TODAY_CACHE_TTL_MS = 60_000;
 const queueTodayCache = new Map();
@@ -605,32 +595,34 @@ async function hasTechnicianQueueToday(pool, { jobCategory, acType, washVariant 
   const cached = queueTodayCache.get(cacheKey);
   if (cached && cached.expiresAt > Date.now()) return cached.value;
 
+  const { listBusyBlocksForTechOnDate, buildStartIntervalsByCollision, toMin, minToHHMM } = slotDeps;
+  if (!listBusyBlocksForTechOnDate || !buildStartIntervalsByCollision || !toMin || !minToHHMM) {
+    queueTodayCache.set(cacheKey, { value: false, expiresAt: Date.now() + QUEUE_TODAY_CACHE_TTL_MS });
+    return false;
+  }
+
   const deps = {
     pool,
     listTechniciansByType: (techType, opts) => listTechniciansForQueueCheck(pool, techType, opts),
+    listBusyBlocksForTechOnDate,
+    buildStartIntervalsByCollision,
+    toMin,
+    minToHHMM,
+    getNowBangkokParts,
   };
-  const eligible = await customerAvailability.eligibleCustomerTechnicians(deps, {
+  const durationMin = computeJobTiming(
+    { job_type: jobCategory, ac_type: acType, wash_variant: washVariant, machine_count: 1 },
+    { source: "catalog_queue_today" }
+  ).service_duration_min;
+  const result = await customerAvailability.computePublicCustomerSlots(deps, {
     date: today,
     tech_type: "company",
     job_type: jobCategory,
     ac_type: acType,
     wash_variant: washVariant || undefined,
+    duration_min: durationMin,
   });
-
-  const durationMin = computeJobTiming(
-    { job_type: jobCategory, ac_type: acType, wash_variant: washVariant, machine_count: 1 },
-    { source: "catalog_queue_today" }
-  ).service_duration_min;
-  const cutoff = minimumStartForDate(today, {
-    ui_start_min: 0,
-    ui_end_min: 24 * 60,
-    now_parts: getNowBangkokParts(),
-  });
-  const cutoffMin = cutoff.minimum_start_min;
-  const value = (Array.isArray(eligible) ? eligible : []).some((tech) => {
-    const endMin = queueCutoffToMin(String((tech.advance_calendar || {}).end_time || "").slice(0, 5));
-    return Number.isFinite(endMin) && (endMin - cutoffMin) >= durationMin;
-  });
+  const value = Array.isArray(result && result.slots) && result.slots.some((s) => s.available);
   queueTodayCache.set(cacheKey, { value, expiresAt: Date.now() + QUEUE_TODAY_CACHE_TTL_MS });
   return value;
 }
@@ -890,7 +882,13 @@ module.exports = function createCatalogItemRoutes(deps = {}) {
   if (typeof requireAdminSession !== "function") {
     throw new Error("createCatalogItemRoutes requires a requireAdminSession middleware function");
   }
-  const queueSlotDeps = deps.getNowBangkokParts ? { getNowBangkokParts: deps.getNowBangkokParts } : {};
+  const queueSlotDeps = {
+    listBusyBlocksForTechOnDate: deps.listBusyBlocksForTechOnDate,
+    buildStartIntervalsByCollision: deps.buildStartIntervalsByCollision,
+    toMin: deps.toMin,
+    minToHHMM: deps.minToHHMM,
+    getNowBangkokParts: deps.getNowBangkokParts,
+  };
   const uploadCatalogImage = deps.uploadCatalogImage || cloudinaryImageUpload.uploadCatalogImage;
   const deleteCatalogImage = deps.deleteCatalogImage || cloudinaryImageUpload.deleteCatalogImage;
   const upload = multer({

--- a/server/routes/catalog/items.js
+++ b/server/routes/catalog/items.js
@@ -1,5 +1,7 @@
 const { money, intOrNull, boolish } = require("../../customerPricing");
 const cloudinaryImageUpload = require("../../lib/cloudinaryImageUpload");
+const customerAvailability = require("../../services/public/customerAvailability");
+const { getBangkokNow } = require("../../services/jobTiming");
 
 const MAX_CATALOG_IMAGES_PER_ITEM = 4;
 
@@ -549,6 +551,96 @@ async function attachBookingCounts(pool, rows, jobsCatalogLinkReady) {
   return rows;
 }
 
+// Mirrors index.js's listTechniciansByType() read-only query exactly (same
+// table, same filters), so this stays a faithful proxy for the real
+// scheduling engine's technician pool instead of an approximate guess.
+// Re-implemented locally rather than imported because the original is a
+// closure over index.js's module-level `pool` and isn't exported.
+async function listTechniciansForQueueCheck(pool, techType, opts = {}) {
+  const t = String(techType || "company").trim().toLowerCase();
+  const includePaused = Boolean(opts.include_paused);
+  const isAll = t === "all";
+  const r = await pool.query(
+    `SELECT u.username,
+            COALESCE(p.employment_type,'company') AS employment_type,
+            COALESCE(p.accept_status,'ready') AS accept_status,
+            p.customer_slot_visible AS customer_slot_visible
+       FROM public.users u
+       LEFT JOIN public.technician_profiles p ON p.username = u.username
+      WHERE u.role = 'technician'
+        AND ($2::boolean IS TRUE OR COALESCE(p.accept_status,'ready') <> 'paused')
+        AND ($3::boolean IS TRUE OR (
+              ($1 = 'company' AND COALESCE(p.employment_type,'company') IN ('company','custom','special_only'))
+           OR ($1 <> 'company' AND COALESCE(p.employment_type,'company') = $1)
+        ))`,
+    [t, includePaused, isAll]
+  );
+  return r.rows || [];
+}
+
+// "มีคิววันนี้" is real today-availability, derived the same way the booking
+// flow itself decides eligibility (server/services/public/customerAvailability's
+// eligibleCustomerTechnicians: service-matrix match + today's advance-calendar
+// gate + remaining daily capacity) -- never a guess, never hardcoded. Scoped to
+// a single in-process cache per (job/ac/wash) combo so a Store list page with
+// many items only re-runs the eligibility check once per distinct service
+// combination, not once per item.
+const QUEUE_TODAY_CACHE_TTL_MS = 60_000;
+const queueTodayCache = new Map();
+
+async function hasTechnicianQueueToday(pool, { jobCategory, acType, washVariant }) {
+  const today = getBangkokNow().ymd;
+  const cacheKey = `${jobCategory}|${acType}|${washVariant || ""}|${today}`;
+  const cached = queueTodayCache.get(cacheKey);
+  if (cached && cached.expiresAt > Date.now()) return cached.value;
+
+  const deps = {
+    pool,
+    listTechniciansByType: (techType, opts) => listTechniciansForQueueCheck(pool, techType, opts),
+  };
+  const eligible = await customerAvailability.eligibleCustomerTechnicians(deps, {
+    date: today,
+    tech_type: "company",
+    job_type: jobCategory,
+    ac_type: acType,
+    wash_variant: washVariant || undefined,
+  });
+  const value = Array.isArray(eligible) && eligible.length > 0;
+  queueTodayCache.set(cacheKey, { value, expiresAt: Date.now() + QUEUE_TODAY_CACHE_TTL_MS });
+  return value;
+}
+
+// Attaches has_queue_today to bookable rows only (a non-bookable/"contact
+// admin" item never shows a queue badge). Supplementary enrichment, same
+// fail-open contract as attachBookingCounts: a failure here (e.g. the
+// technician-matrix tables aren't ready yet) must never block the Store
+// from loading -- it just leaves has_queue_today=false for the affected rows.
+async function attachTodayQueueAvailability(pool, rows) {
+  rows.forEach((row) => { row.has_queue_today = false; });
+  const bookableRows = rows.filter((row) => row.booking_mode === "bookable" && row.job_category && row.booking_ac_type);
+  if (!bookableRows.length) return rows;
+
+  try {
+    const seen = new Map();
+    for (const row of bookableRows) {
+      const key = `${row.job_category}|${row.booking_ac_type}|${row.booking_wash_variant || ""}`;
+      if (seen.has(key)) continue;
+      seen.set(key, await hasTechnicianQueueToday(pool, {
+        jobCategory: row.job_category,
+        acType: row.booking_ac_type,
+        washVariant: row.booking_wash_variant,
+      }));
+    }
+    bookableRows.forEach((row) => {
+      const key = `${row.job_category}|${row.booking_ac_type}|${row.booking_wash_variant || ""}`;
+      row.has_queue_today = Boolean(seen.get(key));
+    });
+  } catch (e) {
+    console.warn("[catalog_queue_today] availability check failed", e && e.code ? { code: e.code } : undefined);
+  }
+  return rows;
+}
+
 function serializeCatalogImage(imgRow) {
   return {
     image_id: imgRow.image_id,
@@ -672,6 +764,9 @@ function serializeCatalogRow(row) {
     // Real COUNT(DISTINCT job_id) only (attachBookingCounts); 0 until the jobs
     // catalog-link migration has run -- never a fabricated/hardcoded number.
     booking_count: Number(row.booking_count || 0),
+    // Real technician-eligibility check for today (attachTodayQueueAvailability);
+    // false until that's run -- never a hardcoded/guessed true.
+    has_queue_today: Boolean(row.has_queue_today),
   };
 }
 
@@ -917,6 +1012,7 @@ module.exports = function createCatalogItemRoutes(deps = {}) {
       await attachCatalogImages(pool, r.rows, marketplaceReady);
       await attachCatalogRatings(pool, r.rows, reviewsReady);
       await attachBookingCounts(pool, r.rows, jobsCatalogLinkReady);
+      await attachTodayQueueAvailability(pool, r.rows);
       res.json(r.rows.map(serializeCatalogRow));
     } catch (e) {
       console.error(e);
@@ -946,6 +1042,7 @@ module.exports = function createCatalogItemRoutes(deps = {}) {
       await attachCatalogImages(pool, [row], marketplaceReady);
       await attachCatalogRatings(pool, [row], reviewsReady);
       await attachBookingCounts(pool, [row], jobsCatalogLinkReady);
+      await attachTodayQueueAvailability(pool, [row]);
       res.json(serializeCatalogDetailRow(row));
     } catch (e) {
       console.error(e);
@@ -1720,3 +1817,7 @@ module.exports.buildCatalogSelect = buildCatalogSelect;
 module.exports.MAX_CATALOG_IMAGES_PER_ITEM = MAX_CATALOG_IMAGES_PER_ITEM;
 module.exports.validateHotField = validateHotField;
 module.exports.attachCatalogRatings = attachCatalogRatings;
+// Test-only: queueTodayCache is a 60s in-process TTL cache, deliberately shared
+// across requests within a process. Tests that need a fresh eligibility check
+// (rather than another test's cached value) must clear it first.
+module.exports.__resetQueueTodayCacheForTests = () => queueTodayCache.clear();

--- a/test/catalogItemsRoutes.test.js
+++ b/test/catalogItemsRoutes.test.js
@@ -810,7 +810,17 @@ test("SQL injection attempts cannot change query structure", async () => {
 
 test("index.js passes the real requireAdminSession middleware into createCatalogItemRoutes", () => {
   const source = fs.readFileSync(path.join(__dirname, "..", "index.js"), "utf8");
-  assert.match(source, /app\.use\(createCatalogItemRoutes\(\{\s*pool,\s*requireAdminSession\s*\}\)\)/);
+  assert.match(source, /app\.use\(createCatalogItemRoutes\(\{\s*pool,\s*requireAdminSession,/);
+});
+
+test("index.js wires the real public slot-engine deps into createCatalogItemRoutes (has_queue_today must use real slots, not just eligibility)", () => {
+  const source = fs.readFileSync(path.join(__dirname, "..", "index.js"), "utf8");
+  const match = source.match(/app\.use\(createCatalogItemRoutes\(\{[^}]*\}\)\);/);
+  assert.ok(match, "createCatalogItemRoutes call site not found");
+  assert.match(match[0], /listBusyBlocksForTechOnDate/);
+  assert.match(match[0], /buildStartIntervalsByCollision/);
+  assert.match(match[0], /toMin/);
+  assert.match(match[0], /minToHHMM/);
 });
 
 test("admin POST rejects an invalid is_active value and never writes to the DB", async () => {
@@ -2818,6 +2828,43 @@ test("booking_count is also attached on the single-item public detail endpoint",
 });
 
 // ---- has_queue_today (real technician-eligibility check, never hardcoded) ----
+// Verifies an actual bookable start slot today (cutoff + collision), not just
+// matrix/calendar/capacity eligibility -- mirrors the real public slot engine's
+// deps shape (see customerSameDayTiming.test.js for the same pattern).
+
+function queueToMin(value) {
+  const [h, m] = String(value).split(":").map(Number);
+  return h * 60 + m;
+}
+
+function queueMinToHHMM(value) {
+  return `${String(Math.floor(value / 60)).padStart(2, "0")}:${String(value % 60).padStart(2, "0")}`;
+}
+
+function queueIntervalsFromBusy(blocks, startMin, endMin, durationMin) {
+  const dur = Math.max(1, Number(durationMin || 0));
+  const busy = (blocks || []).slice().sort((a, b) => a.startMin - b.startMin);
+  const out = [];
+  let cursor = startMin;
+  for (const b of busy) {
+    const bs = Math.max(startMin, Number(b.startMin));
+    const be = Math.min(endMin, Number(b.busyEndMin ?? b.endMin));
+    if (bs - cursor >= dur) out.push({ startMin: cursor, endMin: bs - dur });
+    cursor = Math.max(cursor, be);
+  }
+  if (endMin - cursor >= dur) out.push({ startMin: cursor, endMin: endMin - dur });
+  return out;
+}
+
+function queueSlotDeps({ busyBlocks = [], nowParts } = {}) {
+  return {
+    listBusyBlocksForTechOnDate: async () => busyBlocks,
+    buildStartIntervalsByCollision: queueIntervalsFromBusy,
+    toMin: queueToMin,
+    minToHHMM: queueMinToHHMM,
+    ...(nowParts ? { getNowBangkokParts: () => nowParts } : {}),
+  };
+}
 
 function bookableWashWallItem(overrides = {}) {
   return {
@@ -2837,10 +2884,12 @@ function eligibleTodayFixtures() {
   };
 }
 
-test("has_queue_today is true on the list endpoint when a real technician is eligible today", async () => {
+const QUEUE_TODAY_MORNING_NOW = { ymd: getBangkokNow().ymd, hour: 9, minute: 0 };
+
+test("has_queue_today is true on the list endpoint when a real bookable start slot exists today", async () => {
   createCatalogItemRoutes.__resetQueueTodayCacheForTests();
   const pool = makePool([bookableWashWallItem()], [], { marketplaceReady: true, ...eligibleTodayFixtures() });
-  const router = createCatalogItemRoutes({ pool, requireAdminSession: allowAdmin });
+  const router = createCatalogItemRoutes({ pool, requireAdminSession: allowAdmin, ...queueSlotDeps({ nowParts: QUEUE_TODAY_MORNING_NOW }) });
   await withServer(router, async (base) => {
     const res = await fetch(`${base}/catalog/items?customer=1`);
     const body = await res.json();
@@ -2852,7 +2901,7 @@ test("has_queue_today is true on the list endpoint when a real technician is eli
 test("has_queue_today is true and consistent on the single-item detail endpoint", async () => {
   createCatalogItemRoutes.__resetQueueTodayCacheForTests();
   const pool = makePool([bookableWashWallItem()], [], { marketplaceReady: true, ...eligibleTodayFixtures() });
-  const router = createCatalogItemRoutes({ pool, requireAdminSession: allowAdmin });
+  const router = createCatalogItemRoutes({ pool, requireAdminSession: allowAdmin, ...queueSlotDeps({ nowParts: QUEUE_TODAY_MORNING_NOW }) });
   await withServer(router, async (base) => {
     const res = await fetch(`${base}/catalog/items/1`);
     const body = await res.json();
@@ -2863,7 +2912,7 @@ test("has_queue_today is true and consistent on the single-item detail endpoint"
 test("has_queue_today is false (never guessed true) when no real technician is eligible today", async () => {
   createCatalogItemRoutes.__resetQueueTodayCacheForTests();
   const pool = makePool([bookableWashWallItem()], [], { marketplaceReady: true });
-  const router = createCatalogItemRoutes({ pool, requireAdminSession: allowAdmin });
+  const router = createCatalogItemRoutes({ pool, requireAdminSession: allowAdmin, ...queueSlotDeps({ nowParts: QUEUE_TODAY_MORNING_NOW }) });
   await withServer(router, async (base) => {
     const res = await fetch(`${base}/catalog/items?customer=1`);
     const body = await res.json();
@@ -2874,7 +2923,60 @@ test("has_queue_today is false (never guessed true) when no real technician is e
 test("has_queue_today is false for contact_admin items even with an eligible technician", async () => {
   createCatalogItemRoutes.__resetQueueTodayCacheForTests();
   const pool = makePool([bookableWashWallItem({ booking_mode: "contact_admin" })], [], { marketplaceReady: true, ...eligibleTodayFixtures() });
-  const router = createCatalogItemRoutes({ pool, requireAdminSession: allowAdmin });
+  const router = createCatalogItemRoutes({ pool, requireAdminSession: allowAdmin, ...queueSlotDeps({ nowParts: QUEUE_TODAY_MORNING_NOW }) });
+  await withServer(router, async (base) => {
+    const res = await fetch(`${base}/catalog/items?customer=1`);
+    const body = await res.json();
+    assert.equal(body.find((x) => x.item_id === 1).has_queue_today, false);
+  });
+});
+
+test("has_queue_today is false when the current time has already passed the technician's end-of-day window", async () => {
+  createCatalogItemRoutes.__resetQueueTodayCacheForTests();
+  const pool = makePool([bookableWashWallItem()], [], { marketplaceReady: true, ...eligibleTodayFixtures() });
+  const router = createCatalogItemRoutes({
+    pool, requireAdminSession: allowAdmin,
+    ...queueSlotDeps({ nowParts: { ymd: getBangkokNow().ymd, hour: 19, minute: 0 } }),
+  });
+  await withServer(router, async (base) => {
+    const res = await fetch(`${base}/catalog/items?customer=1`);
+    const body = await res.json();
+    assert.equal(body.find((x) => x.item_id === 1).has_queue_today, false);
+  });
+});
+
+test("has_queue_today is false when the technician's whole window today is already booked solid (collision-full)", async () => {
+  createCatalogItemRoutes.__resetQueueTodayCacheForTests();
+  const pool = makePool([bookableWashWallItem()], [], { marketplaceReady: true, ...eligibleTodayFixtures() });
+  const router = createCatalogItemRoutes({
+    pool, requireAdminSession: allowAdmin,
+    ...queueSlotDeps({
+      nowParts: QUEUE_TODAY_MORNING_NOW,
+      busyBlocks: [{ startMin: queueToMin("09:00"), busyEndMin: queueToMin("18:00") }],
+    }),
+  });
+  await withServer(router, async (base) => {
+    const res = await fetch(`${base}/catalog/items?customer=1`);
+    const body = await res.json();
+    assert.equal(body.find((x) => x.item_id === 1).has_queue_today, false);
+  });
+});
+
+test("has_queue_today is false when the technician's daily job capacity is already used up today", async () => {
+  createCatalogItemRoutes.__resetQueueTodayCacheForTests();
+  const today = getBangkokNow().ymd;
+  const pool = makePool([bookableWashWallItem()], [], {
+    marketplaceReady: true,
+    technicians: [{ username: "tech1", employment_type: "company", accept_status: "ready", customer_slot_visible: true }],
+    serviceMatrix: [{ username: "tech1", matrix_json: { job_types: { wash: true }, ac_types: { wall: true }, wash_wall_variants: { normal: true } } }],
+    calendarRows: [{ technician_username: "tech1", work_date: today, can_accept_advance_job: true, start_time: "09:00:00", end_time: "18:00:00", max_jobs_per_day: 1, max_units_per_day: null }],
+  });
+  const originalQuery = pool.query;
+  pool.query = async (sql, params) => {
+    if (String(sql).includes("WITH assigned AS")) return { rows: [{ technician_username: "tech1", jobs_count: 1, units_count: 1 }] };
+    return originalQuery(sql, params);
+  };
+  const router = createCatalogItemRoutes({ pool, requireAdminSession: allowAdmin, ...queueSlotDeps({ nowParts: QUEUE_TODAY_MORNING_NOW }) });
   await withServer(router, async (base) => {
     const res = await fetch(`${base}/catalog/items?customer=1`);
     const body = await res.json();
@@ -2890,7 +2992,7 @@ test("has_queue_today fails open to false (never crashes the Store listing) when
     if (String(sql).includes("FROM public.technician_service_matrix")) throw new Error("simulated queue-today failure");
     return originalQuery(sql, params);
   };
-  const router = createCatalogItemRoutes({ pool, requireAdminSession: allowAdmin });
+  const router = createCatalogItemRoutes({ pool, requireAdminSession: allowAdmin, ...queueSlotDeps({ nowParts: QUEUE_TODAY_MORNING_NOW }) });
   await withServer(router, async (base) => {
     const res = await fetch(`${base}/catalog/items?customer=1`);
     const body = await res.json();
@@ -2906,7 +3008,7 @@ test("has_queue_today reuses one cached eligibility check across multiple items 
     bookableWashWallItem({ item_id: 2, item_name: "ล้างแอร์ผนัง B" }),
   ];
   const pool = makePool(items, [], { marketplaceReady: true, ...eligibleTodayFixtures() });
-  const router = createCatalogItemRoutes({ pool, requireAdminSession: allowAdmin });
+  const router = createCatalogItemRoutes({ pool, requireAdminSession: allowAdmin, ...queueSlotDeps({ nowParts: QUEUE_TODAY_MORNING_NOW }) });
   await withServer(router, async (base) => {
     const res = await fetch(`${base}/catalog/items?customer=1`);
     const body = await res.json();

--- a/test/catalogItemsRoutes.test.js
+++ b/test/catalogItemsRoutes.test.js
@@ -6,9 +6,13 @@ const http = require("node:http");
 const express = require("express");
 
 const createCatalogItemRoutes = require("../server/routes/catalog/items");
+const { getBangkokNow } = require("../server/services/jobTiming");
 
-function makePool(initialItems = [], initialRules = [], { schemaReady = true, marketplaceReady = false, autoplayReady = false, jobsCatalogLinkReady = false, jobs = [], jobUnits = [], forceBookingCountError = false } = {}) {
+function makePool(initialItems = [], initialRules = [], { schemaReady = true, marketplaceReady = false, autoplayReady = false, jobsCatalogLinkReady = false, jobs = [], jobUnits = [], forceBookingCountError = false, technicians = [], serviceMatrix = [], calendarRows = [] } = {}) {
   const state = {
+    technicians: technicians.map((x) => ({ ...x })),
+    serviceMatrix: serviceMatrix.map((x) => ({ ...x })),
+    calendarRows: calendarRows.map((x) => ({ ...x })),
     items: initialItems.map((x) => ({
       image_url: null, image_public_id: null, price_rule_id: null,
       short_description: null, long_description: null, highlights: null, service_conditions: null,
@@ -126,6 +130,46 @@ function makePool(initialItems = [], initialRules = [], { schemaReady = true, ma
       }
       return { rows: Array.from(byItem.entries()).map(([item_id, jobIds]) => ({ item_id, cnt: jobIds.size })) };
     }
+
+    // listTechniciansForQueueCheck (attachTodayQueueAvailability's local proxy
+    // for index.js's listTechniciansByType).
+    if (s.includes("FROM public.users u") && s.includes("LEFT JOIN public.technician_profiles")) {
+      const [techType, includePaused, isAll] = params;
+      const rows = state.technicians.filter((t) => {
+        if (!includePaused && (t.accept_status || "ready") === "paused") return false;
+        if (isAll) return true;
+        if (techType === "company") return ["company", "custom", "special_only"].includes(t.employment_type || "company");
+        return (t.employment_type || "company") === techType;
+      }).map((t) => ({
+        username: t.username,
+        employment_type: t.employment_type || "company",
+        accept_status: t.accept_status || "ready",
+        customer_slot_visible: t.customer_slot_visible === true,
+      }));
+      return { rows };
+    }
+
+    // customerAvailability.loadServiceMatrixMap
+    if (s.includes("FROM public.technician_service_matrix")) {
+      const [usernames] = params;
+      const rows = state.serviceMatrix
+        .filter((m) => usernames.map(String).includes(String(m.username)))
+        .map((m) => ({ username: m.username, matrix_json: m.matrix_json }));
+      return { rows };
+    }
+
+    // customerAvailability.loadAdvanceCalendarMap
+    if (s.includes("FROM public.technician_monthly_work_calendar")) {
+      const [usernames, date] = params;
+      const rows = state.calendarRows.filter((c) =>
+        usernames.map(String).includes(String(c.technician_username)) && String(c.work_date) === String(date)
+      );
+      return { rows };
+    }
+
+    // customerAvailability.loadDailyUsageMap -- tests never pre-seed competing
+    // bookings for the queue-today check, so capacity is always open.
+    if (s.includes("WITH assigned AS")) return { rows: [] };
 
     if (/^\s*(BEGIN|COMMIT|ROLLBACK)\s*;?\s*$/i.test(s)) return { rows: [] };
     if (s.includes("ALTER TABLE") || s.includes("CREATE INDEX") || s.includes("ADD CONSTRAINT") || s.includes("DO $$")) return { rows: [] };
@@ -2770,5 +2814,104 @@ test("booking_count is also attached on the single-item public detail endpoint",
     const res = await fetch(`${base}/catalog/items/1`);
     const body = await res.json();
     assert.equal(body.booking_count, 1);
+  });
+});
+
+// ---- has_queue_today (real technician-eligibility check, never hardcoded) ----
+
+function bookableWashWallItem(overrides = {}) {
+  return {
+    item_id: 1, item_name: "ล้างแอร์ผนัง", item_category: "ล้างแอร์", base_price: 700, unit_label: "เครื่อง",
+    job_category: "ล้าง", ac_type: "ผนัง", btu_min: 9000, btu_max: 12000, is_active: true, is_customer_visible: true,
+    booking_mode: "bookable", booking_ac_type: "ผนัง", booking_btu: 9000, booking_wash_variant: "ล้างธรรมดา",
+    ...overrides,
+  };
+}
+
+function eligibleTodayFixtures() {
+  const today = getBangkokNow().ymd;
+  return {
+    technicians: [{ username: "tech1", employment_type: "company", accept_status: "ready", customer_slot_visible: true }],
+    serviceMatrix: [{ username: "tech1", matrix_json: { job_types: { wash: true }, ac_types: { wall: true }, wash_wall_variants: { normal: true } } }],
+    calendarRows: [{ technician_username: "tech1", work_date: today, can_accept_advance_job: true, start_time: "09:00:00", end_time: "18:00:00", max_jobs_per_day: null, max_units_per_day: null }],
+  };
+}
+
+test("has_queue_today is true on the list endpoint when a real technician is eligible today", async () => {
+  createCatalogItemRoutes.__resetQueueTodayCacheForTests();
+  const pool = makePool([bookableWashWallItem()], [], { marketplaceReady: true, ...eligibleTodayFixtures() });
+  const router = createCatalogItemRoutes({ pool, requireAdminSession: allowAdmin });
+  await withServer(router, async (base) => {
+    const res = await fetch(`${base}/catalog/items?customer=1`);
+    const body = await res.json();
+    assert.equal(res.status, 200);
+    assert.equal(body.find((x) => x.item_id === 1).has_queue_today, true);
+  });
+});
+
+test("has_queue_today is true and consistent on the single-item detail endpoint", async () => {
+  createCatalogItemRoutes.__resetQueueTodayCacheForTests();
+  const pool = makePool([bookableWashWallItem()], [], { marketplaceReady: true, ...eligibleTodayFixtures() });
+  const router = createCatalogItemRoutes({ pool, requireAdminSession: allowAdmin });
+  await withServer(router, async (base) => {
+    const res = await fetch(`${base}/catalog/items/1`);
+    const body = await res.json();
+    assert.equal(body.has_queue_today, true);
+  });
+});
+
+test("has_queue_today is false (never guessed true) when no real technician is eligible today", async () => {
+  createCatalogItemRoutes.__resetQueueTodayCacheForTests();
+  const pool = makePool([bookableWashWallItem()], [], { marketplaceReady: true });
+  const router = createCatalogItemRoutes({ pool, requireAdminSession: allowAdmin });
+  await withServer(router, async (base) => {
+    const res = await fetch(`${base}/catalog/items?customer=1`);
+    const body = await res.json();
+    assert.equal(body.find((x) => x.item_id === 1).has_queue_today, false);
+  });
+});
+
+test("has_queue_today is false for contact_admin items even with an eligible technician", async () => {
+  createCatalogItemRoutes.__resetQueueTodayCacheForTests();
+  const pool = makePool([bookableWashWallItem({ booking_mode: "contact_admin" })], [], { marketplaceReady: true, ...eligibleTodayFixtures() });
+  const router = createCatalogItemRoutes({ pool, requireAdminSession: allowAdmin });
+  await withServer(router, async (base) => {
+    const res = await fetch(`${base}/catalog/items?customer=1`);
+    const body = await res.json();
+    assert.equal(body.find((x) => x.item_id === 1).has_queue_today, false);
+  });
+});
+
+test("has_queue_today fails open to false (never crashes the Store listing) when the eligibility check throws", async () => {
+  createCatalogItemRoutes.__resetQueueTodayCacheForTests();
+  const pool = makePool([bookableWashWallItem()], [], { marketplaceReady: true, ...eligibleTodayFixtures() });
+  const originalQuery = pool.query;
+  pool.query = async (sql, params) => {
+    if (String(sql).includes("FROM public.technician_service_matrix")) throw new Error("simulated queue-today failure");
+    return originalQuery(sql, params);
+  };
+  const router = createCatalogItemRoutes({ pool, requireAdminSession: allowAdmin });
+  await withServer(router, async (base) => {
+    const res = await fetch(`${base}/catalog/items?customer=1`);
+    const body = await res.json();
+    assert.equal(res.status, 200);
+    assert.equal(body.find((x) => x.item_id === 1).has_queue_today, false);
+  });
+});
+
+test("has_queue_today reuses one cached eligibility check across multiple items with identical service criteria", async () => {
+  createCatalogItemRoutes.__resetQueueTodayCacheForTests();
+  const items = [
+    bookableWashWallItem({ item_id: 1, item_name: "ล้างแอร์ผนัง A" }),
+    bookableWashWallItem({ item_id: 2, item_name: "ล้างแอร์ผนัง B" }),
+  ];
+  const pool = makePool(items, [], { marketplaceReady: true, ...eligibleTodayFixtures() });
+  const router = createCatalogItemRoutes({ pool, requireAdminSession: allowAdmin });
+  await withServer(router, async (base) => {
+    const res = await fetch(`${base}/catalog/items?customer=1`);
+    const body = await res.json();
+    assert.ok(body.every((x) => x.has_queue_today === true));
+    const matrixQueries = pool.state.queries.filter((q) => q.sql.includes("FROM public.technician_service_matrix"));
+    assert.equal(matrixQueries.length, 1);
   });
 });

--- a/test/catalogItemsRoutes.test.js
+++ b/test/catalogItemsRoutes.test.js
@@ -810,7 +810,17 @@ test("SQL injection attempts cannot change query structure", async () => {
 
 test("index.js passes the real requireAdminSession middleware into createCatalogItemRoutes", () => {
   const source = fs.readFileSync(path.join(__dirname, "..", "index.js"), "utf8");
-  assert.match(source, /app\.use\(createCatalogItemRoutes\(\{\s*pool,\s*requireAdminSession\s*\}\)\)/);
+  assert.match(source, /app\.use\(createCatalogItemRoutes\(\{\s*pool,\s*requireAdminSession,/);
+});
+
+test("index.js wires the real public slot-engine deps into createCatalogItemRoutes (has_queue_today must use real slots, not just eligibility)", () => {
+  const source = fs.readFileSync(path.join(__dirname, "..", "index.js"), "utf8");
+  const match = source.match(/app\.use\(createCatalogItemRoutes\(\{[^}]*\}\)\);/);
+  assert.ok(match, "createCatalogItemRoutes call site not found");
+  assert.match(match[0], /listBusyBlocksForTechOnDate/);
+  assert.match(match[0], /buildStartIntervalsByCollision/);
+  assert.match(match[0], /toMin/);
+  assert.match(match[0], /minToHHMM/);
 });
 
 test("admin POST rejects an invalid is_active value and never writes to the DB", async () => {
@@ -2818,13 +2828,42 @@ test("booking_count is also attached on the single-item public detail endpoint",
 });
 
 // ---- has_queue_today (real technician-eligibility check, never hardcoded) ----
-// Verifies matrix/calendar/capacity eligibility PLUS a same-day cutoff check
-// (a technician whose work window for today has already ended never counts),
-// derived from the real getNowBangkokParts clock unless a test injects a
-// fixed one for determinism.
+// Verifies an actual bookable start slot today (cutoff + collision), not just
+// matrix/calendar/capacity eligibility -- mirrors the real public slot engine's
+// deps shape (see customerSameDayTiming.test.js for the same pattern).
 
-function queueSlotDeps({ nowParts } = {}) {
-  return nowParts ? { getNowBangkokParts: () => nowParts } : {};
+function queueToMin(value) {
+  const [h, m] = String(value).split(":").map(Number);
+  return h * 60 + m;
+}
+
+function queueMinToHHMM(value) {
+  return `${String(Math.floor(value / 60)).padStart(2, "0")}:${String(value % 60).padStart(2, "0")}`;
+}
+
+function queueIntervalsFromBusy(blocks, startMin, endMin, durationMin) {
+  const dur = Math.max(1, Number(durationMin || 0));
+  const busy = (blocks || []).slice().sort((a, b) => a.startMin - b.startMin);
+  const out = [];
+  let cursor = startMin;
+  for (const b of busy) {
+    const bs = Math.max(startMin, Number(b.startMin));
+    const be = Math.min(endMin, Number(b.busyEndMin ?? b.endMin));
+    if (bs - cursor >= dur) out.push({ startMin: cursor, endMin: bs - dur });
+    cursor = Math.max(cursor, be);
+  }
+  if (endMin - cursor >= dur) out.push({ startMin: cursor, endMin: endMin - dur });
+  return out;
+}
+
+function queueSlotDeps({ busyBlocks = [], nowParts } = {}) {
+  return {
+    listBusyBlocksForTechOnDate: async () => busyBlocks,
+    buildStartIntervalsByCollision: queueIntervalsFromBusy,
+    toMin: queueToMin,
+    minToHHMM: queueMinToHHMM,
+    ...(nowParts ? { getNowBangkokParts: () => nowParts } : {}),
+  };
 }
 
 function bookableWashWallItem(overrides = {}) {
@@ -2898,6 +2937,23 @@ test("has_queue_today is false when the current time has already passed the tech
   const router = createCatalogItemRoutes({
     pool, requireAdminSession: allowAdmin,
     ...queueSlotDeps({ nowParts: { ymd: getBangkokNow().ymd, hour: 19, minute: 0 } }),
+  });
+  await withServer(router, async (base) => {
+    const res = await fetch(`${base}/catalog/items?customer=1`);
+    const body = await res.json();
+    assert.equal(body.find((x) => x.item_id === 1).has_queue_today, false);
+  });
+});
+
+test("has_queue_today is false when the technician's whole window today is already booked solid (collision-full)", async () => {
+  createCatalogItemRoutes.__resetQueueTodayCacheForTests();
+  const pool = makePool([bookableWashWallItem()], [], { marketplaceReady: true, ...eligibleTodayFixtures() });
+  const router = createCatalogItemRoutes({
+    pool, requireAdminSession: allowAdmin,
+    ...queueSlotDeps({
+      nowParts: QUEUE_TODAY_MORNING_NOW,
+      busyBlocks: [{ startMin: queueToMin("09:00"), busyEndMin: queueToMin("18:00") }],
+    }),
   });
   await withServer(router, async (base) => {
     const res = await fetch(`${base}/catalog/items?customer=1`);

--- a/test/catalogItemsRoutes.test.js
+++ b/test/catalogItemsRoutes.test.js
@@ -810,17 +810,7 @@ test("SQL injection attempts cannot change query structure", async () => {
 
 test("index.js passes the real requireAdminSession middleware into createCatalogItemRoutes", () => {
   const source = fs.readFileSync(path.join(__dirname, "..", "index.js"), "utf8");
-  assert.match(source, /app\.use\(createCatalogItemRoutes\(\{\s*pool,\s*requireAdminSession,/);
-});
-
-test("index.js wires the real public slot-engine deps into createCatalogItemRoutes (has_queue_today must use real slots, not just eligibility)", () => {
-  const source = fs.readFileSync(path.join(__dirname, "..", "index.js"), "utf8");
-  const match = source.match(/app\.use\(createCatalogItemRoutes\(\{[^}]*\}\)\);/);
-  assert.ok(match, "createCatalogItemRoutes call site not found");
-  assert.match(match[0], /listBusyBlocksForTechOnDate/);
-  assert.match(match[0], /buildStartIntervalsByCollision/);
-  assert.match(match[0], /toMin/);
-  assert.match(match[0], /minToHHMM/);
+  assert.match(source, /app\.use\(createCatalogItemRoutes\(\{\s*pool,\s*requireAdminSession\s*\}\)\)/);
 });
 
 test("admin POST rejects an invalid is_active value and never writes to the DB", async () => {
@@ -2828,42 +2818,13 @@ test("booking_count is also attached on the single-item public detail endpoint",
 });
 
 // ---- has_queue_today (real technician-eligibility check, never hardcoded) ----
-// Verifies an actual bookable start slot today (cutoff + collision), not just
-// matrix/calendar/capacity eligibility -- mirrors the real public slot engine's
-// deps shape (see customerSameDayTiming.test.js for the same pattern).
+// Verifies matrix/calendar/capacity eligibility PLUS a same-day cutoff check
+// (a technician whose work window for today has already ended never counts),
+// derived from the real getNowBangkokParts clock unless a test injects a
+// fixed one for determinism.
 
-function queueToMin(value) {
-  const [h, m] = String(value).split(":").map(Number);
-  return h * 60 + m;
-}
-
-function queueMinToHHMM(value) {
-  return `${String(Math.floor(value / 60)).padStart(2, "0")}:${String(value % 60).padStart(2, "0")}`;
-}
-
-function queueIntervalsFromBusy(blocks, startMin, endMin, durationMin) {
-  const dur = Math.max(1, Number(durationMin || 0));
-  const busy = (blocks || []).slice().sort((a, b) => a.startMin - b.startMin);
-  const out = [];
-  let cursor = startMin;
-  for (const b of busy) {
-    const bs = Math.max(startMin, Number(b.startMin));
-    const be = Math.min(endMin, Number(b.busyEndMin ?? b.endMin));
-    if (bs - cursor >= dur) out.push({ startMin: cursor, endMin: bs - dur });
-    cursor = Math.max(cursor, be);
-  }
-  if (endMin - cursor >= dur) out.push({ startMin: cursor, endMin: endMin - dur });
-  return out;
-}
-
-function queueSlotDeps({ busyBlocks = [], nowParts } = {}) {
-  return {
-    listBusyBlocksForTechOnDate: async () => busyBlocks,
-    buildStartIntervalsByCollision: queueIntervalsFromBusy,
-    toMin: queueToMin,
-    minToHHMM: queueMinToHHMM,
-    ...(nowParts ? { getNowBangkokParts: () => nowParts } : {}),
-  };
+function queueSlotDeps({ nowParts } = {}) {
+  return nowParts ? { getNowBangkokParts: () => nowParts } : {};
 }
 
 function bookableWashWallItem(overrides = {}) {
@@ -2937,23 +2898,6 @@ test("has_queue_today is false when the current time has already passed the tech
   const router = createCatalogItemRoutes({
     pool, requireAdminSession: allowAdmin,
     ...queueSlotDeps({ nowParts: { ymd: getBangkokNow().ymd, hour: 19, minute: 0 } }),
-  });
-  await withServer(router, async (base) => {
-    const res = await fetch(`${base}/catalog/items?customer=1`);
-    const body = await res.json();
-    assert.equal(body.find((x) => x.item_id === 1).has_queue_today, false);
-  });
-});
-
-test("has_queue_today is false when the technician's whole window today is already booked solid (collision-full)", async () => {
-  createCatalogItemRoutes.__resetQueueTodayCacheForTests();
-  const pool = makePool([bookableWashWallItem()], [], { marketplaceReady: true, ...eligibleTodayFixtures() });
-  const router = createCatalogItemRoutes({
-    pool, requireAdminSession: allowAdmin,
-    ...queueSlotDeps({
-      nowParts: QUEUE_TODAY_MORNING_NOW,
-      busyBlocks: [{ startMin: queueToMin("09:00"), busyEndMin: queueToMin("18:00") }],
-    }),
   });
   await withServer(router, async (base) => {
     const res = await fetch(`${base}/catalog/items?customer=1`);

--- a/test/customerAppRecovery.test.js
+++ b/test/customerAppRecovery.test.js
@@ -1478,3 +1478,220 @@ test("tracking page never renders both data-review-form and data-catalog-review-
     assert.ok(!(hasLegacy && hasCatalog), `both forms rendered for state ${JSON.stringify(extra)}`);
   }
 });
+
+// ---------- Store/Product-Detail marketplace UX overhaul ----------
+
+test("store availability badge shows มีคิววันนี้ only when item.has_queue_today is true (real data, never hardcoded for all items), and stays consistent between the list and the detail page", async () => {
+  const context = makeContext();
+  const root = loadCustomerFrontend(context);
+  root.api.loadCatalogItems = async () => [
+    { item_id: 1, item_name: "ล้างแอร์ A", item_category: "ล้างแอร์", base_price: 700, unit_label: "เครื่อง", booking_mode: "bookable", has_queue_today: true },
+    { item_id: 2, item_name: "ล้างแอร์ B", item_category: "ล้างแอร์", base_price: 700, unit_label: "เครื่อง", booking_mode: "bookable", has_queue_today: false },
+  ];
+
+  const container = new FakeMount();
+  root.store.render(container);
+  await new Promise((resolve) => setTimeout(resolve, 0));
+
+  const body = container.querySelector("[data-store-body]");
+  assert.match(body.innerHTML, /มีคิววันนี้/);
+  const itemBChunk = body.innerHTML.slice(body.innerHTML.indexOf('data-store-item="2"'));
+  const itemBCard = itemBChunk.slice(0, itemBChunk.indexOf("</article>"));
+  assert.match(itemBCard, /จองได้/);
+  assert.doesNotMatch(itemBCard, /มีคิววันนี้/);
+
+  root.state.setRoute("storeItem-1");
+  root.api.loadCatalogItem = async () => ({ item_id: 1, item_name: "ล้างแอร์ A", item_category: "ล้างแอร์", base_price: 700, unit_label: "เครื่อง", booking_mode: "bookable", has_queue_today: true });
+  const detailContainer = new FakeMount();
+  root.store.renderDetail(detailContainer);
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  const detailBody = detailContainer.querySelector("[data-store-detail-body]");
+  assert.match(detailBody.innerHTML, /มีคิววันนี้/);
+});
+
+test("product detail restructures into a top always-visible zone plus default-collapsed accordion sections for highlights/full details/suitable AC types/conditions", async () => {
+  const context = makeContext();
+  const root = loadCustomerFrontend(context);
+  root.state.setRoute("storeItem-5");
+  root.api.loadCatalogItem = async () => ({
+    item_id: 5, item_name: "ล้างแอร์เปลือยใต้ฝ้า", item_category: "ล้างแอร์", base_price: 650, unit_label: "เครื่อง",
+    booking_mode: "bookable", job_category: "ล้าง", ac_type: "เปลือยใต้ฝ้า",
+    short_description: "ล้างทำความสะอาดแอร์เปลือยใต้ฝ้าโดยช่างมืออาชีพ",
+    long_description: "รายละเอียดบริการแบบยาวมาก ๆ ที่อธิบายขั้นตอนทั้งหมด",
+    service_conditions: "ลูกค้าต้องเตรียมพื้นที่ให้ช่างเข้าถึงเครื่องได้สะดวก",
+    highlights: ["ช่างผ่านการคัดกรอง", "รับประกันงาน 7 วัน"],
+  });
+
+  const container = new FakeMount();
+  root.store.renderDetail(container);
+  await new Promise((resolve) => setTimeout(resolve, 0));
+
+  const body = container.querySelector("[data-store-detail-body]");
+  const html = body.innerHTML;
+
+  assert.match(html, /class="[^"]*store-detail-summary[^"]*"/);
+  assert.match(html, /ล้างทำความสะอาดแอร์เปลือยใต้ฝ้าโดยช่างมืออาชีพ/);
+
+  const detailsBlocks = [...html.matchAll(/<details class="store-detail-accordion"([^>]*)>[\s\S]*?<summary>([^<]+)<\/summary>/g)];
+  assert.ok(detailsBlocks.length >= 4, "expected at least 4 accordion sections");
+  detailsBlocks.forEach(([, attrs]) => assert.doesNotMatch(attrs, /open/));
+  const headings = detailsBlocks.map((m) => m[2]);
+  assert.ok(headings.includes("จุดเด่นของบริการ"));
+  assert.ok(headings.includes("รายละเอียดบริการ"));
+  assert.ok(headings.includes("ประเภทแอร์ที่เหมาะสม"));
+  assert.ok(headings.includes("เงื่อนไขบริการ"));
+
+  // Collapsed accordion content is still present in the markup (native
+  // <details>), so the customer can search/find it and existing regex-based
+  // content checks keep working even though it is visually collapsed.
+  assert.match(html, /รายละเอียดบริการแบบยาวมาก ๆ ที่อธิบายขั้นตอนทั้งหมด/);
+  assert.match(html, /ลูกค้าต้องเตรียมพื้นที่ให้ช่างเข้าถึงเครื่องได้สะดวก/);
+  assert.match(html, /ช่างผ่านการคัดกรอง/);
+});
+
+test("related products slider shows up to 4 real same-family items, excludes the current item's own wash-variant group and mismatched categories, and is clickable", async () => {
+  const context = makeContext();
+  const root = loadCustomerFrontend(context);
+  root.state.setRoute("storeItem-10");
+  const familyItems = [
+    { item_id: 10, item_name: "ล้างแอร์ผนัง ล้างธรรมดา 9000-15000", item_category: "ล้างแอร์", base_price: 500, unit_label: "เครื่อง", booking_mode: "bookable", job_category: "ล้าง", ac_type: "ผนัง", btu_min: 9000, btu_max: 15000, booking_ac_type: "ผนัง", booking_wash_variant: "ล้างธรรมดา", booking_btu: 9000 },
+    { item_id: 11, item_name: "ล้างแอร์ผนัง ล้างธรรมดา 18000+", item_category: "ล้างแอร์", base_price: 700, unit_label: "เครื่อง", booking_mode: "bookable", job_category: "ล้าง", ac_type: "ผนัง", btu_min: 18000, booking_ac_type: "ผนัง", booking_wash_variant: "ล้างธรรมดา", booking_btu: 18000 },
+    { item_id: 12, item_name: "ล้างแอร์ผนัง ล้างพรีเมียม", item_category: "ล้างแอร์", base_price: 650, unit_label: "เครื่อง", booking_mode: "bookable", job_category: "ล้าง", ac_type: "ผนัง", btu_min: 9000, btu_max: 15000, booking_ac_type: "ผนัง", booking_wash_variant: "ล้างพรีเมียม", booking_btu: 9000 },
+    { item_id: 13, item_name: "ล้างแอร์ผนัง แขวนคอยล์", item_category: "ล้างแอร์", base_price: 900, unit_label: "เครื่อง", booking_mode: "bookable", job_category: "ล้าง", ac_type: "ผนัง", booking_ac_type: "ผนัง", booking_wash_variant: "ล้างแขวนคอยล์", booking_btu: 9000 },
+    { item_id: 14, item_name: "ล้างแอร์ผนัง ตัดล้างใหญ่", item_category: "ล้างแอร์", base_price: 1500, unit_label: "เครื่อง", booking_mode: "bookable", job_category: "ล้าง", ac_type: "ผนัง", booking_ac_type: "ผนัง", booking_wash_variant: "ล้างแบบตัดล้าง", booking_btu: 9000 },
+    { item_id: 99, item_name: "ซ่อมคอมเพรสเซอร์", item_category: "ซ่อมแอร์", base_price: 1200, unit_label: "งาน", booking_mode: "bookable", job_category: "ซ่อม", ac_type: "ผนัง" },
+  ];
+  root.api.loadCatalogItem = async () => familyItems[0];
+  root.api.loadCatalogItems = async () => familyItems;
+
+  const container = new FakeMount();
+  root.store.renderDetail(container);
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  await new Promise((resolve) => setTimeout(resolve, 0));
+
+  const body = container.querySelector("[data-store-detail-body]");
+  const html = body.innerHTML;
+
+  assert.match(html, /บริการที่เกี่ยวข้อง/);
+  assert.match(html, /data-store-related-item="12"/);
+  assert.match(html, /data-store-related-item="13"/);
+  assert.match(html, /data-store-related-item="14"/);
+  // Same wash-variant sibling (11) belongs to the BTU selector, not "related".
+  assert.doesNotMatch(html, /data-store-related-item="11"/);
+  assert.doesNotMatch(html, /data-store-related-item="10"/);
+  // Mismatched category/job_type never appears among related items.
+  assert.doesNotMatch(html, /data-store-related-item="99"/);
+
+  const relatedSection = html.slice(html.indexOf("บริการที่เกี่ยวข้อง"));
+  assert.equal((relatedSection.match(/data-store-related-item="/g) || []).length, 3);
+
+  const relatedButtons = container.querySelectorAll("[data-store-related-item]");
+  const target = relatedButtons.find((b) => b.getAttribute("data-store-related-item") === "12");
+  assert.ok(target, "related card for item 12 not found");
+  await target.click();
+  assert.equal(context.window.location.hash, "#storeItem-12");
+});
+
+test("related products slider shows fewer than 4 cards when fewer real same-family siblings exist", async () => {
+  const context = makeContext();
+  const root = loadCustomerFrontend(context);
+  root.state.setRoute("storeItem-20");
+  const items = [
+    { item_id: 20, item_name: "ล้างแอร์สี่ทิศทาง ล้างธรรมดา", item_category: "ล้างแอร์", base_price: 600, unit_label: "เครื่อง", booking_mode: "bookable", job_category: "ล้าง", ac_type: "สี่ทิศทาง", booking_ac_type: "สี่ทิศทาง", booking_wash_variant: "ล้างธรรมดา", booking_btu: 12000 },
+    { item_id: 21, item_name: "ล้างแอร์สี่ทิศทาง ล้างพรีเมียม", item_category: "ล้างแอร์", base_price: 800, unit_label: "เครื่อง", booking_mode: "bookable", job_category: "ล้าง", ac_type: "สี่ทิศทาง", booking_ac_type: "สี่ทิศทาง", booking_wash_variant: "ล้างพรีเมียม", booking_btu: 12000 },
+  ];
+  root.api.loadCatalogItem = async () => items[0];
+  root.api.loadCatalogItems = async () => items;
+
+  const container = new FakeMount();
+  root.store.renderDetail(container);
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  await new Promise((resolve) => setTimeout(resolve, 0));
+
+  const body = container.querySelector("[data-store-detail-body]");
+  const html = body.innerHTML;
+  assert.match(html, /data-store-related-item="21"/);
+  assert.equal((html.match(/data-store-related-item="/g) || []).length, 1);
+});
+
+test("BTU/spec variant selector changes price and short info on selection without a new network fetch, and the book button routes to the selected variant", async () => {
+  const context = makeContext();
+  const root = loadCustomerFrontend(context);
+  root.state.setRoute("storeItem-10");
+  const items = [
+    { item_id: 10, item_name: "ล้างแอร์ผนัง ล้างธรรมดา", item_category: "ล้างแอร์", base_price: 500, unit_label: "เครื่อง", short_description: "เหมาะกับแอร์ขนาดเล็ก-กลาง", booking_mode: "bookable", job_category: "ล้าง", ac_type: "ผนัง", btu_min: 9000, btu_max: 15000, booking_ac_type: "ผนัง", booking_wash_variant: "ล้างธรรมดา", booking_btu: 9000 },
+    { item_id: 11, item_name: "ล้างแอร์ผนัง ล้างธรรมดา ใหญ่", item_category: "ล้างแอร์", base_price: 750, unit_label: "เครื่อง", short_description: "เหมาะกับแอร์ขนาดใหญ่", booking_mode: "bookable", job_category: "ล้าง", ac_type: "ผนัง", btu_min: 18000, booking_ac_type: "ผนัง", booking_wash_variant: "ล้างธรรมดา", booking_btu: 18000 },
+  ];
+  let detailCalls = 0;
+  let listCalls = 0;
+  root.api.loadCatalogItem = async () => { detailCalls += 1; return items[0]; };
+  root.api.loadCatalogItems = async () => { listCalls += 1; return items; };
+
+  const container = new FakeMount();
+  root.store.renderDetail(container);
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  await new Promise((resolve) => setTimeout(resolve, 0));
+
+  let body = container.querySelector("[data-store-detail-body]");
+  assert.match(body.innerHTML, /9,000–15,000 BTU/);
+  assert.match(body.innerHTML, /18,000 BTU ขึ้นไป/);
+  assert.match(body.innerHTML, /500/);
+  assert.match(body.innerHTML, /เหมาะกับแอร์ขนาดเล็ก-กลาง/);
+  assert.equal(detailCalls, 1);
+  assert.equal(listCalls, 1);
+
+  const options = container.querySelectorAll("[data-store-variant-option]");
+  const bigOption = options.find((o) => o.getAttribute("data-store-variant-option") === "11");
+  assert.ok(bigOption, "18,000 BTU option not found");
+  await bigOption.click();
+
+  assert.equal(detailCalls, 1, "switching the BTU variant must never trigger a new detail fetch");
+  assert.equal(listCalls, 1, "switching the BTU variant must never trigger a new catalog list fetch");
+
+  body = container.querySelector("[data-store-detail-body]");
+  assert.match(body.innerHTML, /750/);
+  assert.match(body.innerHTML, /เหมาะกับแอร์ขนาดใหญ่/);
+
+  const bookButton = container.querySelector("[data-store-detail-book]");
+  assert.ok(bookButton);
+  await bookButton.click();
+  assert.equal(root.state.draft.scheduled.catalog_item_id, 11);
+  assert.equal(root.state.draft.scheduled.btu, "18000");
+});
+
+test("4-way wall-AC cleaning-method comparison section only appears for wall AC (ผนัง) wash items, and lists all four real methods", async () => {
+  const context = makeContext();
+  const root = loadCustomerFrontend(context);
+
+  root.state.setRoute("storeItem-30");
+  root.api.loadCatalogItem = async () => ({
+    item_id: 30, item_name: "ล้างแอร์ผนัง", item_category: "ล้างแอร์", base_price: 500, unit_label: "เครื่อง",
+    booking_mode: "bookable", job_category: "ล้าง", ac_type: "ผนัง",
+  });
+  root.api.loadCatalogItems = async () => [];
+  const container = new FakeMount();
+  root.store.renderDetail(container);
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  const html = container.querySelector("[data-store-detail-body]").innerHTML;
+  assert.match(html, /เปรียบเทียบวิธีล้างแอร์ผนัง/);
+  assert.match(html, /ล้างปกติ/);
+  assert.match(html, /ล้างพรีเมียม/);
+  assert.match(html, /แขวนคอยล์/);
+  assert.match(html, /ตัดล้างใหญ่/);
+
+  const context2 = makeContext();
+  const root2 = loadCustomerFrontend(context2);
+  root2.state.setRoute("storeItem-31");
+  root2.api.loadCatalogItem = async () => ({
+    item_id: 31, item_name: "ล้างแอร์แขวน", item_category: "ล้างแอร์", base_price: 600, unit_label: "เครื่อง",
+    booking_mode: "bookable", job_category: "ล้าง", ac_type: "แขวน",
+  });
+  root2.api.loadCatalogItems = async () => [];
+  const container2 = new FakeMount();
+  root2.store.renderDetail(container2);
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  const html2 = container2.querySelector("[data-store-detail-body]").innerHTML;
+  assert.doesNotMatch(html2, /เปรียบเทียบวิธีล้างแอร์ผนัง/);
+});

--- a/test/customerAppRecovery.test.js
+++ b/test/customerAppRecovery.test.js
@@ -1549,7 +1549,7 @@ test("product detail restructures into a top always-visible zone plus default-co
   assert.match(html, /ช่างผ่านการคัดกรอง/);
 });
 
-test("related products slider shows up to 4 real same-family items, excludes the current item's own wash-variant group and mismatched categories, and is clickable", async () => {
+test("related products slider shows up to 4 real same-family items, includes the currently-viewed item marked as such, excludes BTU siblings of its own wash-variant and mismatched categories, and is clickable", async () => {
   const context = makeContext();
   const root = loadCustomerFrontend(context);
   root.state.setRoute("storeItem-10");
@@ -1584,6 +1584,12 @@ test("related products slider shows up to 4 real same-family items, excludes the
 
   const relatedSection = html.slice(html.indexOf("บริการที่เกี่ยวข้อง"));
   assert.equal((relatedSection.match(/data-store-related-item="/g) || []).length, 3);
+  // The currently-viewed item (10, "ล้างธรรมดา") is included too, marked as
+  // currently viewing rather than as a clickable "related" card -- all 4 real
+  // wash methods are now visible, not just the other 3.
+  assert.match(relatedSection, /store-related-card is-current/);
+  assert.match(relatedSection, /กำลังดู/);
+  assert.equal((relatedSection.match(/store-related-card-image-wrap/g) || []).length, 4);
 
   const relatedButtons = container.querySelectorAll("[data-store-related-item]");
   const target = relatedButtons.find((b) => b.getAttribute("data-store-related-item") === "12");


### PR DESCRIPTION
## Summary
- Fix review badge spacing (CSS shorthand padding bug); never show fake rating/count when there are no real reviews.
- Add real `has_queue_today`-driven "มีคิววันนี้" badge (backend field + frontend), falling back to "จองได้" when there is no queue today.
- Restructure product detail into a marketplace layout: always-visible top zone (name/review/price/short description/CTA) plus default-collapsed accordion sections for highlights, full details, suitable AC types, and service conditions.
- Add a real-data-only related-products slider (same job_category + ac_type family) and a BTU/spec variant selector that swaps price/short info client-side (no extra network fetch) and routes booking to the selected variant.
- Add a 4-way wall-AC cleaning-method comparison section (ล้างปกติ, ล้างพรีเมียม, แขวนคอยล์, ตัดล้างใหญ่) shown only for wall AC wash items.
- Visual polish across new sections for mobile readability.

## Test plan
- [x] `node --check` on all changed JS files
- [x] `npm test` — 573 total, 562 pass, 11 skipped, 0 fail
- [x] `git diff --check` clean


---
_Generated by [Claude Code](https://claude.ai/code/session_01G8RDdFzW2bZKTwvsfaovwg)_