### PR TITLE
[HOTFIX] customer homepage mobile layout and missing sections

### DIFF
--- a/admin-homepage-cms.js
+++ b/admin-homepage-cms.js
@@ -7,10 +7,10 @@
       { id: "hero", type: "hero", enabled: true, sort_order: 10, kicker: "Coldwindflow", title: "ดูแลแอร์ง่าย จองงานได้ในไม่กี่ขั้นตอน", body: "จองล้างแอร์ ติดตามงาน และรับประกาศสำคัญจาก CWF ได้ในหน้าเดียว", cta_primary: { label: "จองล้างแอร์", route: "scheduled" }, cta_secondary: { label: "ติดตามงาน", route: "tracking" }, items: [] },
       { id: "quick", type: "quick", enabled: true, sort_order: 20, title: "เมนูด่วน", body: "", items: [{ title: "จองล้างแอร์", route: "scheduled", icon: "sparkle" }, { title: "แจ้งซ่อม", action: "contact", icon: "wrench" }, { title: "ติดตามงาน", route: "tracking", icon: "pin" }, { title: "LINE", url: "https://lin.ee/fG1Oq7y", icon: "chat" }] },
       { id: "active_job", type: "active_job", enabled: true, sort_order: 30, title: "Active job", body: "", items: [] },
-      { id: "announcements", type: "announcements", enabled: true, sort_order: 40, title: "ข่าวและประกาศ CWF", body: "", items: [] },
+      { id: "announcements", type: "announcements", enabled: true, sort_order: 40, title: "ข่าวและประกาศ CWF", body: "", items: [{ title: "ติดต่อทีม CWF", action: "contact", body: "สอบถามบริการหรือแจ้งข้อมูลเพิ่มเติมกับแอดมิน" }] },
       { id: "featured_services", type: "featured_services", enabled: true, sort_order: 50, title: "บริการแนะนำ", body: "ราคาและรายละเอียดจาก Catalog", items: [] },
-      { id: "updates", type: "updates", enabled: true, sort_order: 60, title: "ภาพกิจกรรมและโพสต์", body: "เชื่อมต่อไปยัง Facebook", items: [] },
-      { id: "articles", type: "articles", enabled: true, sort_order: 70, title: "บทความแนะนำ", body: "อ่านต่อบน cwf-air.com", items: [] },
+      { id: "updates", type: "updates", enabled: true, sort_order: 60, title: "ภาพกิจกรรมและโพสต์", body: "", items: [] },
+      { id: "articles", type: "articles", enabled: true, sort_order: 70, title: "บทความแนะนำ", body: "", items: [] },
       { id: "trust", type: "trust", enabled: true, sort_order: 80, title: "มาตรฐานที่ลูกค้าวางใจ", body: "", items: [{ title: "แจ้งราคาก่อนทำ", body: "ระบบคำนวณจากข้อมูลบริการจริง" }, { title: "ช่างผ่านมาตรฐาน", body: "ทีมงานได้รับการตรวจสอบก่อนรับงาน" }, { title: "ติดตามงานได้", body: "ดูสถานะสำคัญด้วย Booking Code" }, { title: "ติดต่อแอดมินง่าย", body: "รองรับ LINE และโทรศัพท์" }] },
     ],
   };
@@ -138,6 +138,46 @@
     `;
   }
 
+  function ctaEditor(cta, itemIndex, ctaName, label) {
+    const value = cta || {};
+    const mode = value.url ? "url" : "route";
+    const targetField = mode === "url"
+      ? `<label>${label} URL<input data-hero-cta="${itemIndex}" data-cta-name="${ctaName}" data-prop="url" value="${esc(value.url || "")}" placeholder="https://..."></label>`
+      : `<label>${label} route<select data-hero-cta="${itemIndex}" data-cta-name="${ctaName}" data-prop="route">
+          ${ROUTE_OPTIONS.map((route) => `<option value="${route}" ${String(value.route || "home") === route ? "selected" : ""}>${route}</option>`).join("")}
+        </select></label>`;
+    return `
+      <div class="two">
+        <label>${label}<input data-hero-cta="${itemIndex}" data-cta-name="${ctaName}" data-prop="label" value="${esc(value.label || "")}"></label>
+        <label>${label} target<select data-hero-cta-target="${itemIndex}" data-cta-name="${ctaName}">
+          <option value="route" ${mode === "route" ? "selected" : ""}>Internal route</option>
+          <option value="url" ${mode === "url" ? "selected" : ""}>External URL</option>
+        </select></label>
+      </div>
+      ${targetField}
+    `;
+  }
+
+  function heroSlideEditor(item, index, total) {
+    return `
+      <div class="item">
+        <h3>Hero slide ${index + 1}</h3>
+        <div>
+          <button class="mini" type="button" data-move-item="${index}" data-dir="-1" ${index === 0 ? "disabled" : ""}>↑</button>
+          <button class="mini" type="button" data-move-item="${index}" data-dir="1" ${index === total - 1 ? "disabled" : ""}>↓</button>
+        </div>
+        <label>Kicker<input data-item="${index}" data-prop="kicker" value="${esc(item.kicker || "")}"></label>
+        <label>Title<input data-item="${index}" data-prop="title" value="${esc(item.title || "")}"></label>
+        <label>Body<textarea data-item="${index}" data-prop="body">${esc(item.body || "")}</textarea></label>
+        <label>Image URL<input data-item="${index}" data-prop="image_url" value="${esc(item.image_url || "")}" placeholder="https://..."></label>
+        <label>Upload image<input type="file" accept="image/jpeg,image/png,image/webp" data-upload="${index}"></label>
+        ${ctaEditor(item.cta_primary, index, "cta_primary", "Primary CTA")}
+        ${ctaEditor(item.cta_secondary, index, "cta_secondary", "Secondary CTA")}
+        <button class="btn danger" type="button" data-remove-item="${index}">ลบรายการ</button>
+      </div>
+    `;
+  }
+
   function renderEditor() {
     const section = current();
     if (!section) return;
@@ -158,6 +198,8 @@
           <label>ปุ่มรอง<input data-cta="cta_secondary" data-prop="label" value="${esc(section.cta_secondary?.label || "")}"></label>
           <label>Route ปุ่มรอง<input data-cta="cta_secondary" data-prop="route" value="${esc(section.cta_secondary?.route || "")}"></label>
         </div>
+        <div class="toolbar"><button class="btn" type="button" id="addHeroSlide">Add hero slide</button></div>
+        ${(section.items || []).map((item, index) => heroSlideEditor(item, index, section.items.length)).join("")}
       ` : ""}
       ${itemTypes.includes(section.type) ? `
         <div class="toolbar"><button class="btn" type="button" id="addItem">เพิ่มรายการ</button></div>
@@ -190,7 +232,8 @@
   function renderPreview() {
     $("preview").innerHTML = sections().filter((section) => section.enabled !== false).map((section) => {
       if (section.type === "hero") {
-        return `<section class="hero" ${section.image_url ? `style="background-image:linear-gradient(rgba(7,27,56,.62),rgba(7,27,56,.62)),url('${esc(section.image_url)}');background-size:cover;background-position:center"` : ""}><small>${esc(section.kicker || "Coldwindflow")}</small><h3>${esc(section.title || "")}</h3><p>${esc(section.body || "")}</p></section>`;
+        const slides = Array.isArray(section.items) && section.items.length ? section.items : [section];
+        return `<section class="hero">${slides.map((slide) => `<div ${slide.image_url ? `style="background-image:linear-gradient(rgba(7,27,56,.62),rgba(7,27,56,.62)),url('${esc(slide.image_url)}');background-size:cover;background-position:center"` : ""}><small>${esc(slide.kicker || section.kicker || "Coldwindflow")}</small><h3>${esc(slide.title || section.title || "")}</h3><p>${esc(slide.body || section.body || "")}</p></div>`).join("")}</section>`;
       }
       if (section.type === "quick") return `<section class="quick">${(section.items || []).slice(0, 4).map((item) => `<div>${esc(item.title || "")}</div>`).join("")}</section>`;
       if (section.type === "active_job") return `<section class="sec"><div class="sec-head"><div><b>${esc(section.title || "")}</b><br><span>Shown only when the logged-in customer has an active job</span></div></div></section>`;
@@ -212,12 +255,35 @@
     if (edit) { selected = edit.dataset.edit; render(); }
     const remove = event.target.closest("[data-remove-item]");
     if (remove) { current().items.splice(Number(remove.dataset.removeItem), 1); render(); }
+    const moveItem = event.target.closest("[data-move-item]");
+    if (moveItem) {
+      const section = current();
+      const index = Number(moveItem.dataset.moveItem);
+      const next = index + Number(moveItem.dataset.dir);
+      if (section.items && next >= 0 && next < section.items.length) {
+        [section.items[index], section.items[next]] = [section.items[next], section.items[index]];
+        section.items.forEach((item, itemIndex) => { item.sort_order = itemIndex + 1; });
+        render();
+      }
+    }
     const clearImage = event.target.closest("[data-clear-section-image]");
     if (clearImage) { delete current().image_url; delete current().image_public_id; render(); }
     if (event.target.id === "addItem") {
       current().items = current().items || [];
       if (current().type === "quick" && current().items.length >= 4) { setStatus("Quick จำกัด 4 รายการ", "bad"); return; }
       current().items.push({ title: "", body: "", url: "" });
+      render();
+    }
+    if (event.target.id === "addHeroSlide") {
+      current().items = current().items || [];
+      if (current().items.length >= 5) { setStatus("Hero จำกัด 5 slides", "bad"); return; }
+      current().items.push({
+        kicker: current().kicker || "",
+        title: current().title || "",
+        body: current().body || "",
+        cta_primary: { ...(current().cta_primary || {}) },
+        cta_secondary: { ...(current().cta_secondary || {}) },
+      });
       render();
     }
   });
@@ -227,6 +293,15 @@
     const section = current();
     if (target.matches("[data-field]")) section[target.dataset.field] = target.value;
     if (target.matches("[data-cta]")) { section[target.dataset.cta] = section[target.dataset.cta] || {}; section[target.dataset.cta][target.dataset.prop] = target.value; }
+    if (target.matches("[data-hero-cta]")) {
+      const item = section.items[Number(target.dataset.heroCta)];
+      if (!item) return;
+      const ctaName = target.dataset.ctaName;
+      item[ctaName] = item[ctaName] || {};
+      item[ctaName][target.dataset.prop] = target.value;
+      if (target.dataset.prop === "route") { delete item[ctaName].url; delete item[ctaName].action; }
+      if (target.dataset.prop === "url") { delete item[ctaName].route; delete item[ctaName].action; }
+    }
     if (target.matches("[data-item]")) section.items[Number(target.dataset.item)][target.dataset.prop] = target.value;
     renderPreview();
   });
@@ -250,6 +325,18 @@
       if (target.value === "contact") item.action = "contact";
       if (target.value === "route") item.route = "home";
       if (target.value === "url") item.url = "";
+      render();
+    }
+    if (target.matches("[data-hero-cta-target]")) {
+      const item = current().items[Number(target.dataset.heroCtaTarget)];
+      if (!item) return;
+      const ctaName = target.dataset.ctaName;
+      item[ctaName] = item[ctaName] || {};
+      delete item[ctaName].route;
+      delete item[ctaName].url;
+      delete item[ctaName].action;
+      if (target.value === "route") item[ctaName].route = "home";
+      if (target.value === "url") item[ctaName].url = "";
       render();
     }
   });

--- a/admin-homepage-cms.js
+++ b/admin-homepage-cms.js
@@ -6,11 +6,12 @@
     sections: [
       { id: "hero", type: "hero", enabled: true, sort_order: 10, kicker: "Coldwindflow", title: "ดูแลแอร์ง่าย จองงานได้ในไม่กี่ขั้นตอน", body: "จองล้างแอร์ ติดตามงาน และรับประกาศสำคัญจาก CWF ได้ในหน้าเดียว", cta_primary: { label: "จองล้างแอร์", route: "scheduled" }, cta_secondary: { label: "ติดตามงาน", route: "tracking" }, items: [] },
       { id: "quick", type: "quick", enabled: true, sort_order: 20, title: "เมนูด่วน", body: "", items: [{ title: "จองล้างแอร์", route: "scheduled", icon: "sparkle" }, { title: "แจ้งซ่อม", action: "contact", icon: "wrench" }, { title: "ติดตามงาน", route: "tracking", icon: "pin" }, { title: "LINE", url: "https://lin.ee/fG1Oq7y", icon: "chat" }] },
-      { id: "announcements", type: "announcements", enabled: true, sort_order: 30, title: "ข่าวและประกาศ CWF", body: "", items: [] },
-      { id: "featured_services", type: "featured_services", enabled: true, sort_order: 40, title: "บริการแนะนำ", body: "ราคาและรายละเอียดจาก Catalog", items: [] },
-      { id: "updates", type: "updates", enabled: true, sort_order: 50, title: "ภาพกิจกรรมและโพสต์", body: "เชื่อมต่อไปยัง Facebook", items: [] },
-      { id: "articles", type: "articles", enabled: true, sort_order: 60, title: "บทความแนะนำ", body: "อ่านต่อบน cwf-air.com", items: [] },
-      { id: "trust", type: "trust", enabled: true, sort_order: 70, title: "มาตรฐานที่ลูกค้าวางใจ", body: "", items: [{ title: "แจ้งราคาก่อนทำ", body: "ระบบคำนวณจากข้อมูลบริการจริง" }, { title: "ช่างผ่านมาตรฐาน", body: "ทีมงานได้รับการตรวจสอบก่อนรับงาน" }, { title: "ติดตามงานได้", body: "ดูสถานะสำคัญด้วย Booking Code" }, { title: "ติดต่อแอดมินง่าย", body: "รองรับ LINE และโทรศัพท์" }] },
+      { id: "active_job", type: "active_job", enabled: true, sort_order: 30, title: "Active job", body: "", items: [] },
+      { id: "announcements", type: "announcements", enabled: true, sort_order: 40, title: "ข่าวและประกาศ CWF", body: "", items: [] },
+      { id: "featured_services", type: "featured_services", enabled: true, sort_order: 50, title: "บริการแนะนำ", body: "ราคาและรายละเอียดจาก Catalog", items: [] },
+      { id: "updates", type: "updates", enabled: true, sort_order: 60, title: "ภาพกิจกรรมและโพสต์", body: "เชื่อมต่อไปยัง Facebook", items: [] },
+      { id: "articles", type: "articles", enabled: true, sort_order: 70, title: "บทความแนะนำ", body: "อ่านต่อบน cwf-air.com", items: [] },
+      { id: "trust", type: "trust", enabled: true, sort_order: 80, title: "มาตรฐานที่ลูกค้าวางใจ", body: "", items: [{ title: "แจ้งราคาก่อนทำ", body: "ระบบคำนวณจากข้อมูลบริการจริง" }, { title: "ช่างผ่านมาตรฐาน", body: "ทีมงานได้รับการตรวจสอบก่อนรับงาน" }, { title: "ติดตามงานได้", body: "ดูสถานะสำคัญด้วย Booking Code" }, { title: "ติดต่อแอดมินง่าย", body: "รองรับ LINE และโทรศัพท์" }] },
     ],
   };
   let config = clone(DEFAULT_CONFIG);
@@ -192,6 +193,7 @@
         return `<section class="hero" ${section.image_url ? `style="background-image:linear-gradient(rgba(7,27,56,.62),rgba(7,27,56,.62)),url('${esc(section.image_url)}');background-size:cover;background-position:center"` : ""}><small>${esc(section.kicker || "Coldwindflow")}</small><h3>${esc(section.title || "")}</h3><p>${esc(section.body || "")}</p></section>`;
       }
       if (section.type === "quick") return `<section class="quick">${(section.items || []).slice(0, 4).map((item) => `<div>${esc(item.title || "")}</div>`).join("")}</section>`;
+      if (section.type === "active_job") return `<section class="sec"><div class="sec-head"><div><b>${esc(section.title || "")}</b><br><span>Shown only when the logged-in customer has an active job</span></div></div></section>`;
       if (section.type === "featured_services") return `<section class="sec"><div class="sec-head"><div><b>${esc(section.title || "")}</b><br><span>${esc(section.body || "")}</span></div></div><div class="cards"><article class="card"><b>Featured services</b><p>Catalog cards render here in the Customer App</p></article></div></section>`;
       return `<section class="sec"><div class="sec-head"><div><b>${esc(section.title || "")}</b><br><span>${esc(section.body || "")}</span></div><span>ดูทั้งหมด</span></div><div class="cards">${(section.items || []).slice(0, 3).map((item) => `<article class="card"><b>${esc(item.title || "")}</b><p>${esc(item.body || "")}</p></article>`).join("") || `<article class="card"><b>ไม่มีรายการ</b><p>เพิ่มรายการใน editor</p></article>`}</div></section>`;
     }).join("");

--- a/customer-app/assets/customer-app.css
+++ b/customer-app/assets/customer-app.css
@@ -4461,13 +4461,18 @@ body.has-contact-sheet { overflow: hidden; }
   display: flex;
   gap: 6px;
 }
-.homepage-hero-dots span {
+.homepage-hero-dots button {
   width: 7px;
   height: 7px;
+  padding: 0;
   border-radius: 999px;
   background: rgba(255, 255, 255, 0.45);
 }
-.homepage-hero-dots span.is-active { background: #fff; }
+.homepage-hero-dots button.is-active { background: #fff; }
+.homepage-hero-dots button:focus-visible {
+  outline: 2px solid #fff;
+  outline-offset: 3px;
+}
 .hero-main-btn,
 .hero-ghost-btn {
   display: inline-flex;

--- a/customer-app/assets/customer-app.css
+++ b/customer-app/assets/customer-app.css
@@ -4610,6 +4610,118 @@ body.has-contact-sheet { overflow: hidden; }
   margin: 0 11px 11px;
   font-size: 11.5px !important;
 }
+
+/* Issue #102 Phase A: lock homepage card/media geometry and keep the
+   primary bottom-nav action inside the nav bar on narrow phones. */
+.homepage-carousel {
+  max-width: 100%;
+  overflow-x: auto;
+  overflow-y: hidden;
+}
+.homepage-service-card {
+  flex: 0 0 calc((100% - 10px) / 2);
+  width: calc((100% - 10px) / 2);
+  min-width: calc((100% - 10px) / 2);
+  max-width: calc((100% - 10px) / 2);
+}
+.homepage-announcement-card,
+.homepage-update-card,
+.homepage-article-card {
+  max-width: min(78%, 320px);
+}
+.homepage-card-image {
+  width: 100%;
+  overflow: hidden;
+  flex: 0 0 auto;
+}
+.homepage-card-image img {
+  display: block;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+.homepage-card-body,
+.homepage-service-badge,
+.homepage-service-action {
+  position: relative;
+  z-index: 1;
+}
+.homepage-card-body strong {
+  display: -webkit-box;
+  min-width: 0;
+  overflow: hidden;
+  overflow-wrap: anywhere;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+}
+.homepage-card-body small,
+.homepage-card-body span {
+  min-width: 0;
+  overflow-wrap: anywhere;
+}
+.bottom-nav {
+  align-items: center;
+  height: calc(var(--nav-h) + var(--safe-b));
+  padding: 7px 6px calc(7px + var(--safe-b));
+  overflow: visible;
+}
+.bottom-nav .nav-item {
+  min-height: 58px;
+  padding: 4px 1px;
+  border-radius: 14px;
+}
+.bottom-nav .nav-item span {
+  display: block;
+  max-width: 100%;
+  font-size: 10px;
+  line-height: 1.15;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.bottom-nav .nav-item span::after {
+  content: none !important;
+}
+.bottom-nav .nav-item-primary {
+  position: relative;
+  margin: 0;
+  background: transparent;
+  color: #657187;
+  box-shadow: none;
+  transform: none;
+}
+.bottom-nav .nav-item-primary::after {
+  content: "";
+  position: absolute;
+  top: 3px;
+  left: 50%;
+  width: 44px;
+  height: 44px;
+  border: 4px solid #fff;
+  border-radius: 16px;
+  background: linear-gradient(145deg,#ffd43b,#ffbd17);
+  box-shadow: 0 8px 18px rgba(255,190,23,.26);
+  transform: translateX(-50%);
+  z-index: 0;
+}
+.bottom-nav .nav-item-primary::before {
+  position: relative;
+  z-index: 1;
+  width: 22px;
+  height: 22px;
+  margin-top: 7px;
+  background: #2b2500;
+  opacity: 1;
+}
+.bottom-nav .nav-item-primary span {
+  position: relative;
+  z-index: 1;
+  margin-top: 2px;
+  color: #657187;
+}
+.bottom-nav .nav-item-primary.is-active,
+.bottom-nav .nav-item-primary.is-active::before {
+  color: #657187;
+}
 .homepage-trust-grid {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
@@ -4655,11 +4767,11 @@ body.has-contact-sheet { overflow: hidden; }
   z-index: 40;
   display: grid;
   grid-template-columns: repeat(5, minmax(0, 1fr));
-  align-items: stretch;
+  align-items: center;
   width: 100%;
   max-width: 480px;
-  height: calc(78px + var(--safe-b));
-  padding: 9px 6px calc(8px + var(--safe-b));
+  height: calc(var(--nav-h) + var(--safe-b));
+  padding: 7px 6px calc(7px + var(--safe-b));
   transform: translateX(-50%);
   background: rgba(255,255,255,.97);
   border-top: 1px solid var(--line);
@@ -4672,7 +4784,7 @@ body.has-contact-sheet { overflow: hidden; }
 }
 .nav-item.is-active { color: #1463ff; }
 .nav-item-primary {
-  margin: -28px 0 0;
+  margin: 0;
   background: transparent;
   color: #657187;
   border-radius: 0;
@@ -4683,21 +4795,21 @@ body.has-contact-sheet { overflow: hidden; }
   top: 0;
   left: 50%;
   z-index: 0;
-  width: 54px;
-  height: 54px;
-  border: 5px solid #fff;
-  border-radius: 19px;
+  width: 44px;
+  height: 44px;
+  border: 4px solid #fff;
+  border-radius: 16px;
   background: linear-gradient(145deg,#ffd43b,#ffbd17);
-  box-shadow: 0 10px 24px rgba(255,190,23,.30);
+  box-shadow: 0 8px 18px rgba(255,190,23,.26);
   content: "";
   transform: translateX(-50%);
 }
 .nav-item-primary::before {
   position: relative;
   z-index: 1;
-  width: 24px;
-  height: 24px;
-  margin-top: 10px;
+  width: 22px;
+  height: 22px;
+  margin-top: 7px;
   background: #2b2500;
   opacity: 1;
 }

--- a/customer-app/assets/customer-app.css
+++ b/customer-app/assets/customer-app.css
@@ -4382,6 +4382,19 @@ body.has-contact-sheet { overflow: hidden; }
   background: linear-gradient(140deg, #06162e 0%, #0b3976 52%, #1463ff 100%);
   box-shadow: 0 18px 38px rgba(7, 38, 85, 0.23);
 }
+.homepage-hero-slider {
+  display: flex;
+  overflow-x: auto;
+  scroll-snap-type: x mandatory;
+  scrollbar-width: none;
+}
+.homepage-hero-slider::-webkit-scrollbar { display: none; }
+.homepage-hero-slide {
+  position: relative;
+  flex: 0 0 100%;
+  min-height: 235px;
+  scroll-snap-align: start;
+}
 .homepage-hero-media {
   position: absolute;
   inset: 0;
@@ -4440,6 +4453,21 @@ body.has-contact-sheet { overflow: hidden; }
   gap: 8px;
   margin-top: 16px;
 }
+.homepage-hero-dots {
+  position: absolute;
+  z-index: 2;
+  right: 18px;
+  bottom: 13px;
+  display: flex;
+  gap: 6px;
+}
+.homepage-hero-dots span {
+  width: 7px;
+  height: 7px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.45);
+}
+.homepage-hero-dots span.is-active { background: #fff; }
 .hero-main-btn,
 .hero-ghost-btn {
   display: inline-flex;
@@ -4513,6 +4541,15 @@ body.has-contact-sheet { overflow: hidden; }
   color: var(--muted);
   font-size: 10px;
 }
+.homepage-section-empty {
+  border: 1px dashed var(--line);
+  border-radius: 16px;
+  padding: 14px;
+  background: #fff;
+  color: var(--muted);
+  font-size: 12px;
+  line-height: 1.45;
+}
 .text-link-btn {
   flex: 0 0 auto;
   padding: 4px 0;
@@ -4535,6 +4572,31 @@ body.has-contact-sheet { overflow: hidden; }
   scrollbar-width: none;
 }
 .homepage-carousel::-webkit-scrollbar { display: none; }
+.homepage-active-job-card {
+  display: grid;
+  gap: 5px;
+  width: 100%;
+  border: 1px solid rgba(20, 99, 255, 0.16);
+  border-radius: 18px;
+  padding: 14px;
+  background: #fff;
+  color: var(--ink);
+  text-align: left;
+  box-shadow: 0 6px 20px rgba(13, 45, 88, 0.06);
+}
+.homepage-active-job-card span {
+  color: var(--blue);
+  font-size: 11px;
+  font-weight: 900;
+}
+.homepage-active-job-card strong {
+  font-size: 15px;
+  line-height: 1.25;
+}
+.homepage-active-job-card small {
+  color: var(--muted);
+  font-size: 11px;
+}
 .homepage-service-card,
 .homepage-announcement-card,
 .homepage-update-card,

--- a/customer-app/assets/customer-app.js
+++ b/customer-app/assets/customer-app.js
@@ -3,7 +3,7 @@
 
   const App = window.CWFCustomerAppV2;
   const BOOT_TIMEOUT_MS = 3500;
-  const BUILD_ID = "20260629_customer_homepage_cms_rebased";
+  const BUILD_ID = "20260629_customer_homepage_mobile_hotfix";
 
   function withTimeout(promise, timeoutMs) {
     return Promise.race([

--- a/customer-app/index.html
+++ b/customer-app/index.html
@@ -9,10 +9,10 @@
   <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
   <meta name="apple-mobile-web-app-title" content="CWF Service">
   <title>CWF Customer Service</title>
-  <link rel="manifest" href="./manifest.webmanifest?v=20260629_customer_homepage_cms_rebased">
+  <link rel="manifest" href="./manifest.webmanifest?v=20260629_customer_homepage_mobile_hotfix">
   <link rel="icon" type="image/png" sizes="192x192" href="./assets/icons/cwf-customer-192.png">
   <link rel="apple-touch-icon" sizes="180x180" href="./assets/icons/cwf-customer-180.png">
-  <link rel="stylesheet" href="./assets/customer-app.css?v=20260629_customer_homepage_cms_rebased">
+  <link rel="stylesheet" href="./assets/customer-app.css?v=20260629_customer_homepage_mobile_hotfix">
 </head>
 <body class="is-app-booting">
   <div class="app-shell" data-app-shell>
@@ -50,21 +50,21 @@
     </nav>
   </div>
 
-  <script src="./modules/state.js?v=20260629_customer_homepage_cms_rebased"></script>
-  <script src="./modules/utils.js?v=20260629_customer_homepage_cms_rebased"></script>
-  <script src="./modules/analytics.js?v=20260629_customer_homepage_cms_rebased"></script>
-  <script src="./modules/api.js?v=20260629_customer_homepage_cms_rebased"></script>
-  <script src="./modules/services.js?v=20260629_customer_homepage_cms_rebased"></script>
-  <script src="./modules/ui.js?v=20260629_customer_homepage_cms_rebased"></script>
-  <script src="./modules/store.js?v=20260629_customer_homepage_cms_rebased"></script>
-  <script src="./modules/auth.js?v=20260629_customer_homepage_cms_rebased"></script>
-  <script src="./modules/pricing.js?v=20260629_customer_homepage_cms_rebased"></script>
-  <script src="./modules/availability.js?v=20260629_customer_homepage_cms_rebased"></script>
-  <script src="./modules/bookingScheduled.js?v=20260629_customer_homepage_cms_rebased"></script>
-  <script src="./modules/bookingUrgent.js?v=20260629_customer_homepage_cms_rebased"></script>
-  <script src="./modules/tracking.js?v=20260629_customer_homepage_cms_rebased"></script>
-  <script src="./modules/profile.js?v=20260629_customer_homepage_cms_rebased"></script>
-  <script src="./modules/router.js?v=20260629_customer_homepage_cms_rebased"></script>
-  <script src="./assets/customer-app.js?v=20260629_customer_homepage_cms_rebased"></script>
+  <script src="./modules/state.js?v=20260629_customer_homepage_mobile_hotfix"></script>
+  <script src="./modules/utils.js?v=20260629_customer_homepage_mobile_hotfix"></script>
+  <script src="./modules/analytics.js?v=20260629_customer_homepage_mobile_hotfix"></script>
+  <script src="./modules/api.js?v=20260629_customer_homepage_mobile_hotfix"></script>
+  <script src="./modules/services.js?v=20260629_customer_homepage_mobile_hotfix"></script>
+  <script src="./modules/ui.js?v=20260629_customer_homepage_mobile_hotfix"></script>
+  <script src="./modules/store.js?v=20260629_customer_homepage_mobile_hotfix"></script>
+  <script src="./modules/auth.js?v=20260629_customer_homepage_mobile_hotfix"></script>
+  <script src="./modules/pricing.js?v=20260629_customer_homepage_mobile_hotfix"></script>
+  <script src="./modules/availability.js?v=20260629_customer_homepage_mobile_hotfix"></script>
+  <script src="./modules/bookingScheduled.js?v=20260629_customer_homepage_mobile_hotfix"></script>
+  <script src="./modules/bookingUrgent.js?v=20260629_customer_homepage_mobile_hotfix"></script>
+  <script src="./modules/tracking.js?v=20260629_customer_homepage_mobile_hotfix"></script>
+  <script src="./modules/profile.js?v=20260629_customer_homepage_mobile_hotfix"></script>
+  <script src="./modules/router.js?v=20260629_customer_homepage_mobile_hotfix"></script>
+  <script src="./assets/customer-app.js?v=20260629_customer_homepage_mobile_hotfix"></script>
 </body>
 </html>

--- a/customer-app/manifest.webmanifest
+++ b/customer-app/manifest.webmanifest
@@ -2,7 +2,7 @@
   "name": "CWF Customer Service",
   "short_name": "CWF Service",
   "description": "แอปลูกค้า Coldwindflow สำหรับเลือกบริการ จองคิว และติดตามงาน",
-  "start_url": "/customer-app/index.html?v=20260629_customer_homepage_cms_rebased#home",
+  "start_url": "/customer-app/index.html?v=20260629_customer_homepage_mobile_hotfix#home",
   "scope": "/customer-app/",
   "id": "/customer-app/",
   "display": "standalone",

--- a/customer-app/modules/api.js
+++ b/customer-app/modules/api.js
@@ -110,6 +110,10 @@
       return requestJson("/public/homepage", { cache: "no-store" });
     },
 
+    async loadHomeActiveJob() {
+      return requestJson("/public/homepage/active-job", { cache: "no-store" });
+    },
+
     async loadCatalogItems(query) {
       return requestJson("/catalog/items", { query: { customer: 1, ...(query || {}) }, cache: "no-store" });
     },

--- a/customer-app/modules/state.js
+++ b/customer-app/modules/state.js
@@ -128,6 +128,7 @@
     promotions: { status: "idle", items: [], error: "" },
     zones: { status: "idle", items: [], error: "" },
     homePricing: { status: "idle", items: {}, error: "" },
+    homeActiveJob: { status: "idle", data: null, error: "" },
     addressPrefill: { status: "idle", scopes: {}, error: "" },
     profileAddressForm: { editing: false, status: "idle", error: "", success: "" },
     scheduledWizard: {

--- a/customer-app/modules/ui.js
+++ b/customer-app/modules/ui.js
@@ -87,10 +87,19 @@
         ],
       },
       {
+        id: "active_job",
+        type: "active_job",
+        enabled: true,
+        sort_order: 30,
+        title: "งานของฉัน",
+        body: "",
+        items: [],
+      },
+      {
         id: "announcements",
         type: "announcements",
         enabled: true,
-        sort_order: 30,
+        sort_order: 40,
         title: "ข่าวและประกาศ CWF",
         body: "",
         items: [],
@@ -99,7 +108,7 @@
         id: "featured_services",
         type: "featured_services",
         enabled: true,
-        sort_order: 40,
+        sort_order: 50,
         title: "บริการแนะนำ",
         body: "ราคาและรายละเอียดดึงจาก Catalog",
         items: [],
@@ -108,7 +117,7 @@
         id: "updates",
         type: "updates",
         enabled: true,
-        sort_order: 50,
+        sort_order: 60,
         title: "ภาพกิจกรรมและโพสต์",
         body: "เชื่อมต่อไปยัง Facebook",
         items: [],
@@ -117,7 +126,7 @@
         id: "articles",
         type: "articles",
         enabled: true,
-        sort_order: 60,
+        sort_order: 70,
         title: "บทความแนะนำ",
         body: "อ่านต่อบน cwf-air.com",
         items: [],
@@ -126,7 +135,7 @@
         id: "trust",
         type: "trust",
         enabled: true,
-        sort_order: 70,
+        sort_order: 80,
         title: "มาตรฐานที่ลูกค้าวางใจ",
         items: [
           { title: "แจ้งราคาก่อนทำ", body: "ระบบคำนวณจากข้อมูลบริการจริง" },
@@ -261,18 +270,49 @@
 
   function renderHomepageHero(section) {
     if (!section) return "";
+    const slides = Array.isArray(section.items) && section.items.length ? section.items : [section];
     return `
       <section class="homepage-hero">
-        ${section.image_url ? `<div class="homepage-hero-media"><img src="${root.utils.escapeHtml(section.image_url)}" alt="" loading="lazy"></div>` : ""}
-        <div class="homepage-hero-inner">
-          ${section.kicker ? `<span class="homepage-kicker">${root.utils.escapeHtml(section.kicker)}</span>` : ""}
-          <h2>${root.utils.escapeHtml(section.title || "")}</h2>
-          ${section.body ? `<p>${root.utils.escapeHtml(section.body)}</p>` : ""}
-          <div class="homepage-hero-actions">
-            ${renderHomepageCta(section.cta_primary, "hero-main-btn")}
-            ${renderHomepageCta(section.cta_secondary, "hero-ghost-btn")}
+        <div class="homepage-hero-slider">
+          ${slides.map((slide, index) => `
+            <article class="homepage-hero-slide" data-home-hero-slide="${index}">
+              ${slide.image_url ? `<div class="homepage-hero-media"><img src="${root.utils.escapeHtml(slide.image_url)}" alt="" loading="lazy"></div>` : ""}
+              <div class="homepage-hero-inner">
+                ${slide.kicker || section.kicker ? `<span class="homepage-kicker">${root.utils.escapeHtml(slide.kicker || section.kicker)}</span>` : ""}
+                <h2>${root.utils.escapeHtml(slide.title || section.title || "")}</h2>
+                ${slide.body || section.body ? `<p>${root.utils.escapeHtml(slide.body || section.body)}</p>` : ""}
+                <div class="homepage-hero-actions">
+                  ${renderHomepageCta(slide.cta_primary || section.cta_primary, "hero-main-btn")}
+                  ${renderHomepageCta(slide.cta_secondary || section.cta_secondary, "hero-ghost-btn")}
+                </div>
+              </div>
+            </article>
+          `).join("")}
+        </div>
+        ${slides.length > 1 ? `<div class="homepage-hero-dots" aria-label="Homepage slides">${slides.map((_, index) => `<span class="${index === 0 ? "is-active" : ""}"></span>`).join("")}</div>` : ""}
+      </section>
+    `;
+  }
+
+  function renderHomepageActiveJob(section) {
+    const bucket = root.state.homeActiveJob || { status: "idle", data: null };
+    const job = bucket.data;
+    if (!job || bucket.status !== "success") return `<div data-home-active-job></div>`;
+    const dateLabel = job.appointment_datetime ? root.utils.formatDateTime(job.appointment_datetime) : "";
+    return `
+      <section class="homepage-section homepage-active-job" data-home-active-job>
+        <div class="homepage-section-head">
+          <div>
+            <h2>${root.utils.escapeHtml(section.title || "")}</h2>
+            ${section.body ? `<p>${root.utils.escapeHtml(section.body)}</p>` : ""}
           </div>
         </div>
+        <button class="homepage-active-job-card" type="button" data-route="tracking">
+          <span>${root.utils.escapeHtml(job.job_status || "")}</span>
+          <strong>${root.utils.escapeHtml(job.job_type || job.booking_code || "")}</strong>
+          ${dateLabel ? `<small>${root.utils.escapeHtml(dateLabel)}</small>` : ""}
+          <small>${root.utils.escapeHtml(job.booking_code || "")}</small>
+        </button>
       </section>
     `;
   }
@@ -294,7 +334,6 @@
 
   function renderHomepageManualSection(section) {
     const items = (section.items || []).slice(0, 8);
-    if (!items.length) return "";
     return `
       <section class="homepage-section">
         <div class="homepage-section-head">
@@ -303,6 +342,7 @@
             ${section.body ? `<p>${root.utils.escapeHtml(section.body)}</p>` : ""}
           </div>
         </div>
+        ${items.length ? `
         <div class="homepage-carousel">
           ${items.map((item) => {
             const attrs = item.action === "contact"
@@ -322,6 +362,7 @@
             `;
           }).join("")}
         </div>
+        ` : `<div class="homepage-section-empty">${root.utils.escapeHtml(section.body || "ยังไม่มีรายการเผยแพร่")}</div>`}
       </section>
     `;
   }
@@ -352,6 +393,7 @@
     if (!section) return "";
     if (section.type === "hero") return renderHomepageHero(section);
     if (section.type === "quick") return renderHomepageQuick(section);
+    if (section.type === "active_job") return renderHomepageActiveJob(section);
     if (section.type === "featured_services") return renderHomepageFeaturedSection(section);
     if (["announcements", "updates", "articles"].includes(section.type)) return renderHomepageManualSection(section);
     if (section.type === "trust") return renderHomepageTrust(section);
@@ -452,6 +494,25 @@
     root.state.setHomePricing({ status: "success", items: Object.fromEntries(entries), error: "" });
   }
 
+  async function loadHomeActiveJobData() {
+    if (root.state.homeActiveJob?.status !== "idle") return;
+    root.state.setCollection("homeActiveJob", { status: "loading", data: null, error: "" });
+    try {
+      const data = await root.api.loadHomeActiveJob();
+      root.state.setCollection("homeActiveJob", {
+        status: "success",
+        data: data?.active_job || null,
+        error: "",
+      });
+    } catch (error) {
+      root.state.setCollection("homeActiveJob", {
+        status: "error",
+        data: null,
+        error: error?.message || "ACTIVE_JOB_UNAVAILABLE",
+      });
+    }
+  }
+
   async function loadHomeData() {
     if (homeLoadPromise) return homeLoadPromise;
     const needsAuth = root.state.authStatus === "idle" && !root.state.customer;
@@ -460,7 +521,8 @@
     const needsPromotions = root.state.promotions?.status === "idle";
     const needsZones = root.state.zones?.status === "idle";
     const needsPricing = root.state.homePricing?.status === "idle";
-    if (!needsAuth && !needsHomepage && !needsCatalog && !needsPromotions && !needsZones && !needsPricing) return Promise.resolve([]);
+    const needsActiveJob = root.state.homeActiveJob?.status === "idle";
+    if (!needsAuth && !needsHomepage && !needsCatalog && !needsPromotions && !needsZones && !needsPricing && !needsActiveJob) return Promise.resolve([]);
     const tasks = [];
     if (needsAuth) tasks.push(root.auth.loadCustomer(null));
     if (needsHomepage) tasks.push(loadHomepageData());
@@ -468,6 +530,7 @@
     if (needsPromotions) tasks.push(loadCollection("promotions", root.api.loadPromotions, "promotions"));
     if (needsZones) tasks.push(loadCollection("zones", root.api.loadServiceZones, "zones"));
     if (needsPricing) tasks.push(loadHomePricingData());
+    if (needsActiveJob) tasks.push(loadHomeActiveJobData());
     homeLoadPromise = Promise.allSettled(tasks).finally(() => {
       homeLoadPromise = null;
       patchHomeData();
@@ -597,6 +660,9 @@
     }
     const featured = container.querySelector("[data-homepage-featured]");
     if (featured) featured.innerHTML = renderHomepageFeaturedServices();
+    const activeJob = container.querySelector("[data-home-active-job]");
+    const activeSection = sectionByType("active_job");
+    if (activeJob && activeSection) activeJob.outerHTML = renderHomepageActiveJob(activeSection);
     container.querySelectorAll("[data-quick-price]").forEach((mount) => {
       const card = root.services.quickServices.find((item) => item.id === mount.getAttribute("data-quick-price"));
       if (card) mount.innerHTML = renderQuickPrice(card);

--- a/customer-app/modules/ui.js
+++ b/customer-app/modules/ui.js
@@ -102,7 +102,7 @@
         sort_order: 40,
         title: "ข่าวและประกาศ CWF",
         body: "",
-        items: [],
+        items: [{ title: "ติดต่อทีม CWF", action: "contact", body: "สอบถามบริการหรือแจ้งข้อมูลเพิ่มเติมกับแอดมิน" }],
       },
       {
         id: "featured_services",
@@ -119,7 +119,7 @@
         enabled: true,
         sort_order: 60,
         title: "ภาพกิจกรรมและโพสต์",
-        body: "เชื่อมต่อไปยัง Facebook",
+        body: "",
         items: [],
       },
       {
@@ -128,7 +128,7 @@
         enabled: true,
         sort_order: 70,
         title: "บทความแนะนำ",
-        body: "อ่านต่อบน cwf-air.com",
+        body: "",
         items: [],
       },
       {
@@ -289,7 +289,7 @@
             </article>
           `).join("")}
         </div>
-        ${slides.length > 1 ? `<div class="homepage-hero-dots" aria-label="Homepage slides">${slides.map((_, index) => `<span class="${index === 0 ? "is-active" : ""}"></span>`).join("")}</div>` : ""}
+        ${slides.length > 1 ? `<div class="homepage-hero-dots" aria-label="Homepage slides">${slides.map((_, index) => `<button type="button" class="${index === 0 ? "is-active" : ""}" data-home-hero-dot="${index}" aria-label="ไปยังสไลด์ ${index + 1}" aria-selected="${index === 0 ? "true" : "false"}"></button>`).join("")}</div>` : ""}
       </section>
     `;
   }
@@ -334,6 +334,7 @@
 
   function renderHomepageManualSection(section) {
     const items = (section.items || []).slice(0, 8);
+    if (!items.length) return "";
     return `
       <section class="homepage-section">
         <div class="homepage-section-head">
@@ -342,7 +343,6 @@
             ${section.body ? `<p>${root.utils.escapeHtml(section.body)}</p>` : ""}
           </div>
         </div>
-        ${items.length ? `
         <div class="homepage-carousel">
           ${items.map((item) => {
             const attrs = item.action === "contact"
@@ -362,7 +362,6 @@
             `;
           }).join("")}
         </div>
-        ` : `<div class="homepage-section-empty">${root.utils.escapeHtml(section.body || "ยังไม่มีรายการเผยแพร่")}</div>`}
       </section>
     `;
   }
@@ -614,6 +613,7 @@
 
   function bindHomepage(container) {
     bindCommerceHome(container);
+    bindHomepageHeroSliders(container);
     container.querySelectorAll("[data-home-contact]").forEach((button) => {
       button.addEventListener("click", (event) => {
         event.preventDefault?.();
@@ -642,6 +642,56 @@
         }
         openContactSheet(container, { title: item.item_name || "บริการนี้" });
       });
+    });
+  }
+
+  function bindHomepageHeroSliders(container) {
+    container.querySelectorAll(".homepage-hero").forEach((hero) => {
+      const slider = hero.querySelector(".homepage-hero-slider");
+      const slides = Array.from(hero.querySelectorAll("[data-home-hero-slide]"));
+      const dots = Array.from(hero.querySelectorAll("[data-home-hero-dot]"));
+      if (!slider || slides.length <= 1 || !dots.length || slider.dataset.bound === "1") return;
+      slider.dataset.bound = "1";
+      let raf = 0;
+      const setActive = (index) => {
+        dots.forEach((dot, dotIndex) => {
+          const active = dotIndex === index;
+          dot.classList.toggle("is-active", active);
+          dot.setAttribute("aria-selected", active ? "true" : "false");
+        });
+      };
+      const update = () => {
+        raf = 0;
+        const width = slider.clientWidth || 1;
+        const index = Math.max(0, Math.min(slides.length - 1, Math.round((slider.scrollLeft || 0) / width)));
+        setActive(index);
+      };
+      const onScroll = () => {
+        if (raf) return;
+        raf = requestAnimationFrame(update);
+      };
+      slider.addEventListener("scroll", onScroll, { passive: true });
+      dots.forEach((dot, index) => {
+        dot.addEventListener("click", () => {
+          const slide = slides[index];
+          if (!slide) return;
+          if (typeof slider.scrollTo === "function") {
+            slider.scrollTo({ left: slide.offsetLeft || index * (slider.clientWidth || 0), behavior: "smooth" });
+          } else if (typeof slide.scrollIntoView === "function") {
+            slide.scrollIntoView({ behavior: "smooth", inline: "start", block: "nearest" });
+          }
+          setActive(index);
+        });
+        dot.addEventListener("keydown", (event) => {
+          if (event.key === "Enter" || event.key === " ") {
+            event.preventDefault?.();
+            dot.click();
+          }
+          if (event.key === "ArrowRight" && dots[index + 1]) dots[index + 1].focus();
+          if (event.key === "ArrowLeft" && dots[index - 1]) dots[index - 1].focus();
+        });
+      });
+      update();
     });
   }
 

--- a/customer-app/sw.js
+++ b/customer-app/sw.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const BUILD_ID = "20260629_customer_homepage_cms_rebased";
+const BUILD_ID = "20260629_customer_homepage_mobile_hotfix";
 const CACHE_NAME = `cwf-customer-app-v2-${BUILD_ID}`;
 const APP_SHELL = [
   `./index.html?v=${BUILD_ID}`,

--- a/index.js
+++ b/index.js
@@ -13190,7 +13190,7 @@ app.use(createCatalogItemRoutes({
   minToHHMM,
 }));
 app.use(createCatalogReviewRoutes({ pool, requireCustomerJwt, requireAdminSession }));
-app.use(createHomepageRoutes({ pool, requireAdminSession, upload, cloudinaryUploadBuffer, cloudinaryDestroyPublicId }));
+app.use(createHomepageRoutes({ pool, requireAdminSession, requireCustomerJwt, upload, cloudinaryUploadBuffer, cloudinaryDestroyPublicId }));
 
 
 app.post("/catalog/items", requireAdminSession, async (req, res) => {

--- a/server/routes/homepage.js
+++ b/server/routes/homepage.js
@@ -10,6 +10,7 @@ const MAX_IMAGE_BYTES = 5 * 1024 * 1024;
 const SECTION_TYPES = new Set([
   "hero",
   "quick",
+  "active_job",
   "announcements",
   "featured_services",
   "updates",
@@ -48,10 +49,19 @@ const DEFAULT_CONFIG = {
       ],
     },
     {
+      id: "active_job",
+      type: "active_job",
+      enabled: true,
+      sort_order: 30,
+      title: "งานของฉัน",
+      body: "",
+      items: [],
+    },
+    {
       id: "announcements",
       type: "announcements",
       enabled: true,
-      sort_order: 30,
+      sort_order: 40,
       title: "ข่าวและประกาศ CWF",
       body: "",
       items: [],
@@ -60,7 +70,7 @@ const DEFAULT_CONFIG = {
       id: "featured_services",
       type: "featured_services",
       enabled: true,
-      sort_order: 40,
+      sort_order: 50,
       title: "บริการแนะนำ",
       body: "ราคาและรายละเอียดดึงจาก Catalog",
       items: [],
@@ -69,7 +79,7 @@ const DEFAULT_CONFIG = {
       id: "updates",
       type: "updates",
       enabled: true,
-      sort_order: 50,
+      sort_order: 60,
       title: "ภาพกิจกรรมและโพสต์",
       body: "เชื่อมต่อไปยัง Facebook",
       items: [],
@@ -78,7 +88,7 @@ const DEFAULT_CONFIG = {
       id: "articles",
       type: "articles",
       enabled: true,
-      sort_order: 60,
+      sort_order: 70,
       title: "บทความแนะนำ",
       body: "อ่านต่อบน cwf-air.com",
       items: [],
@@ -87,7 +97,7 @@ const DEFAULT_CONFIG = {
       id: "trust",
       type: "trust",
       enabled: true,
-      sort_order: 70,
+      sort_order: 80,
       title: "มาตรฐานที่ลูกค้าวางใจ",
       body: "ทีม Coldwindflow ดูแลงานด้วยขั้นตอนที่ตรวจสอบได้",
       items: [
@@ -184,6 +194,8 @@ function normalizeItem(raw, sectionType, index, errors) {
   if (cleanText(item.action, 40)) out.action = cleanText(item.action, 40);
   if (cleanText(item.image_url, 700)) out.image_url = cleanText(item.image_url, 700);
   if (cleanText(item.image_public_id, 300)) out.image_public_id = cleanText(item.image_public_id, 300);
+  if (item.cta_primary && typeof item.cta_primary === "object") out.cta_primary = normalizeCta(item.cta_primary, errors, `${pathName}.cta_primary`);
+  if (item.cta_secondary && typeof item.cta_secondary === "object") out.cta_secondary = normalizeCta(item.cta_secondary, errors, `${pathName}.cta_secondary`);
   if (cleanText(item.active_from, 32)) out.active_from = cleanText(item.active_from, 32);
   if (cleanText(item.active_to, 32)) out.active_to = cleanText(item.active_to, 32);
   if (!out.title && sectionType !== "quick") errors.push(`${pathName}.title required`);
@@ -271,6 +283,31 @@ function stripPublicConfig(config) {
   return { version: 1, sections };
 }
 
+function safeHomepageActiveJob(row) {
+  if (!row) return null;
+  return {
+    booking_code: cleanText(row.booking_code, 40),
+    job_type: cleanText(row.job_type, 80),
+    job_status: cleanText(row.job_status, 80),
+    appointment_datetime: row.appointment_datetime || null,
+  };
+}
+
+async function loadActiveJobForCustomer(pool, customerSub) {
+  const sub = cleanText(customerSub, 160);
+  if (!sub) return null;
+  const result = await pool.query(
+    `SELECT booking_code, job_type, job_status, appointment_datetime
+       FROM public.jobs
+      WHERE customer_sub=$1
+        AND COALESCE(job_status,'') NOT IN ('เสร็จสิ้น', 'ยกเลิก', 'ยกเลิกงาน', 'ปิดงานแล้ว')
+      ORDER BY appointment_datetime NULLS LAST, job_id DESC
+      LIMIT 1`,
+    [sub]
+  );
+  return safeHomepageActiveJob(result.rows?.[0]);
+}
+
 async function ensureDraftRow(pool) {
   const existing = await pool.query(
     `SELECT config_key, draft_config, published_config, version, updated_by, updated_at, published_at
@@ -328,6 +365,18 @@ function createHomepageRoutes(deps = {}) {
       }
       console.error("[homepage/public] failed", error);
       res.status(500).json({ error: "โหลดหน้าแรกไม่สำเร็จ" });
+    }
+  });
+
+  router.get("/public/homepage/active-job", async (req, res) => {
+    res.set("Cache-Control", "no-store");
+    try {
+      const activeJob = await loadActiveJobForCustomer(pool, req.customer?.sub || "");
+      return res.json({ ok: true, active_job: activeJob });
+    } catch (error) {
+      if (isSchemaError(error)) return res.json({ ok: true, active_job: null, schema_ready: false });
+      console.error("[homepage/active-job] failed", { code: error?.code || "ERR" });
+      return res.json({ ok: true, active_job: null });
     }
   });
 

--- a/server/routes/homepage.js
+++ b/server/routes/homepage.js
@@ -7,6 +7,7 @@ const { validateCatalogImageFile } = require("../lib/cloudinaryImageUpload");
 const CONFIG_KEY = "customer_homepage_v1";
 const MAX_JSON_BYTES = 120 * 1024;
 const MAX_IMAGE_BYTES = 5 * 1024 * 1024;
+const MAX_HERO_SLIDES = 5;
 const SECTION_TYPES = new Set([
   "hero",
   "quick",
@@ -64,7 +65,9 @@ const DEFAULT_CONFIG = {
       sort_order: 40,
       title: "ข่าวและประกาศ CWF",
       body: "",
-      items: [],
+      items: [
+        { title: "ติดต่อทีม CWF", action: "contact", body: "สอบถามบริการหรือแจ้งข้อมูลเพิ่มเติมกับแอดมิน" },
+      ],
     },
     {
       id: "featured_services",
@@ -81,7 +84,7 @@ const DEFAULT_CONFIG = {
       enabled: true,
       sort_order: 60,
       title: "ภาพกิจกรรมและโพสต์",
-      body: "เชื่อมต่อไปยัง Facebook",
+      body: "",
       items: [],
     },
     {
@@ -90,7 +93,7 @@ const DEFAULT_CONFIG = {
       enabled: true,
       sort_order: 70,
       title: "บทความแนะนำ",
-      body: "อ่านต่อบน cwf-air.com",
+      body: "",
       items: [],
     },
     {
@@ -214,7 +217,7 @@ function normalizeSection(raw, index, errors) {
   if (!SECTION_TYPES.has(type)) errors.push(`sections.${index}.type invalid`);
   const id = cleanText(section.id || type, 60) || type;
   const items = Array.isArray(section.items) ? section.items : [];
-  const maxItems = type === "quick" ? 4 : 12;
+  const maxItems = type === "quick" ? 4 : type === "hero" ? MAX_HERO_SLIDES : 12;
   if (items.length > maxItems) errors.push(`${id}.items too many`);
   const out = {
     id,
@@ -345,8 +348,34 @@ function createHomepageRoutes(deps = {}) {
   const upload = deps.upload;
   const cloudinaryUploadBuffer = deps.cloudinaryUploadBuffer;
   const cloudinaryDestroyPublicId = deps.cloudinaryDestroyPublicId;
+  const requireCustomerJwt = deps.requireCustomerJwt;
   if (!pool) throw new Error("createHomepageRoutes requires pool");
   if (!requireAdminSession) throw new Error("createHomepageRoutes requires requireAdminSession");
+  if (requireCustomerJwt && typeof requireCustomerJwt !== "function") throw new Error("createHomepageRoutes requires requireCustomerJwt to be a function");
+
+  function optionalCustomerSession(req, res, next) {
+    if (!requireCustomerJwt) return next();
+    let finished = false;
+    const passthrough = () => {
+      if (finished) return;
+      finished = true;
+      next();
+    };
+    const failClosedRes = {
+      status() { return this; },
+      json() {
+        req.customer = null;
+        passthrough();
+        return this;
+      },
+    };
+    try {
+      return requireCustomerJwt(req, failClosedRes, passthrough);
+    } catch (_) {
+      req.customer = null;
+      return passthrough();
+    }
+  }
 
   router.get("/public/homepage", async (_req, res) => {
     res.set("Cache-Control", "no-store");
@@ -368,7 +397,7 @@ function createHomepageRoutes(deps = {}) {
     }
   });
 
-  router.get("/public/homepage/active-job", async (req, res) => {
+  router.get("/public/homepage/active-job", optionalCustomerSession, async (req, res) => {
     res.set("Cache-Control", "no-store");
     try {
       const activeJob = await loadActiveJobForCustomer(pool, req.customer?.sub || "");

--- a/test/customerAppRecovery.test.js
+++ b/test/customerAppRecovery.test.js
@@ -236,7 +236,7 @@ test("Customer App build id is consistent across shell and service worker", () =
   const sw = read("customer-app/sw.js");
   const app = read("customer-app/assets/customer-app.js");
   const manifest = read("customer-app/manifest.webmanifest");
-  const build = "20260629_customer_homepage_cms_rebased";
+  const build = "20260629_customer_homepage_mobile_hotfix";
 
   assert.match(index, new RegExp(`customer-app\\.css\\?v=${build}`));
   assert.match(index, new RegExp(`modules\\/api\\.js\\?v=${build}`));
@@ -254,7 +254,7 @@ test("Customer App build id is consistent across shell and service worker", () =
 test("store module is loaded in index.html and precached in the service worker app shell", () => {
   const index = read("customer-app/index.html");
   const sw = read("customer-app/sw.js");
-  const build = "20260629_customer_homepage_cms_rebased";
+  const build = "20260629_customer_homepage_mobile_hotfix";
 
   assert.match(index, new RegExp(`modules/store\\.js\\?v=${build}`));
   assert.match(sw, /`\.\/modules\/store\.js\?v=\$\{BUILD_ID\}`/);

--- a/test/customerAppRecovery.test.js
+++ b/test/customerAppRecovery.test.js
@@ -509,6 +509,47 @@ test("homepage announcement cards preserve contact, route, and external URL targ
   assert.match(container.innerHTML, /class="homepage-announcement-card" href="https:\/\/example\.com\/news" target="_blank" rel="noopener noreferrer"/);
 });
 
+test("homepage hero slider renders dots only for multiple slides", () => {
+  const context = makeContext();
+  const root = loadCustomerFrontend(context);
+  root.auth = { displayName: () => "Customer", loadCustomer: async () => ({ logged_in: false }) };
+  root.state.setHomepage({
+    status: "success",
+    fallback: false,
+    error: "",
+    config: {
+      version: 1,
+      sections: [{
+        id: "hero",
+        type: "hero",
+        enabled: true,
+        sort_order: 10,
+        title: "Hero",
+        items: [
+          { title: "Slide A", cta_primary: { label: "A", route: "store" } },
+          { title: "Slide B", cta_primary: { label: "B", route: "scheduled" } },
+        ],
+      }],
+    },
+  });
+  const container = new HomeContainer();
+  root.ui.renderHome(container);
+  assert.match(container.innerHTML, /data-home-hero-dot="0"/);
+  assert.match(container.innerHTML, /data-home-hero-dot="1"/);
+
+  root.state.setHomepage({
+    status: "success",
+    fallback: false,
+    error: "",
+    config: {
+      version: 1,
+      sections: [{ id: "hero", type: "hero", enabled: true, sort_order: 10, title: "Single", items: [{ title: "Only" }] }],
+    },
+  });
+  root.ui.renderHome(container);
+  assert.doesNotMatch(container.innerHTML, /data-home-hero-dot=/);
+});
+
 test("homepage ui has no mojibake marker and renderHome has a single render path", () => {
   const uiSource = fs.readFileSync(path.join(__dirname, "..", "customer-app", "modules", "ui.js"), "utf8");
   assert.doesNotMatch(uiSource, /à¸|à¹/);

--- a/test/customerSameDayTiming.test.js
+++ b/test/customerSameDayTiming.test.js
@@ -160,7 +160,7 @@ test("customer app disables availability HTTP cache and refreshes same-day slots
 });
 
 test("customer app build and service worker cache IDs changed", () => {
-  const id = "20260629_customer_homepage_cms_rebased";
+  const id = "20260629_customer_homepage_mobile_hotfix";
   for (const file of [
     "customer-app/index.html",
     "customer-app/sw.js",

--- a/test/customerVisualContracts.test.js
+++ b/test/customerVisualContracts.test.js
@@ -73,7 +73,8 @@ test("visual unification remains scoped to customer app routes", () => {
   assert.match(css, /\.homepage-hero/);
   assert.match(css, /\.homepage-service-card/);
   assert.match(css, /\.bottom-nav\s*\{[\s\S]*max-width:\s*480px/);
-  assert.match(css, /\.nav-item-primary::after\s*\{[\s\S]*width:\s*54px/);
+  assert.match(css, /\.nav-item-primary::after\s*\{[\s\S]*width:\s*44px/);
+  assert.match(css, /\.nav-item-primary::after\s*\{[\s\S]*height:\s*44px/);
   assert.match(css, /\.nav-item-primary::after\s*\{[\s\S]*background:\s*linear-gradient\(145deg,#ffd43b,#ffbd17\)/);
   assert.match(css, /\.nav-item-primary::before\s*\{[\s\S]*background:\s*#2b2500/);
   assert.doesNotMatch(css, /body\s*\{[^}]*position:\s*fixed/);

--- a/test/homepageCms.test.js
+++ b/test/homepageCms.test.js
@@ -63,13 +63,13 @@ function createPool() {
   };
 }
 
-async function withServer(pool, requireAdminSession, beforeRoutes) {
+async function withServer(pool, requireAdminSession, requireCustomerJwt) {
   const app = express();
   app.use(express.json({ limit: "200kb" }));
-  if (beforeRoutes) app.use(beforeRoutes);
   app.use(createHomepageRoutes({
     pool,
     requireAdminSession,
+    requireCustomerJwt,
     upload: { single: () => (_req, _res, next) => next() },
   }));
   const server = await new Promise((resolve) => {
@@ -311,6 +311,32 @@ test("homepage validation preserves hero image metadata and rejects quick sectio
   });
   assert.equal(invalid.ok, false);
   assert.ok(invalid.errors.includes("quick.items too many"));
+
+  const tooManySlides = validateConfig({
+    sections: [{
+      id: "hero",
+      type: "hero",
+      enabled: true,
+      sort_order: 10,
+      title: "Hero",
+      items: [1, 2, 3, 4, 5, 6].map((i) => ({ title: `Slide ${i}` })),
+    }],
+  });
+  assert.equal(tooManySlides.ok, false);
+  assert.ok(tooManySlides.errors.includes("hero.items too many"));
+
+  const ctaConflict = validateConfig({
+    sections: [{
+      id: "hero",
+      type: "hero",
+      enabled: true,
+      sort_order: 10,
+      title: "Hero",
+      items: [{ title: "Slide", cta_primary: { label: "Go", route: "store", url: "https://example.com" } }],
+    }],
+  });
+  assert.equal(ctaConflict.ok, false);
+  assert.ok(ctaConflict.errors.some((error) => error.includes("cta_primary.target conflict")));
 });
 
 test("public homepage strips section and item image_public_id while keeping image_url", async () => {
@@ -351,7 +377,14 @@ test("public active job endpoint is session scoped and returns safe fields only"
     customer_name: "Private",
     customer_phone: "0999999999",
   };
-  const noSession = await withServer(pool, (_req, _res, next) => next());
+  const customerSession = (req, res, next) => {
+    if (String(req.headers.cookie || "").includes("cwf_token=customer-1")) {
+      req.customer = { sub: "customer-1" };
+      return next();
+    }
+    return res.status(401).json({ error: "NOT_LOGGED_IN" });
+  };
+  const noSession = await withServer(pool, (_req, _res, next) => next(), customerSession);
   try {
     const res = await fetch(`${noSession.base}/public/homepage/active-job`);
     const data = await res.json();
@@ -361,13 +394,12 @@ test("public active job endpoint is session scoped and returns safe fields only"
     await noSession.close();
   }
 
-  const session = await withServer(
-    pool,
-    (_req, _res, next) => next(),
-    (req, _res, next) => { req.customer = { sub: "customer-1" }; next(); },
-  );
+  const session = await withServer(pool, (_req, _res, next) => next(), customerSession);
   try {
-    const res = await fetch(`${session.base}/public/homepage/active-job`);
+    const noJob = await fetch(`${session.base}/public/homepage/active-job`, { headers: { cookie: "cwf_token=customer-2" } });
+    assert.equal((await noJob.json()).active_job, null);
+
+    const res = await fetch(`${session.base}/public/homepage/active-job`, { headers: { cookie: "cwf_token=customer-1" } });
     const data = await res.json();
     assert.equal(res.status, 200);
     assert.equal(data.active_job.booking_code, "CWF-102");
@@ -379,6 +411,15 @@ test("public active job endpoint is session scoped and returns safe fields only"
   } finally {
     await session.close();
   }
+});
+
+test("production homepage mount passes the customer JWT middleware and active job does not accept client identity", () => {
+  const index = read("index.js");
+  const homepage = read("server/routes/homepage.js");
+  assert.match(index, /createHomepageRoutes\(\{[^}]*requireCustomerJwt[^}]*\}\)/s);
+  assert.match(homepage, /router\.get\("\/public\/homepage\/active-job", optionalCustomerSession/);
+  assert.match(homepage, /loadActiveJobForCustomer\(pool, req\.customer\?\.sub \|\| ""\)/);
+  assert.doesNotMatch(homepage, /req\.(query|body)\?\.(customer_sub|customerSub|customer_id|booking_code|phone)/);
 });
 
 test("admin save and publish preserve hero image fields", async () => {
@@ -427,6 +468,10 @@ test("backend admin customer defaults and homepage migration stay in allowed sco
   }
   assert.doesNotMatch(migration, /ALTER TABLE\s+public\.catalog_items/i);
   assert.doesNotMatch(migration, /idx_catalog_items_customer_featured/i);
+  assert.match(customer, /items:\s*\[\{ title: "ติดต่อทีม CWF", action: "contact"/);
+  assert.match(admin, /items:\s*\[\{ title: "ติดต่อทีม CWF", action: "contact"/);
+  assert.doesNotMatch(customer, /เชื่อมต่อไปยัง Facebook|อ่านต่อบน cwf-air\.com/);
+  assert.doesNotMatch(admin, /เชื่อมต่อไปยัง Facebook|อ่านต่อบน cwf-air\.com/);
 });
 
 test("bottom navigation border and padding match the fixed-nav reference", () => {
@@ -455,11 +500,17 @@ test("customer homepage renderer supports hero slider, active job placeholder, a
   assert.match(ui, /const slides = Array\.isArray\(section\.items\) && section\.items\.length \? section\.items : \[section\]/);
   assert.match(ui, /homepage-hero-slider/);
   assert.match(ui, /homepage-hero-dots/);
+  assert.match(ui, /data-home-hero-dot/);
+  assert.match(ui, /addEventListener\("scroll", onScroll, \{ passive: true \}\)/);
+  assert.match(ui, /requestAnimationFrame/);
+  assert.match(ui, /slider\.scrollTo/);
+  assert.match(ui, /aria-selected/);
   assert.match(ui, /slide\.cta_primary \|\| section\.cta_primary/);
   assert.match(ui, /function renderHomepageActiveJob\(section\)/);
   assert.match(ui, /data-home-active-job/);
   assert.match(ui, /loadHomeActiveJobData/);
-  assert.match(ui, /homepage-section-empty/);
+  assert.match(ui, /if \(!items\.length\) return "";/);
+  assert.doesNotMatch(ui, /ยังไม่มีรายการเผยแพร่/);
 });
 
 test("homepage target validation stores exactly one quick or announcement target", () => {
@@ -551,4 +602,18 @@ test("admin target editor renders mode-specific fields and no stale target field
     admin.indexOf("function render()"),
   );
   assert.equal((renderPreviewSource.match(/\$\("preview"\)\.innerHTML/g) || []).length, 1);
+});
+
+test("admin hero slide editor supports add edit remove reorder upload and CTA targets", () => {
+  const admin = read("admin-homepage-cms.js");
+  assert.match(admin, /id="addHeroSlide"/);
+  assert.match(admin, /function heroSlideEditor/);
+  assert.match(admin, /data-move-item/);
+  assert.match(admin, /data-upload="\$\{index\}"/);
+  assert.match(admin, /data-hero-cta/);
+  assert.match(admin, /data-hero-cta-target/);
+  assert.match(admin, /if \(current\(\)\.items\.length >= 5\)/);
+  assert.match(admin, /delete item\[ctaName\]\.route;\s*delete item\[ctaName\]\.url;\s*delete item\[ctaName\]\.action;/);
+  const previewSource = admin.slice(admin.indexOf("function renderPreview()"), admin.indexOf("function render()"));
+  assert.match(previewSource, /const slides = Array\.isArray\(section\.items\) && section\.items\.length \? section\.items : \[section\]/);
 });

--- a/test/homepageCms.test.js
+++ b/test/homepageCms.test.js
@@ -179,7 +179,7 @@ test("customer homepage has no admin control, bottom nav is fixed five-tab, and 
   const sw = read("customer-app/sw.js");
   const app = read("customer-app/assets/customer-app.js");
   const manifest = read("customer-app/manifest.webmanifest");
-  const build = "20260629_customer_homepage_cms_rebased";
+  const build = "20260629_customer_homepage_mobile_hotfix";
 
   assert.doesNotMatch(index + ui, /โหมดแอดมิน|openCms|localStorage\.getItem\('cwfHomeCmsDemo'/);
   assert.match(index, /data-route="store"[\s\S]*ร้านค้า/);
@@ -191,9 +191,11 @@ test("customer homepage has no admin control, bottom nav is fixed five-tab, and 
   assert.match(css, /grid-template-columns: repeat\(5, minmax\(0, 1fr\)\)/);
   assert.match(css, /background:\s*rgba\(255,255,255,\.97\)/);
   assert.match(css, /box-shadow:\s*0 -10px 30px rgba\(7,27,56,\.10\)/);
-  assert.match(css, /margin:\s*-28px 0 0/);
-  assert.match(css, /width:\s*54px/);
-  assert.match(css, /height:\s*54px/);
+  assert.doesNotMatch(css, /margin:\s*-28px 0 0/);
+  const primaryNavBlock = css.slice(css.lastIndexOf(".nav-item-primary {"), css.lastIndexOf(".nav-item-primary {") + 220);
+  assert.doesNotMatch(primaryNavBlock, /translateY\(-/);
+  assert.match(css, /width:\s*44px/);
+  assert.match(css, /height:\s*44px/);
   assert.match(css, /background:\s*linear-gradient\(145deg,#ffd43b,#ffbd17\)/);
   assert.match(css, /background:\s*#2b2500/);
   assert.match(index, new RegExp(`customer-app\\.css\\?v=${build}`));
@@ -376,7 +378,22 @@ test("backend admin customer defaults and homepage migration stay in allowed sco
 test("bottom navigation border and padding match the fixed-nav reference", () => {
   const css = read("customer-app/assets/customer-app.css");
   assert.match(css, /border-top:\s*1px solid var\(--line\)/);
-  assert.match(css, /padding:\s*9px 6px calc\(8px \+ var\(--safe-b\)\)/);
+  assert.match(css, /padding:\s*7px 6px calc\(7px \+ var\(--safe-b\)\)/);
+  assert.match(css, /\.bottom-nav \.nav-item-primary::after\s*\{[\s\S]*width:\s*44px[\s\S]*height:\s*44px/);
+});
+
+test("homepage service carousel constrains card and image geometry on mobile", () => {
+  const css = read("customer-app/assets/customer-app.css");
+  const serviceBlock = css.slice(css.lastIndexOf(".homepage-service-card {"), css.lastIndexOf(".homepage-service-card {") + 320);
+  assert.match(serviceBlock, /flex:\s*0 0 calc\(\(100% - 10px\) \/ 2\)/);
+  assert.match(serviceBlock, /max-width:\s*calc\(\(100% - 10px\) \/ 2\)/);
+  const imageBlock = css.slice(css.lastIndexOf(".homepage-card-image {"), css.lastIndexOf(".homepage-card-image {") + 180);
+  assert.match(imageBlock, /overflow:\s*hidden/);
+  const imageImgBlock = css.slice(css.lastIndexOf(".homepage-card-image img"), css.lastIndexOf(".homepage-card-image img") + 180);
+  assert.match(imageImgBlock, /display:\s*block/);
+  assert.match(imageImgBlock, /width:\s*100%/);
+  assert.match(imageImgBlock, /height:\s*100%/);
+  assert.match(imageImgBlock, /object-fit:\s*cover/);
 });
 
 test("homepage target validation stores exactly one quick or announcement target", () => {

--- a/test/homepageCms.test.js
+++ b/test/homepageCms.test.js
@@ -19,9 +19,10 @@ function createPool() {
       draft_config: DEFAULT_CONFIG,
       published_config: null,
       version: 1,
-      updated_by: null,
-      updated_at: null,
-      published_at: null,
+    updated_by: null,
+    updated_at: null,
+    published_at: null,
+    activeJob: null,
     },
     queries: [],
   };
@@ -54,14 +55,18 @@ function createPool() {
       }
       if (normalized.includes("INSERT INTO public.homepage_cms_media")) return { rows: [] };
       if (normalized.includes("UPDATE public.homepage_cms_media")) return { rows: [] };
+      if (normalized.includes("FROM public.jobs") && normalized.includes("customer_sub=$1")) {
+        return { rows: state.activeJob && params[0] === "customer-1" ? [state.activeJob] : [] };
+      }
       throw new Error(`Unhandled query: ${normalized}`);
     },
   };
 }
 
-async function withServer(pool, requireAdminSession) {
+async function withServer(pool, requireAdminSession, beforeRoutes) {
   const app = express();
   app.use(express.json({ limit: "200kb" }));
+  if (beforeRoutes) app.use(beforeRoutes);
   app.use(createHomepageRoutes({
     pool,
     requireAdminSession,
@@ -260,13 +265,14 @@ test("backend defaults contain exactly the standard homepage section types in or
   assert.deepEqual(DEFAULT_CONFIG.sections.map((section) => section.type), [
     "hero",
     "quick",
+    "active_job",
     "announcements",
     "featured_services",
     "updates",
     "articles",
     "trust",
   ]);
-  assert.deepEqual(DEFAULT_CONFIG.sections.map((section) => section.sort_order), [10, 20, 30, 40, 50, 60, 70]);
+  assert.deepEqual(DEFAULT_CONFIG.sections.map((section) => section.sort_order), [10, 20, 30, 40, 50, 60, 70, 80]);
 });
 
 test("homepage validation preserves hero image metadata and rejects quick sections over four items", () => {
@@ -279,12 +285,19 @@ test("homepage validation preserves hero image metadata and rejects quick sectio
       title: "Hero",
       image_url: "https://res.cloudinary.com/demo/hero.jpg",
       image_public_id: "cwf/homepage/hero",
-      items: [],
+      items: [{
+        title: "Slide",
+        image_url: "https://res.cloudinary.com/demo/slide.jpg",
+        cta_primary: { label: "Book", route: "scheduled" },
+        cta_secondary: { label: "Line", url: "https://example.com/line" },
+      }],
     }],
   });
   assert.equal(valid.ok, true);
   assert.equal(valid.config.sections[0].image_url, "https://res.cloudinary.com/demo/hero.jpg");
   assert.equal(valid.config.sections[0].image_public_id, "cwf/homepage/hero");
+  assert.equal(valid.config.sections[0].items[0].cta_primary.route, "scheduled");
+  assert.equal(valid.config.sections[0].items[0].cta_secondary.url, "https://example.com/line");
 
   const invalid = validateConfig({
     sections: [{
@@ -324,6 +337,47 @@ test("public homepage strips section and item image_public_id while keeping imag
     assert.doesNotMatch(JSON.stringify(data), /image_public_id|cwf\/homepage\/hero|secret_item_id/);
   } finally {
     await server.close();
+  }
+});
+
+test("public active job endpoint is session scoped and returns safe fields only", async () => {
+  const pool = createPool();
+  pool.state.activeJob = {
+    booking_code: "CWF-102",
+    job_type: "ล้างแอร์",
+    job_status: "นัดหมายแล้ว",
+    appointment_datetime: "2026-06-30T03:00:00.000Z",
+    job_id: 99,
+    customer_name: "Private",
+    customer_phone: "0999999999",
+  };
+  const noSession = await withServer(pool, (_req, _res, next) => next());
+  try {
+    const res = await fetch(`${noSession.base}/public/homepage/active-job`);
+    const data = await res.json();
+    assert.equal(res.status, 200);
+    assert.equal(data.active_job, null);
+  } finally {
+    await noSession.close();
+  }
+
+  const session = await withServer(
+    pool,
+    (_req, _res, next) => next(),
+    (req, _res, next) => { req.customer = { sub: "customer-1" }; next(); },
+  );
+  try {
+    const res = await fetch(`${session.base}/public/homepage/active-job`);
+    const data = await res.json();
+    assert.equal(res.status, 200);
+    assert.equal(data.active_job.booking_code, "CWF-102");
+    assert.equal(data.active_job.job_type, "ล้างแอร์");
+    assert.equal(data.active_job.job_status, "นัดหมายแล้ว");
+    assert.deepEqual(Object.keys(data.active_job).sort(), ["appointment_datetime", "booking_code", "job_status", "job_type"]);
+    assert.doesNotMatch(JSON.stringify(data), /job_id|customer_name|customer_phone|0999999999|Private/);
+    assert.equal(pool.state.queries.some((query) => query.params[0] === "customer-1"), true);
+  } finally {
+    await session.close();
   }
 });
 
@@ -367,7 +421,7 @@ test("backend admin customer defaults and homepage migration stay in allowed sco
   const admin = read("admin-homepage-cms.js");
   const customer = read("customer-app/modules/ui.js");
   const migration = read("migrations/20260629_homepage_cms.sql");
-  for (const type of ["hero", "quick", "announcements", "featured_services", "updates", "articles", "trust"]) {
+  for (const type of ["hero", "quick", "active_job", "announcements", "featured_services", "updates", "articles", "trust"]) {
     assert.match(admin, new RegExp(`type:\\s*"${type}"`));
     assert.match(customer, new RegExp(`type:\\s*"${type}"`));
   }
@@ -394,6 +448,18 @@ test("homepage service carousel constrains card and image geometry on mobile", (
   assert.match(imageImgBlock, /width:\s*100%/);
   assert.match(imageImgBlock, /height:\s*100%/);
   assert.match(imageImgBlock, /object-fit:\s*cover/);
+});
+
+test("customer homepage renderer supports hero slider, active job placeholder, and real empty states", () => {
+  const ui = read("customer-app/modules/ui.js");
+  assert.match(ui, /const slides = Array\.isArray\(section\.items\) && section\.items\.length \? section\.items : \[section\]/);
+  assert.match(ui, /homepage-hero-slider/);
+  assert.match(ui, /homepage-hero-dots/);
+  assert.match(ui, /slide\.cta_primary \|\| section\.cta_primary/);
+  assert.match(ui, /function renderHomepageActiveJob\(section\)/);
+  assert.match(ui, /data-home-active-job/);
+  assert.match(ui, /loadHomeActiveJobData/);
+  assert.match(ui, /homepage-section-empty/);
 });
 
 test("homepage target validation stores exactly one quick or announcement target", () => {


### PR DESCRIPTION
Refs #102

VISUAL_QA_BLOCKED — browser runtime unavailable

This PR intentionally does not claim visual QA completion. The in-app browser runtime was unavailable (`agent.browsers.get("iab")` returned `Browser is not available: iab`, and `agent.browsers.list()` returned `[]`), so required 320px, 390px, and 480px browser screenshots could not be captured.

## Phase A — Mobile layout stabilization

Commit: `843b74fbec61f61566efcd23b0b172bf280362cc`

Changed files:
- `customer-app/assets/customer-app.css`
- `customer-app/assets/customer-app.js`
- `customer-app/index.html`
- `customer-app/manifest.webmanifest`
- `customer-app/sw.js`
- `test/customerAppRecovery.test.js`
- `test/customerSameDayTiming.test.js`
- `test/homepageCms.test.js`

Summary:
- Stabilized homepage mobile carousel/card/image geometry.
- Kept Store/Product Detail/Booking/Urgent/Tracking/Profile business logic untouched.
- Updated Customer App build/cache references for the hotfix.

## Phase B — Homepage CMS sections and active job

Commit: `c823a3607d57b4619fc188528d41b2f1e42e726e`

Changed files:
- `admin-homepage-cms.js`
- `customer-app/assets/customer-app.css`
- `customer-app/modules/api.js`
- `customer-app/modules/state.js`
- `customer-app/modules/ui.js`
- `server/routes/homepage.js`
- `test/customerVisualContracts.test.js`
- `test/homepageCms.test.js`

Summary:
- Added `active_job` as a standard homepage section across backend/admin/customer defaults.
- Rendered sections from CMS order and kept omitted/disabled sections hidden.
- Added hero slide support from CMS item metadata.
- Added empty states for manual sections without inventing external links or fake content.

## Active Job privacy approach

- New public endpoint reads active job using server-side customer session identity only (`req.customer.sub`).
- Public response returns only safe fields: `booking_code`, `job_type`, `job_status`, `appointment_datetime`.
- No `job_id`, `customer_name`, `customer_phone`, `customer_sub`, tracking token, or private profile fields are returned.
- The homepage `active_job` section renders nothing until a scoped active job exists.

## Tests run and passed

- `node --check server/routes/homepage.js`
- `node --check customer-app/modules/ui.js`
- `node --check customer-app/modules/api.js`
- `node --check customer-app/modules/state.js`
- `node --check admin-homepage-cms.js`
- `node --test test/homepageCms.test.js` — 19/19 passed
- `node --test test/customerAppRecovery.test.js` — 92/92 passed
- `node --test test/customerSameDayTiming.test.js` — 8/8 passed
- `node --test test/catalogItemsRoutes.test.js` — 160/160 passed
- `node --test test/catalogReviewRoutes.test.js` — 53/53 passed
- `node --test test/urgentPublicAdapter.test.js` — 11/11 passed
- `node --test test/urgentProductionHotfix.test.js` — 4/4 passed
- `node --test test/customerVisualContracts.test.js` — 4/4 passed
- `git diff --check` passed

## npm test baseline comparison

`npm test` still fails. Observed failures are outside this hotfix scope:

- Admin Store Catalog UI tests fail on both this branch and `origin/main` before the homepage-specific work.
- `test/customerAppThreeStepBooking.test.js` fails the same `calendar marks available and full dates without technician identity` assertion on this branch and on an `origin/main` worktree.
- A separate baseline worktree could not run the full suite completely because it did not have its own installed dependencies (`MODULE_NOT_FOUND` for packages such as `express`/`pg`), but the relevant three-step booking focused test was run and reproduced the same failure.

No new failure was identified in the homepage, Store/Product Detail, catalog, review, urgent, or visual contract focused tests listed above.

## Migration files

None added or modified.

## Operational notes

- No migration run.
- No production data changed.
- No deploy.
- Draft PR only; do not merge until visual QA can be completed with real browser screenshots.