### PR TITLE
Homepage CMS: live-site fixes, article auto-sync, and premium visual polish

### DIFF
--- a/admin-homepage-cms.js
+++ b/admin-homepage-cms.js
@@ -20,6 +20,8 @@
   let selected = "hero";
   let catalogItems = null;
   let catalogLoadFailed = false;
+  let articleSyncStatus = null;
+  let articleSyncStatusLoading = false;
   const ROUTE_OPTIONS = ["home", "store", "scheduled", "urgent", "tracking", "profile"];
 
   const $ = (id) => document.getElementById(id);
@@ -238,6 +240,66 @@
     `;
   }
 
+  async function ensureArticleSyncStatus(sourceUrl) {
+    if (!sourceUrl) return;
+    if (articleSyncStatusLoading) return;
+    if (articleSyncStatus && articleSyncStatus.source_url === sourceUrl) return;
+    articleSyncStatusLoading = true;
+    try {
+      const data = await requestJson(`/admin/homepage-cms/synced-articles?source_url=${encodeURIComponent(sourceUrl)}`);
+      articleSyncStatus = { source_url: sourceUrl, count: (data.articles || []).length, last_synced_at: data.last_synced_at || null };
+    } catch (_) {
+      articleSyncStatus = { source_url: sourceUrl, count: 0, last_synced_at: null, error: true };
+    }
+    articleSyncStatusLoading = false;
+    render();
+  }
+
+  async function syncArticlesNow() {
+    const section = current();
+    if (section.type !== "articles") return;
+    if (!section.source_url) { setStatus("กรอก URL เว็บไซต์ต้นทางก่อนซิงค์", "bad"); return; }
+    setStatus("กำลังซิงค์บทความ...", "");
+    const data = await requestJson("/admin/homepage-cms/sync-articles", {
+      method: "POST",
+      body: JSON.stringify({ source_url: section.source_url, seed_urls: section.seed_urls || [] }),
+    });
+    articleSyncStatus = { source_url: section.source_url, count: (data.articles || []).length, last_synced_at: data.last_synced_at || null };
+    setStatus(`ซิงค์สำเร็จ ดึงได้ ${data.synced_count} บทความ (พบทั้งหมด ${data.fetched_count})`, "ok");
+    render();
+  }
+
+  function formatSyncedAt(value) {
+    if (!value) return "ยังไม่เคยซิงค์";
+    try {
+      return new Date(value).toLocaleString("th-TH", { year: "numeric", month: "short", day: "numeric", hour: "2-digit", minute: "2-digit" });
+    } catch (_) {
+      return "ยังไม่เคยซิงค์";
+    }
+  }
+
+  function articlesAutoSyncEditor(section) {
+    const seedUrlsText = (Array.isArray(section.seed_urls) ? section.seed_urls : []).join("\n");
+    if (section.source_url) ensureArticleSyncStatus(section.source_url);
+    const status = articleSyncStatus && articleSyncStatus.source_url === section.source_url ? articleSyncStatus : null;
+    const statusText = articleSyncStatusLoading
+      ? "กำลังตรวจสอบสถานะ..."
+      : status
+        ? (status.error ? "ตรวจสอบสถานะไม่สำเร็จ" : `ซิงค์ล่าสุด: ${formatSyncedAt(status.last_synced_at)} · มีบทความ ${status.count} รายการ`)
+        : "";
+    return `
+      <div class="item" style="border-style:dashed">
+        <h3>ดึงบทความอัตโนมัติจากเว็บไซต์</h3>
+        <label class="switch"><input type="checkbox" data-auto-sync ${section.auto_sync ? "checked" : ""}> เปิดดึงบทความอัตโนมัติ (sync เป็นระยะ)</label>
+        <label>URL เว็บไซต์ต้นทาง<input data-field="source_url" value="${esc(section.source_url || "")}" placeholder="https://www.cwf-air.com"></label>
+        <label>Seed URL สำรอง (ใช้เมื่อ API ของเว็บไม่พร้อม ใส่ลิงก์บทความทีละบรรทัด)<textarea data-seed-urls>${esc(seedUrlsText)}</textarea></label>
+        <div class="toolbar"><button class="btn" type="button" id="syncArticlesNow">ซิงค์ตอนนี้</button></div>
+        ${statusText ? `<p style="color:#7d899c;font-size:13px">${esc(statusText)}</p>` : ""}
+        ${section.auto_sync ? `<p style="color:#7d899c;font-size:12px">เปิดใช้งานแล้ว ระบบจะดึงบทความให้อัตโนมัติเป็นระยะ รายการที่เพิ่มด้วยมือด้านบนจะไม่ถูกใช้แสดงผลจริงขณะเปิดโหมดนี้</p>` : ""}
+      </div>
+    `;
+  }
+
   function renderEditor() {
     const section = current();
     if (!section) return;
@@ -266,7 +328,8 @@
         <div class="toolbar"><button class="btn" type="button" id="addHeroSlide">Add hero slide</button></div>
         ${(section.items || []).map((item, index) => heroSlideEditor(item, index, section.items.length)).join("")}
       ` : ""}
-      ${itemTypes.includes(section.type) ? `
+      ${section.type === "articles" ? articlesAutoSyncEditor(section) : ""}
+      ${itemTypes.includes(section.type) && !(section.type === "articles" && section.auto_sync) ? `
         <div class="toolbar"><button class="btn" type="button" id="addItem">เพิ่มรายการ</button></div>
         ${section.type === "promo_banner" ? (section.items || []).map((item, index) => `
           <div>
@@ -437,6 +500,7 @@
       }
     }
     if (event.target.id === "retryCatalog") retryLoadCatalogItems();
+    if (event.target.id === "syncArticlesNow") syncArticlesNow().catch((error) => setStatus(error.message, "bad"));
     if (event.target.id === "addItem") {
       current().items = current().items || [];
       if (current().type === "quick" && current().items.length >= 4) { setStatus("Quick จำกัด 4 รายการ", "bad"); return; }
@@ -480,6 +544,7 @@
     }
     if (target.matches("[data-item]")) section.items[Number(target.dataset.item)][target.dataset.prop] = target.value;
     if (target.matches("[data-featured-limit]")) section.featured_limit = Math.max(1, Math.min(12, Number(target.value) || 8));
+    if (target.matches("[data-seed-urls]")) section.seed_urls = target.value.split("\n").map((line) => line.trim()).filter(Boolean).slice(0, 8);
     renderPreview();
   });
 
@@ -496,6 +561,7 @@
     if (target.matches("[data-upload]")) uploadImage(target, Number(target.dataset.upload)).catch((error) => setStatus(error.message, "bad"));
     if (target.matches("[data-upload-section]")) uploadImage(target, target.dataset.uploadSection).catch((error) => setStatus(error.message, "bad"));
     if (target.matches("[data-featured-mode]")) { current().featured_mode = target.value; render(); }
+    if (target.matches("[data-auto-sync]")) { current().auto_sync = target.checked; render(); }
     if (target.matches("[data-featured-bool]")) { current()[target.dataset.featuredBool] = target.checked; renderPreview(); }
     if (target.matches("[data-featured-item]")) {
       const section = current();

--- a/admin-homepage-cms.js
+++ b/admin-homepage-cms.js
@@ -178,7 +178,7 @@
             <option value="url" ${targetMode === "url" ? "selected" : ""}>External URL</option>
           </select></label>
         ` : ""}
-        ${quick ? `<label>Icon<input data-item="${index}" data-prop="icon" value="${esc(item.icon || "")}" placeholder="sparkle, wrench, pin, chat"></label>` : ""}
+        ${quick ? `<label>Icon<input data-item="${index}" data-prop="icon" value="${esc(item.icon || "")}" placeholder="sparkle, wrench, pin, line, chat, bolt, shield, tag, clock, phone"></label>` : ""}
         ${targetField}
         ${trust || targetEditable ? "" : `<label>${social ? `ลิงก์โพสต์/วิดีโอ (${(item.platform || "youtube") === "facebook" ? "facebook.com..." : "youtube.com... หรือ youtu.be..."})` : external ? "External URL" : "Route / URL"}<input data-item="${index}" data-prop="${external ? "url" : "route"}" value="${esc(external ? item.url || "" : item.route || item.url || "")}" placeholder="${social ? ((item.platform || "youtube") === "facebook" ? "https://www.facebook.com/.../posts/..." : "https://www.youtube.com/watch?v=...") : ""}"></label>`}
         ${trust ? "" : `<label>${social ? "Thumbnail รูปภาพ (ไม่บังคับ — ถ้าไม่ใส่จะใช้ภาพปกอัตโนมัติของ YouTube หรือไอคอน Facebook)" : "Image URL"}<input data-item="${index}" data-prop="image_url" value="${esc(item.image_url || "")}"></label>`}

--- a/customer-app/assets/customer-app.css
+++ b/customer-app/assets/customer-app.css
@@ -4602,6 +4602,11 @@ body.has-contact-sheet { overflow: hidden; }
   line-height: 1.26;
   color: var(--ink);
 }
+.homepage-quick.is-line span:first-child {
+  background: linear-gradient(135deg, #06c755 0%, #04a847 100%);
+  color: #fff;
+  box-shadow: 0 3px 8px rgba(6, 199, 85, 0.28);
+}
 
 /* ─── Promo banner — CMS-managed, full-width, uncropped image ────────── */
 .homepage-promo-banner {

--- a/customer-app/assets/customer-app.css
+++ b/customer-app/assets/customer-app.css
@@ -139,6 +139,18 @@ p { margin: 0; }
   -webkit-backdrop-filter: blur(18px) saturate(140%);
   border-bottom: 1px solid rgba(255, 255, 255, 0.06);
 }
+/* Signature CWF hairline: gold → blue → cobalt. Recurs on hero/cards/banner
+   below so the brand reads as one deliberate system, not a stock template. */
+.app-header::after {
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: -1px;
+  height: 2px;
+  background: linear-gradient(90deg, var(--yellow) 0%, var(--blue) 45%, var(--cobalt) 100%);
+  opacity: 0.85;
+  content: "";
+}
 
 .brand-lockup { display: flex; align-items: center; gap: 12px; min-width: 0; flex: 1 1 auto; }
 .brand-lockup > div:last-child { min-width: 0; }
@@ -4394,6 +4406,18 @@ body.has-contact-sheet { overflow: hidden; }
   scrollbar-width: none;
 }
 .homepage-hero-slider::-webkit-scrollbar { display: none; }
+/* Glossy premium sheen — a soft diagonal highlight plus a gold corner glow,
+   layered under the existing legibility gradient (::after, below). */
+.homepage-hero::before {
+  position: absolute;
+  inset: 0;
+  z-index: 0;
+  background:
+    radial-gradient(60% 70% at 100% 0%, rgba(255, 210, 59, 0.22) 0%, transparent 60%),
+    linear-gradient(115deg, rgba(255, 255, 255, 0.14) 0%, rgba(255, 255, 255, 0) 26%, rgba(255, 255, 255, 0) 100%);
+  pointer-events: none;
+  content: "";
+}
 .homepage-hero-slide {
   position: relative;
   flex: 0 0 100%;
@@ -4615,6 +4639,17 @@ body.has-contact-sheet { overflow: hidden; }
   border-radius: 20px;
   box-shadow: 0 6px 16px rgba(6, 24, 47, 0.08);
 }
+/* Thin brand frame so a CMS-uploaded banner image always reads as part of
+   the CWF system, never a bare stock photo dropped onto the page. */
+.homepage-promo-banner::after {
+  position: absolute;
+  inset: 0;
+  z-index: 2;
+  border-radius: inherit;
+  box-shadow: inset 0 0 0 1.5px rgba(255, 255, 255, 0.34), inset 0 -28px 32px -24px rgba(6, 24, 47, 0.30);
+  pointer-events: none;
+  content: "";
+}
 .homepage-promo-banner-track {
   display: flex;
   overflow-x: auto;
@@ -4772,6 +4807,16 @@ body.has-contact-sheet { overflow: hidden; }
 .homepage-article-card:active {
   transform: scale(0.97);
   box-shadow: 0 3px 10px rgba(6, 24, 47, 0.09);
+}
+/* Signature top edge — same gold/blue/cobalt hairline as the header, echoed
+   on every editorial card so the brand reads consistently across the app. */
+.homepage-service-card::before,
+.homepage-announcement-card::before,
+.homepage-article-card::before {
+  flex: 0 0 auto;
+  height: 3px;
+  background: linear-gradient(90deg, var(--yellow) 0%, var(--blue) 45%, var(--cobalt) 100%);
+  content: "";
 }
 
 /* Featured service: ~2 cards visible at 390 px */
@@ -4961,6 +5006,12 @@ body.has-contact-sheet { overflow: hidden; }
   transition: transform 0.1s, box-shadow 0.12s;
 }
 .homepage-social-card:active { transform: scale(0.97); box-shadow: 0 3px 10px rgba(6, 24, 47, 0.09); }
+.homepage-social-card::before {
+  flex: 0 0 auto;
+  height: 3px;
+  background: linear-gradient(90deg, var(--yellow) 0%, var(--blue) 45%, var(--cobalt) 100%);
+  content: "";
+}
 
 .homepage-social-media {
   position: relative;

--- a/customer-app/assets/customer-app.js
+++ b/customer-app/assets/customer-app.js
@@ -3,7 +3,7 @@
 
   const App = window.CWFCustomerAppV2;
   const BOOT_TIMEOUT_MS = 3500;
-  const BUILD_ID = "20260630_homepage_live_fixes";
+  const BUILD_ID = "20260630_homepage_polish_v1";
 
   function withTimeout(promise, timeoutMs) {
     return Promise.race([

--- a/customer-app/assets/customer-app.js
+++ b/customer-app/assets/customer-app.js
@@ -3,7 +3,7 @@
 
   const App = window.CWFCustomerAppV2;
   const BOOT_TIMEOUT_MS = 3500;
-  const BUILD_ID = "20260630_homepage_social_embeds";
+  const BUILD_ID = "20260630_homepage_live_fixes";
 
   function withTimeout(promise, timeoutMs) {
     return Promise.race([

--- a/customer-app/index.html
+++ b/customer-app/index.html
@@ -9,10 +9,10 @@
   <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
   <meta name="apple-mobile-web-app-title" content="CWF Service">
   <title>CWF Customer Service</title>
-  <link rel="manifest" href="./manifest.webmanifest?v=20260630_homepage_social_embeds">
+  <link rel="manifest" href="./manifest.webmanifest?v=20260630_homepage_live_fixes">
   <link rel="icon" type="image/png" sizes="192x192" href="./assets/icons/cwf-customer-192.png">
   <link rel="apple-touch-icon" sizes="180x180" href="./assets/icons/cwf-customer-180.png">
-  <link rel="stylesheet" href="./assets/customer-app.css?v=20260630_homepage_social_embeds">
+  <link rel="stylesheet" href="./assets/customer-app.css?v=20260630_homepage_live_fixes">
 </head>
 <body class="is-app-booting">
   <div class="app-shell" data-app-shell>
@@ -50,21 +50,21 @@
     </nav>
   </div>
 
-  <script src="./modules/state.js?v=20260630_homepage_social_embeds"></script>
-  <script src="./modules/utils.js?v=20260630_homepage_social_embeds"></script>
-  <script src="./modules/analytics.js?v=20260630_homepage_social_embeds"></script>
-  <script src="./modules/api.js?v=20260630_homepage_social_embeds"></script>
-  <script src="./modules/services.js?v=20260630_homepage_social_embeds"></script>
-  <script src="./modules/ui.js?v=20260630_homepage_social_embeds"></script>
-  <script src="./modules/store.js?v=20260630_homepage_social_embeds"></script>
-  <script src="./modules/auth.js?v=20260630_homepage_social_embeds"></script>
-  <script src="./modules/pricing.js?v=20260630_homepage_social_embeds"></script>
-  <script src="./modules/availability.js?v=20260630_homepage_social_embeds"></script>
-  <script src="./modules/bookingScheduled.js?v=20260630_homepage_social_embeds"></script>
-  <script src="./modules/bookingUrgent.js?v=20260630_homepage_social_embeds"></script>
-  <script src="./modules/tracking.js?v=20260630_homepage_social_embeds"></script>
-  <script src="./modules/profile.js?v=20260630_homepage_social_embeds"></script>
-  <script src="./modules/router.js?v=20260630_homepage_social_embeds"></script>
-  <script src="./assets/customer-app.js?v=20260630_homepage_social_embeds"></script>
+  <script src="./modules/state.js?v=20260630_homepage_live_fixes"></script>
+  <script src="./modules/utils.js?v=20260630_homepage_live_fixes"></script>
+  <script src="./modules/analytics.js?v=20260630_homepage_live_fixes"></script>
+  <script src="./modules/api.js?v=20260630_homepage_live_fixes"></script>
+  <script src="./modules/services.js?v=20260630_homepage_live_fixes"></script>
+  <script src="./modules/ui.js?v=20260630_homepage_live_fixes"></script>
+  <script src="./modules/store.js?v=20260630_homepage_live_fixes"></script>
+  <script src="./modules/auth.js?v=20260630_homepage_live_fixes"></script>
+  <script src="./modules/pricing.js?v=20260630_homepage_live_fixes"></script>
+  <script src="./modules/availability.js?v=20260630_homepage_live_fixes"></script>
+  <script src="./modules/bookingScheduled.js?v=20260630_homepage_live_fixes"></script>
+  <script src="./modules/bookingUrgent.js?v=20260630_homepage_live_fixes"></script>
+  <script src="./modules/tracking.js?v=20260630_homepage_live_fixes"></script>
+  <script src="./modules/profile.js?v=20260630_homepage_live_fixes"></script>
+  <script src="./modules/router.js?v=20260630_homepage_live_fixes"></script>
+  <script src="./assets/customer-app.js?v=20260630_homepage_live_fixes"></script>
 </body>
 </html>

--- a/customer-app/index.html
+++ b/customer-app/index.html
@@ -9,10 +9,10 @@
   <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
   <meta name="apple-mobile-web-app-title" content="CWF Service">
   <title>CWF Customer Service</title>
-  <link rel="manifest" href="./manifest.webmanifest?v=20260630_homepage_live_fixes">
+  <link rel="manifest" href="./manifest.webmanifest?v=20260630_homepage_polish_v1">
   <link rel="icon" type="image/png" sizes="192x192" href="./assets/icons/cwf-customer-192.png">
   <link rel="apple-touch-icon" sizes="180x180" href="./assets/icons/cwf-customer-180.png">
-  <link rel="stylesheet" href="./assets/customer-app.css?v=20260630_homepage_live_fixes">
+  <link rel="stylesheet" href="./assets/customer-app.css?v=20260630_homepage_polish_v1">
 </head>
 <body class="is-app-booting">
   <div class="app-shell" data-app-shell>
@@ -50,21 +50,21 @@
     </nav>
   </div>
 
-  <script src="./modules/state.js?v=20260630_homepage_live_fixes"></script>
-  <script src="./modules/utils.js?v=20260630_homepage_live_fixes"></script>
-  <script src="./modules/analytics.js?v=20260630_homepage_live_fixes"></script>
-  <script src="./modules/api.js?v=20260630_homepage_live_fixes"></script>
-  <script src="./modules/services.js?v=20260630_homepage_live_fixes"></script>
-  <script src="./modules/ui.js?v=20260630_homepage_live_fixes"></script>
-  <script src="./modules/store.js?v=20260630_homepage_live_fixes"></script>
-  <script src="./modules/auth.js?v=20260630_homepage_live_fixes"></script>
-  <script src="./modules/pricing.js?v=20260630_homepage_live_fixes"></script>
-  <script src="./modules/availability.js?v=20260630_homepage_live_fixes"></script>
-  <script src="./modules/bookingScheduled.js?v=20260630_homepage_live_fixes"></script>
-  <script src="./modules/bookingUrgent.js?v=20260630_homepage_live_fixes"></script>
-  <script src="./modules/tracking.js?v=20260630_homepage_live_fixes"></script>
-  <script src="./modules/profile.js?v=20260630_homepage_live_fixes"></script>
-  <script src="./modules/router.js?v=20260630_homepage_live_fixes"></script>
-  <script src="./assets/customer-app.js?v=20260630_homepage_live_fixes"></script>
+  <script src="./modules/state.js?v=20260630_homepage_polish_v1"></script>
+  <script src="./modules/utils.js?v=20260630_homepage_polish_v1"></script>
+  <script src="./modules/analytics.js?v=20260630_homepage_polish_v1"></script>
+  <script src="./modules/api.js?v=20260630_homepage_polish_v1"></script>
+  <script src="./modules/services.js?v=20260630_homepage_polish_v1"></script>
+  <script src="./modules/ui.js?v=20260630_homepage_polish_v1"></script>
+  <script src="./modules/store.js?v=20260630_homepage_polish_v1"></script>
+  <script src="./modules/auth.js?v=20260630_homepage_polish_v1"></script>
+  <script src="./modules/pricing.js?v=20260630_homepage_polish_v1"></script>
+  <script src="./modules/availability.js?v=20260630_homepage_polish_v1"></script>
+  <script src="./modules/bookingScheduled.js?v=20260630_homepage_polish_v1"></script>
+  <script src="./modules/bookingUrgent.js?v=20260630_homepage_polish_v1"></script>
+  <script src="./modules/tracking.js?v=20260630_homepage_polish_v1"></script>
+  <script src="./modules/profile.js?v=20260630_homepage_polish_v1"></script>
+  <script src="./modules/router.js?v=20260630_homepage_polish_v1"></script>
+  <script src="./assets/customer-app.js?v=20260630_homepage_polish_v1"></script>
 </body>
 </html>

--- a/customer-app/manifest.webmanifest
+++ b/customer-app/manifest.webmanifest
@@ -2,7 +2,7 @@
   "name": "CWF Customer Service",
   "short_name": "CWF Service",
   "description": "แอปลูกค้า Coldwindflow สำหรับเลือกบริการ จองคิว และติดตามงาน",
-  "start_url": "/customer-app/index.html?v=20260630_homepage_social_embeds#home",
+  "start_url": "/customer-app/index.html?v=20260630_homepage_live_fixes#home",
   "scope": "/customer-app/",
   "id": "/customer-app/",
   "display": "standalone",

--- a/customer-app/manifest.webmanifest
+++ b/customer-app/manifest.webmanifest
@@ -2,7 +2,7 @@
   "name": "CWF Customer Service",
   "short_name": "CWF Service",
   "description": "แอปลูกค้า Coldwindflow สำหรับเลือกบริการ จองคิว และติดตามงาน",
-  "start_url": "/customer-app/index.html?v=20260630_homepage_live_fixes#home",
+  "start_url": "/customer-app/index.html?v=20260630_homepage_polish_v1#home",
   "scope": "/customer-app/",
   "id": "/customer-app/",
   "display": "standalone",

--- a/customer-app/modules/ui.js
+++ b/customer-app/modules/ui.js
@@ -291,9 +291,10 @@
             : item.action === "contact"
               ? `href="#" data-home-contact="${root.utils.escapeHtml(item.title || "ติดต่อ CWF")}"`
               : `href="#${root.utils.escapeHtml(item.route || "home")}" data-route="${root.utils.escapeHtml(item.route || "home")}"`;
+          const iconName = item.icon || ["sparkle", "wrench", "pin", "line"][index] || "sparkle";
           return `
-            <a class="homepage-quick" ${attrs}>
-              <span>${root.utils.icon(item.icon || ["sparkle", "wrench", "pin", "chat"][index] || "sparkle", 20)}</span>
+            <a class="homepage-quick${iconName === "line" ? " is-line" : ""}" ${attrs}>
+              <span>${root.utils.icon(iconName, 20)}</span>
               <strong>${root.utils.escapeHtml(item.title || "-")}</strong>
             </a>
           `;
@@ -531,9 +532,8 @@
     if (section.type === "promo_banner") return renderHomepagePromoBanner(section);
     if (section.type === "active_job") return renderHomepageActiveJob(section);
     if (section.type === "featured_services") return renderHomepageFeaturedSection(section);
-    if (["updates", "articles"].includes(section.type)) return renderHomepageManualSection(section);
+    if (["updates", "articles", "announcements"].includes(section.type)) return renderHomepageManualSection(section);
     if (section.type === "social") return renderHomepageSocial(section);
-    if (section.type === "announcements") return "";
     if (section.type === "trust") return renderHomepageTrust(section);
     return "";
   }

--- a/customer-app/modules/utils.js
+++ b/customer-app/modules/utils.js
@@ -96,6 +96,7 @@
     wrench: '<path d="M21 4a5 5 0 0 1-6.5 6.5L6 19l-3-3 8.5-8.5A5 5 0 0 1 18 1l-3 3 2 2 3-3z"/>',
     play: '<path d="M8 5l11 7-11 7V5z" fill="currentColor" stroke="none"/>',
     facebook: '<path d="M14 22v-8h3l1-4h-4V8c0-1.1.6-2 2-2h2V2h-3c-3 0-5 2-5 5v3H7v4h3v8h4z" fill="currentColor" stroke="none"/>',
+    line: '<path d="M12 2C6.48 2 2 5.69 2 10.24c0 4.08 3.55 7.5 8.35 8.15.32.07.77.21.88.49.1.25.07.65.03.91l-.14.86c-.04.25-.2 1 .87.55.6-.27.74-.34.74-.34l.16-.09c3.41-1.46 5.31-2.91 6.93-4.78C21.05 13.7 22 11.96 22 10.24 22 5.69 17.52 2 12 2z" fill="currentColor" stroke="none"/><circle cx="8.2" cy="10.2" r="1" fill="#fff" stroke="none"/><circle cx="12" cy="10.2" r="1" fill="#fff" stroke="none"/><circle cx="15.8" cy="10.2" r="1" fill="#fff" stroke="none"/>',
   };
 
   function icon(name, size) {

--- a/customer-app/sw.js
+++ b/customer-app/sw.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const BUILD_ID = "20260630_homepage_live_fixes";
+const BUILD_ID = "20260630_homepage_polish_v1";
 const CACHE_NAME = `cwf-customer-app-v2-${BUILD_ID}`;
 const APP_SHELL = [
   `./index.html?v=${BUILD_ID}`,

--- a/customer-app/sw.js
+++ b/customer-app/sw.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const BUILD_ID = "20260630_homepage_social_embeds";
+const BUILD_ID = "20260630_homepage_live_fixes";
 const CACHE_NAME = `cwf-customer-app-v2-${BUILD_ID}`;
 const APP_SHELL = [
   `./index.html?v=${BUILD_ID}`,

--- a/index.js
+++ b/index.js
@@ -43,7 +43,8 @@ const createSystemRoutes = require("./server/routes/system");
 const createTechnicianDirectoryRoutes = require("./server/routes/users/technicians");
 const createCatalogItemRoutes = require("./server/routes/catalog/items");
 const createCatalogReviewRoutes = require("./server/routes/catalog/reviews");
-const { createHomepageRoutes } = require("./server/routes/homepage");
+const { createHomepageRoutes, CONFIG_KEY: HOMEPAGE_CONFIG_KEY } = require("./server/routes/homepage");
+const articleSync = require("./server/services/articleSync");
 const createServiceZoneRoutes = require("./server/routes/serviceZones");
 const createPageRoutes = require("./server/routes/pages");
 const createDocumentRoutes = require("./server/routes/docs");
@@ -18665,6 +18666,54 @@ function startUrgentFinalizerRunner() {
   return urgentFinalizerRunnerTimer;
 }
 
+// Homepage CMS "articles" section auto-sync (e.g. pulling posts from
+// www.cwf-air.com). Source URL / seed URLs are whatever the admin configured
+// in the CMS draft's published config — no server env config needed, the
+// admin controls it entirely from the Homepage CMS editor.
+const ARTICLE_SYNC_INTERVAL_MS = Math.max(1, Number(process.env.ARTICLE_SYNC_INTERVAL_HOURS) || 6) * 60 * 60 * 1000;
+let articleSyncRunnerInFlight = false;
+let articleSyncRunnerTimer = null;
+
+async function runArticleSyncOnce(source = 'manual') {
+  if (articleSyncRunnerInFlight) return { skipped: true, reason: 'in_flight' };
+  articleSyncRunnerInFlight = true;
+  try {
+    const configRow = await pool.query(
+      `SELECT published_config FROM public.homepage_cms_configs WHERE config_key=$1`,
+      [HOMEPAGE_CONFIG_KEY]
+    );
+    const config = configRow.rows?.[0]?.published_config;
+    const sections = Array.isArray(config?.sections) ? config.sections : [];
+    const results = [];
+    for (const section of sections) {
+      if (section?.type !== 'articles' || !section.auto_sync || !section.source_url) continue;
+      try {
+        const result = await articleSync.syncArticles(pool, section.source_url, { seedUrls: section.seed_urls || [], limit: 12 });
+        results.push({ source_url: section.source_url, ...result });
+      } catch (e) {
+        console.warn('[article_sync_runner] section sync failed', { source, source_url: section.source_url, error: e.message });
+      }
+    }
+    return { ok: true, results };
+  } catch (e) {
+    console.warn('[article_sync_runner] skip', { source, error: e.message });
+    return { ok: false, error: e.message };
+  } finally {
+    articleSyncRunnerInFlight = false;
+  }
+}
+
+function startArticleSyncRunner() {
+  if (articleSyncRunnerTimer) return articleSyncRunnerTimer;
+  if (!envBool('ARTICLE_SYNC_ENABLED', true)) return null;
+  setTimeout(() => { runArticleSyncOnce('startup').catch(() => {}); }, 15000).unref?.();
+  articleSyncRunnerTimer = setInterval(() => {
+    runArticleSyncOnce('interval').catch(() => {});
+  }, ARTICLE_SYNC_INTERVAL_MS);
+  if (typeof articleSyncRunnerTimer.unref === 'function') articleSyncRunnerTimer.unref();
+  return articleSyncRunnerTimer;
+}
+
 app.post("/tech/income-summary-batch", requireTechnicianSession, async (req, res) => {
   const requestedUsername = String(req.body?.username || req.query?.username || '').trim();
   const username = _authUsername(req);
@@ -26321,6 +26370,7 @@ function startServer() {
         console.log(`🔒 HTTPS CWF Server running`);
         console.log(`🔒 Local: https://localhost:${PORT}`);
         startUrgentFinalizerRunner();
+        startArticleSyncRunner();
       });
       return;
     }
@@ -26331,6 +26381,7 @@ function startServer() {
   app.listen(PORT, HOST, () => {
     console.log(`🌐 HTTP CWF Server running at http://localhost:${PORT}`);
     startUrgentFinalizerRunner();
+    startArticleSyncRunner();
   });
 }
 

--- a/migrations/20260630_homepage_article_sync.sql
+++ b/migrations/20260630_homepage_article_sync.sql
@@ -1,0 +1,28 @@
+-- Customer App Homepage CMS: synced articles cache for the "articles"
+-- section's auto-sync mode (pulls posts from an external site, e.g. the
+-- main cwf-air.com marketing site).
+-- Additive only. Review before running against production.
+
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS public.homepage_synced_articles (
+  id BIGSERIAL PRIMARY KEY,
+  source_url TEXT NOT NULL,
+  external_id TEXT NOT NULL,
+  title TEXT NOT NULL,
+  summary TEXT,
+  image_url TEXT,
+  link TEXT NOT NULL,
+  published_at TIMESTAMPTZ,
+  synced_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE (source_url, external_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_homepage_synced_articles_source
+  ON public.homepage_synced_articles(source_url, published_at DESC NULLS LAST);
+
+COMMIT;
+
+-- Rollback plan:
+-- DROP INDEX IF EXISTS public.idx_homepage_synced_articles_source;
+-- DROP TABLE IF EXISTS public.homepage_synced_articles;

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "migrate:catalog-autoplay": "node scripts/run-catalog-autoplay-migration.js",
     "migrate:catalog-hot-sale-reviews": "node scripts/run-catalog-store-hot-sale-reviews-migration.js",
     "migrate:homepage-cms": "node scripts/run-homepage-cms-migration.js",
+    "migrate:homepage-article-sync": "node scripts/run-homepage-article-sync-migration.js",
     "test": "node --test test/*.test.js"
   },
   "dependencies": {

--- a/scripts/run-homepage-article-sync-migration.js
+++ b/scripts/run-homepage-article-sync-migration.js
@@ -1,0 +1,111 @@
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+const { Client } = require("pg");
+
+const MIGRATION_RELATIVE_PATH = "migrations/20260630_homepage_article_sync.sql";
+const ADVISORY_LOCK_KEY = "202606300101";
+
+function clean(value) {
+  return String(value == null ? "" : value).trim();
+}
+
+function safeErrorMessage(error) {
+  return clean(error && error.message ? error.message : error)
+    .replace(/postgres(?:ql)?:\/\/[^\s"'<>]+/gi, "[REDACTED_DATABASE_URL]")
+    .replace(/(password|passwd|pwd|secret|token)=([^&\s]+)/gi, "$1=[REDACTED]");
+}
+
+function resolveMigrationPath(repoRoot = path.resolve(__dirname, "..")) {
+  const root = path.resolve(repoRoot);
+  const migrationPath = path.resolve(root, MIGRATION_RELATIVE_PATH);
+  const expected = path.resolve(root, "migrations", "20260630_homepage_article_sync.sql");
+  if (migrationPath !== expected || !migrationPath.startsWith(root + path.sep)) {
+    throw new Error("migration path rejected");
+  }
+  return migrationPath;
+}
+
+function readMigrationSql(repoRoot) {
+  return fs.readFileSync(resolveMigrationPath(repoRoot), "utf8");
+}
+
+function createClientConfig(env = process.env) {
+  const databaseUrl = clean(env.DATABASE_URL);
+  if (databaseUrl) {
+    return {
+      connectionString: databaseUrl,
+      options: "-c timezone=Asia/Bangkok",
+      ssl: { rejectUnauthorized: false },
+    };
+  }
+  return {
+    host: clean(env.DB_HOST),
+    port: Number(env.DB_PORT || 5432),
+    user: clean(env.DB_USER),
+    password: env.DB_PASSWORD,
+    database: clean(env.DB_NAME),
+    options: "-c timezone=Asia/Bangkok",
+    ssl: { rejectUnauthorized: false },
+  };
+}
+
+async function verifySchema(client) {
+  const tables = await client.query(`
+    SELECT to_regclass('public.homepage_synced_articles') AS synced_articles
+  `);
+  if (!tables.rows?.[0]?.synced_articles) throw new Error("homepage_synced_articles table missing after migration");
+}
+
+async function runMigration(options = {}) {
+  const env = options.env || process.env;
+  const logger = options.logger || console;
+  const repoRoot = options.repoRoot || path.resolve(__dirname, "..");
+  const clientFactory = options.clientFactory || ((config) => new Client(config));
+  const client = clientFactory(createClientConfig(env));
+  const sql = readMigrationSql(repoRoot);
+  let locked = false;
+
+  logger.log("HOMEPAGE_ARTICLE_SYNC_MIGRATION_START");
+  try {
+    await client.connect();
+    await client.query("SELECT pg_advisory_lock($1::bigint)", [ADVISORY_LOCK_KEY]);
+    locked = true;
+    await client.query(sql);
+    await verifySchema(client);
+    logger.log("HOMEPAGE_ARTICLE_SYNC_MIGRATION_OK");
+  } finally {
+    if (locked) await client.query("SELECT pg_advisory_unlock($1::bigint)", [ADVISORY_LOCK_KEY]).catch(() => {});
+    await client.end();
+  }
+}
+
+async function runCli(options = {}) {
+  const logger = options.logger || console;
+  try {
+    await runMigration(options);
+    return 0;
+  } catch (error) {
+    logger.error(`HOMEPAGE_ARTICLE_SYNC_MIGRATION_FAILED: ${safeErrorMessage(error)}`);
+    return 1;
+  }
+}
+
+if (require.main === module) {
+  runCli().then((code) => {
+    process.exitCode = code;
+  });
+}
+
+module.exports = {
+  ADVISORY_LOCK_KEY,
+  MIGRATION_RELATIVE_PATH,
+  createClientConfig,
+  readMigrationSql,
+  resolveMigrationPath,
+  runCli,
+  runMigration,
+  safeErrorMessage,
+  verifySchema,
+};

--- a/server/routes/homepage.js
+++ b/server/routes/homepage.js
@@ -61,7 +61,7 @@ const DEFAULT_CONFIG = {
         { title: "จองล้างแอร์", route: "scheduled", icon: "sparkle" },
         { title: "แจ้งซ่อม", action: "contact", icon: "wrench" },
         { title: "ติดตามงาน", route: "tracking", icon: "pin" },
-        { title: "LINE", url: "https://lin.ee/fG1Oq7y", icon: "chat" },
+        { title: "LINE", url: "https://lin.ee/fG1Oq7y", icon: "line" },
       ],
     },
     {

--- a/server/routes/homepage.js
+++ b/server/routes/homepage.js
@@ -3,6 +3,7 @@
 const crypto = require("crypto");
 const express = require("express");
 const { validateCatalogImageFile } = require("../lib/cloudinaryImageUpload");
+const articleSync = require("../services/articleSync");
 
 const CONFIG_KEY = "customer_homepage_v1";
 const MAX_JSON_BYTES = 120 * 1024;
@@ -25,6 +26,7 @@ const FOCAL_POSITIONS = new Set(["top", "center", "bottom"]);
 const ASPECT_MODES = new Set(["contain", "cover"]);
 const MAX_PROMO_BANNERS = 8;
 const MAX_SOCIAL_ITEMS = 8;
+const MAX_SEED_URLS = 8;
 const SOCIAL_PLATFORMS = new Set(["facebook", "youtube"]);
 // Admin pastes a public post/video URL; no Graph/YouTube Data API calls are
 // made server-side, so the only safety check we can do is confirm the URL
@@ -308,6 +310,32 @@ function normalizeSection(raw, index, errors) {
     out.item_ids = [...new Set(itemIds.map((value) => cleanText(value, 80)).filter(Boolean))].slice(0, 12);
     if (mode === "manual" && !out.item_ids.length) errors.push(`${id}.item_ids required for manual mode`);
   }
+  if (type === "articles") {
+    out.auto_sync = section.auto_sync === true;
+    const sourceUrl = cleanText(section.source_url, 300);
+    if (sourceUrl) {
+      try {
+        const parsed = new URL(sourceUrl);
+        if (!["http:", "https:"].includes(parsed.protocol)) errors.push(`${id}.source_url must be http/https`);
+      } catch (_) {
+        errors.push(`${id}.source_url invalid`);
+      }
+    }
+    out.source_url = sourceUrl;
+    const seedUrls = Array.isArray(section.seed_urls) ? section.seed_urls : [];
+    out.seed_urls = seedUrls.slice(0, MAX_SEED_URLS).map((value, seedIndex) => {
+      const url = cleanText(value, 500);
+      if (!url) return "";
+      try {
+        const parsed = new URL(url);
+        if (!["http:", "https:"].includes(parsed.protocol)) errors.push(`${id}.seed_urls.${seedIndex} must be http/https`);
+      } catch (_) {
+        errors.push(`${id}.seed_urls.${seedIndex} invalid`);
+      }
+      return url;
+    }).filter(Boolean);
+    if (out.auto_sync && !out.source_url) errors.push(`${id}.source_url required when auto_sync is enabled`);
+  }
   return out;
 }
 
@@ -381,6 +409,20 @@ function stripPublicConfig(config) {
       return cleanSection;
     });
   return { version: 1, sections };
+}
+
+async function hydrateAutoSyncArticles(pool, publicConfig) {
+  const sections = publicConfig?.sections || [];
+  for (const section of sections) {
+    if (section.type !== "articles" || !section.auto_sync || !section.source_url) continue;
+    try {
+      const synced = await articleSync.getSyncedArticles(pool, section.source_url, 8);
+      if (synced.articles.length) section.items = synced.articles;
+    } catch (error) {
+      if (!isSchemaError(error)) console.error("[homepage/public/sync-hydrate] failed", error);
+      // sync cache unavailable — keep whatever items were already on the section
+    }
+  }
 }
 
 function safeHomepageActiveJob(row) {
@@ -490,9 +532,11 @@ function createHomepageRoutes(deps = {}) {
     try {
       const row = await loadPublished(pool);
       const config = row?.published_config || DEFAULT_CONFIG;
+      const publicConfig = stripPublicConfig(config);
+      await hydrateAutoSyncArticles(pool, publicConfig);
       res.json({
         ok: true,
-        config: stripPublicConfig(config),
+        config: publicConfig,
         featured_services: [],
         fallback: !row?.published_config,
       });
@@ -661,6 +705,43 @@ function createHomepageRoutes(deps = {}) {
       if (isSchemaError(error)) return res.status(503).json({ error: "HOMEPAGE_CMS_SCHEMA_NOT_READY" });
       console.error("[homepage/admin/delete-image] failed", error);
       res.status(500).json({ error: "ลบรูปไม่สำเร็จ" });
+    }
+  });
+
+  router.post("/admin/homepage-cms/sync-articles", requireAdminSession, async (req, res) => {
+    try {
+      const sourceUrl = cleanText(req.body?.source_url, 300);
+      if (!sourceUrl) return res.status(400).json({ error: "source_url required" });
+      const seedUrls = Array.isArray(req.body?.seed_urls)
+        ? req.body.seed_urls.map((value) => cleanText(value, 500)).filter(Boolean).slice(0, MAX_SEED_URLS)
+        : [];
+      const result = await articleSync.syncArticles(pool, sourceUrl, { seedUrls, limit: 12 });
+      if (!result.ok) return res.status(400).json({ error: result.error || "SYNC_FAILED" });
+      const synced = await articleSync.getSyncedArticles(pool, sourceUrl, 12);
+      res.json({
+        ok: true,
+        synced_count: result.synced,
+        fetched_count: result.fetched,
+        articles: synced.articles,
+        last_synced_at: synced.last_synced_at,
+      });
+    } catch (error) {
+      if (isSchemaError(error)) return res.status(503).json({ error: "HOMEPAGE_CMS_SCHEMA_NOT_READY" });
+      console.error("[homepage/admin/sync-articles] failed", error);
+      res.status(500).json({ error: error.message || "ซิงค์บทความไม่สำเร็จ" });
+    }
+  });
+
+  router.get("/admin/homepage-cms/synced-articles", requireAdminSession, async (req, res) => {
+    try {
+      const sourceUrl = cleanText(req.query?.source_url, 300);
+      if (!sourceUrl) return res.json({ ok: true, articles: [], last_synced_at: null });
+      const synced = await articleSync.getSyncedArticles(pool, sourceUrl, 12);
+      res.json({ ok: true, ...synced });
+    } catch (error) {
+      if (isSchemaError(error)) return res.status(503).json({ error: "HOMEPAGE_CMS_SCHEMA_NOT_READY" });
+      console.error("[homepage/admin/synced-articles] failed", error);
+      res.status(500).json({ error: "โหลดข้อมูลที่ซิงค์ไม่สำเร็จ" });
     }
   });
 

--- a/server/services/articleSync.js
+++ b/server/services/articleSync.js
@@ -1,0 +1,238 @@
+"use strict";
+
+// Pulls articles from an external site (the cwf-air.com marketing site) into
+// the homepage CMS's "articles" section when auto_sync is enabled. Tries the
+// site's WordPress REST API first (structured, reliable); falls back to
+// scraping Open Graph / JSON-LD metadata off admin-provided seed URLs when
+// the REST API isn't available (e.g. disabled, or the site isn't WordPress).
+
+const DEFAULT_TIMEOUT_MS = 10000;
+const DEFAULT_PER_PAGE = 12;
+
+function cleanText(value, max = 500) {
+  return String(value == null ? "" : value).replace(/\s+/g, " ").trim().slice(0, max);
+}
+
+function stripHtml(value) {
+  return cleanText(String(value || "").replace(/<[^>]*>/g, " "));
+}
+
+function decodeHtmlEntities(value) {
+  return String(value || "")
+    .replace(/&amp;/g, "&")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, "\"")
+    .replace(/&#0?39;/g, "'");
+}
+
+function normalizeSourceUrl(sourceUrl) {
+  const trimmed = cleanText(sourceUrl, 300).replace(/\/+$/, "");
+  if (!trimmed) return "";
+  try {
+    const parsed = new URL(trimmed);
+    if (!["http:", "https:"].includes(parsed.protocol)) return "";
+    return `${parsed.protocol}//${parsed.host}`;
+  } catch (_) {
+    return "";
+  }
+}
+
+async function fetchWithTimeout(url, options = {}) {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), options.timeoutMs || DEFAULT_TIMEOUT_MS);
+  try {
+    return await fetch(url, { ...options, signal: controller.signal });
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+function pickFeaturedImage(post) {
+  const media = post?._embedded?.["wp:featuredmedia"]?.[0];
+  return media?.source_url ? cleanText(media.source_url, 700) : "";
+}
+
+function extractRenderedField(value) {
+  return value && typeof value === "object" ? value.rendered : value;
+}
+
+function normalizeWordPressPost(post) {
+  if (!post || typeof post !== "object") return null;
+  const externalId = cleanText(post.slug || post.id, 200);
+  const link = cleanText(post.link, 700);
+  const title = stripHtml(decodeHtmlEntities(extractRenderedField(post.title))).slice(0, 120);
+  if (!externalId || !link || !title) return null;
+  return {
+    external_id: externalId,
+    title,
+    summary: stripHtml(decodeHtmlEntities(extractRenderedField(post.excerpt))).slice(0, 260),
+    image_url: pickFeaturedImage(post),
+    link,
+    published_at: post.date_gmt ? `${post.date_gmt}Z` : (post.date || null),
+  };
+}
+
+async function fetchFromWordPressApi(baseUrl, options = {}) {
+  const perPage = Math.max(1, Math.min(20, Number(options.limit) || DEFAULT_PER_PAGE));
+  const url = `${baseUrl}/wp-json/wp/v2/posts?per_page=${perPage}&_embed=true&orderby=date&order=desc`;
+  const res = await fetchWithTimeout(url, { timeoutMs: options.timeoutMs, headers: { Accept: "application/json" } });
+  if (!res.ok) throw new Error(`WP_API_HTTP_${res.status}`);
+  const contentType = String(res.headers.get("content-type") || "");
+  if (!contentType.includes("application/json")) throw new Error("WP_API_NOT_JSON");
+  const body = await res.json();
+  if (!Array.isArray(body)) throw new Error("WP_API_UNEXPECTED_SHAPE");
+  return body.map(normalizeWordPressPost).filter(Boolean);
+}
+
+function extractMetaContent(html, propertyOrName) {
+  const forward = new RegExp(`<meta[^>]+(?:property|name)=["']${propertyOrName}["'][^>]+content=["']([^"']*)["']`, "i");
+  const forwardMatch = html.match(forward);
+  if (forwardMatch) return forwardMatch[1];
+  const reversed = new RegExp(`<meta[^>]+content=["']([^"']*)["'][^>]+(?:property|name)=["']${propertyOrName}["']`, "i");
+  const reversedMatch = html.match(reversed);
+  return reversedMatch ? reversedMatch[1] : "";
+}
+
+function extractJsonLdArticle(html) {
+  const blocks = html.match(/<script[^>]+type=["']application\/ld\+json["'][^>]*>([\s\S]*?)<\/script>/gi) || [];
+  for (const block of blocks) {
+    const inner = block.replace(/^[\s\S]*?>/, "").replace(/<\/script>\s*$/i, "");
+    try {
+      const parsed = JSON.parse(inner);
+      const candidates = Array.isArray(parsed) ? parsed : [parsed];
+      for (const candidate of candidates) {
+        const types = Array.isArray(candidate?.["@type"]) ? candidate["@type"] : [candidate?.["@type"]];
+        if (types.some((t) => /article|blogposting|newsarticle/i.test(String(t || "")))) return candidate;
+      }
+    } catch (_) {
+      // ignore unparsable JSON-LD blocks, keep scanning the rest
+    }
+  }
+  return null;
+}
+
+function parseArticleHtml(html, pageUrl) {
+  const jsonLd = extractJsonLdArticle(html);
+  const ogTitle = decodeHtmlEntities(extractMetaContent(html, "og:title"));
+  const ogDescription = decodeHtmlEntities(extractMetaContent(html, "og:description"));
+  const ogImage = extractMetaContent(html, "og:image");
+  const titleTagMatch = html.match(/<title[^>]*>([^<]*)<\/title>/i);
+
+  const title = stripHtml(jsonLd?.headline || ogTitle || (titleTagMatch ? decodeHtmlEntities(titleTagMatch[1]) : "")).slice(0, 120);
+  if (!title) return null;
+  const summary = stripHtml(jsonLd?.description || ogDescription).slice(0, 260);
+  const jsonLdImage = Array.isArray(jsonLd?.image) ? jsonLd.image[0] : (jsonLd?.image?.url || jsonLd?.image);
+  const image = cleanText(jsonLdImage || ogImage, 700);
+  const publishedAt = cleanText(jsonLd?.datePublished || "", 40) || null;
+
+  let externalId = pageUrl;
+  try {
+    externalId = new URL(pageUrl).pathname.replace(/\/+$/, "").split("/").pop() || pageUrl;
+  } catch (_) {
+    // keep pageUrl as the external_id fallback
+  }
+  return {
+    external_id: cleanText(externalId, 200),
+    title,
+    summary,
+    image_url: image,
+    link: pageUrl,
+    published_at: publishedAt,
+  };
+}
+
+async function fetchFromSeedUrls(seedUrls, options = {}) {
+  const results = [];
+  for (const seedUrl of seedUrls) {
+    try {
+      const res = await fetchWithTimeout(seedUrl, { timeoutMs: options.timeoutMs, headers: { Accept: "text/html" } });
+      if (!res.ok) continue;
+      const html = await res.text();
+      const article = parseArticleHtml(html, seedUrl);
+      if (article) results.push(article);
+    } catch (_) {
+      // skip unreachable/unparsable seed URLs, keep going with the rest
+    }
+  }
+  return results;
+}
+
+async function fetchArticlesFromSource(sourceUrl, options = {}) {
+  const baseUrl = normalizeSourceUrl(sourceUrl);
+  if (!baseUrl) throw new Error("INVALID_SOURCE_URL");
+  try {
+    const fromApi = await fetchFromWordPressApi(baseUrl, options);
+    if (fromApi.length) return fromApi;
+  } catch (_) {
+    // WP REST API unavailable/disabled/non-WordPress site — fall back below
+  }
+  const seedUrls = Array.isArray(options.seedUrls) ? options.seedUrls.filter(Boolean) : [];
+  if (!seedUrls.length) return [];
+  return fetchFromSeedUrls(seedUrls, options);
+}
+
+async function syncArticles(pool, sourceUrl, options = {}) {
+  const baseUrl = normalizeSourceUrl(sourceUrl);
+  if (!baseUrl) return { ok: false, error: "INVALID_SOURCE_URL", synced: 0, fetched: 0 };
+  const articles = await fetchArticlesFromSource(baseUrl, options);
+  let synced = 0;
+  for (const article of articles) {
+    await pool.query(
+      `INSERT INTO public.homepage_synced_articles
+         (source_url, external_id, title, summary, image_url, link, published_at, synced_at)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, NOW())
+       ON CONFLICT (source_url, external_id) DO UPDATE
+         SET title=EXCLUDED.title,
+             summary=EXCLUDED.summary,
+             image_url=EXCLUDED.image_url,
+             link=EXCLUDED.link,
+             published_at=EXCLUDED.published_at,
+             synced_at=NOW()`,
+      [baseUrl, article.external_id, article.title, article.summary || null, article.image_url || null, article.link, article.published_at]
+    );
+    synced += 1;
+  }
+  return { ok: true, synced, fetched: articles.length };
+}
+
+async function getSyncedArticles(pool, sourceUrl, limit = 12) {
+  const baseUrl = normalizeSourceUrl(sourceUrl);
+  if (!baseUrl) return { articles: [], last_synced_at: null };
+  const result = await pool.query(
+    `SELECT title, summary, image_url, link, published_at, synced_at
+       FROM public.homepage_synced_articles
+      WHERE source_url=$1
+      ORDER BY published_at DESC NULLS LAST, synced_at DESC
+      LIMIT $2`,
+    [baseUrl, Math.max(1, Math.min(20, Number(limit) || 12))]
+  );
+  const rows = result.rows || [];
+  const lastSyncedAt = rows.reduce((latest, row) => {
+    const ts = row.synced_at ? new Date(row.synced_at).getTime() : 0;
+    return ts > latest ? ts : latest;
+  }, 0);
+  return {
+    articles: rows.map((row) => ({
+      title: row.title,
+      body: row.summary || "",
+      image_url: row.image_url || "",
+      url: row.link,
+      date_label: row.published_at
+        ? new Date(row.published_at).toLocaleDateString("th-TH", { year: "numeric", month: "short", day: "numeric" })
+        : "",
+    })),
+    last_synced_at: lastSyncedAt ? new Date(lastSyncedAt).toISOString() : null,
+  };
+}
+
+module.exports = {
+  normalizeSourceUrl,
+  fetchArticlesFromSource,
+  fetchFromWordPressApi,
+  fetchFromSeedUrls,
+  parseArticleHtml,
+  normalizeWordPressPost,
+  syncArticles,
+  getSyncedArticles,
+};

--- a/test/articleSync.test.js
+++ b/test/articleSync.test.js
@@ -1,0 +1,263 @@
+"use strict";
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const {
+  normalizeSourceUrl,
+  fetchFromWordPressApi,
+  fetchFromSeedUrls,
+  parseArticleHtml,
+  normalizeWordPressPost,
+  fetchArticlesFromSource,
+  syncArticles,
+  getSyncedArticles,
+} = require("../server/services/articleSync");
+
+function jsonResponse(body, init = {}) {
+  return {
+    ok: init.status == null || (init.status >= 200 && init.status < 300),
+    status: init.status || 200,
+    headers: { get: (name) => (String(name).toLowerCase() === "content-type" ? (init.contentType || "application/json") : "") },
+    json: async () => body,
+    text: async () => JSON.stringify(body),
+  };
+}
+
+function htmlResponse(html, init = {}) {
+  return {
+    ok: init.status == null || (init.status >= 200 && init.status < 300),
+    status: init.status || 200,
+    headers: { get: (name) => (String(name).toLowerCase() === "content-type" ? "text/html" : "") },
+    text: async () => html,
+  };
+}
+
+async function withMockFetch(handler, fn) {
+  const original = global.fetch;
+  global.fetch = handler;
+  try {
+    await fn();
+  } finally {
+    global.fetch = original;
+  }
+}
+
+function createSyncPool() {
+  const rows = [];
+  return {
+    rows,
+    async query(sql, params = []) {
+      const normalized = String(sql).replace(/\s+/g, " ");
+      if (normalized.includes("INSERT INTO public.homepage_synced_articles")) {
+        const [source_url, external_id, title, summary, image_url, link, published_at] = params;
+        const idx = rows.findIndex((row) => row.source_url === source_url && row.external_id === external_id);
+        const row = { source_url, external_id, title, summary, image_url, link, published_at, synced_at: new Date().toISOString() };
+        if (idx >= 0) rows[idx] = row; else rows.push(row);
+        return { rows: [] };
+      }
+      if (normalized.includes("FROM public.homepage_synced_articles")) {
+        const [sourceUrl, limit] = params;
+        const filtered = rows
+          .filter((row) => row.source_url === sourceUrl)
+          .sort((a, b) => {
+            const ad = a.published_at ? new Date(a.published_at).getTime() : -Infinity;
+            const bd = b.published_at ? new Date(b.published_at).getTime() : -Infinity;
+            if (bd !== ad) return bd - ad;
+            return new Date(b.synced_at).getTime() - new Date(a.synced_at).getTime();
+          })
+          .slice(0, limit);
+        return { rows: filtered };
+      }
+      throw new Error(`Unhandled query: ${normalized}`);
+    },
+  };
+}
+
+test("normalizeSourceUrl keeps only protocol+host and rejects non-http(s)/invalid input", () => {
+  assert.equal(normalizeSourceUrl("https://www.cwf-air.com/blog/?x=1"), "https://www.cwf-air.com");
+  assert.equal(normalizeSourceUrl("https://www.cwf-air.com///"), "https://www.cwf-air.com");
+  assert.equal(normalizeSourceUrl("ftp://www.cwf-air.com"), "");
+  assert.equal(normalizeSourceUrl("not a url"), "");
+  assert.equal(normalizeSourceUrl(""), "");
+});
+
+test("normalizeWordPressPost decodes HTML entities in title/excerpt, strips tags, and picks featured media", () => {
+  const post = {
+    id: 501,
+    slug: "air-conditioner-water-leaking",
+    link: "https://www.cwf-air.com/air-conditioner-water-leaking/",
+    title: { rendered: "แอร์มีน้ำหยด &amp; วิธีแก้ไขเบื้องต้น" },
+    excerpt: { rendered: "<p>สาเหตุที่แอร์มีน้ำหยด &amp; วิธีแก้ไขที่ถูกต้อง</p>\n" },
+    date: "2026-06-01T09:00:00",
+    date_gmt: "2026-06-01T02:00:00",
+    _embedded: { "wp:featuredmedia": [{ source_url: "https://www.cwf-air.com/wp-content/uploads/leak.jpg" }] },
+  };
+  const normalized = normalizeWordPressPost(post);
+  assert.equal(normalized.external_id, "air-conditioner-water-leaking");
+  assert.equal(normalized.title, "แอร์มีน้ำหยด & วิธีแก้ไขเบื้องต้น");
+  assert.equal(normalized.summary, "สาเหตุที่แอร์มีน้ำหยด & วิธีแก้ไขที่ถูกต้อง");
+  assert.equal(normalized.image_url, "https://www.cwf-air.com/wp-content/uploads/leak.jpg");
+  assert.equal(normalized.link, post.link);
+  assert.equal(normalized.published_at, "2026-06-01T02:00:00Z");
+});
+
+test("normalizeWordPressPost returns null when slug, link, or title is missing", () => {
+  assert.equal(normalizeWordPressPost(null), null);
+  assert.equal(normalizeWordPressPost({ link: "https://x.com/a", title: { rendered: "x" } }), null);
+  assert.equal(normalizeWordPressPost({ slug: "a", title: { rendered: "x" } }), null);
+  assert.equal(normalizeWordPressPost({ slug: "a", link: "https://x.com/a", title: { rendered: "" } }), null);
+});
+
+test("fetchFromWordPressApi requests the expected REST endpoint and maps posts", async () => {
+  const posts = [
+    { id: 1, slug: "post-a", link: "https://www.cwf-air.com/post-a/", title: { rendered: "Post A" }, excerpt: { rendered: "Body A" }, date: "2026-01-01T00:00:00" },
+    { id: 2, slug: "post-b", link: "https://www.cwf-air.com/post-b/", title: { rendered: "Post B" }, excerpt: { rendered: "Body B" }, date: "2026-01-02T00:00:00" },
+  ];
+  let requestedUrl = null;
+  await withMockFetch(async (url) => { requestedUrl = url; return jsonResponse(posts); }, async () => {
+    const result = await fetchFromWordPressApi("https://www.cwf-air.com", { limit: 5 });
+    assert.equal(result.length, 2);
+    assert.equal(result[0].external_id, "post-a");
+    assert.equal(result[1].title, "Post B");
+  });
+  assert.match(requestedUrl, /^https:\/\/www\.cwf-air\.com\/wp-json\/wp\/v2\/posts\?per_page=5&_embed=true&orderby=date&order=desc$/);
+});
+
+test("fetchFromWordPressApi throws on non-2xx status, non-JSON content-type, or unexpected body shape", async () => {
+  await withMockFetch(async () => jsonResponse({}, { status: 404 }), async () => {
+    await assert.rejects(() => fetchFromWordPressApi("https://www.cwf-air.com"), /WP_API_HTTP_404/);
+  });
+  await withMockFetch(async () => jsonResponse([], { contentType: "text/html" }), async () => {
+    await assert.rejects(() => fetchFromWordPressApi("https://www.cwf-air.com"), /WP_API_NOT_JSON/);
+  });
+  await withMockFetch(async () => jsonResponse({ not: "an array" }), async () => {
+    await assert.rejects(() => fetchFromWordPressApi("https://www.cwf-air.com"), /WP_API_UNEXPECTED_SHAPE/);
+  });
+});
+
+const SAMPLE_ARTICLE_HTML = `<!doctype html>
+<html><head>
+<title>แอร์ไม่เย็น สาเหตุและวิธีแก้ - CWF</title>
+<meta property="og:title" content="แอร์ไม่เย็น สาเหตุและวิธีแก้ไข &amp; การดูแลรักษา">
+<meta property="og:description" content="รวมสาเหตุที่แอร์ไม่เย็นและวิธีแก้ไขเบื้องต้นก่อนเรียกช่าง">
+<meta property="og:image" content="https://www.cwf-air.com/wp-content/uploads/not-cooling.jpg">
+<script type="application/ld+json">
+{"@context":"https://schema.org","@type":"Article","headline":"แอร์ไม่เย็น สาเหตุและวิธีแก้ไข","description":"คำอธิบายแบบละเอียดเกี่ยวกับแอร์ไม่เย็น","image":["https://www.cwf-air.com/wp-content/uploads/not-cooling-jsonld.jpg"],"datePublished":"2026-05-20T08:00:00+07:00"}
+</script>
+</head><body><p>เนื้อหาบทความ</p></body></html>`;
+
+test("parseArticleHtml prefers JSON-LD over OG tags and derives external_id from the URL slug", () => {
+  const article = parseArticleHtml(SAMPLE_ARTICLE_HTML, "https://www.cwf-air.com/air-conditioner-not-cooling/");
+  assert.equal(article.external_id, "air-conditioner-not-cooling");
+  assert.equal(article.title, "แอร์ไม่เย็น สาเหตุและวิธีแก้ไข");
+  assert.equal(article.summary, "คำอธิบายแบบละเอียดเกี่ยวกับแอร์ไม่เย็น");
+  assert.equal(article.image_url, "https://www.cwf-air.com/wp-content/uploads/not-cooling-jsonld.jpg");
+  assert.equal(article.published_at, "2026-05-20T08:00:00+07:00");
+  assert.equal(article.link, "https://www.cwf-air.com/air-conditioner-not-cooling/");
+});
+
+test("parseArticleHtml falls back to OG tags, then <title>, when JSON-LD is absent", () => {
+  const ogOnly = `<html><head>
+    <meta property="og:title" content="หัวข้อจาก OG &amp; เครื่องหมาย">
+    <meta property="og:description" content="คำอธิบายจาก OG">
+    <meta property="og:image" content="https://www.cwf-air.com/og.jpg">
+  </head><body></body></html>`;
+  const article = parseArticleHtml(ogOnly, "https://www.cwf-air.com/some-post/");
+  assert.equal(article.title, "หัวข้อจาก OG & เครื่องหมาย");
+  assert.equal(article.summary, "คำอธิบายจาก OG");
+  assert.equal(article.image_url, "https://www.cwf-air.com/og.jpg");
+
+  const titleOnly = `<html><head><title>หัวข้อจาก title tag</title></head><body></body></html>`;
+  const fromTitle = parseArticleHtml(titleOnly, "https://www.cwf-air.com/other-post/");
+  assert.equal(fromTitle.title, "หัวข้อจาก title tag");
+});
+
+test("parseArticleHtml returns null when no usable title can be found", () => {
+  assert.equal(parseArticleHtml("<html><head></head><body>no metadata here</body></html>", "https://www.cwf-air.com/x/"), null);
+});
+
+test("fetchFromSeedUrls skips unreachable or unparsable URLs and keeps going", async () => {
+  const seedUrls = [
+    "https://www.cwf-air.com/air-conditioner-water-leaking/",
+    "https://www.cwf-air.com/broken-page/",
+    "https://www.cwf-air.com/air-conditioner-not-cooling/",
+  ];
+  await withMockFetch(async (url) => {
+    if (String(url).includes("broken-page")) return htmlResponse("", { status: 500 });
+    if (String(url).includes("water-leaking")) return htmlResponse(`<html><head><meta property="og:title" content="แอร์มีน้ำหยด"></head></html>`);
+    return htmlResponse(SAMPLE_ARTICLE_HTML);
+  }, async () => {
+    const results = await fetchFromSeedUrls(seedUrls);
+    assert.equal(results.length, 2);
+    assert.equal(results[0].title, "แอร์มีน้ำหยด");
+    assert.equal(results[1].external_id, "air-conditioner-not-cooling");
+  });
+});
+
+test("fetchArticlesFromSource tries the WordPress REST API first and only falls back to seed URLs when it yields nothing", async () => {
+  let apiCalled = false;
+  let seedCalled = false;
+  await withMockFetch(async (url) => {
+    if (String(url).includes("/wp-json/")) { apiCalled = true; return jsonResponse([{ id: 1, slug: "a", link: "https://www.cwf-air.com/a/", title: { rendered: "A" }, excerpt: { rendered: "x" }, date: "2026-01-01" }]); }
+    seedCalled = true;
+    return htmlResponse(SAMPLE_ARTICLE_HTML);
+  }, async () => {
+    const result = await fetchArticlesFromSource("https://www.cwf-air.com", { seedUrls: ["https://www.cwf-air.com/air-conditioner-not-cooling/"] });
+    assert.equal(result.length, 1);
+    assert.equal(apiCalled, true);
+    assert.equal(seedCalled, false);
+  });
+
+  await withMockFetch(async (url) => {
+    if (String(url).includes("/wp-json/")) { apiCalled = true; return jsonResponse({}, { status: 404 }); }
+    seedCalled = true;
+    return htmlResponse(SAMPLE_ARTICLE_HTML);
+  }, async () => {
+    apiCalled = false;
+    seedCalled = false;
+    const result = await fetchArticlesFromSource("https://www.cwf-air.com", { seedUrls: ["https://www.cwf-air.com/air-conditioner-not-cooling/"] });
+    assert.equal(result.length, 1);
+    assert.equal(apiCalled, true);
+    assert.equal(seedCalled, true);
+  });
+});
+
+test("syncArticles upserts fetched articles into the pool and getSyncedArticles shapes them as homepage items", async () => {
+  const pool = createSyncPool();
+  await withMockFetch(async () => jsonResponse([
+    { id: 1, slug: "air-conditioner-not-cooling", link: "https://www.cwf-air.com/air-conditioner-not-cooling/", title: { rendered: "แอร์ไม่เย็น" }, excerpt: { rendered: "สาเหตุและวิธีแก้" }, date_gmt: "2026-05-20T08:00:00", _embedded: { "wp:featuredmedia": [{ source_url: "https://www.cwf-air.com/img.jpg" }] } },
+  ]), async () => {
+    const result = await syncArticles(pool, "https://www.cwf-air.com/", {});
+    assert.equal(result.ok, true);
+    assert.equal(result.synced, 1);
+    assert.equal(result.fetched, 1);
+  });
+
+  const { articles, last_synced_at } = await getSyncedArticles(pool, "https://www.cwf-air.com", 12);
+  assert.equal(articles.length, 1);
+  assert.equal(articles[0].title, "แอร์ไม่เย็น");
+  assert.equal(articles[0].body, "สาเหตุและวิธีแก้");
+  assert.equal(articles[0].image_url, "https://www.cwf-air.com/img.jpg");
+  assert.equal(articles[0].url, "https://www.cwf-air.com/air-conditioner-not-cooling/");
+  assert.ok(articles[0].date_label);
+  assert.ok(last_synced_at);
+});
+
+test("syncArticles rejects an invalid source URL without making any network calls", async () => {
+  const pool = createSyncPool();
+  let fetchCalled = false;
+  await withMockFetch(async () => { fetchCalled = true; return jsonResponse([]); }, async () => {
+    const result = await syncArticles(pool, "not-a-url", {});
+    assert.equal(result.ok, false);
+    assert.equal(result.error, "INVALID_SOURCE_URL");
+  });
+  assert.equal(fetchCalled, false);
+});
+
+test("getSyncedArticles returns an empty result for a source with no cached rows", async () => {
+  const pool = createSyncPool();
+  const { articles, last_synced_at } = await getSyncedArticles(pool, "https://www.cwf-air.com", 12);
+  assert.deepEqual(articles, []);
+  assert.equal(last_synced_at, null);
+});

--- a/test/customerAppRecovery.test.js
+++ b/test/customerAppRecovery.test.js
@@ -236,7 +236,7 @@ test("Customer App build id is consistent across shell and service worker", () =
   const sw = read("customer-app/sw.js");
   const app = read("customer-app/assets/customer-app.js");
   const manifest = read("customer-app/manifest.webmanifest");
-  const build = "20260630_homepage_social_embeds";
+  const build = "20260630_homepage_live_fixes";
 
   assert.match(index, new RegExp(`customer-app\\.css\\?v=${build}`));
   assert.match(index, new RegExp(`modules\\/api\\.js\\?v=${build}`));
@@ -254,7 +254,7 @@ test("Customer App build id is consistent across shell and service worker", () =
 test("store module is loaded in index.html and precached in the service worker app shell", () => {
   const index = read("customer-app/index.html");
   const sw = read("customer-app/sw.js");
-  const build = "20260630_homepage_social_embeds";
+  const build = "20260630_homepage_live_fixes";
 
   assert.match(index, new RegExp(`modules/store\\.js\\?v=${build}`));
   assert.match(sw, /`\.\/modules\/store\.js\?v=\$\{BUILD_ID\}`/);
@@ -467,7 +467,7 @@ test("homepage section sort_order controls DOM order", () => {
   assert.ok(container.innerHTML.indexOf("Trust First") < container.innerHTML.indexOf("Featured Later"));
 });
 
-test("homepage announcement-card link targets (contact, route, external URL) render for manual sections, and the announcements section type itself is suppressed on the customer homepage", () => {
+test("homepage announcement-card link targets (contact, route, external URL) render for manual sections, including the announcements section type itself", () => {
   const context = makeContext();
   const root = loadCustomerFrontend(context);
   root.auth = { displayName: () => "Customer", loadCustomer: async () => ({ logged_in: false }) };
@@ -492,7 +492,7 @@ test("homepage announcement-card link targets (contact, route, external URL) ren
           enabled: true,
           sort_order: 20,
           title: "Announcements",
-          items: [{ title: "Should never render", action: "contact" }],
+          items: [{ title: "Should render now", action: "contact" }],
         },
         {
           id: "updates",
@@ -514,7 +514,7 @@ test("homepage announcement-card link targets (contact, route, external URL) ren
   root.ui.renderHome(container);
 
   assert.match(container.innerHTML, /class="homepage-quick" href="#" data-home-contact="Quick Contact"/);
-  assert.doesNotMatch(container.innerHTML, /Should never render/);
+  assert.match(container.innerHTML, /class="homepage-announcement-card" href="#" data-home-contact="Should render now"/);
   assert.match(container.innerHTML, /class="homepage-update-card" href="#" data-home-contact="Contact Admin"/);
   assert.doesNotMatch(container.innerHTML, /data-home-contact="Contact Admin"[^>]*data-route="home"/);
   assert.doesNotMatch(container.innerHTML, /data-route="home"[^>]*Contact Admin/);

--- a/test/customerAppRecovery.test.js
+++ b/test/customerAppRecovery.test.js
@@ -236,7 +236,7 @@ test("Customer App build id is consistent across shell and service worker", () =
   const sw = read("customer-app/sw.js");
   const app = read("customer-app/assets/customer-app.js");
   const manifest = read("customer-app/manifest.webmanifest");
-  const build = "20260630_homepage_live_fixes";
+  const build = "20260630_homepage_polish_v1";
 
   assert.match(index, new RegExp(`customer-app\\.css\\?v=${build}`));
   assert.match(index, new RegExp(`modules\\/api\\.js\\?v=${build}`));
@@ -254,7 +254,7 @@ test("Customer App build id is consistent across shell and service worker", () =
 test("store module is loaded in index.html and precached in the service worker app shell", () => {
   const index = read("customer-app/index.html");
   const sw = read("customer-app/sw.js");
-  const build = "20260630_homepage_live_fixes";
+  const build = "20260630_homepage_polish_v1";
 
   assert.match(index, new RegExp(`modules/store\\.js\\?v=${build}`));
   assert.match(sw, /`\.\/modules\/store\.js\?v=\$\{BUILD_ID\}`/);

--- a/test/customerSameDayTiming.test.js
+++ b/test/customerSameDayTiming.test.js
@@ -160,7 +160,7 @@ test("customer app disables availability HTTP cache and refreshes same-day slots
 });
 
 test("customer app build and service worker cache IDs changed", () => {
-  const id = "20260630_homepage_social_embeds";
+  const id = "20260630_homepage_live_fixes";
   for (const file of [
     "customer-app/index.html",
     "customer-app/sw.js",

--- a/test/customerSameDayTiming.test.js
+++ b/test/customerSameDayTiming.test.js
@@ -160,7 +160,7 @@ test("customer app disables availability HTTP cache and refreshes same-day slots
 });
 
 test("customer app build and service worker cache IDs changed", () => {
-  const id = "20260630_homepage_live_fixes";
+  const id = "20260630_homepage_polish_v1";
   for (const file of [
     "customer-app/index.html",
     "customer-app/sw.js",

--- a/test/homepageCms.test.js
+++ b/test/homepageCms.test.js
@@ -25,6 +25,7 @@ function createPool() {
     activeJob: null,
     },
     queries: [],
+    syncedArticles: [],
   };
   return {
     state,
@@ -58,8 +59,51 @@ function createPool() {
       if (normalized.includes("FROM public.jobs") && normalized.includes("customer_sub=$1")) {
         return { rows: state.activeJob && params[0] === "customer-1" ? [state.activeJob] : [] };
       }
+      if (normalized.includes("INSERT INTO public.homepage_synced_articles")) {
+        const [source_url, external_id, title, summary, image_url, link, published_at] = params;
+        const idx = state.syncedArticles.findIndex((row) => row.source_url === source_url && row.external_id === external_id);
+        const row = { source_url, external_id, title, summary, image_url, link, published_at, synced_at: new Date().toISOString() };
+        if (idx >= 0) state.syncedArticles[idx] = row; else state.syncedArticles.push(row);
+        return { rows: [] };
+      }
+      if (normalized.includes("FROM public.homepage_synced_articles")) {
+        const [sourceUrl, limit] = params;
+        const rows = state.syncedArticles
+          .filter((row) => row.source_url === sourceUrl)
+          .sort((a, b) => {
+            const ad = a.published_at ? new Date(a.published_at).getTime() : -Infinity;
+            const bd = b.published_at ? new Date(b.published_at).getTime() : -Infinity;
+            if (bd !== ad) return bd - ad;
+            return new Date(b.synced_at).getTime() - new Date(a.synced_at).getTime();
+          })
+          .slice(0, limit);
+        return { rows };
+      }
       throw new Error(`Unhandled query: ${normalized}`);
     },
+  };
+}
+
+async function withMockFetch(handler, fn) {
+  const original = global.fetch;
+  global.fetch = (url, options) => {
+    if (String(url).includes("127.0.0.1")) return original(url, options);
+    return handler(url, options);
+  };
+  try {
+    return await fn();
+  } finally {
+    global.fetch = original;
+  }
+}
+
+function jsonFetchResponse(body, init = {}) {
+  return {
+    ok: init.status == null || (init.status >= 200 && init.status < 300),
+    status: init.status || 200,
+    headers: { get: (name) => (String(name).toLowerCase() === "content-type" ? (init.contentType || "application/json") : "") },
+    json: async () => body,
+    text: async () => JSON.stringify(body),
   };
 }
 
@@ -234,7 +278,7 @@ test("customer homepage has no admin control, bottom nav is fixed five-tab, and 
   const sw = read("customer-app/sw.js");
   const app = read("customer-app/assets/customer-app.js");
   const manifest = read("customer-app/manifest.webmanifest");
-  const build = "20260630_homepage_live_fixes";
+  const build = "20260630_homepage_polish_v1";
 
   assert.doesNotMatch(index + ui, /โหมดแอดมิน|openCms|localStorage\.getItem\('cwfHomeCmsDemo'/);
   assert.match(index, /data-route="store"[\s\S]*ร้านค้า/);
@@ -1097,4 +1141,168 @@ test("activeNow: explicit date-time active_from/active_to keep their own offset 
 test("activeNow: an invalid date boundary fails closed (excludes the item) rather than showing it indefinitely", () => {
   assert.equal(activeNow({ active_from: "not-a-date" }, new Date("2026-06-30T08:00:00.000Z")), false);
   assert.equal(activeNow({ active_to: "not-a-date" }, new Date("2026-06-30T08:00:00.000Z")), false);
+});
+
+test("articles section validates auto_sync, source_url, and seed_urls and requires source_url when auto_sync is on", () => {
+  const valid = validateConfig({
+    sections: [{
+      id: "articles", type: "articles", title: "บทความแนะนำ",
+      auto_sync: true, source_url: "https://www.cwf-air.com",
+      seed_urls: ["https://www.cwf-air.com/air-conditioner-not-cooling/", "https://www.cwf-air.com/air-conditioner-water-leaking/"],
+      items: [],
+    }],
+  });
+  assert.equal(valid.ok, true);
+  const section = valid.config.sections[0];
+  assert.equal(section.auto_sync, true);
+  assert.equal(section.source_url, "https://www.cwf-air.com");
+  assert.deepEqual(section.seed_urls, ["https://www.cwf-air.com/air-conditioner-not-cooling/", "https://www.cwf-air.com/air-conditioner-water-leaking/"]);
+
+  const badSourceUrl = validateConfig({
+    sections: [{ id: "articles", type: "articles", title: "x", source_url: "javascript:alert(1)", items: [] }],
+  });
+  assert.equal(badSourceUrl.ok, false);
+  assert.ok(badSourceUrl.errors.some((error) => error.includes("source_url must be http/https")));
+
+  const badSeedUrl = validateConfig({
+    sections: [{ id: "articles", type: "articles", title: "x", seed_urls: ["not-a-url"], items: [] }],
+  });
+  assert.equal(badSeedUrl.ok, false);
+  assert.ok(badSeedUrl.errors.some((error) => error.includes("seed_urls.0 invalid")));
+
+  const autoSyncWithoutSource = validateConfig({
+    sections: [{ id: "articles", type: "articles", title: "x", auto_sync: true, items: [] }],
+  });
+  assert.equal(autoSyncWithoutSource.ok, false);
+  assert.ok(autoSyncWithoutSource.errors.some((error) => error.includes("source_url required when auto_sync is enabled")));
+
+  const tooManySeedUrls = validateConfig({
+    sections: [{ id: "articles", type: "articles", title: "x", seed_urls: Array.from({ length: 12 }, (_, i) => `https://www.cwf-air.com/post-${i}/`), items: [] }],
+  });
+  assert.equal(tooManySeedUrls.ok, true);
+  assert.equal(tooManySeedUrls.config.sections[0].seed_urls.length, 8);
+});
+
+test("POST /admin/homepage-cms/sync-articles requires admin auth and a source_url, then upserts and returns synced articles", async () => {
+  const pool = createPool();
+  const deny = await withServer(pool, (_req, res) => res.status(401).json({ error: "UNAUTHORIZED" }));
+  try {
+    const denied = await fetch(`${deny.base}/admin/homepage-cms/sync-articles`, { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ source_url: "https://www.cwf-air.com" }) });
+    assert.equal(denied.status, 401);
+  } finally {
+    await deny.close();
+  }
+
+  const allow = await withServer(pool, (req, _res, next) => { req.actor = { username: "admin", role: "admin" }; next(); });
+  try {
+    const missingUrl = await fetch(`${allow.base}/admin/homepage-cms/sync-articles`, { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify({}) });
+    assert.equal(missingUrl.status, 400);
+
+    await withMockFetch(async () => jsonFetchResponse([
+      { id: 1, slug: "air-conditioner-not-cooling", link: "https://www.cwf-air.com/air-conditioner-not-cooling/", title: { rendered: "แอร์ไม่เย็น" }, excerpt: { rendered: "สาเหตุและวิธีแก้" }, date_gmt: "2026-05-20T08:00:00", _embedded: { "wp:featuredmedia": [{ source_url: "https://www.cwf-air.com/img.jpg" }] } },
+    ]), async () => {
+      const res = await fetch(`${allow.base}/admin/homepage-cms/sync-articles`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ source_url: "https://www.cwf-air.com" }),
+      });
+      assert.equal(res.status, 200);
+      const data = await res.json();
+      assert.equal(data.ok, true);
+      assert.equal(data.synced_count, 1);
+      assert.equal(data.articles.length, 1);
+      assert.equal(data.articles[0].title, "แอร์ไม่เย็น");
+      assert.ok(data.last_synced_at);
+    });
+
+    const statusRes = await fetch(`${allow.base}/admin/homepage-cms/synced-articles?source_url=${encodeURIComponent("https://www.cwf-air.com")}`);
+    const statusData = await statusRes.json();
+    assert.equal(statusData.ok, true);
+    assert.equal(statusData.articles.length, 1);
+    assert.ok(statusData.last_synced_at);
+  } finally {
+    await allow.close();
+  }
+});
+
+test("GET /admin/homepage-cms/synced-articles returns an empty result without a source_url and requires admin auth", async () => {
+  const pool = createPool();
+  const deny = await withServer(pool, (_req, res) => res.status(401).json({ error: "UNAUTHORIZED" }));
+  try {
+    const denied = await fetch(`${deny.base}/admin/homepage-cms/synced-articles?source_url=https://www.cwf-air.com`);
+    assert.equal(denied.status, 401);
+  } finally {
+    await deny.close();
+  }
+
+  const allow = await withServer(pool, (req, _res, next) => { req.actor = { username: "admin", role: "admin" }; next(); });
+  try {
+    const res = await fetch(`${allow.base}/admin/homepage-cms/synced-articles`);
+    const data = await res.json();
+    assert.equal(data.ok, true);
+    assert.deepEqual(data.articles, []);
+    assert.equal(data.last_synced_at, null);
+  } finally {
+    await allow.close();
+  }
+});
+
+test("public homepage hydrates an auto_sync articles section from the synced-articles cache, replacing manually-curated items", async () => {
+  const pool = createPool();
+  pool.state.syncedArticles = [
+    { source_url: "https://www.cwf-air.com", external_id: "a", title: "แอร์ไม่เย็น", summary: "สาเหตุและวิธีแก้", image_url: "https://www.cwf-air.com/a.jpg", link: "https://www.cwf-air.com/a/", published_at: "2026-05-20T08:00:00Z", synced_at: new Date().toISOString() },
+  ];
+  pool.state.row.published_config = {
+    version: 1,
+    sections: [{
+      id: "articles", type: "articles", enabled: true, sort_order: 70, title: "บทความแนะนำ",
+      auto_sync: true, source_url: "https://www.cwf-air.com", seed_urls: [],
+      items: [{ title: "บทความเดิมที่กรอกด้วยมือ", url: "https://example.com/manual" }],
+    }],
+  };
+  const server = await withServer(pool, (_req, _res, next) => next());
+  try {
+    const res = await fetch(`${server.base}/public/homepage`);
+    const data = await res.json();
+    const section = data.config.sections.find((s) => s.type === "articles");
+    assert.ok(section);
+    assert.equal(section.items.length, 1);
+    assert.equal(section.items[0].title, "แอร์ไม่เย็น");
+    assert.equal(section.items[0].url, "https://www.cwf-air.com/a/");
+    assert.ok(!JSON.stringify(section.items).includes("บทความเดิมที่กรอกด้วยมือ"));
+  } finally {
+    await server.close();
+  }
+});
+
+test("public homepage leaves manually-curated articles items untouched when auto_sync is off", async () => {
+  const pool = createPool();
+  pool.state.row.published_config = {
+    version: 1,
+    sections: [{
+      id: "articles", type: "articles", enabled: true, sort_order: 70, title: "บทความแนะนำ",
+      auto_sync: false, source_url: "", seed_urls: [],
+      items: [{ title: "บทความที่กรอกด้วยมือ", url: "https://example.com/manual" }],
+    }],
+  };
+  const server = await withServer(pool, (_req, _res, next) => next());
+  try {
+    const res = await fetch(`${server.base}/public/homepage`);
+    const data = await res.json();
+    const section = data.config.sections.find((s) => s.type === "articles");
+    assert.equal(section.items[0].title, "บทความที่กรอกด้วยมือ");
+  } finally {
+    await server.close();
+  }
+});
+
+test("admin-homepage-cms.js wires the articles auto-sync editor: toggle, source_url, seed_urls, sync-now, and hiding manual items when enabled", () => {
+  const admin = read("admin-homepage-cms.js");
+  assert.match(admin, /data-auto-sync/);
+  assert.match(admin, /\.auto_sync = target\.checked/);
+  assert.match(admin, /data-seed-urls/);
+  assert.match(admin, /id="syncArticlesNow"/);
+  assert.match(admin, /\/admin\/homepage-cms\/sync-articles/);
+  assert.match(admin, /\/admin\/homepage-cms\/synced-articles/);
+  assert.match(admin, /itemTypes\.includes\(section\.type\) && !\(section\.type === "articles" && section\.auto_sync\)/);
 });

--- a/test/homepageCms.test.js
+++ b/test/homepageCms.test.js
@@ -234,7 +234,7 @@ test("customer homepage has no admin control, bottom nav is fixed five-tab, and 
   const sw = read("customer-app/sw.js");
   const app = read("customer-app/assets/customer-app.js");
   const manifest = read("customer-app/manifest.webmanifest");
-  const build = "20260630_homepage_social_embeds";
+  const build = "20260630_homepage_live_fixes";
 
   assert.doesNotMatch(index + ui, /โหมดแอดมิน|openCms|localStorage\.getItem\('cwfHomeCmsDemo'/);
   assert.match(index, /data-route="store"[\s\S]*ร้านค้า/);


### PR DESCRIPTION
## Summary

Follow-up to the prior homepage CMS work (#109), addressing live-site feedback that several features looked unchanged or felt incomplete.

### Live-site bug fixes
- **Fixed: `announcements` sections were never rendered on the customer homepage.** `renderHomepageSection()` in `customer-app/modules/ui.js` had a hardcoded `if (section.type === "announcements") return "";` stub, even though the admin CMS editor, backend schema/validation, and CSS for this section type were already fully built. Now `announcements` renders through the same path as `updates`/`articles`.
- **Fixed: LINE quick-action icon now uses a real LINE-style speech-bubble icon** with brand-green styling, instead of the generic chat-bubble icon. Updated `ICON_PATHS` in `customer-app/modules/utils.js`, the default LINE quick item's `icon` field in `server/routes/homepage.js`, and added a `.homepage-quick.is-line` CSS rule (brand-green gradient chip).

### New: automatic article sync from cwf-air.com
Admin can now point an `articles` section at the company's marketing site and have it stay current automatically, instead of pasting in articles by hand:
- `server/services/articleSync.js` — pulls posts from the source site's WordPress REST API (`/wp-json/wp/v2/posts`) first; falls back to scraping Open Graph / JSON-LD metadata off admin-provided seed URLs when the API isn't available (site isn't WordPress, API disabled, etc).
- New `homepage_synced_articles` cache table (migration + `npm run migrate:homepage-article-sync`), with admin endpoints to trigger an immediate sync and check sync status.
- A background runner (mirroring the existing urgent-finalizer pattern) keeps the cache fresh periodically once `auto_sync` is enabled on a section.
- Admin CMS UI: toggle auto-sync, set the source URL, optional fallback seed URLs, "sync now" button, and last-synced status — manual item entry is hidden while auto-sync is active since items come from the sync cache.
- Public homepage hydrates synced articles from the cache when `auto_sync` is on, otherwise renders manually-curated items unchanged (zero client-side rendering changes needed — synced articles are shaped to the same `{title, body, image_url, url, date_label}` item contract).

### Visual polish — CWF's own style (point 4 from feedback)
Per explicit guidance that the homepage felt "thin" and should look distinctively CWF-branded rather than copying another app's style: added a recurring signature accent — a gold → blue → cobalt gradient hairline — across the sticky header, hero corner glow, content-card top edges, and the promo banner frame. Built entirely from the existing `:root` brand palette (`--yellow`, `--blue`, `--cobalt`) already established in `customer-app.css`; no new colors or foreign design language introduced.

Bumped `BUILD_ID` (`20260630_homepage_live_fixes` → `20260630_homepage_polish_v1`) to force the PWA service worker to pick up the new build.

## Tests

- `node --test test/*.test.js`: 727 total, 716 passed, 0 failed, 11 skipped (pre-existing Postgres-dependent integration tests, unrelated, skip cleanly without a local Postgres).
- New `test/articleSync.test.js` (13 tests): WordPress REST API parsing, OG/JSON-LD HTML fallback parsing, HTML-entity decoding, seed-URL skip-and-continue behavior, source-first/fallback-only-when-empty ordering, and the sync/cache round-trip.
- Extended `test/homepageCms.test.js` with route-level coverage: validation of `auto_sync`/`source_url`/`seed_urls`, the sync-now and synced-articles admin endpoints (auth-gated), and public-homepage hydration with/without auto-sync.
- Visual changes verified via a static Playwright screenshot harness reusing the real homepage markup/CSS, confirming the new accent system renders correctly at 390px.
- In the process of writing fixtures, found and fixed two real correctness bugs in `articleSync.js`'s WordPress-API path (HTML entities not decoded in `title`/`excerpt`, and an empty `.rendered` field incorrectly falling back to the whole truthy object).

---
_Generated by [Claude Code](https://claude.ai/code/session_01LmdP3TGN5uQrfT8ZYefNco)_