### PR TITLE
Fix Homepage CMS mobile UX: tab navigation + cache-bust

### DIFF
--- a/admin-homepage-cms.html
+++ b/admin-homepage-cms.html
@@ -14,29 +14,29 @@
     }
     *,*::before,*::after{box-sizing:border-box;margin:0;padding:0}
     html,body{height:100%}
-    body{font-family:"Noto Sans Thai","Segoe UI",Arial,sans-serif;background:var(--bg);color:var(--ink);font-size:14px;overflow:hidden}
+    body{font-family:"Noto Sans Thai","Segoe UI",Arial,sans-serif;background:var(--bg);color:var(--ink);font-size:14px}
     button,input,textarea,select{font:inherit;color:inherit}
     button{cursor:pointer}
 
     /* ── topbar ── */
     .topbar{
-      position:fixed;top:0;left:0;right:0;z-index:100;
+      position:sticky;top:0;left:0;right:0;z-index:100;
       background:#fff;border-bottom:1px solid var(--line);
-      display:flex;align-items:center;gap:10px;
-      padding:0 16px;height:52px;
+      display:flex;align-items:center;gap:8px;
+      padding:0 12px;height:52px;
       box-shadow:0 2px 10px rgba(13,45,88,.07);
     }
     .topbar-back{
-      color:var(--muted);text-decoration:none;font-weight:900;font-size:13px;
-      display:flex;align-items:center;gap:5px;white-space:nowrap;
-      padding:6px 11px;border-radius:10px;border:1px solid var(--line);background:#fafbfd;
+      color:var(--muted);text-decoration:none;font-weight:900;font-size:12px;
+      display:flex;align-items:center;gap:4px;white-space:nowrap;
+      padding:6px 10px;border-radius:10px;border:1px solid var(--line);background:#fafbfd;flex-shrink:0;
     }
     .topbar-back:hover{color:var(--blue);border-color:rgba(20,99,255,.3)}
-    .topbar-brand{font-weight:900;font-size:17px;color:var(--navy);flex:1;padding-left:4px}
-    .topbar-actions{display:flex;gap:8px;align-items:center}
+    .topbar-brand{font-weight:900;font-size:15px;color:var(--navy);flex:1;min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+    .topbar-actions{display:flex;gap:6px;align-items:center;flex-shrink:0}
 
     .status-chip{
-      padding:5px 12px;border-radius:999px;font-size:12px;font-weight:900;
+      padding:4px 10px;border-radius:999px;font-size:11px;font-weight:900;
       background:var(--blue-soft);color:var(--blue);white-space:nowrap;
       border:1px solid rgba(20,99,255,.15);
     }
@@ -54,17 +54,25 @@
     .btn-danger{background:#fee2e2;color:#991b1b}
     .btn-sm{min-height:30px;padding:5px 10px;font-size:12px;border-radius:8px}
 
-    /* ── 3-col layout ── */
-    .cms-layout{
-      display:grid;
-      grid-template-columns:252px 1fr 344px;
-      margin-top:52px;
-      height:calc(100vh - 52px);
-      overflow:hidden;
+    /* ── mobile tab bar ── */
+    .cms-tabs{
+      display:none;position:sticky;top:52px;z-index:90;
+      background:#fff;border-bottom:2px solid var(--line);
     }
+    .cms-tab{
+      flex:1;padding:11px 4px 10px;font-weight:900;font-size:12px;
+      border:none;background:transparent;color:var(--muted);
+      border-bottom:2px solid transparent;margin-bottom:-2px;
+      cursor:pointer;transition:color .15s,border-color .15s;
+    }
+    .cms-tab.active{color:var(--blue);border-bottom-color:var(--blue)}
+
+    /* ── desktop 3-col layout ── */
+    .cms-layout{display:flex;height:calc(100vh - 52px)}
 
     /* ── left nav ── */
     .cms-nav{
+      width:252px;flex-shrink:0;
       background:#fff;border-right:1px solid var(--line);
       overflow-y:auto;padding:10px 8px;
       display:flex;flex-direction:column;gap:2px;
@@ -73,6 +81,17 @@
       font-size:10px;font-weight:900;color:var(--muted);
       letter-spacing:.1em;text-transform:uppercase;
       padding:8px 10px 6px;
+    }
+
+    /* ── center editor ── */
+    .cms-editor{flex:1;overflow-y:auto;padding:14px;display:flex;flex-direction:column;gap:12px}
+
+    /* ── right preview ── */
+    .cms-preview{
+      width:340px;flex-shrink:0;
+      background:#e6edf5;border-left:1px solid var(--line);
+      overflow-y:auto;padding:14px;
+      display:flex;flex-direction:column;align-items:center;gap:10px;
     }
 
     /* ── section row ── */
@@ -86,10 +105,10 @@
     .sec-row.is-disabled .sec-name{opacity:.38}
     .sec-row-body{
       flex:1;min-width:0;display:flex;align-items:center;gap:8px;
-      cursor:pointer;padding:1px 0;
+      cursor:pointer;padding:2px 0;
     }
     .sec-icon{
-      font-size:15px;width:32px;height:32px;border-radius:9px;
+      font-size:15px;width:34px;height:34px;border-radius:9px;
       background:var(--bg);box-shadow:0 1px 4px rgba(13,45,88,.09);
       display:flex;align-items:center;justify-content:center;flex-shrink:0;
       transition:background .12s;
@@ -102,30 +121,27 @@
 
     /* mini arrow btns */
     .mini{
-      width:26px;height:26px;border:1px solid var(--line);border-radius:7px;
-      background:#fff;color:var(--muted);font-size:11px;
+      width:28px;height:28px;border:1px solid var(--line);border-radius:7px;
+      background:#fff;color:var(--muted);font-size:12px;
       display:flex;align-items:center;justify-content:center;cursor:pointer;flex-shrink:0;
     }
     .mini:hover:not(:disabled){background:var(--blue-soft);border-color:rgba(20,99,255,.3);color:var(--blue)}
     .mini:disabled{opacity:.25;cursor:default}
 
-    /* toggle switch */
-    .tog{display:block;cursor:pointer;flex-shrink:0}
-    .tog input{display:none}
+    /* custom toggle switch */
+    .tog{display:block;cursor:pointer;flex-shrink:0;-webkit-tap-highlight-color:transparent}
+    .tog input{position:absolute;opacity:0;width:0;height:0;pointer-events:none}
     .tog span{
-      display:block;width:34px;height:18px;border-radius:9px;
+      display:block;width:36px;height:20px;border-radius:10px;
       background:#cbd5e1;position:relative;transition:background .18s;
     }
     .tog span::after{
       content:"";position:absolute;top:3px;left:3px;
-      width:12px;height:12px;border-radius:6px;background:#fff;
-      box-shadow:0 1px 3px rgba(0,0,0,.2);transition:transform .18s;
+      width:14px;height:14px;border-radius:7px;background:#fff;
+      box-shadow:0 1px 3px rgba(0,0,0,.25);transition:transform .18s;
     }
     .tog input:checked+span{background:var(--blue)}
     .tog input:checked+span::after{transform:translateX(16px)}
-
-    /* ── center editor ── */
-    .cms-editor{overflow-y:auto;padding:14px;display:flex;flex-direction:column;gap:12px}
 
     /* editor header card */
     .editor-hd{
@@ -187,12 +203,7 @@
     .sync-info{background:#f8fafd;border:1px solid var(--line);border-radius:10px;padding:10px 12px;font-size:12px;color:var(--muted);font-weight:800;line-height:1.5}
     .sync-info.has-data{border-color:rgba(22,163,74,.2);background:var(--ok-bg);color:var(--ok)}
 
-    /* ── right preview ── */
-    .cms-preview{
-      background:#e6edf5;border-left:1px solid var(--line);
-      overflow-y:auto;padding:14px;
-      display:flex;flex-direction:column;align-items:center;gap:10px;
-    }
+    /* preview phone */
     .preview-hd{font-size:10px;font-weight:900;color:var(--muted);letter-spacing:.1em;text-transform:uppercase}
     .phone{
       width:100%;max-width:320px;background:#f3f6fb;
@@ -200,9 +211,7 @@
       box-shadow:0 16px 40px rgba(7,27,56,.14);
     }
     .phone-head{padding:11px 14px;background:#fff;border-bottom:1px solid var(--line);font-weight:950;font-size:13px}
-    .phone-body{padding:10px 12px 90px;min-height:600px}
-
-    /* preview inner elements */
+    .phone-body{padding:10px 12px 90px;min-height:500px}
     .p-hero{min-height:185px;border-radius:18px;color:#fff;background:linear-gradient(140deg,#06162e,#0b3976 52%,#1463ff);padding:18px 14px;display:flex;flex-direction:column;justify-content:flex-end}
     .p-hero small{font-weight:900;font-size:10px}
     .p-hero h3{font-size:20px;line-height:1.15;margin:6px 0 4px}
@@ -218,16 +227,46 @@
     .p-card b{font-size:12px}
     .p-card p{font-size:10px;color:var(--muted);line-height:1.4;margin-top:3px}
 
-    /* ── responsive ── */
-    @media(max-width:1100px){.cms-layout{grid-template-columns:220px 1fr 290px}}
+    /* ── responsive: mobile tab-based layout ── */
     @media(max-width:880px){
       body{overflow:auto}
-      .topbar{position:sticky}
-      .cms-layout{grid-template-columns:1fr;height:auto;overflow:visible;margin-top:0}
-      .cms-nav{max-height:240px;border-right:none;border-bottom:1px solid var(--line)}
-      .cms-preview{border-left:none;border-top:1px solid var(--line)}
+      .cms-layout{flex-direction:column;height:auto}
+      .cms-tabs{display:flex}
+
+      /* hide all panels, show only active tab */
+      .cms-nav,.cms-editor,.cms-preview{display:none;width:auto}
+      .cms-nav.tab-active,.cms-editor.tab-active,.cms-preview.tab-active{display:flex;flex-direction:column}
+      .cms-nav.tab-active{padding:12px;gap:6px;overflow-y:visible;border-right:none;border-bottom:1px solid var(--line)}
+      .cms-editor.tab-active{padding:12px;overflow-y:visible;border:none;gap:12px}
+      .cms-preview.tab-active{border-left:none;border-top:1px solid var(--line);align-items:center}
+
+      /* bigger section rows for touch */
+      .sec-row{min-height:58px;border-radius:14px;padding:10px 12px;border:1.5px solid var(--line);background:#fff;box-shadow:0 1px 4px rgba(13,45,88,.06)}
+      .sec-row.is-active{border-color:rgba(20,99,255,.4);background:var(--blue-soft);box-shadow:0 2px 8px rgba(20,99,255,.12)}
+      .sec-icon{width:40px;height:40px;font-size:18px;border-radius:11px}
+      .sec-name{font-size:14px}
+      .mini{width:34px;height:34px;font-size:14px;border-radius:9px}
+      .tog span{width:42px;height:24px;border-radius:12px}
+      .tog span::after{width:18px;height:18px;border-radius:9px;top:3px;left:3px}
+      .tog input:checked+span::after{transform:translateX(18px)}
       .two{grid-template-columns:1fr}
+      .topbar-brand{font-size:14px}
+
+      /* back to sections button in editor */
+      .back-to-sections{
+        display:inline-flex;align-items:center;gap:6px;
+        padding:8px 12px;border-radius:10px;border:1.5px solid var(--line);
+        background:#fff;color:var(--muted);font-weight:900;font-size:12px;
+        cursor:pointer;margin-bottom:4px;
+      }
     }
+    @media(min-width:881px){
+      body{overflow:hidden}
+      .back-to-sections{display:none}
+      .cms-nav,.cms-editor,.cms-preview{display:flex}
+      .cms-nav{flex-direction:column}
+    }
+    @media(max-width:1100px){.cms-nav{width:220px}.cms-preview{width:290px}}
   </style>
 </head>
 <body>
@@ -242,18 +281,26 @@
     </div>
   </div>
 
+  <!-- mobile tab bar -->
+  <div class="cms-tabs" id="cmsTabs">
+    <button class="cms-tab active" data-tab="sections">📋 Sections</button>
+    <button class="cms-tab" data-tab="editor">✏️ แก้ไข</button>
+    <button class="cms-tab" data-tab="preview">👁️ Preview</button>
+  </div>
+
   <div class="cms-layout">
-    <nav class="cms-nav">
+    <nav class="cms-nav tab-active" data-panel="sections">
       <div class="nav-hd">Sections</div>
       <div id="sectionList"></div>
     </nav>
 
-    <div class="cms-editor" id="editorPane">
+    <div class="cms-editor" data-panel="editor" id="editorPane">
+      <button class="back-to-sections" id="backToSections">← กลับ Sections</button>
       <div id="editorHeader"></div>
       <div id="editor"></div>
     </div>
 
-    <div class="cms-preview">
+    <div class="cms-preview" data-panel="preview" id="previewPane">
       <div class="preview-hd">Mobile Preview</div>
       <div class="phone">
         <div class="phone-head">Coldwindflow</div>
@@ -263,6 +310,6 @@
   </div>
 
   <select id="sectionPicker" style="display:none"></select>
-  <script src="/admin-homepage-cms.js"></script>
+  <script src="/admin-homepage-cms.js?v=20260701_mobile_tabs"></script>
 </body>
 </html>

--- a/admin-homepage-cms.js
+++ b/admin-homepage-cms.js
@@ -25,6 +25,7 @@
 
   let config = clone(DEFAULT_CONFIG);
   let selected = "hero";
+  let activeTab = "sections";
   let catalogItems = null;
   let catalogLoadFailed = false;
   let articleSyncStatus = null;
@@ -516,12 +517,22 @@
     renderPreview();
   }
 
+  function switchTab(name) {
+    activeTab = name;
+    document.querySelectorAll(".cms-tab").forEach((btn) => btn.classList.toggle("active", btn.dataset.tab === name));
+    document.querySelectorAll("[data-panel]").forEach((panel) => panel.classList.toggle("tab-active", panel.dataset.panel === name));
+  }
+
   /* ── event handlers ── */
   document.addEventListener("click", (event) => {
     const moveBtn = event.target.closest("[data-move]");
     if (moveBtn) move(moveBtn.dataset.move, Number(moveBtn.dataset.dir));
     const edit = event.target.closest("[data-edit]");
-    if (edit) { selected = edit.dataset.edit; render(); }
+    if (edit) {
+      selected = edit.dataset.edit;
+      render();
+      if (window.innerWidth <= 880) switchTab("editor");
+    }
     const remove = event.target.closest("[data-remove-item]");
     if (remove) { current().items.splice(Number(remove.dataset.removeItem), 1); render(); }
     const moveItem = event.target.closest("[data-move-item]");
@@ -632,5 +643,11 @@
   $("saveDraft").addEventListener("click", () => saveDraft().catch((error) => setStatus(error.message, "bad")));
   $("publish").addEventListener("click", () => publish().catch((error) => setStatus(error.message, "bad")));
   $("reload").addEventListener("click", () => load().catch((error) => setStatus(error.message, "bad")));
+  $("cmsTabs").addEventListener("click", (event) => {
+    const tab = event.target.closest(".cms-tab");
+    if (tab) switchTab(tab.dataset.tab);
+  });
+  $("backToSections").addEventListener("click", () => switchTab("sections"));
+  switchTab("sections");
   load().catch((error) => { config = clone(DEFAULT_CONFIG); render(); setStatus(error.message, "bad"); });
 })();


### PR DESCRIPTION
## Summary

- **Mobile tab bar** (📋 Sections | ✏️ แก้ไข | 👁️ Preview): replaces broken 3-column stack on small screens with a sticky tab bar — only the active panel is shown at a time
- **Auto-switch to editor** when tapping a section row on mobile (≤ 880px)
- **"← กลับ Sections"** button inside the editor panel for easy one-tap return
- **Bigger touch targets** throughout: section rows 58px min-height, icons 40px, arrow buttons 34px, toggle switches 42×24px
- **Toggle switch fix**: hidden input now uses `position:absolute; opacity:0` instead of `display:none` — fixes native checkbox rendering on some mobile browsers
- **JS cache-bust**: `?v=20260701_mobile_tabs` query string on the script tag forces browsers that cached the old JS to reload

## Desktop unchanged

On screens wider than 880px the original 3-column layout is preserved (`body { overflow: hidden }`, flex row with nav / editor / preview columns side-by-side).

## Test plan

- [ ] Mobile (< 880px): 3 tabs appear below topbar; tapping a section opens editor tab
- [ ] "← กลับ Sections" returns to section list
- [ ] Toggle switches render as custom pills (not native checkboxes)
- [ ] Section rows are large enough to tap comfortably
- [ ] Desktop (> 880px): 3-column layout unchanged, tabs hidden

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LmdP3TGN5uQrfT8ZYefNco

---
_Generated by [Claude Code](https://claude.ai/code/session_01LmdP3TGN5uQrfT8ZYefNco)_