### PR TITLE
Redesign Homepage CMS admin UI: 3-column layout, panel editors, phone preview

### DIFF
--- a/admin-homepage-cms.html
+++ b/admin-homepage-cms.html
@@ -5,77 +5,264 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>CWF Homepage CMS</title>
   <style>
-    :root{--navy:#071b38;--blue:#1463ff;--yellow:#ffd43b;--bg:#f3f6fb;--card:#fff;--ink:#10213b;--muted:#6f7d92;--line:#e5ebf4;--bad:#b91c1c;--ok:#15803d}
-    *{box-sizing:border-box}
-    body{margin:0;font-family:"Noto Sans Thai","Segoe UI",Arial,sans-serif;background:var(--bg);color:var(--ink)}
-    button,input,textarea,select{font:inherit}
+    :root{
+      --navy:#071b38;--blue:#1463ff;--blue-soft:#ebf1ff;
+      --yellow:#ffd43b;--bg:#eef3fa;--ink:#10213b;
+      --muted:#6b7793;--line:#e3ebf6;
+      --ok:#16a34a;--ok-bg:#ecfdf5;--bad:#b91c1c;--bad-bg:#fef2f2;
+      --sh:0 2px 14px rgba(13,45,88,.08);--r:14px;
+    }
+    *,*::before,*::after{box-sizing:border-box;margin:0;padding:0}
+    html,body{height:100%}
+    body{font-family:"Noto Sans Thai","Segoe UI",Arial,sans-serif;background:var(--bg);color:var(--ink);font-size:14px;overflow:hidden}
+    button,input,textarea,select{font:inherit;color:inherit}
     button{cursor:pointer}
-    .shell{max-width:1220px;margin:0 auto;padding:22px 14px 44px}
-    .top{display:flex;justify-content:space-between;gap:14px;align-items:flex-start;margin-bottom:16px}
-    .top h1{margin:0;color:var(--navy);font-size:28px;line-height:1.15}.top p{margin:6px 0 0;color:var(--muted);font-weight:700}
-    .status{padding:10px 12px;border-radius:12px;background:#fff;border:1px solid var(--line);font-size:13px;font-weight:800;color:var(--muted)}
-    .status.ok{color:var(--ok);background:#ecfdf5}.status.bad{color:var(--bad);background:#fef2f2}
-    .grid{display:grid;grid-template-columns:minmax(0,1fr) 390px;gap:14px;align-items:start}
-    .panel{background:#fff;border:1px solid var(--line);border-radius:18px;box-shadow:0 10px 28px rgba(13,45,88,.07);padding:14px}
-    .panel h2{margin:0 0 12px;font-size:17px;color:var(--navy)}
-    .toolbar{display:flex;gap:8px;flex-wrap:wrap;margin-bottom:12px}
-    .btn{border:0;border-radius:12px;min-height:42px;padding:10px 13px;font-weight:900;background:#eaf2ff;color:var(--blue)}
-    .btn.primary{background:var(--blue);color:#fff}.btn.publish{background:var(--yellow);color:#2c2600}.btn.danger{background:#fee2e2;color:#991b1b}
-    .section-row{display:grid;grid-template-columns:auto 1fr auto auto;gap:9px;align-items:center;padding:10px;border:1px solid var(--line);border-radius:14px;margin-bottom:8px;background:#fbfcff}
-    .section-row b{display:block;font-size:13px}.section-row small{display:block;color:var(--muted);font-size:11px}
-    .mini{width:32px;height:32px;border:1px solid var(--line);border-radius:10px;background:#fff;font-weight:900}
-    .switch{display:flex;gap:5px;align-items:center;color:var(--muted);font-size:12px;font-weight:800}
-    .editor{display:grid;gap:10px}
-    label{display:grid;gap:5px;color:#3f4d63;font-size:12px;font-weight:900}
-    input,textarea,select{width:100%;border:1px solid #dce4ef;border-radius:11px;padding:10px;background:#fff;color:var(--ink)}
-    textarea{min-height:78px;resize:vertical}.two{display:grid;grid-template-columns:1fr 1fr;gap:8px}
-    .item{border:1px solid var(--line);border-radius:14px;padding:10px;margin-bottom:8px;background:#fff}.item h3{margin:0 0 8px;font-size:13px}
-    .preview-wrap{position:sticky;top:12px}.phone{width:100%;max-width:390px;margin:auto;background:#f3f6fb;border:1px solid #dce4ef;border-radius:28px;overflow:hidden;box-shadow:0 18px 48px rgba(7,27,56,.18)}
-    .phone-head{padding:12px 14px;background:#fff;border-bottom:1px solid var(--line);font-weight:950}.phone-body{padding:10px 12px 90px;min-height:680px}
-    .hero{min-height:220px;border-radius:24px;color:#fff;background:linear-gradient(140deg,#06162e,#0b3976 52%,#1463ff);padding:22px 18px;display:flex;flex-direction:column;justify-content:flex-end}.hero small{font-weight:900}.hero h3{font-size:25px;line-height:1.12;margin:10px 0 6px}.hero p{font-size:12px;line-height:1.55;margin:0;color:rgba(255,255,255,.85)}
-    .quick{display:grid;grid-template-columns:repeat(4,1fr);gap:8px;margin-top:12px}.quick div{min-height:84px;background:#fff;border:1px solid var(--line);border-radius:18px;padding:10px 5px;text-align:center;font-size:10px;font-weight:900}
-    .sec{margin-top:20px}.sec-head{display:flex;justify-content:space-between;gap:10px;margin-bottom:8px}.sec-head b{font-size:16px}.sec-head span{color:var(--muted);font-size:10px}
-    .cards{display:flex;gap:9px;overflow:hidden}.card{min-width:72%;background:#fff;border:1px solid var(--line);border-radius:18px;padding:12px}.card b{font-size:13px}.card p{font-size:10px;color:var(--muted);line-height:1.45}
-    .bottom{position:absolute}
-    @media(max-width:900px){.grid{grid-template-columns:1fr}.preview-wrap{position:static}.top{display:block}.status{margin-top:10px}}
+
+    /* ── topbar ── */
+    .topbar{
+      position:fixed;top:0;left:0;right:0;z-index:100;
+      background:#fff;border-bottom:1px solid var(--line);
+      display:flex;align-items:center;gap:10px;
+      padding:0 16px;height:52px;
+      box-shadow:0 2px 10px rgba(13,45,88,.07);
+    }
+    .topbar-back{
+      color:var(--muted);text-decoration:none;font-weight:900;font-size:13px;
+      display:flex;align-items:center;gap:5px;white-space:nowrap;
+      padding:6px 11px;border-radius:10px;border:1px solid var(--line);background:#fafbfd;
+    }
+    .topbar-back:hover{color:var(--blue);border-color:rgba(20,99,255,.3)}
+    .topbar-brand{font-weight:900;font-size:17px;color:var(--navy);flex:1;padding-left:4px}
+    .topbar-actions{display:flex;gap:8px;align-items:center}
+
+    .status-chip{
+      padding:5px 12px;border-radius:999px;font-size:12px;font-weight:900;
+      background:var(--blue-soft);color:var(--blue);white-space:nowrap;
+      border:1px solid rgba(20,99,255,.15);
+    }
+    .status-chip.ok{background:var(--ok-bg);color:var(--ok);border-color:rgba(22,163,74,.18)}
+    .status-chip.bad{background:var(--bad-bg);color:var(--bad);border-color:rgba(185,28,28,.18)}
+
+    /* ── buttons ── */
+    .btn{border:0;border-radius:10px;min-height:36px;padding:7px 14px;font-weight:900;font-size:13px;cursor:pointer;transition:filter .12s,transform .1s;display:inline-flex;align-items:center;gap:5px}
+    .btn:hover{filter:brightness(.92)}
+    .btn:active{transform:scale(.96)}
+    .btn-primary{background:var(--blue);color:#fff}
+    .btn-publish{background:var(--yellow);color:#2c2600}
+    .btn-ghost{background:var(--blue-soft);color:var(--blue)}
+    .btn-icon{width:36px;height:36px;padding:0;justify-content:center;border-radius:10px;background:#f0f4fa;color:var(--muted);font-size:16px;border:1px solid var(--line)}
+    .btn-danger{background:#fee2e2;color:#991b1b}
+    .btn-sm{min-height:30px;padding:5px 10px;font-size:12px;border-radius:8px}
+
+    /* ── 3-col layout ── */
+    .cms-layout{
+      display:grid;
+      grid-template-columns:252px 1fr 344px;
+      margin-top:52px;
+      height:calc(100vh - 52px);
+      overflow:hidden;
+    }
+
+    /* ── left nav ── */
+    .cms-nav{
+      background:#fff;border-right:1px solid var(--line);
+      overflow-y:auto;padding:10px 8px;
+      display:flex;flex-direction:column;gap:2px;
+    }
+    .nav-hd{
+      font-size:10px;font-weight:900;color:var(--muted);
+      letter-spacing:.1em;text-transform:uppercase;
+      padding:8px 10px 6px;
+    }
+
+    /* ── section row ── */
+    .sec-row{
+      display:flex;align-items:center;gap:6px;
+      border-radius:12px;border:1.5px solid transparent;
+      padding:8px;transition:background .12s,border-color .12s;
+    }
+    .sec-row:hover{background:var(--blue-soft)}
+    .sec-row.is-active{background:var(--blue-soft);border-color:rgba(20,99,255,.35)}
+    .sec-row.is-disabled .sec-name{opacity:.38}
+    .sec-row-body{
+      flex:1;min-width:0;display:flex;align-items:center;gap:8px;
+      cursor:pointer;padding:1px 0;
+    }
+    .sec-icon{
+      font-size:15px;width:32px;height:32px;border-radius:9px;
+      background:var(--bg);box-shadow:0 1px 4px rgba(13,45,88,.09);
+      display:flex;align-items:center;justify-content:center;flex-shrink:0;
+      transition:background .12s;
+    }
+    .sec-row.is-active .sec-icon{background:var(--blue);box-shadow:0 2px 8px rgba(20,99,255,.3)}
+    .sec-info{min-width:0}
+    .sec-name{font-weight:900;font-size:13px;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;line-height:1.3}
+    .sec-type{font-size:10px;color:var(--muted);font-weight:700;margin-top:1px}
+    .sec-controls{display:flex;gap:3px;align-items:center;flex-shrink:0}
+
+    /* mini arrow btns */
+    .mini{
+      width:26px;height:26px;border:1px solid var(--line);border-radius:7px;
+      background:#fff;color:var(--muted);font-size:11px;
+      display:flex;align-items:center;justify-content:center;cursor:pointer;flex-shrink:0;
+    }
+    .mini:hover:not(:disabled){background:var(--blue-soft);border-color:rgba(20,99,255,.3);color:var(--blue)}
+    .mini:disabled{opacity:.25;cursor:default}
+
+    /* toggle switch */
+    .tog{display:block;cursor:pointer;flex-shrink:0}
+    .tog input{display:none}
+    .tog span{
+      display:block;width:34px;height:18px;border-radius:9px;
+      background:#cbd5e1;position:relative;transition:background .18s;
+    }
+    .tog span::after{
+      content:"";position:absolute;top:3px;left:3px;
+      width:12px;height:12px;border-radius:6px;background:#fff;
+      box-shadow:0 1px 3px rgba(0,0,0,.2);transition:transform .18s;
+    }
+    .tog input:checked+span{background:var(--blue)}
+    .tog input:checked+span::after{transform:translateX(16px)}
+
+    /* ── center editor ── */
+    .cms-editor{overflow-y:auto;padding:14px;display:flex;flex-direction:column;gap:12px}
+
+    /* editor header card */
+    .editor-hd{
+      background:#fff;border:1px solid var(--line);border-radius:var(--r);
+      box-shadow:var(--sh);padding:14px 16px;
+      display:flex;align-items:center;gap:12px;
+    }
+    .editor-hd-icon{
+      font-size:22px;width:44px;height:44px;border-radius:12px;
+      background:linear-gradient(135deg,var(--blue-soft),#d4e4ff);
+      display:flex;align-items:center;justify-content:center;flex-shrink:0;
+    }
+    .editor-hd-title{font-size:16px;font-weight:900;color:var(--navy)}
+    .editor-hd-sub{font-size:11px;color:var(--muted);font-weight:700;margin-top:3px}
+
+    /* editor panel card */
+    .ep{background:#fff;border:1px solid var(--line);border-radius:var(--r);box-shadow:var(--sh);overflow:hidden}
+    .ep-head{
+      padding:10px 14px;border-bottom:1px solid var(--line);
+      font-weight:900;font-size:12px;color:var(--muted);letter-spacing:.04em;
+      display:flex;align-items:center;justify-content:space-between;
+      background:#fafbfd;
+    }
+    .ep-body{padding:14px;display:grid;gap:12px}
+
+    /* form fields */
+    label.field{display:grid;gap:5px;font-size:12px;font-weight:900;color:#3a4a60}
+    input.fi,textarea.fi,select.fi{
+      width:100%;border:1.5px solid #dce4ef;border-radius:10px;
+      padding:9px 11px;background:#fff;color:var(--ink);
+      transition:border-color .15s,box-shadow .15s;
+    }
+    input.fi:focus,textarea.fi:focus,select.fi:focus{
+      outline:none;border-color:var(--blue);
+      box-shadow:0 0 0 3px rgba(20,99,255,.1);
+    }
+    textarea.fi{min-height:68px;resize:vertical}
+    select.fi{cursor:pointer}
+    .two{display:grid;grid-template-columns:1fr 1fr;gap:10px}
+    .switch{display:inline-flex;gap:7px;align-items:center;font-size:13px;font-weight:900;cursor:pointer}
+
+    /* item card */
+    .item-card{
+      border:1.5px solid var(--line);border-radius:12px;overflow:hidden;
+      margin-bottom:10px;background:#fff;box-shadow:0 2px 6px rgba(13,45,88,.04);
+    }
+    .item-card-head{
+      background:#f8fafd;border-bottom:1px solid var(--line);
+      padding:9px 12px;display:flex;align-items:center;justify-content:space-between;gap:8px;
+    }
+    .item-num{
+      width:22px;height:22px;border-radius:6px;background:var(--blue-soft);
+      color:var(--blue);font-size:11px;font-weight:900;
+      display:inline-flex;align-items:center;justify-content:center;flex-shrink:0;
+    }
+    .item-card-body{padding:12px;display:grid;gap:10px}
+
+    .toolbar{display:flex;gap:8px;flex-wrap:wrap;align-items:center}
+    .sync-info{background:#f8fafd;border:1px solid var(--line);border-radius:10px;padding:10px 12px;font-size:12px;color:var(--muted);font-weight:800;line-height:1.5}
+    .sync-info.has-data{border-color:rgba(22,163,74,.2);background:var(--ok-bg);color:var(--ok)}
+
+    /* ── right preview ── */
+    .cms-preview{
+      background:#e6edf5;border-left:1px solid var(--line);
+      overflow-y:auto;padding:14px;
+      display:flex;flex-direction:column;align-items:center;gap:10px;
+    }
+    .preview-hd{font-size:10px;font-weight:900;color:var(--muted);letter-spacing:.1em;text-transform:uppercase}
+    .phone{
+      width:100%;max-width:320px;background:#f3f6fb;
+      border:1px solid #dce4ef;border-radius:26px;overflow:hidden;
+      box-shadow:0 16px 40px rgba(7,27,56,.14);
+    }
+    .phone-head{padding:11px 14px;background:#fff;border-bottom:1px solid var(--line);font-weight:950;font-size:13px}
+    .phone-body{padding:10px 12px 90px;min-height:600px}
+
+    /* preview inner elements */
+    .p-hero{min-height:185px;border-radius:18px;color:#fff;background:linear-gradient(140deg,#06162e,#0b3976 52%,#1463ff);padding:18px 14px;display:flex;flex-direction:column;justify-content:flex-end}
+    .p-hero small{font-weight:900;font-size:10px}
+    .p-hero h3{font-size:20px;line-height:1.15;margin:6px 0 4px}
+    .p-hero p{font-size:10px;line-height:1.5;margin:0;color:rgba(255,255,255,.85)}
+    .p-quick{display:grid;grid-template-columns:repeat(4,1fr);gap:6px;margin-top:10px}
+    .p-quick div{min-height:66px;background:#fff;border:1px solid var(--line);border-radius:14px;padding:7px 4px;text-align:center;font-size:10px;font-weight:900}
+    .p-sec{margin-top:14px}
+    .p-sec-head{display:flex;justify-content:space-between;gap:8px;margin-bottom:6px}
+    .p-sec-head b{font-size:13px}
+    .p-sec-head span{color:var(--muted);font-size:10px}
+    .p-cards{display:flex;gap:7px;overflow:hidden}
+    .p-card{min-width:65%;background:#fff;border:1px solid var(--line);border-radius:13px;padding:9px}
+    .p-card b{font-size:12px}
+    .p-card p{font-size:10px;color:var(--muted);line-height:1.4;margin-top:3px}
+
+    /* ── responsive ── */
+    @media(max-width:1100px){.cms-layout{grid-template-columns:220px 1fr 290px}}
+    @media(max-width:880px){
+      body{overflow:auto}
+      .topbar{position:sticky}
+      .cms-layout{grid-template-columns:1fr;height:auto;overflow:visible;margin-top:0}
+      .cms-nav{max-height:240px;border-right:none;border-bottom:1px solid var(--line)}
+      .cms-preview{border-left:none;border-top:1px solid var(--line)}
+      .two{grid-template-columns:1fr}
+    }
   </style>
 </head>
 <body>
-  <main class="shell">
-    <header class="top">
-      <div>
-        <a href="/admin-review-v2.html" style="display:inline-flex;align-items:center;gap:5px;color:var(--muted);font-size:13px;font-weight:900;text-decoration:none;margin-bottom:8px">← กลับแอดมิน</a>
-        <h1>Homepage CMS</h1>
-        <p>จัดหน้าแรก Customer App: Draft, Preview และ Publish</p>
-      </div>
-      <div id="status" class="status">กำลังโหลด...</div>
-    </header>
-    <div class="grid">
-      <section class="panel">
-        <div class="toolbar">
-          <button class="btn primary" id="saveDraft" type="button">บันทึก Draft</button>
-          <button class="btn publish" id="publish" type="button">Publish</button>
-          <button class="btn" id="reload" type="button">โหลดใหม่</button>
-        </div>
-        <h2>Section</h2>
-        <div id="sectionList"></div>
-      </section>
-      <aside class="preview-wrap">
-        <section class="panel">
-          <h2>Mobile Preview</h2>
-          <div class="phone">
-            <div class="phone-head">Coldwindflow</div>
-            <div class="phone-body" id="preview"></div>
-          </div>
-        </section>
-      </aside>
-      <section class="panel">
-        <h2>Content Editor</h2>
-        <label>เลือก Section<select id="sectionPicker"></select></label>
-        <div id="editor" class="editor"></div>
-      </section>
+  <div class="topbar">
+    <a href="/admin-review-v2.html" class="topbar-back">← แอดมิน</a>
+    <div class="topbar-brand">Homepage CMS</div>
+    <div class="topbar-actions">
+      <div id="status" class="status-chip">กำลังโหลด...</div>
+      <button class="btn btn-primary" id="saveDraft">💾 Draft</button>
+      <button class="btn btn-publish" id="publish">🚀 Publish</button>
+      <button class="btn btn-icon" id="reload" title="โหลดใหม่">↻</button>
     </div>
-  </main>
+  </div>
+
+  <div class="cms-layout">
+    <nav class="cms-nav">
+      <div class="nav-hd">Sections</div>
+      <div id="sectionList"></div>
+    </nav>
+
+    <div class="cms-editor" id="editorPane">
+      <div id="editorHeader"></div>
+      <div id="editor"></div>
+    </div>
+
+    <div class="cms-preview">
+      <div class="preview-hd">Mobile Preview</div>
+      <div class="phone">
+        <div class="phone-head">Coldwindflow</div>
+        <div class="phone-body" id="preview"></div>
+      </div>
+    </div>
+  </div>
+
+  <select id="sectionPicker" style="display:none"></select>
   <script src="/admin-homepage-cms.js"></script>
 </body>
 </html>

--- a/admin-homepage-cms.js
+++ b/admin-homepage-cms.js
@@ -16,6 +16,13 @@
       { id: "trust", type: "trust", enabled: true, sort_order: 80, title: "มาตรฐานที่ลูกค้าวางใจ", body: "", items: [{ title: "แจ้งราคาก่อนทำ", body: "ระบบคำนวณจากข้อมูลบริการจริง" }, { title: "ช่างผ่านมาตรฐาน", body: "ทีมงานได้รับการตรวจสอบก่อนรับงาน" }, { title: "ติดตามงานได้", body: "ดูสถานะสำคัญด้วย Booking Code" }, { title: "ติดต่อแอดมินง่าย", body: "รองรับ LINE และโทรศัพท์" }] },
     ],
   };
+
+  const TYPE_ICONS = {
+    hero: "🏠", quick: "⚡", promo_banner: "🎨",
+    active_job: "🔧", announcements: "📣", featured_services: "⭐",
+    updates: "📸", articles: "📝", social: "📱", trust: "🛡️",
+  };
+
   let config = clone(DEFAULT_CONFIG);
   let selected = "hero";
   let catalogItems = null;
@@ -38,7 +45,7 @@
     next.sections = next.sections.filter((section) => standard.some((std) => std.type === section.type));
     return next;
   }
-  function setStatus(text, kind) { $("status").textContent = text; $("status").className = `status ${kind || ""}`; }
+  function setStatus(text, kind) { $("status").textContent = text; $("status").className = `status-chip ${kind || ""}`; }
   function sections() { return config.sections.sort((a, b) => Number(a.sort_order || 0) - Number(b.sort_order || 0)); }
   function current() { return sections().find((section) => section.id === selected) || sections()[0]; }
 
@@ -113,24 +120,50 @@
     render();
   }
 
+  /* ── section list ── */
   function renderSectionList() {
-    $("sectionList").innerHTML = sections().map((section, index, list) => `
-      <div class="section-row">
-        <div><button class="mini" data-move="${section.id}" data-dir="-1" ${index === 0 ? "disabled" : ""}>↑</button><button class="mini" data-move="${section.id}" data-dir="1" ${index === list.length - 1 ? "disabled" : ""}>↓</button></div>
-        <div><b>${esc(section.title || section.type)}</b><small>${esc(section.type)}</small></div>
-        <label class="switch"><input type="checkbox" data-toggle="${section.id}" ${section.enabled !== false ? "checked" : ""}> เปิด</label>
-        <button class="mini" data-edit="${section.id}">แก้</button>
+    const list = sections();
+    $("sectionList").innerHTML = list.map((section, index) => `
+      <div class="sec-row ${section.id === selected ? "is-active" : ""} ${section.enabled !== false ? "" : "is-disabled"}">
+        <div class="sec-row-body" data-edit="${section.id}">
+          <div class="sec-icon">${TYPE_ICONS[section.type] || "📄"}</div>
+          <div class="sec-info">
+            <div class="sec-name">${esc(section.title || section.type)}</div>
+            <div class="sec-type">${section.type}</div>
+          </div>
+        </div>
+        <div class="sec-controls">
+          <button class="mini" data-move="${section.id}" data-dir="-1" ${index === 0 ? "disabled" : ""}>↑</button>
+          <button class="mini" data-move="${section.id}" data-dir="1" ${index === list.length - 1 ? "disabled" : ""}>↓</button>
+          <label class="tog"><input type="checkbox" data-toggle="${section.id}" ${section.enabled !== false ? "checked" : ""}><span></span></label>
+        </div>
       </div>
     `).join("");
-    $("sectionPicker").innerHTML = sections().map((section) => `<option value="${esc(section.id)}">${esc(section.title || section.type)}</option>`).join("");
+    $("sectionPicker").innerHTML = list.map((section) => `<option value="${esc(section.id)}">${esc(section.title || section.type)}</option>`).join("");
     $("sectionPicker").value = selected;
   }
 
-  function field(label, prop, type) {
+  /* ── editor header ── */
+  function renderEditorHeader() {
+    const section = current();
+    if (!section) { $("editorHeader").innerHTML = ""; return; }
+    $("editorHeader").innerHTML = `
+      <div class="editor-hd">
+        <div class="editor-hd-icon">${TYPE_ICONS[section.type] || "📄"}</div>
+        <div>
+          <div class="editor-hd-title">${esc(section.title || section.type)}</div>
+          <div class="editor-hd-sub">${section.type} · ${section.enabled !== false ? "เปิดใช้งานอยู่" : "ปิดอยู่"}</div>
+        </div>
+      </div>
+    `;
+  }
+
+  /* ── field helpers ── */
+  function field(lbl, prop, type) {
     const section = current();
     const value = section[prop] || "";
-    if (type === "textarea") return `<label>${label}<textarea data-field="${prop}">${esc(value)}</textarea></label>`;
-    return `<label>${label}<input data-field="${prop}" value="${esc(value)}"></label>`;
+    if (type === "textarea") return `<label class="field">${lbl}<textarea class="fi" data-field="${prop}">${esc(value)}</textarea></label>`;
+    return `<label class="field">${lbl}<input class="fi" data-field="${prop}" value="${esc(value)}"></label>`;
   }
 
   function itemEditor(item, index, sectionType) {
@@ -144,52 +177,45 @@
     const targetField = (() => {
       if (!targetEditable) return "";
       if (targetMode === "contact") return "";
-      if (targetMode === "url") {
-        return `<label>External URL<input data-item="${index}" data-prop="url" value="${esc(item.url || "")}" placeholder="https://..."></label>`;
-      }
-      return `<label>Internal route<select data-item="${index}" data-prop="route">
-        ${ROUTE_OPTIONS.map((route) => `<option value="${route}" ${String(item.route || "home") === route ? "selected" : ""}>${route}</option>`).join("")}
-      </select></label>`;
+      if (targetMode === "url") return `<label class="field">External URL<input class="fi" data-item="${index}" data-prop="url" value="${esc(item.url || "")}" placeholder="https://..."></label>`;
+      return `<label class="field">Internal route<select class="fi" data-item="${index}" data-prop="route">${ROUTE_OPTIONS.map((r) => `<option value="${r}" ${String(item.route || "home") === r ? "selected" : ""}>${r}</option>`).join("")}</select></label>`;
     })();
     return `
-      <div class="item">
-        <h3>รายการ ${index + 1}</h3>
-        <label class="switch"><input type="checkbox" data-item-enabled="${index}" ${item.enabled !== false ? "checked" : ""}> เปิดใช้งานรายการนี้</label>
-        <div class="two">
-          <label>หัวข้อ${promo ? " (ไม่บังคับ)" : ""}<input data-item="${index}" data-prop="title" value="${esc(item.title || "")}"></label>
-          <label>ป้าย/วันที่<input data-item="${index}" data-prop="tag" value="${esc(item.tag || item.date_label || "")}"></label>
+      <div class="item-card">
+        <div class="item-card-head">
+          <div style="display:flex;align-items:center;gap:8px">
+            <span class="item-num">${index + 1}</span>
+            <span style="font-weight:900;font-size:13px">รายการ ${index + 1}</span>
+          </div>
+          <div style="display:flex;gap:8px;align-items:center">
+            <label class="switch"><input type="checkbox" data-item-enabled="${index}" ${item.enabled !== false ? "checked" : ""}> เปิด</label>
+            <button class="btn btn-danger btn-sm" type="button" data-remove-item="${index}">ลบ</button>
+          </div>
         </div>
-        <label>คำอธิบาย<textarea data-item="${index}" data-prop="body">${esc(item.body || "")}</textarea></label>
-        ${social ? `
-          <label>แพลตฟอร์ม<select data-item="${index}" data-prop="platform">
-            <option value="youtube" ${(item.platform || "youtube") === "youtube" ? "selected" : ""}>YouTube</option>
-            <option value="facebook" ${item.platform === "facebook" ? "selected" : ""}>Facebook</option>
-          </select></label>
-        ` : ""}
-        ${promo ? `
-          <label>Alt text (คำอธิบายภาพ)<input data-item="${index}" data-prop="alt_text" value="${esc(item.alt_text || "")}"></label>
-          <label>การแสดงภาพ<select data-item="${index}" data-prop="aspect_mode">
-            <option value="contain" ${(item.aspect_mode || "contain") === "contain" ? "selected" : ""}>Contain (เห็นภาพเต็ม ไม่ครอป)</option>
-            <option value="cover" ${item.aspect_mode === "cover" ? "selected" : ""}>Cover (เต็มกรอบ อาจครอป)</option>
-          </select></label>
-        ` : ""}
-        ${targetEditable ? `
-          <label>Target type<select data-item-target="${index}">
-            <option value="route" ${targetMode === "route" ? "selected" : ""}>Internal route</option>
-            <option value="contact" ${targetMode === "contact" ? "selected" : ""}>Contact admin</option>
-            <option value="url" ${targetMode === "url" ? "selected" : ""}>External URL</option>
-          </select></label>
-        ` : ""}
-        ${quick ? `<label>Icon<input data-item="${index}" data-prop="icon" value="${esc(item.icon || "")}" placeholder="sparkle, wrench, pin, line, chat, bolt, shield, tag, clock, phone"></label>` : ""}
-        ${targetField}
-        ${trust || targetEditable ? "" : `<label>${social ? `ลิงก์โพสต์/วิดีโอ (${(item.platform || "youtube") === "facebook" ? "facebook.com..." : "youtube.com... หรือ youtu.be..."})` : external ? "External URL" : "Route / URL"}<input data-item="${index}" data-prop="${external ? "url" : "route"}" value="${esc(external ? item.url || "" : item.route || item.url || "")}" placeholder="${social ? ((item.platform || "youtube") === "facebook" ? "https://www.facebook.com/.../posts/..." : "https://www.youtube.com/watch?v=...") : ""}"></label>`}
-        ${trust ? "" : `<label>${social ? "Thumbnail รูปภาพ (ไม่บังคับ — ถ้าไม่ใส่จะใช้ภาพปกอัตโนมัติของ YouTube หรือไอคอน Facebook)" : "Image URL"}<input data-item="${index}" data-prop="image_url" value="${esc(item.image_url || "")}"></label>`}
-        ${trust ? "" : `<div class="two">
-          <label>Active from<input data-item="${index}" data-prop="active_from" value="${esc(item.active_from || "")}" placeholder="YYYY-MM-DD"></label>
-          <label>Active to<input data-item="${index}" data-prop="active_to" value="${esc(item.active_to || "")}" placeholder="YYYY-MM-DD"></label>
+        <div class="item-card-body">
+          <div class="two">
+            <label class="field">หัวข้อ${promo ? " (ไม่บังคับ)" : ""}<input class="fi" data-item="${index}" data-prop="title" value="${esc(item.title || "")}"></label>
+            <label class="field">ป้าย/วันที่<input class="fi" data-item="${index}" data-prop="tag" value="${esc(item.tag || item.date_label || "")}"></label>
+          </div>
+          <label class="field">คำอธิบาย<textarea class="fi" data-item="${index}" data-prop="body">${esc(item.body || "")}</textarea></label>
+          ${social ? `<label class="field">แพลตฟอร์ม<select class="fi" data-item="${index}" data-prop="platform"><option value="youtube" ${(item.platform || "youtube") === "youtube" ? "selected" : ""}>YouTube</option><option value="facebook" ${item.platform === "facebook" ? "selected" : ""}>Facebook</option></select></label>` : ""}
+          ${promo ? `
+            <label class="field">Alt text<input class="fi" data-item="${index}" data-prop="alt_text" value="${esc(item.alt_text || "")}"></label>
+            <label class="field">การแสดงภาพ<select class="fi" data-item="${index}" data-prop="aspect_mode"><option value="contain" ${(item.aspect_mode || "contain") === "contain" ? "selected" : ""}>Contain (เห็นเต็ม)</option><option value="cover" ${item.aspect_mode === "cover" ? "selected" : ""}>Cover (เต็มกรอบ)</option></select></label>
+          ` : ""}
+          ${targetEditable ? `<label class="field">Target type<select class="fi" data-item-target="${index}"><option value="route" ${targetMode === "route" ? "selected" : ""}>Internal route</option><option value="contact" ${targetMode === "contact" ? "selected" : ""}>Contact admin</option><option value="url" ${targetMode === "url" ? "selected" : ""}>External URL</option></select></label>` : ""}
+          ${quick ? `<label class="field">Icon<input class="fi" data-item="${index}" data-prop="icon" value="${esc(item.icon || "")}" placeholder="sparkle, wrench, pin, chat, bolt, shield, tag, clock, phone"></label>` : ""}
+          ${targetField}
+          ${trust || targetEditable ? "" : `<label class="field">${social ? `ลิงก์โพสต์/วิดีโอ` : external ? "External URL" : "Route / URL"}<input class="fi" data-item="${index}" data-prop="${external ? "url" : "route"}" value="${esc(external ? item.url || "" : item.route || item.url || "")}" placeholder="${social ? ((item.platform || "youtube") === "facebook" ? "https://www.facebook.com/..." : "https://www.youtube.com/watch?v=...") : ""}"></label>`}
+          ${trust ? "" : `<label class="field">${social ? "Thumbnail (ไม่บังคับ)" : "Image URL"}<input class="fi" data-item="${index}" data-prop="image_url" value="${esc(item.image_url || "")}"></label>`}
+          ${trust ? "" : `
+            <div class="two">
+              <label class="field">Active from<input class="fi" data-item="${index}" data-prop="active_from" value="${esc(item.active_from || "")}" placeholder="YYYY-MM-DD"></label>
+              <label class="field">Active to<input class="fi" data-item="${index}" data-prop="active_to" value="${esc(item.active_to || "")}" placeholder="YYYY-MM-DD"></label>
+            </div>
+            <label class="field">อัปโหลดรูป<input class="fi" type="file" accept="image/jpeg,image/png,image/webp" data-upload="${index}"></label>
+          `}
         </div>
-        <label>อัปโหลดรูป<input type="file" accept="image/jpeg,image/png,image/webp" data-upload="${index}"></label>`}
-        <button class="btn danger" type="button" data-remove-item="${index}">ลบรายการ</button>
       </div>
     `;
   }
@@ -198,17 +224,12 @@
     const value = cta || {};
     const mode = value.url ? "url" : "route";
     const targetField = mode === "url"
-      ? `<label>${label} URL<input data-hero-cta="${itemIndex}" data-cta-name="${ctaName}" data-prop="url" value="${esc(value.url || "")}" placeholder="https://..."></label>`
-      : `<label>${label} route<select data-hero-cta="${itemIndex}" data-cta-name="${ctaName}" data-prop="route">
-          ${ROUTE_OPTIONS.map((route) => `<option value="${route}" ${String(value.route || "home") === route ? "selected" : ""}>${route}</option>`).join("")}
-        </select></label>`;
+      ? `<label class="field">${label} URL<input class="fi" data-hero-cta="${itemIndex}" data-cta-name="${ctaName}" data-prop="url" value="${esc(value.url || "")}" placeholder="https://..."></label>`
+      : `<label class="field">${label} route<select class="fi" data-hero-cta="${itemIndex}" data-cta-name="${ctaName}" data-prop="route">${ROUTE_OPTIONS.map((r) => `<option value="${r}" ${String(value.route || "home") === r ? "selected" : ""}>${r}</option>`).join("")}</select></label>`;
     return `
       <div class="two">
-        <label>${label}<input data-hero-cta="${itemIndex}" data-cta-name="${ctaName}" data-prop="label" value="${esc(value.label || "")}"></label>
-        <label>${label} target<select data-hero-cta-target="${itemIndex}" data-cta-name="${ctaName}">
-          <option value="route" ${mode === "route" ? "selected" : ""}>Internal route</option>
-          <option value="url" ${mode === "url" ? "selected" : ""}>External URL</option>
-        </select></label>
+        <label class="field">${label}<input class="fi" data-hero-cta="${itemIndex}" data-cta-name="${ctaName}" data-prop="label" value="${esc(value.label || "")}"></label>
+        <label class="field">${label} target<select class="fi" data-hero-cta-target="${itemIndex}" data-cta-name="${ctaName}"><option value="route" ${mode === "route" ? "selected" : ""}>Internal route</option><option value="url" ${mode === "url" ? "selected" : ""}>External URL</option></select></label>
       </div>
       ${targetField}
     `;
@@ -216,26 +237,31 @@
 
   function heroSlideEditor(item, index, total) {
     return `
-      <div class="item">
-        <h3>Hero slide ${index + 1}</h3>
-        <label class="switch"><input type="checkbox" data-item-enabled="${index}" ${item.enabled !== false ? "checked" : ""}> เปิดใช้งานสไลด์นี้</label>
-        <div>
-          <button class="mini" type="button" data-move-item="${index}" data-dir="-1" ${index === 0 ? "disabled" : ""}>↑</button>
-          <button class="mini" type="button" data-move-item="${index}" data-dir="1" ${index === total - 1 ? "disabled" : ""}>↓</button>
+      <div class="item-card">
+        <div class="item-card-head">
+          <div style="display:flex;align-items:center;gap:8px">
+            <span class="item-num">${index + 1}</span>
+            <span style="font-weight:900;font-size:13px">Slide ${index + 1}</span>
+            <button class="mini" type="button" data-move-item="${index}" data-dir="-1" ${index === 0 ? "disabled" : ""}>↑</button>
+            <button class="mini" type="button" data-move-item="${index}" data-dir="1" ${index === total - 1 ? "disabled" : ""}>↓</button>
+          </div>
+          <div style="display:flex;gap:8px;align-items:center">
+            <label class="switch"><input type="checkbox" data-item-enabled="${index}" ${item.enabled !== false ? "checked" : ""}> เปิด</label>
+            <button class="btn btn-danger btn-sm" type="button" data-remove-item="${index}">ลบ</button>
+          </div>
         </div>
-        <label>Kicker<input data-item="${index}" data-prop="kicker" value="${esc(item.kicker || "")}"></label>
-        <label>Title<input data-item="${index}" data-prop="title" value="${esc(item.title || "")}"></label>
-        <label>Body<textarea data-item="${index}" data-prop="body">${esc(item.body || "")}</textarea></label>
-        <label>Image URL<input data-item="${index}" data-prop="image_url" value="${esc(item.image_url || "")}" placeholder="https://..."></label>
-        <label>Upload image<input type="file" accept="image/jpeg,image/png,image/webp" data-upload="${index}"></label>
-        <label>ตำแหน่งโฟกัสภาพ<select data-item="${index}" data-prop="focal_position">
-          <option value="top" ${item.focal_position === "top" ? "selected" : ""}>บน</option>
-          <option value="center" ${(item.focal_position || "center") === "center" ? "selected" : ""}>กลาง</option>
-          <option value="bottom" ${item.focal_position === "bottom" ? "selected" : ""}>ล่าง</option>
-        </select></label>
-        ${ctaEditor(item.cta_primary, index, "cta_primary", "Primary CTA")}
-        ${ctaEditor(item.cta_secondary, index, "cta_secondary", "Secondary CTA")}
-        <button class="btn danger" type="button" data-remove-item="${index}">ลบรายการ</button>
+        <div class="item-card-body">
+          <div class="two">
+            <label class="field">Kicker<input class="fi" data-item="${index}" data-prop="kicker" value="${esc(item.kicker || "")}"></label>
+            <label class="field">ตำแหน่งโฟกัส<select class="fi" data-item="${index}" data-prop="focal_position"><option value="top" ${item.focal_position === "top" ? "selected" : ""}>บน</option><option value="center" ${(item.focal_position || "center") === "center" ? "selected" : ""}>กลาง</option><option value="bottom" ${item.focal_position === "bottom" ? "selected" : ""}>ล่าง</option></select></label>
+          </div>
+          <label class="field">Title<input class="fi" data-item="${index}" data-prop="title" value="${esc(item.title || "")}"></label>
+          <label class="field">Body<textarea class="fi" data-item="${index}" data-prop="body">${esc(item.body || "")}</textarea></label>
+          <label class="field">Image URL<input class="fi" data-item="${index}" data-prop="image_url" value="${esc(item.image_url || "")}" placeholder="https://..."></label>
+          <label class="field">Upload image<input class="fi" type="file" accept="image/jpeg,image/png,image/webp" data-upload="${index}"></label>
+          ${ctaEditor(item.cta_primary, index, "cta_primary", "ปุ่มหลัก")}
+          ${ctaEditor(item.cta_secondary, index, "cta_secondary", "ปุ่มรอง")}
+        </div>
       </div>
     `;
   }
@@ -271,11 +297,8 @@
 
   function formatSyncedAt(value) {
     if (!value) return "ยังไม่เคยซิงค์";
-    try {
-      return new Date(value).toLocaleString("th-TH", { year: "numeric", month: "short", day: "numeric", hour: "2-digit", minute: "2-digit" });
-    } catch (_) {
-      return "ยังไม่เคยซิงค์";
-    }
+    try { return new Date(value).toLocaleString("th-TH", { year: "numeric", month: "short", day: "numeric", hour: "2-digit", minute: "2-digit" }); }
+    catch (_) { return "ยังไม่เคยซิงค์"; }
   }
 
   function articlesAutoSyncEditor(section) {
@@ -285,17 +308,22 @@
     const statusText = articleSyncStatusLoading
       ? "กำลังตรวจสอบสถานะ..."
       : status
-        ? (status.error ? "ตรวจสอบสถานะไม่สำเร็จ" : `ซิงค์ล่าสุด: ${formatSyncedAt(status.last_synced_at)} · มีบทความ ${status.count} รายการ`)
+        ? (status.error ? "⚠️ ตรวจสอบสถานะไม่สำเร็จ" : `✅ ซิงค์ล่าสุด: ${formatSyncedAt(status.last_synced_at)} · มีบทความ ${status.count} รายการ`)
         : "";
+    const hasData = status && !status.error && status.count > 0;
     return `
-      <div class="item" style="border-style:dashed">
-        <h3>ดึงบทความอัตโนมัติจากเว็บไซต์</h3>
-        <label class="switch"><input type="checkbox" data-auto-sync ${section.auto_sync ? "checked" : ""}> เปิดดึงบทความอัตโนมัติ (sync เป็นระยะ)</label>
-        <label>URL เว็บไซต์ต้นทาง<input data-field="source_url" value="${esc(section.source_url || "")}" placeholder="https://www.cwf-air.com"></label>
-        <label>Seed URL สำรอง (ใช้เมื่อ API ของเว็บไม่พร้อม ใส่ลิงก์บทความทีละบรรทัด)<textarea data-seed-urls>${esc(seedUrlsText)}</textarea></label>
-        <div class="toolbar"><button class="btn" type="button" id="syncArticlesNow">ซิงค์ตอนนี้</button></div>
-        ${statusText ? `<p style="color:#7d899c;font-size:13px">${esc(statusText)}</p>` : ""}
-        ${section.auto_sync ? `<p style="color:#7d899c;font-size:12px">เปิดใช้งานแล้ว ระบบจะดึงบทความให้อัตโนมัติเป็นระยะ รายการที่เพิ่มด้วยมือด้านบนจะไม่ถูกใช้แสดงผลจริงขณะเปิดโหมดนี้</p>` : ""}
+      <div class="ep">
+        <div class="ep-head">🔄 ดึงบทความอัตโนมัติจากเว็บไซต์</div>
+        <div class="ep-body">
+          <label class="switch"><input type="checkbox" data-auto-sync ${section.auto_sync ? "checked" : ""}> <span>เปิดดึงบทความอัตโนมัติ (sync เป็นระยะ)</span></label>
+          <label class="field">URL เว็บไซต์ต้นทาง<input class="fi" data-field="source_url" value="${esc(section.source_url || "")}" placeholder="https://www.cwf-air.com"></label>
+          <label class="field">Seed URL สำรอง (ใส่ลิงก์บทความทีละบรรทัด)<textarea class="fi" data-seed-urls>${esc(seedUrlsText)}</textarea></label>
+          <div class="toolbar">
+            <button class="btn btn-ghost" type="button" id="syncArticlesNow">🔄 ซิงค์ตอนนี้</button>
+          </div>
+          ${statusText ? `<div class="sync-info ${hasData ? "has-data" : ""}">${esc(statusText)}</div>` : ""}
+          ${section.auto_sync ? `<p style="font-size:12px;color:var(--muted);line-height:1.55">เปิดใช้งานแล้ว — ระบบจะดึงบทความให้อัตโนมัติเป็นระยะ รายการที่เพิ่มด้วยมือด้านล่างจะไม่ถูกใช้แสดงผลจริงขณะเปิดโหมดนี้</p>` : ""}
+        </div>
       </div>
     `;
   }
@@ -304,42 +332,79 @@
     const section = current();
     if (!section) return;
     const itemTypes = ["announcements", "updates", "articles", "social", "trust", "quick", "promo_banner"];
-    $("editor").innerHTML = `
-      ${field("ชื่อ Section", "title")}
-      ${field("คำอธิบาย", "body", "textarea")}
-      ${section.type === "hero" ? `
-        ${field("Kicker", "kicker")}
-        <label>Hero Image URL<input data-field="image_url" value="${esc(section.image_url || "")}"></label>
-        <label>Hero Image Upload<input type="file" accept="image/jpeg,image/png,image/webp" data-upload-section="hero"></label>
-        ${section.image_url ? `<button class="btn danger" type="button" data-clear-section-image="hero">Remove hero image</button>` : ""}
-        <label>ตำแหน่งโฟกัสภาพ<select data-field="focal_position">
-          <option value="top" ${section.focal_position === "top" ? "selected" : ""}>บน</option>
-          <option value="center" ${(section.focal_position || "center") === "center" ? "selected" : ""}>กลาง</option>
-          <option value="bottom" ${section.focal_position === "bottom" ? "selected" : ""}>ล่าง</option>
-        </select></label>
-        <div class="two">
-          <label>ปุ่มหลัก<input data-cta="cta_primary" data-prop="label" value="${esc(section.cta_primary?.label || "")}"></label>
-          <label>Route ปุ่มหลัก<input data-cta="cta_primary" data-prop="route" value="${esc(section.cta_primary?.route || "")}"></label>
+
+    let content = `
+      <div class="ep">
+        <div class="ep-head">ข้อมูลทั่วไป</div>
+        <div class="ep-body">
+          ${field("ชื่อ Section", "title")}
+          ${field("คำอธิบาย", "body", "textarea")}
         </div>
-        <div class="two">
-          <label>ปุ่มรอง<input data-cta="cta_secondary" data-prop="label" value="${esc(section.cta_secondary?.label || "")}"></label>
-          <label>Route ปุ่มรอง<input data-cta="cta_secondary" data-prop="route" value="${esc(section.cta_secondary?.route || "")}"></label>
-        </div>
-        <div class="toolbar"><button class="btn" type="button" id="addHeroSlide">Add hero slide</button></div>
-        ${(section.items || []).map((item, index) => heroSlideEditor(item, index, section.items.length)).join("")}
-      ` : ""}
-      ${section.type === "articles" ? articlesAutoSyncEditor(section) : ""}
-      ${itemTypes.includes(section.type) && !(section.type === "articles" && section.auto_sync) ? `
-        <div class="toolbar"><button class="btn" type="button" id="addItem">เพิ่มรายการ</button></div>
-        ${section.type === "promo_banner" ? (section.items || []).map((item, index) => `
-          <div>
-            <button class="mini" type="button" data-move-item="${index}" data-dir="-1" ${index === 0 ? "disabled" : ""}>↑</button>
-            <button class="mini" type="button" data-move-item="${index}" data-dir="1" ${index === section.items.length - 1 ? "disabled" : ""}>↓</button>
-          </div>
-        ${itemEditor(item, index, section.type)}`).join("") : (section.items || []).map((item, index) => itemEditor(item, index, section.type)).join("")}
-      ` : ""}
-      ${section.type === "featured_services" ? featuredServicesEditor(section) : ""}
+      </div>
     `;
+
+    if (section.type === "hero") {
+      content += `
+        <div class="ep">
+          <div class="ep-head">Hero Image &amp; Focal</div>
+          <div class="ep-body">
+            <label class="field">Hero Image URL<input class="fi" data-field="image_url" value="${esc(section.image_url || "")}" placeholder="https://..."></label>
+            <label class="field">อัปโหลดรูป Hero<input class="fi" type="file" accept="image/jpeg,image/png,image/webp" data-upload-section="hero"></label>
+            ${section.image_url ? `<button class="btn btn-danger btn-sm" type="button" data-clear-section-image="hero">ลบรูป Hero</button>` : ""}
+            <label class="field">Kicker<input class="fi" data-field="kicker" value="${esc(section.kicker || "")}"></label>
+            <label class="field">ตำแหน่งโฟกัสภาพ<select class="fi" data-field="focal_position"><option value="top" ${section.focal_position === "top" ? "selected" : ""}>บน</option><option value="center" ${(section.focal_position || "center") === "center" ? "selected" : ""}>กลาง</option><option value="bottom" ${section.focal_position === "bottom" ? "selected" : ""}>ล่าง</option></select></label>
+          </div>
+        </div>
+        <div class="ep">
+          <div class="ep-head">CTA ปุ่มหลัก / ปุ่มรอง (ใช้เมื่อไม่มี Slides)</div>
+          <div class="ep-body">
+            <div class="two">
+              <label class="field">ปุ่มหลัก<input class="fi" data-cta="cta_primary" data-prop="label" value="${esc(section.cta_primary?.label || "")}"></label>
+              <label class="field">Route ปุ่มหลัก<input class="fi" data-cta="cta_primary" data-prop="route" value="${esc(section.cta_primary?.route || "")}"></label>
+            </div>
+            <div class="two">
+              <label class="field">ปุ่มรอง<input class="fi" data-cta="cta_secondary" data-prop="label" value="${esc(section.cta_secondary?.label || "")}"></label>
+              <label class="field">Route ปุ่มรอง<input class="fi" data-cta="cta_secondary" data-prop="route" value="${esc(section.cta_secondary?.route || "")}"></label>
+            </div>
+          </div>
+        </div>
+        <div class="ep">
+          <div class="ep-head">Hero Slides <div class="toolbar" style="display:inline-flex;margin-left:10px"><button class="btn btn-ghost btn-sm" type="button" id="addHeroSlide">+ เพิ่ม Slide</button></div></div>
+          <div class="ep-body">
+            ${(section.items || []).map((item, index) => heroSlideEditor(item, index, section.items.length)).join("") || `<p style="color:var(--muted);font-size:13px">ยังไม่มี Slide — จะใช้ข้อมูล Section หลัก</p>`}
+          </div>
+        </div>
+      `;
+    }
+
+    if (section.type === "articles") {
+      content += articlesAutoSyncEditor(section);
+    }
+
+    if (section.type === "featured_services") {
+      content += `<div class="ep"><div class="ep-head">บริการแนะนำ</div><div class="ep-body">${featuredServicesEditor(section)}</div></div>`;
+    }
+
+    if (itemTypes.includes(section.type) && !(section.type === "articles" && section.auto_sync)) {
+      const moveControls = (index, len) => section.type === "promo_banner" ? `
+        <button class="mini" type="button" data-move-item="${index}" data-dir="-1" ${index === 0 ? "disabled" : ""}>↑</button>
+        <button class="mini" type="button" data-move-item="${index}" data-dir="1" ${index === len - 1 ? "disabled" : ""}>↓</button>
+      ` : "";
+      const items = (section.items || []);
+      content += `
+        <div class="ep">
+          <div class="ep-head">
+            รายการ (${items.length})
+            <button class="btn btn-ghost btn-sm" type="button" id="addItem">+ เพิ่มรายการ</button>
+          </div>
+          <div class="ep-body">
+            ${items.length ? items.map((item, index) => (moveControls(index, items.length) ? `<div class="toolbar" style="margin-bottom:4px">${moveControls(index, items.length)}</div>` : "") + itemEditor(item, index, section.type)).join("") : `<p style="color:var(--muted);font-size:13px">ยังไม่มีรายการ</p>`}
+          </div>
+        </div>
+      `;
+    }
+
+    $("editor").innerHTML = content;
   }
 
   function featuredServicesEditor(section) {
@@ -349,52 +414,46 @@
     let manualBlock = "";
     if (mode === "manual") {
       if (catalogLoadFailed) {
-        manualBlock = `<p>โหลดรายการ Catalog ไม่สำเร็จ</p><button class="btn" type="button" id="retryCatalog">ลองใหม่</button>`;
+        manualBlock = `<p style="color:var(--muted)">โหลดรายการ Catalog ไม่สำเร็จ</p><button class="btn btn-ghost btn-sm" type="button" id="retryCatalog">ลองใหม่</button>`;
       } else if (!catalogItems) {
-        manualBlock = `<p>กำลังโหลดรายการ Catalog...</p>`;
+        manualBlock = `<p style="color:var(--muted)">กำลังโหลดรายการ Catalog...</p>`;
       } else {
         const byId = new Map(catalogItems.map((item) => [String(item.item_id), item]));
         const selectedRows = itemIds.map((id) => byId.get(id)).filter(Boolean);
         const unselectedRows = catalogItems.filter((item) => !itemIds.includes(String(item.item_id)));
-        const inactiveNote = (item) => (catalogIsSelectable(item) ? "" : ` <small style="color:#b42318">(ปิดใช้งาน/ไม่แสดงลูกค้า — จะไม่แสดงจริง)</small>`);
+        const inactiveNote = (item) => (catalogIsSelectable(item) ? "" : ` <small style="color:#b42318">(ปิดอยู่)</small>`);
         manualBlock = `
-          <p style="margin:8px 0 4px;font-weight:600">รายการที่เลือก (ลำดับ = ลำดับที่แสดงจริง)</p>
-          <div class="editor" style="max-height:240px;overflow:auto;border:1px solid #dce4ef;border-radius:11px;padding:8px">
+          <p style="font-size:12px;font-weight:900;color:var(--muted)">รายการที่เลือก (ลำดับ = ลำดับที่แสดงจริง)</p>
+          <div style="max-height:220px;overflow:auto;border:1.5px solid var(--line);border-radius:10px;padding:8px;display:grid;gap:6px">
             ${selectedRows.length ? selectedRows.map((item, index) => `
-              <div class="section-row">
-                <div>
+              <div class="sec-row">
+                <div style="display:flex;gap:4px">
                   <button class="mini" type="button" data-move-featured-item="${esc(item.item_id)}" data-dir="-1" ${index === 0 ? "disabled" : ""}>↑</button>
                   <button class="mini" type="button" data-move-featured-item="${esc(item.item_id)}" data-dir="1" ${index === selectedRows.length - 1 ? "disabled" : ""}>↓</button>
                 </div>
-                <div><b>${esc(item.item_name || item.item_id)}</b>${inactiveNote(item)}</div>
-                <label class="switch"><input type="checkbox" data-featured-item="${esc(item.item_id)}" checked> แสดงผล</label>
+                <div style="flex:1;font-weight:900;font-size:13px">${esc(item.item_name || item.item_id)}${inactiveNote(item)}</div>
+                <label class="switch"><input type="checkbox" data-featured-item="${esc(item.item_id)}" checked> แสดง</label>
               </div>
-            `).join("") : "<p>ยังไม่ได้เลือกรายการ</p>"}
+            `).join("") : "<p style='color:var(--muted);font-size:13px'>ยังไม่ได้เลือก</p>"}
           </div>
-          <p style="margin:10px 0 4px;font-weight:600">รายการที่ยังไม่เลือก</p>
-          <div class="editor" style="max-height:240px;overflow:auto;border:1px solid #dce4ef;border-radius:11px;padding:8px">
+          <p style="font-size:12px;font-weight:900;color:var(--muted);margin-top:6px">รายการที่ยังไม่เลือก</p>
+          <div style="max-height:220px;overflow:auto;border:1.5px solid var(--line);border-radius:10px;padding:8px;display:grid;gap:6px">
             ${unselectedRows.length ? unselectedRows.map((item) => {
               const selectable = catalogIsSelectable(item);
-              return `
-                <label class="switch" style="justify-content:flex-start">
-                  <input type="checkbox" data-featured-item="${esc(item.item_id)}" ${selectable ? "" : "disabled"}>
-                  ${esc(item.item_name || item.item_id)}${inactiveNote(item)}
-                </label>
-              `;
-            }).join("") : "<p>ไม่มีรายการเพิ่มเติม</p>"}
+              return `<label class="switch" style="justify-content:flex-start"><input type="checkbox" data-featured-item="${esc(item.item_id)}" ${selectable ? "" : "disabled"}> ${esc(item.item_name || item.item_id)}${inactiveNote(item)}</label>`;
+            }).join("") : "<p style='color:var(--muted);font-size:13px'>ไม่มีรายการเพิ่มเติม</p>"}
           </div>
         `;
       }
     }
     return `
-      <label>แหล่งข้อมูลบริการแนะนำ<select data-featured-mode>
-        <option value="auto" ${mode === "auto" ? "selected" : ""}>ดึงจาก Catalog อัตโนมัติ (is_featured)</option>
-        <option value="manual" ${mode === "manual" ? "selected" : ""}>เลือกรายการเอง</option>
-      </select></label>
-      <label>จำนวนรายการสูงสุด<input type="number" min="1" max="12" data-featured-limit value="${esc(section.featured_limit || 8)}"></label>
-      <label class="switch"><input type="checkbox" data-featured-bool="show_price" ${section.show_price !== false ? "checked" : ""}> แสดงราคา</label>
-      <label class="switch"><input type="checkbox" data-featured-bool="show_badge" ${section.show_badge !== false ? "checked" : ""}> แสดง Badge สถานะจอง</label>
-      ${mode === "manual" ? `<label>เลือกและจัดลำดับบริการที่ต้องการแสดง${manualBlock}</label>` : ""}
+      <label class="field">แหล่งข้อมูล<select class="fi" data-featured-mode><option value="auto" ${mode === "auto" ? "selected" : ""}>ดึงจาก Catalog อัตโนมัติ (is_featured)</option><option value="manual" ${mode === "manual" ? "selected" : ""}>เลือกรายการเอง</option></select></label>
+      <label class="field">จำนวนสูงสุด<input class="fi" type="number" min="1" max="12" data-featured-limit value="${esc(section.featured_limit || 8)}"></label>
+      <div style="display:flex;gap:14px;flex-wrap:wrap">
+        <label class="switch"><input type="checkbox" data-featured-bool="show_price" ${section.show_price !== false ? "checked" : ""}> แสดงราคา</label>
+        <label class="switch"><input type="checkbox" data-featured-bool="show_badge" ${section.show_badge !== false ? "checked" : ""}> แสดง Badge</label>
+      </div>
+      ${mode === "manual" ? manualBlock : ""}
     `;
   }
 
@@ -419,53 +478,45 @@
     setStatus("อัปโหลดรูปแล้ว", "ok");
   }
 
+  /* ── preview ── */
   function renderPreview() {
-    $("preview").innerHTML = sections().filter((section) => section.enabled !== false).map((section) => {
+    $("preview").innerHTML = sections().filter((s) => s.enabled !== false).map((section) => {
       if (section.type === "hero") {
         const enabledSlides = (section.items || []).filter((slide) => slide.enabled !== false);
         const slides = enabledSlides.length ? enabledSlides : [section];
-        return `<section class="hero">${slides.map((slide) => `<div ${slide.image_url ? `style="background-image:linear-gradient(rgba(7,27,56,.62),rgba(7,27,56,.62)),url('${esc(slide.image_url)}');background-size:cover;background-position:center"` : ""}><small>${esc(slide.kicker || section.kicker || "Coldwindflow")}</small><h3>${esc(slide.title || section.title || "")}</h3><p>${esc(slide.body || section.body || "")}</p></div>`).join("")}</section>`;
+        return `<section class="p-hero">${slides.map((slide) => `<div ${slide.image_url ? `style="background-image:linear-gradient(rgba(7,27,56,.62),rgba(7,27,56,.62)),url('${esc(slide.image_url)}');background-size:cover;background-position:${slide.focal_position||"center"}"` : ""}><small>${esc(slide.kicker || section.kicker || "Coldwindflow")}</small><h3>${esc(slide.title || section.title || "")}</h3><p>${esc(slide.body || section.body || "")}</p></div>`).join("")}</section>`;
       }
-      if (section.type === "quick") return `<section class="quick">${(section.items || []).filter((item) => item.enabled !== false).slice(0, 4).map((item) => `<div>${esc(item.title || "")}</div>`).join("")}</section>`;
+      if (section.type === "quick") return `<section class="p-quick">${(section.items || []).filter((i) => i.enabled !== false).slice(0, 4).map((i) => `<div>${esc(i.title || "")}</div>`).join("")}</section>`;
       if (section.type === "promo_banner") {
-        const banners = (section.items || []).filter((item) => item.enabled !== false && item.image_url);
+        const banners = (section.items || []).filter((i) => i.enabled !== false && i.image_url);
         if (!banners.length) return "";
-        return `<section class="sec"><div style="aspect-ratio:1/1;border-radius:18px;overflow:hidden;background:#eef2f7"><img src="${esc(banners[0].image_url)}" alt="${esc(banners[0].alt_text || "")}" style="width:100%;height:100%;object-fit:${banners[0].aspect_mode === "cover" ? "cover" : "contain"}"></div>${banners.length > 1 ? `<p style="text-align:center;margin-top:6px;color:#7d899c;font-size:12px">${banners.length} banners</p>` : ""}</section>`;
+        return `<section class="p-sec"><div style="aspect-ratio:1/1;border-radius:16px;overflow:hidden;background:#eef2f7"><img src="${esc(banners[0].image_url)}" alt="${esc(banners[0].alt_text || "")}" style="width:100%;height:100%;object-fit:${banners[0].aspect_mode === "cover" ? "cover" : "contain"}"></div>${banners.length > 1 ? `<p style="text-align:center;margin-top:5px;color:var(--muted);font-size:11px">${banners.length} banners</p>` : ""}</section>`;
       }
-      if (section.type === "active_job") return `<section class="sec"><div class="sec-head"><div><b>${esc(section.title || "")}</b><br><span>Shown only when the logged-in customer has an active job</span></div></div></section>`;
+      if (section.type === "active_job") return `<section class="p-sec"><div class="p-sec-head"><b>${esc(section.title || "")}</b><span style="color:var(--muted);font-size:10px">Shown only when logged-in customer has an active job</span></div></section>`;
       if (section.type === "featured_services") {
         const items = resolveFeaturedPreviewItems(section);
         const showPrice = section.show_price !== false;
         const showBadge = section.show_badge !== false;
-        const priceText = (item) => {
-          const value = Number(item.display_price ?? item.active_price ?? item.base_price);
-          return Number.isFinite(value) && value > 0 ? `${value.toLocaleString("th-TH")} บาท` : "สอบถามราคา";
-        };
+        const priceText = (item) => { const v = Number(item.display_price ?? item.active_price ?? item.base_price); return Number.isFinite(v) && v > 0 ? `${v.toLocaleString("th-TH")} บาท` : "สอบถามราคา"; };
         const cards = items.length
-          ? items.map((item) => `
-              <article class="card">
-                <b>${esc(item.item_name || item.item_id)}</b>
-                ${showBadge ? `<p><span style="display:inline-block;padding:2px 8px;border-radius:999px;background:#eef2ff;color:#3346a6;font-size:11px">${item.booking_mode === "bookable" ? "จองได้" : "สอบถามแอดมิน"}</span></p>` : ""}
-                ${showPrice ? `<p>${esc(priceText(item))}</p>` : ""}
-              </article>
-            `).join("")
-          : catalogLoadFailed
-            ? `<article class="card"><b>โหลด Catalog ไม่สำเร็จ</b><p>กดลองใหม่ในตัวแก้ไข</p></article>`
-            : !catalogItems
-              ? `<article class="card"><b>กำลังโหลด Catalog...</b></article>`
-              : `<article class="card"><b>ไม่มีบริการแนะนำที่แสดงผลได้</b><p>Section นี้จะถูกซ่อนจากลูกค้าจริง</p></article>`;
-        return `<section class="sec"><div class="sec-head"><div><b>${esc(section.title || "")}</b><br><span>${esc(section.body || "")}</span></div></div><div class="cards">${cards}</div></section>`;
+          ? items.map((item) => `<article class="p-card"><b>${esc(item.item_name || item.item_id)}</b>${showBadge ? `<p><span style="display:inline-block;padding:2px 7px;border-radius:999px;background:#eef2ff;color:#3346a6;font-size:10px">${item.booking_mode === "bookable" ? "จองได้" : "สอบถาม"}</span></p>` : ""}${showPrice ? `<p>${esc(priceText(item))}</p>` : ""}</article>`).join("")
+          : catalogLoadFailed ? `<article class="p-card"><b>โหลด Catalog ไม่สำเร็จ</b></article>`
+          : !catalogItems ? `<article class="p-card"><b>กำลังโหลด...</b></article>`
+          : `<article class="p-card"><b>ไม่มีบริการแนะนำ</b><p>Section นี้จะถูกซ่อน</p></article>`;
+        return `<section class="p-sec"><div class="p-sec-head"><b>${esc(section.title || "")}</b></div><div class="p-cards">${cards}</div></section>`;
       }
-      return `<section class="sec"><div class="sec-head"><div><b>${esc(section.title || "")}</b><br><span>${esc(section.body || "")}</span></div><span>ดูทั้งหมด</span></div><div class="cards">${(section.items || []).filter((item) => item.enabled !== false).slice(0, 3).map((item) => `<article class="card">${section.type === "social" ? `<span style="display:inline-block;padding:2px 8px;border-radius:999px;background:#eef2ff;color:#3346a6;font-size:10px;margin-bottom:4px">${esc((item.platform || "youtube") === "facebook" ? "Facebook" : "YouTube")}</span><br>` : ""}<b>${esc(item.title || "")}</b><p>${esc(item.body || "")}</p></article>`).join("") || `<article class="card"><b>ไม่มีรายการ</b><p>เพิ่มรายการใน editor</p></article>`}</div></section>`;
+      return `<section class="p-sec"><div class="p-sec-head"><b>${esc(section.title || "")}</b><span>ดูทั้งหมด</span></div><div class="p-cards">${(section.items || []).filter((i) => i.enabled !== false).slice(0, 3).map((i) => `<article class="p-card">${section.type === "social" ? `<span style="display:inline-block;padding:2px 7px;border-radius:999px;background:#eef2ff;color:#3346a6;font-size:10px;margin-bottom:3px">${esc((i.platform || "youtube") === "facebook" ? "Facebook" : "YouTube")}</span><br>` : ""}<b>${esc(i.title || "")}</b><p>${esc(i.body || "")}</p></article>`).join("") || `<article class="p-card"><b>ไม่มีรายการ</b><p>เพิ่มรายการใน editor</p></article>`}</div></section>`;
     }).join("");
   }
 
   function render() {
     renderSectionList();
+    renderEditorHeader();
     renderEditor();
     renderPreview();
   }
 
+  /* ── event handlers ── */
   document.addEventListener("click", (event) => {
     const moveBtn = event.target.closest("[data-move]");
     if (moveBtn) move(moveBtn.dataset.move, Number(moveBtn.dataset.dir));
@@ -480,7 +531,7 @@
       const next = index + Number(moveItem.dataset.dir);
       if (section.items && next >= 0 && next < section.items.length) {
         [section.items[index], section.items[next]] = [section.items[next], section.items[index]];
-        section.items.forEach((item, itemIndex) => { item.sort_order = itemIndex + 1; });
+        section.items.forEach((item, i) => { item.sort_order = i + 1; });
         render();
       }
     }
@@ -493,11 +544,7 @@
       const id = moveFeatured.dataset.moveFeaturedItem;
       const index = ids.indexOf(id);
       const next = index + Number(moveFeatured.dataset.dir);
-      if (index >= 0 && next >= 0 && next < ids.length) {
-        [ids[index], ids[next]] = [ids[next], ids[index]];
-        section.item_ids = ids;
-        render();
-      }
+      if (index >= 0 && next >= 0 && next < ids.length) { [ids[index], ids[next]] = [ids[next], ids[index]]; section.item_ids = ids; render(); }
     }
     if (event.target.id === "retryCatalog") retryLoadCatalogItems();
     if (event.target.id === "syncArticlesNow") syncArticlesNow().catch((error) => setStatus(error.message, "bad"));
@@ -516,14 +563,7 @@
     if (event.target.id === "addHeroSlide") {
       current().items = current().items || [];
       if (current().items.length >= 5) { setStatus("Hero จำกัด 5 slides", "bad"); return; }
-      current().items.push({
-        kicker: current().kicker || "",
-        title: current().title || "",
-        body: current().body || "",
-        focal_position: current().focal_position || "center",
-        cta_primary: { ...(current().cta_primary || {}) },
-        cta_secondary: { ...(current().cta_secondary || {}) },
-      });
+      current().items.push({ kicker: current().kicker || "", title: current().title || "", body: current().body || "", focal_position: current().focal_position || "center", cta_primary: { ...(current().cta_primary || {}) }, cta_secondary: { ...(current().cta_secondary || {}) } });
       render();
     }
   });
@@ -544,7 +584,7 @@
     }
     if (target.matches("[data-item]")) section.items[Number(target.dataset.item)][target.dataset.prop] = target.value;
     if (target.matches("[data-featured-limit]")) section.featured_limit = Math.max(1, Math.min(12, Number(target.value) || 8));
-    if (target.matches("[data-seed-urls]")) section.seed_urls = target.value.split("\n").map((line) => line.trim()).filter(Boolean).slice(0, 8);
+    if (target.matches("[data-seed-urls]")) section.seed_urls = target.value.split("\n").map((l) => l.trim()).filter(Boolean).slice(0, 8);
     renderPreview();
   });
 
@@ -552,11 +592,7 @@
     const target = event.target;
     if (target.matches("select[data-item]")) { current().items[Number(target.dataset.item)][target.dataset.prop] = target.value; renderPreview(); }
     if (target.matches("select[data-field]")) { current()[target.dataset.field] = target.value; renderPreview(); }
-    if (target.matches("[data-toggle]")) {
-      const section = sections().find((row) => row.id === target.dataset.toggle);
-      if (section) section.enabled = target.checked;
-      renderPreview();
-    }
+    if (target.matches("[data-toggle]")) { const s = sections().find((row) => row.id === target.dataset.toggle); if (s) s.enabled = target.checked; renderPreview(); }
     if (target.id === "sectionPicker") { selected = target.value; render(); }
     if (target.matches("[data-upload]")) uploadImage(target, Number(target.dataset.upload)).catch((error) => setStatus(error.message, "bad"));
     if (target.matches("[data-upload-section]")) uploadImage(target, target.dataset.uploadSection).catch((error) => setStatus(error.message, "bad"));
@@ -567,25 +603,15 @@
       const section = current();
       section.item_ids = Array.isArray(section.item_ids) ? section.item_ids : [];
       const id = target.dataset.featuredItem;
-      if (target.checked) {
-        if (!section.item_ids.includes(id)) section.item_ids.push(id);
-      } else {
-        section.item_ids = section.item_ids.filter((value) => value !== id);
-      }
+      if (target.checked) { if (!section.item_ids.includes(id)) section.item_ids.push(id); }
+      else { section.item_ids = section.item_ids.filter((v) => v !== id); }
       render();
     }
-    if (target.matches("[data-item-enabled]")) {
-      const item = current().items[Number(target.dataset.itemEnabled)];
-      if (!item) return;
-      item.enabled = target.checked;
-      renderPreview();
-    }
+    if (target.matches("[data-item-enabled]")) { const item = current().items[Number(target.dataset.itemEnabled)]; if (item) { item.enabled = target.checked; renderPreview(); } }
     if (target.matches("[data-item-target]")) {
       const item = current().items[Number(target.dataset.itemTarget)];
       if (!item) return;
-      delete item.route;
-      delete item.url;
-      delete item.action;
+      delete item.route; delete item.url; delete item.action;
       if (target.value === "contact") item.action = "contact";
       if (target.value === "route") item.route = "home";
       if (target.value === "url") item.url = "";
@@ -596,9 +622,7 @@
       if (!item) return;
       const ctaName = target.dataset.ctaName;
       item[ctaName] = item[ctaName] || {};
-      delete item[ctaName].route;
-      delete item[ctaName].url;
-      delete item[ctaName].action;
+      delete item[ctaName].route; delete item[ctaName].url; delete item[ctaName].action;
       if (target.value === "route") item[ctaName].route = "home";
       if (target.value === "url") item[ctaName].url = "";
       render();


### PR DESCRIPTION
## Summary

- **3-column layout**: 252px section nav sidebar | scrollable editor panels | 344px live phone preview — all visible at once without scrolling back and forth
- **Section nav sidebar**: each section shows a type icon (🏠 hero, ⚡ quick actions, 🎨 promo banner, etc.), an enable/disable toggle switch, and up/down reorder arrows — no more hunting for which section is which
- **Panel-grouped editor**: related fields are grouped into labeled `.ep` panel cards (General Info, Hero Slides, Auto-sync, Items) so the form feels structured rather than a wall of inputs
- **Item/slide cards**: numbered pill badges, per-item enable toggles, and delete buttons all in a clean card header — easy to scan and manage
- **Live phone preview**: right panel renders a mobile mockup that reflects the active section's content in real time
- **Custom toggle switches**: CSS-only `.tog` switches replace raw checkboxes throughout for a cleaner look
- **Responsive**: stacks to single column on screens ≤ 880px

## Files changed

- `admin-homepage-cms.html` — full layout rewrite with new CSS design system (variables, topbar, 3-col grid, nav, editor, preview, phone mockup)
- `admin-homepage-cms.js` — all original API/event logic preserved; HTML templates updated to use new class names (`TYPE_ICONS` map, `.sec-row`, `.ep`, `.item-card`, `.tog`, `.fi`, `.p-hero`, etc.)

## Test plan

- [ ] Open `/admin/homepage-cms` — 3-column layout loads, section list populates in left nav
- [ ] Click a section row → editor panels appear in center with fields pre-filled
- [ ] Toggle section enable/disable → toggle animates, save draft persists state
- [ ] Click ↑ / ↓ arrows → section reorders in nav list
- [ ] Edit hero title → phone preview updates instantly
- [ ] Articles section → "ซิงค์ตอนนี้" button works, sync status turns green
- [ ] Save Draft / Publish buttons → status chip updates correctly
- [ ] Resize to mobile width → layout stacks to single column

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LmdP3TGN5uQrfT8ZYefNco

---
_Generated by [Claude Code](https://claude.ai/code/session_01LmdP3TGN5uQrfT8ZYefNco)_