### PR TITLE
Store production completion: work packages A–G

### DIFF
--- a/admin-store-catalog.css
+++ b/admin-store-catalog.css
@@ -73,6 +73,12 @@
 .asc-review-stars{ font-size:14px; color:#f5b700; margin-top:4px; }
 .asc-review-comment{ font-size:13px; color:#1f2937; margin-top:4px; white-space:pre-wrap; overflow-wrap:anywhere; }
 .asc-review-actions{ display:flex; gap:6px; flex-wrap:wrap; margin-top:8px; width:100%; }
+.asc-review-visibility{ font-size:12px; font-weight:600; margin-top:4px; }
+.asc-review-visible{ color:#15803d; }
+.asc-review-not-visible{ color:#b45309; }
+.asc-review-assign{ display:flex; gap:6px; flex-wrap:wrap; margin-top:8px; width:100%; align-items:center; }
+.asc-review-assign-search{ flex:1 1 180px; min-width:0; }
+.asc-review-assign-select{ flex:1 1 220px; min-width:0; }
 
 .asc-gallery-grid{
   display:grid;

--- a/admin-store-catalog.css
+++ b/admin-store-catalog.css
@@ -75,7 +75,10 @@
 .asc-review-actions{ display:flex; gap:6px; flex-wrap:wrap; margin-top:8px; width:100%; }
 .asc-review-visibility{ font-size:12px; font-weight:600; margin-top:4px; }
 .asc-review-visible{ color:#15803d; }
-.asc-review-not-visible{ color:#b45309; }
+.asc-review-unassigned{ color:#b45309; }
+.asc-review-assigned_pending{ color:#0369a1; }
+.asc-review-rejected{ color:#b91c1c; }
+.asc-review-hidden{ color:#6b7280; }
 .asc-review-assign{ display:flex; gap:6px; flex-wrap:wrap; margin-top:8px; width:100%; align-items:center; }
 .asc-review-assign-search{ flex:1 1 180px; min-width:0; }
 .asc-review-assign-select{ flex:1 1 220px; min-width:0; }

--- a/admin-store-catalog.html
+++ b/admin-store-catalog.html
@@ -58,6 +58,13 @@
           <option value="approved">อนุมัติแล้ว</option>
           <option value="rejected">ปฏิเสธแล้ว</option>
           <option value="hidden">ซ่อนอยู่</option>
+          <option value="unassigned">ยังไม่ผูกสินค้า</option>
+          <option value="approved_unassigned">อนุมัติแล้วแต่ยังไม่แสดงใน Store</option>
+        </select>
+        <select id="review_filter_source" class="asc-filter">
+          <option value="">ทุกแหล่งที่มา</option>
+          <option value="customer_app">Customer App</option>
+          <option value="tracking">Tracking</option>
         </select>
         <select id="review_filter_item" class="asc-filter">
           <option value="">ทุกรายการ</option>

--- a/admin-store-catalog.js
+++ b/admin-store-catalog.js
@@ -1083,11 +1083,28 @@ function reviewEffectiveItemId(review) {
 function reviewEffectiveItemName(review) {
   return review.assigned_item_name || review.item_name || null;
 }
-// Approved is not the same as "done": a service_type/overall review that's
-// approved but still has no effective item never shows in the Store, so the
-// card must never look like a completed task in that state.
-function reviewIsStoreVisible(review) {
-  return review.moderation_status === "approved" && Boolean(reviewEffectiveItemId(review));
+// Distinguishes the 5 states an admin actually needs to tell apart -- a
+// linked-but-pending or linked-but-hidden review must never read as
+// "ยังไม่ผูกสินค้า" (that label is reserved for genuinely orphan reviews with
+// no effective item at all).
+function reviewVisibilityState(review) {
+  const hasItem = Boolean(reviewEffectiveItemId(review));
+  if (!hasItem) return "unassigned";
+  if (review.moderation_status === "approved") return "visible";
+  if (review.moderation_status === "rejected") return "rejected";
+  if (review.moderation_status === "hidden") return "hidden";
+  return "assigned_pending";
+}
+
+function reviewVisibilityLabel(review) {
+  const labels = {
+    unassigned: "⚠️ ยังไม่ผูกสินค้า",
+    assigned_pending: "⏳ ผูกสินค้าแล้ว รออนุมัติ",
+    visible: "✅ แสดงใน Store ได้",
+    rejected: "🚫 ถูกปฏิเสธ ไม่แสดงใน Store",
+    hidden: "🙈 ถูกซ่อน ไม่แสดงใน Store",
+  };
+  return labels[reviewVisibilityState(review)];
 }
 
 function reviewActionButtons(review) {
@@ -1112,10 +1129,30 @@ function catalogItemPickerLabel(item) {
   return parts.filter(Boolean).join(" • ");
 }
 
+// Active + customer-visible items are what a customer can actually book
+// against, so they're listed first and unambiguously labeled; anything else
+// (inactive or hidden) still appears -- an admin may legitimately need to
+// assign a review to a retired item -- but sorted last and flagged so it's
+// never mistaken for a normal pick.
+function reviewAssignPickerSortedItems(items) {
+  const visible = [];
+  const notVisible = [];
+  for (const it of items) {
+    if (it.is_active && it.is_customer_visible) visible.push(it);
+    else notVisible.push(it);
+  }
+  return [...visible, ...notVisible];
+}
+
 function reviewAssignOptionsHtml(review, items) {
   const assignedId = review.assigned_item_id ? Number(review.assigned_item_id) : null;
-  return `<option value="">-- เลือกสินค้า --</option>${items
-    .map((it) => `<option value="${it.item_id}" ${assignedId === Number(it.item_id) ? "selected" : ""}>${escapeHtml(catalogItemPickerLabel(it))}</option>`)
+  const sorted = reviewAssignPickerSortedItems(items);
+  return `<option value="">-- เลือกสินค้า --</option>${sorted
+    .map((it) => {
+      const isVisible = it.is_active && it.is_customer_visible;
+      const label = catalogItemPickerLabel(it) + (isVisible ? "" : " (ไม่แสดงใน Store)");
+      return `<option value="${it.item_id}" ${assignedId === Number(it.item_id) ? "selected" : ""}>${escapeHtml(label)}</option>`;
+    })
     .join("")}`;
 }
 
@@ -1136,7 +1173,7 @@ function reviewAssignPickerHtml(review) {
 }
 
 function reviewCardHtml(review) {
-  const storeVisible = reviewIsStoreVisible(review);
+  const visibilityState = reviewVisibilityState(review);
   const effectiveName = reviewEffectiveItemName(review);
   return `
   <div class="asc-item-card asc-review-card" data-review-id="${review.review_id}">
@@ -1145,7 +1182,7 @@ function reviewCardHtml(review) {
       <div class="asc-item-meta">${escapeHtml(review.customer_identity || "ลูกค้า")} • งาน #${escapeHtml(String(review.completed_job_id || "-"))} • ${fmtDateTime(review.created_at)}</div>
       <div class="asc-item-meta">แหล่งที่มา: ${reviewSourceLabel(review.review_source)} • Scope: ${reviewScopeLabel(review.review_scope)}${review.service_type ? ` • ประเภทบริการ: ${escapeHtml(review.service_type)}` : ""}</div>
       <div class="asc-item-meta">สินค้าต้นทาง: ${escapeHtml(review.item_name || "-")} • สินค้าที่มอบหมาย: ${escapeHtml(review.assigned_item_name || "-")}</div>
-      <div class="asc-review-visibility ${storeVisible ? "asc-review-visible" : "asc-review-not-visible"}">${storeVisible ? "✅ แสดงใน Store ได้" : "⚠️ ยังไม่ผูกสินค้า"}</div>
+      <div class="asc-review-visibility asc-review-${visibilityState}">${reviewVisibilityLabel(review)}</div>
       <div class="asc-review-stars">${reviewStarsHtml(review.rating)}</div>
       ${review.comment ? `<div class="asc-review-comment">${escapeHtml(review.comment)}</div>` : `<div class="muted2 mini">ไม่มีความเห็นเพิ่มเติม</div>`}
       ${review.moderated_by ? `<div class="muted2 mini">ตรวจสอบล่าสุดโดย ${escapeHtml(review.moderated_by)} เมื่อ ${fmtDateTime(review.moderated_at)}</div>` : ""}

--- a/admin-store-catalog.js
+++ b/admin-store-catalog.js
@@ -1063,9 +1063,39 @@ function reviewStarsHtml(rating) {
   return Array.from({ length: 5 }, (_, i) => (i < n ? "★" : "☆")).join("");
 }
 
+function reviewSourceLabel(source) {
+  return source === "tracking" ? "Tracking" : "Customer App";
+}
+
+function reviewScopeLabel(scope) {
+  if (scope === "item") return "สินค้า";
+  if (scope === "service_type") return "ประเภทบริการ";
+  return "ภาพรวม";
+}
+
+// The review's real target for display/rating purposes is always the
+// admin-assigned item if one exists, falling back to its original item_id
+// (mirrors COALESCE(assigned_item_id, item_id) used server-side in
+// attachCatalogRatings and the public reviews endpoint).
+function reviewEffectiveItemId(review) {
+  return review.assigned_item_id || review.item_id || null;
+}
+function reviewEffectiveItemName(review) {
+  return review.assigned_item_name || review.item_name || null;
+}
+// Approved is not the same as "done": a service_type/overall review that's
+// approved but still has no effective item never shows in the Store, so the
+// card must never look like a completed task in that state.
+function reviewIsStoreVisible(review) {
+  return review.moderation_status === "approved" && Boolean(reviewEffectiveItemId(review));
+}
+
 function reviewActionButtons(review) {
   const buttons = [];
-  if (review.moderation_status !== "approved") buttons.push(`<button class="secondary btn-small" type="button" data-ract="approved" data-review-id="${review.review_id}">อนุมัติ</button>`);
+  const needsAssignmentBeforeApproval = review.review_scope !== "item" && !reviewEffectiveItemId(review);
+  if (!needsAssignmentBeforeApproval && review.moderation_status !== "approved") {
+    buttons.push(`<button class="secondary btn-small" type="button" data-ract="approved" data-review-id="${review.review_id}">อนุมัติ</button>`);
+  }
   if (review.moderation_status !== "rejected") buttons.push(`<button class="secondary btn-small" type="button" data-ract="rejected" data-review-id="${review.review_id}">ปฏิเสธ</button>`);
   if (review.moderation_status !== "hidden") buttons.push(`<button class="secondary btn-small" type="button" data-ract="hidden" data-review-id="${review.review_id}">ซ่อน</button>`);
   if (review.moderation_status === "hidden" || review.moderation_status === "rejected") {
@@ -1074,15 +1104,52 @@ function reviewActionButtons(review) {
   return buttons.join("");
 }
 
+function catalogItemPickerLabel(item) {
+  const parts = [item.item_name];
+  if (item.booking_ac_type) parts.push(item.booking_ac_type);
+  if (item.booking_btu) parts.push(`${Number(item.booking_btu).toLocaleString("th-TH")} BTU`);
+  if (item.booking_wash_variant) parts.push(item.booking_wash_variant);
+  return parts.filter(Boolean).join(" • ");
+}
+
+function reviewAssignOptionsHtml(review, items) {
+  const assignedId = review.assigned_item_id ? Number(review.assigned_item_id) : null;
+  return `<option value="">-- เลือกสินค้า --</option>${items
+    .map((it) => `<option value="${it.item_id}" ${assignedId === Number(it.item_id) ? "selected" : ""}>${escapeHtml(catalogItemPickerLabel(it))}</option>`)
+    .join("")}`;
+}
+
+// Only service_type/overall-scoped reviews (review_scope !== "item") are
+// ever eligible for assignment -- an item-scoped review already has a real,
+// known target and the backend itself rejects reassigning it (409).
+function reviewAssignPickerHtml(review) {
+  if (review.review_scope === "item") return "";
+  const isAlreadyApproved = review.moderation_status === "approved";
+  const mainLabel = isAlreadyApproved ? "ผูกกับสินค้า" : "ผูกสินค้าและอนุมัติ";
+  const mainAct = isAlreadyApproved ? "assign-only" : "assign-approve";
+  return `
+    <div class="asc-review-assign" data-review-id="${review.review_id}">
+      <input type="text" class="asc-review-assign-search" placeholder="ค้นหาสินค้า (ชื่อ/ประเภทแอร์/BTU/วิธีล้าง)" data-review-id="${review.review_id}">
+      <select class="asc-review-assign-select" data-review-id="${review.review_id}">${reviewAssignOptionsHtml(review, catalogItems)}</select>
+      <button class="primary btn-small" type="button" data-aact="${mainAct}" data-review-id="${review.review_id}">${mainLabel}</button>
+    </div>`;
+}
+
 function reviewCardHtml(review) {
+  const storeVisible = reviewIsStoreVisible(review);
+  const effectiveName = reviewEffectiveItemName(review);
   return `
   <div class="asc-item-card asc-review-card" data-review-id="${review.review_id}">
     <div class="asc-item-main">
-      <div class="asc-item-title">${escapeHtml(review.item_name || "-")} <span class="asc-badge asc-badge-${review.moderation_status}">${reviewStatusLabel(review.moderation_status)}</span></div>
+      <div class="asc-item-title">${escapeHtml(effectiveName || "(ยังไม่ทราบสินค้า)")} <span class="asc-badge asc-badge-${review.moderation_status}">${reviewStatusLabel(review.moderation_status)}</span></div>
       <div class="asc-item-meta">${escapeHtml(review.customer_identity || "ลูกค้า")} • งาน #${escapeHtml(String(review.completed_job_id || "-"))} • ${fmtDateTime(review.created_at)}</div>
+      <div class="asc-item-meta">แหล่งที่มา: ${reviewSourceLabel(review.review_source)} • Scope: ${reviewScopeLabel(review.review_scope)}${review.service_type ? ` • ประเภทบริการ: ${escapeHtml(review.service_type)}` : ""}</div>
+      <div class="asc-item-meta">สินค้าต้นทาง: ${escapeHtml(review.item_name || "-")} • สินค้าที่มอบหมาย: ${escapeHtml(review.assigned_item_name || "-")}</div>
+      <div class="asc-review-visibility ${storeVisible ? "asc-review-visible" : "asc-review-not-visible"}">${storeVisible ? "✅ แสดงใน Store ได้" : "⚠️ ยังไม่ผูกสินค้า"}</div>
       <div class="asc-review-stars">${reviewStarsHtml(review.rating)}</div>
       ${review.comment ? `<div class="asc-review-comment">${escapeHtml(review.comment)}</div>` : `<div class="muted2 mini">ไม่มีความเห็นเพิ่มเติม</div>`}
       ${review.moderated_by ? `<div class="muted2 mini">ตรวจสอบล่าสุดโดย ${escapeHtml(review.moderated_by)} เมื่อ ${fmtDateTime(review.moderated_at)}</div>` : ""}
+      ${reviewAssignPickerHtml(review)}
     </div>
     <div class="asc-item-actions asc-review-actions">${reviewActionButtons(review)}</div>
   </div>`;
@@ -1092,7 +1159,11 @@ function renderReviewItemFilterOptions() {
   const select = el("review_filter_item");
   const current = select.value;
   const seen = new Map();
-  reviewItems.forEach((r) => { if (!seen.has(r.item_id)) seen.set(r.item_id, r.item_name); });
+  reviewItems.forEach((r) => {
+    const id = reviewEffectiveItemId(r);
+    const name = reviewEffectiveItemName(r);
+    if (id && !seen.has(id)) seen.set(id, name);
+  });
   select.innerHTML = `<option value="">ทุกรายการ</option>${Array.from(seen.entries()).map(([id, name]) => `<option value="${id}">${escapeHtml(name)}</option>`).join("")}`;
   select.value = current;
 }
@@ -1100,10 +1171,19 @@ function renderReviewItemFilterOptions() {
 function renderReviewList() {
   const box = el("review_list");
   const statusFilter = el("review_filter_status").value;
+  const sourceFilter = el("review_filter_source").value;
   const itemFilter = el("review_filter_item").value;
   const filtered = reviewItems.filter((r) => {
-    if (statusFilter && r.moderation_status !== statusFilter) return false;
-    if (itemFilter && String(r.item_id) !== String(itemFilter)) return false;
+    const effectiveId = reviewEffectiveItemId(r);
+    if (statusFilter === "unassigned") {
+      if (effectiveId) return false;
+    } else if (statusFilter === "approved_unassigned") {
+      if (!(r.moderation_status === "approved" && !effectiveId)) return false;
+    } else if (statusFilter && r.moderation_status !== statusFilter) {
+      return false;
+    }
+    if (sourceFilter && r.review_source !== sourceFilter) return false;
+    if (itemFilter && String(effectiveId) !== String(itemFilter)) return false;
     return true;
   });
   if (!filtered.length) {
@@ -1148,11 +1228,66 @@ async function setReviewModerationStatus(reviewId, nextStatus) {
   }
 }
 
+// Single, atomic request for both "assign + approve" (the primary action for
+// a fresh service_type/overall review) and "assign only" (for a review
+// that's already approved but still orphaned) -- never two separate calls,
+// so the review is never left briefly approved-without-a-target.
+async function setReviewAssignment(reviewId, mode) {
+  if (reviewActionPending) return;
+  const review = reviewItems.find((r) => Number(r.review_id) === Number(reviewId));
+  if (!review) return;
+  const select = document.querySelector(`.asc-review-assign-select[data-review-id="${reviewId}"]`);
+  const assignedItemId = select ? Number(select.value) : NaN;
+  if (!Number.isFinite(assignedItemId) || assignedItemId <= 0) {
+    showToast("กรุณาเลือกสินค้าก่อน", "error");
+    return;
+  }
+  const body = { assigned_item_id: assignedItemId };
+  if (mode === "assign-approve") body.moderation_status = "approved";
+  reviewActionPending = reviewId;
+  try {
+    const updated = await apiFetch(`/admin/catalog/reviews/${reviewId}`, {
+      method: "PATCH",
+      body: JSON.stringify(body),
+    });
+    Object.assign(review, updated);
+    const assignedItem = catalogItems.find((it) => Number(it.item_id) === Number(review.assigned_item_id));
+    review.assigned_item_name = assignedItem ? assignedItem.item_name : review.assigned_item_name;
+    renderReviewList();
+    showToast(mode === "assign-approve" ? "ผูกสินค้าและอนุมัติแล้ว" : "ผูกสินค้าแล้ว", "success");
+  } catch (e) {
+    showToast(e.message || "ผูกสินค้าไม่สำเร็จ", "error");
+  } finally {
+    reviewActionPending = null;
+  }
+}
+
+function filterReviewAssignSelect(reviewId, query) {
+  const select = document.querySelector(`.asc-review-assign-select[data-review-id="${reviewId}"]`);
+  if (!select) return;
+  const review = reviewItems.find((r) => Number(r.review_id) === Number(reviewId));
+  if (!review) return;
+  const q = String(query || "").trim().toLowerCase();
+  const matches = q ? catalogItems.filter((it) => catalogItemPickerLabel(it).toLowerCase().includes(q)) : catalogItems;
+  select.innerHTML = reviewAssignOptionsHtml(review, matches);
+}
+
 function bindReviewListActions() {
   el("review_list").addEventListener("click", (event) => {
-    const button = event.target.closest("[data-ract]");
-    if (!button) return;
-    setReviewModerationStatus(Number(button.getAttribute("data-review-id")), button.getAttribute("data-ract"));
+    const ractButton = event.target.closest("[data-ract]");
+    if (ractButton) {
+      setReviewModerationStatus(Number(ractButton.getAttribute("data-review-id")), ractButton.getAttribute("data-ract"));
+      return;
+    }
+    const aactButton = event.target.closest("[data-aact]");
+    if (aactButton) {
+      setReviewAssignment(Number(aactButton.getAttribute("data-review-id")), aactButton.getAttribute("data-aact"));
+    }
+  });
+  el("review_list").addEventListener("input", (event) => {
+    const input = event.target.closest(".asc-review-assign-search");
+    if (!input) return;
+    filterReviewAssignSelect(Number(input.getAttribute("data-review-id")), input.value);
   });
 }
 
@@ -1168,6 +1303,7 @@ document.addEventListener("DOMContentLoaded", () => {
   bindReviewListActions();
   el("btnReloadReviews").addEventListener("click", loadReviews);
   el("review_filter_status").addEventListener("change", renderReviewList);
+  el("review_filter_source").addEventListener("change", renderReviewList);
   el("review_filter_item").addEventListener("change", renderReviewList);
   loadReviews();
 });

--- a/admin-store-catalog.js
+++ b/admin-store-catalog.js
@@ -1205,24 +1205,16 @@ function renderReviewItemFilterOptions() {
   select.value = current;
 }
 
+// item_id filtering stays client-side over the already status/source-filtered
+// fetch (see loadReviews) -- status and source are sent to the server so an
+// "unassigned"/"approved_unassigned" filter matches against the *entire*
+// table in SQL, not just the most recent 200 rows fetched before filtering.
 function renderReviewList() {
   const box = el("review_list");
-  const statusFilter = el("review_filter_status").value;
-  const sourceFilter = el("review_filter_source").value;
   const itemFilter = el("review_filter_item").value;
-  const filtered = reviewItems.filter((r) => {
-    const effectiveId = reviewEffectiveItemId(r);
-    if (statusFilter === "unassigned") {
-      if (effectiveId) return false;
-    } else if (statusFilter === "approved_unassigned") {
-      if (!(r.moderation_status === "approved" && !effectiveId)) return false;
-    } else if (statusFilter && r.moderation_status !== statusFilter) {
-      return false;
-    }
-    if (sourceFilter && r.review_source !== sourceFilter) return false;
-    if (itemFilter && String(effectiveId) !== String(itemFilter)) return false;
-    return true;
-  });
+  const filtered = itemFilter
+    ? reviewItems.filter((r) => String(reviewEffectiveItemId(r)) === String(itemFilter))
+    : reviewItems;
   if (!filtered.length) {
     box.innerHTML = `<div class="asc-empty">ไม่พบรีวิวที่ตรงกับตัวกรอง</div>`;
     return;
@@ -1233,8 +1225,14 @@ function renderReviewList() {
 async function loadReviews() {
   const box = el("review_list");
   box.innerHTML = `<div class="asc-loading">กำลังโหลดรีวิว...</div>`;
+  const statusFilter = el("review_filter_status").value;
+  const sourceFilter = el("review_filter_source").value;
+  const params = new URLSearchParams();
+  if (statusFilter) params.set("status", statusFilter);
+  if (sourceFilter) params.set("source", sourceFilter);
+  const qs = params.toString();
   try {
-    reviewItems = await apiFetch("/admin/catalog/reviews");
+    reviewItems = await apiFetch(`/admin/catalog/reviews${qs ? `?${qs}` : ""}`);
     renderReviewItemFilterOptions();
     renderReviewList();
   } catch (e) {
@@ -1339,8 +1337,8 @@ document.addEventListener("DOMContentLoaded", () => {
 
   bindReviewListActions();
   el("btnReloadReviews").addEventListener("click", loadReviews);
-  el("review_filter_status").addEventListener("change", renderReviewList);
-  el("review_filter_source").addEventListener("change", renderReviewList);
+  el("review_filter_status").addEventListener("change", loadReviews);
+  el("review_filter_source").addEventListener("change", loadReviews);
   el("review_filter_item").addEventListener("change", renderReviewList);
   loadReviews();
 });

--- a/customer-app/assets/customer-app.css
+++ b/customer-app/assets/customer-app.css
@@ -3518,14 +3518,20 @@ body.has-contact-sheet { overflow: hidden; }
   white-space: nowrap;
 }
 .store-filters {
-  display: grid;
-  grid-template-columns: minmax(0, 1.4fr) minmax(0, 1fr);
+  display: flex;
+  flex-wrap: wrap;
   gap: 8px;
   margin-bottom: 14px;
 }
+.store-search-input {
+  flex: 1 1 100%;
+}
 .store-search-input,
-.store-category-select {
-  width: 100%;
+.store-category-select,
+.store-actype-select,
+.store-wash-select,
+.store-btu-select,
+.store-sort-select {
   min-width: 0;
   height: 44px;
   padding: 0 12px;
@@ -3535,8 +3541,47 @@ body.has-contact-sheet { overflow: hidden; }
   font-size: 14px;
   color: var(--ink);
 }
-@media (max-width: 360px) {
-  .store-filters { grid-template-columns: 1fr; }
+.store-category-select,
+.store-actype-select,
+.store-wash-select,
+.store-btu-select,
+.store-sort-select {
+  flex: 1 1 calc(50% - 4px);
+}
+.store-queue-today-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  height: 44px;
+  padding: 0 12px;
+  border-radius: 999px;
+  border: 1px solid var(--line);
+  background: #fff;
+  font-size: 13px;
+  color: var(--ink);
+  flex: 1 1 calc(50% - 4px);
+}
+.store-queue-today-chip input {
+  width: 16px;
+  height: 16px;
+}
+.store-promo-info {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin: 4px 0;
+  font-size: 12px;
+}
+.store-promo-name {
+  color: var(--danger);
+  font-weight: 600;
+}
+.store-promo-savings {
+  color: var(--success);
+  font-weight: 600;
+}
+.store-promo-end {
+  color: var(--muted);
 }
 
 /* Mobile-first 2-column marketplace grid (Lazada/Shopee-style).

--- a/customer-app/assets/customer-app.css
+++ b/customer-app/assets/customer-app.css
@@ -4198,6 +4198,7 @@ body.has-contact-sheet { overflow: hidden; }
 .store-reviews-summary .store-rating-star { font-size: 14px; }
 .store-reviews-summary .store-rating-value { color: var(--ink); font-weight: 700; }
 .store-reviews-summary .store-rating-count { color: var(--muted); font-weight: 500; }
+.store-reviews-summary .store-rating-count-empty { font-weight: 400; font-size: 13px; }
 
 .store-reviews-empty { color: var(--muted); font-size: 13.5px; }
 .store-reviews-list {

--- a/customer-app/index.html
+++ b/customer-app/index.html
@@ -52,6 +52,7 @@
 
   <script src="./modules/state.js?v=20260624_store_hot_sale_verified_reviews"></script>
   <script src="./modules/utils.js?v=20260624_store_hot_sale_verified_reviews"></script>
+  <script src="./modules/analytics.js?v=20260624_store_hot_sale_verified_reviews"></script>
   <script src="./modules/api.js?v=20260624_store_hot_sale_verified_reviews"></script>
   <script src="./modules/services.js?v=20260624_store_hot_sale_verified_reviews"></script>
   <script src="./modules/ui.js?v=20260624_store_hot_sale_verified_reviews"></script>

--- a/customer-app/modules/analytics.js
+++ b/customer-app/modules/analytics.js
@@ -1,0 +1,60 @@
+(function () {
+  "use strict";
+
+  const root = window.CWFCustomerAppV2 = window.CWFCustomerAppV2 || {};
+
+  // Store funnel analytics events. Dependency-free: safely no-ops when
+  // neither window.dataLayer nor window.gtag exists (e.g. ad blockers,
+  // consent not yet granted, or this test/server-side context).
+  // Allowed fields ONLY -- never PII, review comment text, auth token, or
+  // booking code. Unknown keys passed in `fields` are dropped silently so a
+  // future caller can never accidentally leak something sensitive.
+  const ALLOWED_EVENTS = new Set([
+    "cwf_store_view",
+    "cwf_store_product_view",
+    "cwf_store_variant_select",
+    "cwf_store_filter",
+    "cwf_store_detail_expand",
+    "cwf_store_related_click",
+    "cwf_store_begin_booking",
+    "cwf_store_contact_admin",
+  ]);
+
+  const ALLOWED_FIELDS = [
+    "item_id",
+    "category",
+    "ac_type",
+    "wash_variant",
+    "btu",
+    "price",
+    "source",
+    "position",
+    "filter_name",
+    "filter_value",
+    "sort",
+  ];
+
+  function sanitizeFields(fields) {
+    const input = fields || {};
+    const safe = {};
+    ALLOWED_FIELDS.forEach((key) => {
+      if (input[key] === undefined || input[key] === null) return;
+      const value = input[key];
+      safe[key] = typeof value === "object" ? String(value) : value;
+    });
+    return safe;
+  }
+
+  function track(eventName, fields) {
+    if (!ALLOWED_EVENTS.has(eventName)) return;
+    const payload = Object.assign({ event: eventName }, sanitizeFields(fields));
+    try {
+      if (Array.isArray(window.dataLayer)) window.dataLayer.push(payload);
+      if (typeof window.gtag === "function") window.gtag("event", eventName, sanitizeFields(fields));
+    } catch (_error) {
+      // Analytics must never break the customer experience.
+    }
+  }
+
+  root.analytics = { track };
+})();

--- a/customer-app/modules/api.js
+++ b/customer-app/modules/api.js
@@ -107,11 +107,11 @@
     },
 
     async loadCatalogItems() {
-      return requestJson("/catalog/items", { query: { customer: 1 } });
+      return requestJson("/catalog/items", { query: { customer: 1 }, cache: "no-store" });
     },
 
     async loadCatalogItem(itemId) {
-      return requestJson(`/catalog/items/${encodeURIComponent(itemId)}`, { query: { customer: 1 } });
+      return requestJson(`/catalog/items/${encodeURIComponent(itemId)}`, { query: { customer: 1 }, cache: "no-store" });
     },
 
     async submitScheduledBooking(payload) {

--- a/customer-app/modules/services.js
+++ b/customer-app/modules/services.js
@@ -255,6 +255,21 @@
   // booking fields are missing or unsupported, this must return null so the
   // caller routes the customer to "contact admin" instead of silently
   // opening a booking screen prefilled with a guessed ac_type/btu/wash.
+  // Deterministic fixed-keyword fallback for items missing a real
+  // booking_wash_variant -- mirrors store.js's canonicalWashVariant()
+  // resolver. Only matches on unambiguous keywords in the item name; never
+  // overrides an existing real booking_wash_variant value, and never guesses
+  // when no fixed keyword is present (the caller still returns null then).
+  function inferWashVariantFromName(itemName) {
+    const norm = String(itemName || "").trim().toLowerCase();
+    if (!norm) return null;
+    if (/ตัดล้าง|overhaul|ใหญ่/.test(norm)) return "ล้างแบบตัดล้าง";
+    if (/แขวนคอยล์|coil/.test(norm)) return "ล้างแขวนคอยล์";
+    if (/พรีเมียม|premium/.test(norm)) return "ล้างพรีเมียม";
+    if (/ปกติ|ธรรมดา|normal/.test(norm)) return "ล้างธรรมดา";
+    return null;
+  }
+
   function catalogItemToCommerceDraft(catalogItem) {
     if (!catalogItem || catalogItem.booking_mode !== "bookable") return null;
 
@@ -265,9 +280,15 @@
     const matchedBtu = bookableBtuOptions.find((item) => item.btu === btuValue);
     if (!matchedBtu) return null;
 
+    let washVariantValue = catalogItem.booking_wash_variant || "";
     if (matchedAcType.value === WALL_AC) {
-      const matchedWash = washVariants.find((item) => item.value === catalogItem.booking_wash_variant);
-      if (!matchedWash) return null;
+      let matchedWash = washVariants.find((item) => item.value === washVariantValue);
+      if (!matchedWash) {
+        const inferred = inferWashVariantFromName(catalogItem.item_name);
+        matchedWash = washVariants.find((item) => item.value === inferred);
+        if (!matchedWash) return null;
+        washVariantValue = matchedWash.value;
+      }
     }
 
     return {
@@ -277,7 +298,7 @@
       draft: createServiceLine({
         ac_type: matchedAcType.value,
         btu: matchedBtu.btu,
-        wash_variant: matchedAcType.value === WALL_AC ? catalogItem.booking_wash_variant : "",
+        wash_variant: matchedAcType.value === WALL_AC ? washVariantValue : "",
         machine_count: 1,
       }),
     };

--- a/customer-app/modules/store.js
+++ b/customer-app/modules/store.js
@@ -1067,8 +1067,7 @@
       <div class="store-reviews-summary">
         <span class="store-rating-label">รีวิว</span>
         <span class="store-rating-stars">${renderReviewStars(hasReviews ? Math.round(avg) : 0, false)}</span>
-        ${hasReviews ? `<span class="store-rating-value">${formatRatingAverage(avg)}</span>` : ""}
-        <span class="store-rating-count">(${count})</span>
+        ${hasReviews ? `<span class="store-rating-value">${formatRatingAverage(avg)}</span><span class="store-rating-count">(${count})</span>` : `<span class="store-rating-count store-rating-count-empty">ยังไม่มีรีวิว</span>`}
       </div>
       <div class="store-reviews-list-mount">${renderReviewsList()}</div>
       <div class="store-review-write-mount">${renderWriteReviewPanel(item)}</div>

--- a/customer-app/modules/store.js
+++ b/customer-app/modules/store.js
@@ -3,7 +3,27 @@
 
   const root = window.CWFCustomerAppV2 = window.CWFCustomerAppV2 || {};
 
-  let filterState = { search: "", category: "" };
+  let filterState = { search: "", category: "", acType: "", washVariant: "", btu: "", queueToday: false, sort: "recommended" };
+
+  const FILTER_AC_TYPES = [
+    { value: "wall", label: "แอร์ผนัง" },
+    { value: "fourway", label: "แอร์สี่ทิศทาง" },
+    { value: "hanging", label: "แอร์แขวน" },
+    { value: "ceiling", label: "แอร์เปลือยใต้ฝ้า" },
+  ];
+  const FILTER_WASH_VARIANTS = [
+    { value: "normal", label: "ล้างปกติ" },
+    { value: "premium", label: "ล้างพรีเมียม" },
+    { value: "coil", label: "แขวนคอยล์" },
+    { value: "overhaul", label: "ตัดล้างใหญ่" },
+  ];
+  const FILTER_BTU_OPTIONS = [9000, 12000, 18000, 24000, 30000];
+  const SORT_OPTIONS = [
+    { value: "recommended", label: "แนะนำโดย CWF" },
+    { value: "booking_count", label: "จองมากที่สุด" },
+    { value: "price_low", label: "ราคา: ต่ำไปสูง" },
+    { value: "price_high", label: "ราคา: สูงไปต่ำ" },
+  ];
 
   function categoriesFromItems(items) {
     const set = new Set();
@@ -209,14 +229,11 @@
     });
   }
 
-  // The item the customer is currently viewing price/short-info for: either the
-  // originally loaded detail item, or whichever sibling they tapped in the BTU
-  // selector. Never a network re-fetch -- purely a client-side selection among
-  // already-known real catalog rows.
-  function currentVariantDisplayItem(item, siblings) {
-    if (!selectedVariantItemId || String(selectedVariantItemId) === String(item.item_id)) return item;
-    return (siblings || []).find((s) => String(s.item_id) === String(selectedVariantItemId)) || item;
-  }
+  // Selecting a BTU/spec sibling navigates to that item's own detail route
+  // (see the [data-store-variant-option] handler below). This makes the
+  // current `item` the single source of truth for the *entire* detail page --
+  // gallery, badges, name, rating, descriptions, related products, reviews --
+  // never a partial "display item" computed separately from what was loaded.
 
   // Picks the one item to represent a wash-method group in the related
   // slider: prefer the candidate whose real BTU is closest to the item
@@ -279,14 +296,60 @@
     return [{ ...item, is_current: true }, ...others];
   }
 
+  function track(eventName, fields) {
+    if (root.analytics && typeof root.analytics.track === "function") {
+      root.analytics.track(eventName, fields);
+    }
+  }
+
+  function trackFilter(filterName, filterValue) {
+    track("cwf_store_filter", { filter_name: filterName, filter_value: filterValue });
+  }
+
+  function trackItemEvent(eventName, item, extra) {
+    if (!item) return;
+    track(eventName, Object.assign({
+      item_id: item.item_id,
+      category: canonicalJobCategory(item) || undefined,
+      ac_type: canonicalAcType(item) || undefined,
+      btu: itemBtuValue(item) || undefined,
+      price: effectiveSalePrice(item) ?? undefined,
+    }, extra || {}));
+  }
+
   function applyFilters(items) {
     const search = filterState.search.trim().toLowerCase();
     const category = filterState.category;
-    return (items || []).filter((item) => {
+    const filtered = (items || []).filter((item) => {
       if (category && String(item.item_category || "") !== category) return false;
       if (search && !String(item.item_name || "").toLowerCase().includes(search)) return false;
+      if (filterState.acType && canonicalAcType(item) !== filterState.acType) return false;
+      if (filterState.washVariant && canonicalWashVariant(item) !== filterState.washVariant) return false;
+      if (filterState.btu && itemBtuValue(item) !== Number(filterState.btu)) return false;
+      if (filterState.queueToday && item.has_queue_today !== true) return false;
       return true;
     });
+    return sortItems(filtered);
+  }
+
+  function sortItems(items) {
+    const list = items.slice();
+    if (filterState.sort === "booking_count") {
+      list.sort((a, b) => Number(b.booking_count || 0) - Number(a.booking_count || 0));
+    } else if (filterState.sort === "price_low" || filterState.sort === "price_high") {
+      const dir = filterState.sort === "price_low" ? 1 : -1;
+      list.sort((a, b) => {
+        const aPrice = effectiveSalePrice(a);
+        const bPrice = effectiveSalePrice(b);
+        if (aPrice === null && bPrice === null) return 0;
+        if (aPrice === null) return 1;
+        if (bPrice === null) return -1;
+        return (aPrice - bPrice) * dir;
+      });
+    }
+    // "recommended" keeps the server-provided order (already prioritized by
+    // is_featured/priority) -- no client resort needed.
+    return list;
   }
 
   function itemGalleryImages(item) {
@@ -325,6 +388,31 @@
     const pct = salePercentOff(item);
     const text = pct ? `SALE -${pct}%` : "SALE";
     return `<span class="store-sale-badge" aria-label="ลดราคา">${root.utils.escapeHtml(text)}</span>`;
+  }
+
+  function promoEndDateLabel(item) {
+    if (!item.effective_to) return "";
+    const dt = new Date(item.effective_to);
+    if (Number.isNaN(dt.getTime())) return "";
+    return dt.toLocaleDateString("th-TH", { dateStyle: "medium" });
+  }
+
+  // Only ever rendered when hasPromo(item) is true (a real, currently-active
+  // promotion rule) -- campaign_name/savings/end date all come straight from
+  // the priced promotion rule, never a guessed/static label.
+  function renderPromoInfo(item) {
+    if (!hasPromo(item)) return "";
+    const name = String(item.campaign_name || item.price_label || "").trim();
+    const normal = Number(item.normal_price);
+    const sale = Number(item.active_price);
+    const savings = Number.isFinite(normal) && Number.isFinite(sale) && sale < normal ? normal - sale : null;
+    const endLabel = promoEndDateLabel(item);
+    const parts = [];
+    if (name) parts.push(`<span class="store-promo-name">${root.utils.escapeHtml(name)}</span>`);
+    if (savings) parts.push(`<span class="store-promo-savings">ประหยัด ${root.utils.escapeHtml(root.utils.formatBaht(savings))}</span>`);
+    if (endLabel) parts.push(`<span class="store-promo-end">หมดเขต ${root.utils.escapeHtml(endLabel)}</span>`);
+    if (!parts.length) return "";
+    return `<div class="store-promo-info">${parts.join("")}</div>`;
   }
 
   // Real review aggregates only. item.rating_average/review_count come straight
@@ -446,6 +534,7 @@
           ${promo ? `<span class="price-strike">${root.utils.escapeHtml(root.utils.formatBaht(item.normal_price))}</span>` : ""}
           ${unit && !priceIsAsk(item) ? `<span class="muted">/ ${root.utils.escapeHtml(unit)}</span>` : ""}
         </div>
+        ${renderPromoInfo(item)}
         <div class="store-card-actions">
           ${bookable
             ? `<button class="primary-btn" type="button" data-store-book="${root.utils.escapeHtml(id)}">จองคิว</button>`
@@ -483,6 +572,25 @@
         <select class="store-category-select" data-store-category aria-label="หมวดหมู่">
           <option value="">ทั้งหมด</option>
           ${categories.map((cat) => `<option value="${root.utils.escapeHtml(cat)}"${filterState.category === cat ? " selected" : ""}>${root.utils.escapeHtml(cat)}</option>`).join("")}
+        </select>
+        <select class="store-actype-select" data-store-actype aria-label="ชนิดแอร์">
+          <option value="">ชนิดแอร์ทั้งหมด</option>
+          ${FILTER_AC_TYPES.map((opt) => `<option value="${opt.value}"${filterState.acType === opt.value ? " selected" : ""}>${root.utils.escapeHtml(opt.label)}</option>`).join("")}
+        </select>
+        <select class="store-wash-select" data-store-wash aria-label="วิธีล้าง">
+          <option value="">วิธีล้างทั้งหมด</option>
+          ${FILTER_WASH_VARIANTS.map((opt) => `<option value="${opt.value}"${filterState.washVariant === opt.value ? " selected" : ""}>${root.utils.escapeHtml(opt.label)}</option>`).join("")}
+        </select>
+        <select class="store-btu-select" data-store-btu aria-label="ขนาด BTU">
+          <option value="">BTU ทั้งหมด</option>
+          ${FILTER_BTU_OPTIONS.map((btu) => `<option value="${btu}"${String(filterState.btu) === String(btu) ? " selected" : ""}>${btu.toLocaleString("th-TH")} BTU</option>`).join("")}
+        </select>
+        <label class="store-queue-today-chip">
+          <input type="checkbox" data-store-queue-today${filterState.queueToday ? " checked" : ""}>
+          <span>มีคิววันนี้</span>
+        </label>
+        <select class="store-sort-select" data-store-sort aria-label="เรียงตาม">
+          ${SORT_OPTIONS.map((opt) => `<option value="${opt.value}"${filterState.sort === opt.value ? " selected" : ""}>${root.utils.escapeHtml(opt.label)}</option>`).join("")}
         </select>
       </div>
       <div data-store-grid-mount>${renderGrid(items)}</div>
@@ -623,16 +731,21 @@
         const item = (root.state.catalog.items || []).find((it) => String(it.item_id) === String(id));
         const draftItem = root.services.catalogItemToCommerceDraft(item);
         if (!draftItem || !root.services.applyCommerceDraft("scheduled", draftItem)) {
+          trackItemEvent("cwf_store_contact_admin", item, { source: "store_list" });
           root.ui.openContactSheet(container, { title: item?.item_name || "รายการนี้" });
           return;
         }
+        trackItemEvent("cwf_store_begin_booking", item, { source: "store_list" });
         root.utils.routeTo("scheduled");
       });
     });
     container.querySelectorAll("[data-store-contact]").forEach((button) => {
       button.addEventListener("click", (event) => {
         event.stopPropagation && event.stopPropagation();
+        const id = button.getAttribute("data-store-contact");
+        const item = (root.state.catalog.items || []).find((it) => String(it.item_id) === String(id));
         const name = button.getAttribute("data-store-contact-name") || "รายการนี้";
+        trackItemEvent("cwf_store_contact_admin", item, { source: "store_list" });
         root.ui.openContactSheet(container, { title: name });
       });
     });
@@ -665,6 +778,47 @@
     if (category) {
       category.addEventListener("change", () => {
         filterState.category = category.value || "";
+        trackFilter("category", filterState.category);
+        patchGrid(container);
+      });
+    }
+    const acType = container.querySelector("[data-store-actype]");
+    if (acType) {
+      acType.addEventListener("change", () => {
+        filterState.acType = acType.value || "";
+        trackFilter("ac_type", filterState.acType);
+        patchGrid(container);
+      });
+    }
+    const wash = container.querySelector("[data-store-wash]");
+    if (wash) {
+      wash.addEventListener("change", () => {
+        filterState.washVariant = wash.value || "";
+        trackFilter("wash_variant", filterState.washVariant);
+        patchGrid(container);
+      });
+    }
+    const btu = container.querySelector("[data-store-btu]");
+    if (btu) {
+      btu.addEventListener("change", () => {
+        filterState.btu = btu.value || "";
+        trackFilter("btu", filterState.btu);
+        patchGrid(container);
+      });
+    }
+    const queueToday = container.querySelector("[data-store-queue-today]");
+    if (queueToday) {
+      queueToday.addEventListener("change", () => {
+        filterState.queueToday = !!queueToday.checked;
+        trackFilter("queue_today", filterState.queueToday);
+        patchGrid(container);
+      });
+    }
+    const sort = container.querySelector("[data-store-sort]");
+    if (sort) {
+      sort.addEventListener("change", () => {
+        filterState.sort = sort.value || "recommended";
+        trackFilter("sort", filterState.sort);
         patchGrid(container);
       });
     }
@@ -745,10 +899,6 @@
     `;
   }
 
-  // Currently selected BTU/spec sibling on the product detail page (per
-  // requirement #5). Reset whenever a new detail item is loaded.
-  let selectedVariantItemId = null;
-
   // Icon shown to the left of each accordion header -- a fixed, deterministic
   // mapping by section title (presentation only, not derived from any
   // per-item data) so every card is instantly recognizable as a tappable row.
@@ -784,7 +934,7 @@
 
   function renderVariantSelector(item, siblings) {
     if (!siblings || siblings.length < 2) return "";
-    const selectedId = selectedVariantItemId || item.item_id;
+    const selectedId = item.item_id;
     return `
       <div class="store-detail-variant-selector" data-store-variant-selector>
         <span class="store-detail-variant-label">เลือกขนาด BTU</span>
@@ -1065,9 +1215,9 @@
     return `
       <h3>รีวิวจากลูกค้า</h3>
       <div class="store-reviews-summary">
-        <span class="store-rating-label">รีวิว</span>
-        <span class="store-rating-stars">${renderReviewStars(hasReviews ? Math.round(avg) : 0, false)}</span>
-        ${hasReviews ? `<span class="store-rating-value">${formatRatingAverage(avg)}</span><span class="store-rating-count">(${count})</span>` : `<span class="store-rating-count store-rating-count-empty">ยังไม่มีรีวิว</span>`}
+        ${hasReviews
+          ? `<span class="store-rating-label">รีวิว</span><span class="store-rating-stars">${renderReviewStars(Math.round(avg), false)}</span><span class="store-rating-value">${formatRatingAverage(avg)}</span><span class="store-rating-count">(${count})</span>`
+          : `<span class="store-rating-count store-rating-count-empty">ยังไม่มีรีวิวจากลูกค้าสำหรับบริการนี้</span>`}
       </div>
       <div class="store-reviews-list-mount">${renderReviewsList()}</div>
       <div class="store-review-write-mount">${renderWriteReviewPanel(item)}</div>
@@ -1160,10 +1310,9 @@
     const highlights = Array.isArray(item.highlights) ? item.highlights : [];
     const allItems = (root.state.catalog && root.state.catalog.items) || [];
     const siblings = variantSiblings(item, allItems);
-    const displayItem = currentVariantDisplayItem(item, siblings);
-    const unit = displayItem.unit_label || "";
-    const promo = hasPromo(displayItem);
-    const bookable = isBookable(displayItem);
+    const unit = item.unit_label || "";
+    const promo = hasPromo(item);
+    const bookable = isBookable(item);
     const showCompare = canonicalAcType(item) === "wall" && canonicalJobCategory(item) === "wash";
     const ctaButton = bookable
       ? `<button class="primary-btn" type="button" data-store-detail-book="1">จองคิว</button>`
@@ -1180,12 +1329,13 @@
       ${renderRatingBadge(item)}
       ${renderBookingCountLabel(item)}
       <div class="store-detail-price" data-store-detail-price>
-        <span class="price-text${priceIsAsk(displayItem) ? " is-estimate" : ""}">${root.utils.escapeHtml(priceLabel(displayItem))}</span>
-        ${promo ? `<span class="price-strike">${root.utils.escapeHtml(root.utils.formatBaht(displayItem.normal_price))}</span>` : ""}
-        ${unit && !priceIsAsk(displayItem) ? `<span class="muted">/ ${root.utils.escapeHtml(unit)}</span>` : ""}
+        <span class="price-text${priceIsAsk(item) ? " is-estimate" : ""}">${root.utils.escapeHtml(priceLabel(item))}</span>
+        ${promo ? `<span class="price-strike">${root.utils.escapeHtml(root.utils.formatBaht(item.normal_price))}</span>` : ""}
+        ${unit && !priceIsAsk(item) ? `<span class="muted">/ ${root.utils.escapeHtml(unit)}</span>` : ""}
       </div>
+      ${renderPromoInfo(item)}
       ${renderVariantSelector(item, siblings)}
-      ${displayItem.short_description ? `<div class="store-detail-section store-detail-summary"><p>${root.utils.escapeHtml(displayItem.short_description)}</p></div>` : ""}
+      ${item.short_description ? `<div class="store-detail-section store-detail-summary"><p>${root.utils.escapeHtml(item.short_description)}</p></div>` : ""}
       <div class="store-detail-inline-cta">${ctaButton}</div>
       <div class="store-detail-accordion-group">
         ${renderAccordionSection("จุดเด่นของบริการ", highlights.length ? `
@@ -1269,19 +1419,20 @@
       bookButton.addEventListener("click", () => {
         const item = root.state.storeDetail?.data;
         if (!item) return;
-        const allItems = (root.state.catalog && root.state.catalog.items) || [];
-        const target = currentVariantDisplayItem(item, variantSiblings(item, allItems));
-        const draftItem = root.services.catalogItemToCommerceDraft(target);
+        const draftItem = root.services.catalogItemToCommerceDraft(item);
         if (!draftItem || !root.services.applyCommerceDraft("scheduled", draftItem)) {
-          root.ui.openContactSheet(container, { title: target?.item_name || item?.item_name || "รายการนี้" });
+          trackItemEvent("cwf_store_contact_admin", item, { source: "store_detail" });
+          root.ui.openContactSheet(container, { title: item?.item_name || "รายการนี้" });
           return;
         }
+        trackItemEvent("cwf_store_begin_booking", item, { source: "store_detail" });
         root.utils.routeTo("scheduled");
       });
     });
     container.querySelectorAll("[data-store-detail-contact]").forEach((contactButton) => {
       contactButton.addEventListener("click", () => {
         const item = root.state.storeDetail?.data;
+        trackItemEvent("cwf_store_contact_admin", item, { source: "store_detail" });
         root.ui.openContactSheet(container, { title: item?.item_name || "รายการนี้" });
       });
     });
@@ -1293,12 +1444,32 @@
     });
     container.querySelectorAll("[data-store-variant-option]").forEach((button) => {
       button.addEventListener("click", () => {
-        selectedVariantItemId = button.getAttribute("data-store-variant-option");
-        patchDetailBody(container);
+        const id = button.getAttribute("data-store-variant-option");
+        if (String(id) === String(detailItemId())) return;
+        track("cwf_store_variant_select", { item_id: id, source: "store_detail" });
+        // Routes to the sibling's own detail URL rather than swapping a local
+        // "display item" -- this makes the route param the single source of
+        // truth for the whole page (gallery/badges/descriptions/reviews all
+        // reload for the newly selected variant via loadDetail()), so there is
+        // never a mismatch between the price shown and the rest of the page.
+        root.utils.routeTo(`storeItem-${id}`);
       });
     });
     container.querySelectorAll("[data-store-related-item]").forEach((card) => {
-      card.addEventListener("click", () => goToDetail(card.getAttribute("data-store-related-item")));
+      card.addEventListener("click", () => {
+        const id = card.getAttribute("data-store-related-item");
+        track("cwf_store_related_click", { item_id: id, source: "store_detail" });
+        goToDetail(id);
+      });
+    });
+    container.querySelectorAll(".store-detail-accordion").forEach((details) => {
+      details.addEventListener("toggle", () => {
+        if (!details.open) return;
+        const title = details.querySelector(".store-detail-accordion-title");
+        trackItemEvent("cwf_store_detail_expand", root.state.storeDetail?.data, {
+          source: title ? title.textContent : "",
+        });
+      });
     });
     const item = root.state.storeDetail?.data;
     if (item) bindReviewsSection(container, item);
@@ -1330,7 +1501,6 @@
 
   async function loadDetail(container, itemId) {
     resetReviewsState(itemId);
-    selectedVariantItemId = null;
     if (!itemId) {
       root.state.setStoreDetail({ status: "error", itemId: "", data: null, error: "ไม่พบรายการนี้" });
       patchDetailBody(container);
@@ -1341,6 +1511,7 @@
     try {
       const data = await root.api.loadCatalogItem(itemId);
       root.state.setStoreDetail({ status: "success", itemId, data, error: "" });
+      trackItemEvent("cwf_store_product_view", data, { source: "store_detail" });
       patchDetailBody(container);
       loadReviewsList(container, data);
       loadEligibility(container, data);
@@ -1357,7 +1528,8 @@
 
   const store = {
     render(container) {
-      filterState = { search: "", category: "" };
+      filterState = { search: "", category: "", acType: "", washVariant: "", btu: "", queueToday: false, sort: "recommended" };
+      track("cwf_store_view", {});
       container.innerHTML = `
         <section class="screen store-screen">
           <div class="store-compact-header">
@@ -1391,6 +1563,8 @@
   store.renderDetail.onLeave = () => {
     clearDetailAutoplay();
   };
+
+  store._test = { loadDetail, loadReviewsList, detailItemId, renderDetailBody, renderReviewsSectionBody };
 
   root.store = store;
 })();

--- a/customer-app/sw.js
+++ b/customer-app/sw.js
@@ -10,6 +10,7 @@ const APP_SHELL = [
   "./assets/icons/cwf-customer-192.png",
   `./modules/state.js?v=${BUILD_ID}`,
   `./modules/utils.js?v=${BUILD_ID}`,
+  `./modules/analytics.js?v=${BUILD_ID}`,
   `./modules/api.js?v=${BUILD_ID}`,
   `./modules/services.js?v=${BUILD_ID}`,
   `./modules/ui.js?v=${BUILD_ID}`,

--- a/server/routes/catalog/reviews.js
+++ b/server/routes/catalog/reviews.js
@@ -528,7 +528,19 @@ module.exports = function createCatalogReviewRoutes(deps = {}) {
       const where = [];
       const params = [];
       let p = 1;
-      if (status) { params.push(status); where.push(`r.moderation_status = $${p++}`); }
+      // "unassigned"/"approved_unassigned" are pseudo-statuses (no effective
+      // item at all) rather than real moderation_status values, so they must
+      // be translated to an effective-item NULL check instead of an equality
+      // match -- this runs in SQL against the full table, not just the most
+      // recent 200 rows, so an older approved orphan review is never missed.
+      if (status === "unassigned") {
+        where.push(`${effectiveItemExpr} IS NULL`);
+      } else if (status === "approved_unassigned") {
+        where.push(`r.moderation_status = 'approved'`);
+        where.push(`${effectiveItemExpr} IS NULL`);
+      } else if (status) {
+        params.push(status); where.push(`r.moderation_status = $${p++}`);
+      }
       if (source) { params.push(source); where.push(`r.review_source = $${p++}`); }
       if (Number.isFinite(itemId) && itemId > 0) { params.push(itemId); where.push(`${effectiveItemExpr} = $${p++}`); }
 

--- a/server/routes/catalog/reviews.js
+++ b/server/routes/catalog/reviews.js
@@ -631,7 +631,7 @@ module.exports = function createCatalogReviewRoutes(deps = {}) {
       await client.query("BEGIN");
 
       const reviewR = await client.query(
-        `SELECT review_id, review_scope FROM public.catalog_item_reviews WHERE review_id = $1 FOR UPDATE`,
+        `SELECT review_id, review_scope, assigned_item_id FROM public.catalog_item_reviews WHERE review_id = $1 FOR UPDATE`,
         [reviewId]
       );
       if (!reviewR.rows.length) {
@@ -639,6 +639,7 @@ module.exports = function createCatalogReviewRoutes(deps = {}) {
         return res.status(404).json({ error: "ไม่พบรีวิว" });
       }
       const currentScope = reviewR.rows[0].review_scope || "item";
+      const currentAssignedItemId = reviewR.rows[0].assigned_item_id == null ? null : Number(reviewR.rows[0].assigned_item_id);
 
       if (hasAssignment && currentScope === "item") {
         await client.query("ROLLBACK");
@@ -650,6 +651,19 @@ module.exports = function createCatalogReviewRoutes(deps = {}) {
         if (!itemR.rows.length) {
           await client.query("ROLLBACK");
           return res.status(404).json({ error: "ไม่พบสินค้า/บริการที่ต้องการมอบหมาย" });
+        }
+      }
+
+      // A service_type/overall-scoped review (no real item_id) can only ever
+      // become 'approved' once it has a real target -- either already
+      // assigned, or assigned atomically in this same request. Never
+      // auto-assign: if neither is present, reject with a clear 409 rather
+      // than silently producing an approved-but-unbound (orphan) review.
+      if (hasStatus && nextStatus === "approved" && currentScope !== "item") {
+        const effectiveAssignedItemId = hasAssignment ? assignedItemId : currentAssignedItemId;
+        if (effectiveAssignedItemId == null) {
+          await client.query("ROLLBACK");
+          return res.status(409).json({ error: "ต้องผูกสินค้า (assigned_item_id) ก่อนอนุมัติรีวิวที่ยังไม่ทราบสินค้า" });
         }
       }
 

--- a/server/routes/catalog/reviews.js
+++ b/server/routes/catalog/reviews.js
@@ -517,14 +517,21 @@ module.exports = function createCatalogReviewRoutes(deps = {}) {
       const status = String(req.query.status || "").trim();
       const source = String(req.query.source || "").trim();
       const itemId = Number(req.query.item_id);
+      const trackingReady = await isTrackingReviewSchemaReady(pool);
+      // Filter by the *effective* item (assigned_item_id when present,
+      // otherwise item_id) so a query for item X also surfaces
+      // service_type/overall-scoped reviews an admin has already assigned to
+      // X -- matching the same COALESCE used for public rating aggregation
+      // and the GET /reviews list above, rather than only matching reviews
+      // whose original item_id happens to equal X.
+      const effectiveItemExpr = trackingReady ? "COALESCE(r.assigned_item_id, r.item_id)" : "r.item_id";
       const where = [];
       const params = [];
       let p = 1;
       if (status) { params.push(status); where.push(`r.moderation_status = $${p++}`); }
       if (source) { params.push(source); where.push(`r.review_source = $${p++}`); }
-      if (Number.isFinite(itemId) && itemId > 0) { params.push(itemId); where.push(`r.item_id = $${p++}`); }
+      if (Number.isFinite(itemId) && itemId > 0) { params.push(itemId); where.push(`${effectiveItemExpr} = $${p++}`); }
 
-      const trackingReady = await isTrackingReviewSchemaReady(pool);
       // item_id is nullable for service_type/overall-scoped reviews (tracking
       // migration), so this must stay a LEFT JOIN -- an INNER JOIN would
       // silently drop every itemless review from the admin queue.

--- a/test/adminStoreCatalogUi.test.js
+++ b/test/adminStoreCatalogUi.test.js
@@ -2,6 +2,7 @@ const test = require("node:test");
 const assert = require("node:assert/strict");
 const fs = require("node:fs");
 const path = require("node:path");
+const vm = require("node:vm");
 
 const commonJsSource = fs.readFileSync(path.join(__dirname, "..", "admin-v2-common.js"), "utf8");
 const catalogHtmlSource = fs.readFileSync(path.join(__dirname, "..", "admin-store-catalog.html"), "utf8");
@@ -536,11 +537,44 @@ test("admin page has a review moderation card with status/item filters and a rel
   assert.match(catalogHtmlSource, /id="review_list"/);
 });
 
-test("loadReviews fetches the admin moderation endpoint and renderReviewList applies status/item filters", () => {
-  assert.match(catalogJsSource, /async function loadReviews\(\)[\s\S]*?apiFetch\("\/admin\/catalog\/reviews"\)/);
-  assert.match(catalogJsSource, /function renderReviewList\(\)/);
-  assert.match(catalogJsSource, /el\("review_filter_status"\)\.value/);
-  assert.match(catalogJsSource, /el\("review_filter_item"\)\.value/);
+test("loadReviews sends status/source as server-side query params (so unassigned/approved_unassigned filter the full table, not just the latest fetched page)", async () => {
+  const calls = [];
+  const els = {
+    review_filter_status: { value: "" },
+    review_filter_source: { value: "" },
+    review_filter_item: { value: "" },
+    review_list: { innerHTML: "" },
+  };
+  const context = {
+    el(id) { return els[id]; },
+    escapeHtml(s) { return String(s); },
+    apiFetch: async (url) => { calls.push(url); return []; },
+    URLSearchParams,
+    console,
+  };
+  vm.createContext(context);
+  const effectiveIdFn = catalogJsSource.match(/function reviewEffectiveItemId\(review\)[\s\S]*?\n}\n/)[0];
+  const effectiveNameFn = catalogJsSource.match(/function reviewEffectiveItemName\(review\)[\s\S]*?\n}\n/)[0];
+  const fnSource = catalogJsSource.match(/function renderReviewItemFilterOptions\(\)[\s\S]*?\n}\n\nasync function loadReviews\(\)[\s\S]*?\n}\n/)[0];
+  vm.runInContext(`let reviewItems = [];\n${effectiveIdFn}\n${effectiveNameFn}\n${fnSource}`, context);
+
+  await vm.runInContext("loadReviews()", context);
+  assert.equal(calls[0], "/admin/catalog/reviews", "no filters selected must not send an empty querystring");
+
+  els.review_filter_status.value = "unassigned";
+  await vm.runInContext("loadReviews()", context);
+  assert.equal(calls[1], "/admin/catalog/reviews?status=unassigned");
+
+  els.review_filter_status.value = "approved_unassigned";
+  els.review_filter_source.value = "tracking";
+  await vm.runInContext("loadReviews()", context);
+  assert.equal(calls[2], "/admin/catalog/reviews?status=approved_unassigned&source=tracking");
+});
+
+test("status/source filter selects re-fetch from the server (loadReviews), item filter only re-renders client-side", () => {
+  assert.match(catalogJsSource, /el\("review_filter_status"\)\.addEventListener\("change",\s*loadReviews\)/);
+  assert.match(catalogJsSource, /el\("review_filter_source"\)\.addEventListener\("change",\s*loadReviews\)/);
+  assert.match(catalogJsSource, /el\("review_filter_item"\)\.addEventListener\("change",\s*renderReviewList\)/);
 });
 
 test("setReviewModerationStatus confirms before acting, PATCHes the review, and updates state without a full reload", () => {

--- a/test/catalogReviewRoutes.test.js
+++ b/test/catalogReviewRoutes.test.js
@@ -180,7 +180,14 @@ function makePool({ schemaReady = true, trackingSchemaReady = false, items = [],
         item_name: (state.items.find((it) => Number(it.item_id) === Number(r.item_id)) || {}).item_name || "?",
         assigned_item_name: r.assigned_item_id == null ? null : ((state.items.find((it) => Number(it.item_id) === Number(r.assigned_item_id)) || {}).item_name || "?"),
       }));
+      const effectiveIdOf = (r) => (r.assigned_item_id != null ? Number(r.assigned_item_id) : (r.item_id != null ? Number(r.item_id) : null));
       let idx = 0;
+      if (s.includes("IS NULL")) {
+        rows = rows.filter((r) => effectiveIdOf(r) == null);
+      }
+      if (s.includes("r.moderation_status = 'approved'")) {
+        rows = rows.filter((r) => r.moderation_status === "approved");
+      }
       if (s.includes("r.moderation_status = $")) {
         idx += 1;
         rows = rows.filter((r) => r.moderation_status === params[idx - 1]);
@@ -189,10 +196,15 @@ function makePool({ schemaReady = true, trackingSchemaReady = false, items = [],
         idx += 1;
         rows = rows.filter((r) => r.review_source === params[idx - 1]);
       }
-      if (s.includes("r.item_id = $")) {
+      if (s.includes("r.item_id = $") || s.includes("r.item_id) = $")) {
         idx += 1;
-        rows = rows.filter((r) => Number(r.item_id) === Number(params[idx - 1]));
+        rows = rows.filter((r) => effectiveIdOf(r) === Number(params[idx - 1]));
       }
+      // Mirror the real query's "ORDER BY r.created_at DESC LIMIT 200": the
+      // WHERE filter (above) must run before this truncation, exactly like
+      // real SQL, so a status filter can still reach an old row that a plain
+      // unfiltered fetch would never see.
+      rows = rows.slice().sort((a, b) => new Date(b.created_at) - new Date(a.created_at)).slice(0, 200);
       return { rows };
     }
 
@@ -1222,5 +1234,47 @@ test("admin filter for 'unassigned' uses the effective item (assigned_item_id ||
     assert.equal(unassigned.length, 1);
     assert.equal(unassigned[0].review_id, 2);
     assert.equal(hasEffectiveItem.length, 2);
+  });
+});
+
+test("admin status=approved_unassigned/unassigned filters run server-side before the recency cap, so an old orphan review is never hidden by a newer batch of 200+ reviews", async () => {
+  const recentReviews = Array.from({ length: 205 }, (_, i) => ({
+    review_id: 100 + i,
+    item_id: 1,
+    completed_job_id: 1000 + i,
+    customer_identity: `recent-${i}`,
+    rating: 5,
+    comment: "ดี",
+    moderation_status: "pending",
+    created_at: `2026-06-${String(10 + (i % 15)).padStart(2, "0")}T00:00:00Z`,
+    review_source: "customer_app",
+    review_scope: "item",
+  }));
+  const oldOrphanApproved = {
+    review_id: 1, item_id: null, completed_job_id: 1, customer_identity: "OldCustomer", rating: 5, comment: "เก่า",
+    moderation_status: "approved", created_at: "2020-01-01T00:00:00Z", review_source: "tracking", review_scope: "overall", assigned_item_id: null,
+  };
+  const oldOrphanPending = {
+    review_id: 2, item_id: null, completed_job_id: 2, customer_identity: "OldCustomer2", rating: 4, comment: "เก่ามาก",
+    moderation_status: "pending", created_at: "2019-01-01T00:00:00Z", review_source: "tracking", review_scope: "overall", assigned_item_id: null,
+  };
+  const pool = makePool({
+    trackingSchemaReady: true,
+    items: [{ item_id: 1, item_name: "ล้างแอร์ผนัง" }],
+    reviews: [oldOrphanApproved, oldOrphanPending, ...recentReviews],
+  });
+  const router = createCatalogReviewRoutes({ pool, requireCustomerJwt: requireCustomerJwtFor(null), requireAdminSession: allowAdmin });
+  await withServer(router, async (base) => {
+    const unfiltered = await (await fetch(`${base}/admin/catalog/reviews`)).json();
+    assert.equal(unfiltered.length, 200, "the plain unfiltered admin fetch is capped at 200 most-recent rows");
+    assert.ok(!unfiltered.some((r) => r.review_id === 1), "the old approved-orphan review must be outside the unfiltered 200-row recency window");
+
+    const approvedUnassigned = await (await fetch(`${base}/admin/catalog/reviews?status=approved_unassigned`)).json();
+    assert.equal(approvedUnassigned.length, 1, "the status filter must run in SQL before the LIMIT, so it still finds the old row the unfiltered fetch can't see");
+    assert.equal(approvedUnassigned[0].review_id, 1);
+
+    const unassigned = await (await fetch(`${base}/admin/catalog/reviews?status=unassigned`)).json();
+    assert.equal(unassigned.length, 2);
+    assert.deepEqual(unassigned.map((r) => r.review_id).sort(), [1, 2]);
   });
 });

--- a/test/catalogReviewRoutes.test.js
+++ b/test/catalogReviewRoutes.test.js
@@ -71,10 +71,10 @@ function makePool({ schemaReady = true, trackingSchemaReady = false, items = [],
     if (/^\s*COMMIT\s*$/i.test(s.trim())) return { rows: [] };
     if (/^\s*ROLLBACK\s*$/i.test(s.trim())) return { rows: [] };
 
-    if (s.includes("SELECT review_id, review_scope FROM public.catalog_item_reviews WHERE review_id = $1 FOR UPDATE")) {
+    if (s.includes("SELECT review_id, review_scope, assigned_item_id FROM public.catalog_item_reviews WHERE review_id = $1 FOR UPDATE")) {
       const [reviewId] = params;
       const row = state.reviews.find((r) => Number(r.review_id) === Number(reviewId));
-      return { rows: row ? [{ review_id: row.review_id, review_scope: row.review_scope || "item" }] : [] };
+      return { rows: row ? [{ review_id: row.review_id, review_scope: row.review_scope || "item", assigned_item_id: row.assigned_item_id ?? null }] : [] };
     }
 
     if (s.includes("SELECT j.job_id, j.appointment_datetime")) {
@@ -160,7 +160,7 @@ function makePool({ schemaReady = true, trackingSchemaReady = false, items = [],
 
     if (s.includes("SELECT AVG(rating)::numeric AS rating_average")) {
       const [itemId] = params;
-      const approved = state.reviews.filter((r) => Number(r.item_id) === Number(itemId) && r.moderation_status === "approved");
+      const approved = state.reviews.filter((r) => Number(r.assigned_item_id ?? r.item_id) === Number(itemId) && r.moderation_status === "approved");
       const avg = approved.length ? approved.reduce((sum, r) => sum + Number(r.rating), 0) / approved.length : null;
       return { rows: [{ rating_average: avg, review_count: approved.length }] };
     }
@@ -168,7 +168,7 @@ function makePool({ schemaReady = true, trackingSchemaReady = false, items = [],
     if (s.includes("SELECT review_id, rating, comment, created_at, customer_identity")) {
       const [itemId, limit, offset] = params;
       const approved = state.reviews
-        .filter((r) => Number(r.item_id) === Number(itemId) && r.moderation_status === "approved")
+        .filter((r) => Number(r.assigned_item_id ?? r.item_id) === Number(itemId) && r.moderation_status === "approved")
         .sort((a, b) => new Date(b.created_at) - new Date(a.created_at))
         .slice(offset, offset + limit);
       return { rows: approved };
@@ -1103,4 +1103,124 @@ test("admin assignment SELECTs FOR UPDATE before validating scope, and moderatio
     assert.ok(body.moderated_at);
   });
   assert.ok(calls.some((c) => /FOR UPDATE/.test(c)));
+});
+
+test("approving a service_type-scoped review with no assigned_item_id (and none sent) is rejected with 409, never silently approved orphan", async () => {
+  const pool = makePool({
+    trackingSchemaReady: true,
+    items: [{ item_id: 1, item_name: "ซ่อมแอร์ผนัง" }],
+    reviews: [{ review_id: 1, item_id: null, completed_job_id: 11, customer_identity: "B", rating: 4, comment: "โอเค", moderation_status: "pending", created_at: "2026-06-02T00:00:00Z", review_source: "tracking", review_scope: "service_type", service_type: "ซ่อมแอร์" }],
+  });
+  const router = createCatalogReviewRoutes({ pool, requireCustomerJwt: requireCustomerJwtFor(null), requireAdminSession: allowAdmin });
+  await withServer(router, async (base) => {
+    const res = await fetch(`${base}/admin/catalog/reviews/1`, {
+      method: "PATCH", headers: { "content-type": "application/json" }, body: JSON.stringify({ moderation_status: "approved" }),
+    });
+    assert.equal(res.status, 409);
+    assert.equal(pool.state.reviews[0].moderation_status, "pending");
+    assert.equal(pool.state.reviews[0].assigned_item_id, undefined);
+  });
+});
+
+test("an overall-scoped review can be assigned and approved atomically in a single request", async () => {
+  const pool = makePool({
+    trackingSchemaReady: true,
+    items: [{ item_id: 1, item_name: "ล้างแอร์ผนัง ล้างปกติ" }],
+    reviews: [{ review_id: 1, item_id: null, completed_job_id: 12, customer_identity: "C", rating: 3, comment: null, moderation_status: "pending", created_at: "2026-06-03T00:00:00Z", review_source: "tracking", review_scope: "overall", service_type: null }],
+  });
+  const router = createCatalogReviewRoutes({ pool, requireCustomerJwt: requireCustomerJwtFor(null), requireAdminSession: allowAdmin });
+  await withServer(router, async (base) => {
+    const res = await fetch(`${base}/admin/catalog/reviews/1`, {
+      method: "PATCH", headers: { "content-type": "application/json" }, body: JSON.stringify({ assigned_item_id: 1, moderation_status: "approved" }),
+    });
+    const body = await res.json();
+    assert.equal(res.status, 200);
+    assert.equal(body.assigned_item_id, 1);
+    assert.equal(body.moderation_status, "approved");
+    assert.equal(pool.state.reviews[0].assigned_item_id, 1);
+    assert.equal(pool.state.reviews[0].moderation_status, "approved");
+  });
+});
+
+test("an already-approved itemless review can later be bound via assignment-only, without resending moderation_status", async () => {
+  const pool = makePool({
+    trackingSchemaReady: true,
+    items: [{ item_id: 1, item_name: "ล้างแอร์ผนัง ล้างปกติ" }],
+    reviews: [{ review_id: 1, item_id: null, completed_job_id: 11, customer_identity: "B", rating: 4, comment: "โอเค", moderation_status: "approved", created_at: "2026-06-02T00:00:00Z", review_source: "tracking", review_scope: "service_type", service_type: "ล้างแอร์" }],
+  });
+  const router = createCatalogReviewRoutes({ pool, requireCustomerJwt: requireCustomerJwtFor(null), requireAdminSession: allowAdmin });
+  await withServer(router, async (base) => {
+    const res = await fetch(`${base}/admin/catalog/reviews/1`, {
+      method: "PATCH", headers: { "content-type": "application/json" }, body: JSON.stringify({ assigned_item_id: 1 }),
+    });
+    const body = await res.json();
+    assert.equal(res.status, 200);
+    assert.equal(body.assigned_item_id, 1);
+    // status was never resent and stays approved -- this is assignment-only, not a re-approval
+    assert.equal(pool.state.reviews[0].moderation_status, "approved");
+  });
+});
+
+test("public item reviews and rating aggregate include a review only after it has been assigned to that item", async () => {
+  const pool = makePool({
+    trackingSchemaReady: true,
+    items: [{ item_id: 1, item_name: "ล้างแอร์ผนัง ล้างปกติ" }],
+    reviews: [
+      { review_id: 1, item_id: 1, completed_job_id: 10, customer_identity: "A", rating: 5, comment: "ดี", moderation_status: "approved", created_at: "2026-06-01T00:00:00Z", review_source: "customer_app", review_scope: "item" },
+      { review_id: 2, item_id: null, completed_job_id: 11, customer_identity: "B", rating: 3, comment: "โอเค", moderation_status: "approved", created_at: "2026-06-02T00:00:00Z", review_source: "tracking", review_scope: "overall", assigned_item_id: null },
+    ],
+  });
+  const router = createCatalogReviewRoutes({ pool, requireCustomerJwt: requireCustomerJwtFor(null), requireAdminSession: allowAdmin });
+  await withServer(router, async (base) => {
+    const before = await (await fetch(`${base}/catalog/items/1/reviews`)).json();
+    assert.equal(before.review_count, 1);
+    assert.equal(before.reviews.length, 1);
+
+    await fetch(`${base}/admin/catalog/reviews/2`, {
+      method: "PATCH", headers: { "content-type": "application/json" }, body: JSON.stringify({ assigned_item_id: 1 }),
+    });
+
+    const after = await (await fetch(`${base}/catalog/items/1/reviews`)).json();
+    assert.equal(after.review_count, 2);
+    assert.equal(after.reviews.length, 2);
+  });
+});
+
+test("an approved review left unassigned never appears under any other item's reviews", async () => {
+  const pool = makePool({
+    trackingSchemaReady: true,
+    items: [{ item_id: 1, item_name: "ล้างแอร์ผนัง" }, { item_id: 2, item_name: "ซ่อมแอร์" }],
+    reviews: [
+      { review_id: 1, item_id: null, completed_job_id: 11, customer_identity: "B", rating: 4, comment: "โอเค", moderation_status: "approved", created_at: "2026-06-02T00:00:00Z", review_source: "tracking", review_scope: "overall", assigned_item_id: null },
+    ],
+  });
+  const router = createCatalogReviewRoutes({ pool, requireCustomerJwt: requireCustomerJwtFor(null), requireAdminSession: allowAdmin });
+  await withServer(router, async (base) => {
+    const item1 = await (await fetch(`${base}/catalog/items/1/reviews`)).json();
+    const item2 = await (await fetch(`${base}/catalog/items/2/reviews`)).json();
+    assert.equal(item1.review_count, 0);
+    assert.equal(item2.review_count, 0);
+  });
+});
+
+test("admin filter for 'unassigned' uses the effective item (assigned_item_id || item_id), not raw item_id alone", async () => {
+  const pool = makePool({
+    trackingSchemaReady: true,
+    items: [{ item_id: 1, item_name: "ล้างแอร์ผนัง" }],
+    reviews: [
+      { review_id: 1, item_id: 1, completed_job_id: 10, customer_identity: "A", rating: 5, comment: "ดี", moderation_status: "approved", created_at: "2026-06-01T00:00:00Z", review_source: "customer_app", review_scope: "item" },
+      { review_id: 2, item_id: null, completed_job_id: 11, customer_identity: "B", rating: 4, comment: "โอเค", moderation_status: "pending", created_at: "2026-06-02T00:00:00Z", review_source: "tracking", review_scope: "overall", assigned_item_id: null },
+      { review_id: 3, item_id: null, completed_job_id: 12, customer_identity: "C", rating: 3, comment: null, moderation_status: "approved", created_at: "2026-06-03T00:00:00Z", review_source: "tracking", review_scope: "overall", assigned_item_id: 1 },
+    ],
+  });
+  const router = createCatalogReviewRoutes({ pool, requireCustomerJwt: requireCustomerJwtFor(null), requireAdminSession: allowAdmin });
+  await withServer(router, async (base) => {
+    const all = await (await fetch(`${base}/admin/catalog/reviews`)).json();
+    const effectiveItemOf = (r) => r.assigned_item_id || r.item_id;
+    const unassigned = all.filter((r) => !effectiveItemOf(r));
+    const hasEffectiveItem = all.filter((r) => effectiveItemOf(r));
+    assert.equal(unassigned.length, 1);
+    assert.equal(unassigned[0].review_id, 2);
+    assert.equal(hasEffectiveItem.length, 2);
+  });
 });

--- a/test/customerAppRecovery.test.js
+++ b/test/customerAppRecovery.test.js
@@ -15,6 +15,7 @@ function makeContext() {
   const listeners = {};
   const window = {
     CWFCustomerAppV2: {},
+    dataLayer: [],
     location: { protocol: "https:", origin: "https://app.example.test", pathname: "/customer-app/index.html", search: "", hash: "" },
     sessionStorage: {
       getItem(key) { return storage.has(key) ? storage.get(key) : null; },
@@ -210,6 +211,7 @@ class FakeInput {
 function loadCustomerFrontend(context = makeContext()) {
   return load(context, [
     "customer-app/modules/utils.js",
+    "customer-app/modules/analytics.js",
     "customer-app/modules/state.js",
     "customer-app/modules/api.js",
     "customer-app/modules/services.js",
@@ -1623,7 +1625,7 @@ test("related products slider shows fewer than 4 cards when fewer real same-fami
   assert.equal((html.match(/data-store-related-item="/g) || []).length, 1);
 });
 
-test("BTU/spec variant selector changes price and short info on selection without a new network fetch, and the book button routes to the selected variant", async () => {
+test("BTU/spec variant selector routes to the sibling's own detail URL on selection, reloading the whole page from a real per-item fetch, and the book button books the routed variant", async () => {
   const context = makeContext();
   const root = loadCustomerFrontend(context);
   root.state.setRoute("storeItem-10");
@@ -1631,9 +1633,10 @@ test("BTU/spec variant selector changes price and short info on selection withou
     { item_id: 10, item_name: "ล้างแอร์ผนัง ล้างธรรมดา", item_category: "ล้างแอร์", base_price: 500, unit_label: "เครื่อง", short_description: "เหมาะกับแอร์ขนาดเล็ก-กลาง", booking_mode: "bookable", job_category: "ล้าง", ac_type: "ผนัง", btu_min: 9000, btu_max: 15000, booking_ac_type: "ผนัง", booking_wash_variant: "ล้างธรรมดา", booking_btu: 9000 },
     { item_id: 11, item_name: "ล้างแอร์ผนัง ล้างธรรมดา ใหญ่", item_category: "ล้างแอร์", base_price: 750, unit_label: "เครื่อง", short_description: "เหมาะกับแอร์ขนาดใหญ่", booking_mode: "bookable", job_category: "ล้าง", ac_type: "ผนัง", btu_min: 18000, booking_ac_type: "ผนัง", booking_wash_variant: "ล้างธรรมดา", booking_btu: 18000 },
   ];
+  const itemsById = new Map(items.map((it) => [String(it.item_id), it]));
   let detailCalls = 0;
   let listCalls = 0;
-  root.api.loadCatalogItem = async () => { detailCalls += 1; return items[0]; };
+  root.api.loadCatalogItem = async (id) => { detailCalls += 1; return itemsById.get(String(id)); };
   root.api.loadCatalogItems = async () => { listCalls += 1; return items; };
 
   const container = new FakeMount();
@@ -1654,8 +1657,17 @@ test("BTU/spec variant selector changes price and short info on selection withou
   assert.ok(bigOption, "18,000 BTU option not found");
   await bigOption.click();
 
-  assert.equal(detailCalls, 1, "switching the BTU variant must never trigger a new detail fetch");
-  assert.equal(listCalls, 1, "switching the BTU variant must never trigger a new catalog list fetch");
+  // The click handler only routes (root.utils.routeTo("storeItem-11")); the
+  // real app's router then re-invokes store.renderDetail for the new route.
+  // This fake DOM has no real EventTarget driving hashchange, so simulate
+  // exactly what the router does on navigation: update the route, then
+  // re-render the detail screen for it.
+  root.state.setRoute("storeItem-11");
+  root.store.renderDetail(container);
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  await new Promise((resolve) => setTimeout(resolve, 0));
+
+  assert.equal(detailCalls, 2, "switching the BTU variant must reload the whole page via a real per-item fetch");
 
   body = container.querySelector("[data-store-detail-body]");
   assert.match(body.innerHTML, /750/);
@@ -1796,7 +1808,7 @@ test("canonical resolver never mixes repair items with wash items, and never put
 // item_name as a deterministic last-resort fallback -- never left as an
 // empty token that silently merges unrelated wash methods together.
 
-test("legacy rows with no booking_wash_variant resolve ล้างปกติ/ล้างธรรมดา from item_name into the same BTU variant group, price changes on selection, and booking uses the selected real item_id", async () => {
+test("legacy rows with no booking_wash_variant resolve ล้างปกติ/ล้างธรรมดา from item_name into the same BTU variant group, the whole page reloads on selection, and booking infers the real wash_variant from the routed item's name", async () => {
   const context = makeContext();
   const root = loadCustomerFrontend(context);
   root.state.setRoute("storeItem-80");
@@ -1804,7 +1816,8 @@ test("legacy rows with no booking_wash_variant resolve ล้างปกติ/
     { item_id: 80, item_name: "ล้างแอร์ผนัง ล้างปกติ 9000", item_category: "ล้างแอร์", base_price: 500, unit_label: "เครื่อง", short_description: "เหมาะกับแอร์ขนาดเล็ก", booking_mode: "bookable", job_category: "ล้าง", ac_type: "ผนัง", btu_min: 9000, btu_max: 15000, booking_ac_type: "ผนัง", booking_btu: 9000 },
     { item_id: 81, item_name: "ล้างแอร์ผนัง ล้างธรรมดา 18000+", item_category: "ล้างแอร์", base_price: 750, unit_label: "เครื่อง", short_description: "เหมาะกับแอร์ขนาดใหญ่", booking_mode: "bookable", job_category: "ล้าง", ac_type: "ผนัง", btu_min: 18000, booking_ac_type: "ผนัง", booking_btu: 18000 },
   ];
-  root.api.loadCatalogItem = async () => items[0];
+  const itemsById = new Map(items.map((it) => [String(it.item_id), it]));
+  root.api.loadCatalogItem = async (id) => itemsById.get(String(id));
   root.api.loadCatalogItems = async () => items;
 
   const container = new FakeMount();
@@ -1821,22 +1834,29 @@ test("legacy rows with no booking_wash_variant resolve ล้างปกติ/
   assert.ok(bigOption, "18,000+ option not found");
   await bigOption.click();
 
+  // Simulate the router re-rendering the detail screen for the newly routed
+  // item, exactly as it would after root.utils.routeTo("storeItem-81") fires
+  // a real hashchange in the browser.
+  root.state.setRoute("storeItem-81");
+  root.store.renderDetail(container);
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  await new Promise((resolve) => setTimeout(resolve, 0));
+
   body = container.querySelector("[data-store-detail-body]");
   assert.match(body.innerHTML, /750/);
 
-  // catalogItemToCommerceDraft requires the real booking_wash_variant enum
-  // field (server-validated) to build an actual booking payload -- the
-  // item_name-derived canonical wash variant is for display/grouping only
-  // and must never be used to fabricate that real booking field. With it
-  // missing, tapping book correctly falls back to the contact-admin sheet
-  // for whichever variant (81) was selected, rather than silently booking
-  // with an unverified wash method.
+  // catalogItemToCommerceDraft deterministically infers wash_variant from the
+  // unambiguous "ธรรมดา" keyword in item 81's own name when the real
+  // booking_wash_variant field is missing -- it must never refuse and fall
+  // back to the contact-admin sheet when a fixed keyword resolves cleanly.
   let contactTitle = null;
   root.ui.openContactSheet = (_container, { title }) => { contactTitle = title; };
   const bookButtons = container.querySelectorAll("[data-store-detail-book]");
   assert.ok(bookButtons.length >= 1);
   await bookButtons[0].click();
-  assert.equal(contactTitle, "ล้างแอร์ผนัง ล้างธรรมดา 18000+");
+  assert.equal(contactTitle, null, "a resolvable item-name keyword must never fall back to the contact-admin sheet");
+  assert.equal(root.state.draft.scheduled.catalog_item_id, 81);
+  assert.equal(root.state.draft.scheduled.wash_variant, "ล้างธรรมดา");
 });
 
 test("legacy rows with no booking_wash_variant show all 4 real wash methods (resolved from item_name) in the related slider, exactly once each", async () => {
@@ -1922,4 +1942,208 @@ test("job_category and item_category empty: wash resolves from item_name alone, 
   const html = body.innerHTML;
   assert.match(html, /data-store-related-item="111"/, "job_category/item_category empty must still resolve wash via item_name");
   assert.doesNotMatch(html, /data-store-related-item="112"/, "a repair item named only in item_name must never be mixed into the wash family");
+});
+
+function storeFilterFixtureItems() {
+  return [
+    {
+      item_id: 201, item_name: "ล้างแอร์ผนัง ล้างปกติ 9000 BTU", item_category: "ล้างแอร์",
+      booking_mode: "bookable", booking_ac_type: "ผนัง", booking_wash_variant: "ล้างธรรมดา", booking_btu: 9000,
+      display_price: 500, base_price: 500, has_queue_today: true, booking_count: 50,
+      has_active_promotion: true, normal_price: 600, active_price: 500, campaign_name: "โปรซัมเมอร์", effective_to: "2026-12-31T00:00:00Z",
+    },
+    {
+      item_id: 202, item_name: "ล้างแอร์สี่ทิศทาง ล้างพรีเมียม 12000 BTU", item_category: "ล้างแอร์",
+      booking_mode: "bookable", booking_ac_type: "สี่ทิศทาง", booking_wash_variant: "ล้างพรีเมียม", booking_btu: 12000,
+      display_price: 700, base_price: 700, has_queue_today: false, booking_count: 10,
+    },
+    {
+      item_id: 203, item_name: "ล้างแอร์ผนัง ล้างปกติ 18000 BTU", item_category: "ล้างแอร์",
+      booking_mode: "bookable", booking_ac_type: "ผนัง", booking_wash_variant: "ล้างธรรมดา", booking_btu: 18000,
+      display_price: 300, base_price: 300, has_queue_today: false, booking_count: 5,
+    },
+  ];
+}
+
+test("store ac_type/wash_variant/BTU/queue-today filters narrow the grid using canonical values, never raw category strings", async () => {
+  const context = makeContext();
+  const root = loadCustomerFrontend(context);
+  root.api.loadCatalogItems = async () => storeFilterFixtureItems();
+
+  const container = new FakeMount();
+  root.store.render(container);
+  await new Promise((resolve) => setTimeout(resolve, 0));
+
+  const acType = container.querySelector("[data-store-actype]");
+  acType.value = "wall";
+  await acType.dispatch("change");
+  let body = container.querySelector("[data-store-grid-mount]");
+  assert.match(body.innerHTML, /data-store-item="201"/);
+  assert.match(body.innerHTML, /data-store-item="203"/);
+  assert.doesNotMatch(body.innerHTML, /data-store-item="202"/);
+
+  const btu = container.querySelector("[data-store-btu]");
+  btu.value = "9000";
+  await btu.dispatch("change");
+  body = container.querySelector("[data-store-grid-mount]");
+  assert.match(body.innerHTML, /data-store-item="201"/);
+  assert.doesNotMatch(body.innerHTML, /data-store-item="203"/);
+
+  btu.value = "";
+  await btu.dispatch("change");
+  acType.value = "";
+  await acType.dispatch("change");
+  const wash = container.querySelector("[data-store-wash]");
+  wash.value = "premium";
+  await wash.dispatch("change");
+  body = container.querySelector("[data-store-grid-mount]");
+  assert.match(body.innerHTML, /data-store-item="202"/);
+  assert.doesNotMatch(body.innerHTML, /data-store-item="201"/);
+  assert.doesNotMatch(body.innerHTML, /data-store-item="203"/);
+
+  wash.value = "";
+  await wash.dispatch("change");
+  const queueToday = container.querySelector("[data-store-queue-today]");
+  queueToday.checked = true;
+  await queueToday.dispatch("change");
+  body = container.querySelector("[data-store-grid-mount]");
+  assert.match(body.innerHTML, /data-store-item="201"/);
+  assert.doesNotMatch(body.innerHTML, /data-store-item="202"/);
+  assert.doesNotMatch(body.innerHTML, /data-store-item="203"/);
+});
+
+test("store sort options order by CWF recommended (default), booking count, and price low/high", async () => {
+  const context = makeContext();
+  const root = loadCustomerFrontend(context);
+  root.api.loadCatalogItems = async () => storeFilterFixtureItems();
+
+  const container = new FakeMount();
+  root.store.render(container);
+  await new Promise((resolve) => setTimeout(resolve, 0));
+
+  const sort = container.querySelector("[data-store-sort]");
+
+  sort.value = "booking_count";
+  await sort.dispatch("change");
+  let grid = container.querySelector("[data-store-grid-mount]");
+  let order = [...grid.innerHTML.matchAll(/data-store-item="(\d+)"/g)].map((m) => m[1]);
+  assert.deepEqual(order, ["201", "202", "203"], "must sort by booking_count descending");
+
+  sort.value = "price_low";
+  await sort.dispatch("change");
+  grid = container.querySelector("[data-store-grid-mount]");
+  order = [...grid.innerHTML.matchAll(/data-store-item="(\d+)"/g)].map((m) => m[1]);
+  assert.deepEqual(order, ["203", "201", "202"], "must sort by effective price ascending");
+
+  sort.value = "price_high";
+  await sort.dispatch("change");
+  grid = container.querySelector("[data-store-grid-mount]");
+  order = [...grid.innerHTML.matchAll(/data-store-item="(\d+)"/g)].map((m) => m[1]);
+  assert.deepEqual(order, ["202", "201", "203"], "must sort by effective price descending");
+});
+
+test("store card and detail show the real promotion name, savings amount, and end date only when has_active_promotion is true", async () => {
+  const context = makeContext();
+  const root = loadCustomerFrontend(context);
+  const items = storeFilterFixtureItems();
+  root.api.loadCatalogItems = async () => items;
+  root.api.loadCatalogItem = async (id) => items.find((it) => String(it.item_id) === String(id));
+
+  const container = new FakeMount();
+  root.store.render(container);
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  const body = container.querySelector("[data-store-body]");
+  assert.match(body.innerHTML, /store-promo-name">โปรซัมเมอร์/);
+  assert.match(body.innerHTML, /ประหยัด/);
+  const promoCardIndex = body.innerHTML.indexOf("data-store-item=\"201\"");
+  const nextCardIndex = body.innerHTML.indexOf("data-store-item=\"202\"");
+  const card202Html = body.innerHTML.slice(nextCardIndex, nextCardIndex + (body.innerHTML.length - nextCardIndex));
+  assert.ok(promoCardIndex < nextCardIndex, "fixture order must put item 201 before 202");
+  assert.ok(!card202Html.slice(0, card202Html.indexOf("</article>")).includes("store-promo-name"), "item without has_active_promotion must show no promo info");
+
+  root.state.setRoute("storeItem-201");
+  root.store.renderDetail(container);
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  const detailBody = container.querySelector("[data-store-detail-body]");
+  assert.match(detailBody.innerHTML, /store-promo-name">โปรซัมเมอร์/);
+  assert.match(detailBody.innerHTML, /ประหยัด/);
+});
+
+test("store funnel analytics: cwf_store_view fires on store list render and cwf_store_filter fires with canonical filter_name/filter_value, never PII", async () => {
+  const context = makeContext();
+  const root = loadCustomerFrontend(context);
+  root.api.loadCatalogItems = async () => storeFilterFixtureItems();
+
+  const container = new FakeMount();
+  root.store.render(container);
+  await new Promise((resolve) => setTimeout(resolve, 0));
+
+  assert.ok(context.window.dataLayer.some((e) => e.event === "cwf_store_view"));
+
+  const acType = container.querySelector("[data-store-actype]");
+  acType.value = "wall";
+  await acType.dispatch("change");
+  const filterEvent = context.window.dataLayer.find((e) => e.event === "cwf_store_filter" && e.filter_name === "ac_type");
+  assert.ok(filterEvent, "ac_type filter change must emit cwf_store_filter");
+  assert.equal(filterEvent.filter_value, "wall");
+  assert.equal(Object.keys(filterEvent).sort().join(","), "event,filter_name,filter_value");
+
+  const queueToday = container.querySelector("[data-store-queue-today]");
+  queueToday.checked = true;
+  await queueToday.dispatch("change");
+  const queueEvent = context.window.dataLayer.find((e) => e.event === "cwf_store_filter" && e.filter_name === "queue_today");
+  assert.ok(queueEvent);
+  assert.equal(queueEvent.filter_value, true);
+});
+
+test("store funnel analytics: cwf_store_begin_booking and cwf_store_contact_admin fire with allowed fields only, no booking code/PII", async () => {
+  const context = makeContext();
+  const root = loadCustomerFrontend(context);
+  const items = [
+    { item_id: 301, item_name: "ล้างแอร์ผนัง ล้างปกติ", booking_mode: "bookable", booking_ac_type: "ผนัง", booking_wash_variant: "ล้างธรรมดา", booking_btu: 9000, display_price: 500, base_price: 500 },
+    { item_id: 302, item_name: "ติดตั้งแอร์ใหม่", booking_mode: "contact", display_price: 0, base_price: 0 },
+  ];
+  root.api.loadCatalogItems = async () => items;
+
+  const container = new FakeMount();
+  root.store.render(container);
+  await new Promise((resolve) => setTimeout(resolve, 0));
+
+  const bookButton = container.querySelectorAll("[data-store-book]").find((b) => b.getAttribute("data-store-book") === "301");
+  await bookButton.click();
+  const bookingEvent = context.window.dataLayer.find((e) => e.event === "cwf_store_begin_booking");
+  assert.ok(bookingEvent);
+  assert.equal(bookingEvent.item_id, 301);
+  assert.ok(!("booking_code" in bookingEvent) && !("phone" in bookingEvent) && !("token" in bookingEvent));
+
+  const contactButton = container.querySelectorAll("[data-store-contact]").find((b) => b.getAttribute("data-store-contact") === "302");
+  await contactButton.click();
+  const contactEvent = context.window.dataLayer.find((e) => e.event === "cwf_store_contact_admin");
+  assert.ok(contactEvent);
+  assert.equal(contactEvent.item_id, 302);
+});
+
+test("store performance guard: navigating from the loaded list to a product detail page reuses the cached catalog list instead of refetching it", async () => {
+  const context = makeContext();
+  const root = loadCustomerFrontend(context);
+  const items = storeFilterFixtureItems();
+  let listCalls = 0;
+  let detailCalls = 0;
+  root.api.loadCatalogItems = async () => { listCalls += 1; return items; };
+  root.api.loadCatalogItem = async (id) => { detailCalls += 1; return items.find((it) => String(it.item_id) === String(id)); };
+
+  const listContainer = new FakeMount();
+  root.store.render(listContainer);
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  assert.equal(listCalls, 1);
+
+  root.state.setRoute("storeItem-201");
+  const detailContainer = new FakeMount();
+  root.store.renderDetail(detailContainer);
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  await new Promise((resolve) => setTimeout(resolve, 0));
+
+  assert.equal(detailCalls, 1, "detail must fetch the routed item exactly once");
+  assert.equal(listCalls, 1, "an already-loaded catalog list must never be refetched just to populate siblings/related items on the detail page");
 });

--- a/test/customerAppStoreVariantAndBookableAdapter.test.js
+++ b/test/customerAppStoreVariantAndBookableAdapter.test.js
@@ -1,0 +1,46 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+
+const storeSource = fs.readFileSync(path.join(__dirname, "..", "customer-app", "modules", "store.js"), "utf8");
+const servicesSource = fs.readFileSync(path.join(__dirname, "..", "customer-app", "modules", "services.js"), "utf8");
+
+test("store.js resolves the displayed/booked variant through one shared helper, never duplicated inline logic", () => {
+  const helperDefMatches = storeSource.match(/function currentVariantDisplayItem\(/g) || [];
+  assert.equal(helperDefMatches.length, 1, "currentVariantDisplayItem must be defined exactly once");
+
+  const callSites = storeSource.match(/currentVariantDisplayItem\(item, variantSiblings\(item, allItems\)\)/g) || [];
+  assert.ok(callSites.length >= 1, "the book-button click handler must resolve the booked item via the same helper used for price display");
+
+  // Only one place may ever assign to the module-level selection — every other
+  // read must go through currentVariantDisplayItem()/variantSiblings() instead
+  // of re-deriving "which sibling is selected" locally.
+  const assignments = storeSource.match(/selectedVariantItemId\s*=/g) || [];
+  assert.equal(assignments.length, 3, "selectedVariantItemId must only ever be declared once, set by the variant-option click handler, and reset on new-detail-load -- not derived ad-hoc elsewhere");
+});
+
+test("services.js exposes a single catalogItemToCommerceDraft adapter, and store.js never builds a booking draft from booking_ac_type/booking_btu/booking_wash_variant by hand", () => {
+  const adapterDefMatches = servicesSource.match(/function catalogItemToCommerceDraft\(/g) || [];
+  assert.equal(adapterDefMatches.length, 1, "catalogItemToCommerceDraft must be the single legacy-bookable adapter");
+
+  const storeCallSites = storeSource.match(/root\.services\.catalogItemToCommerceDraft\(/g) || [];
+  assert.equal(storeCallSites.length, 2, "both the store grid's book button and the product detail's book button must route through the shared adapter");
+
+  // store.js must never read these raw booking_* fields itself to build a draft;
+  // only the shared adapter in services.js is allowed to interpret them.
+  assert.ok(!/draft:\s*\{[^}]*booking_ac_type/.test(storeSource), "store.js must not hand-construct a booking draft from booking_ac_type");
+  assert.ok(!storeSource.includes("createServiceLine("), "store.js must not call createServiceLine() directly -- only the shared adapter does");
+});
+
+test("catalogItemToCommerceDraft refuses to fabricate a draft when any bookable field is unsupported, routing the caller to contact-admin instead", () => {
+  assert.match(servicesSource, /if \(!matchedAcType\) return null;/);
+  assert.match(servicesSource, /if \(!matchedBtu\) return null;/);
+  assert.match(servicesSource, /if \(!matchedWash\) return null;/);
+});
+
+test("product detail review summary shows an honest empty state instead of a fabricated (0) count", () => {
+  const fn = storeSource.match(/function renderReviewsSectionBody\([\s\S]*?\n  \}/)[0];
+  assert.ok(!/<span class="store-rating-count">\(\$\{count\}\)<\/span>\s*<\/div>/.test(fn), "must not unconditionally render a (0) count badge when there are no reviews yet");
+  assert.match(fn, /hasReviews \? `<span class="store-rating-value">[\s\S]*?<\/span><span class="store-rating-count">\(\$\{count\}\)<\/span>` : `<span class="store-rating-count store-rating-count-empty">ยังไม่มีรีวิว<\/span>`/);
+});

--- a/test/customerAppStoreVariantAndBookableAdapter.test.js
+++ b/test/customerAppStoreVariantAndBookableAdapter.test.js
@@ -2,45 +2,240 @@ const test = require("node:test");
 const assert = require("node:assert/strict");
 const fs = require("node:fs");
 const path = require("node:path");
+const vm = require("node:vm");
 
-const storeSource = fs.readFileSync(path.join(__dirname, "..", "customer-app", "modules", "store.js"), "utf8");
-const servicesSource = fs.readFileSync(path.join(__dirname, "..", "customer-app", "modules", "services.js"), "utf8");
+const REPO_ROOT = path.resolve(__dirname, "..");
 
-test("store.js resolves the displayed/booked variant through one shared helper, never duplicated inline logic", () => {
-  const helperDefMatches = storeSource.match(/function currentVariantDisplayItem\(/g) || [];
-  assert.equal(helperDefMatches.length, 1, "currentVariantDisplayItem must be defined exactly once");
+function file(relativePath) {
+  return fs.readFileSync(path.join(REPO_ROOT, relativePath), "utf8");
+}
 
-  const callSites = storeSource.match(/currentVariantDisplayItem\(item, variantSiblings\(item, allItems\)\)/g) || [];
-  assert.ok(callSites.length >= 1, "the book-button click handler must resolve the booked item via the same helper used for price display");
+function makeContainer() {
+  return {
+    html: "",
+    dataset: {},
+    set innerHTML(value) { this.html = String(value || ""); },
+    get innerHTML() { return this.html; },
+    querySelector() { return null; },
+    querySelectorAll() { return []; },
+    scrollIntoView() {},
+  };
+}
 
-  // Only one place may ever assign to the module-level selection — every other
-  // read must go through currentVariantDisplayItem()/variantSiblings() instead
-  // of re-deriving "which sibling is selected" locally.
-  const assignments = storeSource.match(/selectedVariantItemId\s*=/g) || [];
-  assert.equal(assignments.length, 3, "selectedVariantItemId must only ever be declared once, set by the variant-option click handler, and reset on new-detail-load -- not derived ad-hoc elsewhere");
+function makeContext() {
+  const window = {
+    CWFCustomerAppV2: {},
+    dataLayer: [],
+    location: { protocol: "https:", origin: "https://app.example.test", pathname: "/customer-app/", search: "", hash: "" },
+    sessionStorage: { getItem() { return null; }, setItem() {}, removeItem() {} },
+    localStorage: { getItem() { return null; }, setItem() {}, removeItem() {} },
+  };
+  const context = {
+    window,
+    document: {
+      body: { classList: { add() {}, remove() {} } },
+      addEventListener() {},
+      createElement(tagName) {
+        return { tagName: String(tagName || "").toUpperCase(), className: "", dataset: {}, textContent: "" };
+      },
+      querySelector() { return null; },
+      querySelectorAll() { return []; },
+    },
+    navigator: {},
+    history: { replaceState() {} },
+    Element: function Element() {},
+    URL,
+    URLSearchParams,
+    Intl,
+    Date,
+    console,
+    setTimeout,
+    clearTimeout,
+    requestAnimationFrame(fn) { return setTimeout(fn, 0); },
+  };
+  context.globalThis = context;
+  return vm.createContext(context);
+}
+
+function load(modules) {
+  const context = makeContext();
+  for (const modulePath of modules) {
+    vm.runInContext(file(modulePath), context, { filename: modulePath });
+  }
+  return { context, root: context.window.CWFCustomerAppV2 };
+}
+
+function loadStore() {
+  const { root } = load([
+    "customer-app/modules/state.js",
+    "customer-app/modules/utils.js",
+    "customer-app/modules/analytics.js",
+    "customer-app/modules/services.js",
+    "customer-app/modules/store.js",
+  ]);
+  root.router = {
+    routeParam(route) {
+      const m = /^storeItem-(\S+)$/.exec(String(route || ""));
+      return m ? m[1] : "";
+    },
+  };
+  root.utils.routeTo = (route) => { root.state.currentRoute = route; };
+  root.ui = { openContactSheet() {} };
+  return root;
+}
+
+function wallWashItem(overrides) {
+  return Object.assign({
+    item_id: 101,
+    item_name: "ล้างแอร์ผนัง 12000 BTU",
+    item_category: "clean",
+    booking_mode: "bookable",
+    booking_ac_type: "ผนัง",
+    booking_btu: 12000,
+    booking_wash_variant: "ล้างธรรมดา",
+    short_description: "สรุปบริการ A",
+    long_description: "รายละเอียดบริการ A",
+    service_conditions: "เงื่อนไข A",
+    ac_type: "ผนัง",
+    highlights: ["จุดเด่น A"],
+    images: ["a1.jpg"],
+    active_price: 500,
+    normal_price: 500,
+    unit_label: "เครื่อง",
+    rating_average: 4.5,
+    review_count: 3,
+    booking_count: 10,
+  }, overrides || {});
+}
+
+async function renderDetailFor(root, allItems, routeItemId) {
+  root.state.setCollection("catalog", { status: "success", items: allItems, error: "" });
+  root.state.currentRoute = `storeItem-${routeItemId}`;
+  const itemsById = new Map(allItems.map((it) => [String(it.item_id), it]));
+  const reviewsByItemId = (id) => {
+    const it = itemsById.get(String(id));
+    const hasReviews = Number.isFinite(it?.rating_average) && it.rating_average >= 1 && it.review_count > 0;
+    return hasReviews
+      ? { reviews: [], total: it.review_count, rating_average: it.rating_average, review_count: it.review_count }
+      : { reviews: [], total: 0, rating_average: null, review_count: 0 };
+  };
+  root.api = {
+    loadCatalogItems: async () => ({ items: allItems }),
+    loadCatalogItem: async (id) => itemsById.get(String(id)),
+    loadCatalogItemReviews: async (id) => reviewsByItemId(id),
+    loadReviewEligibility: async () => ({ eligible: false, eligible_jobs: [] }),
+  };
+  const container = makeContainer();
+  root.store.renderDetail(container);
+  await root.store._test.loadDetail(container, String(routeItemId));
+  await root.store._test.loadReviewsList(container, itemsById.get(String(routeItemId)));
+  // The fake DOM's querySelector always returns null (no real layout
+  // engine), so the patchDetailBody/patchReviewsSection in-place DOM mutation
+  // is a no-op here -- but root.state.storeDetail.data and reviewsState are
+  // real, so render the body straight from that state, exactly as
+  // patchDetailBody would have, to assert on actual rendered output.
+  return root.store._test.renderDetailBody();
+}
+
+test("product detail page reloads every section (name, image, price, descriptions, highlights, ac type, conditions) from the routed item, not a partial display overlay", async () => {
+  const root = loadStore();
+  const itemA = wallWashItem({ item_id: 101, item_name: "ล้างแอร์ผนัง 9000 BTU", booking_btu: 9000, active_price: 400, normal_price: 400, long_description: "รายละเอียด A", service_conditions: "เงื่อนไข A", highlights: ["จุดเด่น A"], images: ["a.jpg"] });
+  const itemB = wallWashItem({ item_id: 102, item_name: "ล้างแอร์ผนัง 18000 BTU", booking_btu: 18000, active_price: 700, normal_price: 700, long_description: "รายละเอียด B", service_conditions: "เงื่อนไข B", highlights: ["จุดเด่น B"], images: ["b.jpg"] });
+
+  const htmlA = await renderDetailFor(root, [itemA, itemB], itemA.item_id);
+  assert.match(htmlA, /ล้างแอร์ผนัง 9000 BTU/);
+  assert.match(htmlA, /รายละเอียด A/);
+  assert.match(htmlA, /เงื่อนไข A/);
+  assert.match(htmlA, /จุดเด่น A/);
+  assert.doesNotMatch(htmlA, /รายละเอียด B/);
+
+  // Simulate clicking the sibling BTU variant option: this must route to the
+  // sibling's own URL and reload the *entire* page from that fetch, not swap
+  // a price-only overlay on top of itemA.
+  const htmlB = await renderDetailFor(root, [itemA, itemB], itemB.item_id);
+  assert.match(htmlB, /ล้างแอร์ผนัง 18000 BTU/);
+  assert.match(htmlB, /รายละเอียด B/);
+  assert.match(htmlB, /เงื่อนไข B/);
+  assert.match(htmlB, /จุดเด่น B/);
+  assert.doesNotMatch(htmlB, /รายละเอียด A/);
 });
 
-test("services.js exposes a single catalogItemToCommerceDraft adapter, and store.js never builds a booking draft from booking_ac_type/booking_btu/booking_wash_variant by hand", () => {
+test("the variant-option click handler routes via root.utils.routeTo to the sibling's own storeItem URL", () => {
+  const storeSource = file("customer-app/modules/store.js");
+  const handlerBlock = storeSource.match(/\[data-store-variant-option\]"\)\.forEach[\s\S]*?\n\s*\}\);\s*\n\s*\}\);/)[0];
+  assert.match(handlerBlock, /root\.utils\.routeTo\(`storeItem-\$\{id\}`\)/);
+  assert.doesNotMatch(storeSource, /selectedVariantItemId/, "must not maintain a separate selected-variant overlay state");
+});
+
+test("the detail book button resolves the booking draft from the currently routed item, matching the displayed price/BTU", async () => {
+  const root = loadStore();
+  const itemA = wallWashItem({ item_id: 201, booking_btu: 9000 });
+  const itemB = wallWashItem({ item_id: 202, booking_btu: 24000 });
+  await renderDetailFor(root, [itemA, itemB], itemB.item_id);
+
+  const item = root.state.storeDetail.data;
+  assert.equal(Number(item.item_id), 202);
+  const draftItem = root.services.catalogItemToCommerceDraft(item);
+  assert.ok(draftItem, "bookable wall+wash item with a real btu/wash_variant must produce a draft");
+  assert.equal(draftItem.draft.btu, 24000);
+});
+
+test("services.js exposes a single catalogItemToCommerceDraft adapter; store.js never hand-builds a booking draft", () => {
+  const storeSource = file("customer-app/modules/store.js");
+  const servicesSource = file("customer-app/modules/services.js");
   const adapterDefMatches = servicesSource.match(/function catalogItemToCommerceDraft\(/g) || [];
   assert.equal(adapterDefMatches.length, 1, "catalogItemToCommerceDraft must be the single legacy-bookable adapter");
-
   const storeCallSites = storeSource.match(/root\.services\.catalogItemToCommerceDraft\(/g) || [];
-  assert.equal(storeCallSites.length, 2, "both the store grid's book button and the product detail's book button must route through the shared adapter");
-
-  // store.js must never read these raw booking_* fields itself to build a draft;
-  // only the shared adapter in services.js is allowed to interpret them.
+  assert.ok(storeCallSites.length >= 1, "the detail book button must route through the shared adapter");
   assert.ok(!/draft:\s*\{[^}]*booking_ac_type/.test(storeSource), "store.js must not hand-construct a booking draft from booking_ac_type");
   assert.ok(!storeSource.includes("createServiceLine("), "store.js must not call createServiceLine() directly -- only the shared adapter does");
 });
 
-test("catalogItemToCommerceDraft refuses to fabricate a draft when any bookable field is unsupported, routing the caller to contact-admin instead", () => {
-  assert.match(servicesSource, /if \(!matchedAcType\) return null;/);
-  assert.match(servicesSource, /if \(!matchedBtu\) return null;/);
-  assert.match(servicesSource, /if \(!matchedWash\) return null;/);
+test("catalogItemToCommerceDraft deterministically infers a missing wash_variant from unambiguous item-name keywords, never overriding a real value", () => {
+  const { root } = load(["customer-app/modules/services.js"]);
+
+  const premiumNoVariant = wallWashItem({ item_id: 1, item_name: "ล้างแอร์ผนังพรีเมียม", booking_wash_variant: null });
+  const draft1 = root.services.catalogItemToCommerceDraft(premiumNoVariant);
+  assert.ok(draft1, "must infer ล้างพรีเมียม from the name keyword instead of refusing");
+  assert.equal(draft1.draft.wash_variant, "ล้างพรีเมียม");
+
+  const overhaulNoVariant = wallWashItem({ item_id: 2, item_name: "ตัดล้างใหญ่แอร์ผนัง", booking_wash_variant: "" });
+  const draft2 = root.services.catalogItemToCommerceDraft(overhaulNoVariant);
+  assert.ok(draft2);
+  assert.equal(draft2.draft.wash_variant, "ล้างแบบตัดล้าง");
+
+  const explicitWins = wallWashItem({ item_id: 3, item_name: "ล้างแอร์ผนังพรีเมียม", booking_wash_variant: "ล้างธรรมดา" });
+  const draft3 = root.services.catalogItemToCommerceDraft(explicitWins);
+  assert.equal(draft3.draft.wash_variant, "ล้างธรรมดา", "a real booking_wash_variant must never be overridden by name-keyword inference");
+
+  const ambiguousNoVariant = wallWashItem({ item_id: 4, item_name: "ล้างแอร์ผนังทั่วไป (ไม่ระบุวิธี)", booking_wash_variant: null });
+  assert.equal(root.services.catalogItemToCommerceDraft(ambiguousNoVariant), null, "must still refuse, not guess, when no fixed keyword matches");
 });
 
-test("product detail review summary shows an honest empty state instead of a fabricated (0) count", () => {
-  const fn = storeSource.match(/function renderReviewsSectionBody\([\s\S]*?\n  \}/)[0];
-  assert.ok(!/<span class="store-rating-count">\(\$\{count\}\)<\/span>\s*<\/div>/.test(fn), "must not unconditionally render a (0) count badge when there are no reviews yet");
-  assert.match(fn, /hasReviews \? `<span class="store-rating-value">[\s\S]*?<\/span><span class="store-rating-count">\(\$\{count\}\)<\/span>` : `<span class="store-rating-count store-rating-count-empty">ยังไม่มีรีวิว<\/span>`/);
+test("catalogItemToCommerceDraft still refuses to fabricate a draft for unsupported ac_type/btu", () => {
+  const { root } = load(["customer-app/modules/services.js"]);
+  const badAcType = wallWashItem({ item_id: 5, booking_ac_type: "ไม่รองรับ" });
+  assert.equal(root.services.catalogItemToCommerceDraft(badAcType), null);
+  const badBtu = wallWashItem({ item_id: 6, booking_btu: 99999 });
+  assert.equal(root.services.catalogItemToCommerceDraft(badBtu), null);
+  const notBookable = wallWashItem({ item_id: 7, booking_mode: "contact" });
+  assert.equal(root.services.catalogItemToCommerceDraft(notBookable), null);
+});
+
+test("product detail review summary shows an honest empty state with no stars and no (0) count when there are no real reviews yet", async () => {
+  const root = loadStore();
+  const item = wallWashItem({ item_id: 301, rating_average: null, review_count: 0 });
+  const html = await renderDetailFor(root, [item], item.item_id);
+  const reviewsSectionHtml = html.match(/<div class="store-detail-section store-reviews-section"[\s\S]*?<\/div>\s*<div class="store-detail-cta-bar">/)[0];
+  assert.match(reviewsSectionHtml, /ยังไม่มีรีวิวจากลูกค้าสำหรับบริการนี้/);
+  assert.doesNotMatch(reviewsSectionHtml, /<span class="store-rating-count">\(0\)<\/span>/);
+  assert.doesNotMatch(reviewsSectionHtml, /store-rating-stars/, "the reviews summary empty state must show text only, not an empty/outline star row");
+});
+
+test("product detail shows real stars and count once reviews exist", async () => {
+  const root = loadStore();
+  const item = wallWashItem({ item_id: 302, rating_average: 4.6, review_count: 8 });
+  const html = await renderDetailFor(root, [item], item.item_id);
+  assert.match(html, /store-rating-stars/);
+  assert.match(html, /<span class="store-rating-count">\(8\)<\/span>/);
 });


### PR DESCRIPTION
## Summary

This PR covers Work Packages A–G of the "Store Production Completion" task, addressing all blocking findings from the review.

### Work Package A — Review assignment P0 (hardened)
- `server/routes/catalog/reviews.js`: the `FOR UPDATE` select locks `assigned_item_id`; a 409 guard blocks approving a `service_type`/`overall`-scoped review until it has an effective (assigned or origin) item; assign+approve is atomic. The admin `item_id` filter matches the *effective* item (`COALESCE(assigned_item_id, item_id)`).
- **`GET /admin/catalog/reviews` now supports `status=unassigned` and `status=approved_unassigned` server-side** as effective-item-NULL SQL predicates, evaluated before the `ORDER BY created_at DESC LIMIT 200` truncation — fixing the gap where an older approved-but-unassigned review outside the most-recent-200 window could never surface under any filter, because the admin UI was previously fetching one unfiltered page and filtering it client-side.
- `admin-store-catalog.js`: `loadReviews()` now sends the selected status/source as real query params and re-fetches on change (only `item_id` stays client-side, applied over the already status/source-filtered result). Review visibility distinguishes 5 states (unassigned / assigned+pending / approved+visible / rejected / hidden) — a linked pending/hidden review no longer reads as "ยังไม่ผูกสินค้า". The assign picker prioritizes active+customer-visible items and labels non-visible targets so "approved" reliably means visible in Store.
- Assignment remains atomic and assignment-only for already-approved orphans; never auto-assigns.

### Work Package B — Variant single source of truth
`renderDetailContent(item)` now renders the entire detail page — gallery, badges/queue, name, rating, booking count, highlights, long description, AC type, service conditions, related products, reviews, and the booking draft — from one routed item (`root.state.storeDetail.data`). The old partial-overlay `displayItem` pattern is gone; selecting a sibling BTU variant routes to that item's own `storeItem-{id}` and reloads the whole page from that fetch, including resetting reviews/eligibility for the newly selected item. Verified with a real render-and-assert behavioral test (not source regex) that switches between two full items and asserts every section — image, descriptions, conditions, highlights, price — changes together, never partially.

### Work Package C — Legacy bookable adapter
`services.js`'s `catalogItemToCommerceDraft` is the single shared adapter for both the store grid and detail book buttons. It now deterministically infers a missing `booking_wash_variant` from unambiguous item-name keywords (premium→ล้างพรีเมียม, overhaul/ตัดล้าง→ล้างแบบตัดล้าง, coil/แขวนคอยล์→ล้างแขวนคอยล์, normal/ธรรมดา→ล้างธรรมดา) instead of refusing whenever the field is empty — while never overriding a real explicit value, and still refusing (`null`) when no fixed keyword matches or the ac_type/btu/booking_mode is unsupported. Verified with executable tests asserting the actual returned draft, not pattern-matching on source code.

### Work Package D — Review UX empty state + cache
- `api.js`: catalog list/detail fetches use `cache: "no-store"` so moderation changes show up immediately.
- `store.js`: the product detail review summary shows only `ยังไม่มีรีวิวจากลูกค้าสำหรับบริการนี้` when there are no real reviews — no `(0)` badge, no zero-score/empty star row. The top display badge keeps its display-only stars with no fake score/count.

### Work Package E — Store conversion UX
Compact mobile filter controls for canonical service category, AC type, wash method, BTU, and "มีคิววันนี้" (queue today), plus a sort select (CWF recommended / booking count desc / price low→high / price high→low) — all reading/comparing canonical values via the existing resolvers, never raw category strings. Active-promotion name, real savings amount, and a readable end date render on list and detail only when `has_active_promotion` is true. `.store-filters` reworked from a 2-column grid into a flex-wrap layout fitting all 7 controls at 320px width without changing the existing visual design.

### Work Package F — Store funnel analytics
New `customer-app/modules/analytics.js`: dependency-free, emits to `window.dataLayer`/`window.gtag` only when present, no-ops otherwise (try/catch wrapped). Explicit allowlist for both event names and field keys — no PII, review text, token, or booking code can be pushed even by accident. Wired through `store.js`: `cwf_store_view`, `cwf_store_product_view`, `cwf_store_variant_select`, `cwf_store_filter`, `cwf_store_detail_expand`, `cwf_store_related_click`, `cwf_store_begin_booking`, `cwf_store_contact_admin`. Registered in `index.html` and `sw.js`'s precache list.

### Work Package G — Performance guard
**Analysis:** the store list and detail page share one cached catalog collection in `root.state.catalog`. `ensureLoaded()` only fetches when `status === "idle"`; `ensureCatalogListLoaded()` (used by the detail page for variant siblings/related items) reuses the cached array whenever `status === "success" && items.length`, never refetching the list merely to populate detail.

**Request flow:** list page = 1 request (`loadCatalogItems`, skipped on repeat visits). List→detail (common path) = 0 additional list requests (siblings/related read from cache) + 1 `loadCatalogItem(id)` + 1 `loadCatalogItemReviews(id)`. Direct deep link to detail (list never loaded) = 1 list request triggered by `ensureCatalogListLoaded()` in parallel with detail/review requests — no worse than the list-first path.

**Conclusion:** the existing guard structure is already the smallest safe solution; no new context endpoint or caching layer was added — a combined endpoint was considered and rejected since it would only help the deep-link path, which already does no worse than the existing flow, while adding a second code path requiring its own staleness/invalidation testing. A new regression test proves no duplicate list fetch occurs across a list render + detail navigation for an already-loaded item.

## Test plan
- [x] `node --check` on every modified `.js` file
- [x] `node --test test/customerAppRecovery.test.js` — 78/78 pass (filters, sort, promo display, all 8 analytics events with exact-allowlisted-field assertions, performance guard)
- [x] `node --test test/customerAppStoreVariantAndBookableAdapter.test.js` — 8/8 pass (real render-and-assert behavioral tests, not source regex)
- [x] `node --test test/adminStoreCatalogUi.test.js` — 63/63 pass
- [x] `node --test test/catalogReviewRoutes.test.js` — 49/49 pass, including a new test seeding 205 recent + 2 decade-old orphan reviews proving `status=approved_unassigned`/`unassigned` reach past the 200-row recency cap
- [x] Full `npm test` — 631/643 pass, 11 skipped, 1 pre-existing failure unrelated to this change (`customerAppThreeStepBooking.test.js:204`, a date-wording flake in calendar full-day rendering) — confirmed failing identically on this same base via `git stash` (base: 18/19 pass in that file with the same failure; head: same single failure, zero new failures)
- [x] `git diff --check` — clean
- [ ] Live browser QA at 320/390/430 — **not performed** (no browser/visual QA tooling in this environment). DOM/markup regression tests were added instead (filter/sort result-set assertions, promo markup presence/absence, full-page-reload-per-variant assertions) to cover the new/changed rendering at the markup level.
- No migrations, no production data touched, no merge/deploy performed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01G8RDdFzW2bZKTwvsfaovwg)_