### PR TITLE
fix(store): honest empty rating state for items with no reviews

### DIFF
--- a/customer-app/assets/customer-app.css
+++ b/customer-app/assets/customer-app.css
@@ -3854,6 +3854,8 @@ body.has-contact-sheet { overflow: hidden; }
 .store-rating-label { color: #92660a; margin-right: 1px; }
 .store-rating-value { color: #92660a; font-weight: 700; margin-left: 2px; }
 .store-rating-count { color: #92660a; font-weight: 500; margin-left: 1px; }
+/* Honest "no reviews yet" label shown beside outline stars for un-reviewed items */
+.store-rating-empty { color: #92660a; font-weight: 500; margin-left: 2px; opacity: 0.85; }
 
 .store-booking-count {
   font-size: 10.5px;

--- a/customer-app/assets/customer-app.js
+++ b/customer-app/assets/customer-app.js
@@ -3,7 +3,7 @@
 
   const App = window.CWFCustomerAppV2;
   const BOOT_TIMEOUT_MS = 3500;
-  const BUILD_ID = "20260701_home_effects_v1";
+  const BUILD_ID = "20260701_store_rating_v1";
 
   function withTimeout(promise, timeoutMs) {
     return Promise.race([

--- a/customer-app/index.html
+++ b/customer-app/index.html
@@ -9,10 +9,10 @@
   <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
   <meta name="apple-mobile-web-app-title" content="CWF Service">
   <title>CWF Customer Service</title>
-  <link rel="manifest" href="./manifest.webmanifest?v=20260701_home_effects_v1">
+  <link rel="manifest" href="./manifest.webmanifest?v=20260701_store_rating_v1">
   <link rel="icon" type="image/png" sizes="192x192" href="./assets/icons/cwf-customer-192.png">
   <link rel="apple-touch-icon" sizes="180x180" href="./assets/icons/cwf-customer-180.png">
-  <link rel="stylesheet" href="./assets/customer-app.css?v=20260701_home_effects_v1">
+  <link rel="stylesheet" href="./assets/customer-app.css?v=20260701_store_rating_v1">
 </head>
 <body class="is-app-booting">
   <div class="app-shell" data-app-shell>
@@ -50,21 +50,21 @@
     </nav>
   </div>
 
-  <script src="./modules/state.js?v=20260701_home_effects_v1"></script>
-  <script src="./modules/utils.js?v=20260701_home_effects_v1"></script>
-  <script src="./modules/analytics.js?v=20260701_home_effects_v1"></script>
-  <script src="./modules/api.js?v=20260701_home_effects_v1"></script>
-  <script src="./modules/services.js?v=20260701_home_effects_v1"></script>
-  <script src="./modules/ui.js?v=20260701_home_effects_v1"></script>
-  <script src="./modules/store.js?v=20260701_home_effects_v1"></script>
-  <script src="./modules/auth.js?v=20260701_home_effects_v1"></script>
-  <script src="./modules/pricing.js?v=20260701_home_effects_v1"></script>
-  <script src="./modules/availability.js?v=20260701_home_effects_v1"></script>
-  <script src="./modules/bookingScheduled.js?v=20260701_home_effects_v1"></script>
-  <script src="./modules/bookingUrgent.js?v=20260701_home_effects_v1"></script>
-  <script src="./modules/tracking.js?v=20260701_home_effects_v1"></script>
-  <script src="./modules/profile.js?v=20260701_home_effects_v1"></script>
-  <script src="./modules/router.js?v=20260701_home_effects_v1"></script>
-  <script src="./assets/customer-app.js?v=20260701_home_effects_v1"></script>
+  <script src="./modules/state.js?v=20260701_store_rating_v1"></script>
+  <script src="./modules/utils.js?v=20260701_store_rating_v1"></script>
+  <script src="./modules/analytics.js?v=20260701_store_rating_v1"></script>
+  <script src="./modules/api.js?v=20260701_store_rating_v1"></script>
+  <script src="./modules/services.js?v=20260701_store_rating_v1"></script>
+  <script src="./modules/ui.js?v=20260701_store_rating_v1"></script>
+  <script src="./modules/store.js?v=20260701_store_rating_v1"></script>
+  <script src="./modules/auth.js?v=20260701_store_rating_v1"></script>
+  <script src="./modules/pricing.js?v=20260701_store_rating_v1"></script>
+  <script src="./modules/availability.js?v=20260701_store_rating_v1"></script>
+  <script src="./modules/bookingScheduled.js?v=20260701_store_rating_v1"></script>
+  <script src="./modules/bookingUrgent.js?v=20260701_store_rating_v1"></script>
+  <script src="./modules/tracking.js?v=20260701_store_rating_v1"></script>
+  <script src="./modules/profile.js?v=20260701_store_rating_v1"></script>
+  <script src="./modules/router.js?v=20260701_store_rating_v1"></script>
+  <script src="./assets/customer-app.js?v=20260701_store_rating_v1"></script>
 </body>
 </html>

--- a/customer-app/manifest.webmanifest
+++ b/customer-app/manifest.webmanifest
@@ -2,7 +2,7 @@
   "name": "CWF Customer Service",
   "short_name": "CWF Service",
   "description": "แอปลูกค้า Coldwindflow สำหรับเลือกบริการ จองคิว และติดตามงาน",
-  "start_url": "/customer-app/index.html?v=20260701_home_effects_v1#home",
+  "start_url": "/customer-app/index.html?v=20260701_store_rating_v1#home",
   "scope": "/customer-app/",
   "id": "/customer-app/",
   "display": "standalone",

--- a/customer-app/modules/store.js
+++ b/customer-app/modules/store.js
@@ -441,12 +441,13 @@
     return rounded % 1 === 0 ? String(rounded) : rounded.toFixed(1);
   }
 
-  // No approved reviews yet: display-only 5-star default (never written to
-  // DB, never a fabricated average/count). Once a real approved review
-  // exists, this switches to the real average/count below.
+  // No approved reviews yet: render an honest empty state — five outline
+  // (unfilled) stars plus a "ยังไม่มีรีวิว" label, never a fabricated full-star
+  // score or average. Once a real approved review exists, this switches to the
+  // real average/count below.
   function renderRatingBadge(item) {
     const { value, count, hasReviews } = realRatingInfo(item);
-    const full = hasReviews ? Math.floor(value) : 5;
+    const full = hasReviews ? Math.floor(value) : 0;
     const hasHalf = hasReviews && full < 5 && value - full >= 0.5;
     const stars = Array.from({ length: 5 }, (_, i) => {
       const filled = i < full;
@@ -456,9 +457,12 @@
     }).join("");
     const id = String(item.item_id || "");
     const valueLabel = hasReviews ? `<span class="store-rating-value">${formatRatingAverage(value)}</span>` : "";
-    const countLabel = hasReviews ? `<span class="store-rating-count">(${count})</span>` : "";
+    const countLabel = hasReviews
+      ? `<span class="store-rating-count">(${count})</span>`
+      : `<span class="store-rating-empty">ยังไม่มีรีวิว</span>`;
+    const title = hasReviews ? "ดูรีวิวจากลูกค้า" : "ยังไม่มีรีวิว — เป็นคนแรกที่รีวิว";
     return `
-      <button type="button" class="store-rating-badge" data-store-rating="${root.utils.escapeHtml(id)}" title="ดูรีวิวจากลูกค้า">
+      <button type="button" class="store-rating-badge" data-store-rating="${root.utils.escapeHtml(id)}" title="${title}">
         <span class="store-rating-label">รีวิว</span>
         <span class="store-rating-stars">${stars}</span>
         ${valueLabel}${countLabel}

--- a/customer-app/sw.js
+++ b/customer-app/sw.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const BUILD_ID = "20260701_home_effects_v1";
+const BUILD_ID = "20260701_store_rating_v1";
 const CACHE_NAME = `cwf-customer-app-v2-${BUILD_ID}`;
 const APP_SHELL = [
   `./index.html?v=${BUILD_ID}`,

--- a/test/customerAppRecovery.test.js
+++ b/test/customerAppRecovery.test.js
@@ -236,7 +236,7 @@ test("Customer App build id is consistent across shell and service worker", () =
   const sw = read("customer-app/sw.js");
   const app = read("customer-app/assets/customer-app.js");
   const manifest = read("customer-app/manifest.webmanifest");
-  const build = "20260701_home_effects_v1";
+  const build = "20260701_store_rating_v1";
 
   assert.match(index, new RegExp(`customer-app\\.css\\?v=${build}`));
   assert.match(index, new RegExp(`modules\\/api\\.js\\?v=${build}`));
@@ -254,7 +254,7 @@ test("Customer App build id is consistent across shell and service worker", () =
 test("store module is loaded in index.html and precached in the service worker app shell", () => {
   const index = read("customer-app/index.html");
   const sw = read("customer-app/sw.js");
-  const build = "20260701_home_effects_v1";
+  const build = "20260701_store_rating_v1";
 
   assert.match(index, new RegExp(`modules/store\\.js\\?v=${build}`));
   assert.match(sw, /`\.\/modules\/store\.js\?v=\$\{BUILD_ID\}`/);
@@ -1231,14 +1231,16 @@ test("store card shows the CWF featured ribbon only for featured items, and an h
   assert.equal((body.innerHTML.match(/store-rating-badge/g) || []).length, 2);
   assert.equal((body.innerHTML.match(/store-rating-label">รีวิว/g) || []).length, 2);
   assert.doesNotMatch(body.innerHTML, /มาตรฐาน CWF/);
-  // neither item has real reviews yet, so both must render the default
-  // display-only 5-filled-star badge with no value/count label.
-  assert.equal((body.innerHTML.match(/store-rating-star is-filled/g) || []).length, 10);
+  // neither item has real reviews yet, so both must render the honest empty
+  // state: five outline stars (no filled) plus a "ยังไม่มีรีวิว" label — never
+  // a fabricated full-star score or a value/count.
+  assert.equal((body.innerHTML.match(/store-rating-star is-filled/g) || []).length, 0);
+  assert.equal((body.innerHTML.match(/store-rating-empty">ยังไม่มีรีวิว<\/span>/g) || []).length, 2);
   assert.doesNotMatch(body.innerHTML, /store-rating-count/);
   assert.doesNotMatch(body.innerHTML, /store-rating-value/);
 });
 
-test("rating badge renders real rating_average/review_count with half stars and a visible count, but falls back to the default 5-star badge when there is no real data", async () => {
+test("rating badge renders real rating_average/review_count with half stars and a visible count, but shows an honest empty state when there is no real data", async () => {
   const context = makeContext();
   const root = loadCustomerFrontend(context);
   root.api.loadCatalogItems = async () => [
@@ -1254,9 +1256,10 @@ test("rating badge renders real rating_average/review_count with half stars and 
   assert.match(body.innerHTML, /store-rating-star is-half/);
   assert.match(body.innerHTML, /store-rating-value">4\.5<\/span>/);
   assert.match(body.innerHTML, /store-rating-count">\(12\)<\/span>/);
-  // item 1 (real data) contributes 4 filled stars + 1 half; item 2 (no
-  // reviews yet) contributes 5 filled stars from the default badge.
-  assert.equal((body.innerHTML.match(/store-rating-star is-filled/g) || []).length, 9);
+  // item 1 (real data) contributes 4 filled stars + 1 half; item 2 (no reviews
+  // yet) contributes 0 filled stars and a "ยังไม่มีรีวิว" label instead.
+  assert.equal((body.innerHTML.match(/store-rating-star is-filled/g) || []).length, 4);
+  assert.match(body.innerHTML, /store-rating-empty">ยังไม่มีรีวิว<\/span>/);
 });
 
 test("rating badge star fill logic only shows a half star once the fractional part reaches 0.5; below that it rounds down to full/empty stars only", async () => {
@@ -1277,7 +1280,7 @@ test("rating badge star fill logic only shows a half star once the fractional pa
   assert.equal((body.innerHTML.match(/store-rating-star is-filled/g) || []).length, 4);
 });
 
-test("rating badge ignores legacy rating_value and fails safe to the default 5-star badge on invalid/null rating_average or review_count", async () => {
+test("rating badge ignores legacy rating_value and fails safe to the honest empty state on invalid/null rating_average or review_count", async () => {
   const context = makeContext();
   const root = loadCustomerFrontend(context);
   root.api.loadCatalogItems = async () => [
@@ -1294,9 +1297,11 @@ test("rating badge ignores legacy rating_value and fails safe to the default 5-s
   await new Promise((resolve) => setTimeout(resolve, 0));
 
   const body = container.querySelector("[data-store-body]");
-  // every item must fail safe to the default 5-filled-star badge -- never a fabricated average/count
+  // every item must fail safe to the honest empty state -- outline stars + a
+  // "ยังไม่มีรีวิว" label, never a fabricated full-star score or average/count
   assert.equal((body.innerHTML.match(/store-rating-badge/g) || []).length, 5);
-  assert.equal((body.innerHTML.match(/store-rating-star is-filled/g) || []).length, 25);
+  assert.equal((body.innerHTML.match(/store-rating-star is-filled/g) || []).length, 0);
+  assert.equal((body.innerHTML.match(/store-rating-empty">ยังไม่มีรีวิว<\/span>/g) || []).length, 5);
   assert.doesNotMatch(body.innerHTML, /store-rating-star is-half/);
   assert.doesNotMatch(body.innerHTML, /store-rating-value/);
   assert.doesNotMatch(body.innerHTML, /store-rating-count/);

--- a/test/customerSameDayTiming.test.js
+++ b/test/customerSameDayTiming.test.js
@@ -160,7 +160,7 @@ test("customer app disables availability HTTP cache and refreshes same-day slots
 });
 
 test("customer app build and service worker cache IDs changed", () => {
-  const id = "20260701_home_effects_v1";
+  const id = "20260701_store_rating_v1";
   for (const file of [
     "customer-app/index.html",
     "customer-app/sw.js",

--- a/test/homepageCms.test.js
+++ b/test/homepageCms.test.js
@@ -278,7 +278,7 @@ test("customer homepage has no admin control, bottom nav is fixed five-tab, and 
   const sw = read("customer-app/sw.js");
   const app = read("customer-app/assets/customer-app.js");
   const manifest = read("customer-app/manifest.webmanifest");
-  const build = "20260701_home_effects_v1";
+  const build = "20260701_store_rating_v1";
 
   assert.doesNotMatch(index + ui, /โหมดแอดมิน|openCms|localStorage\.getItem\('cwfHomeCmsDemo'/);
   assert.match(index, /data-route="store"[\s\S]*ร้านค้า/);


### PR DESCRIPTION
## Summary

Found during a release-readiness review of the store + booking pages (booted the real customer app end-to-end).

**Issue:** store items with **zero approved reviews** rendered **five filled gold stars** (no count) — which reads to a customer as a genuine **5.0 rating**. The code comments even contradicted the behavior (one said it should show an honest "no reviews yet" empty state, the other filled all five stars).

**Fix:** un-reviewed items now render **five outline stars + a "ยังไม่มีรีวิว" label**, so customers are never shown a fabricated perfect score. Items with real approved reviews are unchanged — they still show the true average, half-stars, and `(count)`.

## Changes
- `customer-app/modules/store.js` — `renderRatingBadge()`: no-review case now uses `full = 0` (outline stars) and a `store-rating-empty` "ยังไม่มีรีวิว" label instead of five filled stars; tooltip becomes "ยังไม่มีรีวิว — เป็นคนแรกที่รีวิว".
- `customer-app/assets/customer-app.css` — style for `.store-rating-empty`.
- `test/customerAppRecovery.test.js` — updated the rating-badge tests to assert the honest empty state (0 filled stars + "ยังไม่มีรีวิว") instead of the old 5-filled default.
- `BUILD_ID` bumped for cache-bust.

## Verification
- Booted the real store page: all 6 cards now show `รีวิว ☆☆☆☆☆ ยังไม่มีรีวิว`; no JS errors.
- Also verified booking mode selector and the scheduled-booking wizard render and price correctly (499 บาท / 90 นาที) — no changes needed there.
- All 717 tests pass.

## Test plan
- [ ] Store item with no reviews shows outline stars + "ยังไม่มีรีวิว" (no gold 5-star)
- [ ] Store item with real reviews shows the true average + (count) + half-stars
- [ ] Product detail page matches the card badge for both cases
- [ ] `npm test` green


---
_Generated by [Claude Code](https://claude.ai/code/session_01LmdP3TGN5uQrfT8ZYefNco)_