### PR TITLE
Fix store card spacing and review privacy

### DIFF
--- a/customer-app/assets/customer-app.css
+++ b/customer-app/assets/customer-app.css
@@ -3568,9 +3568,11 @@ body.has-contact-sheet { overflow: hidden; }
 .store-promo-info {
   display: flex;
   flex-wrap: wrap;
-  gap: 6px;
+  column-gap: 8px;
+  row-gap: 4px;
   margin: 4px 0;
   font-size: 12px;
+  line-height: 1.35;
 }
 .store-promo-name {
   color: var(--danger);
@@ -3615,10 +3617,12 @@ body.has-contact-sheet { overflow: hidden; }
 .store-card-badges,
 .store-card-head,
 .store-rating-badge,
+.store-booking-count,
 .store-card-price,
+.store-promo-info,
 .store-card-actions {
-  padding-left: 10px;
-  padding-right: 10px;
+  padding-left: 14px;
+  padding-right: 14px;
 }
 .store-card-head {
   display: flex;
@@ -3803,7 +3807,7 @@ body.has-contact-sheet { overflow: hidden; }
 
 /* Note: padding is intentionally top/bottom only here -- this rule shares
    specificity with the combined ".store-card-badges, .store-card-head, ..."
-   rule above that grants 10px horizontal padding on the card; a shorthand
+   rule above that grants horizontal padding on the card; a shorthand
    `padding` here would zero that back out and cram the rating row against
    the card's left edge. */
 .store-rating-badge {
@@ -3849,8 +3853,10 @@ body.has-contact-sheet { overflow: hidden; }
 .store-card-price {
   display: flex;
   align-items: baseline;
-  gap: 6px;
+  column-gap: 8px;
+  row-gap: 3px;
   flex-wrap: wrap;
+  line-height: 1.35;
 }
 .price-strike {
   text-decoration: line-through;
@@ -3858,13 +3864,16 @@ body.has-contact-sheet { overflow: hidden; }
   font-size: 12px;
 }
 .price-text { font-weight: 700; }
+.price-unit {
+  flex-basis: 100%;
+}
 .price-text.is-estimate { font-weight: 600; color: var(--muted); }
 
 .store-card-actions {
   display: grid;
   grid-template-columns: 1fr;
   gap: 6px;
-  margin-top: 4px;
+  margin-top: auto;
 }
 .store-card-actions .primary-btn,
 .store-card-actions .secondary-btn {
@@ -4259,13 +4268,27 @@ body.has-contact-sheet { overflow: hidden; }
 }
 .store-review-item-head {
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   justify-content: space-between;
   gap: 8px;
   margin-bottom: 4px;
 }
-.store-review-item-name { font-size: 12.5px; font-weight: 700; color: var(--ink); }
-.store-review-item-stars { font-size: 12px; }
+.store-review-item-name {
+  min-width: 0;
+  font-size: 12.5px;
+  font-weight: 700;
+  color: var(--ink);
+  overflow-wrap: anywhere;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+.store-review-item-stars {
+  flex: 0 0 auto;
+  font-size: 12px;
+  line-height: 1.2;
+}
 .store-review-item-comment { font-size: 13px; color: var(--ink); white-space: pre-wrap; overflow-wrap: anywhere; margin-bottom: 4px; }
 .store-review-item-date { font-size: 11px; color: var(--muted); }
 .store-reviews-load-more { width: 100%; margin-bottom: 12px; }

--- a/customer-app/assets/customer-app.js
+++ b/customer-app/assets/customer-app.js
@@ -3,7 +3,7 @@
 
   const App = window.CWFCustomerAppV2;
   const BOOT_TIMEOUT_MS = 3500;
-  const BUILD_ID = "20260628_store_review_name_final";
+  const BUILD_ID = "20260629_store_card_spacing_review_privacy";
 
   function withTimeout(promise, timeoutMs) {
     return Promise.race([

--- a/customer-app/index.html
+++ b/customer-app/index.html
@@ -9,10 +9,10 @@
   <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
   <meta name="apple-mobile-web-app-title" content="CWF Service">
   <title>CWF Customer Service</title>
-  <link rel="manifest" href="./manifest.webmanifest?v=20260628_store_review_name_final">
+  <link rel="manifest" href="./manifest.webmanifest?v=20260629_store_card_spacing_review_privacy">
   <link rel="icon" type="image/png" sizes="192x192" href="./assets/icons/cwf-customer-192.png">
   <link rel="apple-touch-icon" sizes="180x180" href="./assets/icons/cwf-customer-180.png">
-  <link rel="stylesheet" href="./assets/customer-app.css?v=20260628_store_review_name_final">
+  <link rel="stylesheet" href="./assets/customer-app.css?v=20260629_store_card_spacing_review_privacy">
 </head>
 <body class="is-app-booting">
   <div class="app-shell" data-app-shell>
@@ -50,21 +50,21 @@
     </nav>
   </div>
 
-  <script src="./modules/state.js?v=20260628_store_review_name_final"></script>
-  <script src="./modules/utils.js?v=20260628_store_review_name_final"></script>
-  <script src="./modules/analytics.js?v=20260628_store_review_name_final"></script>
-  <script src="./modules/api.js?v=20260628_store_review_name_final"></script>
-  <script src="./modules/services.js?v=20260628_store_review_name_final"></script>
-  <script src="./modules/ui.js?v=20260628_store_review_name_final"></script>
-  <script src="./modules/store.js?v=20260628_store_review_name_final"></script>
-  <script src="./modules/auth.js?v=20260628_store_review_name_final"></script>
-  <script src="./modules/pricing.js?v=20260628_store_review_name_final"></script>
-  <script src="./modules/availability.js?v=20260628_store_review_name_final"></script>
-  <script src="./modules/bookingScheduled.js?v=20260628_store_review_name_final"></script>
-  <script src="./modules/bookingUrgent.js?v=20260628_store_review_name_final"></script>
-  <script src="./modules/tracking.js?v=20260628_store_review_name_final"></script>
-  <script src="./modules/profile.js?v=20260628_store_review_name_final"></script>
-  <script src="./modules/router.js?v=20260628_store_review_name_final"></script>
-  <script src="./assets/customer-app.js?v=20260628_store_review_name_final"></script>
+  <script src="./modules/state.js?v=20260629_store_card_spacing_review_privacy"></script>
+  <script src="./modules/utils.js?v=20260629_store_card_spacing_review_privacy"></script>
+  <script src="./modules/analytics.js?v=20260629_store_card_spacing_review_privacy"></script>
+  <script src="./modules/api.js?v=20260629_store_card_spacing_review_privacy"></script>
+  <script src="./modules/services.js?v=20260629_store_card_spacing_review_privacy"></script>
+  <script src="./modules/ui.js?v=20260629_store_card_spacing_review_privacy"></script>
+  <script src="./modules/store.js?v=20260629_store_card_spacing_review_privacy"></script>
+  <script src="./modules/auth.js?v=20260629_store_card_spacing_review_privacy"></script>
+  <script src="./modules/pricing.js?v=20260629_store_card_spacing_review_privacy"></script>
+  <script src="./modules/availability.js?v=20260629_store_card_spacing_review_privacy"></script>
+  <script src="./modules/bookingScheduled.js?v=20260629_store_card_spacing_review_privacy"></script>
+  <script src="./modules/bookingUrgent.js?v=20260629_store_card_spacing_review_privacy"></script>
+  <script src="./modules/tracking.js?v=20260629_store_card_spacing_review_privacy"></script>
+  <script src="./modules/profile.js?v=20260629_store_card_spacing_review_privacy"></script>
+  <script src="./modules/router.js?v=20260629_store_card_spacing_review_privacy"></script>
+  <script src="./assets/customer-app.js?v=20260629_store_card_spacing_review_privacy"></script>
 </body>
 </html>

--- a/customer-app/manifest.webmanifest
+++ b/customer-app/manifest.webmanifest
@@ -2,7 +2,7 @@
   "name": "CWF Customer Service",
   "short_name": "CWF Service",
   "description": "แอปลูกค้า Coldwindflow สำหรับเลือกบริการ จองคิว และติดตามงาน",
-  "start_url": "/customer-app/index.html?v=20260628_store_review_name_final#home",
+  "start_url": "/customer-app/index.html?v=20260629_store_card_spacing_review_privacy#home",
   "scope": "/customer-app/",
   "id": "/customer-app/",
   "display": "standalone",

--- a/customer-app/modules/store.js
+++ b/customer-app/modules/store.js
@@ -9,7 +9,7 @@
   let eligibilityRequestSeq = 0;
   let reviewSubmitSeq = 0;
 
-  console.info("[customer-store] review-name-final 20260628 loaded");
+  console.info("[customer-store] store-card-spacing-review-privacy 20260629 loaded");
 
   const FILTER_AC_TYPES = [
     { value: "wall", label: "แอร์ผนัง" },
@@ -538,7 +538,7 @@
         <div class="store-card-price">
           <span class="price-text${priceIsAsk(item) ? " is-estimate" : ""}">${root.utils.escapeHtml(priceLabel(item))}</span>
           ${promo ? `<span class="price-strike">${root.utils.escapeHtml(root.utils.formatBaht(item.normal_price))}</span>` : ""}
-          ${unit && !priceIsAsk(item) ? `<span class="muted">/ ${root.utils.escapeHtml(unit)}</span>` : ""}
+          ${unit && !priceIsAsk(item) ? `<span class="muted price-unit">/ ${root.utils.escapeHtml(unit)}</span>` : ""}
         </div>
         ${renderPromoInfo(item)}
         <div class="store-card-actions">

--- a/customer-app/sw.js
+++ b/customer-app/sw.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const BUILD_ID = "20260628_store_review_name_final";
+const BUILD_ID = "20260629_store_card_spacing_review_privacy";
 const CACHE_NAME = `cwf-customer-app-v2-${BUILD_ID}`;
 const APP_SHELL = [
   `./index.html?v=${BUILD_ID}`,

--- a/server/routes/catalog/reviews.js
+++ b/server/routes/catalog/reviews.js
@@ -92,6 +92,33 @@ function normalizeReviewDisplayName(value) {
   return normalizeReviewNameCore(value) || "ลูกค้า CWF";
 }
 
+function segmentGraphemes(value) {
+  const text = String(value || "");
+  if (typeof Intl !== "undefined" && typeof Intl.Segmenter === "function") {
+    return Array.from(new Intl.Segmenter("th", { granularity: "grapheme" }).segment(text), (part) => part.segment);
+  }
+  return Array.from(text);
+}
+
+function publicNameInitial(value) {
+  const graphemes = segmentGraphemes(value);
+  if (graphemes[0] === "ห" && /^[งญนมยรวล]$/u.test(graphemes[1] || "")) return graphemes[1];
+  return graphemes[0] || "";
+}
+
+function formatPublicReviewDisplayName(value) {
+  const name = normalizeReviewDisplayName(value);
+  if (name === "ลูกค้า CWF") return name;
+  const parts = name.split(" ").filter(Boolean);
+  if (parts.length >= 2) {
+    const lastInitial = publicNameInitial(parts[parts.length - 1]);
+    return `${parts[0]} ${lastInitial}.`;
+  }
+  const graphemes = segmentGraphemes(name);
+  if (graphemes.length > 3) return `${graphemes.slice(0, 3).join("")}…`;
+  return name;
+}
+
 function validateRatingAndComment(body) {
   const rating = Number(body?.rating);
   if (!Number.isInteger(rating) || rating < 1 || rating > 5) {
@@ -254,7 +281,7 @@ module.exports = function createCatalogReviewRoutes(deps = {}) {
         review_id: Number(row.review_id),
         rating: Number(row.rating),
         comment: row.comment || "",
-        display_name: normalizeReviewDisplayName(row.customer_identity),
+        display_name: formatPublicReviewDisplayName(row.customer_identity),
         created_at: row.created_at,
       }));
 
@@ -745,6 +772,7 @@ module.exports = function createCatalogReviewRoutes(deps = {}) {
 module.exports.MAX_COMMENT_LENGTH = MAX_COMMENT_LENGTH;
 module.exports.normalizeReviewNameCore = normalizeReviewNameCore;
 module.exports.normalizeReviewDisplayName = normalizeReviewDisplayName;
+module.exports.formatPublicReviewDisplayName = formatPublicReviewDisplayName;
 module.exports.validateRatingAndComment = validateRatingAndComment;
 module.exports.DONE_JOB_STATUSES = DONE_JOB_STATUSES;
 module.exports.createFixedWindowLimiter = createFixedWindowLimiter;

--- a/test/catalogReviewRoutes.test.js
+++ b/test/catalogReviewRoutes.test.js
@@ -277,7 +277,7 @@ test("createCatalogReviewRoutes throws without requireCustomerJwt or requireAdmi
 });
 
 test("normalizeReviewDisplayName strips only proven leading คุณ honorifics and never masks names", () => {
-  const { normalizeReviewNameCore, normalizeReviewDisplayName } = require("../server/routes/catalog/reviews");
+  const { normalizeReviewNameCore, normalizeReviewDisplayName, formatPublicReviewDisplayName } = require("../server/routes/catalog/reviews");
   assert.equal(normalizeReviewNameCore("คุณ สมชาย ใจดี"), "สมชาย ใจดี");
   assert.equal(normalizeReviewNameCore("คุณคุณสมชาย"), "สมชาย");
   assert.equal(normalizeReviewNameCore("คุณ คุณ แอนนา"), "แอนนา");
@@ -295,6 +295,16 @@ test("normalizeReviewDisplayName strips only proven leading คุณ honorifics
   assert.equal(normalizeReviewDisplayName(""), "ลูกค้า CWF");
   assert.equal(normalizeReviewDisplayName("คุณ"), "ลูกค้า CWF");
   assert.equal(normalizeReviewDisplayName("บริษัทคุณภาพดี"), "บริษัทคุณภาพดี");
+  assert.equal(formatPublicReviewDisplayName("คุณ เสาวลักษณ์ หมอยา"), "เสาวลักษณ์ ม.");
+  assert.equal(formatPublicReviewDisplayName("สมชาย ใจดี"), "สมชาย ใ.");
+  assert.equal(formatPublicReviewDisplayName("Anna Smith"), "Anna S.");
+  assert.equal(formatPublicReviewDisplayName("แพรพลอย"), "แพร…");
+  assert.equal(formatPublicReviewDisplayName("Bob"), "Bob");
+  assert.equal(formatPublicReviewDisplayName("คุณ คุณ แอนนา"), "แอน…");
+  assert.equal(formatPublicReviewDisplayName("คุณ"), "ลูกค้า CWF");
+  assert.equal(formatPublicReviewDisplayName(""), "ลูกค้า CWF");
+  assert.ok(!formatPublicReviewDisplayName("คุณ เสาวลักษณ์ หมอยา").includes("คุณ"));
+  assert.ok(!formatPublicReviewDisplayName("คุณ เสาวลักษณ์ หมอยา").includes("*"));
 });
 
 test("public reviews list is approved-only and never exposes job_id, customer_sub, or moderation fields", async () => {
@@ -316,13 +326,13 @@ test("public reviews list is approved-only and never exposes job_id, customer_su
     assert.equal(body.rating_average, 5);
     assert.equal(body.reviews.length, 1);
     assert.equal(body.reviews[0].rating, 5);
-    assert.equal(body.reviews[0].display_name, "สมชาย");
+    assert.equal(body.reviews[0].display_name, "สมช…");
     assert.ok(!body.reviews[0].display_name.includes("คุณ"));
     assert.ok(!body.reviews[0].display_name.includes("*"));
     assert.ok(!("completed_job_id" in body.reviews[0]));
     assert.ok(!("customer_identity" in body.reviews[0]));
     assert.ok(!("moderation_status" in body.reviews[0]));
-    assert.ok(JSON.stringify(body).includes("สมชาย"));
+    assert.ok(!JSON.stringify(body).includes("สมชาย ใจดี"));
   });
 });
 
@@ -356,10 +366,11 @@ test("public reviews normalize existing approved rows without exposing raw ident
     assert.equal(res.status, 200);
     assert.equal(body.review_count, 1);
     assert.equal(body.rating_average, 5);
-    assert.equal(body.reviews[0].display_name, "สมชาย ใจดี");
+    assert.equal(body.reviews[0].display_name, "สมชาย ใ.");
     assert.equal(body.reviews[0].comment, "ช่างสุภาพมาก ทำงานละเอียด");
     assert.ok(!body.reviews[0].display_name.includes("คุณ"));
     assert.ok(!body.reviews[0].display_name.includes("*"));
+    assert.ok(!body.reviews[0].display_name.includes("ใจดี"));
     assert.ok(!("customer_identity" in body.reviews[0]));
     assert.ok(!("completed_job_id" in body.reviews[0]));
     assert.ok(!("job_id" in body.reviews[0]));

--- a/test/customerAppRecovery.test.js
+++ b/test/customerAppRecovery.test.js
@@ -230,7 +230,7 @@ test("Customer App build id is consistent across shell and service worker", () =
   const sw = read("customer-app/sw.js");
   const app = read("customer-app/assets/customer-app.js");
   const manifest = read("customer-app/manifest.webmanifest");
-  const build = "20260628_store_review_name_final";
+  const build = "20260629_store_card_spacing_review_privacy";
 
   assert.match(index, new RegExp(`customer-app\\.css\\?v=${build}`));
   assert.match(index, new RegExp(`modules\\/api\\.js\\?v=${build}`));
@@ -248,7 +248,7 @@ test("Customer App build id is consistent across shell and service worker", () =
 test("store module is loaded in index.html and precached in the service worker app shell", () => {
   const index = read("customer-app/index.html");
   const sw = read("customer-app/sw.js");
-  const build = "20260628_store_review_name_final";
+  const build = "20260629_store_card_spacing_review_privacy";
 
   assert.match(index, new RegExp(`modules/store\\.js\\?v=${build}`));
   assert.match(sw, /`\.\/modules\/store\.js\?v=\$\{BUILD_ID\}`/);
@@ -956,6 +956,35 @@ test("store grid stays 2-column at every viewport width since the app shell neve
   assert.doesNotMatch(css, /\.store-grid\s*\{\s*grid-template-columns:\s*repeat\(5,/);
 });
 
+test("store card text regions share horizontal padding while images stay edge-to-edge and CTAs align to the bottom", () => {
+  const css = read("customer-app/assets/customer-app.css");
+  const sharedPaddingBlock = css.slice(css.indexOf(".store-card-badges,"), css.indexOf(".store-card-badges,") + 260);
+  for (const selector of [
+    ".store-card-badges",
+    ".store-card-head",
+    ".store-rating-badge",
+    ".store-booking-count",
+    ".store-card-price",
+    ".store-promo-info",
+    ".store-card-actions",
+  ]) {
+    assert.match(sharedPaddingBlock, new RegExp(selector.replace(".", "\\.")));
+  }
+  assert.match(sharedPaddingBlock, /padding-left:\s*14px/);
+  assert.match(sharedPaddingBlock, /padding-right:\s*14px/);
+  const galleryBlock = css.slice(css.indexOf(".store-card-gallery {"), css.indexOf(".store-card-gallery {") + 260);
+  assert.doesNotMatch(galleryBlock, /padding-left|padding-right|padding:/);
+  const priceBlock = css.slice(css.indexOf(".store-card-price {"), css.indexOf(".store-card-price {") + 260);
+  assert.match(priceBlock, /flex-wrap:\s*wrap/);
+  assert.match(priceBlock, /column-gap:\s*8px/);
+  assert.match(priceBlock, /row-gap:\s*3px/);
+  assert.doesNotMatch(priceBlock, /white-space:\s*nowrap/);
+  const unitBlock = css.slice(css.indexOf(".price-unit {"), css.indexOf(".price-unit {") + 120);
+  assert.match(unitBlock, /flex-basis:\s*100%/);
+  const actionsBlock = css.match(/\.store-card-actions \{\s*display: grid[\s\S]*?\}/)?.[0] || "";
+  assert.match(actionsBlock, /margin-top:\s*auto/);
+});
+
 test("store card shows a multi-image slider with dot indicators when an item has several images", async () => {
   const context = makeContext();
   const root = loadCustomerFrontend(context);
@@ -1348,14 +1377,14 @@ test("opening item A then item B ignores the stale item A detail response", asyn
   assert.doesNotMatch(html, /Conditions A/);
 });
 
-test("store review card shows the normalized full reviewer name without คุณ prefix or masking", async () => {
+test("store review card shows the public shortened reviewer name without คุณ prefix, full surname, or masking", async () => {
   const context = makeContext();
   const root = loadCustomerFrontend(context);
   const item = { item_id: 1, item_name: "Review item", item_category: "service", base_price: 700 };
   root.state.setRoute("storeItem-1");
   root.state.setStoreDetail({ status: "success", itemId: "1", data: item, error: "" });
   root.api.loadCatalogItemReviews = async () => ({
-    reviews: [{ review_id: 1, display_name: "สมชาย ใจดี", rating: 5, comment: "ช่างสุภาพมาก ทำงานละเอียด", created_at: "2026-06-01T00:00:00Z" }],
+    reviews: [{ review_id: 1, display_name: "สมชาย ใ.", rating: 5, comment: "ช่างสุภาพมาก ทำงานละเอียด", created_at: "2026-06-01T00:00:00Z" }],
     total: 1,
     rating_average: 5,
     review_count: 1,
@@ -1366,10 +1395,20 @@ test("store review card shows the normalized full reviewer name without คุ�
   await root.store._test.loadReviewsList(container, item);
 
   const section = container.querySelector("[data-store-reviews-section]");
-  assert.match(section.innerHTML, /สมชาย ใจดี/);
+  assert.match(section.innerHTML, /สมชาย ใ\./);
   assert.match(section.innerHTML, /ช่างสุภาพมาก ทำงานละเอียด/);
   assert.doesNotMatch(section.innerHTML, /คุณ\s*สมชาย/);
+  assert.doesNotMatch(section.innerHTML, /ใจดี/);
   assert.doesNotMatch(section.innerHTML, /\*\*\*\*/);
+  const css = read("customer-app/assets/customer-app.css");
+  const headBlock = css.slice(css.indexOf(".store-review-item-head {"), css.indexOf(".store-review-item-head {") + 220);
+  const nameBlock = css.slice(css.indexOf(".store-review-item-name {"), css.indexOf(".store-review-item-name {") + 360);
+  const starsBlock = css.slice(css.indexOf(".store-review-item-stars {"), css.indexOf(".store-review-item-stars {") + 180);
+  assert.match(headBlock, /display:\s*flex/);
+  assert.match(nameBlock, /min-width:\s*0/);
+  assert.match(nameBlock, /overflow-wrap:\s*anywhere/);
+  assert.match(nameBlock, /-webkit-line-clamp:\s*2/);
+  assert.match(starsBlock, /flex:\s*0 0 auto/);
 });
 
 test("stale review list response from item A never replaces item B reviews", async () => {

--- a/test/customerSameDayTiming.test.js
+++ b/test/customerSameDayTiming.test.js
@@ -160,7 +160,7 @@ test("customer app disables availability HTTP cache and refreshes same-day slots
 });
 
 test("customer app build and service worker cache IDs changed", () => {
-  const id = "20260628_store_review_name_final";
+  const id = "20260629_store_card_spacing_review_privacy";
   for (const file of [
     "customer-app/index.html",
     "customer-app/sw.js",


### PR DESCRIPTION
## Summary
- Add consistent inner spacing for Store product-card text regions while keeping service images edge-to-edge.
- Improve price/unit/promotion wrapping and align card actions at the bottom of two-column cards.
- Keep internal normalized reviewer identity, but format public review display names with privacy-shortened output.
- Bump Customer App cache/build version to `20260629_store_card_spacing_review_privacy` across shell, service worker, app bootstrap, and manifest.

## Proven root causes
- Product-card horizontal padding was applied only to selected regions and omitted `.store-booking-count` and `.store-promo-info`; the existing 10px inset was too tight for two-column mobile cards.
- `GET /catalog/items/:itemId/reviews` returned `normalizeReviewDisplayName(row.customer_identity)` directly, exposing the full normalized review identity as the public `display_name`.

## Verification
- `node --check server/routes/catalog/reviews.js`
- `node --check customer-app/modules/store.js`
- `node --check customer-app/assets/customer-app.js`
- `node --check customer-app/sw.js`
- `node --test test/catalogReviewRoutes.test.js`
- `node --test test/customerAppRecovery.test.js`
- `node --test test/customerSameDayTiming.test.js`
- `git diff --check`

## Full suite comparison
`npm test` still fails on this branch, but the failing test names match base `a116b360a0512bed877d6854519f98270265bc1d`; new failures: 0.

## Notes
- Migration: none.
- Production data changes: none.
- Browser visual QA was not run because the in-app browser runtime was unavailable in this session.