### PR TITLE
Fix Store Product Detail: real BTU variants, canonical resolver, related-wash slider, white accordions

### DIFF
--- a/customer-app/assets/customer-app.css
+++ b/customer-app/assets/customer-app.css
@@ -3937,11 +3937,14 @@ body.has-contact-sheet { overflow: hidden; }
   gap: 8px;
 }
 .store-detail-variant-option {
+  display: flex;
+  align-items: center;
+  gap: 6px;
   font: inherit;
   font-size: 12.5px;
   font-weight: 600;
-  padding: 8px 12px;
-  border-radius: 999px;
+  padding: 9px 14px;
+  border-radius: 14px;
   border: 1.5px solid var(--line);
   background: #fff;
   color: var(--ink);
@@ -3954,6 +3957,26 @@ body.has-contact-sheet { overflow: hidden; }
   background: var(--soft-blue, rgba(31, 123, 255, 0.08));
   font-weight: 700;
 }
+.store-detail-variant-check {
+  color: var(--accent, #1f7bff);
+  font-weight: 700;
+}
+.store-detail-variant-spec { white-space: nowrap; }
+.store-detail-variant-price {
+  color: var(--muted);
+  font-weight: 600;
+}
+.store-detail-variant-option.is-selected .store-detail-variant-price { color: var(--accent, #1f7bff); }
+
+/* Inline CTA shown mid-page (between price/description and accordion); the
+   same buttons are mirrored in the fixed bottom bar via shared markup. */
+.store-detail-inline-cta {
+  display: flex;
+  gap: 8px;
+  margin-top: 16px;
+}
+.store-detail-inline-cta .primary-btn,
+.store-detail-inline-cta .secondary-btn { flex: 1; min-height: 46px; }
 
 /* Related-products horizontal slider (same family, different wash method). */
 .store-detail-related { margin-top: 18px; }
@@ -4023,40 +4046,82 @@ body.has-contact-sheet { overflow: hidden; }
 }
 
 /* Collapsible product-detail accordion (native <details>/<summary>; default
-   collapsed except where explicitly opened). */
+   collapsed except where explicitly opened). White tappable card with icon,
+   title, helper hint and a chevron that rotates open -- never the old bare
+   "+"/"-" text marker, so it reads as an obviously tappable row. */
 .store-detail-accordion-group {
   margin-top: 18px;
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: 10px;
 }
 .store-detail-accordion {
+  background: #fff;
   border: 1px solid var(--line);
-  border-radius: var(--radius-sm);
-  padding: 0 12px;
+  border-radius: 17px;
+  box-shadow: 0 2px 10px rgba(15, 23, 42, 0.05);
+  padding: 0 14px;
+  overflow: hidden;
 }
 .store-detail-accordion summary {
-  font-size: 14px;
-  font-weight: 700;
-  color: var(--ink);
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  min-height: 54px;
   padding: 12px 0;
   cursor: pointer;
   list-style: none;
+  -webkit-tap-highlight-color: transparent;
 }
 .store-detail-accordion summary::-webkit-details-marker { display: none; }
-.store-detail-accordion summary::after {
-  content: "+";
-  float: right;
+.store-detail-accordion summary:active { background: var(--soft-blue, #f3f6fb); }
+.store-detail-accordion-icon {
+  flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 34px;
+  height: 34px;
+  border-radius: 50%;
+  background: var(--soft-blue, rgba(31, 123, 255, 0.08));
+  color: var(--accent, #1f7bff);
+}
+.store-detail-accordion-text {
+  flex: 1 1 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+.store-detail-accordion-title {
+  font-size: 14.5px;
   font-weight: 700;
+  color: var(--ink);
+}
+.store-detail-accordion-hint {
+  font-size: 11.5px;
+  font-weight: 500;
   color: var(--muted);
 }
-.store-detail-accordion[open] summary::after { content: "–"; }
-.store-detail-accordion-body { padding: 0 0 14px; }
+.store-detail-accordion-chevron {
+  flex: 0 0 auto;
+  font-size: 20px;
+  font-weight: 600;
+  color: var(--muted);
+  transition: transform 0.18s ease;
+}
+.store-detail-accordion[open] .store-detail-accordion-chevron { transform: rotate(-90deg); }
+.store-detail-accordion-body {
+  padding: 2px 0 16px;
+  border-top: 1px solid var(--line);
+  margin-top: 2px;
+}
 .store-detail-accordion-body p {
   font-size: 13.5px;
   color: var(--ink);
   white-space: pre-wrap;
   overflow-wrap: anywhere;
+  padding-top: 12px;
 }
 
 /* 4-way wall-AC cleaning-method comparison: mobile-readable stacked cards. */

--- a/customer-app/modules/store.js
+++ b/customer-app/modules/store.js
@@ -79,30 +79,111 @@
     return "ไม่ระบุ BTU";
   }
 
-  // "Family" = same job_category + ac_type, spanning different wash methods
-  // (ล้างปกติ/ล้างพรีเมียม/แขวนคอยล์/ตัดล้างใหญ่) -- used for related-products.
-  // "Variant group" = family + the specific wash method, spanning different BTU
-  // bands of that one method -- used for the BTU/spec selector. Both keys are
-  // built only from real per-row catalog fields, never a fabricated mapping.
+  // ---------- Canonical product-family resolver ----------
+  // Raw catalog rows are not guaranteed to use one consistent token for the
+  // same real-world concept (e.g. ac_type might say "ผนัง" or "wall", a free-
+  // text job_category might say "ล้างแอร์" or "wash"). Grouping logic must
+  // never compare those raw strings directly -- it must resolve them to one
+  // of a small, fixed set of canonical tokens first. Resolution order always
+  // prefers the most authoritative, already-constrained field first
+  // (booking_ac_type / booking_wash_variant, validated server-side against a
+  // fixed enum -- see ALLOWED_BOOKING_AC_TYPES/ALLOWED_BOOKING_WASH_VARIANTS
+  // in server/routes/catalog/items.js) before falling back to the free-text
+  // display field, and only as a last resort to a deterministic keyword match
+  // against the item name. Returns null when nothing recognizable is found --
+  // never a guessed/fuzzy cross-category match.
+  function normalizeForMatch(value) {
+    return String(value || "").trim().toLowerCase();
+  }
+
+  function canonicalAcType(item) {
+    const candidates = [item.booking_ac_type, item.ac_type, item.item_name];
+    for (const raw of candidates) {
+      const norm = normalizeForMatch(raw);
+      if (!norm) continue;
+      if (/ผนัง|wall/.test(norm)) return "wall";
+      if (/สี่ทิศทาง|four.?way|cassette/.test(norm)) return "fourway";
+      if (/แขวน(?!คอยล์)|hanging/.test(norm)) return "hanging";
+      if (/เปลือย|ใต้ฝ้า|ceiling/.test(norm)) return "ceiling";
+    }
+    return null;
+  }
+
+  function canonicalJobCategory(item) {
+    const candidates = [item.job_category, item.item_category];
+    for (const raw of candidates) {
+      const norm = normalizeForMatch(raw);
+      if (!norm) continue;
+      if (/ล้าง|wash|clean/.test(norm)) return "wash";
+      if (/ซ่อม|repair/.test(norm)) return "repair";
+      if (/ติดตั้ง|install/.test(norm)) return "install";
+      if (/ตรวจเช็ค|ตรวจสอบ|inspect/.test(norm)) return "inspection";
+    }
+    return null;
+  }
+
+  function canonicalWashVariant(item) {
+    const candidates = [item.booking_wash_variant];
+    for (const raw of candidates) {
+      const norm = normalizeForMatch(raw);
+      if (!norm) continue;
+      if (/ตัดล้าง|overhaul|ใหญ่/.test(norm)) return "overhaul";
+      if (/แขวนคอยล์|coil/.test(norm)) return "coil";
+      if (/พรีเมียม|premium/.test(norm)) return "premium";
+      if (/ปกติ|ธรรมดา|normal/.test(norm)) return "normal";
+    }
+    return null;
+  }
+
+  // Best real BTU figure available for an item, preferring the bookable
+  // booking_btu (a single supported value), then the display btu_min/btu_max
+  // range. Returns null when no real BTU figure exists at all.
+  function itemBtuValue(item) {
+    const btu = Number(item.booking_btu);
+    if (Number.isFinite(btu) && btu > 0) return btu;
+    const min = Number(item.btu_min);
+    if (Number.isFinite(min) && min > 0) return min;
+    const max = Number(item.btu_max);
+    if (Number.isFinite(max) && max > 0) return max;
+    return null;
+  }
+
+  // "Family" = same canonical job category + canonical AC type, spanning
+  // different wash methods (ล้างปกติ/ล้างพรีเมียม/แขวนคอยล์/ตัดล้างใหญ่) --
+  // used for related-products. "Variant group" = family + the specific
+  // canonical wash method, spanning different BTU bands of that one method --
+  // used for the BTU/spec selector. Returns null when the item's job category
+  // or AC type cannot be resolved at all, so unrelated/unrecognized items
+  // never get fuzzily grouped together.
   function familyKey(item) {
-    return `${item.job_category || ""}|${item.ac_type || ""}`;
+    const job = canonicalJobCategory(item);
+    const ac = canonicalAcType(item);
+    if (!job || !ac) return null;
+    return `${job}|${ac}`;
   }
 
   function variantGroupKey(item) {
-    return `${item.job_category || ""}|${item.ac_type || ""}|${item.booking_wash_variant || ""}`;
+    const fam = familyKey(item);
+    if (!fam) return null;
+    return `${fam}|${canonicalWashVariant(item) || ""}`;
   }
 
-  // Siblings sharing this item's exact variant group (same method, different
-  // BTU). Only meaningful for bookable items with a real booking_wash_variant;
-  // otherwise there is nothing to group, so the item is its own only "sibling".
+  // Siblings sharing this item's exact variant group (same canonical job
+  // category + AC type + wash method, differing only by BTU/price/item_id).
+  // Bookable items whose AC type doesn't require a wash method (e.g.
+  // สี่ทิศทาง/แขวน/เปลือยใต้ฝ้า) still group correctly since both sides of the
+  // comparison share the same (empty) wash-variant token. Only meaningful for
+  // bookable items with a resolvable canonical group; otherwise there is
+  // nothing real to group, so the item is its own only "sibling".
   function variantSiblings(item, allItems) {
-    if (!item || item.booking_mode !== "bookable" || !item.booking_wash_variant) return [item];
+    if (!item || item.booking_mode !== "bookable") return [item];
     const key = variantGroupKey(item);
+    if (!key) return [item];
     const list = (allItems || []).filter((it) => it.booking_mode === "bookable" && variantGroupKey(it) === key);
     if (!list.some((it) => String(it.item_id) === String(item.item_id))) list.push(item);
     return list.slice().sort((a, b) => {
-      const aBtu = Number(a.btu_min) || Number(a.booking_btu) || 0;
-      const bBtu = Number(b.btu_min) || Number(b.booking_btu) || 0;
+      const aBtu = itemBtuValue(a) || 0;
+      const bBtu = itemBtuValue(b) || 0;
       return aBtu - bBtu;
     });
   }
@@ -116,23 +197,56 @@
     return (siblings || []).find((s) => String(s.item_id) === String(selectedVariantItemId)) || item;
   }
 
-  // Up to 4 same-family items, one representative per distinct wash variant
-  // (BTU siblings within one variant are not repeated -- those are shown in
-  // the BTU selector instead). Includes the item currently being viewed as
-  // the first card (marked is_current) so all real wash-method variants in
-  // the family are visible, not just the other three. Real catalog data only.
+  // Picks the one item to represent a wash-method group in the related
+  // slider: prefer the candidate whose real BTU is closest to the item
+  // currently being viewed (so the slider naturally suggests a comparable
+  // size), and among customer-visible/active candidates first. Falls back to
+  // the first candidate at all when nothing carries a real BTU value or an
+  // is_active/is_customer_visible flag -- never fabricates a choice.
+  function pickRepresentative(candidates, currentBtu) {
+    const visible = candidates.filter((it) => it.is_active !== false && it.is_customer_visible !== false);
+    const pool = visible.length ? visible : candidates;
+    if (currentBtu != null) {
+      let best = null;
+      let bestDiff = Infinity;
+      for (const it of pool) {
+        const btu = itemBtuValue(it);
+        if (btu == null) continue;
+        const diff = Math.abs(btu - currentBtu);
+        if (diff < bestDiff) {
+          bestDiff = diff;
+          best = it;
+        }
+      }
+      if (best) return best;
+    }
+    return pool[0] || candidates[0];
+  }
+
+  // Up to 4 same-family items, one representative per distinct canonical wash
+  // method (BTU siblings within one method are never repeated -- those are
+  // shown in the BTU selector instead). Includes the item currently being
+  // viewed as the first card (marked is_current) so all real wash-method
+  // variants in the family are visible, not just the other three. Real
+  // catalog data only -- never a fabricated/placeholder card.
   function relatedFamilyItems(item, allItems) {
-    if (!item || !item.job_category || !item.ac_type) return [];
     const fam = familyKey(item);
-    const seenVariants = new Set([variantGroupKey(item)]);
-    const others = [];
+    if (!fam) return [];
+    const currentBtu = itemBtuValue(item);
+    const currentVariant = canonicalWashVariant(item) || "";
+    const groups = new Map();
     for (const it of allItems || []) {
       if (String(it.item_id) === String(item.item_id)) continue;
       if (familyKey(it) !== fam) continue;
-      const vk = variantGroupKey(it);
-      if (seenVariants.has(vk)) continue;
-      seenVariants.add(vk);
-      others.push(it);
+      const wv = canonicalWashVariant(it) || "";
+      if (!groups.has(wv)) groups.set(wv, []);
+      groups.get(wv).push(it);
+    }
+    const others = [];
+    for (const [wv, candidates] of groups) {
+      if (wv === currentVariant) continue;
+      const rep = pickRepresentative(candidates, currentBtu);
+      if (rep) others.push(rep);
       if (others.length >= 3) break;
     }
     if (!others.length) return [];
@@ -609,11 +723,34 @@
   // requirement #5). Reset whenever a new detail item is loaded.
   let selectedVariantItemId = null;
 
+  // Icon shown to the left of each accordion header -- a fixed, deterministic
+  // mapping by section title (presentation only, not derived from any
+  // per-item data) so every card is instantly recognizable as a tappable row.
+  const ACCORDION_ICONS = {
+    "จุดเด่นของบริการ": "sparkle",
+    "รายละเอียดบริการ": "chat",
+    "เหมาะกับแอร์แบบไหน": "wrench",
+    "เงื่อนไขบริการ": "shield",
+    "เปรียบเทียบวิธีล้าง": "clock",
+  };
+
+  // Premium white-card accordion row (iOS/Shopee style): icon, title + a
+  // small "แตะเพื่อดูรายละเอียด" affordance hint, and a chevron that rotates
+  // open -- never the old bare "+"/"-" text marker, so it reads as an
+  // obviously tappable row rather than plain text.
   function renderAccordionSection(title, bodyHtml, { open } = {}) {
     if (!bodyHtml) return "";
+    const icon = ACCORDION_ICONS[title] || "sparkle";
     return `
       <details class="store-detail-accordion"${open ? " open" : ""}>
-        <summary>${root.utils.escapeHtml(title)}</summary>
+        <summary>
+          <span class="store-detail-accordion-icon">${root.utils.icon(icon, 18)}</span>
+          <span class="store-detail-accordion-text">
+            <span class="store-detail-accordion-title">${root.utils.escapeHtml(title)}</span>
+            <span class="store-detail-accordion-hint">แตะเพื่อดูรายละเอียด</span>
+          </span>
+          <span class="store-detail-accordion-chevron" aria-hidden="true">›</span>
+        </summary>
         <div class="store-detail-accordion-body">${bodyHtml}</div>
       </details>
     `;
@@ -626,11 +763,16 @@
       <div class="store-detail-variant-selector" data-store-variant-selector>
         <span class="store-detail-variant-label">เลือกขนาด BTU</span>
         <div class="store-detail-variant-options">
-          ${siblings.map((s) => `
-            <button type="button" class="store-detail-variant-option${String(s.item_id) === String(selectedId) ? " is-selected" : ""}" data-store-variant-option="${root.utils.escapeHtml(String(s.item_id))}">
-              ${root.utils.escapeHtml(variantBtuLabel(s))}
-            </button>
-          `).join("")}
+          ${siblings.map((s) => {
+            const selected = String(s.item_id) === String(selectedId);
+            return `
+              <button type="button" class="store-detail-variant-option${selected ? " is-selected" : ""}" data-store-variant-option="${root.utils.escapeHtml(String(s.item_id))}">
+                ${selected ? `<span class="store-detail-variant-check" aria-hidden="true">✓</span>` : ""}
+                <span class="store-detail-variant-spec">${root.utils.escapeHtml(variantBtuLabel(s))}</span>
+                <span class="store-detail-variant-price">${root.utils.escapeHtml(priceLabel(s))}</span>
+              </button>
+            `;
+          }).join("")}
         </div>
       </div>
     `;
@@ -639,9 +781,11 @@
   function renderRelatedProducts(item, allItems) {
     const related = relatedFamilyItems(item, allItems);
     if (!related.length) return "";
+    const isWallWash = canonicalAcType(item) === "wall" && canonicalJobCategory(item) === "wash";
+    const heading = isWallWash ? "เลือกวิธีล้างที่เหมาะกับคุณ" : "บริการที่เกี่ยวข้อง";
     return `
       <div class="store-detail-related" data-store-related>
-        <h3>บริการที่เกี่ยวข้อง</h3>
+        <h3>${root.utils.escapeHtml(heading)}</h3>
         <div class="store-related-slider">
           ${related.map((r) => {
             const images = itemGalleryImages(r);
@@ -674,38 +818,25 @@
   // Static, factual comparison content (not derived from per-item DB fields --
   // these four wash methods are fixed domain concepts shared by every wall-AC
   // wash item, not a guess about any specific catalog row's price/availability).
+  // Wording is limited strictly to CWF-verified service steps -- no
+  // disinfection/germ-kill claims, no guaranteed-leak-fix claims, and no
+  // "removes the coil" claim (only แขวนคอยล์ removes panels/trays, not the coil).
   const WALL_AC_CLEANING_COMPARISON = [
     {
       title: "ล้างปกติ",
-      bestFor: "แอร์ที่ดูแลสม่ำเสมอ ไม่มีกลิ่นอับหรือคราบสะสมมาก",
-      thoroughness: "ล้างฟิลเตอร์ คอยล์เย็น คอยล์ร้อน และฉีดอัดท่อน้ำทิ้ง",
-      advantages: "เร็ว ราคาประหยัด เหมาะกับการล้างตามรอบปกติ",
-      depth: "ล้างจากภายนอกตัวเครื่อง ไม่ถอดชิ้นส่วนภายใน",
-      dirtLevel: "เหมาะกับสิ่งสกปรกระดับน้อยถึงปานกลาง",
+      steps: "ล้างฟิลเตอร์ คอยล์เย็น คอยล์ร้อน และฉีดอัดท่อน้ำทิ้ง",
     },
     {
       title: "ล้างพรีเมียม",
-      bestFor: "แอร์ที่ใช้งานหนักหรือไม่ได้ล้างมานาน",
-      thoroughness: "ล้างละเอียดคอยล์เย็น-คอยล์ร้อน ถอดรางน้ำทิ้งและโพรงกระรอกออกล้าง พร้อมฉีดอัดท่อน้ำทิ้ง",
-      advantages: "ลดกลิ่นอับ ลดเชื้อแบคทีเรีย อากาศเย็นสะอาดขึ้น",
-      depth: "เปิดฝาครอบและล้างชิ้นส่วนภายในมากกว่าล้างปกติ",
-      dirtLevel: "เหมาะกับสิ่งสกปรกระดับปานกลางถึงมาก",
+      steps: "ล้างละเอียดคอยล์เย็น-คอยล์ร้อน ถอดรางน้ำทิ้ง ทำความสะอาดโพรงกระรอก และฉีดอัดท่อน้ำทิ้ง",
     },
     {
       title: "แขวนคอยล์",
-      bestFor: "แอร์ที่มีน้ำหยด ตันบ่อย หรือคอยล์สกปรกมาก",
-      thoroughness: "ถอดแผงไฟและถาดหลังออกมาทำความสะอาดอย่างละเอียด",
-      advantages: "ล้างได้ทั่วถึงทุกซอกของคอยล์ แก้ปัญหาน้ำหยดได้ตรงจุด",
-      depth: "ถอดชิ้นส่วนคอยล์ออกจากตัวเครื่องเพื่อล้าง",
-      dirtLevel: "เหมาะกับสิ่งสกปรกระดับมากถึงมากที่สุด",
+      steps: "ถอดแผงไฟ ถอดถาดหลัง และทำความสะอาดภายในอย่างละเอียด",
     },
     {
       title: "ตัดล้างใหญ่",
-      bestFor: "แอร์ที่ไม่เคยล้างใหญ่มานาน หรือมีปัญหาสะสมหลายจุด",
-      thoroughness: "ถอดล้างทั้งตัวเครื่อง ทำความสะอาดครบทุกระบบ โดยประเมินหน้างานก่อนเริ่มงาน",
-      advantages: "ครอบคลุมที่สุด เหมาะกับการแก้ปัญหาสะสมระยะยาว",
-      depth: "เปิดและถอดชิ้นส่วนภายในเกือบทั้งหมดเพื่อล้างลึกที่สุด",
-      dirtLevel: "เหมาะกับสิ่งสกปรกสะสมมากที่สุด",
+      steps: "ถอดล้างทั้งตัว ทำความสะอาดครบระบบ ต้องประเมินสภาพเครื่องและหน้างานก่อน",
     },
   ];
 
@@ -716,11 +847,7 @@
           <div class="store-compare-card">
             <h4>${root.utils.escapeHtml(c.title)}</h4>
             <dl>
-              <dt>เหมาะกับ</dt><dd>${root.utils.escapeHtml(c.bestFor)}</dd>
-              <dt>ความละเอียด</dt><dd>${root.utils.escapeHtml(c.thoroughness)}</dd>
-              <dt>ข้อดี</dt><dd>${root.utils.escapeHtml(c.advantages)}</dd>
-              <dt>ความลึกในการเข้าถึงเครื่อง</dt><dd>${root.utils.escapeHtml(c.depth)}</dd>
-              <dt>ระดับความสกปรกที่เหมาะสม</dt><dd>${root.utils.escapeHtml(c.dirtLevel)}</dd>
+              <dt>ขั้นตอน</dt><dd>${root.utils.escapeHtml(c.steps)}</dd>
             </dl>
           </div>
         `).join("")}
@@ -1012,7 +1139,10 @@
     const unit = displayItem.unit_label || "";
     const promo = hasPromo(displayItem);
     const bookable = isBookable(displayItem);
-    const showCompare = item.ac_type === "ผนัง" && item.job_category === "ล้าง";
+    const showCompare = canonicalAcType(item) === "wall" && canonicalJobCategory(item) === "wash";
+    const ctaButton = bookable
+      ? `<button class="primary-btn" type="button" data-store-detail-book="1">จองคิว</button>`
+      : `<button class="primary-btn" type="button" data-store-detail-contact="1">สอบถามแอดมิน</button>`;
 
     return `
       <button class="store-detail-back" type="button" data-store-detail-back>${root.utils.icon("pin", 16)}กลับไปหน้าร้านค้า</button>
@@ -1031,7 +1161,7 @@
       </div>
       ${renderVariantSelector(item, siblings)}
       ${displayItem.short_description ? `<div class="store-detail-section store-detail-summary"><p>${root.utils.escapeHtml(displayItem.short_description)}</p></div>` : ""}
-      ${renderRelatedProducts(item, allItems)}
+      <div class="store-detail-inline-cta">${ctaButton}</div>
       <div class="store-detail-accordion-group">
         ${renderAccordionSection("จุดเด่นของบริการ", highlights.length ? `
           <ul class="store-detail-highlights">
@@ -1039,22 +1169,19 @@
           </ul>
         ` : "")}
         ${renderAccordionSection("รายละเอียดบริการ", item.long_description ? `<p>${root.utils.escapeHtml(item.long_description)}</p>` : "")}
-        ${renderAccordionSection("ประเภทแอร์ที่เหมาะสม", item.ac_type ? `
+        ${renderAccordionSection("เหมาะกับแอร์แบบไหน", item.ac_type ? `
           <ul class="store-detail-highlights">
             <li>${root.utils.icon("sparkle", 16)}<span>${root.utils.escapeHtml(item.ac_type)}</span></li>
           </ul>
         ` : "")}
         ${renderAccordionSection("เงื่อนไขบริการ", item.service_conditions ? `<p>${root.utils.escapeHtml(item.service_conditions)}</p>` : "")}
-        ${showCompare ? renderAccordionSection("เปรียบเทียบวิธีล้างแอร์ผนัง", renderCleaningComparison()) : ""}
+        ${showCompare ? renderAccordionSection("เปรียบเทียบวิธีล้าง", renderCleaningComparison()) : ""}
       </div>
+      ${renderRelatedProducts(item, allItems)}
       <div class="store-detail-section store-reviews-section" data-store-reviews-section>
         ${renderReviewsSectionBody(item)}
       </div>
-      <div class="store-detail-cta-bar">
-        ${bookable
-          ? `<button class="primary-btn" type="button" data-store-detail-book>จองคิว</button>`
-          : `<button class="primary-btn" type="button" data-store-detail-contact>สอบถามแอดมิน</button>`}
-      </div>
+      <div class="store-detail-cta-bar">${ctaButton}</div>
     `;
   }
 
@@ -1113,8 +1240,7 @@
     });
     const retry = container.querySelector("[data-store-detail-retry]");
     if (retry) retry.addEventListener("click", () => loadDetail(container, detailItemId()));
-    const bookButton = container.querySelector("[data-store-detail-book]");
-    if (bookButton) {
+    container.querySelectorAll("[data-store-detail-book]").forEach((bookButton) => {
       bookButton.addEventListener("click", () => {
         const item = root.state.storeDetail?.data;
         if (!item) return;
@@ -1127,14 +1253,13 @@
         }
         root.utils.routeTo("scheduled");
       });
-    }
-    const contactButton = container.querySelector("[data-store-detail-contact]");
-    if (contactButton) {
+    });
+    container.querySelectorAll("[data-store-detail-contact]").forEach((contactButton) => {
       contactButton.addEventListener("click", () => {
         const item = root.state.storeDetail?.data;
         root.ui.openContactSheet(container, { title: item?.item_name || "รายการนี้" });
       });
-    }
+    });
     container.querySelectorAll("[data-store-rating]").forEach((button) => {
       button.addEventListener("click", () => {
         const section = container.querySelector("[data-store-reviews-section]");

--- a/customer-app/modules/store.js
+++ b/customer-app/modules/store.js
@@ -110,7 +110,7 @@
   }
 
   function canonicalJobCategory(item) {
-    const candidates = [item.job_category, item.item_category];
+    const candidates = [item.job_category, item.item_category, item.item_name];
     for (const raw of candidates) {
       const norm = normalizeForMatch(raw);
       if (!norm) continue;
@@ -122,8 +122,14 @@
     return null;
   }
 
+  // booking_wash_variant is the authoritative, server-validated field (see
+  // ALLOWED_BOOKING_WASH_VARIANTS); older catalog rows predating that field
+  // often have it null/missing entirely but still encode the real wash
+  // method in their item_name (e.g. "ล้างแอร์ผนัง ล้างปกติ"), so item_name is
+  // checked as the last-resort deterministic fallback -- never fuzzy, and
+  // only ever returns one of the 4 fixed canonical wash-method tokens.
   function canonicalWashVariant(item) {
-    const candidates = [item.booking_wash_variant];
+    const candidates = [item.booking_wash_variant, item.item_name];
     for (const raw of candidates) {
       const norm = normalizeForMatch(raw);
       if (!norm) continue;
@@ -133,6 +139,15 @@
       if (/ปกติ|ธรรมดา|normal/.test(norm)) return "normal";
     }
     return null;
+  }
+
+  // Only canonical wall + wash items are split into 4 distinct wash-method
+  // variant groups (ล้างปกติ/ล้างพรีเมียม/แขวนคอยล์/ตัดล้างใหญ่). Other AC
+  // types/job categories never need a wash-method axis at all, so an
+  // unresolved wash variant there is not an error -- both sides of a BTU
+  // comparison simply share the same (empty) wash-variant token.
+  function requiresWashVariant(item) {
+    return canonicalAcType(item) === "wall" && canonicalJobCategory(item) === "wash";
   }
 
   // Best real BTU figure available for an item, preferring the bookable
@@ -165,7 +180,13 @@
   function variantGroupKey(item) {
     const fam = familyKey(item);
     if (!fam) return null;
-    return `${fam}|${canonicalWashVariant(item) || ""}`;
+    const wash = canonicalWashVariant(item);
+    // A wall-wash item whose wash method cannot be resolved at all must never
+    // be grouped under the shared empty-token bucket -- that would silently
+    // merge it with siblings of a real, different wash method instead of
+    // standing alone (it always stands alone until its method is known).
+    if (!wash && requiresWashVariant(item)) return null;
+    return `${fam}|${wash || ""}`;
   }
 
   // Siblings sharing this item's exact variant group (same canonical job
@@ -238,9 +259,14 @@
     for (const it of allItems || []) {
       if (String(it.item_id) === String(item.item_id)) continue;
       if (familyKey(it) !== fam) continue;
-      const wv = canonicalWashVariant(it) || "";
-      if (!groups.has(wv)) groups.set(wv, []);
-      groups.get(wv).push(it);
+      const wv = canonicalWashVariant(it);
+      // An item whose wash method can't be resolved at all (wall-wash with no
+      // matching field or item-name keyword) never counts as a representative
+      // "method" card -- we don't actually know which of the 4 methods it is.
+      if (!wv && requiresWashVariant(it)) continue;
+      const key = wv || "";
+      if (!groups.has(key)) groups.set(key, []);
+      groups.get(key).push(it);
     }
     const others = [];
     for (const [wv, candidates] of groups) {

--- a/test/customerAppRecovery.test.js
+++ b/test/customerAppRecovery.test.js
@@ -1790,3 +1790,136 @@ test("canonical resolver never mixes repair items with wash items, and never put
   assert.equal(options.length, 0, "a different wash method (ล้างพรีเมียม) must never enter the ล้างธรรมดา BTU selector");
   assert.doesNotMatch(body.innerHTML, /data-store-related-item="72"/, "repair items must never be mixed into a wash item's related family");
 });
+
+// ---------- Production-shaped legacy rows: booking_wash_variant is missing
+// entirely (predates that field), so the wash method must be resolved from
+// item_name as a deterministic last-resort fallback -- never left as an
+// empty token that silently merges unrelated wash methods together.
+
+test("legacy rows with no booking_wash_variant resolve ล้างปกติ/ล้างธรรมดา from item_name into the same BTU variant group, price changes on selection, and booking uses the selected real item_id", async () => {
+  const context = makeContext();
+  const root = loadCustomerFrontend(context);
+  root.state.setRoute("storeItem-80");
+  const items = [
+    { item_id: 80, item_name: "ล้างแอร์ผนัง ล้างปกติ 9000", item_category: "ล้างแอร์", base_price: 500, unit_label: "เครื่อง", short_description: "เหมาะกับแอร์ขนาดเล็ก", booking_mode: "bookable", job_category: "ล้าง", ac_type: "ผนัง", btu_min: 9000, btu_max: 15000, booking_ac_type: "ผนัง", booking_btu: 9000 },
+    { item_id: 81, item_name: "ล้างแอร์ผนัง ล้างธรรมดา 18000+", item_category: "ล้างแอร์", base_price: 750, unit_label: "เครื่อง", short_description: "เหมาะกับแอร์ขนาดใหญ่", booking_mode: "bookable", job_category: "ล้าง", ac_type: "ผนัง", btu_min: 18000, booking_ac_type: "ผนัง", booking_btu: 18000 },
+  ];
+  root.api.loadCatalogItem = async () => items[0];
+  root.api.loadCatalogItems = async () => items;
+
+  const container = new FakeMount();
+  root.store.renderDetail(container);
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  await new Promise((resolve) => setTimeout(resolve, 0));
+
+  let body = container.querySelector("[data-store-detail-body]");
+  let options = container.querySelectorAll("[data-store-variant-option]");
+  assert.equal(options.length, 2, "ล้างปกติ/ล้างธรรมดา item_name fallback must resolve to the same canonical wash variant");
+  assert.match(body.innerHTML, /500/);
+
+  const bigOption = options.find((o) => o.getAttribute("data-store-variant-option") === "81");
+  assert.ok(bigOption, "18,000+ option not found");
+  await bigOption.click();
+
+  body = container.querySelector("[data-store-detail-body]");
+  assert.match(body.innerHTML, /750/);
+
+  // catalogItemToCommerceDraft requires the real booking_wash_variant enum
+  // field (server-validated) to build an actual booking payload -- the
+  // item_name-derived canonical wash variant is for display/grouping only
+  // and must never be used to fabricate that real booking field. With it
+  // missing, tapping book correctly falls back to the contact-admin sheet
+  // for whichever variant (81) was selected, rather than silently booking
+  // with an unverified wash method.
+  let contactTitle = null;
+  root.ui.openContactSheet = (_container, { title }) => { contactTitle = title; };
+  const bookButtons = container.querySelectorAll("[data-store-detail-book]");
+  assert.ok(bookButtons.length >= 1);
+  await bookButtons[0].click();
+  assert.equal(contactTitle, "ล้างแอร์ผนัง ล้างธรรมดา 18000+");
+});
+
+test("legacy rows with no booking_wash_variant show all 4 real wash methods (resolved from item_name) in the related slider, exactly once each", async () => {
+  const context = makeContext();
+  const root = loadCustomerFrontend(context);
+  root.state.setRoute("storeItem-90");
+  const items = [
+    { item_id: 90, item_name: "ล้างแอร์ผนัง ล้างปกติ", item_category: "ล้างแอร์", base_price: 500, unit_label: "เครื่อง", booking_mode: "bookable", job_category: "ล้าง", ac_type: "ผนัง", booking_ac_type: "ผนัง", booking_btu: 9000 },
+    { item_id: 91, item_name: "ล้างแอร์ผนัง ล้างพรีเมียม", item_category: "ล้างแอร์", base_price: 650, unit_label: "เครื่อง", booking_mode: "bookable", job_category: "ล้าง", ac_type: "ผนัง", booking_ac_type: "ผนัง", booking_btu: 9000 },
+    { item_id: 92, item_name: "ล้างแอร์ผนัง แขวนคอยล์", item_category: "ล้างแอร์", base_price: 900, unit_label: "เครื่อง", booking_mode: "bookable", job_category: "ล้าง", ac_type: "ผนัง", booking_ac_type: "ผนัง", booking_btu: 9000 },
+    { item_id: 93, item_name: "ล้างแอร์ผนัง ตัดล้างใหญ่", item_category: "ล้างแอร์", base_price: 1500, unit_label: "เครื่อง", booking_mode: "bookable", job_category: "ล้าง", ac_type: "ผนัง", booking_ac_type: "ผนัง", booking_btu: 9000 },
+  ];
+  root.api.loadCatalogItem = async () => items[0];
+  root.api.loadCatalogItems = async () => items;
+
+  const container = new FakeMount();
+  root.store.renderDetail(container);
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  await new Promise((resolve) => setTimeout(resolve, 0));
+
+  const body = container.querySelector("[data-store-detail-body]");
+  const html = body.innerHTML;
+  const relatedSection = html.slice(html.indexOf("เลือกวิธีล้างที่เหมาะกับคุณ"));
+  assert.equal((relatedSection.match(/store-related-card-image-wrap/g) || []).length, 4, "all 4 real wash methods must appear exactly once");
+  assert.match(relatedSection, /data-store-related-item="91"/);
+  assert.match(relatedSection, /data-store-related-item="92"/);
+  assert.match(relatedSection, /data-store-related-item="93"/);
+});
+
+test("a wall-wash item whose wash method cannot be resolved from any field or item_name keyword is never merged into another item's BTU group or counted as a related-slider method", async () => {
+  const context = makeContext();
+  const root = loadCustomerFrontend(context);
+  root.state.setRoute("storeItem-100");
+  const items = [
+    { item_id: 100, item_name: "ล้างแอร์ผนัง ล้างปกติ", item_category: "ล้างแอร์", base_price: 500, unit_label: "เครื่อง", booking_mode: "bookable", job_category: "ล้าง", ac_type: "ผนัง", booking_ac_type: "ผนัง", booking_btu: 9000 },
+    { item_id: 101, item_name: "ล้างแอร์ผนัง", item_category: "ล้างแอร์", base_price: 520, unit_label: "เครื่อง", booking_mode: "bookable", job_category: "ล้าง", ac_type: "ผนัง", booking_ac_type: "ผนัง", booking_btu: 12000 },
+  ];
+  root.api.loadCatalogItem = async () => items[0];
+  root.api.loadCatalogItems = async () => items;
+
+  const container = new FakeMount();
+  root.store.renderDetail(container);
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  await new Promise((resolve) => setTimeout(resolve, 0));
+
+  let body = container.querySelector("[data-store-detail-body]");
+  let options = container.querySelectorAll("[data-store-variant-option]");
+  assert.equal(options.length, 0, "the resolvable item must not gain an unresolved-method sibling in its BTU selector");
+  assert.doesNotMatch(body.innerHTML, /data-store-related-item="101"/, "an unresolved wash method must never be counted as a related-slider method card");
+
+  const context2 = makeContext();
+  const root2 = loadCustomerFrontend(context2);
+  root2.state.setRoute("storeItem-101");
+  root2.api.loadCatalogItem = async () => items[1];
+  root2.api.loadCatalogItems = async () => items;
+  const container2 = new FakeMount();
+  root2.store.renderDetail(container2);
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  body = container2.querySelector("[data-store-detail-body]");
+  options = container2.querySelectorAll("[data-store-variant-option]");
+  assert.equal(options.length, 0, "the unresolved item itself must never gain a sibling either");
+});
+
+test("job_category and item_category empty: wash resolves from item_name alone, and a repair item named only in item_name is never mixed into the wash family", async () => {
+  const context = makeContext();
+  const root = loadCustomerFrontend(context);
+  root.state.setRoute("storeItem-110");
+  const items = [
+    { item_id: 110, item_name: "ล้างแอร์ผนัง ล้างปกติ", base_price: 500, unit_label: "เครื่อง", booking_mode: "bookable", ac_type: "ผนัง", booking_ac_type: "ผนัง", booking_btu: 9000 },
+    { item_id: 111, item_name: "ล้างแอร์ผนัง ล้างพรีเมียม", base_price: 650, unit_label: "เครื่อง", booking_mode: "bookable", ac_type: "ผนัง", booking_ac_type: "ผนัง", booking_btu: 9000 },
+    { item_id: 112, item_name: "ซ่อมแอร์ผนัง", base_price: 1200, unit_label: "งาน", booking_mode: "bookable", ac_type: "ผนัง", booking_ac_type: "ผนัง" },
+  ];
+  root.api.loadCatalogItem = async () => items[0];
+  root.api.loadCatalogItems = async () => items;
+
+  const container = new FakeMount();
+  root.store.renderDetail(container);
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  await new Promise((resolve) => setTimeout(resolve, 0));
+
+  const body = container.querySelector("[data-store-detail-body]");
+  const html = body.innerHTML;
+  assert.match(html, /data-store-related-item="111"/, "job_category/item_category empty must still resolve wash via item_name");
+  assert.doesNotMatch(html, /data-store-related-item="112"/, "a repair item named only in item_name must never be mixed into the wash family");
+});

--- a/test/customerAppRecovery.test.js
+++ b/test/customerAppRecovery.test.js
@@ -1532,14 +1532,17 @@ test("product detail restructures into a top always-visible zone plus default-co
   assert.match(html, /class="[^"]*store-detail-summary[^"]*"/);
   assert.match(html, /ล้างทำความสะอาดแอร์เปลือยใต้ฝ้าโดยช่างมืออาชีพ/);
 
-  const detailsBlocks = [...html.matchAll(/<details class="store-detail-accordion"([^>]*)>[\s\S]*?<summary>([^<]+)<\/summary>/g)];
+  const detailsBlocks = [...html.matchAll(/<details class="store-detail-accordion"([^>]*)>[\s\S]*?<span class="store-detail-accordion-title">([^<]+)<\/span>/g)];
   assert.ok(detailsBlocks.length >= 4, "expected at least 4 accordion sections");
   detailsBlocks.forEach(([, attrs]) => assert.doesNotMatch(attrs, /open/));
   const headings = detailsBlocks.map((m) => m[2]);
   assert.ok(headings.includes("จุดเด่นของบริการ"));
   assert.ok(headings.includes("รายละเอียดบริการ"));
-  assert.ok(headings.includes("ประเภทแอร์ที่เหมาะสม"));
+  assert.ok(headings.includes("เหมาะกับแอร์แบบไหน"));
   assert.ok(headings.includes("เงื่อนไขบริการ"));
+  assert.match(html, /แตะเพื่อดูรายละเอียด/);
+  assert.match(html, /store-detail-accordion-chevron/);
+  assert.match(html, /<summary>\s*<span class="store-detail-accordion-icon">/);
 
   // Collapsed accordion content is still present in the markup (native
   // <details>), so the customer can search/find it and existing regex-based
@@ -1572,7 +1575,7 @@ test("related products slider shows up to 4 real same-family items, includes the
   const body = container.querySelector("[data-store-detail-body]");
   const html = body.innerHTML;
 
-  assert.match(html, /บริการที่เกี่ยวข้อง/);
+  assert.match(html, /เลือกวิธีล้างที่เหมาะกับคุณ/);
   assert.match(html, /data-store-related-item="12"/);
   assert.match(html, /data-store-related-item="13"/);
   assert.match(html, /data-store-related-item="14"/);
@@ -1582,7 +1585,7 @@ test("related products slider shows up to 4 real same-family items, includes the
   // Mismatched category/job_type never appears among related items.
   assert.doesNotMatch(html, /data-store-related-item="99"/);
 
-  const relatedSection = html.slice(html.indexOf("บริการที่เกี่ยวข้อง"));
+  const relatedSection = html.slice(html.indexOf("เลือกวิธีล้างที่เหมาะกับคุณ"));
   assert.equal((relatedSection.match(/data-store-related-item="/g) || []).length, 3);
   // The currently-viewed item (10, "ล้างธรรมดา") is included too, marked as
   // currently viewing rather than as a clickable "related" card -- all 4 real
@@ -1658,9 +1661,9 @@ test("BTU/spec variant selector changes price and short info on selection withou
   assert.match(body.innerHTML, /750/);
   assert.match(body.innerHTML, /เหมาะกับแอร์ขนาดใหญ่/);
 
-  const bookButton = container.querySelector("[data-store-detail-book]");
-  assert.ok(bookButton);
-  await bookButton.click();
+  const bookButtons = container.querySelectorAll("[data-store-detail-book]");
+  assert.ok(bookButtons.length >= 1);
+  await bookButtons[0].click();
   assert.equal(root.state.draft.scheduled.catalog_item_id, 11);
   assert.equal(root.state.draft.scheduled.btu, "18000");
 });
@@ -1680,11 +1683,16 @@ test("4-way wall-AC cleaning-method comparison section only appears for wall AC 
   await new Promise((resolve) => setTimeout(resolve, 0));
   await new Promise((resolve) => setTimeout(resolve, 0));
   const html = container.querySelector("[data-store-detail-body]").innerHTML;
-  assert.match(html, /เปรียบเทียบวิธีล้างแอร์ผนัง/);
+  assert.match(html, /เปรียบเทียบวิธีล้าง/);
   assert.match(html, /ล้างปกติ/);
   assert.match(html, /ล้างพรีเมียม/);
   assert.match(html, /แขวนคอยล์/);
   assert.match(html, /ตัดล้างใหญ่/);
+  // Comparison copy must only contain CWF-verified facts -- no disinfection,
+  // no guaranteed-leak-fix, and no "removes the coil" claims.
+  assert.doesNotMatch(html, /ฆ่าเชื้อ/);
+  assert.doesNotMatch(html, /รับรองแก้น้ำหยด/);
+  assert.doesNotMatch(html, /ถอดคอยล์ออก/);
 
   const context2 = makeContext();
   const root2 = loadCustomerFrontend(context2);
@@ -1699,5 +1707,86 @@ test("4-way wall-AC cleaning-method comparison section only appears for wall AC 
   await new Promise((resolve) => setTimeout(resolve, 0));
   await new Promise((resolve) => setTimeout(resolve, 0));
   const html2 = container2.querySelector("[data-store-detail-body]").innerHTML;
-  assert.doesNotMatch(html2, /เปรียบเทียบวิธีล้างแอร์ผนัง/);
+  assert.doesNotMatch(html2, /เปรียบเทียบวิธีล้าง/);
+});
+
+test("canonical product-family resolver groups ผนัง/wall AC-type synonyms into the same BTU variant family", async () => {
+  const context = makeContext();
+  const root = loadCustomerFrontend(context);
+  root.state.setRoute("storeItem-40");
+  const items = [
+    { item_id: 40, item_name: "ล้างแอร์ผนัง ล้างธรรมดา 9000", item_category: "ล้างแอร์", base_price: 500, unit_label: "เครื่อง", booking_mode: "bookable", job_category: "ล้าง", ac_type: "ผนัง", btu_min: 9000, btu_max: 9000, booking_ac_type: "ผนัง", booking_wash_variant: "ล้างธรรมดา", booking_btu: 9000 },
+    { item_id: 41, item_name: "Wall mounted AC wash 18000", item_category: "wash", base_price: 700, unit_label: "เครื่อง", booking_mode: "bookable", job_category: "wash", ac_type: "wall", btu_min: 18000, booking_ac_type: "wall", booking_wash_variant: "ล้างธรรมดา", booking_btu: 18000 },
+  ];
+  root.api.loadCatalogItem = async () => items[0];
+  root.api.loadCatalogItems = async () => items;
+
+  const container = new FakeMount();
+  root.store.renderDetail(container);
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  await new Promise((resolve) => setTimeout(resolve, 0));
+
+  const options = container.querySelectorAll("[data-store-variant-option]");
+  assert.equal(options.length, 2, "wall/ผนัง synonyms must resolve to the same canonical AC-type family");
+});
+
+test("canonical wash-variant resolver groups ล้างปกติ/ล้างธรรมดา synonyms, and แขวนคอยล์/ล้างแขวนคอยล์ synonyms, into the same BTU variant group", async () => {
+  const context = makeContext();
+  const root = loadCustomerFrontend(context);
+  root.state.setRoute("storeItem-50");
+  const items = [
+    { item_id: 50, item_name: "ล้างแอร์ผนัง ล้างปกติ", item_category: "ล้างแอร์", base_price: 500, unit_label: "เครื่อง", booking_mode: "bookable", job_category: "ล้าง", ac_type: "ผนัง", btu_min: 9000, booking_ac_type: "ผนัง", booking_wash_variant: "ล้างปกติ", booking_btu: 9000 },
+    { item_id: 51, item_name: "ล้างแอร์ผนัง ล้างธรรมดา ใหญ่", item_category: "ล้างแอร์", base_price: 700, unit_label: "เครื่อง", booking_mode: "bookable", job_category: "ล้าง", ac_type: "ผนัง", btu_min: 18000, booking_ac_type: "ผนัง", booking_wash_variant: "ล้างธรรมดา", booking_btu: 18000 },
+  ];
+  root.api.loadCatalogItem = async () => items[0];
+  root.api.loadCatalogItems = async () => items;
+
+  const container = new FakeMount();
+  root.store.renderDetail(container);
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  await new Promise((resolve) => setTimeout(resolve, 0));
+
+  let options = container.querySelectorAll("[data-store-variant-option]");
+  assert.equal(options.length, 2, "ล้างปกติ/ล้างธรรมดา synonyms must resolve to the same canonical wash variant");
+
+  const context2 = makeContext();
+  const root2 = loadCustomerFrontend(context2);
+  root2.state.setRoute("storeItem-60");
+  const items2 = [
+    { item_id: 60, item_name: "ล้างแอร์ผนัง แขวนคอยล์", item_category: "ล้างแอร์", base_price: 800, unit_label: "เครื่อง", booking_mode: "bookable", job_category: "ล้าง", ac_type: "ผนัง", btu_min: 9000, booking_ac_type: "ผนัง", booking_wash_variant: "แขวนคอยล์", booking_btu: 9000 },
+    { item_id: 61, item_name: "ล้างแอร์ผนัง ล้างแขวนคอยล์ ใหญ่", item_category: "ล้างแอร์", base_price: 950, unit_label: "เครื่อง", booking_mode: "bookable", job_category: "ล้าง", ac_type: "ผนัง", btu_min: 18000, booking_ac_type: "ผนัง", booking_wash_variant: "ล้างแขวนคอยล์", booking_btu: 18000 },
+  ];
+  root2.api.loadCatalogItem = async () => items2[0];
+  root2.api.loadCatalogItems = async () => items2;
+
+  const container2 = new FakeMount();
+  root2.store.renderDetail(container2);
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  await new Promise((resolve) => setTimeout(resolve, 0));
+
+  options = container2.querySelectorAll("[data-store-variant-option]");
+  assert.equal(options.length, 2, "แขวนคอยล์/ล้างแขวนคอยล์ synonyms must resolve to the same canonical wash variant");
+});
+
+test("canonical resolver never mixes repair items with wash items, and never puts cross-wash-method variants into the BTU selector", async () => {
+  const context = makeContext();
+  const root = loadCustomerFrontend(context);
+  root.state.setRoute("storeItem-70");
+  const items = [
+    { item_id: 70, item_name: "ล้างแอร์ผนัง ล้างธรรมดา", item_category: "ล้างแอร์", base_price: 500, unit_label: "เครื่อง", booking_mode: "bookable", job_category: "ล้าง", ac_type: "ผนัง", btu_min: 9000, booking_ac_type: "ผนัง", booking_wash_variant: "ล้างธรรมดา", booking_btu: 9000 },
+    { item_id: 71, item_name: "ล้างแอร์ผนัง ล้างพรีเมียม", item_category: "ล้างแอร์", base_price: 650, unit_label: "เครื่อง", booking_mode: "bookable", job_category: "ล้าง", ac_type: "ผนัง", btu_min: 18000, booking_ac_type: "ผนัง", booking_wash_variant: "ล้างพรีเมียม", booking_btu: 18000 },
+    { item_id: 72, item_name: "ซ่อมแอร์ผนัง", item_category: "ซ่อมแอร์", base_price: 1200, unit_label: "งาน", booking_mode: "bookable", job_category: "ซ่อม", ac_type: "ผนัง", booking_ac_type: "ผนัง" },
+  ];
+  root.api.loadCatalogItem = async () => items[0];
+  root.api.loadCatalogItems = async () => items;
+
+  const container = new FakeMount();
+  root.store.renderDetail(container);
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  await new Promise((resolve) => setTimeout(resolve, 0));
+
+  const body = container.querySelector("[data-store-detail-body]");
+  const options = container.querySelectorAll("[data-store-variant-option]");
+  assert.equal(options.length, 0, "a different wash method (ล้างพรีเมียม) must never enter the ล้างธรรมดา BTU selector");
+  assert.doesNotMatch(body.innerHTML, /data-store-related-item="72"/, "repair items must never be mixed into a wash item's related family");
 });


### PR DESCRIPTION
## Summary

Fixes a production UX/correctness issue on the Store Product Detail page where the BTU/spec selector silently failed to appear for non-wall AC types, and where raw catalog string comparisons (instead of canonicalized values) caused real wash-method/AC-type variants to be missed or mismatched.

**Root cause**: `variantSiblings()` had a hard early-exit gate `if (!item.booking_wash_variant) return [item]`, so the BTU selector only ever worked for items that had a `booking_wash_variant` set (wall-type wash items). Family/variant grouping also compared raw `ac_type`/`job_category`/`booking_wash_variant` strings directly, so synonyms ("ผนัง" vs "wall", "ล้างปกติ" vs "ล้างธรรมดา", "แขวนคอยล์" vs "ล้างแขวนคอยล์") were treated as different groups instead of the same one.

### Changes

1. **Canonical Product Family Resolver** (`customer-app/modules/store.js`) — `canonicalAcType`, `canonicalJobCategory`, `canonicalWashVariant` normalize raw catalog fields to a small fixed set of tokens, with strict priority order: `booking_*` enum fields (server-validated, most authoritative) → free-text display fields → item-name keyword match as a last resort only. Never fuzzy-matches across different product types; returns `null` when nothing resolves.
2. **BTU/Spec Variant Selector** — `variantSiblings` now groups on the canonical variant-group key (job + AC type + wash variant) with no early-exit gate, so it works for every AC type, not just wall-wash. Selecting a variant updates price, description, BTU label, and the booking button's real `item_id` — no extra network fetch (catalog list is reused). Re-renders if the catalog list finishes loading after the detail page.
3. **Related Products Slider** — `relatedFamilyItems`/`pickRepresentative` show one representative card per real wash method (BTU-nearest to the current item, active/visible-first), max 4 cards, current method marked "กำลังดู", never duplicate BTU siblings, never fabricated items. Heading is "เลือกวิธีล้างที่เหมาะกับคุณ" for wall-wash families.
4. **Accordion redesign** (`customer-app/assets/customer-app.css`) — white cards, light border, soft shadow, 16-18px radius, ≥54px tappable header, icon + title + "แตะเพื่อดูรายละเอียด" hint + rotating chevron, replacing the old bare "+"/"–" text marker.
5. **Page reorder** — Gallery → queue badge → name → review badge → price → BTU selector → short description → inline CTA → accordions (including comparison) → related slider → reviews, with an inline CTA so the fixed bottom CTA bar never buries the related slider.
6. **Comparison copy** — trimmed to only CWF-verified service steps (ล้างปกติ/ล้างพรีเมียม/แขวนคอยล์/ตัดล้างใหญ่), removing invented/unconfirmed claims (no disinfection claims, no guaranteed-leak-fix claims, no "removes the coil" claim for methods that don't do that).

### Scope

Touched only the authorized files: `customer-app/modules/store.js`, `customer-app/assets/customer-app.css`, `test/customerAppRecovery.test.js`. No changes to payment, auth, technician core, tracking core, pricing engine, database, migrations, or production data.

## Test plan

- [x] `node --check customer-app/modules/store.js` — passes
- [x] `npm test` — 569 pass / 11 skip / 0 fail
- [x] `git diff --check` — clean (no whitespace errors)
- [x] New tests added: canonical AC-type synonyms (ผนัง/wall) resolve to the same BTU family; canonical wash-variant synonyms (ล้างปกติ/ล้างธรรมดา, แขวนคอยล์/ล้างแขวนคอยล์) resolve to the same variant group; repair items never mixed with wash items; cross-wash-method variants never enter the BTU selector; accordion markup uses icon/hint/chevron (no old "+" marker); comparison copy excludes forbidden claims.
- [ ] Live browser QA against real catalog data at 320px/390px/430px — **not performed**. This sandboxed environment has no database connection configured (`DATABASE_URL` unset, no Postgres instance) and no browser-automation tooling installed, so the app server cannot be started against real data here. Recommend manual QA in an environment with DB access before merging, per the original request's required browser verification step.

## Remaining risks

- Browser QA against real production catalog data has not been performed in this environment (see above) — please verify visually before merging.
- `WALL_AC_CLEANING_COMPARISON` copy was condensed to the minimal CWF-verified fact set; if there are additional approved marketing copy lines elsewhere in the business, those were intentionally excluded to avoid unconfirmed claims.


---
_Generated by [Claude Code](https://claude.ai/code/session_01G8RDdFzW2bZKTwvsfaovwg)_