### PR TITLE
Fix store review display names and race guards

### DIFF
--- a/customer-app/assets/customer-app.js
+++ b/customer-app/assets/customer-app.js
@@ -3,7 +3,7 @@
 
   const App = window.CWFCustomerAppV2;
   const BOOT_TIMEOUT_MS = 3500;
-  const BUILD_ID = "20260628_store_detail_content_missing";
+  const BUILD_ID = "20260628_store_review_name_final";
 
   function withTimeout(promise, timeoutMs) {
     return Promise.race([

--- a/customer-app/index.html
+++ b/customer-app/index.html
@@ -9,10 +9,10 @@
   <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
   <meta name="apple-mobile-web-app-title" content="CWF Service">
   <title>CWF Customer Service</title>
-  <link rel="manifest" href="./manifest.webmanifest?v=20260628_store_detail_content_missing">
+  <link rel="manifest" href="./manifest.webmanifest?v=20260628_store_review_name_final">
   <link rel="icon" type="image/png" sizes="192x192" href="./assets/icons/cwf-customer-192.png">
   <link rel="apple-touch-icon" sizes="180x180" href="./assets/icons/cwf-customer-180.png">
-  <link rel="stylesheet" href="./assets/customer-app.css?v=20260628_store_detail_content_missing">
+  <link rel="stylesheet" href="./assets/customer-app.css?v=20260628_store_review_name_final">
 </head>
 <body class="is-app-booting">
   <div class="app-shell" data-app-shell>
@@ -50,21 +50,21 @@
     </nav>
   </div>
 
-  <script src="./modules/state.js?v=20260628_store_detail_content_missing"></script>
-  <script src="./modules/utils.js?v=20260628_store_detail_content_missing"></script>
-  <script src="./modules/analytics.js?v=20260628_store_detail_content_missing"></script>
-  <script src="./modules/api.js?v=20260628_store_detail_content_missing"></script>
-  <script src="./modules/services.js?v=20260628_store_detail_content_missing"></script>
-  <script src="./modules/ui.js?v=20260628_store_detail_content_missing"></script>
-  <script src="./modules/store.js?v=20260628_store_detail_content_missing"></script>
-  <script src="./modules/auth.js?v=20260628_store_detail_content_missing"></script>
-  <script src="./modules/pricing.js?v=20260628_store_detail_content_missing"></script>
-  <script src="./modules/availability.js?v=20260628_store_detail_content_missing"></script>
-  <script src="./modules/bookingScheduled.js?v=20260628_store_detail_content_missing"></script>
-  <script src="./modules/bookingUrgent.js?v=20260628_store_detail_content_missing"></script>
-  <script src="./modules/tracking.js?v=20260628_store_detail_content_missing"></script>
-  <script src="./modules/profile.js?v=20260628_store_detail_content_missing"></script>
-  <script src="./modules/router.js?v=20260628_store_detail_content_missing"></script>
-  <script src="./assets/customer-app.js?v=20260628_store_detail_content_missing"></script>
+  <script src="./modules/state.js?v=20260628_store_review_name_final"></script>
+  <script src="./modules/utils.js?v=20260628_store_review_name_final"></script>
+  <script src="./modules/analytics.js?v=20260628_store_review_name_final"></script>
+  <script src="./modules/api.js?v=20260628_store_review_name_final"></script>
+  <script src="./modules/services.js?v=20260628_store_review_name_final"></script>
+  <script src="./modules/ui.js?v=20260628_store_review_name_final"></script>
+  <script src="./modules/store.js?v=20260628_store_review_name_final"></script>
+  <script src="./modules/auth.js?v=20260628_store_review_name_final"></script>
+  <script src="./modules/pricing.js?v=20260628_store_review_name_final"></script>
+  <script src="./modules/availability.js?v=20260628_store_review_name_final"></script>
+  <script src="./modules/bookingScheduled.js?v=20260628_store_review_name_final"></script>
+  <script src="./modules/bookingUrgent.js?v=20260628_store_review_name_final"></script>
+  <script src="./modules/tracking.js?v=20260628_store_review_name_final"></script>
+  <script src="./modules/profile.js?v=20260628_store_review_name_final"></script>
+  <script src="./modules/router.js?v=20260628_store_review_name_final"></script>
+  <script src="./assets/customer-app.js?v=20260628_store_review_name_final"></script>
 </body>
 </html>

--- a/customer-app/manifest.webmanifest
+++ b/customer-app/manifest.webmanifest
@@ -2,7 +2,7 @@
   "name": "CWF Customer Service",
   "short_name": "CWF Service",
   "description": "แอปลูกค้า Coldwindflow สำหรับเลือกบริการ จองคิว และติดตามงาน",
-  "start_url": "/customer-app/index.html?v=20260628_store_detail_content_missing#home",
+  "start_url": "/customer-app/index.html?v=20260628_store_review_name_final#home",
   "scope": "/customer-app/",
   "id": "/customer-app/",
   "display": "standalone",

--- a/customer-app/modules/store.js
+++ b/customer-app/modules/store.js
@@ -5,8 +5,11 @@
 
   let filterState = { search: "", category: "", acType: "", washVariant: "", btu: "", queueToday: false, sort: "recommended" };
   let detailLoadSeq = 0;
+  let reviewsRequestSeq = 0;
+  let eligibilityRequestSeq = 0;
+  let reviewSubmitSeq = 0;
 
-  console.info("[customer-store] detail-content-hotfix 20260628 loaded");
+  console.info("[customer-store] review-name-final 20260628 loaded");
 
   const FILTER_AC_TYPES = [
     { value: "wall", label: "แอร์ผนัง" },
@@ -1054,14 +1057,39 @@
   };
 
   function resetReviewsState(itemId) {
+    reviewsRequestSeq += 1;
+    eligibilityRequestSeq += 1;
+    reviewSubmitSeq += 1;
     reviewsState = { itemId, status: "idle", reviews: [], total: 0, ratingAverage: null, reviewCount: 0, offset: 0 };
     writeReviewState = {
-      open: false, eligibilityStatus: "idle", eligible: false, eligibleJobs: [],
+      itemId, open: false, eligibilityStatus: "idle", eligible: false, eligibleJobs: [],
       jobId: null, rating: 0, comment: "", step: "form", submitting: false, error: "", success: false,
     };
   }
 
+  function isCurrentDetailContext(itemId) {
+    const bucket = root.state.storeDetail || {};
+    return String(detailItemId()) === String(itemId)
+      && String(bucket.itemId) === String(itemId)
+      && bucket.status === "success"
+      && bucket.data
+      && String(bucket.data.item_id) === String(itemId);
+  }
+
+  function isCurrentReviewsRequest(itemId, requestSeq) {
+    return requestSeq === reviewsRequestSeq && isCurrentDetailContext(itemId) && String(reviewsState.itemId) === String(itemId);
+  }
+
+  function isCurrentEligibilityRequest(itemId, requestSeq) {
+    return requestSeq === eligibilityRequestSeq && isCurrentDetailContext(itemId) && String(writeReviewState.itemId || itemId) === String(itemId);
+  }
+
+  function isCurrentReviewSubmit(itemId, requestSeq) {
+    return requestSeq === reviewSubmitSeq && isCurrentDetailContext(itemId) && String(writeReviewState.itemId || itemId) === String(itemId);
+  }
+
   function patchReviewsSection(container, item) {
+    if (!item || !isCurrentDetailContext(item.item_id)) return;
     const mount = container.querySelector("[data-store-reviews-section]");
     if (!mount) return;
     mount.innerHTML = renderReviewsSectionBody(item);
@@ -1070,11 +1098,16 @@
 
   async function loadReviewsList(container, item, { append } = {}) {
     const itemId = item.item_id;
-    reviewsState.status = append ? reviewsState.status : "loading";
+    if (!isCurrentDetailContext(itemId)) return;
+    if (append && reviewsState.status === "loading_more") return;
+    const requestSeq = ++reviewsRequestSeq;
+    reviewsState.itemId = itemId;
+    reviewsState.status = append ? "loading_more" : "loading";
     if (!append) patchReviewsSection(container, item);
     try {
       const offset = append ? reviewsState.offset : 0;
       const data = await root.api.loadCatalogItemReviews(itemId, { limit: REVIEWS_PAGE_SIZE, offset });
+      if (!isCurrentReviewsRequest(itemId, requestSeq)) return;
       const incoming = root.utils.normalizeList(data, "reviews");
       reviewsState = {
         itemId,
@@ -1086,6 +1119,7 @@
         offset: offset + incoming.length,
       };
     } catch (error) {
+      if (!isCurrentReviewsRequest(itemId, requestSeq)) return;
       reviewsState.status = "error";
       reviewsState.error = error?.message || "โหลดรีวิวไม่สำเร็จ";
     }
@@ -1094,16 +1128,23 @@
 
   async function loadEligibility(container, item) {
     if (!root.state.customer?.logged_in) return;
+    const itemId = item.item_id;
+    if (!isCurrentDetailContext(itemId)) return;
+    const requestSeq = ++eligibilityRequestSeq;
+    writeReviewState.itemId = itemId;
     writeReviewState.eligibilityStatus = "loading";
     try {
-      const data = await root.api.loadReviewEligibility(item.item_id);
+      const data = await root.api.loadReviewEligibility(itemId);
+      if (!isCurrentEligibilityRequest(itemId, requestSeq)) return;
       writeReviewState.eligibilityStatus = "success";
       writeReviewState.eligible = Boolean(data?.eligible);
       writeReviewState.eligibleJobs = root.utils.normalizeList(data, "eligible_jobs");
       writeReviewState.jobId = writeReviewState.eligibleJobs[0]?.job_id || null;
     } catch (error) {
+      if (!isCurrentEligibilityRequest(itemId, requestSeq)) return;
       writeReviewState.eligibilityStatus = "error";
       writeReviewState.eligible = false;
+      writeReviewState.error = error?.message || "ตรวจสอบสิทธิ์รีวิวไม่สำเร็จ";
     }
     patchReviewsSection(container, item);
   }
@@ -1129,8 +1170,16 @@
     if (writeReviewState.eligibilityStatus === "loading" || writeReviewState.eligibilityStatus === "idle") {
       return `<div class="content-skeleton" aria-label="กำลังตรวจสอบสิทธิ์รีวิว"><span></span></div>`;
     }
+    if (writeReviewState.eligibilityStatus === "error") {
+      return `
+        <div class="store-review-write-gate">
+          <p class="store-review-ineligible">ตรวจสอบสิทธิ์รีวิวไม่สำเร็จ</p>
+          <button type="button" class="secondary-btn" data-store-review-retry>ลองใหม่</button>
+        </div>
+      `;
+    }
     if (!writeReviewState.eligible) {
-      return `<p class="store-review-ineligible">คุณยังไม่มีงานที่เสร็จสมบูรณ์สำหรับสินค้า/บริการนี้ที่สามารถรีวิวได้ในขณะนี้</p>`;
+      return `<p class="store-review-ineligible">เขียนรีวิวได้หลังงานบริการเสร็จสมบูรณ์</p>`;
     }
     if (writeReviewState.success) {
       return root.utils.stateBox("success", "ส่งรีวิวแล้ว รอแอดมินตรวจสอบ");
@@ -1207,7 +1256,7 @@
     const hasMore = reviewsState.reviews.length < reviewsState.total;
     return `
       <div class="store-reviews-list">${items}</div>
-      ${hasMore ? `<button type="button" class="secondary-btn store-reviews-load-more" data-store-reviews-more>โหลดรีวิวเพิ่ม</button>` : ""}
+      ${hasMore ? `<button type="button" class="secondary-btn store-reviews-load-more" data-store-reviews-more ${reviewsState.status === "loading_more" ? "disabled" : ""}>${reviewsState.status === "loading_more" ? "กำลังโหลด..." : "โหลดรีวิวเพิ่ม"}</button>` : ""}
     `;
   }
 
@@ -1239,12 +1288,17 @@
 
     const openButton = section.querySelector("[data-store-review-open]");
     if (openButton) openButton.addEventListener("click", () => {
+      if (!isCurrentDetailContext(item.item_id)) return;
       writeReviewState.open = true;
       patchReviewsSection(container, item);
     });
 
+    const retryButton = section.querySelector("[data-store-review-retry]");
+    if (retryButton) retryButton.addEventListener("click", () => loadEligibility(container, root.state.storeDetail?.data || item));
+
     const cancelButton = section.querySelector("[data-store-review-cancel]");
     if (cancelButton) cancelButton.addEventListener("click", () => {
+      if (!isCurrentDetailContext(item.item_id)) return;
       writeReviewState.open = false;
       writeReviewState.rating = 0;
       writeReviewState.comment = "";
@@ -1257,6 +1311,7 @@
 
     section.querySelectorAll("[data-review-star]").forEach((button) => {
       button.addEventListener("click", () => {
+        if (!isCurrentDetailContext(item.item_id)) return;
         writeReviewState.rating = Number(button.getAttribute("data-review-star") || 0);
         patchReviewsSection(container, item);
       });
@@ -1267,6 +1322,7 @@
 
     const nextButton = section.querySelector("[data-store-review-next]");
     if (nextButton) nextButton.addEventListener("click", () => {
+      if (!isCurrentDetailContext(item.item_id)) return;
       if (!writeReviewState.rating) {
         writeReviewState.error = "กรุณาให้คะแนน 1-5 ดาว";
         patchReviewsSection(container, item);
@@ -1279,27 +1335,33 @@
 
     const backButton = section.querySelector("[data-store-review-back]");
     if (backButton) backButton.addEventListener("click", () => {
+      if (!isCurrentDetailContext(item.item_id)) return;
       writeReviewState.step = "form";
       patchReviewsSection(container, item);
     });
 
     const confirmButton = section.querySelector("[data-store-review-confirm]");
     if (confirmButton) confirmButton.addEventListener("click", async () => {
+      if (!isCurrentDetailContext(item.item_id)) return;
       if (writeReviewState.submitting) return;
+      const itemId = item.item_id;
+      const requestSeq = ++reviewSubmitSeq;
       writeReviewState.submitting = true;
       writeReviewState.error = "";
       patchReviewsSection(container, item);
       try {
-        await root.api.submitCatalogItemReview(item.item_id, {
+        await root.api.submitCatalogItemReview(itemId, {
           job_id: writeReviewState.jobId,
           rating: writeReviewState.rating,
           comment: writeReviewState.comment,
         });
+        if (!isCurrentReviewSubmit(itemId, requestSeq)) return;
         writeReviewState.submitting = false;
         writeReviewState.open = false;
         writeReviewState.success = true;
         patchReviewsSection(container, item);
       } catch (error) {
+        if (!isCurrentReviewSubmit(itemId, requestSeq)) return;
         writeReviewState.submitting = false;
         writeReviewState.error = error?.message || "ส่งรีวิวไม่สำเร็จ";
         patchReviewsSection(container, item);
@@ -1575,7 +1637,7 @@
     clearDetailAutoplay();
   };
 
-  store._test = { loadDetail, loadReviewsList, detailItemId, renderDetailBody, renderReviewsSectionBody };
+  store._test = { loadDetail, loadReviewsList, loadEligibility, detailItemId, renderDetailBody, renderReviewsSectionBody };
 
   root.store = store;
 })();

--- a/customer-app/modules/store.js
+++ b/customer-app/modules/store.js
@@ -1103,7 +1103,7 @@
     const requestSeq = ++reviewsRequestSeq;
     reviewsState.itemId = itemId;
     reviewsState.status = append ? "loading_more" : "loading";
-    if (!append) patchReviewsSection(container, item);
+    patchReviewsSection(container, item);
     try {
       const offset = append ? reviewsState.offset : 0;
       const data = await root.api.loadCatalogItemReviews(itemId, { limit: REVIEWS_PAGE_SIZE, offset });
@@ -1133,6 +1133,7 @@
     const requestSeq = ++eligibilityRequestSeq;
     writeReviewState.itemId = itemId;
     writeReviewState.eligibilityStatus = "loading";
+    writeReviewState.error = "";
     try {
       const data = await root.api.loadReviewEligibility(itemId);
       if (!isCurrentEligibilityRequest(itemId, requestSeq)) return;
@@ -1140,6 +1141,7 @@
       writeReviewState.eligible = Boolean(data?.eligible);
       writeReviewState.eligibleJobs = root.utils.normalizeList(data, "eligible_jobs");
       writeReviewState.jobId = writeReviewState.eligibleJobs[0]?.job_id || null;
+      writeReviewState.error = "";
     } catch (error) {
       if (!isCurrentEligibilityRequest(itemId, requestSeq)) return;
       writeReviewState.eligibilityStatus = "error";

--- a/customer-app/sw.js
+++ b/customer-app/sw.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const BUILD_ID = "20260628_store_detail_content_missing";
+const BUILD_ID = "20260628_store_review_name_final";
 const CACHE_NAME = `cwf-customer-app-v2-${BUILD_ID}`;
 const APP_SHELL = [
   `./index.html?v=${BUILD_ID}`,

--- a/server/routes/catalog/reviews.js
+++ b/server/routes/catalog/reviews.js
@@ -71,14 +71,25 @@ function createFixedWindowLimiter({ windowMs, maxRequests, now = () => Date.now(
   };
 }
 
-function normalizeReviewDisplayName(value) {
+function normalizeReviewNameCore(value) {
   let name = String(value || "").trim().replace(/\s+/g, " ");
+  if (name === "คุณ" || name === "คุณคุณ") return "";
   while (name) {
-    const next = name.replace(/^คุณ\s*/u, "").trim().replace(/\s+/g, " ");
+    let next = name;
+    if (/^คุณ\s+/u.test(name)) {
+      next = name.replace(/^คุณ\s+/u, "");
+    } else if (/^คุณคุณ\S/u.test(name)) {
+      next = name.replace(/^คุณคุณ/u, "");
+    }
     if (next === name) break;
-    name = next;
+    name = next.trim().replace(/\s+/g, " ");
+    if (name === "คุณ" || name === "คุณคุณ") return "";
   }
-  return name || "ลูกค้า CWF";
+  return name;
+}
+
+function normalizeReviewDisplayName(value) {
+  return normalizeReviewNameCore(value) || "ลูกค้า CWF";
 }
 
 function validateRatingAndComment(body) {
@@ -341,7 +352,9 @@ module.exports = function createCatalogReviewRoutes(deps = {}) {
 
         // customer_identity stores only the normalized display name derived
         // from the verified job/session, never the LINE sub, phone, or email.
-        const customerIdentity = normalizeReviewDisplayName(matchedJob.customer_name || req.customer?.name);
+        const customerIdentity = normalizeReviewNameCore(matchedJob.customer_name)
+          || normalizeReviewNameCore(req.customer?.name)
+          || "ลูกค้า CWF";
         insertResult = await client.query(
           `INSERT INTO public.catalog_item_reviews
              (item_id, completed_job_id, customer_identity, rating, comment, moderation_status)
@@ -730,6 +743,7 @@ module.exports = function createCatalogReviewRoutes(deps = {}) {
 };
 
 module.exports.MAX_COMMENT_LENGTH = MAX_COMMENT_LENGTH;
+module.exports.normalizeReviewNameCore = normalizeReviewNameCore;
 module.exports.normalizeReviewDisplayName = normalizeReviewDisplayName;
 module.exports.validateRatingAndComment = validateRatingAndComment;
 module.exports.DONE_JOB_STATUSES = DONE_JOB_STATUSES;

--- a/server/routes/catalog/reviews.js
+++ b/server/routes/catalog/reviews.js
@@ -71,11 +71,14 @@ function createFixedWindowLimiter({ windowMs, maxRequests, now = () => Date.now(
   };
 }
 
-function maskCustomerDisplayName(name) {
-  const trimmed = String(name || "").trim();
-  if (!trimmed) return "คุณลูกค้า";
-  const first = trimmed[0];
-  return `คุณ ${first}${"*".repeat(Math.max(1, Math.min(trimmed.length - 1, 4)))}`;
+function normalizeReviewDisplayName(value) {
+  let name = String(value || "").trim().replace(/\s+/g, " ");
+  while (name) {
+    const next = name.replace(/^คุณ\s*/u, "").trim().replace(/\s+/g, " ");
+    if (next === name) break;
+    name = next;
+  }
+  return name || "ลูกค้า CWF";
 }
 
 function validateRatingAndComment(body) {
@@ -184,7 +187,7 @@ module.exports = function createCatalogReviewRoutes(deps = {}) {
   // concurrent submissions for the same job can't both see it as eligible).
   async function findEligibleJobsForReview(db, customerSub, itemId, { forUpdate = false } = {}) {
     const r = await db.query(
-      `SELECT j.job_id, j.appointment_datetime
+      `SELECT j.job_id, j.appointment_datetime, j.customer_name
          FROM public.jobs j
         WHERE j.customer_sub = $1
           AND j.catalog_item_id = $2
@@ -240,7 +243,7 @@ module.exports = function createCatalogReviewRoutes(deps = {}) {
         review_id: Number(row.review_id),
         rating: Number(row.rating),
         comment: row.comment || "",
-        display_name: maskCustomerDisplayName(row.customer_identity),
+        display_name: normalizeReviewDisplayName(row.customer_identity),
         created_at: row.created_at,
       }));
 
@@ -336,10 +339,9 @@ module.exports = function createCatalogReviewRoutes(deps = {}) {
           return res.status(403).json({ error: "คุณยังไม่มีงานที่เสร็จสมบูรณ์สำหรับสินค้า/บริการนี้ หรือเคยรีวิวงานนี้ไปแล้ว" });
         }
 
-        // customer_identity stores only the customer's own display name as it
-        // appeared at submission time (used solely to derive the public masked
-        // label, e.g. "คุณ ส***") — never the LINE sub, phone, or email.
-        const customerIdentity = String(req.customer?.name || "").trim() || "ลูกค้า";
+        // customer_identity stores only the normalized display name derived
+        // from the verified job/session, never the LINE sub, phone, or email.
+        const customerIdentity = normalizeReviewDisplayName(matchedJob.customer_name || req.customer?.name);
         insertResult = await client.query(
           `INSERT INTO public.catalog_item_reviews
              (item_id, completed_job_id, customer_identity, rating, comment, moderation_status)
@@ -464,7 +466,7 @@ module.exports = function createCatalogReviewRoutes(deps = {}) {
         }
 
         const target = await resolveHistoricalServiceTarget(client, job.job_id);
-        const customerIdentity = String(job.customer_name || "").trim() || "ลูกค้า";
+        const customerIdentity = normalizeReviewDisplayName(job.customer_name);
 
         insertResult = await client.query(
           `INSERT INTO public.catalog_item_reviews
@@ -728,7 +730,7 @@ module.exports = function createCatalogReviewRoutes(deps = {}) {
 };
 
 module.exports.MAX_COMMENT_LENGTH = MAX_COMMENT_LENGTH;
-module.exports.maskCustomerDisplayName = maskCustomerDisplayName;
+module.exports.normalizeReviewDisplayName = normalizeReviewDisplayName;
 module.exports.validateRatingAndComment = validateRatingAndComment;
 module.exports.DONE_JOB_STATUSES = DONE_JOB_STATUSES;
 module.exports.createFixedWindowLimiter = createFixedWindowLimiter;

--- a/test/catalogReviewRoutes.test.js
+++ b/test/catalogReviewRoutes.test.js
@@ -276,12 +276,22 @@ test("createCatalogReviewRoutes throws without requireCustomerJwt or requireAdmi
   assert.throws(() => createCatalogReviewRoutes({ pool: makePool(), requireCustomerJwt: requireCustomerJwtFor("s1") }), /requireAdminSession/);
 });
 
-test("normalizeReviewDisplayName strips only leading repeated คุณ prefixes and never masks names", () => {
-  const { normalizeReviewDisplayName } = require("../server/routes/catalog/reviews");
+test("normalizeReviewDisplayName strips only proven leading คุณ honorifics and never masks names", () => {
+  const { normalizeReviewNameCore, normalizeReviewDisplayName } = require("../server/routes/catalog/reviews");
+  assert.equal(normalizeReviewNameCore("คุณ สมชาย ใจดี"), "สมชาย ใจดี");
+  assert.equal(normalizeReviewNameCore("คุณคุณสมชาย"), "สมชาย");
+  assert.equal(normalizeReviewNameCore("คุณ คุณ แอนนา"), "แอนนา");
+  assert.equal(normalizeReviewNameCore("คุณากร"), "คุณากร");
+  assert.equal(normalizeReviewNameCore("คุณภาพดี"), "คุณภาพดี");
+  assert.equal(normalizeReviewNameCore("บริษัทคุณภาพดี"), "บริษัทคุณภาพดี");
+  assert.equal(normalizeReviewNameCore(""), "");
+  assert.equal(normalizeReviewNameCore("คุณ"), "");
   assert.equal(normalizeReviewDisplayName("คุณ สมชาย ใจดี"), "สมชาย ใจดี");
   assert.equal(normalizeReviewDisplayName("คุณคุณสมชาย"), "สมชาย");
   assert.equal(normalizeReviewDisplayName("คุณ คุณ แอนนา"), "แอนนา");
   assert.equal(normalizeReviewDisplayName("Anna Smith"), "Anna Smith");
+  assert.equal(normalizeReviewDisplayName("คุณากร"), "คุณากร");
+  assert.equal(normalizeReviewDisplayName("คุณภาพดี"), "คุณภาพดี");
   assert.equal(normalizeReviewDisplayName(""), "ลูกค้า CWF");
   assert.equal(normalizeReviewDisplayName("คุณ"), "ลูกค้า CWF");
   assert.equal(normalizeReviewDisplayName("บริษัทคุณภาพดี"), "บริษัทคุณภาพดี");
@@ -499,6 +509,39 @@ test("customer-app review falls back to ลูกค้า CWF when job and sess
     assert.equal(res.status, 201);
     assert.equal(pool.state.reviews[0].customer_identity, "ลูกค้า CWF");
   });
+});
+
+test("customer-app review chooses the first source with a real normalized name", async () => {
+  const scenarios = [
+    { jobName: "คุณ", sessionName: "สมหญิง", expected: "สมหญิง" },
+    { jobName: "   ", sessionName: "Anna Smith", expected: "Anna Smith" },
+    { jobName: "คุณ สมชาย", sessionName: "LINE Name", expected: "สมชาย" },
+  ];
+
+  for (const [index, scenario] of scenarios.entries()) {
+    const pool = makePool({
+      items: [{ item_id: 1, item_name: "ล้างแอร์ผนัง" }],
+      jobs: [{
+        job_id: 100 + index,
+        customer_sub: "sub-1",
+        catalog_item_id: 1,
+        job_status: DONE_STATUS,
+        appointment_datetime: "2026-06-01T00:00:00Z",
+        customer_name: scenario.jobName,
+      }],
+    });
+    const router = createCatalogReviewRoutes({ pool, requireCustomerJwt: requireCustomerJwtFor("sub-1", scenario.sessionName), requireAdminSession: denyAdmin });
+    await withServer(router, async (base) => {
+      const res = await fetch(`${base}/catalog/items/1/reviews`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ rating: 5, customer_name: "ชื่อปลอมจาก client" }),
+      });
+      assert.equal(res.status, 201);
+      assert.equal(pool.state.reviews[0].customer_identity, scenario.expected);
+      assert.notEqual(pool.state.reviews[0].customer_identity, "ชื่อปลอมจาก client");
+    });
+  }
 });
 
 test("a duplicate review on the same job is rejected and never inserts a second row", async () => {

--- a/test/catalogReviewRoutes.test.js
+++ b/test/catalogReviewRoutes.test.js
@@ -276,6 +276,17 @@ test("createCatalogReviewRoutes throws without requireCustomerJwt or requireAdmi
   assert.throws(() => createCatalogReviewRoutes({ pool: makePool(), requireCustomerJwt: requireCustomerJwtFor("s1") }), /requireAdminSession/);
 });
 
+test("normalizeReviewDisplayName strips only leading repeated คุณ prefixes and never masks names", () => {
+  const { normalizeReviewDisplayName } = require("../server/routes/catalog/reviews");
+  assert.equal(normalizeReviewDisplayName("คุณ สมชาย ใจดี"), "สมชาย ใจดี");
+  assert.equal(normalizeReviewDisplayName("คุณคุณสมชาย"), "สมชาย");
+  assert.equal(normalizeReviewDisplayName("คุณ คุณ แอนนา"), "แอนนา");
+  assert.equal(normalizeReviewDisplayName("Anna Smith"), "Anna Smith");
+  assert.equal(normalizeReviewDisplayName(""), "ลูกค้า CWF");
+  assert.equal(normalizeReviewDisplayName("คุณ"), "ลูกค้า CWF");
+  assert.equal(normalizeReviewDisplayName("บริษัทคุณภาพดี"), "บริษัทคุณภาพดี");
+});
+
 test("public reviews list is approved-only and never exposes job_id, customer_sub, or moderation fields", async () => {
   const pool = makePool({
     items: [{ item_id: 1, item_name: "ล้างแอร์ผนัง" }],
@@ -295,11 +306,59 @@ test("public reviews list is approved-only and never exposes job_id, customer_su
     assert.equal(body.rating_average, 5);
     assert.equal(body.reviews.length, 1);
     assert.equal(body.reviews[0].rating, 5);
-    assert.match(body.reviews[0].display_name, /^คุณ /);
+    assert.equal(body.reviews[0].display_name, "สมชาย");
+    assert.ok(!body.reviews[0].display_name.includes("คุณ"));
+    assert.ok(!body.reviews[0].display_name.includes("*"));
     assert.ok(!("completed_job_id" in body.reviews[0]));
     assert.ok(!("customer_identity" in body.reviews[0]));
     assert.ok(!("moderation_status" in body.reviews[0]));
-    assert.ok(!JSON.stringify(body).includes("สมชาย"));
+    assert.ok(JSON.stringify(body).includes("สมชาย"));
+  });
+});
+
+test("public reviews normalize existing approved rows without exposing raw identity or private fields", async () => {
+  const pool = makePool({
+    items: [{ item_id: 1, item_name: "ล้างแอร์ผนัง" }],
+    reviews: [
+      {
+        review_id: 1,
+        item_id: 1,
+        completed_job_id: 101,
+        customer_identity: "คุณ คุณ สมชาย ใจดี",
+        customer_phone: "0812345678",
+        customer_sub: "line-secret",
+        booking_code: "CWFSECRET",
+        tracking_token_hash: "hash-secret",
+        rating: 5,
+        comment: "ช่างสุภาพมาก ทำงานละเอียด",
+        moderation_status: "approved",
+        moderation_notes: "internal",
+        created_at: "2026-06-01T00:00:00Z",
+      },
+    ],
+  });
+  const router = createCatalogReviewRoutes({ pool, requireCustomerJwt: requireCustomerJwtFor(null), requireAdminSession: denyAdmin });
+
+  await withServer(router, async (base) => {
+    const res = await fetch(`${base}/catalog/items/1/reviews`);
+    const body = await res.json();
+    const json = JSON.stringify(body);
+    assert.equal(res.status, 200);
+    assert.equal(body.review_count, 1);
+    assert.equal(body.rating_average, 5);
+    assert.equal(body.reviews[0].display_name, "สมชาย ใจดี");
+    assert.equal(body.reviews[0].comment, "ช่างสุภาพมาก ทำงานละเอียด");
+    assert.ok(!body.reviews[0].display_name.includes("คุณ"));
+    assert.ok(!body.reviews[0].display_name.includes("*"));
+    assert.ok(!("customer_identity" in body.reviews[0]));
+    assert.ok(!("completed_job_id" in body.reviews[0]));
+    assert.ok(!("job_id" in body.reviews[0]));
+    assert.ok(!("moderation_status" in body.reviews[0]));
+    assert.ok(!json.includes("0812345678"));
+    assert.ok(!json.includes("line-secret"));
+    assert.ok(!json.includes("CWFSECRET"));
+    assert.ok(!json.includes("hash-secret"));
+    assert.ok(!json.includes("internal"));
   });
 });
 
@@ -404,14 +463,14 @@ test("submitting a review with no eligible job at all is rejected even if the cl
 test("a valid review submission is created as pending and is attached to the real eligible job", async () => {
   const pool = makePool({
     items: [{ item_id: 1, item_name: "ล้างแอร์ผนัง" }],
-    jobs: [{ job_id: 10, customer_sub: "sub-1", catalog_item_id: 1, job_status: DONE_STATUS, appointment_datetime: "2026-06-01T00:00:00Z" }],
+    jobs: [{ job_id: 10, customer_sub: "sub-1", catalog_item_id: 1, job_status: DONE_STATUS, appointment_datetime: "2026-06-01T00:00:00Z", customer_name: "คุณ สมชาย ใจดี" }],
   });
-  const router = createCatalogReviewRoutes({ pool, requireCustomerJwt: requireCustomerJwtFor("sub-1", "ลูกค้า A"), requireAdminSession: denyAdmin });
+  const router = createCatalogReviewRoutes({ pool, requireCustomerJwt: requireCustomerJwtFor("sub-1", "LINE Name"), requireAdminSession: denyAdmin });
   await withServer(router, async (base) => {
     const res = await fetch(`${base}/catalog/items/1/reviews`, {
       method: "POST",
       headers: { "content-type": "application/json" },
-      body: JSON.stringify({ rating: 5, comment: "ดีมาก" }),
+      body: JSON.stringify({ rating: 5, comment: "ดีมาก", customer_name: "ชื่อปลอมจาก client", customer_identity: "ชื่อปลอมจาก client" }),
     });
     const body = await res.json();
     assert.equal(res.status, 201);
@@ -419,6 +478,26 @@ test("a valid review submission is created as pending and is attached to the rea
     assert.equal(pool.state.reviews.length, 1);
     assert.equal(pool.state.reviews[0].completed_job_id, 10);
     assert.equal(pool.state.reviews[0].moderation_status, "pending");
+    assert.equal(pool.state.reviews[0].customer_identity, "สมชาย ใจดี");
+    assert.notEqual(pool.state.reviews[0].customer_identity, "LINE Name");
+    assert.notEqual(pool.state.reviews[0].customer_identity, "ชื่อปลอมจาก client");
+  });
+});
+
+test("customer-app review falls back to ลูกค้า CWF when job and session names are empty", async () => {
+  const pool = makePool({
+    items: [{ item_id: 1, item_name: "ล้างแอร์ผนัง" }],
+    jobs: [{ job_id: 10, customer_sub: "sub-1", catalog_item_id: 1, job_status: DONE_STATUS, appointment_datetime: "2026-06-01T00:00:00Z", customer_name: "" }],
+  });
+  const router = createCatalogReviewRoutes({ pool, requireCustomerJwt: requireCustomerJwtFor("sub-1", ""), requireAdminSession: denyAdmin });
+  await withServer(router, async (base) => {
+    const res = await fetch(`${base}/catalog/items/1/reviews`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ rating: 5 }),
+    });
+    assert.equal(res.status, 201);
+    assert.equal(pool.state.reviews[0].customer_identity, "ลูกค้า CWF");
   });
 });
 
@@ -721,7 +800,7 @@ test("GET /public/catalog-reviews/status reflects eligible/already-reviewed stat
 test("POST /public/catalog-reviews never trusts client-supplied job_id/item_id and derives the target from the token's real job", async () => {
   const pool = makePool({
     trackingSchemaReady: true,
-    jobs: [{ job_id: 20, job_type: "ล้าง", catalog_item_id: 1, job_status: DONE_STATUS, canceled_at: null, booking_token: "tok-20", customer_name: "สมชาย" }],
+    jobs: [{ job_id: 20, job_type: "ล้าง", catalog_item_id: 1, job_status: DONE_STATUS, canceled_at: null, booking_token: "tok-20", customer_name: "คุณคุณสมชาย ใจดี" }],
   });
   const router = createCatalogReviewRoutes({ pool, requireCustomerJwt: requireCustomerJwtFor(null), requireAdminSession: denyAdmin });
   await withServer(router, async (base) => {
@@ -735,6 +814,7 @@ test("POST /public/catalog-reviews never trusts client-supplied job_id/item_id a
     assert.equal(pool.state.reviews.length, 1);
     assert.equal(pool.state.reviews[0].completed_job_id, 20);
     assert.equal(pool.state.reviews[0].item_id, 1); // resolved from the job's own catalog_item_id, never the client's item_id
+    assert.equal(pool.state.reviews[0].customer_identity, "สมชาย ใจดี");
     assert.equal(pool.state.reviews[0].review_source, "tracking");
     assert.equal(pool.state.reviews[0].moderation_status, "pending");
     assert.equal(body.moderation_status, "pending");

--- a/test/customerAppRecovery.test.js
+++ b/test/customerAppRecovery.test.js
@@ -163,7 +163,7 @@ class FakeMount {
     const m = selector.match(/\[data-([a-z-]+)\]/);
     if (!m) return null;
     const attr = `data-${m[1]}`;
-    if (attr === "data-store-body" || attr === "data-store-grid-mount" || attr === "data-contact-sheet-mount" || attr === "data-store-detail-body") {
+    if (attr === "data-store-body" || attr === "data-store-grid-mount" || attr === "data-contact-sheet-mount" || attr === "data-store-detail-body" || attr === "data-store-reviews-section") {
       const owner = this._findOwner(attr);
       if (!owner) return null;
       if (!owner.mountCache.has(attr)) owner.mountCache.set(attr, new FakeMount());
@@ -230,7 +230,7 @@ test("Customer App build id is consistent across shell and service worker", () =
   const sw = read("customer-app/sw.js");
   const app = read("customer-app/assets/customer-app.js");
   const manifest = read("customer-app/manifest.webmanifest");
-  const build = "20260628_store_detail_content_missing";
+  const build = "20260628_store_review_name_final";
 
   assert.match(index, new RegExp(`customer-app\\.css\\?v=${build}`));
   assert.match(index, new RegExp(`modules\\/api\\.js\\?v=${build}`));
@@ -248,7 +248,7 @@ test("Customer App build id is consistent across shell and service worker", () =
 test("store module is loaded in index.html and precached in the service worker app shell", () => {
   const index = read("customer-app/index.html");
   const sw = read("customer-app/sw.js");
-  const build = "20260628_store_detail_content_missing";
+  const build = "20260628_store_review_name_final";
 
   assert.match(index, new RegExp(`modules/store\\.js\\?v=${build}`));
   assert.match(sw, /`\.\/modules\/store\.js\?v=\$\{BUILD_ID\}`/);
@@ -1346,6 +1346,195 @@ test("opening item A then item B ignores the stale item A detail response", asyn
   assert.match(html, /Conditions B/);
   assert.doesNotMatch(html, /Long A/);
   assert.doesNotMatch(html, /Conditions A/);
+});
+
+test("store review card shows the normalized full reviewer name without คุณ prefix or masking", async () => {
+  const context = makeContext();
+  const root = loadCustomerFrontend(context);
+  const item = { item_id: 1, item_name: "Review item", item_category: "service", base_price: 700 };
+  root.state.setRoute("storeItem-1");
+  root.state.setStoreDetail({ status: "success", itemId: "1", data: item, error: "" });
+  root.api.loadCatalogItemReviews = async () => ({
+    reviews: [{ review_id: 1, display_name: "สมชาย ใจดี", rating: 5, comment: "ช่างสุภาพมาก ทำงานละเอียด", created_at: "2026-06-01T00:00:00Z" }],
+    total: 1,
+    rating_average: 5,
+    review_count: 1,
+  });
+
+  const container = new FakeMount();
+  container.innerHTML = `<section data-store-detail-body><div data-store-reviews-section></div></section>`;
+  await root.store._test.loadReviewsList(container, item);
+
+  const section = container.querySelector("[data-store-reviews-section]");
+  assert.match(section.innerHTML, /สมชาย ใจดี/);
+  assert.match(section.innerHTML, /ช่างสุภาพมาก ทำงานละเอียด/);
+  assert.doesNotMatch(section.innerHTML, /คุณ\s*สมชาย/);
+  assert.doesNotMatch(section.innerHTML, /\*\*\*\*/);
+});
+
+test("stale review list response from item A never replaces item B reviews", async () => {
+  const context = makeContext();
+  const root = loadCustomerFrontend(context);
+  const itemA = { item_id: 1, item_name: "Item A", item_category: "service", base_price: 700 };
+  const itemB = { item_id: 2, item_name: "Item B", item_category: "service", base_price: 800 };
+  let resolveA;
+  root.api.loadCatalogItemReviews = async (id) => {
+    if (String(id) === "1") {
+      return new Promise((resolve) => { resolveA = resolve; });
+    }
+    return {
+      reviews: [{ review_id: 2, display_name: "Reviewer B", rating: 4, comment: "Review B", created_at: "2026-06-02T00:00:00Z" }],
+      total: 1,
+      rating_average: 4,
+      review_count: 1,
+    };
+  };
+
+  const container = new FakeMount();
+  container.innerHTML = `<section data-store-detail-body><div data-store-reviews-section></div></section>`;
+  root.state.setRoute("storeItem-1");
+  root.state.setStoreDetail({ status: "success", itemId: "1", data: itemA, error: "" });
+  const loadA = root.store._test.loadReviewsList(container, itemA);
+  root.state.setRoute("storeItem-2");
+  root.state.setStoreDetail({ status: "success", itemId: "2", data: itemB, error: "" });
+  await root.store._test.loadReviewsList(container, itemB);
+  resolveA({ reviews: [{ review_id: 1, display_name: "Reviewer A", rating: 5, comment: "Review A", created_at: "2026-06-01T00:00:00Z" }], total: 1, rating_average: 5, review_count: 1 });
+  await loadA;
+
+  const section = container.querySelector("[data-store-reviews-section]");
+  assert.match(section.innerHTML, /Reviewer B/);
+  assert.match(section.innerHTML, /Review B/);
+  assert.doesNotMatch(section.innerHTML, /Reviewer A/);
+  assert.doesNotMatch(section.innerHTML, /Review A/);
+});
+
+test("stale load-more response from item A is not appended into item B reviews", async () => {
+  const context = makeContext();
+  const root = loadCustomerFrontend(context);
+  const itemA = { item_id: 1, item_name: "Item A", item_category: "service", base_price: 700 };
+  const itemB = { item_id: 2, item_name: "Item B", item_category: "service", base_price: 800 };
+  let resolveALoadMore;
+  root.api.loadCatalogItemReviews = async (id, { offset } = {}) => {
+    if (String(id) === "1" && Number(offset) > 0) {
+      return new Promise((resolve) => { resolveALoadMore = resolve; });
+    }
+    if (String(id) === "1") {
+      return { reviews: [{ review_id: 1, display_name: "Reviewer A1", rating: 5, comment: "A1", created_at: "2026-06-01T00:00:00Z" }], total: 2, rating_average: 5, review_count: 2 };
+    }
+    return { reviews: [{ review_id: 3, display_name: "Reviewer B", rating: 4, comment: "B", created_at: "2026-06-03T00:00:00Z" }], total: 1, rating_average: 4, review_count: 1 };
+  };
+
+  const container = new FakeMount();
+  container.innerHTML = `<section data-store-detail-body><div data-store-reviews-section></div></section>`;
+  root.state.setRoute("storeItem-1");
+  root.state.setStoreDetail({ status: "success", itemId: "1", data: itemA, error: "" });
+  await root.store._test.loadReviewsList(container, itemA);
+  const appendA = root.store._test.loadReviewsList(container, itemA, { append: true });
+  root.state.setRoute("storeItem-2");
+  root.state.setStoreDetail({ status: "success", itemId: "2", data: itemB, error: "" });
+  await root.store._test.loadReviewsList(container, itemB);
+  resolveALoadMore({ reviews: [{ review_id: 2, display_name: "Reviewer A2", rating: 5, comment: "A2", created_at: "2026-06-02T00:00:00Z" }], total: 2, rating_average: 5, review_count: 2 });
+  await appendA;
+
+  const section = container.querySelector("[data-store-reviews-section]");
+  assert.match(section.innerHTML, /Reviewer B/);
+  assert.doesNotMatch(section.innerHTML, /Reviewer A1/);
+  assert.doesNotMatch(section.innerHTML, /Reviewer A2/);
+});
+
+test("stale eligibility response from item A never changes item B review panel", async () => {
+  const context = makeContext();
+  const root = loadCustomerFrontend(context);
+  root.state.customer = { logged_in: true };
+  const itemA = { item_id: 1, item_name: "Item A", item_category: "service", base_price: 700 };
+  const itemB = { item_id: 2, item_name: "Item B", item_category: "service", base_price: 800 };
+  let resolveA;
+  root.api.loadReviewEligibility = async (id) => {
+    if (String(id) === "1") return new Promise((resolve) => { resolveA = resolve; });
+    return { eligible: false, eligible_jobs: [] };
+  };
+
+  const container = new FakeMount();
+  container.innerHTML = `<section data-store-detail-body><div data-store-reviews-section></div></section>`;
+  root.state.setRoute("storeItem-1");
+  root.state.setStoreDetail({ status: "success", itemId: "1", data: itemA, error: "" });
+  const loadA = root.store._test.loadEligibility(container, itemA);
+  root.state.setRoute("storeItem-2");
+  root.state.setStoreDetail({ status: "success", itemId: "2", data: itemB, error: "" });
+  await root.store._test.loadEligibility(container, itemB);
+  resolveA({ eligible: true, eligible_jobs: [{ job_id: 1, appointment_datetime: "2026-06-01T10:00:00Z" }] });
+  await loadA;
+
+  const section = container.querySelector("[data-store-reviews-section]");
+  assert.match(section.innerHTML, /เขียนรีวิวได้หลังงานบริการเสร็จสมบูรณ์/);
+  assert.doesNotMatch(section.innerHTML, /data-store-review-open/);
+  assert.doesNotMatch(section.innerHTML, /คุณยังไม่มีงาน/);
+});
+
+test("eligibility error shows retry for the current item instead of a no-eligible-job message", async () => {
+  const context = makeContext();
+  const root = loadCustomerFrontend(context);
+  root.state.customer = { logged_in: true };
+  const item = { item_id: 9, item_name: "Item 9", item_category: "service", base_price: 700 };
+  let calls = 0;
+  root.api.loadReviewEligibility = async (id) => {
+    calls += 1;
+    assert.equal(String(id), "9");
+    if (calls === 1) throw new Error("network down");
+    return { eligible: true, eligible_jobs: [{ job_id: 99, appointment_datetime: "2026-06-01T10:00:00Z" }] };
+  };
+
+  const container = new FakeMount();
+  container.innerHTML = `<section data-store-detail-body><div data-store-reviews-section></div></section>`;
+  root.state.setRoute("storeItem-9");
+  root.state.setStoreDetail({ status: "success", itemId: "9", data: item, error: "" });
+  await root.store._test.loadEligibility(container, item);
+  let section = container.querySelector("[data-store-reviews-section]");
+  assert.match(section.innerHTML, /ตรวจสอบสิทธิ์รีวิวไม่สำเร็จ/);
+  assert.match(section.innerHTML, /ลองใหม่/);
+  assert.doesNotMatch(section.innerHTML, /คุณยังไม่มีงาน/);
+
+  const retry = container.querySelector("[data-store-review-retry]");
+  assert.ok(retry);
+  await retry.click();
+  section = container.querySelector("[data-store-reviews-section]");
+  assert.match(section.innerHTML, /data-store-review-open/);
+});
+
+test("stale review submit response from item A never patches item B detail state", async () => {
+  const context = makeContext();
+  const root = loadCustomerFrontend(context);
+  root.state.customer = { logged_in: true };
+  const itemA = { item_id: 1, item_name: "Item A", item_category: "service", base_price: 700 };
+  const itemB = { item_id: 2, item_name: "Item B", item_category: "service", base_price: 800 };
+  root.api.loadReviewEligibility = async () => ({ eligible: true, eligible_jobs: [{ job_id: 11, appointment_datetime: "2026-06-01T10:00:00Z" }] });
+  root.api.loadCatalogItem = async () => itemB;
+  root.api.loadCatalogItems = async () => [itemB];
+  root.api.loadCatalogItemReviews = async () => ({ reviews: [], total: 0, rating_average: null, review_count: 0 });
+  let resolveSubmit;
+  root.api.submitCatalogItemReview = async () => new Promise((resolve) => { resolveSubmit = resolve; });
+
+  const container = new FakeMount();
+  container.innerHTML = `<section data-store-detail-body><div data-store-reviews-section></div></section>`;
+  root.state.setRoute("storeItem-1");
+  root.state.setStoreDetail({ status: "success", itemId: "1", data: itemA, error: "" });
+  await root.store._test.loadEligibility(container, itemA);
+  await container.querySelector("[data-store-review-open]").click();
+  await container.querySelectorAll("[data-review-star]")[4].click();
+  await container.querySelector("[data-store-review-next]").click();
+  const submitPromise = container.querySelector("[data-store-review-confirm]").click();
+
+  root.state.setRoute("storeItem-2");
+  await root.store._test.loadDetail(container, "2");
+  resolveSubmit({ review_id: 1, moderation_status: "pending" });
+  await submitPromise;
+  await new Promise((resolve) => setTimeout(resolve, 0));
+
+  const body = container.querySelector("[data-store-detail-body]");
+  assert.equal(root.state.storeDetail.itemId, "2");
+  assert.match(body.innerHTML, /Item B/);
+  assert.doesNotMatch(body.innerHTML, /ส่งรีวิวแล้ว/);
+  assert.doesNotMatch(body.innerHTML, /Item A/);
 });
 
 test("product detail shows a 404-style not-found error when the catalog item does not exist", async () => {

--- a/test/customerAppRecovery.test.js
+++ b/test/customerAppRecovery.test.js
@@ -1442,6 +1442,55 @@ test("stale load-more response from item A is not appended into item B reviews",
   assert.doesNotMatch(section.innerHTML, /Reviewer A2/);
 });
 
+test("review load-more shows a loading state and ignores duplicate clicks while the request is pending", async () => {
+  const context = makeContext();
+  const root = loadCustomerFrontend(context);
+  const item = { item_id: 1, item_name: "Item", item_category: "service", base_price: 700 };
+  let calls = 0;
+  let resolveLoadMore;
+  root.api.loadCatalogItemReviews = async (_id, { offset } = {}) => {
+    calls += 1;
+    if (Number(offset) > 0) {
+      return new Promise((resolve) => { resolveLoadMore = resolve; });
+    }
+    return {
+      reviews: [{ review_id: 1, display_name: "Reviewer 1", rating: 5, comment: "First", created_at: "2026-06-01T00:00:00Z" }],
+      total: 2,
+      rating_average: 5,
+      review_count: 2,
+    };
+  };
+
+  const container = new FakeMount();
+  container.innerHTML = `<section data-store-detail-body><div data-store-reviews-section></div></section>`;
+  root.state.setRoute("storeItem-1");
+  root.state.setStoreDetail({ status: "success", itemId: "1", data: item, error: "" });
+  await root.store._test.loadReviewsList(container, item);
+  const append = root.store._test.loadReviewsList(container, item, { append: true });
+
+  let section = container.querySelector("[data-store-reviews-section]");
+  assert.match(section.innerHTML, /กำลังโหลด\.\.\./);
+  assert.match(section.innerHTML, /data-store-reviews-more disabled/);
+  assert.equal(calls, 2);
+
+  const more = container.querySelector("[data-store-reviews-more]");
+  assert.ok(more);
+  await more.click();
+  assert.equal(calls, 2, "duplicate click while loading_more must not start a second request");
+
+  resolveLoadMore({
+    reviews: [{ review_id: 2, display_name: "Reviewer 2", rating: 4, comment: "Second", created_at: "2026-06-02T00:00:00Z" }],
+    total: 2,
+    rating_average: 4.5,
+    review_count: 2,
+  });
+  await append;
+  section = container.querySelector("[data-store-reviews-section]");
+  assert.match(section.innerHTML, /Reviewer 1/);
+  assert.match(section.innerHTML, /Reviewer 2/);
+  assert.doesNotMatch(section.innerHTML, /กำลังโหลด\.\.\./);
+});
+
 test("stale eligibility response from item A never changes item B review panel", async () => {
   const context = makeContext();
   const root = loadCustomerFrontend(context);
@@ -1499,6 +1548,12 @@ test("eligibility error shows retry for the current item instead of a no-eligibl
   await retry.click();
   section = container.querySelector("[data-store-reviews-section]");
   assert.match(section.innerHTML, /data-store-review-open/);
+  assert.doesNotMatch(section.innerHTML, /network down/);
+
+  await container.querySelector("[data-store-review-open]").click();
+  section = container.querySelector("[data-store-reviews-section]");
+  assert.match(section.innerHTML, /data-store-review-next/);
+  assert.doesNotMatch(section.innerHTML, /network down/);
 });
 
 test("stale review submit response from item A never patches item B detail state", async () => {

--- a/test/customerSameDayTiming.test.js
+++ b/test/customerSameDayTiming.test.js
@@ -160,7 +160,7 @@ test("customer app disables availability HTTP cache and refreshes same-day slots
 });
 
 test("customer app build and service worker cache IDs changed", () => {
-  const id = "20260628_store_detail_content_missing";
+  const id = "20260628_store_review_name_final";
   for (const file of [
     "customer-app/index.html",
     "customer-app/sw.js",


### PR DESCRIPTION
## Summary
- Replace public review-name masking with a shared normalization rule that removes repeated leading `คุณ`, preserves the real reviewer name, and falls back to `ลูกค้า CWF`.
- Store new Customer App reviews with the verified eligible job's `jobs.customer_name` before falling back to the customer session name; tracking reviews use the same normalization from the tracked job.
- Add stale-response guards for Store review list, load more, eligibility, retry, and submit flows so item A responses cannot patch item B.
- Update Customer App cache/build ID to `20260628_store_review_name_final` across shell, service worker, bootstrap, manifest, and tests.

## Root Cause
- `GET /catalog/items/:itemId/reviews` used `maskCustomerDisplayName()`, which prepended `คุณ` and replaced the rest of the name with stars.
- Customer App review submission stored `req.customer.name` even when an eligible completed job carried the admin-entered customer name.
- Product detail protected the item detail request from stale async responses, but review list, load-more, eligibility, and submit responses lacked equivalent item/route/detail-state guards.

## Validation
- `node --check server/routes/catalog/reviews.js`
- `node --check customer-app/modules/store.js`
- `node --check customer-app/modules/api.js`
- `node --check customer-app/assets/customer-app.js`
- `node --check customer-app/sw.js`
- `node --test test/catalogReviewRoutes.test.js` (52/52)
- `node --test test/customerAppRecovery.test.js` (86/86)
- `node --test test/customerSameDayTiming.test.js` (8/8)
- `git diff --check`
- `npm test` still fails only with existing base failures reproduced on `fbd9ae55a87d5778e2b283d33afba5a3723f6a7c`: `adminStoreCatalogUi.test.js` function-not-found assertions and `customerAppThreeStepBooking.test.js` `/เต็ม/` assertion.

## Notes
- Migration: None
- Production data changes: None
- Browser QA: not run because the in-app browser runtime reported no available browser instances (`agent.browsers.list()` returned `[]`).