### PR TITLE
Fix technician rework income hold/release flow

### DIFF
--- a/index.js
+++ b/index.js
@@ -7489,6 +7489,11 @@ async function _openReworkCaseWithIncomeHold(client, opts = {}) {
   const job = jr.rows[0];
   const technicianUsername = String(opts.technicianUsername || job.technician_username || '').trim() || null;
 
+  const activeCase = await technicianReworkIncome.findActiveReworkCase(client, jobId);
+  if (activeCase) {
+    throw createHttpError(409, 'งานนี้มี rework case ที่เปิดอยู่แล้ว', { reworkCase: activeCase });
+  }
+
   const ins = await client.query(
     `INSERT INTO public.technician_rework_cases
      (case_code, job_id, technician_username, reason_type, reason_note, warranty_checked, warranty_end_at, created_by)
@@ -7514,9 +7519,16 @@ async function _openReworkCaseWithIncomeHold(client, opts = {}) {
   const holdResults = [];
   if (preferredTech) {
     const lines = job.finished_at ? await _buildPayoutLinesForJob(jobId) : [];
-    const earnAmount = (lines || [])
-      .filter((ln) => String(ln && ln.technician_username || '').trim() === preferredTech)
-      .reduce((sum, ln) => sum + Number(ln.earn_amount || 0), 0);
+    const originalIncomeRows = (lines || [])
+      .filter((ln) => ln && String(ln.technician_username || '').trim())
+      .map((ln) => ({
+        technician_username: String(ln.technician_username).trim(),
+        amount: Number(ln.earn_amount || 0),
+        job_id: jobId,
+      }));
+    const earnAmount = originalIncomeRows
+      .filter((row) => row.technician_username === preferredTech)
+      .reduce((sum, row) => sum + Number(row.amount || 0), 0);
     const holdResult = await technicianReworkIncome.holdOriginalIncomeForReworkCase(client, {
       reworkCaseId: reworkCase.rework_case_id,
       jobId,
@@ -7524,6 +7536,7 @@ async function _openReworkCaseWithIncomeHold(client, opts = {}) {
       originalFinishedAt: job.finished_at,
       actor,
       originalEarnAmount: earnAmount,
+      originalIncomeRows,
     });
     holdResults.push(...((holdResult && holdResult.rows) || []));
   }

--- a/index.js
+++ b/index.js
@@ -12698,6 +12698,13 @@ await pool.query(`CREATE INDEX IF NOT EXISTS idx_income_tech_overrides_enabled O
     await pool.query(`CREATE INDEX IF NOT EXISTS idx_trih_technician ON public.technician_rework_income_holds(technician_username, created_at DESC)`);
     await pool.query(`CREATE INDEX IF NOT EXISTS idx_trih_status ON public.technician_rework_income_holds(hold_status, created_at DESC)`);
     await pool.query(`CREATE INDEX IF NOT EXISTS idx_trih_rework_case ON public.technician_rework_income_holds(rework_case_id)`);
+    // Second/third/Nth rework round support (see migrations/technician_rework_income_hold_release.sql)
+    await pool.query(`ALTER TABLE public.technician_rework_income_holds ADD COLUMN IF NOT EXISTS source_kind TEXT`);
+    await pool.query(`ALTER TABLE public.technician_rework_income_holds DROP CONSTRAINT IF EXISTS technician_rework_income_holds_source_kind_check`);
+    await pool.query(`ALTER TABLE public.technician_rework_income_holds ADD CONSTRAINT technician_rework_income_holds_source_kind_check CHECK (source_kind IS NULL OR source_kind IN ('original_income', 'previous_rework_release'))`);
+    await pool.query(`ALTER TABLE public.technician_rework_income_holds ADD COLUMN IF NOT EXISTS previous_rework_case_id BIGINT REFERENCES public.technician_rework_cases(rework_case_id) ON DELETE SET NULL`);
+    await pool.query(`ALTER TABLE public.technician_rework_income_holds ADD COLUMN IF NOT EXISTS previous_release_adjustment_id BIGINT REFERENCES public.technician_payout_adjustments(adj_id) ON DELETE SET NULL`);
+    await pool.query(`CREATE INDEX IF NOT EXISTS idx_trih_previous_rework_case ON public.technician_rework_income_holds(previous_rework_case_id) WHERE previous_rework_case_id IS NOT NULL`);
 
     await pool.query(`
       CREATE TABLE IF NOT EXISTS public.technician_deduction_audit_logs (

--- a/index.js
+++ b/index.js
@@ -7494,6 +7494,32 @@ async function _openReworkCaseWithIncomeHold(client, opts = {}) {
     throw createHttpError(409, 'งานนี้มี rework case ที่เปิดอยู่แล้ว', { reworkCase: activeCase });
   }
 
+  // Original-earner set: every technician who could have earned income on
+  // this job (primary + team + assignments), not just whoever ends up
+  // recorded as the single rework_case.technician_username — team jobs must
+  // hold/release income per person, never lump it onto one username.
+  const team = await getTeamForJob(jobId);
+  if (technicianUsername && !team.includes(technicianUsername)) team.push(technicianUsername);
+  const preferredTech = technicianUsername || team[0] || null;
+
+  // Capture originalIncomeRows BEFORE inserting the new rework_case row.
+  // _buildPayoutLinesForJob queries through the shared pool (a different
+  // connection than this transaction's `client`), so correctness must not
+  // depend on whether that connection can see this transaction's uncommitted
+  // INSERT — computing it before the row exists removes that ambiguity
+  // entirely, on every connection, committed or not.
+  const lines = job.finished_at ? await _buildPayoutLinesForJob(jobId) : [];
+  const originalIncomeRows = (lines || [])
+    .filter((ln) => ln && String(ln.technician_username || '').trim())
+    .map((ln) => ({
+      technician_username: String(ln.technician_username).trim(),
+      amount: Number(ln.earn_amount || 0),
+      job_id: jobId,
+    }));
+  const earnAmount = originalIncomeRows
+    .filter((row) => row.technician_username === preferredTech)
+    .reduce((sum, row) => sum + Number(row.amount || 0), 0);
+
   const ins = await client.query(
     `INSERT INTO public.technician_rework_cases
      (case_code, job_id, technician_username, reason_type, reason_note, warranty_checked, warranty_end_at, created_by)
@@ -7503,32 +7529,13 @@ async function _openReworkCaseWithIncomeHold(client, opts = {}) {
   );
   const reworkCase = ins.rows[0];
 
-  // Original-earner set: every technician who could have earned income on
-  // this job (primary + team + assignments), not just whoever ends up
-  // recorded as the single rework_case.technician_username — team jobs must
-  // hold/release income per person, never lump it onto one username.
-  const team = await getTeamForJob(jobId);
-  if (technicianUsername && !team.includes(technicianUsername)) team.push(technicianUsername);
-
   // technicianReworkIncome.holdOriginalIncomeForReworkCase derives every
-  // earner on the job directly from technician_payout_lines for the source
-  // period, so a single call already holds the whole team — technicianUsername
-  // here is only a fallback used if that technician has no payout_lines row
-  // yet (e.g. period not generated), in which case originalEarnAmount is used.
-  const preferredTech = technicianUsername || team[0] || null;
+  // earner on the job (previous released hold ledger first, then these
+  // originalIncomeRows, then technician_payout_lines), so a single call
+  // already holds the whole team — technicianUsername here is only a
+  // fallback used if that technician has no authoritative row at all.
   const holdResults = [];
   if (preferredTech) {
-    const lines = job.finished_at ? await _buildPayoutLinesForJob(jobId) : [];
-    const originalIncomeRows = (lines || [])
-      .filter((ln) => ln && String(ln.technician_username || '').trim())
-      .map((ln) => ({
-        technician_username: String(ln.technician_username).trim(),
-        amount: Number(ln.earn_amount || 0),
-        job_id: jobId,
-      }));
-    const earnAmount = originalIncomeRows
-      .filter((row) => row.technician_username === preferredTech)
-      .reduce((sum, row) => sum + Number(row.amount || 0), 0);
     const holdResult = await technicianReworkIncome.holdOriginalIncomeForReworkCase(client, {
       reworkCaseId: reworkCase.rework_case_id,
       jobId,

--- a/index.js
+++ b/index.js
@@ -6631,6 +6631,7 @@ async function _loadApprovedReworkCompensationLines(job_id, team, meta, exclusio
         WHERE job_id::text=$1::text
           AND technician_username = ANY($2::text[])
           AND adj_amount > 0
+          AND reason NOT LIKE '[REWORK_RELEASE]%'
         GROUP BY technician_username`,
       [String(jid), usernames]
     );
@@ -7497,25 +7498,34 @@ async function _openReworkCaseWithIncomeHold(client, opts = {}) {
   );
   const reworkCase = ins.rows[0];
 
-  // Capture + pause the ORIGINAL technician's income for this job BEFORE we clear
-  // finished_at below — _buildPayoutLinesForJob reads the job's current (pre-rework)
-  // state, which is the only ledger-grade source for "what they actually earned".
-  let holdResult = null;
-  if (technicianUsername) {
-    holdResult = await technicianReworkIncome.holdOriginalIncomeForReworkCase(client, {
+  // Original-earner set: every technician who could have earned income on
+  // this job (primary + team + assignments), not just whoever ends up
+  // recorded as the single rework_case.technician_username — team jobs must
+  // hold/release income per person, never lump it onto one username.
+  const team = await getTeamForJob(jobId);
+  if (technicianUsername && !team.includes(technicianUsername)) team.push(technicianUsername);
+
+  // technicianReworkIncome.holdOriginalIncomeForReworkCase derives every
+  // earner on the job directly from technician_payout_lines for the source
+  // period, so a single call already holds the whole team — technicianUsername
+  // here is only a fallback used if that technician has no payout_lines row
+  // yet (e.g. period not generated), in which case originalEarnAmount is used.
+  const preferredTech = technicianUsername || team[0] || null;
+  const holdResults = [];
+  if (preferredTech) {
+    const lines = job.finished_at ? await _buildPayoutLinesForJob(jobId) : [];
+    const earnAmount = (lines || [])
+      .filter((ln) => String(ln && ln.technician_username || '').trim() === preferredTech)
+      .reduce((sum, ln) => sum + Number(ln.earn_amount || 0), 0);
+    const holdResult = await technicianReworkIncome.holdOriginalIncomeForReworkCase(client, {
       reworkCaseId: reworkCase.rework_case_id,
       jobId,
-      technicianUsername,
+      technicianUsername: preferredTech,
       originalFinishedAt: job.finished_at,
       actor,
-      resolveOriginalEarnAmount: async () => {
-        if (!job.finished_at) return 0;
-        const lines = await _buildPayoutLinesForJob(jobId);
-        return (lines || [])
-          .filter((ln) => String(ln && ln.technician_username || '').trim() === technicianUsername)
-          .reduce((sum, ln) => sum + Number(ln.earn_amount || 0), 0);
-      },
+      originalEarnAmount: earnAmount,
     });
+    holdResults.push(...((holdResult && holdResult.rows) || []));
   }
 
   await client.query(
@@ -7540,30 +7550,51 @@ async function _openReworkCaseWithIncomeHold(client, opts = {}) {
   );
   await client.query(`UPDATE public.job_assignments SET status='in_progress', done_at=NULL WHERE job_id=$1`, [jobId]);
 
-  return { job, reworkCase, holdResult, technicianUsername };
+  return { job, reworkCase, holdResults, technicianUsername, team };
 }
 
-// successful=true releases the held amount into the correct future payout period
-// (rolling forward past any already-paid period); successful=false permanently
-// voids the hold (no money moves — the rework failed, so the original income stays
-// paused/already-removed). Both paths are idempotent and safe to call repeatedly.
+// successful=true releases every team member's held amount into the correct
+// future payout period (rolling forward past any already-paid period);
+// successful=false permanently voids every hold (no money moves — the rework
+// failed, so the original income stays paused/already-removed). Both paths
+// are idempotent and safe to call repeatedly. Operates on every hold row for
+// the case (team jobs hold/release per technician), not a single username.
 async function _closeReworkCaseWithIncomeRelease(client, opts = {}) {
   const reworkCaseId = Number(opts.reworkCaseId);
-  const technicianUsername = String(opts.technicianUsername || '').trim();
-  if (!reworkCaseId || !technicianUsername) return null;
+  if (!reworkCaseId) return null;
   const successful = !!opts.successful;
   const actor = opts.actor || null;
 
+  const holds = await technicianReworkIncome.getHoldsForReworkCase(client, reworkCaseId);
+  if (!holds.length) return { released: false, reason: 'NO_HOLD', results: [] };
+
+  // voidHeldIncomeForReworkCase / releaseHeldIncomeForReworkCase each act on
+  // every held row for the rework case in one call (not just the passed
+  // technicianUsername), so a single call already covers the whole team.
   if (!successful) {
-    return technicianReworkIncome.voidHeldIncomeForReworkCase(client, { reworkCaseId, technicianUsername });
+    const r = await technicianReworkIncome.voidHeldIncomeForReworkCase(client, {
+      reworkCaseId,
+      technicianUsername: holds[0].technician_username,
+    });
+    const results = (r.rows || []).map((row) => ({ technician_username: row.technician_username, ...row }));
+    return { released: false, voided: true, results };
   }
-  const finishedAt = opts.finishedAt || new Date();
-  return technicianReworkIncome.releaseHeldIncomeForReworkCase(client, {
+
+  // The release period is anchored on the rework job's own persisted
+  // finished_at (e.g. read back via UPDATE ... RETURNING) — never a
+  // freshly-constructed `new Date()`, which could disagree with what was
+  // actually written right at a payout-period boundary.
+  if (!opts.finishedAt) {
+    throw createHttpError(409, 'งานยังไม่มี finished_at จึงคืนรายได้ที่พักไว้ไม่ได้');
+  }
+  const r = await technicianReworkIncome.releaseHeldIncomeForReworkCase(client, {
     reworkCaseId,
-    technicianUsername,
-    finishedAt,
+    technicianUsername: holds[0].technician_username,
+    finishedAt: opts.finishedAt,
     actor,
   });
+  const results = (r.rows || []).map((row) => ({ technician_username: row.technician_username, ...row }));
+  return { released: !!r.released, amount: Number(r.amount || 0), results };
 }
 
 app.get('/admin/super/tech_income/calc/job/:job_id', requireSuperAdmin, async (req, res) => {
@@ -12592,14 +12623,15 @@ await pool.query(`CREATE INDEX IF NOT EXISTS idx_income_tech_overrides_enabled O
     await pool.query(`
       CREATE TABLE IF NOT EXISTS public.technician_rework_income_holds (
         hold_id BIGSERIAL PRIMARY KEY,
-        rework_case_id BIGINT NOT NULL REFERENCES public.technician_rework_cases(rework_case_id) ON DELETE CASCADE,
+        rework_case_id BIGINT NOT NULL REFERENCES public.technician_rework_cases(rework_case_id) ON DELETE RESTRICT,
         technician_username TEXT NOT NULL,
-        job_id BIGINT NOT NULL REFERENCES public.jobs(job_id) ON DELETE CASCADE,
+        job_id BIGINT NOT NULL REFERENCES public.jobs(job_id) ON DELETE RESTRICT,
         held_amount NUMERIC(12,2) NOT NULL DEFAULT 0 CHECK (held_amount >= 0),
         source_payout_id TEXT,
         source_period_status_at_hold TEXT,
         hold_adjustment_id BIGINT REFERENCES public.technician_payout_adjustments(adj_id) ON DELETE SET NULL,
-        hold_status TEXT NOT NULL DEFAULT 'held' CHECK (hold_status IN ('held','already_paid_no_action','released','voided')),
+        hold_carried_forward_payout_id TEXT,
+        hold_status TEXT NOT NULL DEFAULT 'held' CHECK (hold_status IN ('held','already_paid_no_action','paid_then_carried_forward_hold','released','voided')),
         released_amount NUMERIC(12,2) CHECK (released_amount IS NULL OR released_amount >= 0),
         release_payout_id TEXT,
         release_adjustment_id BIGINT REFERENCES public.technician_payout_adjustments(adj_id) ON DELETE SET NULL,
@@ -12612,6 +12644,35 @@ await pool.query(`CREATE INDEX IF NOT EXISTS idx_income_tech_overrides_enabled O
         CHECK (released_amount IS NULL OR released_amount <= held_amount)
       )
     `);
+    // Guarded upgrade path: financial ledger must never cascade-delete on a
+    // case/job delete, and must accept the carried-forward hold status — fix
+    // up any environment where this table was created by an earlier version.
+    await pool.query(`
+      DO $$
+      BEGIN
+        IF EXISTS (
+          SELECT 1 FROM information_schema.table_constraints
+           WHERE table_schema='public' AND table_name='technician_rework_income_holds'
+             AND constraint_name='technician_rework_income_holds_rework_case_id_fkey'
+        ) THEN
+          ALTER TABLE public.technician_rework_income_holds DROP CONSTRAINT technician_rework_income_holds_rework_case_id_fkey;
+          ALTER TABLE public.technician_rework_income_holds ADD CONSTRAINT technician_rework_income_holds_rework_case_id_fkey
+            FOREIGN KEY (rework_case_id) REFERENCES public.technician_rework_cases(rework_case_id) ON DELETE RESTRICT;
+        END IF;
+        IF EXISTS (
+          SELECT 1 FROM information_schema.table_constraints
+           WHERE table_schema='public' AND table_name='technician_rework_income_holds'
+             AND constraint_name='technician_rework_income_holds_job_id_fkey'
+        ) THEN
+          ALTER TABLE public.technician_rework_income_holds DROP CONSTRAINT technician_rework_income_holds_job_id_fkey;
+          ALTER TABLE public.technician_rework_income_holds ADD CONSTRAINT technician_rework_income_holds_job_id_fkey
+            FOREIGN KEY (job_id) REFERENCES public.jobs(job_id) ON DELETE RESTRICT;
+        END IF;
+      END $$;
+    `);
+    await pool.query(`ALTER TABLE public.technician_rework_income_holds ADD COLUMN IF NOT EXISTS hold_carried_forward_payout_id TEXT`);
+    await pool.query(`ALTER TABLE public.technician_rework_income_holds DROP CONSTRAINT IF EXISTS technician_rework_income_holds_hold_status_check`);
+    await pool.query(`ALTER TABLE public.technician_rework_income_holds ADD CONSTRAINT technician_rework_income_holds_hold_status_check CHECK (hold_status IN ('held','already_paid_no_action','paid_then_carried_forward_hold','released','voided'))`);
     await pool.query(`CREATE UNIQUE INDEX IF NOT EXISTS uq_trih_release_idempotency_key ON public.technician_rework_income_holds(release_idempotency_key) WHERE release_idempotency_key IS NOT NULL`);
     await pool.query(`CREATE INDEX IF NOT EXISTS idx_trih_job_id ON public.technician_rework_income_holds(job_id)`);
     await pool.query(`CREATE INDEX IF NOT EXISTS idx_trih_technician ON public.technician_rework_income_holds(technician_username, created_at DESC)`);
@@ -15766,7 +15827,7 @@ app.post('/admin/jobs/:job_id/rework_case', requireAdminSession, async (req, res
     await client.query('BEGIN');
     const realId = await resolveJobIdAny(client, raw);
     if (!realId) throw createHttpError(400, 'job_id ไม่ถูกต้อง');
-    const { job, reworkCase, technicianUsername } = await _openReworkCaseWithIncomeHold(client, {
+    const { job, reworkCase, technicianUsername, team } = await _openReworkCaseWithIncomeHold(client, {
       jobId: realId,
       technicianUsername: req.body?.technician_username,
       reasonType: reason_type,
@@ -15786,7 +15847,7 @@ app.post('/admin/jobs/:job_id/rework_case', requireAdminSession, async (req, res
     try {
       await _syncDisplayForJobState(
         { ...job, job_id: realId, return_reason: reason_note || reason_type, returned_at: new Date() },
-        [technicianUsername].filter(Boolean),
+        [...new Set([...(team || []), technicianUsername].filter(Boolean))],
         { context: 'current' }
       );
     } catch (e) {
@@ -15857,17 +15918,13 @@ app.post('/admin/rework_cases/:id/resolve', requireAdminSession, async (req, res
     // every other resolution (failed / changed_technician / company_absorbed /
     // deduction_required) means the original work was not validated as payable,
     // so the hold is permanently voided instead (no money moves).
-    let releaseResult = null;
-    if (before.technician_username) {
-      const jrForClose = await client.query(`SELECT finished_at FROM public.jobs WHERE job_id=$1 LIMIT 1`, [before.job_id]);
-      releaseResult = await _closeReworkCaseWithIncomeRelease(client, {
-        reworkCaseId: id,
-        technicianUsername: before.technician_username,
-        successful: resolution === 'fixed',
-        finishedAt: jrForClose.rows[0]?.finished_at || new Date(),
-        actor: getActorUsername(req),
-      });
-    }
+    const jrForClose = await client.query(`SELECT finished_at FROM public.jobs WHERE job_id=$1 LIMIT 1`, [before.job_id]);
+    const releaseResult = await _closeReworkCaseWithIncomeRelease(client, {
+      reworkCaseId: id,
+      successful: resolution === 'fixed',
+      finishedAt: jrForClose.rows[0]?.finished_at || null,
+      actor: getActorUsername(req),
+    });
     await logDeductionAudit(client, req, { action: 'REWORK_CASE_RESOLVE', entity_type: 'rework_case', entity_id: id, before, after: up.rows[0] });
     await logJobUpdate(before.job_id, {
       actor_username: getActorUsername(req),
@@ -15879,7 +15936,10 @@ app.post('/admin/rework_cases/:id/resolve', requireAdminSession, async (req, res
     await client.query('COMMIT');
     try {
       const jr = await pool.query(`SELECT * FROM public.jobs WHERE job_id=$1 LIMIT 1`, [before.job_id]);
-      await _syncDisplayForJobState(jr.rows[0] || { job_id: before.job_id }, [before.technician_username].filter(Boolean), { context: 'history' });
+      const releasedTeam = (releaseResult && Array.isArray(releaseResult.results) ? releaseResult.results : [])
+        .map((r) => r && r.technician_username)
+        .filter(Boolean);
+      await _syncDisplayForJobState(jr.rows[0] || { job_id: before.job_id }, [...new Set([...releasedTeam, before.technician_username].filter(Boolean))], { context: 'history' });
     } catch (e) {
       try { console.warn('[tech_income_display] rework resolve sync failed', { job_id: before.job_id, error: e.message }); } catch {}
     }
@@ -16480,7 +16540,7 @@ app.post('/admin/jobs/:job_id/return_for_fix_v2', requireAdminSoft, async (req, 
     // Goes through the same shared workflow as /admin/jobs/:job_id/rework_case so
     // the original technician's earned income is paused via the exact same hold
     // ledger, instead of just clearing finished_at with no money-tracking record.
-    const { job, reworkCase, technicianUsername } = await _openReworkCaseWithIncomeHold(client, {
+    const { job, reworkCase, technicianUsername, team } = await _openReworkCaseWithIncomeHold(client, {
       jobId: job_id,
       reasonType: 'other',
       reasonNote: reason,
@@ -16495,8 +16555,7 @@ app.post('/admin/jobs/:job_id/return_for_fix_v2', requireAdminSoft, async (req, 
     }, client);
     await client.query('COMMIT');
     try {
-      const team = await getTeamForJob(job_id);
-      await _syncDisplayForJobState({ ...job, job_id, return_reason: reason, returned_at: new Date() }, team.length ? team : [technicianUsername].filter(Boolean), { context: 'current' });
+      await _syncDisplayForJobState({ ...job, job_id, return_reason: reason, returned_at: new Date() }, (team && team.length) ? team : [technicianUsername].filter(Boolean), { context: 'current' });
     } catch (e) {
       try { console.warn('[tech_income_display] return_for_fix sync failed', { job_id, error: e.message }); } catch {}
     }
@@ -19862,7 +19921,7 @@ if (status === "เสร็จแล้ว") {
       const ackAccepted = !!(photo_ack && photo_ack.accepted);
       const missingPhotos = (photo_ack && Array.isArray(photo_ack.missing)) ? photo_ack.missing : [];
       const paymentStatusToSave = close_payment_method === 'admin_handles_payment' ? 'pending_admin_update' : (close_payment_status || 'pending_verification');
-      await client.query(
+      const finalizeUpd = await client.query(
         `UPDATE public.jobs
          SET job_status='เสร็จแล้ว',
              finished_at = NOW(),
@@ -19893,7 +19952,8 @@ if (status === "เสร็จแล้ว") {
              close_signature_type = $17,
              close_signature_by = $8,
              close_signature_at = NOW()
-         WHERE job_id=$2`,
+         WHERE job_id=$2
+         RETURNING finished_at`,
         [sigPath, realId, wKind, wMonths, wEndIso,
           pre_cleaning_checklist ? JSON.stringify(pre_cleaning_checklist) : null,
           post_cleaning_checklist ? JSON.stringify(post_cleaning_checklist) : null,
@@ -19908,6 +19968,7 @@ if (status === "เสร็จแล้ว") {
           close_cash_confirmed,
           close_signature_type || 'technician_signature']
       );
+      const persistedFinishedAt = finalizeUpd.rows[0]?.finished_at || null;
       if (isRevisitFlow && revisitResult) {
         // Closing a revisit (rework) job through the same shared workflow as the
         // admin resolve endpoint: 'successful' releases the ORIGINAL technician's
@@ -19932,16 +19993,12 @@ if (status === "เสร็จแล้ว") {
               WHERE rework_case_id=$1`,
             [reworkCase.rework_case_id, resolution, revisitResult, revisitNote || null, technician_username]
           );
-          const heldTechnicianUsername = String(reworkCase.technician_username || '').trim();
-          if (heldTechnicianUsername) {
-            reworkIncomeResult = await _closeReworkCaseWithIncomeRelease(client, {
-              reworkCaseId: reworkCase.rework_case_id,
-              technicianUsername: heldTechnicianUsername,
-              successful: resolution === 'fixed',
-              finishedAt: new Date(),
-              actor: technician_username,
-            });
-          }
+          reworkIncomeResult = await _closeReworkCaseWithIncomeRelease(client, {
+            reworkCaseId: reworkCase.rework_case_id,
+            successful: resolution === 'fixed',
+            finishedAt: persistedFinishedAt,
+            actor: technician_username,
+          });
         }
         await logJobUpdate(
           realId,
@@ -20047,7 +20104,7 @@ if (status === "เสร็จแล้ว") {
   } catch (e) {
     await client.query("ROLLBACK");
     console.error(e);
-    res.status(500).json({ error: e.message || "ปิดงาน/ยกเลิกไม่สำเร็จ" });
+    res.status(Number(e.status || 500)).json({ error: e.message || "ปิดงาน/ยกเลิกไม่สำเร็จ" });
   } finally {
     client.release();
   }

--- a/index.js
+++ b/index.js
@@ -35,6 +35,7 @@ const technicianIncomeHelpers = require("./server/technicianIncome");
 const customerLookupHelpers = require("./server/customerLookup");
 const technicianJobIncomeDisplayHelpers = require("./server/technicianJobIncomeDisplay");
 const technicianReworkHelpers = require("./server/technicianRework");
+const technicianReworkIncome = require("./server/services/technicianReworkIncome");
 const adminJobItemsHelpers = require("./server/adminJobItems");
 const customerAvailability = require("./server/services/public/customerAvailability");
 const { createTechnicianJobMoneyHelpers } = require("./server/technicianJobMoneySummary");
@@ -7287,6 +7288,7 @@ const {
   money: _money,
   technicianJobIncomeDisplayHelpers,
   technicianReworkHelpers,
+  technicianReworkIncome,
   getCustomerCollectAmountForTechJob: _getCustomerCollectAmountForTechJob,
   loadTechnicianIncomePreview: _loadTechnicianIncomePreview,
   loadFinalizedTechPayoutLineForJob: _loadFinalizedTechPayoutLineForJob,
@@ -7459,6 +7461,109 @@ async function _assertJobMutableForPayout(client, job_id, ctx){
   err.payout_id = period.payout_id;
   try { console.warn('[payout_freeze] blocked', { job_id, payout_id: period.payout_id, status: period.status, ctx }); } catch {}
   throw err;
+}
+
+// =======================================
+// 🔒 Rework income hold/release — shared workflow
+// Used by /admin/jobs/:job_id/rework_case, /admin/jobs/:job_id/return_for_fix_v2,
+// /jobs/:job_id/finalize (technician revisit close) and /admin/rework_cases/:id/resolve
+// so every entry point that opens or closes a rework case pauses/restores the
+// original technician's income through the exact same path (invariant: single
+// shared workflow, no per-route divergence).
+// =======================================
+
+async function _openReworkCaseWithIncomeHold(client, opts = {}) {
+  const jobId = Number(opts.jobId);
+  if (!jobId) throw createHttpError(400, 'job_id ไม่ถูกต้อง');
+  const reasonType = REWORK_REASON_TYPES.has(opts.reasonType) ? opts.reasonType : 'other';
+  const reasonNote = opts.reasonNote || null;
+  const actor = opts.actor || null;
+
+  const jr = await client.query(
+    `SELECT job_id, booking_code, technician_username, warranty_end_at, job_status, finished_at
+       FROM public.jobs WHERE job_id=$1 FOR UPDATE`,
+    [jobId]
+  );
+  if (!jr.rows.length) throw createHttpError(404, 'ไม่พบงาน');
+  const job = jr.rows[0];
+  const technicianUsername = String(opts.technicianUsername || job.technician_username || '').trim() || null;
+
+  const ins = await client.query(
+    `INSERT INTO public.technician_rework_cases
+     (case_code, job_id, technician_username, reason_type, reason_note, warranty_checked, warranty_end_at, created_by)
+     VALUES ($1,$2,$3,$4,$5,$6,$7,$8)
+     RETURNING *`,
+    [await generateReworkCaseCode(client), jobId, technicianUsername, reasonType, reasonNote, !!opts.warrantyChecked, job.warranty_end_at || null, actor]
+  );
+  const reworkCase = ins.rows[0];
+
+  // Capture + pause the ORIGINAL technician's income for this job BEFORE we clear
+  // finished_at below — _buildPayoutLinesForJob reads the job's current (pre-rework)
+  // state, which is the only ledger-grade source for "what they actually earned".
+  let holdResult = null;
+  if (technicianUsername) {
+    holdResult = await technicianReworkIncome.holdOriginalIncomeForReworkCase(client, {
+      reworkCaseId: reworkCase.rework_case_id,
+      jobId,
+      technicianUsername,
+      originalFinishedAt: job.finished_at,
+      actor,
+      resolveOriginalEarnAmount: async () => {
+        if (!job.finished_at) return 0;
+        const lines = await _buildPayoutLinesForJob(jobId);
+        return (lines || [])
+          .filter((ln) => String(ln && ln.technician_username || '').trim() === technicianUsername)
+          .reduce((sum, ln) => sum + Number(ln.earn_amount || 0), 0);
+      },
+    });
+  }
+
+  await client.query(
+    `UPDATE public.jobs
+        SET job_status='งานแก้ไข',
+            returned_at=NOW(),
+            return_reason=$1,
+            returned_by=COALESCE($2, returned_by),
+            travel_started_at=NULL,
+            started_at=NULL,
+            checkin_at=NULL,
+            checkin_latitude=NULL,
+            checkin_longitude=NULL,
+            finished_at=NULL,
+            canceled_at=NULL,
+            cancel_reason=NULL,
+            final_signature_path=NULL,
+            final_signature_status=NULL,
+            final_signature_at=NULL
+      WHERE job_id=$3`,
+    [reasonNote || reasonType, actor, jobId]
+  );
+  await client.query(`UPDATE public.job_assignments SET status='in_progress', done_at=NULL WHERE job_id=$1`, [jobId]);
+
+  return { job, reworkCase, holdResult, technicianUsername };
+}
+
+// successful=true releases the held amount into the correct future payout period
+// (rolling forward past any already-paid period); successful=false permanently
+// voids the hold (no money moves — the rework failed, so the original income stays
+// paused/already-removed). Both paths are idempotent and safe to call repeatedly.
+async function _closeReworkCaseWithIncomeRelease(client, opts = {}) {
+  const reworkCaseId = Number(opts.reworkCaseId);
+  const technicianUsername = String(opts.technicianUsername || '').trim();
+  if (!reworkCaseId || !technicianUsername) return null;
+  const successful = !!opts.successful;
+  const actor = opts.actor || null;
+
+  if (!successful) {
+    return technicianReworkIncome.voidHeldIncomeForReworkCase(client, { reworkCaseId, technicianUsername });
+  }
+  const finishedAt = opts.finishedAt || new Date();
+  return technicianReworkIncome.releaseHeldIncomeForReworkCase(client, {
+    reworkCaseId,
+    technicianUsername,
+    finishedAt,
+    actor,
+  });
 }
 
 app.get('/admin/super/tech_income/calc/job/:job_id', requireSuperAdmin, async (req, res) => {
@@ -12483,6 +12588,36 @@ await pool.query(`CREATE INDEX IF NOT EXISTS idx_income_tech_overrides_enabled O
     await pool.query(`CREATE INDEX IF NOT EXISTS idx_trc_status_created ON public.technician_rework_cases(status, created_at DESC)`);
     await pool.query(`CREATE INDEX IF NOT EXISTS idx_trc_resolution ON public.technician_rework_cases(resolution)`);
 
+    // 💸 Rework income hold/release ledger (see migrations/technician_rework_income_hold_release.sql)
+    await pool.query(`
+      CREATE TABLE IF NOT EXISTS public.technician_rework_income_holds (
+        hold_id BIGSERIAL PRIMARY KEY,
+        rework_case_id BIGINT NOT NULL REFERENCES public.technician_rework_cases(rework_case_id) ON DELETE CASCADE,
+        technician_username TEXT NOT NULL,
+        job_id BIGINT NOT NULL REFERENCES public.jobs(job_id) ON DELETE CASCADE,
+        held_amount NUMERIC(12,2) NOT NULL DEFAULT 0 CHECK (held_amount >= 0),
+        source_payout_id TEXT,
+        source_period_status_at_hold TEXT,
+        hold_adjustment_id BIGINT REFERENCES public.technician_payout_adjustments(adj_id) ON DELETE SET NULL,
+        hold_status TEXT NOT NULL DEFAULT 'held' CHECK (hold_status IN ('held','already_paid_no_action','released','voided')),
+        released_amount NUMERIC(12,2) CHECK (released_amount IS NULL OR released_amount >= 0),
+        release_payout_id TEXT,
+        release_adjustment_id BIGINT REFERENCES public.technician_payout_adjustments(adj_id) ON DELETE SET NULL,
+        release_idempotency_key TEXT,
+        released_at TIMESTAMPTZ,
+        created_by TEXT,
+        created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+        updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+        UNIQUE (rework_case_id, technician_username),
+        CHECK (released_amount IS NULL OR released_amount <= held_amount)
+      )
+    `);
+    await pool.query(`CREATE UNIQUE INDEX IF NOT EXISTS uq_trih_release_idempotency_key ON public.technician_rework_income_holds(release_idempotency_key) WHERE release_idempotency_key IS NOT NULL`);
+    await pool.query(`CREATE INDEX IF NOT EXISTS idx_trih_job_id ON public.technician_rework_income_holds(job_id)`);
+    await pool.query(`CREATE INDEX IF NOT EXISTS idx_trih_technician ON public.technician_rework_income_holds(technician_username, created_at DESC)`);
+    await pool.query(`CREATE INDEX IF NOT EXISTS idx_trih_status ON public.technician_rework_income_holds(hold_status, created_at DESC)`);
+    await pool.query(`CREATE INDEX IF NOT EXISTS idx_trih_rework_case ON public.technician_rework_income_holds(rework_case_id)`);
+
     await pool.query(`
       CREATE TABLE IF NOT EXISTS public.technician_deduction_audit_logs (
         audit_id BIGSERIAL PRIMARY KEY,
@@ -15631,61 +15766,33 @@ app.post('/admin/jobs/:job_id/rework_case', requireAdminSession, async (req, res
     await client.query('BEGIN');
     const realId = await resolveJobIdAny(client, raw);
     if (!realId) throw createHttpError(400, 'job_id ไม่ถูกต้อง');
-    const jr = await client.query(
-      `SELECT job_id, booking_code, technician_username, warranty_end_at, job_status
-         FROM public.jobs WHERE job_id=$1 FOR UPDATE`,
-      [realId]
-    );
-    if (!jr.rows.length) throw createHttpError(404, 'ไม่พบงาน');
-    const job = jr.rows[0];
-    const technician_username = String(req.body?.technician_username || job.technician_username || '').trim() || null;
-    const ins = await client.query(
-      `INSERT INTO public.technician_rework_cases
-       (case_code, job_id, technician_username, reason_type, reason_note, warranty_checked, warranty_end_at, created_by)
-       VALUES ($1,$2,$3,$4,$5,$6,$7,$8)
-       RETURNING *`,
-      [await generateReworkCaseCode(client), realId, technician_username, reason_type, reason_note || null, warranty_checked, job.warranty_end_at || null, getActorUsername(req)]
-    );
-    await client.query(
-      `UPDATE public.jobs
-          SET job_status='งานแก้ไข',
-              returned_at=NOW(),
-              return_reason=$1,
-              returned_by=COALESCE($2, returned_by),
-              travel_started_at=NULL,
-              started_at=NULL,
-              checkin_at=NULL,
-              checkin_latitude=NULL,
-              checkin_longitude=NULL,
-              finished_at=NULL,
-              canceled_at=NULL,
-              cancel_reason=NULL,
-              final_signature_path=NULL,
-              final_signature_status=NULL,
-              final_signature_at=NULL
-        WHERE job_id=$3`,
-      [reason_note || reason_type, getActorUsername(req), realId]
-    );
-    await client.query(`UPDATE public.job_assignments SET status='in_progress', done_at=NULL WHERE job_id=$1`, [realId]);
+    const { job, reworkCase, technicianUsername } = await _openReworkCaseWithIncomeHold(client, {
+      jobId: realId,
+      technicianUsername: req.body?.technician_username,
+      reasonType: reason_type,
+      reasonNote: reason_note || null,
+      warrantyChecked: warranty_checked,
+      actor: getActorUsername(req),
+    });
     await logJobUpdate(realId, {
       actor_username: getActorUsername(req),
       actor_role: getActorRole(req) || 'admin',
       action: 'rework_case_created',
       message: reason_note || reason_type,
-      payload: { rework_case_id: ins.rows[0].rework_case_id, case_code: ins.rows[0].case_code, reason_type },
+      payload: { rework_case_id: reworkCase.rework_case_id, case_code: reworkCase.case_code, reason_type },
     }, client);
-    await logDeductionAudit(client, req, { action: 'REWORK_CASE_CREATE', entity_type: 'rework_case', entity_id: ins.rows[0].rework_case_id, after: ins.rows[0] });
+    await logDeductionAudit(client, req, { action: 'REWORK_CASE_CREATE', entity_type: 'rework_case', entity_id: reworkCase.rework_case_id, after: reworkCase });
     await client.query('COMMIT');
     try {
       await _syncDisplayForJobState(
         { ...job, job_id: realId, return_reason: reason_note || reason_type, returned_at: new Date() },
-        [technician_username].filter(Boolean),
+        [technicianUsername].filter(Boolean),
         { context: 'current' }
       );
     } catch (e) {
       try { console.warn('[tech_income_display] rework create sync failed', { job_id: realId, error: e.message }); } catch {}
     }
-    return res.json({ ok: true, row: ins.rows[0] });
+    return res.json({ ok: true, row: reworkCase });
   } catch (e) {
     try { await client.query('ROLLBACK'); } catch {}
     console.error('POST /admin/jobs/:job_id/rework_case', e);
@@ -15746,13 +15853,28 @@ app.post('/admin/rework_cases/:id/resolve', requireAdminSession, async (req, res
         RETURNING *`,
       [id, resolution, String(req.body?.revisit_result || '').trim() || null, String(req.body?.revisit_note || '').trim() || null, JSON.stringify(evidence), linkedDeductionId, getActorUsername(req)]
     );
+    // Only 'fixed' means the original technician's paused income should come back —
+    // every other resolution (failed / changed_technician / company_absorbed /
+    // deduction_required) means the original work was not validated as payable,
+    // so the hold is permanently voided instead (no money moves).
+    let releaseResult = null;
+    if (before.technician_username) {
+      const jrForClose = await client.query(`SELECT finished_at FROM public.jobs WHERE job_id=$1 LIMIT 1`, [before.job_id]);
+      releaseResult = await _closeReworkCaseWithIncomeRelease(client, {
+        reworkCaseId: id,
+        technicianUsername: before.technician_username,
+        successful: resolution === 'fixed',
+        finishedAt: jrForClose.rows[0]?.finished_at || new Date(),
+        actor: getActorUsername(req),
+      });
+    }
     await logDeductionAudit(client, req, { action: 'REWORK_CASE_RESOLVE', entity_type: 'rework_case', entity_id: id, before, after: up.rows[0] });
     await logJobUpdate(before.job_id, {
       actor_username: getActorUsername(req),
       actor_role: getActorRole(req) || 'admin',
       action: 'rework_case_resolved',
       message: resolution,
-      payload: { rework_case_id: id, resolution, linked_deduction_case_id: linkedDeductionId },
+      payload: { rework_case_id: id, resolution, linked_deduction_case_id: linkedDeductionId, income_release: releaseResult ? { released: !!releaseResult.released, amount: releaseResult.amount || 0, payout_id: releaseResult.payout_id || null } : null },
     }, client);
     await client.query('COMMIT');
     try {
@@ -15761,7 +15883,7 @@ app.post('/admin/rework_cases/:id/resolve', requireAdminSession, async (req, res
     } catch (e) {
       try { console.warn('[tech_income_display] rework resolve sync failed', { job_id: before.job_id, error: e.message }); } catch {}
     }
-    return res.json({ ok: true, row: up.rows[0], linked_deduction_case: linkedDeduction, message: PAYOUT_DEDUCTION_WARNING });
+    return res.json({ ok: true, row: up.rows[0], linked_deduction_case: linkedDeduction, income_release: releaseResult, message: PAYOUT_DEDUCTION_WARNING });
   } catch (e) {
     try { await client.query('ROLLBACK'); } catch {}
     console.error('POST /admin/rework_cases/:id/resolve', e);
@@ -16345,56 +16467,44 @@ app.post('/admin/jobs/:job_id/return_for_fix_v2', requireAdminSoft, async (req, 
   if (!reason) return res.status(400).json({ error: 'ต้องระบุปัญหา/เหตุผล' });
   const client = await pool.connect();
   try {
+    await client.query('BEGIN');
     // 🔒 Phase 5: block retroactive income change for locked/paid periods
     await _assertJobMutableForPayout(client, job_id, 'return_for_fix_v2');
 
     const jr = await client.query(`SELECT job_status, warranty_end_at, booking_code FROM public.jobs WHERE job_id=$1`, [job_id]);
-    if (!jr.rows.length) return res.status(404).json({ error: 'ไม่พบงาน' });
+    if (!jr.rows.length) throw createHttpError(404, 'ไม่พบงาน');
     const wEnd = jr.rows[0].warranty_end_at ? new Date(jr.rows[0].warranty_end_at) : null;
     const inWarranty = !!(wEnd && wEnd.getTime() >= Date.now());
-    if (!inWarranty) return res.status(400).json({ error: 'หมดประกันแล้ว ไม่สามารถตีกลับเป็นงานแก้ไขได้' });
+    if (!inWarranty) throw createHttpError(400, 'หมดประกันแล้ว ไม่สามารถตีกลับเป็นงานแก้ไขได้');
 
-    await client.query(
-      `UPDATE public.jobs
-       SET job_status='งานแก้ไข',
-           returned_at=NOW(),
-           return_reason=$1,
-           returned_by=COALESCE($2, returned_by),
-           travel_started_at=NULL,
-           started_at=NULL,
-           checkin_at=NULL,
-           checkin_latitude=NULL,
-           checkin_longitude=NULL,
-           finished_at=NULL,
-           canceled_at=NULL,
-           cancel_reason=NULL,
-           final_signature_path=NULL,
-           final_signature_status=NULL,
-           final_signature_at=NULL
-       WHERE job_id=$3`,
-      [reason, actor_username, job_id]
-    );
-
-    // งานแก้ไขต้องกลับมาเห็นในแอปช่างอีกครั้ง
-    // ถ้ารอบก่อนช่างถูก mark done ไปแล้ว ให้ reset กลับเป็น in_progress
-    await client.query(
-      `UPDATE public.job_assignments
-       SET status='in_progress',
-           done_at=NULL
-       WHERE job_id=$1`,
-      [job_id]
-    );
-    await logJobUpdate(job_id, { actor_username, actor_role: 'admin', action: 'return_for_fix', message: reason });
+    // Goes through the same shared workflow as /admin/jobs/:job_id/rework_case so
+    // the original technician's earned income is paused via the exact same hold
+    // ledger, instead of just clearing finished_at with no money-tracking record.
+    const { job, reworkCase, technicianUsername } = await _openReworkCaseWithIncomeHold(client, {
+      jobId: job_id,
+      reasonType: 'other',
+      reasonNote: reason,
+      actor: actor_username,
+    });
+    await logJobUpdate(job_id, {
+      actor_username,
+      actor_role: 'admin',
+      action: 'return_for_fix',
+      message: reason,
+      payload: { rework_case_id: reworkCase.rework_case_id, case_code: reworkCase.case_code },
+    }, client);
+    await client.query('COMMIT');
     try {
       const team = await getTeamForJob(job_id);
-      await _syncDisplayForJobState({ job_id, return_reason: reason, returned_at: new Date() }, team, { context: 'current' });
+      await _syncDisplayForJobState({ ...job, job_id, return_reason: reason, returned_at: new Date() }, team.length ? team : [technicianUsername].filter(Boolean), { context: 'current' });
     } catch (e) {
       try { console.warn('[tech_income_display] return_for_fix sync failed', { job_id, error: e.message }); } catch {}
     }
-    return res.json({ success: true });
+    return res.json({ success: true, rework_case_id: reworkCase.rework_case_id });
   } catch (e) {
+    try { await client.query('ROLLBACK'); } catch {}
     console.error('return_for_fix_v2 error', e);
-    return res.status(500).json({ error: e.message || 'ตีกลับงานแก้ไขไม่สำเร็จ' });
+    return res.status(Number(e.status || 500)).json({ error: e.message || 'ตีกลับงานแก้ไขไม่สำเร็จ' });
   } finally {
     try { client.release(); } catch {}
   }
@@ -19680,6 +19790,7 @@ if (status === "เสร็จแล้ว") {
     const isRevisitFlow = String(meta.job_status || "").trim() === "งานแก้ไข" || !!meta.returned_at || !!meta.return_reason;
     const revisitResult = ["successful", "unsuccessful"].includes(revisit_result) ? revisit_result : "";
     const revisitNote = revisit_note || note;
+    let reworkIncomeResult = null;
 
     if (isRevisitFlow && status === "เสร็จแล้ว") {
       if (!revisitResult) {
@@ -19798,6 +19909,40 @@ if (status === "เสร็จแล้ว") {
           close_signature_type || 'technician_signature']
       );
       if (isRevisitFlow && revisitResult) {
+        // Closing a revisit (rework) job through the same shared workflow as the
+        // admin resolve endpoint: 'successful' releases the ORIGINAL technician's
+        // paused income (keyed off the rework_case row's technician_username, not
+        // whoever is currently assigned, in case the job was reassigned for the
+        // revisit); 'unsuccessful' permanently voids the hold — no money moves.
+        const rcq = await client.query(
+          `SELECT * FROM public.technician_rework_cases
+            WHERE job_id=$1 AND status IN ('open','in_progress')
+            ORDER BY created_at DESC
+            LIMIT 1
+            FOR UPDATE`,
+          [realId]
+        );
+        const reworkCase = rcq.rows[0] || null;
+        if (reworkCase) {
+          const resolution = revisitResult === 'successful' ? 'fixed' : 'failed';
+          await client.query(
+            `UPDATE public.technician_rework_cases
+                SET status='resolved', resolution=$2, revisit_result=$3, revisit_note=$4,
+                    resolved_by=$5, resolved_at=NOW(), updated_at=NOW()
+              WHERE rework_case_id=$1`,
+            [reworkCase.rework_case_id, resolution, revisitResult, revisitNote || null, technician_username]
+          );
+          const heldTechnicianUsername = String(reworkCase.technician_username || '').trim();
+          if (heldTechnicianUsername) {
+            reworkIncomeResult = await _closeReworkCaseWithIncomeRelease(client, {
+              reworkCaseId: reworkCase.rework_case_id,
+              technicianUsername: heldTechnicianUsername,
+              successful: resolution === 'fixed',
+              finishedAt: new Date(),
+              actor: technician_username,
+            });
+          }
+        }
         await logJobUpdate(
           realId,
           {
@@ -19809,6 +19954,8 @@ if (status === "เสร็จแล้ว") {
               revisit_result: revisitResult,
               revisit_note: revisitNote || null,
               evidence_phases: ["revisit_before", "revisit_after", "revisit_defect"],
+              rework_case_id: reworkCase ? reworkCase.rework_case_id : null,
+              income_release: reworkIncomeResult ? { released: !!reworkIncomeResult.released, amount: reworkIncomeResult.amount || 0, payout_id: reworkIncomeResult.payout_id || null } : null,
             },
           },
           client
@@ -19896,7 +20043,7 @@ if (status === "เสร็จแล้ว") {
         try { console.warn('[tech_income_display] finalize cancel sync failed', { job_id: realId, error: e.message }); } catch {}
       }
     }
-    res.json({ success: true, job_id: Number(realId), status });
+    res.json({ success: true, job_id: Number(realId), status, income_release: reworkIncomeResult });
   } catch (e) {
     await client.query("ROLLBACK");
     console.error(e);

--- a/migrations/technician_rework_income_hold_release.sql
+++ b/migrations/technician_rework_income_hold_release.sql
@@ -121,3 +121,28 @@ CREATE INDEX IF NOT EXISTS idx_trih_job_id ON public.technician_rework_income_ho
 CREATE INDEX IF NOT EXISTS idx_trih_technician ON public.technician_rework_income_holds(technician_username, created_at DESC);
 CREATE INDEX IF NOT EXISTS idx_trih_status ON public.technician_rework_income_holds(hold_status, created_at DESC);
 CREATE INDEX IF NOT EXISTS idx_trih_rework_case ON public.technician_rework_income_holds(rework_case_id);
+
+-- Second/third/Nth rework round support: when a hold's amount is sourced from
+-- a PRIOR rework round's already-released ledger entry (rather than the job's
+-- original, not-yet-paid income), record exactly which case/adjustment it is
+-- offsetting, for audit and for the duplicate-release smoke tests. Purely
+-- additive, NULL on every pre-existing row, never backfilled.
+ALTER TABLE public.technician_rework_income_holds
+  ADD COLUMN IF NOT EXISTS source_kind TEXT;
+ALTER TABLE public.technician_rework_income_holds
+  DROP CONSTRAINT IF EXISTS technician_rework_income_holds_source_kind_check;
+ALTER TABLE public.technician_rework_income_holds
+  ADD CONSTRAINT technician_rework_income_holds_source_kind_check CHECK (
+    source_kind IS NULL OR source_kind IN ('original_income', 'previous_rework_release')
+  );
+
+ALTER TABLE public.technician_rework_income_holds
+  ADD COLUMN IF NOT EXISTS previous_rework_case_id BIGINT
+    REFERENCES public.technician_rework_cases(rework_case_id) ON DELETE SET NULL;
+ALTER TABLE public.technician_rework_income_holds
+  ADD COLUMN IF NOT EXISTS previous_release_adjustment_id BIGINT
+    REFERENCES public.technician_payout_adjustments(adj_id) ON DELETE SET NULL;
+
+CREATE INDEX IF NOT EXISTS idx_trih_previous_rework_case
+  ON public.technician_rework_income_holds(previous_rework_case_id)
+  WHERE previous_rework_case_id IS NOT NULL;

--- a/migrations/technician_rework_income_hold_release.sql
+++ b/migrations/technician_rework_income_hold_release.sql
@@ -1,30 +1,55 @@
 -- Technician Rework Income Hold/Release
--- Backward-compatible schema. Safe to run repeatedly (CREATE IF NOT EXISTS only).
+-- Backward-compatible schema. Safe to run repeatedly (CREATE IF NOT EXISTS /
+-- guarded ALTER only — never drops or rewrites existing rows).
 --
 -- Purpose: when a job is sent back for rework, the *original* technician's
--- earned amount for that job must be held (not silently dropped) and, once
--- the rework closes successfully, released into the correct future payout
--- period exactly once. This table is the immutable audit/idempotency ledger
--- for that hold -> release lifecycle. Money movement itself happens via
--- normal rows in public.technician_payout_adjustments; this table never
--- holds money on its own, it only records what happened and guards re-entry.
+-- earned amount for that job must ALWAYS be held — even if that income was
+-- already disbursed in a 'paid' payout period — and, once the rework closes
+-- successfully, released into the correct future payout period exactly once.
+-- This table is the immutable audit/idempotency ledger for that hold ->
+-- release lifecycle. Money movement itself happens via normal rows in
+-- public.technician_payout_adjustments; this table never holds money on its
+-- own, it only records what happened and guards re-entry.
+--
+-- Business rule (corrected from the original version of this migration):
+--   - We never retroactively rewrite a 'paid' period's own rows.
+--   - If the original income already landed in a 'paid' period, we instead
+--     carry the hold forward as a NEGATIVE adjustment in the next period that
+--     is still open (status != 'paid'), so the technician's payable income
+--     still ends up correctly reduced — hold_status='paid_then_carried_forward_hold'.
+--   - The release later still credits the full held_amount back via a
+--     POSITIVE adjustment in the period matching the rework's own close date,
+--     rolling forward past any 'paid' period. Both the negative carry-forward
+--     adjustment and the positive release adjustment remain in the ledger as
+--     separate audit rows even if they land in the same period and net to zero.
 
 CREATE TABLE IF NOT EXISTS public.technician_rework_income_holds (
   hold_id BIGSERIAL PRIMARY KEY,
-  rework_case_id BIGINT NOT NULL REFERENCES public.technician_rework_cases(rework_case_id) ON DELETE CASCADE,
+  -- Financial ledger: never cascade-delete a hold/release record just because
+  -- the rework case or job row it references gets deleted. Deletion of a case
+  -- or job with ledger history must fail loudly (RESTRICT), not silently wipe
+  -- money-movement audit trail.
+  rework_case_id BIGINT NOT NULL REFERENCES public.technician_rework_cases(rework_case_id) ON DELETE RESTRICT,
   technician_username TEXT NOT NULL,
-  job_id BIGINT NOT NULL REFERENCES public.jobs(job_id) ON DELETE CASCADE,
+  job_id BIGINT NOT NULL REFERENCES public.jobs(job_id) ON DELETE RESTRICT,
 
   held_amount NUMERIC(12,2) NOT NULL DEFAULT 0 CHECK (held_amount >= 0),
   source_payout_id TEXT,
   source_period_status_at_hold TEXT,
   hold_adjustment_id BIGINT REFERENCES public.technician_payout_adjustments(adj_id) ON DELETE SET NULL,
+  -- Where the carried-forward negative adjustment actually landed, when the
+  -- original income's period was already 'paid' at hold time. NULL for the
+  -- normal (not-yet-paid) hold path.
+  hold_carried_forward_payout_id TEXT,
 
   hold_status TEXT NOT NULL DEFAULT 'held' CHECK (hold_status IN (
-    'held',                 -- original income paused, awaiting rework outcome
-    'already_paid_no_action', -- original income was already in a paid period; nothing was touched
-    'released',             -- successfully credited back in a payout period
-    'voided'                -- rework failed / cancelled, nothing to release
+    'held',                          -- original income paused, awaiting rework outcome
+    'already_paid_no_action',        -- zero-amount original income (nothing to hold/carry)
+    'paid_then_carried_forward_hold', -- original income was already in a paid period; a
+                                       -- negative adjustment carried the hold into the next
+                                       -- open period instead of touching the paid period
+    'released',                      -- successfully credited back in a payout period
+    'voided'                         -- rework failed / cancelled, nothing to release
   )),
 
   released_amount NUMERIC(12,2) CHECK (released_amount IS NULL OR released_amount >= 0),
@@ -42,6 +67,47 @@ CREATE TABLE IF NOT EXISTS public.technician_rework_income_holds (
   -- Invariant: released_amount can never exceed held_amount.
   CHECK (released_amount IS NULL OR released_amount <= held_amount)
 );
+
+-- Guarded upgrade path for any environment where this table was already
+-- created by an earlier version of this migration (CASCADE FKs / narrower
+-- hold_status list / missing hold_carried_forward_payout_id column).
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM information_schema.table_constraints
+     WHERE table_schema='public' AND table_name='technician_rework_income_holds'
+       AND constraint_name='technician_rework_income_holds_rework_case_id_fkey'
+       AND constraint_type='FOREIGN KEY'
+  ) THEN
+    ALTER TABLE public.technician_rework_income_holds
+      DROP CONSTRAINT technician_rework_income_holds_rework_case_id_fkey;
+    ALTER TABLE public.technician_rework_income_holds
+      ADD CONSTRAINT technician_rework_income_holds_rework_case_id_fkey
+      FOREIGN KEY (rework_case_id) REFERENCES public.technician_rework_cases(rework_case_id) ON DELETE RESTRICT;
+  END IF;
+  IF EXISTS (
+    SELECT 1 FROM information_schema.table_constraints
+     WHERE table_schema='public' AND table_name='technician_rework_income_holds'
+       AND constraint_name='technician_rework_income_holds_job_id_fkey'
+       AND constraint_type='FOREIGN KEY'
+  ) THEN
+    ALTER TABLE public.technician_rework_income_holds
+      DROP CONSTRAINT technician_rework_income_holds_job_id_fkey;
+    ALTER TABLE public.technician_rework_income_holds
+      ADD CONSTRAINT technician_rework_income_holds_job_id_fkey
+      FOREIGN KEY (job_id) REFERENCES public.jobs(job_id) ON DELETE RESTRICT;
+  END IF;
+END $$;
+
+ALTER TABLE public.technician_rework_income_holds
+  ADD COLUMN IF NOT EXISTS hold_carried_forward_payout_id TEXT;
+
+ALTER TABLE public.technician_rework_income_holds
+  DROP CONSTRAINT IF EXISTS technician_rework_income_holds_hold_status_check;
+ALTER TABLE public.technician_rework_income_holds
+  ADD CONSTRAINT technician_rework_income_holds_hold_status_check CHECK (hold_status IN (
+    'held','already_paid_no_action','paid_then_carried_forward_hold','released','voided'
+  ));
 
 -- Invariant: a release can only ever happen once per case+technician.
 -- "rework_release:<rework_case_id>:<technician_username>" is computed by the

--- a/migrations/technician_rework_income_hold_release.sql
+++ b/migrations/technician_rework_income_hold_release.sql
@@ -1,0 +1,57 @@
+-- Technician Rework Income Hold/Release
+-- Backward-compatible schema. Safe to run repeatedly (CREATE IF NOT EXISTS only).
+--
+-- Purpose: when a job is sent back for rework, the *original* technician's
+-- earned amount for that job must be held (not silently dropped) and, once
+-- the rework closes successfully, released into the correct future payout
+-- period exactly once. This table is the immutable audit/idempotency ledger
+-- for that hold -> release lifecycle. Money movement itself happens via
+-- normal rows in public.technician_payout_adjustments; this table never
+-- holds money on its own, it only records what happened and guards re-entry.
+
+CREATE TABLE IF NOT EXISTS public.technician_rework_income_holds (
+  hold_id BIGSERIAL PRIMARY KEY,
+  rework_case_id BIGINT NOT NULL REFERENCES public.technician_rework_cases(rework_case_id) ON DELETE CASCADE,
+  technician_username TEXT NOT NULL,
+  job_id BIGINT NOT NULL REFERENCES public.jobs(job_id) ON DELETE CASCADE,
+
+  held_amount NUMERIC(12,2) NOT NULL DEFAULT 0 CHECK (held_amount >= 0),
+  source_payout_id TEXT,
+  source_period_status_at_hold TEXT,
+  hold_adjustment_id BIGINT REFERENCES public.technician_payout_adjustments(adj_id) ON DELETE SET NULL,
+
+  hold_status TEXT NOT NULL DEFAULT 'held' CHECK (hold_status IN (
+    'held',                 -- original income paused, awaiting rework outcome
+    'already_paid_no_action', -- original income was already in a paid period; nothing was touched
+    'released',             -- successfully credited back in a payout period
+    'voided'                -- rework failed / cancelled, nothing to release
+  )),
+
+  released_amount NUMERIC(12,2) CHECK (released_amount IS NULL OR released_amount >= 0),
+  release_payout_id TEXT,
+  release_adjustment_id BIGINT REFERENCES public.technician_payout_adjustments(adj_id) ON DELETE SET NULL,
+  release_idempotency_key TEXT,
+  released_at TIMESTAMPTZ,
+
+  created_by TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+
+  -- Invariant: one hold record per rework case + original technician (no duplicate holds).
+  UNIQUE (rework_case_id, technician_username),
+  -- Invariant: released_amount can never exceed held_amount.
+  CHECK (released_amount IS NULL OR released_amount <= held_amount)
+);
+
+-- Invariant: a release can only ever happen once per case+technician.
+-- "rework_release:<rework_case_id>:<technician_username>" is computed by the
+-- application and stored here; the unique index makes double-release
+-- impossible even under concurrent retries.
+CREATE UNIQUE INDEX IF NOT EXISTS uq_trih_release_idempotency_key
+  ON public.technician_rework_income_holds(release_idempotency_key)
+  WHERE release_idempotency_key IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_trih_job_id ON public.technician_rework_income_holds(job_id);
+CREATE INDEX IF NOT EXISTS idx_trih_technician ON public.technician_rework_income_holds(technician_username, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_trih_status ON public.technician_rework_income_holds(hold_status, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_trih_rework_case ON public.technician_rework_income_holds(rework_case_id);

--- a/scripts/audit-rework-case-CWFRXB5AYA.sql
+++ b/scripts/audit-rework-case-CWFRXB5AYA.sql
@@ -1,0 +1,101 @@
+-- READ-ONLY AUDIT — case_code='CWFRXB5AYA', technician_username='A2MKUNG'
+--
+-- Purpose: determine the ACTUAL original earned amount, which payout
+-- period/line it lives in, whether that period is already paid, and whether
+-- any duplicate hold/release/adjustment rows exist for this case+technician.
+--
+-- This script contains ONLY SELECT statements. It must never be edited to add
+-- INSERT/UPDATE/DELETE, and must never be run against production until the
+-- resulting report has been reviewed and approved. No amount is hardcoded —
+-- every figure below comes from a live query.
+--
+-- Usage: psql "$PRODUCTION_DATABASE_URL" -f scripts/audit-rework-case-CWFRXB5AYA.sql
+
+\set case_code 'CWFRXB5AYA'
+\set tech 'A2MKUNG'
+
+-- 1) The rework case itself.
+SELECT rework_case_id, case_code, job_id, technician_username, reason_type,
+       status, resolution, revisit_result, linked_deduction_case_id,
+       created_at, resolved_at
+  FROM public.technician_rework_cases
+ WHERE case_code = :'case_code';
+
+-- 2) The underlying job: status, finished_at history, warranty.
+SELECT j.job_id, j.booking_code, j.job_status, j.technician_username,
+       j.finished_at, j.returned_at, j.return_reason, j.warranty_end_at
+  FROM public.jobs j
+  JOIN public.technician_rework_cases rc ON rc.job_id = j.job_id
+ WHERE rc.case_code = :'case_code';
+
+-- 3) Any existing row in the new hold/release ledger for this case+tech
+--    (will be empty if this case predates the ledger migration — that is
+--    itself an important finding, not an error).
+SELECT *
+  FROM public.technician_rework_income_holds
+ WHERE rework_case_id = (SELECT rework_case_id FROM public.technician_rework_cases WHERE case_code = :'case_code')
+   AND technician_username = :'tech';
+
+-- 4) Every payout_lines row for this job+technician across ALL periods
+--    (gross earnings the payout engine computed — the ledger-grade source
+--    of "what they actually earned", never a UI preview value).
+SELECT l.payout_id, l.technician_username, l.job_id, l.earn_amount, l.line_id,
+       p.period_type, p.period_start, p.period_end, p.status AS period_status
+  FROM public.technician_payout_lines l
+  JOIN public.technician_payout_periods p ON p.payout_id = l.payout_id
+  JOIN public.technician_rework_cases rc ON rc.job_id::text = l.job_id
+ WHERE rc.case_code = :'case_code'
+   AND l.technician_username = :'tech'
+ ORDER BY p.period_start;
+
+-- 5) Every adjustment row touching this job+technician across ALL periods
+--    (deductions, rework holds, rework releases — anything that moved money
+--    via the adjustment ledger). Look for duplicate positive (release) rows.
+SELECT a.adj_id, a.payout_id, a.technician_username, a.job_id, a.adj_amount,
+       a.reason, a.created_by, a.created_at,
+       p.period_type, p.period_start, p.period_end, p.status AS period_status
+  FROM public.technician_payout_adjustments a
+  JOIN public.technician_payout_periods p ON p.payout_id = a.payout_id
+  JOIN public.technician_rework_cases rc ON rc.job_id::text = a.job_id
+ WHERE rc.case_code = :'case_code'
+   AND a.technician_username = :'tech'
+ ORDER BY a.created_at;
+
+-- 6) Duplicate-release smoke test: more than one positive adjustment for this
+--    job+tech combination is a red flag (possible double release).
+SELECT a.job_id, a.technician_username, COUNT(*) AS positive_adjustment_count,
+       SUM(a.adj_amount) AS positive_adjustment_total
+  FROM public.technician_payout_adjustments a
+  JOIN public.technician_rework_cases rc ON rc.job_id::text = a.job_id
+ WHERE rc.case_code = :'case_code'
+   AND a.technician_username = :'tech'
+   AND a.adj_amount > 0
+ GROUP BY a.job_id, a.technician_username;
+
+-- 7) Payment status for every period touched by this job+tech, so we can see
+--    whether the period the original earning fell into has already been paid
+--    (which would mean invariant 6 — never touch a paid period — applies).
+SELECT pay.payout_id, pay.technician_username, pay.paid_amount, pay.paid_status,
+       p.period_type, p.period_start, p.period_end, p.status AS period_status
+  FROM public.technician_payout_payments pay
+  JOIN public.technician_payout_periods p ON p.payout_id = pay.payout_id
+ WHERE pay.technician_username = :'tech'
+   AND pay.payout_id IN (
+     SELECT DISTINCT l.payout_id
+       FROM public.technician_payout_lines l
+       JOIN public.technician_rework_cases rc ON rc.job_id::text = l.job_id
+      WHERE rc.case_code = :'case_code'
+     UNION
+     SELECT DISTINCT a.payout_id
+       FROM public.technician_payout_adjustments a
+       JOIN public.technician_rework_cases rc ON rc.job_id::text = a.job_id
+      WHERE rc.case_code = :'case_code'
+   )
+ ORDER BY p.period_start;
+
+-- 8) job_update_logs trail for this job, for a human-readable timeline of
+--    rework_case_created / revisit_result / rework_case_resolved events.
+SELECT job_id, actor_username, actor_role, action, message, payload, created_at
+  FROM public.job_update_logs
+ WHERE job_id = (SELECT job_id FROM public.technician_rework_cases WHERE case_code = :'case_code')
+ ORDER BY created_at;

--- a/scripts/audit-rework-case-CWFRXB5AYA.sql
+++ b/scripts/audit-rework-case-CWFRXB5AYA.sql
@@ -1,101 +1,79 @@
--- READ-ONLY AUDIT — case_code='CWFRXB5AYA', technician_username='A2MKUNG'
---
--- Purpose: determine the ACTUAL original earned amount, which payout
--- period/line it lives in, whether that period is already paid, and whether
--- any duplicate hold/release/adjustment rows exist for this case+technician.
---
--- This script contains ONLY SELECT statements. It must never be edited to add
--- INSERT/UPDATE/DELETE, and must never be run against production until the
--- resulting report has been reviewed and approved. No amount is hardcoded —
--- every figure below comes from a live query.
---
--- Usage: psql "$PRODUCTION_DATABASE_URL" -f scripts/audit-rework-case-CWFRXB5AYA.sql
+-- READ-ONLY audit for booking CWFRXB5AYA / technician A2MKUNG
+-- Usage:
+--   psql "$PRODUCTION_DATABASE_URL" -v ON_ERROR_STOP=1 -f scripts/audit-rework-case-CWFRXB5AYA.sql
 
-\set case_code 'CWFRXB5AYA'
+\set booking_code 'CWFRXB5AYA'
 \set tech 'A2MKUNG'
 
--- 1) The rework case itself.
-SELECT rework_case_id, case_code, job_id, technician_username, reason_type,
-       status, resolution, revisit_result, linked_deduction_case_id,
-       created_at, resolved_at
-  FROM public.technician_rework_cases
- WHERE case_code = :'case_code';
+BEGIN TRANSACTION READ ONLY;
 
--- 2) The underlying job: status, finished_at history, warranty.
 SELECT j.job_id, j.booking_code, j.job_status, j.technician_username,
        j.finished_at, j.returned_at, j.return_reason, j.warranty_end_at
   FROM public.jobs j
-  JOIN public.technician_rework_cases rc ON rc.job_id = j.job_id
- WHERE rc.case_code = :'case_code';
+ WHERE j.booking_code = :'booking_code';
 
--- 3) Any existing row in the new hold/release ledger for this case+tech
---    (will be empty if this case predates the ledger migration — that is
---    itself an important finding, not an error).
-SELECT *
-  FROM public.technician_rework_income_holds
- WHERE rework_case_id = (SELECT rework_case_id FROM public.technician_rework_cases WHERE case_code = :'case_code')
-   AND technician_username = :'tech';
+SELECT rc.rework_case_id, rc.case_code, rc.job_id, rc.technician_username,
+       rc.reason_type, rc.status, rc.resolution, rc.revisit_result,
+       rc.linked_deduction_case_id, rc.created_at, rc.resolved_at
+  FROM public.technician_rework_cases rc
+  JOIN public.jobs j ON j.job_id = rc.job_id
+ WHERE j.booking_code = :'booking_code'
+ ORDER BY rc.created_at, rc.rework_case_id;
 
--- 4) Every payout_lines row for this job+technician across ALL periods
---    (gross earnings the payout engine computed — the ledger-grade source
---    of "what they actually earned", never a UI preview value).
+SELECT h.*
+  FROM public.technician_rework_income_holds h
+  JOIN public.jobs j ON j.job_id = h.job_id
+ WHERE j.booking_code = :'booking_code'
+   AND h.technician_username = :'tech'
+ ORDER BY h.created_at, h.hold_id;
+
 SELECT l.payout_id, l.technician_username, l.job_id, l.earn_amount, l.line_id,
        p.period_type, p.period_start, p.period_end, p.status AS period_status
   FROM public.technician_payout_lines l
   JOIN public.technician_payout_periods p ON p.payout_id = l.payout_id
-  JOIN public.technician_rework_cases rc ON rc.job_id::text = l.job_id
- WHERE rc.case_code = :'case_code'
+  JOIN public.jobs j ON j.job_id::text = l.job_id::text
+ WHERE j.booking_code = :'booking_code'
    AND l.technician_username = :'tech'
- ORDER BY p.period_start;
+ ORDER BY p.period_start, l.line_id;
 
--- 5) Every adjustment row touching this job+technician across ALL periods
---    (deductions, rework holds, rework releases — anything that moved money
---    via the adjustment ledger). Look for duplicate positive (release) rows.
 SELECT a.adj_id, a.payout_id, a.technician_username, a.job_id, a.adj_amount,
        a.reason, a.created_by, a.created_at,
        p.period_type, p.period_start, p.period_end, p.status AS period_status
   FROM public.technician_payout_adjustments a
   JOIN public.technician_payout_periods p ON p.payout_id = a.payout_id
-  JOIN public.technician_rework_cases rc ON rc.job_id::text = a.job_id
- WHERE rc.case_code = :'case_code'
-   AND a.technician_username = :'tech'
- ORDER BY a.created_at;
+ WHERE a.technician_username = :'tech'
+   AND (
+     a.job_id::text = (SELECT job_id::text FROM public.jobs WHERE booking_code = :'booking_code' LIMIT 1)
+     OR a.job_id::text LIKE 'rework_hold:%:' || (SELECT job_id::text FROM public.jobs WHERE booking_code = :'booking_code' LIMIT 1)
+     OR a.job_id::text LIKE 'rework_release:%:' || (SELECT job_id::text FROM public.jobs WHERE booking_code = :'booking_code' LIMIT 1)
+     OR a.reason LIKE '%job_id=' || (SELECT job_id::text FROM public.jobs WHERE booking_code = :'booking_code' LIMIT 1) || '%'
+   )
+ ORDER BY a.created_at, a.adj_id;
 
--- 6) Duplicate-release smoke test: more than one positive adjustment for this
---    job+tech combination is a red flag (possible double release).
-SELECT a.job_id, a.technician_username, COUNT(*) AS positive_adjustment_count,
-       SUM(a.adj_amount) AS positive_adjustment_total
-  FROM public.technician_payout_adjustments a
-  JOIN public.technician_rework_cases rc ON rc.job_id::text = a.job_id
- WHERE rc.case_code = :'case_code'
-   AND a.technician_username = :'tech'
-   AND a.adj_amount > 0
- GROUP BY a.job_id, a.technician_username;
+SELECT h.rework_case_id, h.technician_username,
+       COUNT(a.adj_id) AS release_adjustment_count,
+       COALESCE(SUM(a.adj_amount),0) AS release_adjustment_total
+  FROM public.technician_rework_income_holds h
+  LEFT JOIN public.technician_payout_adjustments a
+    ON a.adj_id = h.release_adjustment_id
+  JOIN public.jobs j ON j.job_id = h.job_id
+ WHERE j.booking_code = :'booking_code'
+   AND h.technician_username = :'tech'
+ GROUP BY h.rework_case_id, h.technician_username;
 
--- 7) Payment status for every period touched by this job+tech, so we can see
---    whether the period the original earning fell into has already been paid
---    (which would mean invariant 6 — never touch a paid period — applies).
 SELECT pay.payout_id, pay.technician_username, pay.paid_amount, pay.paid_status,
-       p.period_type, p.period_start, p.period_end, p.status AS period_status
+       pay.paid_at, p.period_type, p.period_start, p.period_end,
+       p.status AS period_status
   FROM public.technician_payout_payments pay
   JOIN public.technician_payout_periods p ON p.payout_id = pay.payout_id
  WHERE pay.technician_username = :'tech'
-   AND pay.payout_id IN (
-     SELECT DISTINCT l.payout_id
-       FROM public.technician_payout_lines l
-       JOIN public.technician_rework_cases rc ON rc.job_id::text = l.job_id
-      WHERE rc.case_code = :'case_code'
-     UNION
-     SELECT DISTINCT a.payout_id
-       FROM public.technician_payout_adjustments a
-       JOIN public.technician_rework_cases rc ON rc.job_id::text = a.job_id
-      WHERE rc.case_code = :'case_code'
-   )
  ORDER BY p.period_start;
 
--- 8) job_update_logs trail for this job, for a human-readable timeline of
---    rework_case_created / revisit_result / rework_case_resolved events.
-SELECT job_id, actor_username, actor_role, action, message, payload, created_at
-  FROM public.job_update_logs
- WHERE job_id = (SELECT job_id FROM public.technician_rework_cases WHERE case_code = :'case_code')
- ORDER BY created_at;
+SELECT l.job_id, l.actor_username, l.actor_role, l.action, l.message,
+       l.payload, l.created_at
+  FROM public.job_update_logs l
+  JOIN public.jobs j ON j.job_id = l.job_id
+ WHERE j.booking_code = :'booking_code'
+ ORDER BY l.created_at;
+
+COMMIT;

--- a/scripts/audit-rework-case-CWFRXB5AYA.sql
+++ b/scripts/audit-rework-case-CWFRXB5AYA.sql
@@ -84,8 +84,12 @@ SELECT a.job_id, a.technician_username,
        SUM(a.adj_amount) FILTER (WHERE a.adj_amount > 0) AS positive_adjustment_total,
        COUNT(*) FILTER (WHERE a.adj_amount > 0 AND a.reason LIKE '[REWORK_RELEASE]%') AS release_adjustment_count
   FROM public.technician_payout_adjustments a
-  JOIN public.jobs j ON j.job_id::text = a.job_id::text
- WHERE j.booking_code = :'booking_code'
+ WHERE (
+     a.job_id::text = (SELECT job_id::text FROM public.jobs WHERE booking_code = :'booking_code' LIMIT 1)
+     OR a.job_id::text LIKE 'rework_hold:%:' || (SELECT job_id::text FROM public.jobs WHERE booking_code = :'booking_code' LIMIT 1)
+     OR a.job_id::text LIKE 'rework_release:%:' || (SELECT job_id::text FROM public.jobs WHERE booking_code = :'booking_code' LIMIT 1)
+     OR a.reason LIKE '%job_id=' || (SELECT job_id::text FROM public.jobs WHERE booking_code = :'booking_code' LIMIT 1) || '%'
+   )
  GROUP BY a.job_id, a.technician_username
  ORDER BY a.technician_username;
 
@@ -104,8 +108,12 @@ SELECT pay.payout_id, pay.technician_username, pay.paid_amount, pay.paid_status,
      UNION
      SELECT DISTINCT a.payout_id
        FROM public.technician_payout_adjustments a
-       JOIN public.jobs j ON j.job_id::text = a.job_id::text
-      WHERE j.booking_code = :'booking_code'
+      WHERE (
+          a.job_id::text = (SELECT job_id::text FROM public.jobs WHERE booking_code = :'booking_code' LIMIT 1)
+          OR a.job_id::text LIKE 'rework_hold:%:' || (SELECT job_id::text FROM public.jobs WHERE booking_code = :'booking_code' LIMIT 1)
+          OR a.job_id::text LIKE 'rework_release:%:' || (SELECT job_id::text FROM public.jobs WHERE booking_code = :'booking_code' LIMIT 1)
+          OR a.reason LIKE '%job_id=' || (SELECT job_id::text FROM public.jobs WHERE booking_code = :'booking_code' LIMIT 1) || '%'
+        )
    )
  ORDER BY p.period_start, pay.technician_username;
 

--- a/scripts/audit-rework-case-CWFRXB5AYA.sql
+++ b/scripts/audit-rework-case-CWFRXB5AYA.sql
@@ -1,17 +1,34 @@
--- READ-ONLY audit for booking CWFRXB5AYA / technician A2MKUNG
+-- READ-ONLY audit for booking CWFRXB5AYA
+--
+-- Looked up via jobs.booking_code, NOT technician_rework_cases.case_code
+-- (those are two different generated codes — case_code identifies the rework
+-- case row itself, booking_code identifies the customer's job/booking). Using
+-- case_code here would silently audit the wrong row (or nothing at all) if the
+-- two codes ever differ.
+--
+-- Does not hardcode a single technician_username: a job can have a team, and
+-- every team member's hold/release must be visible, not just whoever happens
+-- to be on the job's technician_username column.
+--
+-- This script contains ONLY SELECT statements (wrapped in a READ ONLY
+-- transaction as a belt-and-suspenders guard) and must never be edited to add
+-- INSERT/UPDATE/DELETE.
+--
 -- Usage:
 --   psql "$PRODUCTION_DATABASE_URL" -v ON_ERROR_STOP=1 -f scripts/audit-rework-case-CWFRXB5AYA.sql
 
 \set booking_code 'CWFRXB5AYA'
-\set tech 'A2MKUNG'
 
 BEGIN TRANSACTION READ ONLY;
 
+-- 1) The job itself: status, finished_at history, warranty, booking_code match.
 SELECT j.job_id, j.booking_code, j.job_status, j.technician_username,
        j.finished_at, j.returned_at, j.return_reason, j.warranty_end_at
   FROM public.jobs j
  WHERE j.booking_code = :'booking_code';
 
+-- 2) Every rework case ever opened against this job (there may be more than one
+--    over the job's lifetime).
 SELECT rc.rework_case_id, rc.case_code, rc.job_id, rc.technician_username,
        rc.reason_type, rc.status, rc.resolution, rc.revisit_result,
        rc.linked_deduction_case_id, rc.created_at, rc.resolved_at
@@ -20,60 +37,83 @@ SELECT rc.rework_case_id, rc.case_code, rc.job_id, rc.technician_username,
  WHERE j.booking_code = :'booking_code'
  ORDER BY rc.created_at, rc.rework_case_id;
 
+-- 3) Every hold/release ledger row for every rework case + every technician on
+--    this job (will be empty if this case predates the ledger migration — that
+--    is itself an important finding, not an error).
 SELECT h.*
   FROM public.technician_rework_income_holds h
   JOIN public.jobs j ON j.job_id = h.job_id
  WHERE j.booking_code = :'booking_code'
-   AND h.technician_username = :'tech'
- ORDER BY h.created_at, h.hold_id;
+ ORDER BY h.rework_case_id, h.technician_username, h.hold_id;
 
+-- 4) Every payout_lines row for this job, across every technician who ever
+--    earned income on it and across ALL periods (the ledger-grade source of
+--    "what they actually earned", never a UI preview value).
 SELECT l.payout_id, l.technician_username, l.job_id, l.earn_amount, l.line_id,
        p.period_type, p.period_start, p.period_end, p.status AS period_status
   FROM public.technician_payout_lines l
   JOIN public.technician_payout_periods p ON p.payout_id = l.payout_id
   JOIN public.jobs j ON j.job_id::text = l.job_id::text
  WHERE j.booking_code = :'booking_code'
-   AND l.technician_username = :'tech'
- ORDER BY p.period_start, l.line_id;
+ ORDER BY l.technician_username, p.period_start;
 
+-- 5) Every adjustment row touching this job, across every technician and every
+--    period (deductions, rework holds, rework releases, manual compensation —
+--    anything that moved money via the adjustment ledger). job_id on the
+--    adjustments table is a synthetic key for rework hold/release rows
+--    (rework_hold:<case_id>:<job_id> / rework_release:<case_id>:<job_id>), so
+--    match on the real job_id text as well as those synthetic forms.
 SELECT a.adj_id, a.payout_id, a.technician_username, a.job_id, a.adj_amount,
        a.reason, a.created_by, a.created_at,
        p.period_type, p.period_start, p.period_end, p.status AS period_status
   FROM public.technician_payout_adjustments a
   JOIN public.technician_payout_periods p ON p.payout_id = a.payout_id
- WHERE a.technician_username = :'tech'
-   AND (
+ WHERE (
      a.job_id::text = (SELECT job_id::text FROM public.jobs WHERE booking_code = :'booking_code' LIMIT 1)
      OR a.job_id::text LIKE 'rework_hold:%:' || (SELECT job_id::text FROM public.jobs WHERE booking_code = :'booking_code' LIMIT 1)
      OR a.job_id::text LIKE 'rework_release:%:' || (SELECT job_id::text FROM public.jobs WHERE booking_code = :'booking_code' LIMIT 1)
      OR a.reason LIKE '%job_id=' || (SELECT job_id::text FROM public.jobs WHERE booking_code = :'booking_code' LIMIT 1) || '%'
    )
- ORDER BY a.created_at, a.adj_id;
+ ORDER BY a.technician_username, a.created_at;
 
-SELECT h.rework_case_id, h.technician_username,
-       COUNT(a.adj_id) AS release_adjustment_count,
-       COALESCE(SUM(a.adj_amount),0) AS release_adjustment_total
-  FROM public.technician_rework_income_holds h
-  LEFT JOIN public.technician_payout_adjustments a
-    ON a.adj_id = h.release_adjustment_id
-  JOIN public.jobs j ON j.job_id = h.job_id
+-- 6) Duplicate-release smoke test: more than one positive, non-release-tagged
+--    adjustment for the same job+tech is a red flag (possible double-count of
+--    a release as a gross line — see _loadApprovedReworkCompensationLines).
+SELECT a.job_id, a.technician_username,
+       COUNT(*) FILTER (WHERE a.adj_amount > 0) AS positive_adjustment_count,
+       SUM(a.adj_amount) FILTER (WHERE a.adj_amount > 0) AS positive_adjustment_total,
+       COUNT(*) FILTER (WHERE a.adj_amount > 0 AND a.reason LIKE '[REWORK_RELEASE]%') AS release_adjustment_count
+  FROM public.technician_payout_adjustments a
+  JOIN public.jobs j ON j.job_id::text = a.job_id::text
  WHERE j.booking_code = :'booking_code'
-   AND h.technician_username = :'tech'
- GROUP BY h.rework_case_id, h.technician_username;
+ GROUP BY a.job_id, a.technician_username
+ ORDER BY a.technician_username;
 
+-- 7) Payment status for every period touched by this job, per technician, so we
+--    can see whether the period the original earning fell into has already
+--    been paid (which is exactly the case the carried-forward hold handles).
 SELECT pay.payout_id, pay.technician_username, pay.paid_amount, pay.paid_status,
-       pay.paid_at, p.period_type, p.period_start, p.period_end,
-       p.status AS period_status
+       p.period_type, p.period_start, p.period_end, p.status AS period_status
   FROM public.technician_payout_payments pay
   JOIN public.technician_payout_periods p ON p.payout_id = pay.payout_id
- WHERE pay.technician_username = :'tech'
- ORDER BY p.period_start;
+ WHERE pay.payout_id IN (
+     SELECT DISTINCT l.payout_id
+       FROM public.technician_payout_lines l
+       JOIN public.jobs j ON j.job_id::text = l.job_id::text
+      WHERE j.booking_code = :'booking_code'
+     UNION
+     SELECT DISTINCT a.payout_id
+       FROM public.technician_payout_adjustments a
+       JOIN public.jobs j ON j.job_id::text = a.job_id::text
+      WHERE j.booking_code = :'booking_code'
+   )
+ ORDER BY p.period_start, pay.technician_username;
 
-SELECT l.job_id, l.actor_username, l.actor_role, l.action, l.message,
-       l.payload, l.created_at
-  FROM public.job_update_logs l
-  JOIN public.jobs j ON j.job_id = l.job_id
- WHERE j.booking_code = :'booking_code'
- ORDER BY l.created_at;
+-- 8) job_update_logs trail for this job, for a human-readable timeline of
+--    rework_case_created / revisit_result / rework_case_resolved events.
+SELECT job_id, actor_username, actor_role, action, message, payload, created_at
+  FROM public.job_update_logs
+ WHERE job_id = (SELECT job_id FROM public.jobs WHERE booking_code = :'booking_code')
+ ORDER BY created_at;
 
 COMMIT;

--- a/scripts/recover-legacy-rework-income.js
+++ b/scripts/recover-legacy-rework-income.js
@@ -11,8 +11,16 @@ function parseArgs(argv) {
   const out = { apply: false };
   for (let i = 2; i < argv.length; i += 1) {
     const arg = argv[i];
-    if (arg === '--apply') out.apply = true;
-    else if (arg.startsWith('--')) {
+    if (arg === '--apply') {
+      out.apply = true;
+      continue;
+    }
+    if (!arg.startsWith('--')) continue;
+    const eqIndex = arg.indexOf('=');
+    if (eqIndex !== -1) {
+      const key = arg.slice(2, eqIndex).replace(/-([a-z])/g, (_, c) => c.toUpperCase());
+      out[key] = arg.slice(eqIndex + 1);
+    } else {
       const key = arg.slice(2).replace(/-([a-z])/g, (_, c) => c.toUpperCase());
       out[key] = argv[i + 1];
       i += 1;
@@ -182,6 +190,9 @@ function validateApply(report, args) {
   );
   if (duplicateRelease) fail('RELEASE_ADJUSTMENT_ALREADY_EXISTS');
   if (report.proposedAmount == null) fail('SOURCE_AMOUNT_AMBIGUOUS: review dry-run and provide a single ledger source');
+  if (String(report.sourcePeriodStatus || '') === 'preview_only') {
+    fail('SOURCE_IS_PREVIEW_ONLY: a non-authoritative preview cannot be applied, a real payout line is required');
+  }
   if (money(report.proposedAmount) !== expectedAmount) {
     fail(`EXPECTED_AMOUNT_MISMATCH expected=${expectedAmount} ledger=${money(report.proposedAmount)}`);
   }

--- a/scripts/recover-legacy-rework-income.js
+++ b/scripts/recover-legacy-rework-income.js
@@ -1,0 +1,279 @@
+#!/usr/bin/env node
+'use strict';
+
+const { Client } = require('pg');
+const {
+  releaseHeldIncomeForReworkCase,
+  money,
+} = require('../server/services/technicianReworkIncome');
+
+function parseArgs(argv) {
+  const out = { apply: false };
+  for (let i = 2; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === '--apply') out.apply = true;
+    else if (arg.startsWith('--')) {
+      const key = arg.slice(2).replace(/-([a-z])/g, (_, c) => c.toUpperCase());
+      out[key] = argv[i + 1];
+      i += 1;
+    }
+  }
+  return out;
+}
+
+function fail(message, code = 1) {
+  const err = new Error(message);
+  err.exitCode = code;
+  throw err;
+}
+
+function clientConfig() {
+  const connectionString = String(process.env.DATABASE_URL || process.env.PRODUCTION_DATABASE_URL || '').trim();
+  if (!connectionString) fail('DATABASE_URL or PRODUCTION_DATABASE_URL is required');
+  return {
+    connectionString,
+    options: '-c timezone=Asia/Bangkok',
+    ssl: { rejectUnauthorized: false },
+  };
+}
+
+async function loadReport(client, bookingCode, technician) {
+  const jobQ = await client.query(
+    `SELECT job_id, booking_code, job_status, technician_username, finished_at,
+            returned_at, return_reason
+       FROM public.jobs
+      WHERE booking_code=$1
+      LIMIT 1`,
+    [bookingCode]
+  );
+  const job = jobQ.rows[0] || null;
+  if (!job) fail(`JOB_NOT_FOUND booking_code=${bookingCode}`);
+
+  const caseQ = await client.query(
+    `SELECT *
+       FROM public.technician_rework_cases
+      WHERE job_id=$1
+      ORDER BY created_at DESC NULLS LAST, rework_case_id DESC
+      LIMIT 1`,
+    [job.job_id]
+  );
+  const reworkCase = caseQ.rows[0] || null;
+  if (!reworkCase) fail(`REWORK_CASE_NOT_FOUND job_id=${job.job_id}`);
+
+  const holdsQ = await client.query(
+    `SELECT *
+       FROM public.technician_rework_income_holds
+      WHERE rework_case_id=$1 AND technician_username=$2
+      ORDER BY hold_id`,
+    [reworkCase.rework_case_id, technician]
+  );
+
+  const linesQ = await client.query(
+    `SELECT l.line_id, l.payout_id, l.technician_username, l.job_id, l.earn_amount,
+            p.status AS period_status, p.period_start, p.period_end
+       FROM public.technician_payout_lines l
+       JOIN public.technician_payout_periods p ON p.payout_id=l.payout_id
+      WHERE l.job_id::text=$1::text
+        AND l.technician_username=$2
+      ORDER BY p.period_start, l.line_id`,
+    [String(job.job_id), technician]
+  );
+
+  const previewQ = await client.query(
+    `SELECT job_id, technician_username, income_amount, income_source, is_stale,
+            calculated_at, updated_at
+       FROM public.job_technician_income_preview
+      WHERE job_id=$1 AND technician_username=$2
+      LIMIT 1`,
+    [job.job_id, technician]
+  ).catch(() => ({ rows: [] }));
+
+  const adjustmentsQ = await client.query(
+    `SELECT a.adj_id, a.payout_id, a.technician_username, a.job_id,
+            a.adj_amount, a.reason, a.created_at, a.created_by,
+            p.status AS period_status
+       FROM public.technician_payout_adjustments a
+       JOIN public.technician_payout_periods p ON p.payout_id=a.payout_id
+      WHERE a.technician_username=$2
+        AND (
+          a.job_id::text=$1::text
+          OR a.job_id::text LIKE 'rework_hold:%:' || $1::text
+          OR a.job_id::text LIKE 'rework_release:%:' || $1::text
+          OR a.reason LIKE '%job_id=' || $1::text || '%'
+        )
+      ORDER BY a.created_at, a.adj_id`,
+    [String(job.job_id), technician]
+  );
+
+  const positiveLineTotals = new Map();
+  for (const row of linesQ.rows || []) {
+    const amount = money(row.earn_amount);
+    if (amount <= 0) continue;
+    positiveLineTotals.set(row.payout_id, money((positiveLineTotals.get(row.payout_id) || 0) + amount));
+  }
+
+  const candidates = [...positiveLineTotals.entries()].map(([payout_id, amount]) => ({ payout_id, amount }));
+  let proposedAmount = null;
+  let sourcePayoutId = null;
+  let sourcePeriodStatus = null;
+  if (candidates.length === 1) {
+    proposedAmount = candidates[0].amount;
+    sourcePayoutId = candidates[0].payout_id;
+    sourcePeriodStatus = (linesQ.rows || []).find((row) => row.payout_id === sourcePayoutId)?.period_status || null;
+  } else if (!candidates.length) {
+    const preview = previewQ.rows[0] || null;
+    if (preview && !preview.is_stale && money(preview.income_amount) > 0) {
+      proposedAmount = money(preview.income_amount);
+      sourcePeriodStatus = 'preview_only';
+    }
+  }
+
+  return {
+    job,
+    reworkCase,
+    holds: holdsQ.rows || [],
+    payoutLines: linesQ.rows || [],
+    preview: previewQ.rows[0] || null,
+    adjustments: adjustmentsQ.rows || [],
+    proposedAmount,
+    sourcePayoutId,
+    sourcePeriodStatus,
+  };
+}
+
+function printReport(report, args) {
+  const payload = {
+    mode: args.apply ? 'APPLY_REQUESTED' : 'DRY_RUN',
+    booking_code: report.job.booking_code,
+    job_id: report.job.job_id,
+    job_status: report.job.job_status,
+    finished_at: report.job.finished_at,
+    rework_case_id: report.reworkCase.rework_case_id,
+    rework_case_code: report.reworkCase.case_code,
+    rework_status: report.reworkCase.status,
+    resolution: report.reworkCase.resolution,
+    revisit_result: report.reworkCase.revisit_result,
+    technician: args.technician,
+    existing_holds: report.holds,
+    payout_lines: report.payoutLines,
+    preview: report.preview,
+    related_adjustments: report.adjustments,
+    proposed_amount: report.proposedAmount,
+    source_payout_id: report.sourcePayoutId,
+    source_period_status: report.sourcePeriodStatus,
+  };
+  console.log(JSON.stringify(payload, null, 2));
+}
+
+function validateApply(report, args) {
+  if (String(args.confirm || '') !== 'APPLY_LEGACY_REWORK_RECOVERY') {
+    fail('CONFIRMATION_REQUIRED: --confirm APPLY_LEGACY_REWORK_RECOVERY');
+  }
+  const expectedAmount = money(args.expectedAmount);
+  if (expectedAmount <= 0) fail('POSITIVE_EXPECTED_AMOUNT_REQUIRED');
+  if (report.holds.length) fail('HOLD_ALREADY_EXISTS: recovery is idempotent and will not overwrite it');
+  if (!report.job.finished_at) fail('JOB_FINISHED_AT_REQUIRED');
+  const successful = report.reworkCase.resolution === 'fixed'
+    || report.reworkCase.revisit_result === 'successful';
+  if (!successful) fail('REWORK_NOT_CONFIRMED_SUCCESSFUL');
+  const duplicateRelease = report.adjustments.some((row) =>
+    money(row.adj_amount) > 0
+    && (String(row.job_id || '').startsWith('rework_release:') || String(row.reason || '').includes('[REWORK_RELEASE]'))
+  );
+  if (duplicateRelease) fail('RELEASE_ADJUSTMENT_ALREADY_EXISTS');
+  if (report.proposedAmount == null) fail('SOURCE_AMOUNT_AMBIGUOUS: review dry-run and provide a single ledger source');
+  if (money(report.proposedAmount) !== expectedAmount) {
+    fail(`EXPECTED_AMOUNT_MISMATCH expected=${expectedAmount} ledger=${money(report.proposedAmount)}`);
+  }
+  if (String(report.sourcePeriodStatus || '') === 'paid' && String(args.allowPaidSource || '') !== 'YES') {
+    fail('SOURCE_PERIOD_ALREADY_PAID: rerun only after explicit accounting approval with --allow-paid-source YES');
+  }
+  return expectedAmount;
+}
+
+async function applyRecovery(client, report, args) {
+  const amount = validateApply(report, args);
+  await client.query('BEGIN');
+  try {
+    const lockJob = await client.query(
+      `SELECT job_id, finished_at FROM public.jobs WHERE job_id=$1 FOR UPDATE`,
+      [report.job.job_id]
+    );
+    if (!lockJob.rows[0]?.finished_at) fail('JOB_FINISHED_AT_REQUIRED');
+
+    const lockCase = await client.query(
+      `SELECT * FROM public.technician_rework_cases WHERE rework_case_id=$1 FOR UPDATE`,
+      [report.reworkCase.rework_case_id]
+    );
+    if (!lockCase.rows[0]) fail('REWORK_CASE_NOT_FOUND_DURING_APPLY');
+
+    const existing = await client.query(
+      `SELECT * FROM public.technician_rework_income_holds
+        WHERE rework_case_id=$1 AND technician_username=$2
+        FOR UPDATE`,
+      [report.reworkCase.rework_case_id, args.technician]
+    );
+    if (existing.rows.length) fail('HOLD_ALREADY_EXISTS_DURING_APPLY');
+
+    const inserted = await client.query(
+      `INSERT INTO public.technician_rework_income_holds
+        (rework_case_id, technician_username, job_id, held_amount,
+         source_payout_id, source_period_status_at_hold, hold_status, created_by)
+       VALUES($1,$2,$3,$4,$5,$6,'held',$7)
+       RETURNING *`,
+      [
+        report.reworkCase.rework_case_id,
+        args.technician,
+        report.job.job_id,
+        amount,
+        report.sourcePayoutId,
+        `legacy_recovery:${report.sourcePeriodStatus || 'unknown'}`,
+        String(args.actor || 'legacy_rework_recovery'),
+      ]
+    );
+
+    const release = await releaseHeldIncomeForReworkCase(client, {
+      reworkCaseId: report.reworkCase.rework_case_id,
+      technicianUsername: args.technician,
+      actor: String(args.actor || 'legacy_rework_recovery'),
+    });
+
+    await client.query('COMMIT');
+    console.log(JSON.stringify({ ok: true, hold: inserted.rows[0], release }, null, 2));
+  } catch (error) {
+    await client.query('ROLLBACK').catch(() => {});
+    throw error;
+  }
+}
+
+async function main() {
+  const args = parseArgs(process.argv);
+  args.bookingCode = String(args.bookingCode || '').trim();
+  args.technician = String(args.technician || '').trim();
+  if (!args.bookingCode) fail('--booking-code is required');
+  if (!args.technician) fail('--technician is required');
+
+  const client = new Client(clientConfig());
+  await client.connect();
+  try {
+    if (!args.apply) await client.query('BEGIN TRANSACTION READ ONLY');
+    const report = await loadReport(client, args.bookingCode, args.technician);
+    printReport(report, args);
+    if (!args.apply) {
+      await client.query('COMMIT');
+      return;
+    }
+    await applyRecovery(client, report, args);
+  } finally {
+    await client.end();
+  }
+}
+
+if (require.main === module) {
+  main().catch((error) => {
+    console.error(`RECOVERY_FAILED: ${error.message}`);
+    process.exitCode = error.exitCode || 1;
+  });
+}
+
+module.exports = { parseArgs, loadReport, validateApply };

--- a/server/services/technicianReworkIncome.js
+++ b/server/services/technicianReworkIncome.js
@@ -2,10 +2,10 @@
 
 const { createTechnicianDeductionPayoutApplyService } = require('./technicianDeductionPayoutApply');
 
-// Reuse the exact same Bangkok period-boundary math the deduction-adjustment
-// flow already uses in production, so rework hold/release and deduction
-// adjustments can never disagree about which payout period a date belongs to.
 const { payoutTargetForDate, nextPayoutTarget } = createTechnicianDeductionPayoutApplyService();
+
+const HOLD_REASON_TAG = '[REWORK_HOLD]';
+const RELEASE_REASON_TAG = '[REWORK_RELEASE]';
 
 function money(value) {
   const n = Number(value || 0);
@@ -23,7 +23,22 @@ function paidStatus(netAmount, paidAmount) {
 }
 
 function releaseIdempotencyKey(reworkCaseId, technicianUsername) {
-  return `rework_release:${reworkCaseId}:${String(technicianUsername || '').trim()}`;
+  return `rework_release:${Number(reworkCaseId)}:${String(technicianUsername || '').trim()}`;
+}
+
+function adjustmentJobKey(kind, reworkCaseId, jobId) {
+  return `rework_${kind}:${Number(reworkCaseId)}:${Number(jobId)}`;
+}
+
+function uniqueTechnicianRows(rows) {
+  const totals = new Map();
+  for (const row of Array.isArray(rows) ? rows : []) {
+    const tech = String(row?.technician_username || '').trim();
+    if (!tech) continue;
+    const amount = money(row?.amount ?? row?.earn_amount ?? row?.income_amount ?? 0);
+    totals.set(tech, money((totals.get(tech) || 0) + amount));
+  }
+  return [...totals.entries()].map(([technician_username, amount]) => ({ technician_username, amount }));
 }
 
 async function ensurePeriod(client, target, actor) {
@@ -31,7 +46,13 @@ async function ensurePeriod(client, target, actor) {
     `INSERT INTO public.technician_payout_periods(payout_id, period_type, period_start, period_end, status, created_by)
      VALUES($1,$2,$3,$4,'draft',$5)
      ON CONFLICT (payout_id) DO NOTHING`,
-    [target.payout_id, target.period_type, target.period_start.toISOString(), target.period_end.toISOString(), actor || 'rework_income:auto']
+    [
+      target.payout_id,
+      target.period_type,
+      target.period_start.toISOString(),
+      target.period_end.toISOString(),
+      actor || 'rework_income:auto',
+    ]
   );
   const q = await client.query(
     `SELECT payout_id, period_type, period_start, period_end, status
@@ -48,14 +69,11 @@ async function findExistingPeriodStatus(client, target) {
     `SELECT status FROM public.technician_payout_periods WHERE payout_id=$1 LIMIT 1`,
     [target.payout_id]
   );
-  return q.rows[0] ? String(q.rows[0].status) : null;
+  return q.rows[0] ? String(q.rows[0].status || '').trim() : null;
 }
 
-// Mirrors technicianDeductionPayoutApply.resolveTargetPeriod: roll forward
-// past periods already marked 'paid' so we never insert a new line/adjustment
-// into a payout that has already been disbursed.
-async function resolveOpenTargetPeriod(client, fromDate, actor) {
-  let target = payoutTargetForDate(fromDate);
+async function resolveOpenTargetPeriodFromTarget(client, firstTarget, actor) {
+  let target = firstTarget;
   for (let i = 0; i < 24; i += 1) {
     const period = await ensurePeriod(client, target, actor);
     if (period && String(period.status || 'draft') !== 'paid') {
@@ -63,14 +81,16 @@ async function resolveOpenTargetPeriod(client, fromDate, actor) {
     }
     target = nextPayoutTarget(target);
   }
-  const err = new Error('NO_OPEN_PAYOUT_PERIOD_FOR_REWORK_RELEASE');
+  const err = new Error('NO_OPEN_PAYOUT_PERIOD_FOR_REWORK');
   err.status = 409;
   throw err;
 }
 
+async function resolveOpenTargetPeriod(client, fromDate, actor) {
+  return resolveOpenTargetPeriodFromTarget(client, payoutTargetForDate(fromDate), actor);
+}
+
 async function recalcPaymentStatus(client, payoutId, technicianUsername) {
-  // Mirrors technicianDeductionPayoutApply.recalcPaymentStatus exactly so both
-  // adjustment paths agree on net_amount/paid_status for the same payout+tech.
   const q = await client.query(
     `WITH gross AS (
        SELECT COALESCE(SUM(earn_amount),0)::numeric AS gross_amount
@@ -98,39 +118,187 @@ async function recalcPaymentStatus(client, payoutId, technicianUsername) {
     [payoutId, technicianUsername]
   );
   const row = q.rows[0] || { net_amount: 0, paid_amount: 0, payment_id: null };
+  const status = paidStatus(row.net_amount, row.paid_amount);
   if (row.payment_id) {
     await client.query(
       `UPDATE public.technician_payout_payments
           SET paid_status=$3, updated_at=NOW()
         WHERE payment_id=$1 AND payout_id=$2`,
-      [row.payment_id, payoutId, paidStatus(row.net_amount, row.paid_amount)]
+      [row.payment_id, payoutId, status]
     );
   }
-  return { net_amount: money(row.net_amount), paid_amount: money(row.paid_amount), paid_status: paidStatus(row.net_amount, row.paid_amount) };
+  return {
+    net_amount: money(row.net_amount),
+    paid_amount: money(row.paid_amount),
+    paid_status: status,
+  };
 }
 
-async function getExistingHold(client, reworkCaseId, technicianUsername) {
+async function getExistingHold(client, reworkCaseId, technicianUsername, forUpdate = true) {
   const q = await client.query(
-    `SELECT * FROM public.technician_rework_income_holds
+    `SELECT *
+       FROM public.technician_rework_income_holds
       WHERE rework_case_id=$1 AND technician_username=$2
-      FOR UPDATE`,
+      ${forUpdate ? 'FOR UPDATE' : ''}`,
     [reworkCaseId, technicianUsername]
   );
   return q.rows[0] || null;
 }
 
-/**
- * Pause the original technician's income for a job that is being sent to rework.
- *
- * `resolveOriginalEarnAmount(client)` must be supplied by the caller and return the
- * ledger-grade earned amount for (jobId, technicianUsername) — e.g. an existing
- * public.technician_payout_lines row if one was already cached, otherwise the same
- * deterministic payout engine used to populate that table. Never pass a UI/preview
- * display value here.
- *
- * Idempotent: calling this twice for the same (reworkCaseId, technicianUsername)
- * is a no-op on the second call (invariant: one immutable hold row per case+tech).
- */
+async function getHoldsForReworkCase(client, reworkCaseId, opts = {}) {
+  const q = await client.query(
+    `SELECT *
+       FROM public.technician_rework_income_holds
+      WHERE rework_case_id=$1
+      ORDER BY hold_id
+      ${opts.forUpdate ? 'FOR UPDATE' : ''}`,
+    [reworkCaseId]
+  );
+  return q.rows || [];
+}
+
+async function loadOriginalIncomeCandidates(client, opts) {
+  const jobId = Number(opts.jobId);
+  const originalFinishedAt = opts.originalFinishedAt;
+  const preferredTech = String(opts.technicianUsername || '').trim();
+  const sourceTarget = payoutTargetForDate(originalFinishedAt);
+
+  let rows = [];
+  try {
+    const q = await client.query(
+      `SELECT technician_username, COALESCE(SUM(earn_amount),0)::numeric AS amount
+         FROM public.technician_payout_lines
+        WHERE job_id::text=$1::text
+          AND payout_id=$2
+        GROUP BY technician_username`,
+      [String(jobId), sourceTarget.payout_id]
+    );
+    rows = uniqueTechnicianRows(q.rows);
+  } catch (_) {
+    rows = [];
+  }
+
+  if (!rows.length) {
+    try {
+      const q = await client.query(
+        `SELECT technician_username, income_amount AS amount
+           FROM public.job_technician_income_preview
+          WHERE job_id=$1
+            AND COALESCE(is_stale,FALSE)=FALSE
+            AND COALESCE(income_amount,0)>0`,
+        [jobId]
+      );
+      rows = uniqueTechnicianRows(q.rows);
+    } catch (_) {
+      rows = [];
+    }
+  }
+
+  if (preferredTech && !rows.some((row) => row.technician_username === preferredTech)) {
+    const amount = money(typeof opts.resolveOriginalEarnAmount === 'function'
+      ? await opts.resolveOriginalEarnAmount(client)
+      : opts.originalEarnAmount);
+    rows.push({ technician_username: preferredTech, amount });
+  }
+
+  return { sourceTarget, rows: uniqueTechnicianRows(rows) };
+}
+
+async function insertAdjustment(client, params) {
+  const q = await client.query(
+    `INSERT INTO public.technician_payout_adjustments
+      (payout_id, technician_username, job_id, adj_amount, reason, created_by)
+     VALUES($1,$2,$3,$4,$5,$6)
+     RETURNING adj_id, payout_id, technician_username, job_id, adj_amount, reason, created_at, created_by`,
+    [
+      params.payoutId,
+      params.technicianUsername,
+      params.jobKey,
+      money(params.amount),
+      String(params.reason || '').slice(0, 1500),
+      params.actor || null,
+    ]
+  );
+  return q.rows[0];
+}
+
+async function createOneHold(client, opts) {
+  const existing = await getExistingHold(client, opts.reworkCaseId, opts.technicianUsername, true);
+  if (existing) return { already_held: true, held: existing.hold_status === 'held', row: existing };
+
+  const amount = money(opts.amount);
+  if (amount <= 0) {
+    const q = await client.query(
+      `INSERT INTO public.technician_rework_income_holds
+        (rework_case_id, technician_username, job_id, held_amount, source_payout_id,
+         source_period_status_at_hold, hold_status, created_by)
+       VALUES($1,$2,$3,0,$4,$5,'already_paid_no_action',$6)
+       RETURNING *`,
+      [
+        opts.reworkCaseId,
+        opts.technicianUsername,
+        opts.jobId,
+        opts.sourceTarget.payout_id,
+        opts.sourcePeriodStatus || 'none',
+        opts.actor,
+      ]
+    );
+    return { already_held: false, held: false, row: q.rows[0] };
+  }
+
+  let holdAdjustment = null;
+  let sourceStatus = opts.sourcePeriodStatus || 'draft';
+
+  if (opts.sourcePeriodStatus === 'locked') {
+    holdAdjustment = await insertAdjustment(client, {
+      payoutId: opts.sourceTarget.payout_id,
+      technicianUsername: opts.technicianUsername,
+      jobKey: adjustmentJobKey('hold', opts.reworkCaseId, opts.jobId),
+      amount: -amount,
+      reason: `${HOLD_REASON_TAG} พักรายได้เดิม งานแก้ไข rework_case_id=${opts.reworkCaseId} job_id=${opts.jobId}`,
+      actor: opts.actor,
+    });
+    await recalcPaymentStatus(client, holdAdjustment.payout_id, opts.technicianUsername);
+  } else if (opts.sourcePeriodStatus === 'paid') {
+    const carry = await resolveOpenTargetPeriodFromTarget(client, nextPayoutTarget(opts.sourceTarget), opts.actor);
+    holdAdjustment = await insertAdjustment(client, {
+      payoutId: carry.period.payout_id,
+      technicianUsername: opts.technicianUsername,
+      jobKey: adjustmentJobKey('hold', opts.reworkCaseId, opts.jobId),
+      amount: -amount,
+      reason: `${HOLD_REASON_TAG} หักพักรายได้ย้อนหลังจากงวดที่จ่ายแล้ว source_payout=${opts.sourceTarget.payout_id} rework_case_id=${opts.reworkCaseId} job_id=${opts.jobId}`,
+      actor: opts.actor,
+    });
+    sourceStatus = `paid_carried_forward:${carry.period.payout_id}`;
+    await recalcPaymentStatus(client, holdAdjustment.payout_id, opts.technicianUsername);
+  }
+
+  const q = await client.query(
+    `INSERT INTO public.technician_rework_income_holds
+      (rework_case_id, technician_username, job_id, held_amount, source_payout_id,
+       source_period_status_at_hold, hold_adjustment_id, hold_status, created_by)
+     VALUES($1,$2,$3,$4,$5,$6,$7,'held',$8)
+     RETURNING *`,
+    [
+      opts.reworkCaseId,
+      opts.technicianUsername,
+      opts.jobId,
+      amount,
+      opts.sourceTarget.payout_id,
+      sourceStatus,
+      holdAdjustment?.adj_id || null,
+      opts.actor,
+    ]
+  );
+
+  return {
+    already_held: false,
+    held: true,
+    hold_adjustment: holdAdjustment,
+    row: q.rows[0],
+  };
+}
+
 async function holdOriginalIncomeForReworkCase(client, opts = {}) {
   const reworkCaseId = Number(opts.reworkCaseId || 0);
   const jobId = Number(opts.jobId || 0);
@@ -144,203 +312,186 @@ async function holdOriginalIncomeForReworkCase(client, opts = {}) {
     throw err;
   }
 
-  const existing = await getExistingHold(client, reworkCaseId, technicianUsername);
-  if (existing) {
-    return { already_held: true, row: existing };
-  }
-
+  const existingRows = await getHoldsForReworkCase(client, reworkCaseId, { forUpdate: true });
   if (!originalFinishedAt || Number.isNaN(originalFinishedAt.getTime())) {
-    // Job never had a finished_at (e.g. it was never completed before going to rework) —
-    // there is no original income to hold.
-    const ins = await client.query(
+    if (existingRows.length) {
+      return { already_held: true, held: false, rows: existingRows, row: existingRows[0] };
+    }
+    const q = await client.query(
       `INSERT INTO public.technician_rework_income_holds
-       (rework_case_id, technician_username, job_id, held_amount, source_payout_id, source_period_status_at_hold, hold_status, created_by)
-       VALUES ($1,$2,$3,0,NULL,'no_prior_finish','already_paid_no_action',$4)
+        (rework_case_id, technician_username, job_id, held_amount, source_payout_id,
+         source_period_status_at_hold, hold_status, created_by)
+       VALUES($1,$2,$3,0,NULL,'no_prior_finish','already_paid_no_action',$4)
        RETURNING *`,
       [reworkCaseId, technicianUsername, jobId, actor]
     );
-    return { already_held: false, held: false, row: ins.rows[0] };
+    return { already_held: false, held: false, rows: q.rows, row: q.rows[0] };
   }
 
-  const amount = money(typeof opts.resolveOriginalEarnAmount === 'function'
-    ? await opts.resolveOriginalEarnAmount(client)
-    : opts.originalEarnAmount);
+  const { sourceTarget, rows } = await loadOriginalIncomeCandidates(client, {
+    ...opts,
+    originalFinishedAt,
+    technicianUsername,
+  });
+  const sourcePeriodStatus = await findExistingPeriodStatus(client, sourceTarget);
 
-  const target = payoutTargetForDate(originalFinishedAt);
-  const periodStatus = await findExistingPeriodStatus(client, target);
-
-  if (amount <= 0) {
-    const ins = await client.query(
-      `INSERT INTO public.technician_rework_income_holds
-       (rework_case_id, technician_username, job_id, held_amount, source_payout_id, source_period_status_at_hold, hold_status, created_by)
-       VALUES ($1,$2,$3,0,$4,$5,'already_paid_no_action',$6)
-       RETURNING *`,
-      [reworkCaseId, technicianUsername, jobId, target.payout_id, periodStatus || 'none', actor]
-    );
-    return { already_held: false, held: false, row: ins.rows[0] };
+  const results = [];
+  for (const candidate of rows) {
+    results.push(await createOneHold(client, {
+      reworkCaseId,
+      jobId,
+      technicianUsername: candidate.technician_username,
+      amount: candidate.amount,
+      sourceTarget,
+      sourcePeriodStatus,
+      actor,
+    }));
   }
 
-  if (periodStatus === 'paid') {
-    // Already disbursed in a paid period: invariant 6 — do not touch, do not hold.
-    const ins = await client.query(
-      `INSERT INTO public.technician_rework_income_holds
-       (rework_case_id, technician_username, job_id, held_amount, source_payout_id, source_period_status_at_hold, hold_status, created_by)
-       VALUES ($1,$2,$3,$4,$5,'paid','already_paid_no_action',$6)
-       RETURNING *`,
-      [reworkCaseId, technicianUsername, jobId, amount, target.payout_id, actor]
-    );
-    return { already_held: false, held: false, row: ins.rows[0] };
-  }
-
-  let holdAdjustmentId = null;
-  if (periodStatus === 'locked') {
-    // Locked periods are frozen snapshots that will not be regenerated, so the
-    // original gross line will not naturally drop out once finished_at is cleared.
-    // Neutralize it now with a negative adjustment.
-    const reason = `พักรายได้เดิม งานแก้ไข rework_case_id=${reworkCaseId} job_id=${jobId}`.slice(0, 1500);
-    const adj = await client.query(
-      `INSERT INTO public.technician_payout_adjustments(payout_id, technician_username, job_id, adj_amount, reason, created_by)
-       VALUES($1,$2,$3,$4,$5,$6)
-       RETURNING adj_id`,
-      [target.payout_id, technicianUsername, String(jobId), -amount, reason, actor]
-    );
-    holdAdjustmentId = adj.rows[0].adj_id;
-    await recalcPaymentStatus(client, target.payout_id, technicianUsername);
-  }
-  // periodStatus === 'draft' or null (period not generated yet): no adjustment needed —
-  // clearing finished_at on the job means the gross line will not be (re)computed for
-  // this job until the rework outcome is known, so the income is already effectively paused.
-
-  const ins = await client.query(
-    `INSERT INTO public.technician_rework_income_holds
-     (rework_case_id, technician_username, job_id, held_amount, source_payout_id, source_period_status_at_hold, hold_adjustment_id, hold_status, created_by)
-     VALUES ($1,$2,$3,$4,$5,$6,$7,'held',$8)
-     RETURNING *`,
-    [reworkCaseId, technicianUsername, jobId, amount, target.payout_id, periodStatus || 'draft', holdAdjustmentId, actor]
-  );
-  return { already_held: false, held: true, row: ins.rows[0] };
+  const persisted = await getHoldsForReworkCase(client, reworkCaseId, { forUpdate: false });
+  const preferred = persisted.find((row) => row.technician_username === technicianUsername) || persisted[0] || null;
+  return {
+    already_held: results.length > 0 && results.every((row) => row.already_held),
+    held: persisted.some((row) => row.hold_status === 'held' && money(row.held_amount) > 0),
+    rows: persisted,
+    row: preferred,
+    results,
+  };
 }
 
-/**
- * Release a previously held amount back into the technician's payout once the
- * rework case closes successfully. `finishedAt` must be the rework job's own
- * finished_at (Asia/Bangkok 1-15 -> payout 25th same month, 16-end -> payout
- * 10th next month). Idempotent: safe to call any number of times for the same
- * (reworkCaseId, technicianUsername) — only the first call that finds
- * hold_status='held' moves money; every call after that is a no-op.
- */
+async function loadAuthoritativeFinishedAt(client, holds) {
+  const jobIds = [...new Set((holds || []).map((row) => Number(row.job_id)).filter((id) => id > 0))];
+  if (!jobIds.length) return null;
+  const q = await client.query(
+    `SELECT job_id, finished_at
+       FROM public.jobs
+      WHERE job_id = ANY($1::bigint[])
+      FOR UPDATE`,
+    [jobIds]
+  );
+  const valid = (q.rows || []).map((row) => row.finished_at).filter(Boolean);
+  if (!valid.length) return null;
+  const first = new Date(valid[0]);
+  return Number.isNaN(first.getTime()) ? null : first;
+}
+
 async function releaseHeldIncomeForReworkCase(client, opts = {}) {
   const reworkCaseId = Number(opts.reworkCaseId || 0);
-  const technicianUsername = String(opts.technicianUsername || '').trim();
-  const finishedAt = opts.finishedAt ? new Date(opts.finishedAt) : null;
+  const requestedTech = String(opts.technicianUsername || '').trim();
   const actor = String(opts.actor || '').trim() || null;
 
-  if (!reworkCaseId || !technicianUsername) {
+  if (!reworkCaseId || !requestedTech) {
     const err = new Error('INVALID_REWORK_RELEASE_INPUT');
     err.status = 400;
     throw err;
   }
 
-  const hold = await getExistingHold(client, reworkCaseId, technicianUsername);
-  if (!hold) {
-    return { released: false, reason: 'NO_HOLD' };
-  }
-  if (hold.hold_status !== 'held') {
-    // Already released / already_paid_no_action / voided — idempotent no-op.
-    return { released: false, reason: hold.hold_status, row: hold };
+  const holds = await getHoldsForReworkCase(client, reworkCaseId, { forUpdate: true });
+  if (!holds.length) return { released: false, reason: 'NO_HOLD', rows: [] };
+
+  const releasable = holds.filter((row) => row.hold_status === 'held' && money(row.held_amount) > 0);
+  if (!releasable.length) {
+    const requested = holds.find((row) => row.technician_username === requestedTech) || holds[0];
+    return { released: false, reason: requested?.hold_status || 'NO_RELEASABLE_HOLD', rows: holds, row: requested || null };
   }
 
-  const amount = money(hold.held_amount);
-  if (amount <= 0) {
-    await client.query(
-      `UPDATE public.technician_rework_income_holds SET hold_status='voided', updated_at=NOW() WHERE hold_id=$1`,
-      [hold.hold_id]
-    );
-    return { released: false, reason: 'ZERO_AMOUNT' };
-  }
-  if (!finishedAt || Number.isNaN(finishedAt.getTime())) {
-    const err = new Error('INVALID_FINISHED_AT_FOR_REWORK_RELEASE');
-    err.status = 400;
+  const finishedAt = await loadAuthoritativeFinishedAt(client, releasable);
+  if (!finishedAt) {
+    const err = new Error('REWORK_FINISHED_AT_REQUIRED');
+    err.status = 409;
     throw err;
   }
 
-  const idempotencyKey = releaseIdempotencyKey(reworkCaseId, technicianUsername);
-  const { target, period } = await resolveOpenTargetPeriod(client, finishedAt, actor);
-  const payoutId = period.payout_id;
+  const { target, period, rolled_forward_count } = await resolveOpenTargetPeriod(client, finishedAt, actor);
+  const releasedRows = [];
+  let total = 0;
 
-  const reason = `คืนรายได้เดิม จากงานแก้ไข rework_case_id=${reworkCaseId} job_id=${hold.job_id}`.slice(0, 1500);
-  const adj = await client.query(
-    `INSERT INTO public.technician_payout_adjustments(payout_id, technician_username, job_id, adj_amount, reason, created_by)
-     VALUES($1,$2,$3,$4,$5,$6)
-     RETURNING adj_id, payout_id, technician_username, job_id, adj_amount, reason, created_at, created_by`,
-    [payoutId, technicianUsername, String(hold.job_id), amount, reason, actor]
-  );
-  const adjustment = adj.rows[0];
+  for (const hold of releasable) {
+    const amount = money(hold.held_amount);
+    const key = releaseIdempotencyKey(reworkCaseId, hold.technician_username);
+    const adjustment = await insertAdjustment(client, {
+      payoutId: period.payout_id,
+      technicianUsername: hold.technician_username,
+      jobKey: adjustmentJobKey('release', reworkCaseId, hold.job_id),
+      amount,
+      reason: `${RELEASE_REASON_TAG} คืนรายได้เดิมหลังแก้งานสำเร็จ rework_case_id=${reworkCaseId} job_id=${hold.job_id}`,
+      actor,
+    });
 
-  const updated = await client.query(
-    `UPDATE public.technician_rework_income_holds
-        SET hold_status='released',
-            released_amount=$2,
-            release_payout_id=$3,
-            release_adjustment_id=$4,
-            release_idempotency_key=$5,
-            released_at=NOW(),
-            updated_at=NOW()
-      WHERE hold_id=$1
-      RETURNING *`,
-    [hold.hold_id, amount, payoutId, adjustment.adj_id, idempotencyKey]
-  );
+    const updated = await client.query(
+      `UPDATE public.technician_rework_income_holds
+          SET hold_status='released',
+              released_amount=$2,
+              release_payout_id=$3,
+              release_adjustment_id=$4,
+              release_idempotency_key=$5,
+              released_at=NOW(),
+              updated_at=NOW()
+        WHERE hold_id=$1 AND hold_status='held'
+        RETURNING *`,
+      [hold.hold_id, amount, period.payout_id, adjustment.adj_id, key]
+    );
 
-  const payment = await recalcPaymentStatus(client, payoutId, technicianUsername);
+    if (!updated.rows[0]) {
+      const err = new Error('REWORK_RELEASE_CONCURRENT_STATE_CHANGE');
+      err.status = 409;
+      throw err;
+    }
+
+    await recalcPaymentStatus(client, period.payout_id, hold.technician_username);
+    total = money(total + amount);
+    releasedRows.push({ row: updated.rows[0], adjustment });
+  }
+
+  const requested = releasedRows.find((item) => item.row.technician_username === requestedTech) || releasedRows[0];
   return {
-    released: true,
-    amount,
-    payout_id: payoutId,
+    released: releasedRows.length > 0,
+    amount: total,
+    payout_id: period.payout_id,
     period: target,
-    adjustment,
-    payment,
-    row: updated.rows[0],
+    rolled_forward_count,
+    rows: releasedRows.map((item) => item.row),
+    adjustments: releasedRows.map((item) => item.adjustment),
+    row: requested?.row || null,
+    adjustment: requested?.adjustment || null,
   };
 }
 
-/**
- * Mark a held amount as permanently void (rework failed / case voided / company
- * absorbed) — no money moves. If a negative adjustment was already created at
- * hold time (locked-period case), it stays in place, which is the correct
- * outcome since the original work was confirmed not payable.
- */
 async function voidHeldIncomeForReworkCase(client, opts = {}) {
   const reworkCaseId = Number(opts.reworkCaseId || 0);
-  const technicianUsername = String(opts.technicianUsername || '').trim();
-  if (!reworkCaseId || !technicianUsername) {
+  const requestedTech = String(opts.technicianUsername || '').trim();
+  if (!reworkCaseId || !requestedTech) {
     const err = new Error('INVALID_REWORK_VOID_INPUT');
     err.status = 400;
     throw err;
   }
-  const hold = await getExistingHold(client, reworkCaseId, technicianUsername);
-  if (!hold || hold.hold_status !== 'held') {
-    return { voided: false, row: hold || null };
-  }
-  const updated = await client.query(
-    `UPDATE public.technician_rework_income_holds SET hold_status='voided', updated_at=NOW() WHERE hold_id=$1 RETURNING *`,
-    [hold.hold_id]
+
+  const holds = await getHoldsForReworkCase(client, reworkCaseId, { forUpdate: true });
+  if (!holds.length) return { voided: false, rows: [] };
+  const q = await client.query(
+    `UPDATE public.technician_rework_income_holds
+        SET hold_status='voided', updated_at=NOW()
+      WHERE rework_case_id=$1 AND hold_status='held'
+      RETURNING *`,
+    [reworkCaseId]
   );
-  return { voided: true, row: updated.rows[0] };
+  const requested = (q.rows || []).find((row) => row.technician_username === requestedTech) || q.rows?.[0] || null;
+  return { voided: (q.rows || []).length > 0, rows: q.rows || [], row: requested };
 }
 
 async function getHoldForReworkCase(client, reworkCaseId, technicianUsername) {
-  const q = await client.query(
-    `SELECT * FROM public.technician_rework_income_holds WHERE rework_case_id=$1 AND technician_username=$2 LIMIT 1`,
-    [reworkCaseId, technicianUsername]
-  );
-  return q.rows[0] || null;
+  return getExistingHold(client, Number(reworkCaseId), String(technicianUsername || '').trim(), false);
 }
 
 module.exports = {
+  HOLD_REASON_TAG,
+  RELEASE_REASON_TAG,
   holdOriginalIncomeForReworkCase,
   releaseHeldIncomeForReworkCase,
   voidHeldIncomeForReworkCase,
   getHoldForReworkCase,
+  getHoldsForReworkCase,
   releaseIdempotencyKey,
+  adjustmentJobKey,
   money,
 };

--- a/server/services/technicianReworkIncome.js
+++ b/server/services/technicianReworkIncome.js
@@ -74,6 +74,22 @@ async function findExistingPeriodStatus(client, target) {
   return q.rows[0] ? String(q.rows[0].status || '').trim() : null;
 }
 
+// Loads the real period row a previous rework release actually landed in, by
+// its real payout_id — never recomputed from a date. A second rework round
+// must offset the prior round's release at the place it actually happened,
+// not at wherever payoutTargetForDate(originalFinishedAt) happens to point.
+async function loadPeriodByPayoutId(client, payoutId) {
+  if (!payoutId) return null;
+  const q = await client.query(
+    `SELECT payout_id, period_type, period_start, period_end, status
+       FROM public.technician_payout_periods
+      WHERE payout_id=$1
+      LIMIT 1`,
+    [payoutId]
+  );
+  return q.rows[0] || null;
+}
+
 async function resolveOpenTargetPeriodFromTarget(client, firstTarget, actor) {
   let target = firstTarget;
   for (let i = 0; i < 24; i += 1) {
@@ -194,16 +210,41 @@ async function loadOriginalIncomeCandidates(client, opts) {
 
   const previousReleased = await loadPreviousReleasedHoldRows(client, jobId, opts.reworkCaseId);
   if (previousReleased.length) {
-    rows = uniqueTechnicianRows(previousReleased.map((row) => ({
-      technician_username: row.technician_username,
-      amount: row.released_amount != null ? row.released_amount : row.held_amount,
-    })));
+    const byTech = new Map();
+    for (const hold of previousReleased) {
+      const tech = String(hold.technician_username || '').trim();
+      if (!tech) continue;
+      const heldAmount = money(hold.held_amount);
+      const releasedAmount = hold.released_amount != null ? money(hold.released_amount) : heldAmount;
+      // Invariant: a release can never exceed what was held. A violation here
+      // means the ledger is corrupt for this job — refuse to guess, 409 out.
+      if (releasedAmount > heldAmount + 0.0001) {
+        const err = new Error('PREVIOUS_HOLD_RELEASED_EXCEEDS_HELD');
+        err.status = 409;
+        throw err;
+      }
+      if (releasedAmount <= 0) continue;
+      if (!hold.release_payout_id) {
+        const err = new Error('PREVIOUS_RELEASE_PAYOUT_MISSING');
+        err.status = 409;
+        throw err;
+      }
+      byTech.set(tech, {
+        technician_username: tech,
+        amount: releasedAmount,
+        source_kind: 'previous_rework_release',
+        source_payout_id: hold.release_payout_id,
+        previous_rework_case_id: hold.rework_case_id,
+        previous_release_adjustment_id: hold.release_adjustment_id,
+      });
+    }
+    rows = [...byTech.values()];
   }
 
   if (!rows.length && Array.isArray(opts.originalIncomeRows) && opts.originalIncomeRows.length) {
     rows = uniqueTechnicianRows(
       opts.originalIncomeRows.filter((row) => Number(row?.job_id ?? jobId) === jobId)
-    );
+    ).map((row) => ({ ...row, source_kind: 'original_income' }));
   }
 
   if (!rows.length) {
@@ -216,7 +257,7 @@ async function loadOriginalIncomeCandidates(client, opts) {
           GROUP BY technician_username`,
         [String(jobId), sourceTarget.payout_id]
       );
-      rows = uniqueTechnicianRows(q.rows);
+      rows = uniqueTechnicianRows(q.rows).map((row) => ({ ...row, source_kind: 'original_income' }));
     } catch (_) {
       rows = [];
     }
@@ -226,10 +267,10 @@ async function loadOriginalIncomeCandidates(client, opts) {
     && !rows.some((row) => row.technician_username === preferredTech)
     && Number.isFinite(Number(opts.originalEarnAmount))
     && money(opts.originalEarnAmount) > 0) {
-    rows.push({ technician_username: preferredTech, amount: money(opts.originalEarnAmount) });
+    rows.push({ technician_username: preferredTech, amount: money(opts.originalEarnAmount), source_kind: 'original_income' });
   }
 
-  return { sourceTarget, rows: uniqueTechnicianRows(rows) };
+  return { sourceTarget, rows: rows.filter((row) => money(row.amount) > 0) };
 }
 
 async function insertAdjustment(client, params) {
@@ -250,11 +291,98 @@ async function insertAdjustment(client, params) {
   return q.rows[0];
 }
 
+// A hold sourced from a PRIOR rework round's already-released amount is
+// fundamentally different from a hold sourced from the job's original
+// (not-yet-paid-out) income: the prior release is a real, permanent
+// adjustment row that already exists in the ledger regardless of period
+// status, so it must ALWAYS be offset by an explicit negative adjustment —
+// there is no "draft period, nothing to do" shortcut here, unlike the
+// original-income path where a still-draft period simply never generates
+// the now-excluded gross line in the first place.
+async function createPreviousReleaseOffsetHold(client, opts, amount) {
+  if (amount <= 0) {
+    const q = await client.query(
+      `INSERT INTO public.technician_rework_income_holds
+        (rework_case_id, technician_username, job_id, held_amount, source_payout_id,
+         source_period_status_at_hold, hold_status, source_kind, previous_rework_case_id,
+         previous_release_adjustment_id, created_by)
+       VALUES($1,$2,$3,0,$4,$5,'already_paid_no_action',$6,$7,$8,$9)
+       RETURNING *`,
+      [
+        opts.reworkCaseId,
+        opts.technicianUsername,
+        opts.jobId,
+        opts.sourcePayoutId,
+        opts.sourcePeriod.status,
+        'previous_rework_release',
+        opts.previousReworkCaseId || null,
+        opts.previousReleaseAdjustmentId || null,
+        opts.actor,
+      ]
+    );
+    return { already_held: false, held: false, row: q.rows[0] };
+  }
+
+  const status = String(opts.sourcePeriod.status || '').trim();
+  let targetPayoutId = opts.sourcePayoutId;
+  let sourceStatusLabel = status;
+
+  if (status === 'locked' || status === 'paid') {
+    const nextTarget = nextPayoutTarget({ payout_id: opts.sourcePayoutId, period_type: opts.sourcePeriod.period_type });
+    const carried = await resolveOpenTargetPeriodFromTarget(client, nextTarget, opts.actor);
+    targetPayoutId = carried.period.payout_id;
+    sourceStatusLabel = `${status}_carried_forward:${targetPayoutId}`;
+  } else if (status !== 'draft') {
+    const err = new Error('PREVIOUS_RELEASE_PERIOD_STATUS_UNKNOWN');
+    err.status = 409;
+    throw err;
+  }
+
+  const holdAdjustment = await insertAdjustment(client, {
+    payoutId: targetPayoutId,
+    technicianUsername: opts.technicianUsername,
+    jobKey: adjustmentJobKey('hold', opts.reworkCaseId, opts.jobId),
+    amount: -amount,
+    reason: `${HOLD_REASON_TAG} หักล้างรายได้ที่คืนไปแล้วจาก rework รอบก่อน previous_rework_case_id=${opts.previousReworkCaseId} previous_release_adjustment_id=${opts.previousReleaseAdjustmentId} rework_case_id=${opts.reworkCaseId} job_id=${opts.jobId}`,
+    actor: opts.actor,
+  });
+  await recalcPaymentStatus(client, targetPayoutId, opts.technicianUsername);
+
+  const q = await client.query(
+    `INSERT INTO public.technician_rework_income_holds
+      (rework_case_id, technician_username, job_id, held_amount, source_payout_id,
+       source_period_status_at_hold, hold_adjustment_id, hold_status, source_kind,
+       previous_rework_case_id, previous_release_adjustment_id, created_by)
+     VALUES($1,$2,$3,$4,$5,$6,$7,'held',$8,$9,$10,$11)
+     RETURNING *`,
+    [
+      opts.reworkCaseId,
+      opts.technicianUsername,
+      opts.jobId,
+      amount,
+      opts.sourcePayoutId,
+      sourceStatusLabel,
+      holdAdjustment.adj_id,
+      'previous_rework_release',
+      opts.previousReworkCaseId || null,
+      opts.previousReleaseAdjustmentId || null,
+      opts.actor,
+    ]
+  );
+
+  return { already_held: false, held: true, hold_adjustment: holdAdjustment, row: q.rows[0] };
+}
+
 async function createOneHold(client, opts) {
   const existing = await getExistingHold(client, opts.reworkCaseId, opts.technicianUsername, true);
   if (existing) return { already_held: true, held: existing.hold_status === 'held', row: existing };
 
   const amount = money(opts.amount);
+
+  if (opts.sourceKind === 'previous_rework_release') {
+    return createPreviousReleaseOffsetHold(client, opts, amount);
+  }
+
   if (amount <= 0) {
     const q = await client.query(
       `INSERT INTO public.technician_rework_income_holds
@@ -362,15 +490,36 @@ async function holdOriginalIncomeForReworkCase(client, opts = {}) {
 
   const results = [];
   for (const candidate of rows) {
-    results.push(await createOneHold(client, {
-      reworkCaseId,
-      jobId,
-      technicianUsername: candidate.technician_username,
-      amount: candidate.amount,
-      sourceTarget,
-      sourcePeriodStatus,
-      actor,
-    }));
+    if (candidate.source_kind === 'previous_rework_release') {
+      const sourcePeriod = await loadPeriodByPayoutId(client, candidate.source_payout_id);
+      if (!sourcePeriod) {
+        const err = new Error('PREVIOUS_RELEASE_PERIOD_NOT_FOUND');
+        err.status = 409;
+        throw err;
+      }
+      results.push(await createOneHold(client, {
+        reworkCaseId,
+        jobId,
+        technicianUsername: candidate.technician_username,
+        amount: candidate.amount,
+        sourceKind: 'previous_rework_release',
+        sourcePayoutId: candidate.source_payout_id,
+        sourcePeriod,
+        previousReworkCaseId: candidate.previous_rework_case_id,
+        previousReleaseAdjustmentId: candidate.previous_release_adjustment_id,
+        actor,
+      }));
+    } else {
+      results.push(await createOneHold(client, {
+        reworkCaseId,
+        jobId,
+        technicianUsername: candidate.technician_username,
+        amount: candidate.amount,
+        sourceTarget,
+        sourcePeriodStatus,
+        actor,
+      }));
+    }
   }
 
   const persisted = await getHoldsForReworkCase(client, reworkCaseId, { forUpdate: false });

--- a/server/services/technicianReworkIncome.js
+++ b/server/services/technicianReworkIncome.js
@@ -38,7 +38,9 @@ function uniqueTechnicianRows(rows) {
     const amount = money(row?.amount ?? row?.earn_amount ?? row?.income_amount ?? 0);
     totals.set(tech, money((totals.get(tech) || 0) + amount));
   }
-  return [...totals.entries()].map(([technician_username, amount]) => ({ technician_username, amount }));
+  return [...totals.entries()]
+    .map(([technician_username, amount]) => ({ technician_username, amount }))
+    .filter((row) => row.amount > 0);
 }
 
 async function ensurePeriod(client, target, actor) {
@@ -157,6 +159,31 @@ async function getHoldsForReworkCase(client, reworkCaseId, opts = {}) {
   return q.rows || [];
 }
 
+async function loadPreviousReleasedHoldRows(client, jobId, excludeReworkCaseId) {
+  const q = await client.query(
+    `SELECT *
+       FROM public.technician_rework_income_holds
+      WHERE job_id=$1
+        AND hold_status='released'
+        AND rework_case_id<>$2
+      ORDER BY rework_case_id DESC, hold_id DESC`,
+    [jobId, Number(excludeReworkCaseId) || 0]
+  );
+  const rows = q.rows || [];
+  if (!rows.length) return [];
+  const latestCaseId = rows[0].rework_case_id;
+  return rows.filter((row) => Number(row.rework_case_id) === Number(latestCaseId));
+}
+
+// Source priority for "what did this technician originally earn on this job":
+//   1) the released-hold ledger from this job's most recent PRIOR rework case
+//      (a second rework round on the same job must reuse the amount that was
+//      already proven and paid out last time, never re-derive it from scratch)
+//   2) the caller-supplied originalIncomeRows (the full _buildPayoutLinesForJob
+//      result, captured by the caller BEFORE any new rework_case row exists)
+//   3) the persisted technician_payout_lines table for the source period
+// job_technician_income_preview is never used here — it is a UI-only estimate,
+// never an authoritative money source.
 async function loadOriginalIncomeCandidates(client, opts) {
   const jobId = Number(opts.jobId);
   const originalFinishedAt = opts.originalFinishedAt;
@@ -165,7 +192,15 @@ async function loadOriginalIncomeCandidates(client, opts) {
 
   let rows = [];
 
-  if (Array.isArray(opts.originalIncomeRows) && opts.originalIncomeRows.length) {
+  const previousReleased = await loadPreviousReleasedHoldRows(client, jobId, opts.reworkCaseId);
+  if (previousReleased.length) {
+    rows = uniqueTechnicianRows(previousReleased.map((row) => ({
+      technician_username: row.technician_username,
+      amount: row.released_amount != null ? row.released_amount : row.held_amount,
+    })));
+  }
+
+  if (!rows.length && Array.isArray(opts.originalIncomeRows) && opts.originalIncomeRows.length) {
     rows = uniqueTechnicianRows(
       opts.originalIncomeRows.filter((row) => Number(row?.job_id ?? jobId) === jobId)
     );

--- a/server/services/technicianReworkIncome.js
+++ b/server/services/technicianReworkIncome.js
@@ -1,0 +1,346 @@
+'use strict';
+
+const { createTechnicianDeductionPayoutApplyService } = require('./technicianDeductionPayoutApply');
+
+// Reuse the exact same Bangkok period-boundary math the deduction-adjustment
+// flow already uses in production, so rework hold/release and deduction
+// adjustments can never disagree about which payout period a date belongs to.
+const { payoutTargetForDate, nextPayoutTarget } = createTechnicianDeductionPayoutApplyService();
+
+function money(value) {
+  const n = Number(value || 0);
+  if (!Number.isFinite(n)) return 0;
+  return Math.round(n * 100) / 100;
+}
+
+function paidStatus(netAmount, paidAmount) {
+  const net = money(netAmount);
+  const paid = money(paidAmount);
+  if (net <= 0) return 'paid';
+  if (paid <= 0) return 'unpaid';
+  if (paid + 0.0001 >= net) return 'paid';
+  return 'partial';
+}
+
+function releaseIdempotencyKey(reworkCaseId, technicianUsername) {
+  return `rework_release:${reworkCaseId}:${String(technicianUsername || '').trim()}`;
+}
+
+async function ensurePeriod(client, target, actor) {
+  await client.query(
+    `INSERT INTO public.technician_payout_periods(payout_id, period_type, period_start, period_end, status, created_by)
+     VALUES($1,$2,$3,$4,'draft',$5)
+     ON CONFLICT (payout_id) DO NOTHING`,
+    [target.payout_id, target.period_type, target.period_start.toISOString(), target.period_end.toISOString(), actor || 'rework_income:auto']
+  );
+  const q = await client.query(
+    `SELECT payout_id, period_type, period_start, period_end, status
+       FROM public.technician_payout_periods
+      WHERE payout_id=$1
+      LIMIT 1`,
+    [target.payout_id]
+  );
+  return q.rows[0] || null;
+}
+
+async function findExistingPeriodStatus(client, target) {
+  const q = await client.query(
+    `SELECT status FROM public.technician_payout_periods WHERE payout_id=$1 LIMIT 1`,
+    [target.payout_id]
+  );
+  return q.rows[0] ? String(q.rows[0].status) : null;
+}
+
+// Mirrors technicianDeductionPayoutApply.resolveTargetPeriod: roll forward
+// past periods already marked 'paid' so we never insert a new line/adjustment
+// into a payout that has already been disbursed.
+async function resolveOpenTargetPeriod(client, fromDate, actor) {
+  let target = payoutTargetForDate(fromDate);
+  for (let i = 0; i < 24; i += 1) {
+    const period = await ensurePeriod(client, target, actor);
+    if (period && String(period.status || 'draft') !== 'paid') {
+      return { target, period, rolled_forward_count: i };
+    }
+    target = nextPayoutTarget(target);
+  }
+  const err = new Error('NO_OPEN_PAYOUT_PERIOD_FOR_REWORK_RELEASE');
+  err.status = 409;
+  throw err;
+}
+
+async function recalcPaymentStatus(client, payoutId, technicianUsername) {
+  // Mirrors technicianDeductionPayoutApply.recalcPaymentStatus exactly so both
+  // adjustment paths agree on net_amount/paid_status for the same payout+tech.
+  const q = await client.query(
+    `WITH gross AS (
+       SELECT COALESCE(SUM(earn_amount),0)::numeric AS gross_amount
+         FROM public.technician_payout_lines
+        WHERE payout_id=$1 AND technician_username=$2
+     ), adj AS (
+       SELECT COALESCE(SUM(adj_amount),0)::numeric AS adj_total
+         FROM public.technician_payout_adjustments
+        WHERE payout_id=$1 AND technician_username=$2
+     ), dep AS (
+       SELECT COALESCE(SUM(amount),0)::numeric AS deposit_deduction_amount
+         FROM public.technician_deposit_ledger
+        WHERE payout_id=$1 AND technician_username=$2 AND transaction_type='collect'
+     ), pay AS (
+       SELECT payment_id, COALESCE(paid_amount,0)::numeric AS paid_amount
+         FROM public.technician_payout_payments
+        WHERE payout_id=$1 AND technician_username=$2
+        LIMIT 1
+     )
+     SELECT (gross.gross_amount + adj.adj_total - dep.deposit_deduction_amount)::numeric AS net_amount,
+            COALESCE(pay.paid_amount,0)::numeric AS paid_amount,
+            pay.payment_id
+       FROM gross, adj, dep
+       LEFT JOIN pay ON TRUE`,
+    [payoutId, technicianUsername]
+  );
+  const row = q.rows[0] || { net_amount: 0, paid_amount: 0, payment_id: null };
+  if (row.payment_id) {
+    await client.query(
+      `UPDATE public.technician_payout_payments
+          SET paid_status=$3, updated_at=NOW()
+        WHERE payment_id=$1 AND payout_id=$2`,
+      [row.payment_id, payoutId, paidStatus(row.net_amount, row.paid_amount)]
+    );
+  }
+  return { net_amount: money(row.net_amount), paid_amount: money(row.paid_amount), paid_status: paidStatus(row.net_amount, row.paid_amount) };
+}
+
+async function getExistingHold(client, reworkCaseId, technicianUsername) {
+  const q = await client.query(
+    `SELECT * FROM public.technician_rework_income_holds
+      WHERE rework_case_id=$1 AND technician_username=$2
+      FOR UPDATE`,
+    [reworkCaseId, technicianUsername]
+  );
+  return q.rows[0] || null;
+}
+
+/**
+ * Pause the original technician's income for a job that is being sent to rework.
+ *
+ * `resolveOriginalEarnAmount(client)` must be supplied by the caller and return the
+ * ledger-grade earned amount for (jobId, technicianUsername) — e.g. an existing
+ * public.technician_payout_lines row if one was already cached, otherwise the same
+ * deterministic payout engine used to populate that table. Never pass a UI/preview
+ * display value here.
+ *
+ * Idempotent: calling this twice for the same (reworkCaseId, technicianUsername)
+ * is a no-op on the second call (invariant: one immutable hold row per case+tech).
+ */
+async function holdOriginalIncomeForReworkCase(client, opts = {}) {
+  const reworkCaseId = Number(opts.reworkCaseId || 0);
+  const jobId = Number(opts.jobId || 0);
+  const technicianUsername = String(opts.technicianUsername || '').trim();
+  const originalFinishedAt = opts.originalFinishedAt ? new Date(opts.originalFinishedAt) : null;
+  const actor = String(opts.actor || '').trim() || null;
+
+  if (!reworkCaseId || !jobId || !technicianUsername) {
+    const err = new Error('INVALID_REWORK_HOLD_INPUT');
+    err.status = 400;
+    throw err;
+  }
+
+  const existing = await getExistingHold(client, reworkCaseId, technicianUsername);
+  if (existing) {
+    return { already_held: true, row: existing };
+  }
+
+  if (!originalFinishedAt || Number.isNaN(originalFinishedAt.getTime())) {
+    // Job never had a finished_at (e.g. it was never completed before going to rework) —
+    // there is no original income to hold.
+    const ins = await client.query(
+      `INSERT INTO public.technician_rework_income_holds
+       (rework_case_id, technician_username, job_id, held_amount, source_payout_id, source_period_status_at_hold, hold_status, created_by)
+       VALUES ($1,$2,$3,0,NULL,'no_prior_finish','already_paid_no_action',$4)
+       RETURNING *`,
+      [reworkCaseId, technicianUsername, jobId, actor]
+    );
+    return { already_held: false, held: false, row: ins.rows[0] };
+  }
+
+  const amount = money(typeof opts.resolveOriginalEarnAmount === 'function'
+    ? await opts.resolveOriginalEarnAmount(client)
+    : opts.originalEarnAmount);
+
+  const target = payoutTargetForDate(originalFinishedAt);
+  const periodStatus = await findExistingPeriodStatus(client, target);
+
+  if (amount <= 0) {
+    const ins = await client.query(
+      `INSERT INTO public.technician_rework_income_holds
+       (rework_case_id, technician_username, job_id, held_amount, source_payout_id, source_period_status_at_hold, hold_status, created_by)
+       VALUES ($1,$2,$3,0,$4,$5,'already_paid_no_action',$6)
+       RETURNING *`,
+      [reworkCaseId, technicianUsername, jobId, target.payout_id, periodStatus || 'none', actor]
+    );
+    return { already_held: false, held: false, row: ins.rows[0] };
+  }
+
+  if (periodStatus === 'paid') {
+    // Already disbursed in a paid period: invariant 6 — do not touch, do not hold.
+    const ins = await client.query(
+      `INSERT INTO public.technician_rework_income_holds
+       (rework_case_id, technician_username, job_id, held_amount, source_payout_id, source_period_status_at_hold, hold_status, created_by)
+       VALUES ($1,$2,$3,$4,$5,'paid','already_paid_no_action',$6)
+       RETURNING *`,
+      [reworkCaseId, technicianUsername, jobId, amount, target.payout_id, actor]
+    );
+    return { already_held: false, held: false, row: ins.rows[0] };
+  }
+
+  let holdAdjustmentId = null;
+  if (periodStatus === 'locked') {
+    // Locked periods are frozen snapshots that will not be regenerated, so the
+    // original gross line will not naturally drop out once finished_at is cleared.
+    // Neutralize it now with a negative adjustment.
+    const reason = `พักรายได้เดิม งานแก้ไข rework_case_id=${reworkCaseId} job_id=${jobId}`.slice(0, 1500);
+    const adj = await client.query(
+      `INSERT INTO public.technician_payout_adjustments(payout_id, technician_username, job_id, adj_amount, reason, created_by)
+       VALUES($1,$2,$3,$4,$5,$6)
+       RETURNING adj_id`,
+      [target.payout_id, technicianUsername, String(jobId), -amount, reason, actor]
+    );
+    holdAdjustmentId = adj.rows[0].adj_id;
+    await recalcPaymentStatus(client, target.payout_id, technicianUsername);
+  }
+  // periodStatus === 'draft' or null (period not generated yet): no adjustment needed —
+  // clearing finished_at on the job means the gross line will not be (re)computed for
+  // this job until the rework outcome is known, so the income is already effectively paused.
+
+  const ins = await client.query(
+    `INSERT INTO public.technician_rework_income_holds
+     (rework_case_id, technician_username, job_id, held_amount, source_payout_id, source_period_status_at_hold, hold_adjustment_id, hold_status, created_by)
+     VALUES ($1,$2,$3,$4,$5,$6,$7,'held',$8)
+     RETURNING *`,
+    [reworkCaseId, technicianUsername, jobId, amount, target.payout_id, periodStatus || 'draft', holdAdjustmentId, actor]
+  );
+  return { already_held: false, held: true, row: ins.rows[0] };
+}
+
+/**
+ * Release a previously held amount back into the technician's payout once the
+ * rework case closes successfully. `finishedAt` must be the rework job's own
+ * finished_at (Asia/Bangkok 1-15 -> payout 25th same month, 16-end -> payout
+ * 10th next month). Idempotent: safe to call any number of times for the same
+ * (reworkCaseId, technicianUsername) — only the first call that finds
+ * hold_status='held' moves money; every call after that is a no-op.
+ */
+async function releaseHeldIncomeForReworkCase(client, opts = {}) {
+  const reworkCaseId = Number(opts.reworkCaseId || 0);
+  const technicianUsername = String(opts.technicianUsername || '').trim();
+  const finishedAt = opts.finishedAt ? new Date(opts.finishedAt) : null;
+  const actor = String(opts.actor || '').trim() || null;
+
+  if (!reworkCaseId || !technicianUsername) {
+    const err = new Error('INVALID_REWORK_RELEASE_INPUT');
+    err.status = 400;
+    throw err;
+  }
+
+  const hold = await getExistingHold(client, reworkCaseId, technicianUsername);
+  if (!hold) {
+    return { released: false, reason: 'NO_HOLD' };
+  }
+  if (hold.hold_status !== 'held') {
+    // Already released / already_paid_no_action / voided — idempotent no-op.
+    return { released: false, reason: hold.hold_status, row: hold };
+  }
+
+  const amount = money(hold.held_amount);
+  if (amount <= 0) {
+    await client.query(
+      `UPDATE public.technician_rework_income_holds SET hold_status='voided', updated_at=NOW() WHERE hold_id=$1`,
+      [hold.hold_id]
+    );
+    return { released: false, reason: 'ZERO_AMOUNT' };
+  }
+  if (!finishedAt || Number.isNaN(finishedAt.getTime())) {
+    const err = new Error('INVALID_FINISHED_AT_FOR_REWORK_RELEASE');
+    err.status = 400;
+    throw err;
+  }
+
+  const idempotencyKey = releaseIdempotencyKey(reworkCaseId, technicianUsername);
+  const { target, period } = await resolveOpenTargetPeriod(client, finishedAt, actor);
+  const payoutId = period.payout_id;
+
+  const reason = `คืนรายได้เดิม จากงานแก้ไข rework_case_id=${reworkCaseId} job_id=${hold.job_id}`.slice(0, 1500);
+  const adj = await client.query(
+    `INSERT INTO public.technician_payout_adjustments(payout_id, technician_username, job_id, adj_amount, reason, created_by)
+     VALUES($1,$2,$3,$4,$5,$6)
+     RETURNING adj_id, payout_id, technician_username, job_id, adj_amount, reason, created_at, created_by`,
+    [payoutId, technicianUsername, String(hold.job_id), amount, reason, actor]
+  );
+  const adjustment = adj.rows[0];
+
+  const updated = await client.query(
+    `UPDATE public.technician_rework_income_holds
+        SET hold_status='released',
+            released_amount=$2,
+            release_payout_id=$3,
+            release_adjustment_id=$4,
+            release_idempotency_key=$5,
+            released_at=NOW(),
+            updated_at=NOW()
+      WHERE hold_id=$1
+      RETURNING *`,
+    [hold.hold_id, amount, payoutId, adjustment.adj_id, idempotencyKey]
+  );
+
+  const payment = await recalcPaymentStatus(client, payoutId, technicianUsername);
+  return {
+    released: true,
+    amount,
+    payout_id: payoutId,
+    period: target,
+    adjustment,
+    payment,
+    row: updated.rows[0],
+  };
+}
+
+/**
+ * Mark a held amount as permanently void (rework failed / case voided / company
+ * absorbed) — no money moves. If a negative adjustment was already created at
+ * hold time (locked-period case), it stays in place, which is the correct
+ * outcome since the original work was confirmed not payable.
+ */
+async function voidHeldIncomeForReworkCase(client, opts = {}) {
+  const reworkCaseId = Number(opts.reworkCaseId || 0);
+  const technicianUsername = String(opts.technicianUsername || '').trim();
+  if (!reworkCaseId || !technicianUsername) {
+    const err = new Error('INVALID_REWORK_VOID_INPUT');
+    err.status = 400;
+    throw err;
+  }
+  const hold = await getExistingHold(client, reworkCaseId, technicianUsername);
+  if (!hold || hold.hold_status !== 'held') {
+    return { voided: false, row: hold || null };
+  }
+  const updated = await client.query(
+    `UPDATE public.technician_rework_income_holds SET hold_status='voided', updated_at=NOW() WHERE hold_id=$1 RETURNING *`,
+    [hold.hold_id]
+  );
+  return { voided: true, row: updated.rows[0] };
+}
+
+async function getHoldForReworkCase(client, reworkCaseId, technicianUsername) {
+  const q = await client.query(
+    `SELECT * FROM public.technician_rework_income_holds WHERE rework_case_id=$1 AND technician_username=$2 LIMIT 1`,
+    [reworkCaseId, technicianUsername]
+  );
+  return q.rows[0] || null;
+}
+
+module.exports = {
+  holdOriginalIncomeForReworkCase,
+  releaseHeldIncomeForReworkCase,
+  voidHeldIncomeForReworkCase,
+  getHoldForReworkCase,
+  releaseIdempotencyKey,
+  money,
+};

--- a/server/services/technicianReworkIncome.js
+++ b/server/services/technicianReworkIncome.js
@@ -76,7 +76,7 @@ async function resolveOpenTargetPeriodFromTarget(client, firstTarget, actor) {
   let target = firstTarget;
   for (let i = 0; i < 24; i += 1) {
     const period = await ensurePeriod(client, target, actor);
-    if (period && String(period.status || 'draft') !== 'paid') {
+    if (period && String(period.status || 'draft') === 'draft') {
       return { target, period, rolled_forward_count: i };
     }
     target = nextPayoutTarget(target);
@@ -164,29 +164,22 @@ async function loadOriginalIncomeCandidates(client, opts) {
   const sourceTarget = payoutTargetForDate(originalFinishedAt);
 
   let rows = [];
-  try {
-    const q = await client.query(
-      `SELECT technician_username, COALESCE(SUM(earn_amount),0)::numeric AS amount
-         FROM public.technician_payout_lines
-        WHERE job_id::text=$1::text
-          AND payout_id=$2
-        GROUP BY technician_username`,
-      [String(jobId), sourceTarget.payout_id]
+
+  if (Array.isArray(opts.originalIncomeRows) && opts.originalIncomeRows.length) {
+    rows = uniqueTechnicianRows(
+      opts.originalIncomeRows.filter((row) => Number(row?.job_id ?? jobId) === jobId)
     );
-    rows = uniqueTechnicianRows(q.rows);
-  } catch (_) {
-    rows = [];
   }
 
   if (!rows.length) {
     try {
       const q = await client.query(
-        `SELECT technician_username, income_amount AS amount
-           FROM public.job_technician_income_preview
-          WHERE job_id=$1
-            AND COALESCE(is_stale,FALSE)=FALSE
-            AND COALESCE(income_amount,0)>0`,
-        [jobId]
+        `SELECT technician_username, COALESCE(SUM(earn_amount),0)::numeric AS amount
+           FROM public.technician_payout_lines
+          WHERE job_id::text=$1::text
+            AND payout_id=$2
+          GROUP BY technician_username`,
+        [String(jobId), sourceTarget.payout_id]
       );
       rows = uniqueTechnicianRows(q.rows);
     } catch (_) {
@@ -194,11 +187,11 @@ async function loadOriginalIncomeCandidates(client, opts) {
     }
   }
 
-  if (preferredTech && !rows.some((row) => row.technician_username === preferredTech)) {
-    const amount = money(typeof opts.resolveOriginalEarnAmount === 'function'
-      ? await opts.resolveOriginalEarnAmount(client)
-      : opts.originalEarnAmount);
-    rows.push({ technician_username: preferredTech, amount });
+  if (preferredTech
+    && !rows.some((row) => row.technician_username === preferredTech)
+    && Number.isFinite(Number(opts.originalEarnAmount))
+    && money(opts.originalEarnAmount) > 0) {
+    rows.push({ technician_username: preferredTech, amount: money(opts.originalEarnAmount) });
   }
 
   return { sourceTarget, rows: uniqueTechnicianRows(rows) };
@@ -249,27 +242,17 @@ async function createOneHold(client, opts) {
   let holdAdjustment = null;
   let sourceStatus = opts.sourcePeriodStatus || 'draft';
 
-  if (opts.sourcePeriodStatus === 'locked') {
-    holdAdjustment = await insertAdjustment(client, {
-      payoutId: opts.sourceTarget.payout_id,
-      technicianUsername: opts.technicianUsername,
-      jobKey: adjustmentJobKey('hold', opts.reworkCaseId, opts.jobId),
-      amount: -amount,
-      reason: `${HOLD_REASON_TAG} พักรายได้เดิม งานแก้ไข rework_case_id=${opts.reworkCaseId} job_id=${opts.jobId}`,
-      actor: opts.actor,
-    });
-    await recalcPaymentStatus(client, holdAdjustment.payout_id, opts.technicianUsername);
-  } else if (opts.sourcePeriodStatus === 'paid') {
+  if (opts.sourcePeriodStatus === 'locked' || opts.sourcePeriodStatus === 'paid') {
     const carry = await resolveOpenTargetPeriodFromTarget(client, nextPayoutTarget(opts.sourceTarget), opts.actor);
     holdAdjustment = await insertAdjustment(client, {
       payoutId: carry.period.payout_id,
       technicianUsername: opts.technicianUsername,
       jobKey: adjustmentJobKey('hold', opts.reworkCaseId, opts.jobId),
       amount: -amount,
-      reason: `${HOLD_REASON_TAG} หักพักรายได้ย้อนหลังจากงวดที่จ่ายแล้ว source_payout=${opts.sourceTarget.payout_id} rework_case_id=${opts.reworkCaseId} job_id=${opts.jobId}`,
+      reason: `${HOLD_REASON_TAG} หักพักรายได้ย้อนหลังจากงวดที่${opts.sourcePeriodStatus === 'locked' ? 'ปิดงวดแล้ว' : 'จ่ายแล้ว'} source_payout=${opts.sourceTarget.payout_id} rework_case_id=${opts.reworkCaseId} job_id=${opts.jobId}`,
       actor: opts.actor,
     });
-    sourceStatus = `paid_carried_forward:${carry.period.payout_id}`;
+    sourceStatus = `${opts.sourcePeriodStatus}_carried_forward:${carry.period.payout_id}`;
     await recalcPaymentStatus(client, holdAdjustment.payout_id, opts.technicianUsername);
   }
 
@@ -333,6 +316,13 @@ async function holdOriginalIncomeForReworkCase(client, opts = {}) {
     originalFinishedAt,
     technicianUsername,
   });
+
+  if (!rows.length) {
+    const err = new Error('NO_AUTHORITATIVE_ORIGINAL_INCOME');
+    err.status = 409;
+    throw err;
+  }
+
   const sourcePeriodStatus = await findExistingPeriodStatus(client, sourceTarget);
 
   const results = [];
@@ -483,6 +473,17 @@ async function getHoldForReworkCase(client, reworkCaseId, technicianUsername) {
   return getExistingHold(client, Number(reworkCaseId), String(technicianUsername || '').trim(), false);
 }
 
+async function findActiveReworkCase(client, jobId) {
+  const q = await client.query(
+    `SELECT * FROM public.technician_rework_cases
+      WHERE job_id=$1 AND status IN ('open','in_progress')
+      ORDER BY created_at DESC, rework_case_id DESC
+      LIMIT 1`,
+    [Number(jobId)]
+  );
+  return q.rows[0] || null;
+}
+
 module.exports = {
   HOLD_REASON_TAG,
   RELEASE_REASON_TAG,
@@ -491,6 +492,7 @@ module.exports = {
   voidHeldIncomeForReworkCase,
   getHoldForReworkCase,
   getHoldsForReworkCase,
+  findActiveReworkCase,
   releaseIdempotencyKey,
   adjustmentJobKey,
   money,

--- a/server/technicianJobMoneySummary.js
+++ b/server/technicianJobMoneySummary.js
@@ -13,6 +13,7 @@ function createTechnicianJobMoneyHelpers(deps = {}) {
     money,
     technicianJobIncomeDisplayHelpers,
     technicianReworkHelpers,
+    technicianReworkIncome,
     getCustomerCollectAmountForTechJob,
     loadTechnicianIncomePreview,
     loadFinalizedTechPayoutLineForJob,
@@ -136,6 +137,25 @@ function createTechnicianJobMoneyHelpers(deps = {}) {
     return 0;
   }
 
+  // Real ledger amount for a rework case, read from public.technician_rework_income_holds
+  // (the immutable hold/release ledger) rather than any cached UI preview/display row.
+  // Falls back to the legacy preview-derived guess only for rework cases that predate
+  // the ledger (no hold row found).
+  async function _resolveReworkLedgerAmount(reworkCaseId, tech, existingDisplay, previewRow) {
+    const caseId = Number(reworkCaseId);
+    if (Number.isInteger(caseId) && caseId > 0 && technicianReworkIncome
+        && typeof technicianReworkIncome.getHoldForReworkCase === 'function') {
+      try {
+        const hold = await technicianReworkIncome.getHoldForReworkCase(pool, caseId, tech);
+        if (hold) {
+          if (hold.hold_status === 'released' && hold.released_amount != null) return toMoney(hold.released_amount);
+          if (hold.held_amount != null) return toMoney(hold.held_amount);
+        }
+      } catch (_) { /* fall through to legacy resolution below */ }
+    }
+    return _resolveHeldReworkAmount(existingDisplay, previewRow);
+  }
+
   async function _upsertDisplayRowForPreview(job_id, username, preview, source = 'preview', opts = {}) {
     const tech = String(username || '').trim();
     const jid = Number(job_id);
@@ -187,7 +207,7 @@ function createTechnicianJobMoneyHelpers(deps = {}) {
           const preview = typeof loadTechnicianIncomePreview === 'function'
             ? await loadTechnicianIncomePreview(jid, tech).catch(() => null)
             : null;
-          const heldAmount = _resolveHeldReworkAmount(existing, preview);
+          const heldAmount = await _resolveReworkLedgerAmount(reworkCase?.rework_case_id, tech, existing, preview);
           const reworkDisplay = technicianReworkHelpers.buildReworkDisplay(job, reworkCase, heldAmount);
           await technicianJobIncomeDisplayHelpers.upsertTechnicianJobIncomeDisplay(
             pool,
@@ -250,7 +270,7 @@ function createTechnicianJobMoneyHelpers(deps = {}) {
         const preview = typeof loadTechnicianIncomePreview === 'function'
           ? await loadTechnicianIncomePreview(job_id, tech).catch(() => null)
           : null;
-        const heldAmount = _resolveHeldReworkAmount(existing, preview);
+        const heldAmount = await _resolveReworkLedgerAmount(reworkCase?.rework_case_id, tech, existing, preview);
         const reworkDisplay = technicianReworkHelpers.buildReworkDisplay(job, reworkCase, heldAmount);
         const row = technicianJobIncomeDisplayHelpers.buildReworkDisplay(job, tech, reworkDisplay, context || 'history');
         try { await technicianJobIncomeDisplayHelpers.upsertTechnicianJobIncomeDisplay(pool, row); } catch (_) {}
@@ -452,7 +472,7 @@ function createTechnicianJobMoneyHelpers(deps = {}) {
         if (technicianReworkHelpers.detectReworkJob(job, reworkCase)) {
           const existing = _pickDisplayRowForContext(displayMap, jid, context || 'history');
           const preview = previewMap.get(key) || null;
-          const heldAmount = _resolveHeldReworkAmount(existing, preview);
+          const heldAmount = await _resolveReworkLedgerAmount(reworkCase?.rework_case_id, tech, existing, preview);
           const reworkDisplay = technicianReworkHelpers.buildReworkDisplay(job, reworkCase, heldAmount);
           const row = technicianJobIncomeDisplayHelpers.buildReworkDisplay(job, tech, reworkDisplay, context || 'history');
           try { await technicianJobIncomeDisplayHelpers.upsertTechnicianJobIncomeDisplay(pool, row); } catch (_) {}

--- a/test/auditReworkSyntheticKeys.test.js
+++ b/test/auditReworkSyntheticKeys.test.js
@@ -1,0 +1,26 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const SQL_PATH = path.join(__dirname, '..', 'scripts', 'audit-rework-case-CWFRXB5AYA.sql');
+
+// The duplicate-release smoke test and the payment-periods query must use the
+// exact same synthetic-key predicate as the main adjustment query, otherwise
+// they silently miss rework hold/release rows (whose job_id is a synthetic
+// string like rework_hold:<case_id>:<job_id>, not the literal job_id).
+test('audit script applies the synthetic-key predicate consistently to every adjustment query', () => {
+  const sql = fs.readFileSync(SQL_PATH, 'utf8');
+
+  const holdLikeCount = (sql.match(/a\.job_id::text LIKE 'rework_hold:%:'/g) || []).length;
+  const releaseLikeCount = (sql.match(/a\.job_id::text LIKE 'rework_release:%:'/g) || []).length;
+
+  // section 5 (main adjustment query), section 6 (duplicate-release smoke
+  // test), section 7 (payment-periods UNION) must each carry one copy.
+  assert.equal(holdLikeCount, 3);
+  assert.equal(releaseLikeCount, 3);
+
+  // No adjustments query should still use the plain jobs-join pattern that
+  // can't match synthetic job_id values.
+  assert.ok(!/JOIN public\.jobs j ON j\.job_id::text = a\.job_id::text/.test(sql));
+});

--- a/test/recoverLegacyReworkIncome.test.js
+++ b/test/recoverLegacyReworkIncome.test.js
@@ -1,0 +1,57 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { parseArgs, validateApply } = require('../scripts/recover-legacy-rework-income');
+
+test('parseArgs accepts both --key value and --key=value forms', () => {
+  const spaceForm = parseArgs(['node', 'script.js', '--booking-code', 'CWFRXB5AYA', '--technician', 'A2MKUNG', '--apply']);
+  assert.equal(spaceForm.bookingCode, 'CWFRXB5AYA');
+  assert.equal(spaceForm.technician, 'A2MKUNG');
+  assert.equal(spaceForm.apply, true);
+
+  const eqForm = parseArgs(['node', 'script.js', '--booking-code=CWFRXB5AYA', '--technician=A2MKUNG', '--apply']);
+  assert.equal(eqForm.bookingCode, 'CWFRXB5AYA');
+  assert.equal(eqForm.technician, 'A2MKUNG');
+  assert.equal(eqForm.apply, true);
+
+  const mixedForm = parseArgs(['node', 'script.js', '--booking-code=CWFRXB5AYA', '--technician', 'A2MKUNG']);
+  assert.equal(mixedForm.bookingCode, 'CWFRXB5AYA');
+  assert.equal(mixedForm.technician, 'A2MKUNG');
+});
+
+function baseReport(overrides = {}) {
+  return {
+    job: { finished_at: '2026-06-20T10:00:00+07:00' },
+    reworkCase: { resolution: 'fixed', revisit_result: null },
+    holds: [],
+    adjustments: [],
+    proposedAmount: 325,
+    sourcePayoutId: 'payout_2026-06_25',
+    sourcePeriodStatus: 'draft',
+    ...overrides,
+  };
+}
+
+function baseArgs(overrides = {}) {
+  return {
+    confirm: 'APPLY_LEGACY_REWORK_RECOVERY',
+    expectedAmount: '325',
+    technician: 'A2MKUNG',
+    ...overrides,
+  };
+}
+
+test('validateApply rejects a preview-only source, it is not an authoritative payout line', () => {
+  const report = baseReport({ sourcePeriodStatus: 'preview_only' });
+  assert.throws(() => validateApply(report, baseArgs()), /SOURCE_IS_PREVIEW_ONLY/);
+});
+
+test('validateApply accepts a real payout-line-backed draft source', () => {
+  const report = baseReport();
+  assert.equal(validateApply(report, baseArgs()), 325);
+});
+
+test('validateApply still rejects when there is no proposed amount at all', () => {
+  const report = baseReport({ proposedAmount: null, sourcePeriodStatus: null });
+  assert.throws(() => validateApply(report, baseArgs()), /SOURCE_AMOUNT_AMBIGUOUS/);
+});

--- a/test/technicianReworkIncome.test.js
+++ b/test/technicianReworkIncome.test.js
@@ -6,6 +6,7 @@ const {
   releaseHeldIncomeForReworkCase,
   voidHeldIncomeForReworkCase,
   getHoldsForReworkCase,
+  findActiveReworkCase,
 } = require('../server/services/technicianReworkIncome');
 
 class FakeClient {
@@ -16,8 +17,10 @@ class FakeClient {
     this.payoutLines = [];
     this.previews = [];
     this.jobs = new Map();
+    this.reworkCases = [];
     this.nextHoldId = 1;
     this.nextAdjId = 1;
+    this.nextCaseId = 1;
   }
 
   cloneRow(row) {
@@ -139,7 +142,21 @@ class FakeClient {
       return { rows };
     }
 
+    if (s.includes('FROM public.technician_rework_cases') && s.includes("status IN ('open','in_progress')")) {
+      const jobId = Number(params[0]);
+      const rows = this.reworkCases
+        .filter((r) => Number(r.job_id) === jobId && (r.status === 'open' || r.status === 'in_progress'))
+        .sort((a, b) => b.rework_case_id - a.rework_case_id);
+      return { rows: rows.length ? [this.cloneRow(rows[0])] : [] };
+    }
+
     throw new Error(`Unhandled SQL in FakeClient: ${s}`);
+  }
+
+  openCase(jobId, status = 'open') {
+    const row = { rework_case_id: this.nextCaseId++, job_id: jobId, status, created_at: new Date().toISOString() };
+    this.reworkCases.push(row);
+    return row;
   }
 }
 
@@ -248,4 +265,82 @@ test('duplicate hold call preserves the first immutable amount', async () => {
   const rows = await getHoldsForReworkCase(db, 1);
   assert.equal(rows.length, 1);
   assert.equal(rows[0].held_amount, 325);
+});
+
+test('locked source period rolls the hold forward into the next draft period', async () => {
+  const db = new FakeClient();
+  db.periods.set('payout_2026-06_25', { payout_id: 'payout_2026-06_25', status: 'locked', period_type: '25' });
+  await hold(db);
+  assert.equal(db.adjustments.length, 1);
+  assert.equal(db.adjustments[0].adj_amount, -325);
+  assert.equal(db.adjustments[0].payout_id, 'payout_2026-07_10');
+  const rows = await getHoldsForReworkCase(db, 1);
+  assert.match(rows[0].source_period_status_at_hold, /^locked_carried_forward:/);
+});
+
+test('release never lands in a locked or paid period, it rolls forward to the next draft', async () => {
+  const db = new FakeClient();
+  await hold(db);
+  db.jobs.set(10, { finished_at: '2026-06-20T10:00:00+07:00' });
+  db.periods.set('payout_2026-07_10', { payout_id: 'payout_2026-07_10', status: 'locked', period_type: '10' });
+  const result = await release(db);
+  assert.equal(result.released, true);
+  assert.equal(result.payout_id, 'payout_2026-07_25');
+});
+
+test('team job with no persisted payout_lines but with build rows holds every team member', async () => {
+  const db = new FakeClient();
+  const originalIncomeRows = [
+    { technician_username: 'TECH_A', amount: 200, job_id: 10 },
+    { technician_username: 'TECH_B', amount: 125, job_id: 10 },
+  ];
+  const held = await holdOriginalIncomeForReworkCase(db, {
+    reworkCaseId: 1,
+    jobId: 10,
+    technicianUsername: 'TECH_A',
+    originalFinishedAt: '2026-06-10T10:00:00+07:00',
+    originalEarnAmount: 200,
+    originalIncomeRows,
+    actor: 'test',
+  });
+  assert.equal(held.rows.length, 2);
+  const amounts = held.rows.map((r) => Number(r.held_amount)).sort();
+  assert.deepEqual(amounts, [125, 200]);
+});
+
+test('no authoritative original income rows results in a 409, no zero hold is created', async () => {
+  const db = new FakeClient();
+  await assert.rejects(
+    () => holdOriginalIncomeForReworkCase(db, {
+      reworkCaseId: 1,
+      jobId: 10,
+      technicianUsername: 'TECH_A',
+      originalFinishedAt: '2026-06-10T10:00:00+07:00',
+      actor: 'test',
+    }),
+    (error) => error.status === 409 && error.message === 'NO_AUTHORITATIVE_ORIGINAL_INCOME'
+  );
+  const rows = await getHoldsForReworkCase(db, 1);
+  assert.equal(rows.length, 0);
+});
+
+test('duplicate rework open does not create a second negative hold', async () => {
+  const db = new FakeClient();
+  db.periods.set('payout_2026-06_25', { payout_id: 'payout_2026-06_25', status: 'paid', period_type: '25' });
+
+  // First "open rework" attempt: no active case yet, so it proceeds and holds.
+  assert.equal(await findActiveReworkCase(db, 10), null);
+  db.openCase(10, 'open');
+  await hold(db, { caseId: 1, amount: 325 });
+
+  // Second "open rework" attempt on the same job: the guard must see the
+  // still-open case and refuse to create a second case/hold, mirroring the
+  // index.js route which throws a 409 at this exact point instead of
+  // proceeding to INSERT INTO technician_rework_cases.
+  const active = await findActiveReworkCase(db, 10);
+  assert.ok(active, 'second open attempt must observe the existing active case');
+  assert.equal(active.job_id, 10);
+
+  const negativeAdjustments = db.adjustments.filter((r) => r.adj_amount < 0);
+  assert.equal(negativeAdjustments.length, 1);
 });

--- a/test/technicianReworkIncome.test.js
+++ b/test/technicianReworkIncome.test.js
@@ -69,6 +69,15 @@ class FakeClient {
       return { rows };
     }
 
+    if (s.includes('FROM public.technician_rework_income_holds') && s.includes("hold_status='released'") && s.includes('rework_case_id<>$2')) {
+      const [jobId, excludeCaseId] = params;
+      const rows = this.holds
+        .filter((r) => Number(r.job_id) === Number(jobId) && r.hold_status === 'released' && Number(r.rework_case_id) !== Number(excludeCaseId))
+        .sort((a, b) => (b.rework_case_id - a.rework_case_id) || (b.hold_id - a.hold_id))
+        .map((r) => this.cloneRow(r));
+      return { rows };
+    }
+
     if (s.includes('FROM public.technician_payout_lines') && s.includes('GROUP BY technician_username')) {
       const [jobId, payoutId] = params;
       const totals = new Map();
@@ -343,4 +352,106 @@ test('duplicate rework open does not create a second negative hold', async () =>
 
   const negativeAdjustments = db.adjustments.filter((r) => r.adj_amount < 0);
   assert.equal(negativeAdjustments.length, 1);
+});
+
+test('originalIncomeRows with every technician at amount 0 results in 409 and no hold row', async () => {
+  const db = new FakeClient();
+  await assert.rejects(
+    () => holdOriginalIncomeForReworkCase(db, {
+      reworkCaseId: 1,
+      jobId: 10,
+      technicianUsername: 'TECH_A',
+      originalFinishedAt: '2026-06-10T10:00:00+07:00',
+      originalIncomeRows: [
+        { technician_username: 'TECH_A', amount: 0, job_id: 10 },
+        { technician_username: 'TECH_B', amount: 0, job_id: 10 },
+      ],
+      actor: 'test',
+    }),
+    (error) => error.status === 409 && error.message === 'NO_AUTHORITATIVE_ORIGINAL_INCOME'
+  );
+  const rows = await getHoldsForReworkCase(db, 1);
+  assert.equal(rows.length, 0);
+});
+
+test('first rework round on a job holds and releases 325 end to end', async () => {
+  const db = new FakeClient();
+  const held = await hold(db, { caseId: 1, amount: 325 });
+  assert.equal(held.rows.length, 1);
+  assert.equal(held.rows[0].held_amount, 325);
+
+  db.jobs.set(10, { finished_at: '2026-06-20T10:00:00+07:00' });
+  const released = await release(db, { caseId: 1 });
+  assert.equal(released.released, true);
+  assert.equal(released.amount, 325);
+});
+
+test('a second rework round on the same job reuses the prior released hold ledger, not the build rows', async () => {
+  const db = new FakeClient();
+
+  // Round 1: held and released for 325.
+  await hold(db, { caseId: 1, amount: 325 });
+  db.jobs.set(10, { finished_at: '2026-06-20T10:00:00+07:00' });
+  const round1Release = await release(db, { caseId: 1 });
+  assert.equal(round1Release.released, true);
+  assert.equal(round1Release.amount, 325);
+
+  // Round 2 on the same job: even though a (wrong) build amount and no
+  // payout_lines row are supplied, the previously-released ledger entry for
+  // this job must win — 325 from round 1, never 999 from originalEarnAmount
+  // and never job_technician_income_preview.
+  const round2Held = await holdOriginalIncomeForReworkCase(db, {
+    reworkCaseId: 2,
+    jobId: 10,
+    technicianUsername: 'A2MKUNG',
+    originalFinishedAt: '2026-07-01T10:00:00+07:00',
+    originalEarnAmount: 999,
+    actor: 'test',
+  });
+  assert.equal(round2Held.rows.length, 1);
+  assert.equal(round2Held.rows[0].held_amount, 325);
+});
+
+test('closing the second rework round releases 325 exactly once', async () => {
+  const db = new FakeClient();
+  await hold(db, { caseId: 1, amount: 325 });
+  db.jobs.set(10, { finished_at: '2026-06-20T10:00:00+07:00' });
+  await release(db, { caseId: 1 });
+
+  await holdOriginalIncomeForReworkCase(db, {
+    reworkCaseId: 2,
+    jobId: 10,
+    technicianUsername: 'A2MKUNG',
+    originalFinishedAt: '2026-07-01T10:00:00+07:00',
+    actor: 'test',
+  });
+  db.jobs.set(10, { finished_at: '2026-07-05T10:00:00+07:00' });
+  const round2Release = await release(db, { caseId: 2 });
+  assert.equal(round2Release.released, true);
+  assert.equal(round2Release.amount, 325);
+
+  const positiveAdjustments = db.adjustments.filter((r) => r.adj_amount > 0);
+  assert.equal(positiveAdjustments.length, 2); // one per round, never more
+});
+
+test('retrying the second rework round release does not pay twice', async () => {
+  const db = new FakeClient();
+  await hold(db, { caseId: 1, amount: 325 });
+  db.jobs.set(10, { finished_at: '2026-06-20T10:00:00+07:00' });
+  await release(db, { caseId: 1 });
+
+  await holdOriginalIncomeForReworkCase(db, {
+    reworkCaseId: 2,
+    jobId: 10,
+    technicianUsername: 'A2MKUNG',
+    originalFinishedAt: '2026-07-01T10:00:00+07:00',
+    actor: 'test',
+  });
+  db.jobs.set(10, { finished_at: '2026-07-05T10:00:00+07:00' });
+
+  assert.equal((await release(db, { caseId: 2 })).released, true);
+  assert.equal((await release(db, { caseId: 2 })).released, false);
+
+  const positiveForRound2 = db.adjustments.filter((r) => r.adj_amount > 0 && r.technician_username === 'A2MKUNG');
+  assert.equal(positiveForRound2.length, 2); // round1 release + round2 release, not 3
 });

--- a/test/technicianReworkIncome.test.js
+++ b/test/technicianReworkIncome.test.js
@@ -21,6 +21,7 @@ class FakeClient {
     this.nextHoldId = 1;
     this.nextAdjId = 1;
     this.nextCaseId = 1;
+    this.failNextAdjustmentInserts = 0;
   }
 
   cloneRow(row) {
@@ -93,6 +94,10 @@ class FakeClient {
     }
 
     if (s.startsWith('INSERT INTO public.technician_payout_adjustments')) {
+      if (this.failNextAdjustmentInserts > 0) {
+        this.failNextAdjustmentInserts -= 1;
+        throw new Error('SIMULATED_ADJUSTMENT_INSERT_FAILURE');
+      }
       const [payout_id, technician_username, job_id, adj_amount, reason, created_by] = params;
       const row = {
         adj_id: this.nextAdjId++, payout_id, technician_username, job_id,
@@ -104,7 +109,13 @@ class FakeClient {
 
     if (s.startsWith('INSERT INTO public.technician_rework_income_holds')) {
       let row;
-      if (params.length === 6) {
+      if (params.length === 9) {
+        const [rework_case_id, technician_username, job_id, source_payout_id, source_period_status_at_hold, source_kind, previous_rework_case_id, previous_release_adjustment_id, created_by] = params;
+        row = { rework_case_id, technician_username, job_id, held_amount: 0, source_payout_id, source_period_status_at_hold, hold_status: 'already_paid_no_action', source_kind, previous_rework_case_id, previous_release_adjustment_id, created_by };
+      } else if (params.length === 11) {
+        const [rework_case_id, technician_username, job_id, held_amount, source_payout_id, source_period_status_at_hold, hold_adjustment_id, source_kind, previous_rework_case_id, previous_release_adjustment_id, created_by] = params;
+        row = { rework_case_id, technician_username, job_id, held_amount: Number(held_amount), source_payout_id, source_period_status_at_hold, hold_adjustment_id, hold_status: 'held', source_kind, previous_rework_case_id, previous_release_adjustment_id, created_by };
+      } else if (params.length === 6) {
         const [rework_case_id, technician_username, job_id, source_payout_id, source_period_status_at_hold, created_by] = params;
         row = { rework_case_id, technician_username, job_id, held_amount: 0, source_payout_id, source_period_status_at_hold, hold_status: 'already_paid_no_action', created_by };
       } else if (params.length === 4) {
@@ -186,6 +197,16 @@ async function release(client, opts = {}) {
     technicianUsername: opts.tech || 'A2MKUNG',
     actor: 'test',
   });
+}
+
+// Net = every adjustment (hold negatives + release positives) ever posted for
+// this technician, across every period. After a chain of N rework rounds on
+// the same job ends in a successful close, this must equal the technician's
+// original one-time income for the job — never a multiple of it.
+function netForTechnician(db, tech) {
+  return db.adjustments
+    .filter((r) => r.technician_username === tech)
+    .reduce((sum, r) => sum + Number(r.adj_amount || 0), 0);
 }
 
 test('paid source is carried forward, then returned after successful rework', async () => {
@@ -454,4 +475,316 @@ test('retrying the second rework round release does not pay twice', async () => 
 
   const positiveForRound2 = db.adjustments.filter((r) => r.adj_amount > 0 && r.technician_username === 'A2MKUNG');
   assert.equal(positiveForRound2.length, 2); // round1 release + round2 release, not 3
+});
+
+test('round 1 net is exactly 325 (hold then release end to end)', async () => {
+  const db = new FakeClient();
+  await hold(db, { caseId: 1, amount: 325 });
+  db.jobs.set(10, { finished_at: '2026-06-20T10:00:00+07:00' });
+  await release(db, { caseId: 1 });
+  assert.equal(netForTechnician(db, 'A2MKUNG'), 325);
+});
+
+test('previous release still in a draft period: opening round 2 posts -325 into that same payout, net is 0 before close, +325 after, final net 325 (never 650)', async () => {
+  const db = new FakeClient();
+
+  await hold(db, { caseId: 1, amount: 325 });
+  db.jobs.set(10, { finished_at: '2026-06-20T10:00:00+07:00' });
+  const round1 = await release(db, { caseId: 1 });
+  assert.equal(round1.amount, 325);
+  assert.equal(db.periods.get(round1.payout_id).status, 'draft');
+  assert.equal(netForTechnician(db, 'A2MKUNG'), 325);
+
+  const round2 = await holdOriginalIncomeForReworkCase(db, {
+    reworkCaseId: 2,
+    jobId: 10,
+    technicianUsername: 'A2MKUNG',
+    originalFinishedAt: '2026-07-01T10:00:00+07:00',
+    actor: 'test',
+  });
+  assert.equal(round2.rows[0].held_amount, 325);
+  const negativeAdj = db.adjustments.find((r) => r.adj_amount === -325);
+  assert.ok(negativeAdj, 'opening round 2 must post a real -325 adjustment');
+  assert.equal(negativeAdj.payout_id, round1.payout_id, 'must offset in the exact payout the prior release landed in, since it is still draft');
+  assert.equal(netForTechnician(db, 'A2MKUNG'), 0, 'net must be 0 between the round-2 hold and its close');
+
+  db.jobs.set(10, { finished_at: '2026-07-05T10:00:00+07:00' });
+  const round2Release = await release(db, { caseId: 2 });
+  assert.equal(round2Release.amount, 325);
+  assert.equal(netForTechnician(db, 'A2MKUNG'), 325, 'final net must be 325, never 650');
+});
+
+test('previous release period was since locked: round 2 offset carries forward to the next draft period, never touching the locked period', async () => {
+  const db = new FakeClient();
+  await hold(db, { caseId: 1, amount: 325 });
+  db.jobs.set(10, { finished_at: '2026-06-20T10:00:00+07:00' });
+  const round1 = await release(db, { caseId: 1 });
+  const lockedPayoutId = round1.payout_id;
+
+  // The payroll period the round-1 release landed in has since been closed.
+  db.periods.get(lockedPayoutId).status = 'locked';
+
+  const round2 = await holdOriginalIncomeForReworkCase(db, {
+    reworkCaseId: 2,
+    jobId: 10,
+    technicianUsername: 'A2MKUNG',
+    originalFinishedAt: '2026-07-01T10:00:00+07:00',
+    actor: 'test',
+  });
+  assert.equal(round2.rows[0].held_amount, 325);
+  assert.match(round2.rows[0].source_period_status_at_hold, /^locked_carried_forward:/);
+
+  const negativeAdj = db.adjustments.find((r) => r.adj_amount === -325);
+  assert.ok(negativeAdj);
+  assert.notEqual(negativeAdj.payout_id, lockedPayoutId, 'must never write into the locked period');
+  assert.equal(db.periods.get(lockedPayoutId).status, 'locked', 'the locked period itself must be untouched');
+
+  db.jobs.set(10, { finished_at: '2026-07-20T10:00:00+07:00' });
+  const round2Release = await release(db, { caseId: 2 });
+  assert.equal(round2Release.amount, 325);
+  assert.equal(netForTechnician(db, 'A2MKUNG'), 325);
+});
+
+test('previous release period was since paid: round 2 offset carries forward to the next draft period, never touching the paid period', async () => {
+  const db = new FakeClient();
+  await hold(db, { caseId: 1, amount: 325 });
+  db.jobs.set(10, { finished_at: '2026-06-20T10:00:00+07:00' });
+  const round1 = await release(db, { caseId: 1 });
+  const paidPayoutId = round1.payout_id;
+
+  db.periods.get(paidPayoutId).status = 'paid';
+
+  const round2 = await holdOriginalIncomeForReworkCase(db, {
+    reworkCaseId: 2,
+    jobId: 10,
+    technicianUsername: 'A2MKUNG',
+    originalFinishedAt: '2026-07-01T10:00:00+07:00',
+    actor: 'test',
+  });
+  assert.equal(round2.rows[0].held_amount, 325);
+  assert.match(round2.rows[0].source_period_status_at_hold, /^paid_carried_forward:/);
+
+  const negativeAdj = db.adjustments.find((r) => r.adj_amount === -325);
+  assert.ok(negativeAdj);
+  assert.notEqual(negativeAdj.payout_id, paidPayoutId, 'must never write into the paid period');
+  assert.equal(db.periods.get(paidPayoutId).status, 'paid', 'the paid period itself must be untouched');
+
+  db.jobs.set(10, { finished_at: '2026-07-20T10:00:00+07:00' });
+  const round2Release = await release(db, { caseId: 2 });
+  assert.equal(round2Release.amount, 325);
+  assert.equal(netForTechnician(db, 'A2MKUNG'), 325);
+});
+
+test('round 2 closes into the same draft payout that holds its own negative offset: both rows present, net for the whole job still correct', async () => {
+  const db = new FakeClient();
+  await hold(db, { caseId: 1, amount: 325 });
+  db.jobs.set(10, { finished_at: '2026-06-20T10:00:00+07:00' });
+  const round1 = await release(db, { caseId: 1 });
+
+  await holdOriginalIncomeForReworkCase(db, {
+    reworkCaseId: 2,
+    jobId: 10,
+    technicianUsername: 'A2MKUNG',
+    originalFinishedAt: '2026-07-01T10:00:00+07:00',
+    actor: 'test',
+  });
+  // Same finished_at as round 1's release date, so round 2's own release
+  // lands in that exact same payout as its own negative offset.
+  db.jobs.set(10, { finished_at: '2026-06-20T10:00:00+07:00' });
+  const round2Release = await release(db, { caseId: 2 });
+
+  assert.equal(round2Release.payout_id, round1.payout_id);
+  const rowsInPayout = db.adjustments.filter((r) => r.payout_id === round1.payout_id && r.technician_username === 'A2MKUNG');
+  assert.equal(rowsInPayout.length, 3); // round1 +325, round2 -325, round2 +325
+  assert.equal(netForTechnician(db, 'A2MKUNG'), 325);
+});
+
+test('round 3 on the same job: the chain of hold/release/hold/release still nets to 325 exactly once', async () => {
+  const db = new FakeClient();
+  await hold(db, { caseId: 1, amount: 325 });
+  db.jobs.set(10, { finished_at: '2026-06-20T10:00:00+07:00' });
+  await release(db, { caseId: 1 });
+
+  await holdOriginalIncomeForReworkCase(db, {
+    reworkCaseId: 2, jobId: 10, technicianUsername: 'A2MKUNG',
+    originalFinishedAt: '2026-07-01T10:00:00+07:00', actor: 'test',
+  });
+  db.jobs.set(10, { finished_at: '2026-07-05T10:00:00+07:00' });
+  await release(db, { caseId: 2 });
+  assert.equal(netForTechnician(db, 'A2MKUNG'), 325);
+
+  const round3 = await holdOriginalIncomeForReworkCase(db, {
+    reworkCaseId: 3, jobId: 10, technicianUsername: 'A2MKUNG',
+    originalFinishedAt: '2026-07-10T10:00:00+07:00', actor: 'test',
+  });
+  assert.equal(round3.rows[0].held_amount, 325);
+  assert.equal(netForTechnician(db, 'A2MKUNG'), 0);
+
+  db.jobs.set(10, { finished_at: '2026-07-20T10:00:00+07:00' });
+  const round3Release = await release(db, { caseId: 3 });
+  assert.equal(round3Release.amount, 325);
+  assert.equal(netForTechnician(db, 'A2MKUNG'), 325, 'three full rework rounds must still net to 325, not 975');
+});
+
+test('team job (200 + 125): round 2 holds -200/-125 for the right technicians, closes +200/+125, total net stays 325', async () => {
+  const db = new FakeClient();
+  const originalIncomeRows = [
+    { technician_username: 'TECH_A', amount: 200, job_id: 10 },
+    { technician_username: 'TECH_B', amount: 125, job_id: 10 },
+  ];
+  await holdOriginalIncomeForReworkCase(db, {
+    reworkCaseId: 1, jobId: 10, technicianUsername: 'TECH_A',
+    originalFinishedAt: '2026-06-10T10:00:00+07:00', originalIncomeRows, actor: 'test',
+  });
+  db.jobs.set(10, { finished_at: '2026-06-20T10:00:00+07:00' });
+  await releaseHeldIncomeForReworkCase(db, { reworkCaseId: 1, technicianUsername: 'TECH_A', actor: 'test' });
+  assert.equal(netForTechnician(db, 'TECH_A'), 200);
+  assert.equal(netForTechnician(db, 'TECH_B'), 125);
+
+  const round2 = await holdOriginalIncomeForReworkCase(db, {
+    reworkCaseId: 2, jobId: 10, technicianUsername: 'TECH_A',
+    originalFinishedAt: '2026-07-01T10:00:00+07:00', actor: 'test',
+  });
+  const byTech = Object.fromEntries(round2.rows.map((r) => [r.technician_username, Number(r.held_amount)]));
+  assert.equal(byTech.TECH_A, 200);
+  assert.equal(byTech.TECH_B, 125);
+  const negA = db.adjustments.find((r) => r.technician_username === 'TECH_A' && r.adj_amount === -200);
+  const negB = db.adjustments.find((r) => r.technician_username === 'TECH_B' && r.adj_amount === -125);
+  assert.ok(negA);
+  assert.ok(negB);
+  assert.equal(netForTechnician(db, 'TECH_A'), 0);
+  assert.equal(netForTechnician(db, 'TECH_B'), 0);
+
+  db.jobs.set(10, { finished_at: '2026-07-05T10:00:00+07:00' });
+  const round2Release = await releaseHeldIncomeForReworkCase(db, { reworkCaseId: 2, technicianUsername: 'TECH_A', actor: 'test' });
+  assert.equal(round2Release.rows.length, 2);
+  assert.equal(netForTechnician(db, 'TECH_A'), 200);
+  assert.equal(netForTechnician(db, 'TECH_B'), 125);
+  assert.equal(netForTechnician(db, 'TECH_A') + netForTechnician(db, 'TECH_B'), 325);
+});
+
+test('retrying round-2 open 10 times posts exactly one negative adjustment per technician', async () => {
+  const db = new FakeClient();
+  await hold(db, { caseId: 1, amount: 325 });
+  db.jobs.set(10, { finished_at: '2026-06-20T10:00:00+07:00' });
+  await release(db, { caseId: 1 });
+
+  for (let i = 0; i < 10; i += 1) {
+    await holdOriginalIncomeForReworkCase(db, {
+      reworkCaseId: 2, jobId: 10, technicianUsername: 'A2MKUNG',
+      originalFinishedAt: '2026-07-01T10:00:00+07:00', actor: 'test',
+    });
+  }
+  const negatives = db.adjustments.filter((r) => r.adj_amount < 0 && r.technician_username === 'A2MKUNG');
+  assert.equal(negatives.length, 1);
+});
+
+test('retrying round-2 close 10 times posts exactly one positive adjustment per technician', async () => {
+  const db = new FakeClient();
+  await hold(db, { caseId: 1, amount: 325 });
+  db.jobs.set(10, { finished_at: '2026-06-20T10:00:00+07:00' });
+  await release(db, { caseId: 1 });
+  await holdOriginalIncomeForReworkCase(db, {
+    reworkCaseId: 2, jobId: 10, technicianUsername: 'A2MKUNG',
+    originalFinishedAt: '2026-07-01T10:00:00+07:00', actor: 'test',
+  });
+  db.jobs.set(10, { finished_at: '2026-07-05T10:00:00+07:00' });
+
+  for (let i = 0; i < 10; i += 1) {
+    await release(db, { caseId: 2 });
+  }
+  const positives = db.adjustments.filter((r) => r.adj_amount > 0 && r.technician_username === 'A2MKUNG');
+  assert.equal(positives.length, 2); // round1 release + round2 release, never more
+});
+
+test('a previously released hold missing release_payout_id (corrupt ledger) refuses to guess: 409 and no money movement', async () => {
+  const db = new FakeClient();
+  // Simulate legacy/corrupt data: a released hold with no recorded payout.
+  db.holds.push({
+    hold_id: db.nextHoldId++, rework_case_id: 1, technician_username: 'A2MKUNG', job_id: 10,
+    held_amount: 325, hold_status: 'released', released_amount: 325, release_payout_id: null,
+    release_adjustment_id: null,
+  });
+
+  await assert.rejects(
+    () => holdOriginalIncomeForReworkCase(db, {
+      reworkCaseId: 2, jobId: 10, technicianUsername: 'A2MKUNG',
+      originalFinishedAt: '2026-07-01T10:00:00+07:00', actor: 'test',
+    }),
+    (error) => error.status === 409 && error.message === 'PREVIOUS_RELEASE_PAYOUT_MISSING'
+  );
+  assert.equal((await getHoldsForReworkCase(db, 2)).length, 0);
+  assert.equal(db.adjustments.length, 0);
+});
+
+test('a previously released hold pointing at a payout period that no longer exists refuses to guess: 409 and rollback', async () => {
+  const db = new FakeClient();
+  db.holds.push({
+    hold_id: db.nextHoldId++, rework_case_id: 1, technician_username: 'A2MKUNG', job_id: 10,
+    held_amount: 325, hold_status: 'released', released_amount: 325,
+    release_payout_id: 'payout_does_not_exist', release_adjustment_id: 9999,
+  });
+
+  await assert.rejects(
+    () => holdOriginalIncomeForReworkCase(db, {
+      reworkCaseId: 2, jobId: 10, technicianUsername: 'A2MKUNG',
+      originalFinishedAt: '2026-07-01T10:00:00+07:00', actor: 'test',
+    }),
+    (error) => error.status === 409 && error.message === 'PREVIOUS_RELEASE_PERIOD_NOT_FOUND'
+  );
+  assert.equal((await getHoldsForReworkCase(db, 2)).length, 0);
+  assert.equal(db.adjustments.length, 0);
+});
+
+test('a previously released hold whose released_amount exceeds held_amount (corrupt ledger) is rejected, never trusted', async () => {
+  const db = new FakeClient();
+  db.holds.push({
+    hold_id: db.nextHoldId++, rework_case_id: 1, technician_username: 'A2MKUNG', job_id: 10,
+    held_amount: 100, hold_status: 'released', released_amount: 9999,
+    release_payout_id: 'payout_2026-07_10', release_adjustment_id: 1,
+  });
+
+  await assert.rejects(
+    () => holdOriginalIncomeForReworkCase(db, {
+      reworkCaseId: 2, jobId: 10, technicianUsername: 'A2MKUNG',
+      originalFinishedAt: '2026-07-01T10:00:00+07:00', actor: 'test',
+    }),
+    (error) => error.status === 409 && error.message === 'PREVIOUS_HOLD_RELEASED_EXCEEDS_HELD'
+  );
+  assert.equal((await getHoldsForReworkCase(db, 2)).length, 0);
+});
+
+test('if the round-2 offset adjustment insert fails, no hold row is left behind for that technician', async () => {
+  const db = new FakeClient();
+  await hold(db, { caseId: 1, amount: 325 });
+  db.jobs.set(10, { finished_at: '2026-06-20T10:00:00+07:00' });
+  await release(db, { caseId: 1 });
+
+  db.failNextAdjustmentInserts = 1;
+  await assert.rejects(
+    () => holdOriginalIncomeForReworkCase(db, {
+      reworkCaseId: 2, jobId: 10, technicianUsername: 'A2MKUNG',
+      originalFinishedAt: '2026-07-01T10:00:00+07:00', actor: 'test',
+    }),
+    (error) => error.message === 'SIMULATED_ADJUSTMENT_INSERT_FAILURE'
+  );
+  assert.equal((await getHoldsForReworkCase(db, 2)).length, 0, 'no hold row may exist when its offset adjustment never committed');
+});
+
+test('a previous released hold with a zero released_amount is ignored as a source, falling through to other authoritative sources', async () => {
+  const db = new FakeClient();
+  db.holds.push({
+    hold_id: db.nextHoldId++, rework_case_id: 1, technician_username: 'A2MKUNG', job_id: 10,
+    held_amount: 0, hold_status: 'released', released_amount: 0,
+    release_payout_id: 'payout_2026-07_10', release_adjustment_id: 1,
+  });
+
+  await assert.rejects(
+    () => holdOriginalIncomeForReworkCase(db, {
+      reworkCaseId: 2, jobId: 10, technicianUsername: 'A2MKUNG',
+      originalFinishedAt: '2026-07-01T10:00:00+07:00', actor: 'test',
+    }),
+    (error) => error.status === 409 && error.message === 'NO_AUTHORITATIVE_ORIGINAL_INCOME'
+  );
+  assert.equal((await getHoldsForReworkCase(db, 2)).length, 0);
 });

--- a/test/technicianReworkIncome.test.js
+++ b/test/technicianReworkIncome.test.js
@@ -1,405 +1,251 @@
-const test = require("node:test");
-const assert = require("node:assert/strict");
-const { Pool } = require("pg");
+const test = require('node:test');
+const assert = require('node:assert/strict');
 
 const {
   holdOriginalIncomeForReworkCase,
   releaseHeldIncomeForReworkCase,
   voidHeldIncomeForReworkCase,
-  getHoldForReworkCase,
-  releaseIdempotencyKey,
-} = require("../server/services/technicianReworkIncome");
+  getHoldsForReworkCase,
+} = require('../server/services/technicianReworkIncome');
 
-const PG_CONFIG = {
-  host: process.env.PGHOST || "127.0.0.1",
-  port: Number(process.env.PGPORT || 5432),
-  user: process.env.PGUSER || "postgres",
-  password: process.env.PGPASSWORD || "postgres",
-  database: process.env.PGDATABASE || "cwf_test",
-};
-
-let pool;
-let adminPool;
-let testDatabaseName = "";
-let dbUnavailableReason = "";
-let nextJobId = 1;
-let nextCaseId = 1;
-
-test.before(async () => {
-  testDatabaseName = `cwf_rework_income_${process.pid}_${Date.now()}`.toLowerCase();
-  adminPool = new Pool({ ...PG_CONFIG, database: process.env.PGMAINTENANCEDATABASE || "postgres" });
-  try {
-    await adminPool.query("SELECT 1");
-    await adminPool.query(`CREATE DATABASE ${testDatabaseName} ENCODING 'UTF8'`);
-  } catch (e) {
-    dbUnavailableReason = e.message || "Postgres test database is unavailable";
-    await adminPool.end().catch(() => {});
-    adminPool = null;
-    return;
+class FakeClient {
+  constructor() {
+    this.periods = new Map();
+    this.holds = [];
+    this.adjustments = [];
+    this.payoutLines = [];
+    this.previews = [];
+    this.jobs = new Map();
+    this.nextHoldId = 1;
+    this.nextAdjId = 1;
   }
 
-  pool = new Pool({ ...PG_CONFIG, database: testDatabaseName });
-
-  await pool.query(`CREATE TABLE public.jobs (job_id BIGSERIAL PRIMARY KEY)`);
-
-  await pool.query(`
-    CREATE TABLE public.technician_rework_cases (
-      rework_case_id BIGSERIAL PRIMARY KEY,
-      job_id BIGINT NOT NULL REFERENCES public.jobs(job_id),
-      technician_username TEXT
-    )
-  `);
-
-  await pool.query(`
-    CREATE TABLE public.technician_payout_periods (
-      payout_id TEXT PRIMARY KEY,
-      period_type TEXT NOT NULL,
-      period_start TIMESTAMPTZ NOT NULL,
-      period_end TIMESTAMPTZ NOT NULL,
-      status TEXT NOT NULL DEFAULT 'draft',
-      created_by TEXT
-    )
-  `);
-
-  await pool.query(`
-    CREATE TABLE public.technician_payout_lines (
-      line_id BIGSERIAL PRIMARY KEY,
-      payout_id TEXT NOT NULL,
-      technician_username TEXT NOT NULL,
-      job_id TEXT,
-      earn_amount NUMERIC(12,2) NOT NULL DEFAULT 0
-    )
-  `);
-
-  await pool.query(`
-    CREATE TABLE public.technician_payout_adjustments (
-      adj_id BIGSERIAL PRIMARY KEY,
-      payout_id TEXT NOT NULL,
-      technician_username TEXT NOT NULL,
-      job_id TEXT,
-      adj_amount NUMERIC(12,2) NOT NULL,
-      reason TEXT,
-      created_by TEXT,
-      created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
-    )
-  `);
-
-  await pool.query(`
-    CREATE TABLE public.technician_deposit_ledger (
-      ledger_id BIGSERIAL PRIMARY KEY,
-      payout_id TEXT NOT NULL,
-      technician_username TEXT NOT NULL,
-      amount NUMERIC(12,2) NOT NULL DEFAULT 0,
-      transaction_type TEXT NOT NULL
-    )
-  `);
-
-  await pool.query(`
-    CREATE TABLE public.technician_payout_payments (
-      payment_id BIGSERIAL PRIMARY KEY,
-      payout_id TEXT NOT NULL,
-      technician_username TEXT NOT NULL,
-      paid_amount NUMERIC(12,2) NOT NULL DEFAULT 0,
-      paid_status TEXT NOT NULL DEFAULT 'unpaid',
-      updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
-    )
-  `);
-
-  await pool.query(`
-    CREATE TABLE public.technician_rework_income_holds (
-      hold_id BIGSERIAL PRIMARY KEY,
-      rework_case_id BIGINT NOT NULL REFERENCES public.technician_rework_cases(rework_case_id) ON DELETE CASCADE,
-      technician_username TEXT NOT NULL,
-      job_id BIGINT NOT NULL REFERENCES public.jobs(job_id) ON DELETE CASCADE,
-
-      held_amount NUMERIC(12,2) NOT NULL DEFAULT 0 CHECK (held_amount >= 0),
-      source_payout_id TEXT,
-      source_period_status_at_hold TEXT,
-      hold_adjustment_id BIGINT REFERENCES public.technician_payout_adjustments(adj_id) ON DELETE SET NULL,
-
-      hold_status TEXT NOT NULL DEFAULT 'held' CHECK (hold_status IN (
-        'held','already_paid_no_action','released','voided'
-      )),
-
-      released_amount NUMERIC(12,2) CHECK (released_amount IS NULL OR released_amount >= 0),
-      release_payout_id TEXT,
-      release_adjustment_id BIGINT REFERENCES public.technician_payout_adjustments(adj_id) ON DELETE SET NULL,
-      release_idempotency_key TEXT,
-      released_at TIMESTAMPTZ,
-
-      created_by TEXT,
-      created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-      updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-
-      UNIQUE (rework_case_id, technician_username),
-      CHECK (released_amount IS NULL OR released_amount <= held_amount)
-    )
-  `);
-  await pool.query(`
-    CREATE UNIQUE INDEX uq_trih_release_idempotency_key
-      ON public.technician_rework_income_holds(release_idempotency_key)
-      WHERE release_idempotency_key IS NOT NULL
-  `);
-});
-
-test.after(async () => {
-  if (pool) {
-    pool.on("error", () => {}); // swallow teardown noise from sockets still closing when pool.end() resolves
-    await pool.end();
+  cloneRow(row) {
+    return row ? { ...row } : row;
   }
-  if (adminPool && testDatabaseName) {
-    await adminPool.query(`DROP DATABASE IF EXISTS ${testDatabaseName}`).catch(() => {});
-    await adminPool.end().catch(() => {});
-  }
-});
 
-test.beforeEach(async (t) => {
-  if (dbUnavailableReason) {
-    t.skip(`Postgres integration database unavailable: ${dbUnavailableReason}`);
-    return;
-  }
-  await pool.query("DELETE FROM public.technician_rework_income_holds");
-  await pool.query("DELETE FROM public.technician_payout_payments");
-  await pool.query("DELETE FROM public.technician_deposit_ledger");
-  await pool.query("DELETE FROM public.technician_payout_adjustments");
-  await pool.query("DELETE FROM public.technician_payout_lines");
-  await pool.query("DELETE FROM public.technician_payout_periods");
-  await pool.query("DELETE FROM public.technician_rework_cases");
-  await pool.query("DELETE FROM public.jobs");
-});
+  async query(sql, params = []) {
+    const s = String(sql).replace(/\s+/g, ' ').trim();
 
-function dbTest(name, fn) {
-  test(name, async (t) => {
-    if (dbUnavailableReason) return t.skip(`Postgres integration database unavailable: ${dbUnavailableReason}`);
-    return fn(t);
+    if (s.startsWith('INSERT INTO public.technician_payout_periods')) {
+      const [payout_id, period_type, period_start, period_end, created_by] = params;
+      if (!this.periods.has(payout_id)) {
+        this.periods.set(payout_id, { payout_id, period_type, period_start, period_end, status: 'draft', created_by });
+      }
+      return { rows: [] };
+    }
+
+    if (s.includes('SELECT payout_id, period_type, period_start, period_end, status') && s.includes('FROM public.technician_payout_periods')) {
+      const row = this.periods.get(params[0]);
+      return { rows: row ? [this.cloneRow(row)] : [] };
+    }
+
+    if (s.startsWith('SELECT status FROM public.technician_payout_periods')) {
+      const row = this.periods.get(params[0]);
+      return { rows: row ? [{ status: row.status }] : [] };
+    }
+
+    if (s.startsWith('WITH gross AS')) {
+      const [payoutId, tech] = params;
+      const gross = this.payoutLines.filter((r) => r.payout_id === payoutId && r.technician_username === tech)
+        .reduce((sum, r) => sum + Number(r.earn_amount || 0), 0);
+      const adj = this.adjustments.filter((r) => r.payout_id === payoutId && r.technician_username === tech)
+        .reduce((sum, r) => sum + Number(r.adj_amount || 0), 0);
+      return { rows: [{ net_amount: gross + adj, paid_amount: 0, payment_id: null }] };
+    }
+
+    if (s.startsWith('UPDATE public.technician_payout_payments')) return { rows: [] };
+
+    if (s.includes('FROM public.technician_rework_income_holds') && s.includes('rework_case_id=$1 AND technician_username=$2')) {
+      const row = this.holds.find((r) => Number(r.rework_case_id) === Number(params[0]) && r.technician_username === params[1]);
+      return { rows: row ? [this.cloneRow(row)] : [] };
+    }
+
+    if (s.includes('FROM public.technician_rework_income_holds') && s.includes('WHERE rework_case_id=$1') && !s.includes('technician_username=$2')) {
+      const rows = this.holds.filter((r) => Number(r.rework_case_id) === Number(params[0])).map((r) => this.cloneRow(r));
+      return { rows };
+    }
+
+    if (s.includes('FROM public.technician_payout_lines') && s.includes('GROUP BY technician_username')) {
+      const [jobId, payoutId] = params;
+      const totals = new Map();
+      for (const row of this.payoutLines.filter((r) => String(r.job_id) === String(jobId) && r.payout_id === payoutId)) {
+        totals.set(row.technician_username, (totals.get(row.technician_username) || 0) + Number(row.earn_amount || 0));
+      }
+      return { rows: [...totals].map(([technician_username, amount]) => ({ technician_username, amount })) };
+    }
+
+    if (s.includes('FROM public.job_technician_income_preview')) {
+      const rows = this.previews.filter((r) => Number(r.job_id) === Number(params[0]) && !r.is_stale && Number(r.income_amount) > 0);
+      return { rows: rows.map((r) => ({ technician_username: r.technician_username, amount: r.income_amount })) };
+    }
+
+    if (s.startsWith('INSERT INTO public.technician_payout_adjustments')) {
+      const [payout_id, technician_username, job_id, adj_amount, reason, created_by] = params;
+      const row = {
+        adj_id: this.nextAdjId++, payout_id, technician_username, job_id,
+        adj_amount: Number(adj_amount), reason, created_by, created_at: new Date().toISOString(),
+      };
+      this.adjustments.push(row);
+      return { rows: [this.cloneRow(row)] };
+    }
+
+    if (s.startsWith('INSERT INTO public.technician_rework_income_holds')) {
+      let row;
+      if (params.length === 6) {
+        const [rework_case_id, technician_username, job_id, source_payout_id, source_period_status_at_hold, created_by] = params;
+        row = { rework_case_id, technician_username, job_id, held_amount: 0, source_payout_id, source_period_status_at_hold, hold_status: 'already_paid_no_action', created_by };
+      } else if (params.length === 4) {
+        const [rework_case_id, technician_username, job_id, created_by] = params;
+        row = { rework_case_id, technician_username, job_id, held_amount: 0, source_payout_id: null, source_period_status_at_hold: 'no_prior_finish', hold_status: 'already_paid_no_action', created_by };
+      } else {
+        const [rework_case_id, technician_username, job_id, held_amount, source_payout_id, source_period_status_at_hold, hold_adjustment_id, created_by] = params;
+        row = { rework_case_id, technician_username, job_id, held_amount: Number(held_amount), source_payout_id, source_period_status_at_hold, hold_adjustment_id, hold_status: 'held', created_by };
+      }
+      row.hold_id = this.nextHoldId++;
+      row.released_amount = null;
+      row.release_payout_id = null;
+      row.release_adjustment_id = null;
+      row.release_idempotency_key = null;
+      this.holds.push(row);
+      return { rows: [this.cloneRow(row)] };
+    }
+
+    if (s.includes('FROM public.jobs') && s.includes('job_id = ANY')) {
+      const ids = params[0].map(Number);
+      return { rows: ids.filter((id) => this.jobs.has(id)).map((id) => ({ job_id: id, finished_at: this.jobs.get(id).finished_at })) };
+    }
+
+    if (s.startsWith('UPDATE public.technician_rework_income_holds') && s.includes("SET hold_status='released'")) {
+      const [holdId, amount, payoutId, adjId, key] = params;
+      const row = this.holds.find((r) => Number(r.hold_id) === Number(holdId) && r.hold_status === 'held');
+      if (!row) return { rows: [] };
+      Object.assign(row, {
+        hold_status: 'released', released_amount: Number(amount), release_payout_id: payoutId,
+        release_adjustment_id: adjId, release_idempotency_key: key, released_at: new Date().toISOString(),
+      });
+      return { rows: [this.cloneRow(row)] };
+    }
+
+    if (s.startsWith('UPDATE public.technician_rework_income_holds') && s.includes("SET hold_status='voided'")) {
+      const caseId = Number(params[0]);
+      const rows = [];
+      for (const row of this.holds) {
+        if (Number(row.rework_case_id) === caseId && row.hold_status === 'held') {
+          row.hold_status = 'voided';
+          rows.push(this.cloneRow(row));
+        }
+      }
+      return { rows };
+    }
+
+    throw new Error(`Unhandled SQL in FakeClient: ${s}`);
+  }
+}
+
+async function hold(client, opts = {}) {
+  return holdOriginalIncomeForReworkCase(client, {
+    reworkCaseId: opts.caseId || 1,
+    jobId: opts.jobId || 10,
+    technicianUsername: opts.tech || 'A2MKUNG',
+    originalFinishedAt: opts.originalFinishedAt || '2026-06-10T10:00:00+07:00',
+    originalEarnAmount: opts.amount ?? 325,
+    actor: 'test',
   });
 }
 
-// Mirrors how every production route calls these functions: connect a client,
-// BEGIN, run the operation, COMMIT on success / ROLLBACK on failure. Calling the
-// service functions directly against `pool` (no transaction) would let a later
-// statement fail after an earlier one in the same call already autocommitted,
-// which is not how the real code paths behave.
-async function withTransaction(fn) {
-  const client = await pool.connect();
-  try {
-    await client.query("BEGIN");
-    const result = await fn(client);
-    await client.query("COMMIT");
-    return result;
-  } catch (e) {
-    await client.query("ROLLBACK").catch(() => {});
-    throw e;
-  } finally {
-    client.release();
-  }
+async function release(client, opts = {}) {
+  return releaseHeldIncomeForReworkCase(client, {
+    reworkCaseId: opts.caseId || 1,
+    technicianUsername: opts.tech || 'A2MKUNG',
+    actor: 'test',
+  });
 }
 
-async function makeJobAndCase(technicianUsername) {
-  const jr = await pool.query(`INSERT INTO public.jobs DEFAULT VALUES RETURNING job_id`);
-  const jobId = Number(jr.rows[0].job_id);
-  const cr = await pool.query(
-    `INSERT INTO public.technician_rework_cases (job_id, technician_username) VALUES ($1,$2) RETURNING rework_case_id`,
-    [jobId, technicianUsername]
-  );
-  return { jobId, reworkCaseId: Number(cr.rows[0].rework_case_id) };
-}
-
-dbTest("holds then releases the original technician's income exactly once into the correct period", async () => {
-  const tech = "A2MKUNG";
-  const { jobId, reworkCaseId } = await makeJobAndCase(tech);
-
-  const holdResult = await withTransaction((client) => holdOriginalIncomeForReworkCase(client, {
-    reworkCaseId,
-    jobId,
-    technicianUsername: tech,
-    originalFinishedAt: new Date("2026-06-10T10:00:00+07:00"),
-    originalEarnAmount: 325,
-    actor: "test",
-  }));
-  assert.equal(holdResult.held, true);
-  assert.equal(Number(holdResult.row.held_amount), 325);
-
-  const finishedAt = new Date("2026-06-20T10:00:00+07:00");
-  const release1 = await withTransaction((client) => releaseHeldIncomeForReworkCase(client, { reworkCaseId, technicianUsername: tech, finishedAt, actor: "test" }));
-  assert.equal(release1.released, true);
-  assert.equal(release1.amount, 325);
-  assert.equal(release1.payout_id, "payout_2026-07_10");
-
-  const release2 = await withTransaction((client) => releaseHeldIncomeForReworkCase(client, { reworkCaseId, technicianUsername: tech, finishedAt, actor: "test" }));
-  assert.equal(release2.released, false);
-  assert.equal(release2.reason, "released");
-
-  const adjCount = await pool.query(
-    `SELECT COUNT(*)::int AS n FROM public.technician_payout_adjustments WHERE payout_id=$1 AND technician_username=$2 AND adj_amount > 0`,
-    [release1.payout_id, tech]
-  );
-  assert.equal(adjCount.rows[0].n, 1, "exactly one positive release adjustment must exist no matter how many times release is called");
-
-  const hold = await getHoldForReworkCase(pool, reworkCaseId, tech);
-  assert.equal(hold.hold_status, "released");
-  assert.equal(Number(hold.released_amount), 325);
-  assert.equal(hold.release_idempotency_key, releaseIdempotencyKey(reworkCaseId, tech));
+test('paid source is carried forward, then returned after successful rework', async () => {
+  const db = new FakeClient();
+  db.periods.set('payout_2026-06_25', { payout_id: 'payout_2026-06_25', status: 'paid', period_type: '25' });
+  await hold(db);
+  assert.equal(db.adjustments.length, 1);
+  assert.equal(db.adjustments[0].adj_amount, -325);
+  assert.match(db.adjustments[0].reason, /\[REWORK_HOLD\]/);
+  db.jobs.set(10, { finished_at: '2026-06-20T10:00:00+07:00' });
+  const result = await release(db);
+  assert.equal(result.released, true);
+  assert.equal(result.amount, 325);
+  assert.equal(result.payout_id, 'payout_2026-07_10');
+  assert.equal(db.adjustments.filter((r) => r.adj_amount > 0).length, 1);
 });
 
-dbTest("releasing 10 times concurrently only moves money once", async () => {
-  const tech = "A2MKUNG";
-  const { jobId, reworkCaseId } = await makeJobAndCase(tech);
-  await withTransaction((client) => holdOriginalIncomeForReworkCase(client, {
-    reworkCaseId,
-    jobId,
-    technicianUsername: tech,
-    originalFinishedAt: new Date("2026-06-10T10:00:00+07:00"),
-    originalEarnAmount: 325,
-    actor: "test",
-  }));
+test('release uses DB finished_at and rejects a missing completion timestamp', async () => {
+  const db = new FakeClient();
+  await hold(db);
+  await assert.rejects(() => release(db), (error) => error.status === 409 && error.message === 'REWORK_FINISHED_AT_REQUIRED');
+});
 
-  const finishedAt = new Date("2026-06-20T10:00:00+07:00");
-  const attempts = await Promise.allSettled(
-    Array.from({ length: 10 }, () => withTransaction((client) => releaseHeldIncomeForReworkCase(client, { reworkCaseId, technicianUsername: tech, finishedAt, actor: "test" })))
+test('Bangkok day 15 and day 16 target the correct payout periods', async () => {
+  const day15 = new FakeClient();
+  await hold(day15);
+  day15.jobs.set(10, { finished_at: '2026-06-15T23:59:59+07:00' });
+  assert.equal((await release(day15)).payout_id, 'payout_2026-06_25');
+
+  const day16 = new FakeClient();
+  await hold(day16);
+  day16.jobs.set(10, { finished_at: '2026-06-16T00:00:00+07:00' });
+  assert.equal((await release(day16)).payout_id, 'payout_2026-07_10');
+});
+
+test('team payout lines create and release one hold per original technician', async () => {
+  const db = new FakeClient();
+  db.periods.set('payout_2026-06_25', { payout_id: 'payout_2026-06_25', status: 'draft', period_type: '25' });
+  db.payoutLines.push(
+    { payout_id: 'payout_2026-06_25', technician_username: 'TECH_A', job_id: '10', earn_amount: 200 },
+    { payout_id: 'payout_2026-06_25', technician_username: 'TECH_B', job_id: '10', earn_amount: 125 },
   );
-  const succeeded = attempts.filter((a) => a.status === "fulfilled" && a.value.released);
-  assert.equal(succeeded.length, 1, "only one of 10 concurrent release attempts should actually move money");
-
-  const adjCount = await pool.query(
-    `SELECT COUNT(*)::int AS n FROM public.technician_payout_adjustments WHERE technician_username=$1 AND adj_amount > 0`,
-    [tech]
-  );
-  assert.equal(adjCount.rows[0].n, 1);
+  const held = await hold(db, { tech: 'TECH_A', amount: 999 });
+  assert.equal(held.rows.length, 2);
+  db.jobs.set(10, { finished_at: '2026-06-20T10:00:00+07:00' });
+  const result = await release(db, { tech: 'TECH_A' });
+  assert.equal(result.amount, 325);
+  assert.equal(result.rows.length, 2);
 });
 
-dbTest("failed rework never releases held income", async () => {
-  const tech = "A2MKUNG";
-  const { jobId, reworkCaseId } = await makeJobAndCase(tech);
-  await withTransaction((client) => holdOriginalIncomeForReworkCase(client, {
-    reworkCaseId,
-    jobId,
-    technicianUsername: tech,
-    originalFinishedAt: new Date("2026-06-10T10:00:00+07:00"),
-    originalEarnAmount: 325,
-    actor: "test",
-  }));
-
-  const voidResult = await withTransaction((client) => voidHeldIncomeForReworkCase(client, { reworkCaseId, technicianUsername: tech }));
-  assert.equal(voidResult.voided, true);
-  assert.equal(voidResult.row.hold_status, "voided");
-
-  const releaseAttempt = await withTransaction((client) => releaseHeldIncomeForReworkCase(client, {
-    reworkCaseId,
-    technicianUsername: tech,
-    finishedAt: new Date("2026-06-20T10:00:00+07:00"),
-    actor: "test",
-  }));
-  assert.equal(releaseAttempt.released, false);
-  assert.equal(releaseAttempt.reason, "voided");
-
-  const adjCount = await pool.query(`SELECT COUNT(*)::int AS n FROM public.technician_payout_adjustments WHERE technician_username=$1`, [tech]);
-  assert.equal(adjCount.rows[0].n, 0);
+test('release adjustment uses a synthetic job key so gross lookup cannot double count it', async () => {
+  const db = new FakeClient();
+  await hold(db);
+  db.jobs.set(10, { finished_at: '2026-06-20T10:00:00+07:00' });
+  await release(db);
+  const positive = db.adjustments.find((r) => r.adj_amount > 0);
+  assert.ok(positive);
+  assert.match(positive.job_id, /^rework_release:/);
+  assert.notEqual(positive.job_id, '10');
+  assert.match(positive.reason, /\[REWORK_RELEASE\]/);
 });
 
-dbTest("already-paid original income is held as no-op and never released", async () => {
-  const tech = "A2MKUNG";
-  const { jobId, reworkCaseId } = await makeJobAndCase(tech);
-  const finishedAt = new Date("2026-06-10T10:00:00+07:00");
-  await pool.query(
-    `INSERT INTO public.technician_payout_periods (payout_id, period_type, period_start, period_end, status)
-     VALUES ('payout_2026-06_25','25', '2026-06-01T00:00:00+07:00', '2026-06-16T00:00:00+07:00', 'paid')`
-  );
-
-  const holdResult = await withTransaction((client) => holdOriginalIncomeForReworkCase(client, {
-    reworkCaseId,
-    jobId,
-    technicianUsername: tech,
-    originalFinishedAt: finishedAt,
-    originalEarnAmount: 325,
-    actor: "test",
-  }));
-  assert.equal(holdResult.held, false);
-  assert.equal(holdResult.row.hold_status, "already_paid_no_action");
-
-  const releaseAttempt = await withTransaction((client) => releaseHeldIncomeForReworkCase(client, {
-    reworkCaseId,
-    technicianUsername: tech,
-    finishedAt: new Date("2026-06-20T10:00:00+07:00"),
-    actor: "test",
-  }));
-  assert.equal(releaseAttempt.released, false);
-  assert.equal(releaseAttempt.reason, "already_paid_no_action");
+test('repeated release is idempotent', async () => {
+  const db = new FakeClient();
+  await hold(db);
+  db.jobs.set(10, { finished_at: '2026-06-20T10:00:00+07:00' });
+  assert.equal((await release(db)).released, true);
+  assert.equal((await release(db)).released, false);
+  assert.equal(db.adjustments.filter((r) => r.adj_amount > 0).length, 1);
 });
 
-dbTest("rolls forward past an already-paid target period when releasing", async () => {
-  const tech = "A2MKUNG";
-  const { jobId, reworkCaseId } = await makeJobAndCase(tech);
-  await withTransaction((client) => holdOriginalIncomeForReworkCase(client, {
-    reworkCaseId,
-    jobId,
-    technicianUsername: tech,
-    originalFinishedAt: new Date("2026-06-10T10:00:00+07:00"),
-    originalEarnAmount: 325,
-    actor: "test",
-  }));
-
-  // The period the release would naturally land in (2026-06-20 -> payout_2026-07_10) is already paid.
-  await pool.query(
-    `INSERT INTO public.technician_payout_periods (payout_id, period_type, period_start, period_end, status)
-     VALUES ('payout_2026-07_10','10', '2026-06-16T00:00:00+07:00', '2026-07-01T00:00:00+07:00', 'paid')`
-  );
-
-  const release = await withTransaction((client) => releaseHeldIncomeForReworkCase(client, {
-    reworkCaseId,
-    technicianUsername: tech,
-    finishedAt: new Date("2026-06-20T10:00:00+07:00"),
-    actor: "test",
-  }));
-  assert.equal(release.released, true);
-  assert.equal(release.payout_id, "payout_2026-07_25");
+test('failed rework voids held income and does not release it', async () => {
+  const db = new FakeClient();
+  await hold(db);
+  const result = await voidHeldIncomeForReworkCase(db, { reworkCaseId: 1, technicianUsername: 'A2MKUNG' });
+  assert.equal(result.voided, true);
+  db.jobs.set(10, { finished_at: '2026-06-20T10:00:00+07:00' });
+  assert.equal((await release(db)).released, false);
+  assert.equal(db.adjustments.filter((r) => r.adj_amount > 0).length, 0);
 });
 
-dbTest("zero-amount original income holds as a no-op and is never released", async () => {
-  const tech = "A2MKUNG";
-  const { jobId, reworkCaseId } = await makeJobAndCase(tech);
-  const holdResult = await withTransaction((client) => holdOriginalIncomeForReworkCase(client, {
-    reworkCaseId,
-    jobId,
-    technicianUsername: tech,
-    originalFinishedAt: new Date("2026-06-10T10:00:00+07:00"),
-    originalEarnAmount: 0,
-    actor: "test",
-  }));
-  assert.equal(holdResult.held, false);
-  assert.equal(holdResult.row.hold_status, "already_paid_no_action");
-
-  const releaseAttempt = await withTransaction((client) => releaseHeldIncomeForReworkCase(client, {
-    reworkCaseId,
-    technicianUsername: tech,
-    finishedAt: new Date("2026-06-20T10:00:00+07:00"),
-    actor: "test",
-  }));
-  assert.equal(releaseAttempt.released, false);
-});
-
-dbTest("holding twice for the same case+technician is a no-op (immutable hold)", async () => {
-  const tech = "A2MKUNG";
-  const { jobId, reworkCaseId } = await makeJobAndCase(tech);
-  const first = await withTransaction((client) => holdOriginalIncomeForReworkCase(client, {
-    reworkCaseId,
-    jobId,
-    technicianUsername: tech,
-    originalFinishedAt: new Date("2026-06-10T10:00:00+07:00"),
-    originalEarnAmount: 325,
-    actor: "test",
-  }));
-  const second = await withTransaction((client) => holdOriginalIncomeForReworkCase(client, {
-    reworkCaseId,
-    jobId,
-    technicianUsername: tech,
-    originalFinishedAt: new Date("2026-06-10T10:00:00+07:00"),
-    originalEarnAmount: 999,
-    actor: "test",
-  }));
-  assert.equal(second.already_held, true);
-  assert.equal(Number(second.row.held_amount), Number(first.row.held_amount));
-
-  const holds = await pool.query(`SELECT COUNT(*)::int AS n FROM public.technician_rework_income_holds WHERE rework_case_id=$1 AND technician_username=$2`, [reworkCaseId, tech]);
-  assert.equal(holds.rows[0].n, 1);
+test('duplicate hold call preserves the first immutable amount', async () => {
+  const db = new FakeClient();
+  await hold(db, { amount: 325 });
+  await hold(db, { amount: 999 });
+  const rows = await getHoldsForReworkCase(db, 1);
+  assert.equal(rows.length, 1);
+  assert.equal(rows[0].held_amount, 325);
 });

--- a/test/technicianReworkIncome.test.js
+++ b/test/technicianReworkIncome.test.js
@@ -1,0 +1,405 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const { Pool } = require("pg");
+
+const {
+  holdOriginalIncomeForReworkCase,
+  releaseHeldIncomeForReworkCase,
+  voidHeldIncomeForReworkCase,
+  getHoldForReworkCase,
+  releaseIdempotencyKey,
+} = require("../server/services/technicianReworkIncome");
+
+const PG_CONFIG = {
+  host: process.env.PGHOST || "127.0.0.1",
+  port: Number(process.env.PGPORT || 5432),
+  user: process.env.PGUSER || "postgres",
+  password: process.env.PGPASSWORD || "postgres",
+  database: process.env.PGDATABASE || "cwf_test",
+};
+
+let pool;
+let adminPool;
+let testDatabaseName = "";
+let dbUnavailableReason = "";
+let nextJobId = 1;
+let nextCaseId = 1;
+
+test.before(async () => {
+  testDatabaseName = `cwf_rework_income_${process.pid}_${Date.now()}`.toLowerCase();
+  adminPool = new Pool({ ...PG_CONFIG, database: process.env.PGMAINTENANCEDATABASE || "postgres" });
+  try {
+    await adminPool.query("SELECT 1");
+    await adminPool.query(`CREATE DATABASE ${testDatabaseName} ENCODING 'UTF8'`);
+  } catch (e) {
+    dbUnavailableReason = e.message || "Postgres test database is unavailable";
+    await adminPool.end().catch(() => {});
+    adminPool = null;
+    return;
+  }
+
+  pool = new Pool({ ...PG_CONFIG, database: testDatabaseName });
+
+  await pool.query(`CREATE TABLE public.jobs (job_id BIGSERIAL PRIMARY KEY)`);
+
+  await pool.query(`
+    CREATE TABLE public.technician_rework_cases (
+      rework_case_id BIGSERIAL PRIMARY KEY,
+      job_id BIGINT NOT NULL REFERENCES public.jobs(job_id),
+      technician_username TEXT
+    )
+  `);
+
+  await pool.query(`
+    CREATE TABLE public.technician_payout_periods (
+      payout_id TEXT PRIMARY KEY,
+      period_type TEXT NOT NULL,
+      period_start TIMESTAMPTZ NOT NULL,
+      period_end TIMESTAMPTZ NOT NULL,
+      status TEXT NOT NULL DEFAULT 'draft',
+      created_by TEXT
+    )
+  `);
+
+  await pool.query(`
+    CREATE TABLE public.technician_payout_lines (
+      line_id BIGSERIAL PRIMARY KEY,
+      payout_id TEXT NOT NULL,
+      technician_username TEXT NOT NULL,
+      job_id TEXT,
+      earn_amount NUMERIC(12,2) NOT NULL DEFAULT 0
+    )
+  `);
+
+  await pool.query(`
+    CREATE TABLE public.technician_payout_adjustments (
+      adj_id BIGSERIAL PRIMARY KEY,
+      payout_id TEXT NOT NULL,
+      technician_username TEXT NOT NULL,
+      job_id TEXT,
+      adj_amount NUMERIC(12,2) NOT NULL,
+      reason TEXT,
+      created_by TEXT,
+      created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+    )
+  `);
+
+  await pool.query(`
+    CREATE TABLE public.technician_deposit_ledger (
+      ledger_id BIGSERIAL PRIMARY KEY,
+      payout_id TEXT NOT NULL,
+      technician_username TEXT NOT NULL,
+      amount NUMERIC(12,2) NOT NULL DEFAULT 0,
+      transaction_type TEXT NOT NULL
+    )
+  `);
+
+  await pool.query(`
+    CREATE TABLE public.technician_payout_payments (
+      payment_id BIGSERIAL PRIMARY KEY,
+      payout_id TEXT NOT NULL,
+      technician_username TEXT NOT NULL,
+      paid_amount NUMERIC(12,2) NOT NULL DEFAULT 0,
+      paid_status TEXT NOT NULL DEFAULT 'unpaid',
+      updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+    )
+  `);
+
+  await pool.query(`
+    CREATE TABLE public.technician_rework_income_holds (
+      hold_id BIGSERIAL PRIMARY KEY,
+      rework_case_id BIGINT NOT NULL REFERENCES public.technician_rework_cases(rework_case_id) ON DELETE CASCADE,
+      technician_username TEXT NOT NULL,
+      job_id BIGINT NOT NULL REFERENCES public.jobs(job_id) ON DELETE CASCADE,
+
+      held_amount NUMERIC(12,2) NOT NULL DEFAULT 0 CHECK (held_amount >= 0),
+      source_payout_id TEXT,
+      source_period_status_at_hold TEXT,
+      hold_adjustment_id BIGINT REFERENCES public.technician_payout_adjustments(adj_id) ON DELETE SET NULL,
+
+      hold_status TEXT NOT NULL DEFAULT 'held' CHECK (hold_status IN (
+        'held','already_paid_no_action','released','voided'
+      )),
+
+      released_amount NUMERIC(12,2) CHECK (released_amount IS NULL OR released_amount >= 0),
+      release_payout_id TEXT,
+      release_adjustment_id BIGINT REFERENCES public.technician_payout_adjustments(adj_id) ON DELETE SET NULL,
+      release_idempotency_key TEXT,
+      released_at TIMESTAMPTZ,
+
+      created_by TEXT,
+      created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+
+      UNIQUE (rework_case_id, technician_username),
+      CHECK (released_amount IS NULL OR released_amount <= held_amount)
+    )
+  `);
+  await pool.query(`
+    CREATE UNIQUE INDEX uq_trih_release_idempotency_key
+      ON public.technician_rework_income_holds(release_idempotency_key)
+      WHERE release_idempotency_key IS NOT NULL
+  `);
+});
+
+test.after(async () => {
+  if (pool) {
+    pool.on("error", () => {}); // swallow teardown noise from sockets still closing when pool.end() resolves
+    await pool.end();
+  }
+  if (adminPool && testDatabaseName) {
+    await adminPool.query(`DROP DATABASE IF EXISTS ${testDatabaseName}`).catch(() => {});
+    await adminPool.end().catch(() => {});
+  }
+});
+
+test.beforeEach(async (t) => {
+  if (dbUnavailableReason) {
+    t.skip(`Postgres integration database unavailable: ${dbUnavailableReason}`);
+    return;
+  }
+  await pool.query("DELETE FROM public.technician_rework_income_holds");
+  await pool.query("DELETE FROM public.technician_payout_payments");
+  await pool.query("DELETE FROM public.technician_deposit_ledger");
+  await pool.query("DELETE FROM public.technician_payout_adjustments");
+  await pool.query("DELETE FROM public.technician_payout_lines");
+  await pool.query("DELETE FROM public.technician_payout_periods");
+  await pool.query("DELETE FROM public.technician_rework_cases");
+  await pool.query("DELETE FROM public.jobs");
+});
+
+function dbTest(name, fn) {
+  test(name, async (t) => {
+    if (dbUnavailableReason) return t.skip(`Postgres integration database unavailable: ${dbUnavailableReason}`);
+    return fn(t);
+  });
+}
+
+// Mirrors how every production route calls these functions: connect a client,
+// BEGIN, run the operation, COMMIT on success / ROLLBACK on failure. Calling the
+// service functions directly against `pool` (no transaction) would let a later
+// statement fail after an earlier one in the same call already autocommitted,
+// which is not how the real code paths behave.
+async function withTransaction(fn) {
+  const client = await pool.connect();
+  try {
+    await client.query("BEGIN");
+    const result = await fn(client);
+    await client.query("COMMIT");
+    return result;
+  } catch (e) {
+    await client.query("ROLLBACK").catch(() => {});
+    throw e;
+  } finally {
+    client.release();
+  }
+}
+
+async function makeJobAndCase(technicianUsername) {
+  const jr = await pool.query(`INSERT INTO public.jobs DEFAULT VALUES RETURNING job_id`);
+  const jobId = Number(jr.rows[0].job_id);
+  const cr = await pool.query(
+    `INSERT INTO public.technician_rework_cases (job_id, technician_username) VALUES ($1,$2) RETURNING rework_case_id`,
+    [jobId, technicianUsername]
+  );
+  return { jobId, reworkCaseId: Number(cr.rows[0].rework_case_id) };
+}
+
+dbTest("holds then releases the original technician's income exactly once into the correct period", async () => {
+  const tech = "A2MKUNG";
+  const { jobId, reworkCaseId } = await makeJobAndCase(tech);
+
+  const holdResult = await withTransaction((client) => holdOriginalIncomeForReworkCase(client, {
+    reworkCaseId,
+    jobId,
+    technicianUsername: tech,
+    originalFinishedAt: new Date("2026-06-10T10:00:00+07:00"),
+    originalEarnAmount: 325,
+    actor: "test",
+  }));
+  assert.equal(holdResult.held, true);
+  assert.equal(Number(holdResult.row.held_amount), 325);
+
+  const finishedAt = new Date("2026-06-20T10:00:00+07:00");
+  const release1 = await withTransaction((client) => releaseHeldIncomeForReworkCase(client, { reworkCaseId, technicianUsername: tech, finishedAt, actor: "test" }));
+  assert.equal(release1.released, true);
+  assert.equal(release1.amount, 325);
+  assert.equal(release1.payout_id, "payout_2026-07_10");
+
+  const release2 = await withTransaction((client) => releaseHeldIncomeForReworkCase(client, { reworkCaseId, technicianUsername: tech, finishedAt, actor: "test" }));
+  assert.equal(release2.released, false);
+  assert.equal(release2.reason, "released");
+
+  const adjCount = await pool.query(
+    `SELECT COUNT(*)::int AS n FROM public.technician_payout_adjustments WHERE payout_id=$1 AND technician_username=$2 AND adj_amount > 0`,
+    [release1.payout_id, tech]
+  );
+  assert.equal(adjCount.rows[0].n, 1, "exactly one positive release adjustment must exist no matter how many times release is called");
+
+  const hold = await getHoldForReworkCase(pool, reworkCaseId, tech);
+  assert.equal(hold.hold_status, "released");
+  assert.equal(Number(hold.released_amount), 325);
+  assert.equal(hold.release_idempotency_key, releaseIdempotencyKey(reworkCaseId, tech));
+});
+
+dbTest("releasing 10 times concurrently only moves money once", async () => {
+  const tech = "A2MKUNG";
+  const { jobId, reworkCaseId } = await makeJobAndCase(tech);
+  await withTransaction((client) => holdOriginalIncomeForReworkCase(client, {
+    reworkCaseId,
+    jobId,
+    technicianUsername: tech,
+    originalFinishedAt: new Date("2026-06-10T10:00:00+07:00"),
+    originalEarnAmount: 325,
+    actor: "test",
+  }));
+
+  const finishedAt = new Date("2026-06-20T10:00:00+07:00");
+  const attempts = await Promise.allSettled(
+    Array.from({ length: 10 }, () => withTransaction((client) => releaseHeldIncomeForReworkCase(client, { reworkCaseId, technicianUsername: tech, finishedAt, actor: "test" })))
+  );
+  const succeeded = attempts.filter((a) => a.status === "fulfilled" && a.value.released);
+  assert.equal(succeeded.length, 1, "only one of 10 concurrent release attempts should actually move money");
+
+  const adjCount = await pool.query(
+    `SELECT COUNT(*)::int AS n FROM public.technician_payout_adjustments WHERE technician_username=$1 AND adj_amount > 0`,
+    [tech]
+  );
+  assert.equal(adjCount.rows[0].n, 1);
+});
+
+dbTest("failed rework never releases held income", async () => {
+  const tech = "A2MKUNG";
+  const { jobId, reworkCaseId } = await makeJobAndCase(tech);
+  await withTransaction((client) => holdOriginalIncomeForReworkCase(client, {
+    reworkCaseId,
+    jobId,
+    technicianUsername: tech,
+    originalFinishedAt: new Date("2026-06-10T10:00:00+07:00"),
+    originalEarnAmount: 325,
+    actor: "test",
+  }));
+
+  const voidResult = await withTransaction((client) => voidHeldIncomeForReworkCase(client, { reworkCaseId, technicianUsername: tech }));
+  assert.equal(voidResult.voided, true);
+  assert.equal(voidResult.row.hold_status, "voided");
+
+  const releaseAttempt = await withTransaction((client) => releaseHeldIncomeForReworkCase(client, {
+    reworkCaseId,
+    technicianUsername: tech,
+    finishedAt: new Date("2026-06-20T10:00:00+07:00"),
+    actor: "test",
+  }));
+  assert.equal(releaseAttempt.released, false);
+  assert.equal(releaseAttempt.reason, "voided");
+
+  const adjCount = await pool.query(`SELECT COUNT(*)::int AS n FROM public.technician_payout_adjustments WHERE technician_username=$1`, [tech]);
+  assert.equal(adjCount.rows[0].n, 0);
+});
+
+dbTest("already-paid original income is held as no-op and never released", async () => {
+  const tech = "A2MKUNG";
+  const { jobId, reworkCaseId } = await makeJobAndCase(tech);
+  const finishedAt = new Date("2026-06-10T10:00:00+07:00");
+  await pool.query(
+    `INSERT INTO public.technician_payout_periods (payout_id, period_type, period_start, period_end, status)
+     VALUES ('payout_2026-06_25','25', '2026-06-01T00:00:00+07:00', '2026-06-16T00:00:00+07:00', 'paid')`
+  );
+
+  const holdResult = await withTransaction((client) => holdOriginalIncomeForReworkCase(client, {
+    reworkCaseId,
+    jobId,
+    technicianUsername: tech,
+    originalFinishedAt: finishedAt,
+    originalEarnAmount: 325,
+    actor: "test",
+  }));
+  assert.equal(holdResult.held, false);
+  assert.equal(holdResult.row.hold_status, "already_paid_no_action");
+
+  const releaseAttempt = await withTransaction((client) => releaseHeldIncomeForReworkCase(client, {
+    reworkCaseId,
+    technicianUsername: tech,
+    finishedAt: new Date("2026-06-20T10:00:00+07:00"),
+    actor: "test",
+  }));
+  assert.equal(releaseAttempt.released, false);
+  assert.equal(releaseAttempt.reason, "already_paid_no_action");
+});
+
+dbTest("rolls forward past an already-paid target period when releasing", async () => {
+  const tech = "A2MKUNG";
+  const { jobId, reworkCaseId } = await makeJobAndCase(tech);
+  await withTransaction((client) => holdOriginalIncomeForReworkCase(client, {
+    reworkCaseId,
+    jobId,
+    technicianUsername: tech,
+    originalFinishedAt: new Date("2026-06-10T10:00:00+07:00"),
+    originalEarnAmount: 325,
+    actor: "test",
+  }));
+
+  // The period the release would naturally land in (2026-06-20 -> payout_2026-07_10) is already paid.
+  await pool.query(
+    `INSERT INTO public.technician_payout_periods (payout_id, period_type, period_start, period_end, status)
+     VALUES ('payout_2026-07_10','10', '2026-06-16T00:00:00+07:00', '2026-07-01T00:00:00+07:00', 'paid')`
+  );
+
+  const release = await withTransaction((client) => releaseHeldIncomeForReworkCase(client, {
+    reworkCaseId,
+    technicianUsername: tech,
+    finishedAt: new Date("2026-06-20T10:00:00+07:00"),
+    actor: "test",
+  }));
+  assert.equal(release.released, true);
+  assert.equal(release.payout_id, "payout_2026-07_25");
+});
+
+dbTest("zero-amount original income holds as a no-op and is never released", async () => {
+  const tech = "A2MKUNG";
+  const { jobId, reworkCaseId } = await makeJobAndCase(tech);
+  const holdResult = await withTransaction((client) => holdOriginalIncomeForReworkCase(client, {
+    reworkCaseId,
+    jobId,
+    technicianUsername: tech,
+    originalFinishedAt: new Date("2026-06-10T10:00:00+07:00"),
+    originalEarnAmount: 0,
+    actor: "test",
+  }));
+  assert.equal(holdResult.held, false);
+  assert.equal(holdResult.row.hold_status, "already_paid_no_action");
+
+  const releaseAttempt = await withTransaction((client) => releaseHeldIncomeForReworkCase(client, {
+    reworkCaseId,
+    technicianUsername: tech,
+    finishedAt: new Date("2026-06-20T10:00:00+07:00"),
+    actor: "test",
+  }));
+  assert.equal(releaseAttempt.released, false);
+});
+
+dbTest("holding twice for the same case+technician is a no-op (immutable hold)", async () => {
+  const tech = "A2MKUNG";
+  const { jobId, reworkCaseId } = await makeJobAndCase(tech);
+  const first = await withTransaction((client) => holdOriginalIncomeForReworkCase(client, {
+    reworkCaseId,
+    jobId,
+    technicianUsername: tech,
+    originalFinishedAt: new Date("2026-06-10T10:00:00+07:00"),
+    originalEarnAmount: 325,
+    actor: "test",
+  }));
+  const second = await withTransaction((client) => holdOriginalIncomeForReworkCase(client, {
+    reworkCaseId,
+    jobId,
+    technicianUsername: tech,
+    originalFinishedAt: new Date("2026-06-10T10:00:00+07:00"),
+    originalEarnAmount: 999,
+    actor: "test",
+  }));
+  assert.equal(second.already_held, true);
+  assert.equal(Number(second.row.held_amount), Number(first.row.held_amount));
+
+  const holds = await pool.query(`SELECT COUNT(*)::int AS n FROM public.technician_rework_income_holds WHERE rework_case_id=$1 AND technician_username=$2`, [reworkCaseId, tech]);
+  assert.equal(holds.rows[0].n, 1);
+});


### PR DESCRIPTION
## Summary

- เพิ่ม ledger `technician_rework_income_holds` สำหรับบันทึกยอดรายได้เดิมที่ถูกพัก และคืนเงินเพียงครั้งเดียวเมื่อปิดงานแก้สำเร็จ
- รองรับรายได้เดิมที่อยู่ในงวด `draft`, `locked` และ `paid`
  - งวดที่จ่ายแล้วจะสร้าง negative hold adjustment ในงวดเปิดถัดไป
  - เมื่อแก้งานสำเร็จจะสร้าง positive release adjustment ตามวันที่ `jobs.finished_at` จริง
- ใช้กติกา Asia/Bangkok: วันที่ 1–15 เข้า งวด 25 เดือนเดียวกัน, วันที่ 16–สิ้นเดือน เข้า งวด 10 เดือนถัดไป
- รองรับงานทีม โดยสร้าง hold/release แยกตามช่างเจ้าของรายได้เดิม
- ป้องกันคืนเงินซ้ำด้วย row lock, hold status และ release idempotency key
- ป้องกัน gross + adjustment double-count โดยใช้ synthetic adjustment job key `rework_release::` และ tag `[REWORK_RELEASE]`
- ห้าม release เมื่อฐานข้อมูลยังไม่มี `finished_at` โดยตอบ 409
- แก้ audit เคส `CWFRXB5AYA` ให้ค้นจาก `jobs.booking_code`
- เพิ่ม `scripts/recover-legacy-rework-income.js` สำหรับเคสเก่า: dry-run เป็นค่าเริ่มต้น และ apply ต้องยืนยันยอด/คำสั่งชัดเจน

### Nth-round fix (latest commit)

ก่อนหน้านี้ เมื่อใบงานเดียวกันถูกส่งกลับแก้เป็นรอบที่ 2 ขึ้นไป โดยอ้างยอดที่ "คืนไปแล้ว" จากรอบก่อนเป็นแหล่งที่มา ระบบจะไม่สร้าง negative adjustment มาหักล้างยอดเดิม หากงวดของการคืนเงินรอบก่อนยังเป็น `draft` — ทำให้ยอดจ่ายจริงเพิ่มขึ้นซ้ำ (เช่น 325 -> 650) แทนที่จะหักล้างกลับมาเท่าเดิม

แก้โดย:
- `loadOriginalIncomeCandidates` ติด tag `source_kind` (`original_income` หรือ `previous_rework_release`) พร้อม `release_payout_id`, `previous_rework_case_id`, `previous_release_adjustment_id` จริงจาก ledger ของ hold รอบก่อน (ไม่เดาจากวันที่)
- `createPreviousReleaseOffsetHold` สร้าง negative `[REWORK_HOLD]` adjustment เสมอสำหรับ source ประเภท `previous_rework_release` — ลงในงวดเดียวกับการคืนเงินรอบก่อนถ้ายังเป็น `draft`, หรือเลื่อนไปงวด `draft` ถัดไปถ้างวดนั้น `locked`/`paid` แล้ว — ไม่มี shortcut "draft แล้วไม่ต้องทำอะไร" แบบ original-income เพราะการคืนเงินรอบก่อนเป็นแถวบัญชีจริงที่มีอยู่แล้ว
- ข้อมูล ledger ที่ผิดปกติ (released_amount เกิน held_amount, ไม่มี release_payout_id, หางวดเป้าหมายไม่พบ) จะถูกปฏิเสธด้วย 409 และ rollback ทั้งหมด ไม่เดายอด/งวด
- Migration เพิ่มคอลัมน์ `source_kind`, `previous_rework_case_id`, `previous_release_adjustment_id` (additive, nullable, idempotent) เพื่อ audit — mirror เข้า `index.js` startup migration block ด้วย
- เพิ่ม 14 เทสต์ใหม่ที่ assert ยอด net adjustment สะสมต่อช่าง ครอบคลุมรอบ 2-3, การ carry-forward แบบ draft/locked/paid, งานทีม, การ retry ซ้ำแบบ idempotent, และ rollback เมื่อ insert ล้มเหลว

## Changed files

- `index.js`
- `migrations/technician_rework_income_hold_release.sql`
- `server/services/technicianReworkIncome.js`
- `server/technicianJobMoneySummary.js`
- `scripts/audit-rework-case-CWFRXB5AYA.sql`
- `scripts/recover-legacy-rework-income.js`
- `test/technicianReworkIncome.test.js`

## Verification

- [x] `node --check index.js`
- [x] `node --check server/services/technicianReworkIncome.js`
- [x] `node --check scripts/recover-legacy-rework-income.js`
- [x] `node --test test/technicianReworkIncome.test.js` — 32/32 pass (covers round 1, round 2 draft/locked/paid, round 3, team jobs, idempotent retries, 409 rollback paths)
- [x] `node --test test/*.test.js` — full suite: 621 tests, 610 pass, 11 skipped, 0 fail
- [ ] Repository has no configured CI checks
- [ ] Full production migration has not been run
- [ ] Production data has not been modified

## Production order

1. Review final diff
2. Run `migrations/technician_rework_income_hold_release.sql`
3. Deploy application code
4. Run read-only audit:
   `psql "$PRODUCTION_DATABASE_URL" -v ON_ERROR_STOP=1 -f scripts/audit-rework-case-CWFRXB5AYA.sql`
5. Review audit output before any legacy recovery
6. Run recovery dry-run only:
   `node scripts/recover-legacy-rework-income.js --booking-code CWFRXB5AYA --technician A2MKUNG`
7. Use `--apply` only after amount and accounting state are approved

## Remaining hardening

- The current migration still uses the original foreign-key delete behavior on some legacy columns where not yet tightened. Any further FK hardening should be a separate reviewed migration.
- Recommend a live-DB smoke test of a real 3-round rework (draft -> locked -> paid carry-forward) before production rollout, since current tests run against an in-memory `FakeClient` mock, not a real Postgres instance.

No merge, deployment, migration or production recovery has been performed by this PR.