### PR TITLE
fix(cms): fix section name visibility on mobile + add more customization fields

### DIFF
--- a/admin-homepage-cms.html
+++ b/admin-homepage-cms.html
@@ -233,21 +233,34 @@
       .cms-layout{flex-direction:column;height:auto}
       .cms-tabs{display:flex}
 
-      /* hide all panels, show only active tab */
-      .cms-nav,.cms-editor,.cms-preview{display:none;width:auto}
-      .cms-nav.tab-active,.cms-editor.tab-active,.cms-preview.tab-active{display:flex;flex-direction:column}
-      .cms-nav.tab-active{padding:12px;gap:6px;overflow-y:visible;border-right:none;border-bottom:1px solid var(--line)}
+      /* hide all panels; show only the active tab — explicit width:100% beats base width:252px */
+      .cms-nav,.cms-editor,.cms-preview{display:none}
+      .cms-nav.tab-active,.cms-editor.tab-active,.cms-preview.tab-active{
+        display:flex;flex-direction:column;width:100%;
+      }
+      .cms-nav.tab-active{padding:12px;gap:8px;overflow-y:visible;border-right:none;border-bottom:1px solid var(--line)}
       .cms-editor.tab-active{padding:12px;overflow-y:visible;border:none;gap:12px}
       .cms-preview.tab-active{border-left:none;border-top:1px solid var(--line);align-items:center}
 
-      /* bigger section rows for touch */
-      .sec-row{min-height:58px;border-radius:14px;padding:10px 12px;border:1.5px solid var(--line);background:#fff;box-shadow:0 1px 4px rgba(13,45,88,.06)}
+      /* section row: 2-line card layout so full name is always visible */
+      .sec-row{
+        flex-wrap:wrap;row-gap:8px;
+        border-radius:14px;padding:12px;
+        border:1.5px solid var(--line);background:#fff;
+        box-shadow:0 1px 4px rgba(13,45,88,.06);
+      }
       .sec-row.is-active{border-color:rgba(20,99,255,.4);background:var(--blue-soft);box-shadow:0 2px 8px rgba(20,99,255,.12)}
+      /* line 1: icon + full section name (takes whole row) */
+      .sec-row-body{flex:0 0 100%;gap:12px}
+      /* line 2: controls indented to align under the name */
+      .sec-controls{flex:0 0 auto;margin-left:52px;gap:10px}
+      /* name: allow wrap, no truncation */
+      .sec-name{white-space:normal;overflow:visible;text-overflow:unset;font-size:14px;line-height:1.4}
+      .sec-type{font-size:11px;margin-top:2px}
       .sec-icon{width:40px;height:40px;font-size:18px;border-radius:11px}
-      .sec-name{font-size:14px}
-      .mini{width:34px;height:34px;font-size:14px;border-radius:9px}
-      .tog span{width:42px;height:24px;border-radius:12px}
-      .tog span::after{width:18px;height:18px;border-radius:9px;top:3px;left:3px}
+      .mini{width:36px;height:36px;font-size:15px;border-radius:9px}
+      .tog span{width:44px;height:26px;border-radius:13px}
+      .tog span::after{width:20px;height:20px;border-radius:10px;top:3px;left:3px}
       .tog input:checked+span::after{transform:translateX(18px)}
       .two{grid-template-columns:1fr}
       .topbar-brand{font-size:14px}
@@ -310,6 +323,6 @@
   </div>
 
   <select id="sectionPicker" style="display:none"></select>
-  <script src="/admin-homepage-cms.js?v=20260701_mobile_tabs"></script>
+  <script src="/admin-homepage-cms.js?v=20260701_fix2"></script>
 </body>
 </html>

--- a/admin-homepage-cms.js
+++ b/admin-homepage-cms.js
@@ -167,7 +167,14 @@
     return `<label class="field">${lbl}<input class="fi" data-field="${prop}" value="${esc(value)}"></label>`;
   }
 
-  function itemEditor(item, index, sectionType) {
+  function selectField(lbl, prop, options) {
+    const section = current();
+    const value = section[prop] || "";
+    const opts = options.map(([v, l]) => `<option value="${esc(v)}" ${value === v ? "selected" : ""}>${esc(l)}</option>`).join("");
+    return `<label class="field">${lbl}<select class="fi" data-field="${prop}">${opts}</select></label>`;
+  }
+
+  function itemEditor(item, index, sectionType, total) {
     const social = sectionType === "social";
     const external = sectionType === "updates" || sectionType === "articles" || social;
     const trust = sectionType === "trust";
@@ -187,6 +194,8 @@
           <div style="display:flex;align-items:center;gap:8px">
             <span class="item-num">${index + 1}</span>
             <span style="font-weight:900;font-size:13px">รายการ ${index + 1}</span>
+            <button class="mini" type="button" data-move-item="${index}" data-dir="-1" ${index === 0 ? "disabled" : ""}>↑</button>
+            <button class="mini" type="button" data-move-item="${index}" data-dir="1" ${index === total - 1 ? "disabled" : ""}>↓</button>
           </div>
           <div style="display:flex;gap:8px;align-items:center">
             <label class="switch"><input type="checkbox" data-item-enabled="${index}" ${item.enabled !== false ? "checked" : ""}> เปิด</label>
@@ -333,6 +342,7 @@
     const section = current();
     if (!section) return;
     const itemTypes = ["announcements", "updates", "articles", "social", "trust", "quick", "promo_banner"];
+    const hasViewAll = ["announcements", "updates", "articles", "social", "trust", "featured_services"].includes(section.type);
 
     let content = `
       <div class="ep">
@@ -340,6 +350,7 @@
         <div class="ep-body">
           ${field("ชื่อ Section", "title")}
           ${field("คำอธิบาย", "body", "textarea")}
+          ${hasViewAll ? `<div class="two">${field("ข้อความปุ่ม ดูทั้งหมด", "view_all_label")}${selectField("Route ปุ่ม ดูทั้งหมด", "view_all_route", [["", "ไม่แสดงปุ่ม"], ...ROUTE_OPTIONS.map((r) => [r, r])])}</div>` : ""}
         </div>
       </div>
     `;
@@ -387,10 +398,6 @@
     }
 
     if (itemTypes.includes(section.type) && !(section.type === "articles" && section.auto_sync)) {
-      const moveControls = (index, len) => section.type === "promo_banner" ? `
-        <button class="mini" type="button" data-move-item="${index}" data-dir="-1" ${index === 0 ? "disabled" : ""}>↑</button>
-        <button class="mini" type="button" data-move-item="${index}" data-dir="1" ${index === len - 1 ? "disabled" : ""}>↓</button>
-      ` : "";
       const items = (section.items || []);
       content += `
         <div class="ep">
@@ -399,7 +406,7 @@
             <button class="btn btn-ghost btn-sm" type="button" id="addItem">+ เพิ่มรายการ</button>
           </div>
           <div class="ep-body">
-            ${items.length ? items.map((item, index) => (moveControls(index, items.length) ? `<div class="toolbar" style="margin-bottom:4px">${moveControls(index, items.length)}</div>` : "") + itemEditor(item, index, section.type)).join("") : `<p style="color:var(--muted);font-size:13px">ยังไม่มีรายการ</p>`}
+            ${items.length ? items.map((item, index) => itemEditor(item, index, section.type, items.length)).join("") : `<p style="color:var(--muted);font-size:13px">ยังไม่มีรายการ</p>`}
           </div>
         </div>
       `;
@@ -504,9 +511,11 @@
           : catalogLoadFailed ? `<article class="p-card"><b>โหลด Catalog ไม่สำเร็จ</b></article>`
           : !catalogItems ? `<article class="p-card"><b>กำลังโหลด...</b></article>`
           : `<article class="p-card"><b>ไม่มีบริการแนะนำ</b><p>Section นี้จะถูกซ่อน</p></article>`;
-        return `<section class="p-sec"><div class="p-sec-head"><b>${esc(section.title || "")}</b></div><div class="p-cards">${cards}</div></section>`;
+        const fsViewAll = section.view_all_label || (section.view_all_route ? "ดูทั้งหมด" : "");
+        return `<section class="p-sec"><div class="p-sec-head"><b>${esc(section.title || "")}</b>${fsViewAll ? `<span>${esc(fsViewAll)}</span>` : ""}</div><div class="p-cards">${cards}</div></section>`;
       }
-      return `<section class="p-sec"><div class="p-sec-head"><b>${esc(section.title || "")}</b><span>ดูทั้งหมด</span></div><div class="p-cards">${(section.items || []).filter((i) => i.enabled !== false).slice(0, 3).map((i) => `<article class="p-card">${section.type === "social" ? `<span style="display:inline-block;padding:2px 7px;border-radius:999px;background:#eef2ff;color:#3346a6;font-size:10px;margin-bottom:3px">${esc((i.platform || "youtube") === "facebook" ? "Facebook" : "YouTube")}</span><br>` : ""}<b>${esc(i.title || "")}</b><p>${esc(i.body || "")}</p></article>`).join("") || `<article class="p-card"><b>ไม่มีรายการ</b><p>เพิ่มรายการใน editor</p></article>`}</div></section>`;
+      const viewAll = section.view_all_label || (section.view_all_route ? "ดูทั้งหมด" : "");
+      return `<section class="p-sec"><div class="p-sec-head"><b>${esc(section.title || "")}</b>${viewAll ? `<span>${esc(viewAll)}</span>` : ""}</div><div class="p-cards">${(section.items || []).filter((i) => i.enabled !== false).slice(0, 3).map((i) => `<article class="p-card">${section.type === "social" ? `<span style="display:inline-block;padding:2px 7px;border-radius:999px;background:#eef2ff;color:#3346a6;font-size:10px;margin-bottom:3px">${esc((i.platform || "youtube") === "facebook" ? "Facebook" : "YouTube")}</span><br>` : ""}<b>${esc(i.title || "")}</b><p>${esc(i.body || "")}</p></article>`).join("") || `<article class="p-card"><b>ไม่มีรายการ</b><p>เพิ่มรายการใน editor</p></article>`}</div></section>`;
     }).join("");
   }
 


### PR DESCRIPTION
## Summary

- **Section names fully visible on mobile**: section rows now wrap to 2 lines — icon + full name take the entire top line, controls (↑↓ + toggle) appear on the second line indented under the name. No more truncation to 1-2 characters.
- **Mobile panel width fixed**: `.tab-active` panels now explicitly set `width:100%`, overriding the base `width:252px` that was leaking through on narrow screens.
- **↑↓ reorder buttons on all item types**: move buttons are now built into every item card header (not just promo_banner). Any section's items can be reordered directly.
- **New `ดูทั้งหมด` customization fields**: list-based sections (announcements, updates, articles, social, trust, featured_services) gain two new fields — *ข้อความปุ่ม ดูทั้งหมด* (button label) and *Route ปุ่ม ดูทั้งหมด* (internal route) — so the "View all" link can be configured per section.
- **`selectField()` helper**: new reusable helper for `<select>` fields bound to `data-field` (same event-listener pattern as existing `field()`).
- **Preview reflects `view_all_label` live**: the mobile phone preview now shows the configured label (or hides the link if no route is set).
- **JS cache-bust bumped** to `?v=20260701_fix2` to force browsers to reload the updated script.

## Files changed

| File | Change |
|---|---|
| `admin-homepage-cms.html` | Mobile CSS: 2-line section rows, explicit `width:100%` on active panels |
| `admin-homepage-cms.js` | `selectField()` helper, `view_all` fields, item reorder on all types, preview update, cache-bust bump |

---
_Generated by [Claude Code](https://claude.ai/code/session_01LmdP3TGN5uQrfT8ZYefNco)_