### PR TITLE
feat(cms): per-page header banners + real LINE logo, shimmer/zoom effects, FB timeline fit

### DIFF
--- a/admin-homepage-cms.html
+++ b/admin-homepage-cms.html
@@ -323,6 +323,6 @@
   </div>
 
   <select id="sectionPicker" style="display:none"></select>
-  <script src="/admin-homepage-cms.js?v=20260701_fix5"></script>
+  <script src="/admin-homepage-cms.js?v=20260701_fix6"></script>
 </body>
 </html>

--- a/admin-homepage-cms.js
+++ b/admin-homepage-cms.js
@@ -31,6 +31,9 @@
   let articleSyncStatus = null;
   let articleSyncStatusLoading = false;
   const ROUTE_OPTIONS = ["home", "store", "scheduled", "urgent", "tracking", "profile"];
+  // Per-page header banners: [key, nav label, icon]. Managed separately from
+  // homepage sections but reuse the hero slide editor for their slides.
+  const PAGE_HEADER_META = [["store", "Head: ร้านค้า", "🛍️"], ["booking", "Head: จองคิว", "📅"], ["tracking", "Head: ติดตามงาน", "📍"]];
 
   const $ = (id) => document.getElementById(id);
   const esc = (value) => String(value == null ? "" : value).replace(/[&<>"']/g, (s) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#039;" }[s]));
@@ -44,11 +47,32 @@
       if (!existingTypes.has(section.type)) next.sections.push(section);
     });
     next.sections = next.sections.filter((section) => standard.some((std) => std.type === section.type));
+    const rawHeaders = next.page_headers && typeof next.page_headers === "object" ? next.page_headers : {};
+    next.page_headers = {};
+    PAGE_HEADER_META.forEach(([key]) => {
+      const header = rawHeaders[key] && typeof rawHeaders[key] === "object" ? rawHeaders[key] : {};
+      next.page_headers[key] = {
+        enabled: header.enabled !== false,
+        kicker: header.kicker || "",
+        title: header.title || "",
+        body: header.body || "",
+        focal_position: header.focal_position || "center",
+        items: Array.isArray(header.items) ? header.items : [],
+      };
+    });
     return next;
   }
   function setStatus(text, kind) { $("status").textContent = text; $("status").className = `status-chip ${kind || ""}`; }
   function sections() { return config.sections.sort((a, b) => Number(a.sort_order || 0) - Number(b.sort_order || 0)); }
-  function current() { return sections().find((section) => section.id === selected) || sections()[0]; }
+  function headKey() { return typeof selected === "string" && selected.startsWith("head:") ? selected.slice(5) : null; }
+  function currentHead() { const key = headKey(); return key && config.page_headers ? config.page_headers[key] || null : null; }
+  // current() resolves to the selected page-header object when a "head:*" entry
+  // is active, so the shared hero handlers (fields, slides, upload) operate on it.
+  function current() {
+    const head = currentHead();
+    if (head) return head;
+    return sections().find((section) => section.id === selected) || sections()[0];
+  }
 
   async function ensureCatalogItems() {
     if (catalogItems || catalogLoadFailed) return;
@@ -143,12 +167,47 @@
         </div>
       </div>
     `).join("");
-    $("sectionPicker").innerHTML = list.map((section) => `<option value="${esc(section.id)}">${esc(section.title || section.type)}</option>`).join("");
+    const headers = config.page_headers || {};
+    const headerRows = PAGE_HEADER_META.map(([key, label, icon]) => {
+      const header = headers[key] || {};
+      const rowId = `head:${key}`;
+      return `
+      <div class="sec-row ${rowId === selected ? "is-active" : ""} ${header.enabled !== false ? "" : "is-disabled"}">
+        <div class="sec-row-body" data-edit="${rowId}">
+          <div class="sec-icon">${icon}</div>
+          <div class="sec-info">
+            <div class="sec-name">${esc(label)}</div>
+            <div class="sec-type">page header · ${(header.items || []).length} slide</div>
+          </div>
+        </div>
+        <div class="sec-controls">
+          <label class="tog"><input type="checkbox" data-head-toggle="${key}" ${header.enabled !== false ? "checked" : ""}><span></span></label>
+        </div>
+      </div>`;
+    }).join("");
+    $("sectionList").innerHTML += `<div class="nav-hd" style="margin-top:8px">แบนเนอร์หัวหน้า (แยกแต่ละหน้า)</div>${headerRows}`;
+    $("sectionPicker").innerHTML = list.map((section) => `<option value="${esc(section.id)}">${esc(section.title || section.type)}</option>`).join("")
+      + PAGE_HEADER_META.map(([key, label]) => `<option value="head:${key}">${esc(label)}</option>`).join("");
     $("sectionPicker").value = selected;
   }
 
   /* ── editor header ── */
   function renderEditorHeader() {
+    const key = headKey();
+    if (key) {
+      const meta = PAGE_HEADER_META.find(([k]) => k === key) || [key, key, "📄"];
+      const header = currentHead() || {};
+      $("editorHeader").innerHTML = `
+        <div class="editor-hd">
+          <div class="editor-hd-icon">${meta[2]}</div>
+          <div>
+            <div class="editor-hd-title">${esc(meta[1])}</div>
+            <div class="editor-hd-sub">page header · ${header.enabled !== false ? "เปิดใช้งานอยู่" : "ปิดอยู่"}</div>
+          </div>
+        </div>
+      `;
+      return;
+    }
     const section = current();
     if (!section) { $("editorHeader").innerHTML = ""; return; }
     $("editorHeader").innerHTML = `
@@ -341,7 +400,32 @@
     `;
   }
 
+  function renderHeadEditor() {
+    const header = currentHead();
+    if (!header) { $("editor").innerHTML = ""; return; }
+    const slides = header.items || [];
+    $("editor").innerHTML = `
+      <div class="ep">
+        <div class="ep-head">ข้อมูลแบนเนอร์หัวหน้า</div>
+        <div class="ep-body">
+          <p style="font-size:12px;color:var(--muted);line-height:1.5">แบนเนอร์นี้จะแสดงบนหัวของหน้านี้เท่านั้น เพิ่มรูปได้หลายสไลด์ (เลื่อนอัตโนมัติ) และกำหนดปุ่ม/ลิงก์ให้แต่ละสไลด์ได้</p>
+          ${field("Kicker (ป้ายเล็กบนสุด)", "kicker")}
+          ${field("หัวข้อ", "title")}
+          ${field("คำอธิบาย", "body", "textarea")}
+          <label class="field">ตำแหน่งโฟกัสภาพ<select class="fi" data-field="focal_position"><option value="top" ${header.focal_position === "top" ? "selected" : ""}>บน</option><option value="center" ${(header.focal_position || "center") === "center" ? "selected" : ""}>กลาง</option><option value="bottom" ${header.focal_position === "bottom" ? "selected" : ""}>ล่าง</option></select></label>
+        </div>
+      </div>
+      <div class="ep">
+        <div class="ep-head">สไลด์รูปภาพ (${slides.length}/5)<div class="toolbar" style="display:inline-flex;margin-left:10px"><button class="btn btn-ghost btn-sm" type="button" id="addHeroSlide">+ เพิ่มสไลด์</button></div></div>
+        <div class="ep-body">
+          ${slides.length ? slides.map((item, index) => heroSlideEditor(item, index, slides.length)).join("") : `<p style="color:var(--muted);font-size:13px">ยังไม่มีสไลด์ — กด "เพิ่มสไลด์" แล้วอัปโหลดรูป</p>`}
+        </div>
+      </div>
+    `;
+  }
+
   function renderEditor() {
+    if (headKey()) { renderHeadEditor(); return; }
     const section = current();
     if (!section) return;
     const itemTypes = ["announcements", "updates", "articles", "social", "trust", "quick", "promo_banner"];
@@ -616,6 +700,7 @@
     if (target.matches("select[data-item]")) { current().items[Number(target.dataset.item)][target.dataset.prop] = target.value; if (target.dataset.prop === "platform") render(); else renderPreview(); }
     if (target.matches("select[data-field]")) { current()[target.dataset.field] = target.value; renderPreview(); }
     if (target.matches("[data-toggle]")) { const s = sections().find((row) => row.id === target.dataset.toggle); if (s) s.enabled = target.checked; renderPreview(); }
+    if (target.matches("[data-head-toggle]")) { const h = (config.page_headers || {})[target.dataset.headToggle]; if (h) h.enabled = target.checked; renderSectionList(); }
     if (target.id === "sectionPicker") { selected = target.value; render(); }
     if (target.matches("[data-upload]")) uploadImage(target, Number(target.dataset.upload)).catch((error) => setStatus(error.message, "bad"));
     if (target.matches("[data-upload-section]")) uploadImage(target, target.dataset.uploadSection).catch((error) => setStatus(error.message, "bad"));

--- a/customer-app/assets/customer-app.css
+++ b/customer-app/assets/customer-app.css
@@ -2943,6 +2943,18 @@ body {
   height: 14px;
   border-radius: 999px;
   background: #e8eef7;
+  /* Shimmer sweep so loading states feel alive rather than a frozen gray bar */
+  background-image: linear-gradient(100deg, #e8eef7 30%, #f5f9ff 48%, #dfe9f8 52%, #e8eef7 70%);
+  background-size: 220% 100%;
+  animation: cwfSkeletonShimmer 1.5s ease-in-out infinite;
+}
+@keyframes cwfSkeletonShimmer {
+  from { background-position: 220% 0; }
+  to { background-position: -120% 0; }
+}
+@media (prefers-reduced-motion: reduce) {
+  .account-skeleton span,
+  .content-skeleton span { animation: none; }
 }
 .account-skeleton span:first-child,
 .content-skeleton span:first-child { width: 68%; }
@@ -4931,7 +4943,19 @@ body.has-contact-sheet { overflow: hidden; }
 .homepage-update-card .homepage-card-image     { height: 140px; }
 .homepage-article-card .homepage-card-image    { aspect-ratio: 16 / 9; }
 
-.homepage-card-image img { display: block; width: 100%; height: 100%; object-fit: cover; }
+.homepage-card-image img { display: block; width: 100%; height: 100%; object-fit: cover; transition: transform 0.4s cubic-bezier(0.22, 0.61, 0.36, 1); }
+/* Gentle image zoom on tap — a premium micro-interaction that reads as "alive" */
+.homepage-card-link:active .homepage-card-image img,
+.homepage-update-card:active .homepage-card-image img,
+.homepage-article-card:active .homepage-card-image img,
+.homepage-announcement-card:active .homepage-card-image img { transform: scale(1.06); }
+@media (prefers-reduced-motion: reduce) {
+  .homepage-card-image img { transition: none; }
+  .homepage-card-link:active .homepage-card-image img,
+  .homepage-update-card:active .homepage-card-image img,
+  .homepage-article-card:active .homepage-card-image img,
+  .homepage-announcement-card:active .homepage-card-image img { transform: none; }
+}
 .homepage-hero-media img { display: block; width: 100%; height: 100%; object-fit: cover; }
 
 /* ─── Card inner layout ─────────────────────────────────────────────── */

--- a/customer-app/assets/customer-app.css
+++ b/customer-app/assets/customer-app.css
@@ -4692,10 +4692,16 @@ body.has-contact-sheet { overflow: hidden; }
   line-height: 1.26;
   color: var(--ink);
 }
+/* LINE uses the real LINE app badge (self-coloured SVG), so the chip itself is
+   transparent and the badge fills it — no doubled green square. */
 .homepage-quick.is-line span:first-child {
-  background: linear-gradient(135deg, #06c755 0%, #04a847 100%);
-  color: #fff;
-  box-shadow: 0 3px 8px rgba(6, 199, 85, 0.28);
+  background: transparent;
+  box-shadow: none;
+}
+.homepage-quick.is-line span:first-child svg {
+  width: 30px; height: 30px;
+  border-radius: 8px;
+  box-shadow: 0 3px 8px rgba(6, 199, 85, 0.30);
 }
 
 /* ─── Promo banner — CMS-managed, full-width, uncropped image ────────── */

--- a/customer-app/assets/customer-app.css
+++ b/customer-app/assets/customer-app.css
@@ -4448,6 +4448,10 @@ body.has-contact-sheet { overflow: hidden; }
   .homepage-carousel.is-revealed > * { animation: none; }
 }
 
+/* Per-page header banner (store / booking / tracking) reuses the hero markup.
+   On non-home screens it needs its own spacing below. */
+.page-header-banner { margin-bottom: 14px; }
+
 /* ─── Hero ─────────────────────────────────────────────────────────── */
 .homepage-hero {
   position: relative;

--- a/customer-app/assets/customer-app.css
+++ b/customer-app/assets/customer-app.css
@@ -5197,11 +5197,14 @@ body.has-contact-sheet { overflow: hidden; }
   overflow: hidden;
   background: #f0f2f5;
 }
+/* width/height are set inline by bindHomepageFbTimelines to match the real
+   container width (the plugin renders at exactly its `width` param). These are
+   just pre-JS defaults so the frame reserves space without a layout jump. */
 .homepage-fb-timeline-frame iframe {
   display: block;
   width: 100%;
   max-width: 500px;
-  height: 560px;
+  height: 640px;
   border: 0;
 }
 .homepage-fb-timeline-cta {

--- a/customer-app/assets/customer-app.js
+++ b/customer-app/assets/customer-app.js
@@ -3,7 +3,7 @@
 
   const App = window.CWFCustomerAppV2;
   const BOOT_TIMEOUT_MS = 3500;
-  const BUILD_ID = "20260701_home_fx_v2";
+  const BUILD_ID = "20260701_page_headers_v1";
 
   function withTimeout(promise, timeoutMs) {
     return Promise.race([

--- a/customer-app/assets/customer-app.js
+++ b/customer-app/assets/customer-app.js
@@ -3,7 +3,7 @@
 
   const App = window.CWFCustomerAppV2;
   const BOOT_TIMEOUT_MS = 3500;
-  const BUILD_ID = "20260701_fb_timeline_v1";
+  const BUILD_ID = "20260701_home_fx_v2";
 
   function withTimeout(promise, timeoutMs) {
     return Promise.race([

--- a/customer-app/index.html
+++ b/customer-app/index.html
@@ -9,10 +9,10 @@
   <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
   <meta name="apple-mobile-web-app-title" content="CWF Service">
   <title>CWF Customer Service</title>
-  <link rel="manifest" href="./manifest.webmanifest?v=20260701_fb_timeline_v1">
+  <link rel="manifest" href="./manifest.webmanifest?v=20260701_home_fx_v2">
   <link rel="icon" type="image/png" sizes="192x192" href="./assets/icons/cwf-customer-192.png">
   <link rel="apple-touch-icon" sizes="180x180" href="./assets/icons/cwf-customer-180.png">
-  <link rel="stylesheet" href="./assets/customer-app.css?v=20260701_fb_timeline_v1">
+  <link rel="stylesheet" href="./assets/customer-app.css?v=20260701_home_fx_v2">
 </head>
 <body class="is-app-booting">
   <div class="app-shell" data-app-shell>
@@ -50,21 +50,21 @@
     </nav>
   </div>
 
-  <script src="./modules/state.js?v=20260701_fb_timeline_v1"></script>
-  <script src="./modules/utils.js?v=20260701_fb_timeline_v1"></script>
-  <script src="./modules/analytics.js?v=20260701_fb_timeline_v1"></script>
-  <script src="./modules/api.js?v=20260701_fb_timeline_v1"></script>
-  <script src="./modules/services.js?v=20260701_fb_timeline_v1"></script>
-  <script src="./modules/ui.js?v=20260701_fb_timeline_v1"></script>
-  <script src="./modules/store.js?v=20260701_fb_timeline_v1"></script>
-  <script src="./modules/auth.js?v=20260701_fb_timeline_v1"></script>
-  <script src="./modules/pricing.js?v=20260701_fb_timeline_v1"></script>
-  <script src="./modules/availability.js?v=20260701_fb_timeline_v1"></script>
-  <script src="./modules/bookingScheduled.js?v=20260701_fb_timeline_v1"></script>
-  <script src="./modules/bookingUrgent.js?v=20260701_fb_timeline_v1"></script>
-  <script src="./modules/tracking.js?v=20260701_fb_timeline_v1"></script>
-  <script src="./modules/profile.js?v=20260701_fb_timeline_v1"></script>
-  <script src="./modules/router.js?v=20260701_fb_timeline_v1"></script>
-  <script src="./assets/customer-app.js?v=20260701_fb_timeline_v1"></script>
+  <script src="./modules/state.js?v=20260701_home_fx_v2"></script>
+  <script src="./modules/utils.js?v=20260701_home_fx_v2"></script>
+  <script src="./modules/analytics.js?v=20260701_home_fx_v2"></script>
+  <script src="./modules/api.js?v=20260701_home_fx_v2"></script>
+  <script src="./modules/services.js?v=20260701_home_fx_v2"></script>
+  <script src="./modules/ui.js?v=20260701_home_fx_v2"></script>
+  <script src="./modules/store.js?v=20260701_home_fx_v2"></script>
+  <script src="./modules/auth.js?v=20260701_home_fx_v2"></script>
+  <script src="./modules/pricing.js?v=20260701_home_fx_v2"></script>
+  <script src="./modules/availability.js?v=20260701_home_fx_v2"></script>
+  <script src="./modules/bookingScheduled.js?v=20260701_home_fx_v2"></script>
+  <script src="./modules/bookingUrgent.js?v=20260701_home_fx_v2"></script>
+  <script src="./modules/tracking.js?v=20260701_home_fx_v2"></script>
+  <script src="./modules/profile.js?v=20260701_home_fx_v2"></script>
+  <script src="./modules/router.js?v=20260701_home_fx_v2"></script>
+  <script src="./assets/customer-app.js?v=20260701_home_fx_v2"></script>
 </body>
 </html>

--- a/customer-app/index.html
+++ b/customer-app/index.html
@@ -9,10 +9,10 @@
   <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
   <meta name="apple-mobile-web-app-title" content="CWF Service">
   <title>CWF Customer Service</title>
-  <link rel="manifest" href="./manifest.webmanifest?v=20260701_home_fx_v2">
+  <link rel="manifest" href="./manifest.webmanifest?v=20260701_page_headers_v1">
   <link rel="icon" type="image/png" sizes="192x192" href="./assets/icons/cwf-customer-192.png">
   <link rel="apple-touch-icon" sizes="180x180" href="./assets/icons/cwf-customer-180.png">
-  <link rel="stylesheet" href="./assets/customer-app.css?v=20260701_home_fx_v2">
+  <link rel="stylesheet" href="./assets/customer-app.css?v=20260701_page_headers_v1">
 </head>
 <body class="is-app-booting">
   <div class="app-shell" data-app-shell>
@@ -50,21 +50,21 @@
     </nav>
   </div>
 
-  <script src="./modules/state.js?v=20260701_home_fx_v2"></script>
-  <script src="./modules/utils.js?v=20260701_home_fx_v2"></script>
-  <script src="./modules/analytics.js?v=20260701_home_fx_v2"></script>
-  <script src="./modules/api.js?v=20260701_home_fx_v2"></script>
-  <script src="./modules/services.js?v=20260701_home_fx_v2"></script>
-  <script src="./modules/ui.js?v=20260701_home_fx_v2"></script>
-  <script src="./modules/store.js?v=20260701_home_fx_v2"></script>
-  <script src="./modules/auth.js?v=20260701_home_fx_v2"></script>
-  <script src="./modules/pricing.js?v=20260701_home_fx_v2"></script>
-  <script src="./modules/availability.js?v=20260701_home_fx_v2"></script>
-  <script src="./modules/bookingScheduled.js?v=20260701_home_fx_v2"></script>
-  <script src="./modules/bookingUrgent.js?v=20260701_home_fx_v2"></script>
-  <script src="./modules/tracking.js?v=20260701_home_fx_v2"></script>
-  <script src="./modules/profile.js?v=20260701_home_fx_v2"></script>
-  <script src="./modules/router.js?v=20260701_home_fx_v2"></script>
-  <script src="./assets/customer-app.js?v=20260701_home_fx_v2"></script>
+  <script src="./modules/state.js?v=20260701_page_headers_v1"></script>
+  <script src="./modules/utils.js?v=20260701_page_headers_v1"></script>
+  <script src="./modules/analytics.js?v=20260701_page_headers_v1"></script>
+  <script src="./modules/api.js?v=20260701_page_headers_v1"></script>
+  <script src="./modules/services.js?v=20260701_page_headers_v1"></script>
+  <script src="./modules/ui.js?v=20260701_page_headers_v1"></script>
+  <script src="./modules/store.js?v=20260701_page_headers_v1"></script>
+  <script src="./modules/auth.js?v=20260701_page_headers_v1"></script>
+  <script src="./modules/pricing.js?v=20260701_page_headers_v1"></script>
+  <script src="./modules/availability.js?v=20260701_page_headers_v1"></script>
+  <script src="./modules/bookingScheduled.js?v=20260701_page_headers_v1"></script>
+  <script src="./modules/bookingUrgent.js?v=20260701_page_headers_v1"></script>
+  <script src="./modules/tracking.js?v=20260701_page_headers_v1"></script>
+  <script src="./modules/profile.js?v=20260701_page_headers_v1"></script>
+  <script src="./modules/router.js?v=20260701_page_headers_v1"></script>
+  <script src="./assets/customer-app.js?v=20260701_page_headers_v1"></script>
 </body>
 </html>

--- a/customer-app/manifest.webmanifest
+++ b/customer-app/manifest.webmanifest
@@ -2,7 +2,7 @@
   "name": "CWF Customer Service",
   "short_name": "CWF Service",
   "description": "แอปลูกค้า Coldwindflow สำหรับเลือกบริการ จองคิว และติดตามงาน",
-  "start_url": "/customer-app/index.html?v=20260701_fb_timeline_v1#home",
+  "start_url": "/customer-app/index.html?v=20260701_home_fx_v2#home",
   "scope": "/customer-app/",
   "id": "/customer-app/",
   "display": "standalone",

--- a/customer-app/manifest.webmanifest
+++ b/customer-app/manifest.webmanifest
@@ -2,7 +2,7 @@
   "name": "CWF Customer Service",
   "short_name": "CWF Service",
   "description": "แอปลูกค้า Coldwindflow สำหรับเลือกบริการ จองคิว และติดตามงาน",
-  "start_url": "/customer-app/index.html?v=20260701_home_fx_v2#home",
+  "start_url": "/customer-app/index.html?v=20260701_page_headers_v1#home",
   "scope": "/customer-app/",
   "id": "/customer-app/",
   "display": "standalone",

--- a/customer-app/modules/bookingScheduled.js
+++ b/customer-app/modules/bookingScheduled.js
@@ -942,7 +942,7 @@
       <div class="page booking-wizard-page">
         <div class="page-toolbar">
           <button type="button" class="text-btn" data-route="home">← หน้าแรก</button>
-          <a class="text-btn" href="https://line.me/R/ti/p/@cwfair" target="_blank" rel="noopener noreferrer">ติดต่อแอดมิน</a>
+          <a class="text-btn" href="https://lin.ee/fG1Oq7y" target="_blank" rel="noopener noreferrer">ติดต่อแอดมิน</a>
         </div>
         <section class="booking-wizard-intro">
           <span class="section-kicker">จองล้างแอร์ล่วงหน้า</span>

--- a/customer-app/modules/bookingScheduled.js
+++ b/customer-app/modules/bookingScheduled.js
@@ -944,6 +944,7 @@
           <button type="button" class="text-btn" data-route="home">← หน้าแรก</button>
           <a class="text-btn" href="https://lin.ee/fG1Oq7y" target="_blank" rel="noopener noreferrer">ติดต่อแอดมิน</a>
         </div>
+        ${root.ui?.pageHeaderHtml ? root.ui.pageHeaderHtml("booking") : ""}
         <section class="booking-wizard-intro">
           <span class="section-kicker">จองล้างแอร์ล่วงหน้า</span>
           <h1>จองล้างแอร์</h1>
@@ -956,6 +957,7 @@
       </div>
     `;
     bind(container);
+    root.ui?.bindPageHeader?.(container);
     ensureSameDayRefresh(container);
   }
 

--- a/customer-app/modules/store.js
+++ b/customer-app/modules/store.js
@@ -1611,6 +1611,7 @@
       track("cwf_store_view", {});
       container.innerHTML = `
         <section class="screen store-screen">
+          ${root.ui?.pageHeaderHtml ? root.ui.pageHeaderHtml("store") : ""}
           <div class="store-compact-header">
             <span class="store-compact-badge">ร้านค้า CWF</span>
             <h2>เลือกบริการและอุปกรณ์</h2>
@@ -1619,6 +1620,7 @@
           <div data-contact-sheet-mount></div>
         </section>
       `;
+      root.ui?.bindPageHeader?.(container);
       bindBody(container);
       ensureLoaded(container);
     },

--- a/customer-app/modules/tracking.js
+++ b/customer-app/modules/tracking.js
@@ -1273,6 +1273,7 @@
       const code = root.state.draft.tracking.trackingCode || "";
       container.innerHTML = `
         <section class="screen">
+          ${root.ui?.pageHeaderHtml ? root.ui.pageHeaderHtml("tracking") : ""}
           <div class="hero tracking-hero">
             <div class="hero-badge">Live job status</div>
             <h2>ติดตามงาน</h2>
@@ -1300,6 +1301,7 @@
           </section>
         </section>
       `;
+      root.ui?.bindPageHeader?.(container);
       container.querySelector("[data-action='track-read']").addEventListener("click", () => lookup(container));
       container.querySelector("#tracking-code").addEventListener("change", (event) => {
         root.state.updateDraft("tracking", { trackingCode: event.target.value });

--- a/customer-app/modules/ui.js
+++ b/customer-app/modules/ui.js
@@ -337,6 +337,29 @@
     `;
   }
 
+  // Per-page header banner (store / booking / tracking). Admin-managed in the
+  // CMS, independent of the homepage hero, but reuses the hero markup so it
+  // auto-slides and its slides are clickable. Returns "" when unset/empty.
+  function renderPageHeader(pageKey) {
+    const cfg = (homepageConfig().page_headers || {})[pageKey];
+    if (!cfg || cfg.enabled === false) return "";
+    const slides = (cfg.items || []).filter((s) => s && s.enabled !== false && s.image_url);
+    if (!slides.length) return "";
+    return `<div class="page-header-banner">${renderHomepageHero({
+      type: "hero",
+      kicker: cfg.kicker,
+      title: cfg.title,
+      body: cfg.body,
+      focal_position: cfg.focal_position,
+      items: slides,
+    })}</div>`;
+  }
+
+  function bindPageHeader(container) {
+    if (!container) return;
+    bindHomepageHeroSliders(container);
+  }
+
   function renderHomepagePromoBanner(section) {
     if (!section) return "";
     const banners = (section.items || []).filter((item) => item && item.image_url);
@@ -1123,6 +1146,8 @@
     patchHomeData,
     updateAccountChrome,
     openContactSheet,
+    pageHeaderHtml: renderPageHeader,
+    bindPageHeader,
 
     renderHome(container) {
       const sectionsHtml = homepageSections().map(renderHomepageSection).filter(Boolean).join("");
@@ -1140,6 +1165,7 @@
     renderBookingMode(container) {
       container.innerHTML = `
         <section class="screen">
+          ${renderPageHeader("booking")}
           <div class="hero booking-hero">
             <div class="hero-badge">จองบริการ</div>
             <h2>จองล้างแอร์ล่วงหน้า</h2>
@@ -1169,6 +1195,7 @@
           </section>
         </section>
       `;
+      bindPageHeader(container);
     },
 
     supportButtons() {

--- a/customer-app/modules/ui.js
+++ b/customer-app/modules/ui.js
@@ -738,7 +738,7 @@
         <h2 id="contact-sheet-title">${root.utils.escapeHtml(title)}</h2>
         <p>บริการนี้ยังไม่เปิดจองอัตโนมัติในแอป กรุณาติดต่อแอดมินเพื่อสอบถามอาการ ประเมินราคา และนัดหมายให้เหมาะกับหน้างาน</p>
         <div class="contact-sheet-actions">
-          <a class="primary-btn" href="https://line.me/R/ti/p/@cwfair" target="_blank" rel="noopener noreferrer">แชท LINE @cwfair</a>
+          <a class="primary-btn" href="https://lin.ee/fG1Oq7y" target="_blank" rel="noopener noreferrer">แชท LINE @cwfair</a>
           <a class="secondary-btn" href="tel:0988777321">โทร 098-877-7321</a>
         </div>
       </section>

--- a/customer-app/modules/ui.js
+++ b/customer-app/modules/ui.js
@@ -471,13 +471,14 @@
     return "";
   }
 
-  // Facebook Page URL → full-width embedded Page Plugin timeline. Rendered as
-  // its own block (never a narrow carousel card) so the cover, page name and
-  // posts are not clipped. adapt_container_width lets the plugin fit the frame.
+  // Facebook Page URL → full-width embedded Page Plugin timeline, rendered as
+  // its own block (never a narrow carousel card). The iframe src is set in JS
+  // (bindHomepageFbTimelines) with the plugin `width` matched to the real
+  // container width — the iframe embed ignores adapt_container_width, so a
+  // hard-coded width would render wider than the frame and clip the cover, page
+  // name and posts. The "เปิดเพจ Facebook" link is the graceful no-JS fallback.
   function renderHomepageFbTimeline(item) {
     const url = String(item.url || "").trim();
-    const encodedUrl = encodeURIComponent(url);
-    const src = `https://www.facebook.com/plugins/page.php?href=${encodedUrl}&tabs=timeline&width=500&height=560&small_header=false&adapt_container_width=true&hide_cover=false&show_facepile=true`;
     return `
       <article class="homepage-fb-timeline">
         ${item.title || item.body ? `
@@ -486,8 +487,8 @@
             ${item.title ? `<strong>${root.utils.escapeHtml(item.title)}</strong>` : ""}
             ${item.body ? `<small>${root.utils.escapeHtml(item.body)}</small>` : ""}
           </div>` : ""}
-        <div class="homepage-fb-timeline-frame">
-          <iframe src="${src}" loading="lazy" scrolling="no" frameborder="0" allowfullscreen="true"
+        <div class="homepage-fb-timeline-frame" data-fb-timeline-frame>
+          <iframe title="Facebook" data-fb-href="${root.utils.escapeHtml(url)}" loading="lazy" scrolling="no" frameborder="0" allowfullscreen="true"
             allow="autoplay; clipboard-write; encrypted-media; picture-in-picture; web-share"></iframe>
         </div>
         <a class="homepage-fb-timeline-cta" href="${root.utils.escapeHtml(url)}" target="_blank" rel="noopener noreferrer">เปิดเพจ Facebook</a>
@@ -830,6 +831,40 @@
       });
     });
     bindHomepageSocialCards(container);
+    bindHomepageFbTimelines(container);
+  }
+
+  // Size each Facebook Page Plugin to its real container width so its cover,
+  // page name and posts are never clipped. The iframe embed renders at exactly
+  // the plugin `width` param (it ignores adapt_container_width), so we measure
+  // the frame and build the src to match, clamped to Facebook's 180–500 range.
+  // Re-fits on viewport resize/rotation (debounced) and only reloads on change.
+  function bindHomepageFbTimelines(container) {
+    const frames = Array.from(container.querySelectorAll("[data-fb-timeline-frame]"));
+    if (!frames.length) return;
+    const HEIGHT = 640;
+    const fit = (frame) => {
+      const iframe = frame.querySelector("iframe");
+      if (!iframe) return;
+      const href = iframe.getAttribute("data-fb-href");
+      if (!href) return;
+      const width = Math.max(180, Math.min(500, Math.round(frame.clientWidth || 340)));
+      if (iframe.getAttribute("data-fb-width") === String(width)) return;
+      iframe.setAttribute("data-fb-width", String(width));
+      iframe.style.width = width + "px";
+      iframe.style.height = HEIGHT + "px";
+      iframe.src = `https://www.facebook.com/plugins/page.php?href=${encodeURIComponent(href)}` +
+        `&tabs=timeline&width=${width}&height=${HEIGHT}&small_header=false&adapt_container_width=true&hide_cover=false&show_facepile=true`;
+    };
+    frames.forEach(fit);
+    if (container.dataset.fbResizeBound !== "1") {
+      container.dataset.fbResizeBound = "1";
+      let raf = 0;
+      window.addEventListener("resize", () => {
+        if (raf) return;
+        raf = requestAnimationFrame(() => { raf = 0; frames.forEach(fit); });
+      }, { passive: true });
+    }
   }
 
   // Lazy click-to-embed: cards load a static thumbnail first (real YouTube

--- a/customer-app/modules/utils.js
+++ b/customer-app/modules/utils.js
@@ -96,7 +96,10 @@
     wrench: '<path d="M21 4a5 5 0 0 1-6.5 6.5L6 19l-3-3 8.5-8.5A5 5 0 0 1 18 1l-3 3 2 2 3-3z"/>',
     play: '<path d="M8 5l11 7-11 7V5z" fill="currentColor" stroke="none"/>',
     facebook: '<path d="M14 22v-8h3l1-4h-4V8c0-1.1.6-2 2-2h2V2h-3c-3 0-5 2-5 5v3H7v4h3v8h4z" fill="currentColor" stroke="none"/>',
-    line: '<path d="M12 2C6.48 2 2 5.69 2 10.24c0 4.08 3.55 7.5 8.35 8.15.32.07.77.21.88.49.1.25.07.65.03.91l-.14.86c-.04.25-.2 1 .87.55.6-.27.74-.34.74-.34l.16-.09c3.41-1.46 5.31-2.91 6.93-4.78C21.05 13.7 22 11.96 22 10.24 22 5.69 17.52 2 12 2z" fill="currentColor" stroke="none"/><circle cx="8.2" cy="10.2" r="1" fill="#fff" stroke="none"/><circle cx="12" cy="10.2" r="1" fill="#fff" stroke="none"/><circle cx="15.8" cy="10.2" r="1" fill="#fff" stroke="none"/>',
+    // Real LINE app mark: green rounded-square badge + white speech balloon +
+    // "LINE" wordmark. Self-coloured (not currentColor) so it reads as the
+    // official logo wherever it appears.
+    line: '<rect x="1" y="1" width="22" height="22" rx="6.5" fill="#06C755" stroke="none"/><path d="M12 5.4c-4.2 0-7.6 2.72-7.6 6.07 0 3 2.7 5.51 6.35 5.99.25.05.58.16.66.37.07.19.05.48.02.66 0 0-.09.53-.11.65-.03.19-.15.75.66.41.81-.34 4.35-2.56 5.94-4.39.98-1.08 1.68-2.32 1.68-3.69 0-3.35-3.4-6.07-7.6-6.07z" fill="#fff" stroke="none"/><text x="12" y="12.4" fill="#06C755" font-family="Arial,Helvetica,sans-serif" font-size="4.1" font-weight="700" letter-spacing="0.1" text-anchor="middle" dominant-baseline="middle" stroke="none">LINE</text>',
   };
 
   function icon(name, size) {

--- a/customer-app/sw.js
+++ b/customer-app/sw.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const BUILD_ID = "20260701_fb_timeline_v1";
+const BUILD_ID = "20260701_home_fx_v2";
 const CACHE_NAME = `cwf-customer-app-v2-${BUILD_ID}`;
 const APP_SHELL = [
   `./index.html?v=${BUILD_ID}`,

--- a/customer-app/sw.js
+++ b/customer-app/sw.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const BUILD_ID = "20260701_home_fx_v2";
+const BUILD_ID = "20260701_page_headers_v1";
 const CACHE_NAME = `cwf-customer-app-v2-${BUILD_ID}`;
 const APP_SHELL = [
   `./index.html?v=${BUILD_ID}`,

--- a/server/routes/homepage.js
+++ b/server/routes/homepage.js
@@ -22,6 +22,8 @@ const SECTION_TYPES = new Set([
   "trust",
 ]);
 const INTERNAL_ROUTES = new Set(["home", "booking", "scheduled", "urgent", "tracking", "profile", "store"]);
+// Per-page header banners the admin manages independently of the homepage hero.
+const PAGE_HEADER_KEYS = ["store", "booking", "tracking"];
 const FOCAL_POSITIONS = new Set(["top", "center", "bottom"]);
 const ASPECT_MODES = new Set(["contain", "cover"]);
 const MAX_PROMO_BANNERS = 8;
@@ -344,6 +346,31 @@ function normalizeSection(raw, index, errors) {
   return out;
 }
 
+// Per-page header banners (store/booking/tracking) reuse the hero slide shape:
+// each is an auto-sliding, optionally-clickable image banner the admin manages
+// in the CMS, independent of the homepage hero.
+function normalizePageHeaders(raw, errors) {
+  const src = raw && typeof raw === "object" && !Array.isArray(raw) ? raw : {};
+  const out = {};
+  for (const key of PAGE_HEADER_KEYS) {
+    const header = src[key];
+    if (!header || typeof header !== "object") continue;
+    const rawItems = Array.isArray(header.items) ? header.items : [];
+    if (rawItems.length > MAX_HERO_SLIDES) errors.push(`page_headers.${key}.items too many`);
+    const items = rawItems.slice(0, MAX_HERO_SLIDES).map((item, index) =>
+      normalizeItem(item, "hero", index, errors));
+    out[key] = {
+      enabled: header.enabled !== false,
+      kicker: cleanText(header.kicker, 60),
+      title: cleanText(header.title, 120),
+      body: cleanText(header.body, 260),
+      focal_position: FOCAL_POSITIONS.has(cleanText(header.focal_position, 10)) ? cleanText(header.focal_position, 10) : "center",
+      items,
+    };
+  }
+  return out;
+}
+
 function validateConfig(input) {
   const errors = [];
   if (!input || typeof input !== "object" || Array.isArray(input)) errors.push("payload must be object");
@@ -355,6 +382,7 @@ function validateConfig(input) {
     version: 1,
     sections: sections.map((section, index) => normalizeSection(section, index, errors))
       .sort((a, b) => a.sort_order - b.sort_order),
+    page_headers: normalizePageHeaders(input?.page_headers, errors),
   };
   return { ok: errors.length === 0, errors, config: normalized };
 }
@@ -413,7 +441,29 @@ function stripPublicConfig(config) {
         });
       return cleanSection;
     });
-  return { version: 1, sections };
+  // Carry per-page headers to the public config, stripping admin metadata and
+  // dropping disabled/expired slides (and headers with no live slide).
+  const rawHeaders = config?.page_headers && typeof config.page_headers === "object" ? config.page_headers : {};
+  const page_headers = {};
+  for (const key of Object.keys(rawHeaders)) {
+    const header = rawHeaders[key];
+    if (!header || typeof header !== "object" || header.enabled === false) continue;
+    const items = (header.items || [])
+      .filter((item) => item.enabled !== false && activeNow(item, now))
+      .sort((a, b) => Number(a.sort_order || 0) - Number(b.sort_order || 0))
+      .map((item) => {
+        const cleanItem = { ...item };
+        delete cleanItem.image_public_id;
+        delete cleanItem.updated_by;
+        return cleanItem;
+      });
+    if (!items.length) continue;
+    const cleanHeader = { ...header, items };
+    delete cleanHeader.image_public_id;
+    delete cleanHeader.updated_by;
+    page_headers[key] = cleanHeader;
+  }
+  return { version: 1, sections, page_headers };
 }
 
 async function hydrateAutoSyncArticles(pool, publicConfig) {

--- a/test/customerAppRecovery.test.js
+++ b/test/customerAppRecovery.test.js
@@ -236,7 +236,7 @@ test("Customer App build id is consistent across shell and service worker", () =
   const sw = read("customer-app/sw.js");
   const app = read("customer-app/assets/customer-app.js");
   const manifest = read("customer-app/manifest.webmanifest");
-  const build = "20260701_home_fx_v2";
+  const build = "20260701_page_headers_v1";
 
   assert.match(index, new RegExp(`customer-app\\.css\\?v=${build}`));
   assert.match(index, new RegExp(`modules\\/api\\.js\\?v=${build}`));
@@ -254,7 +254,7 @@ test("Customer App build id is consistent across shell and service worker", () =
 test("store module is loaded in index.html and precached in the service worker app shell", () => {
   const index = read("customer-app/index.html");
   const sw = read("customer-app/sw.js");
-  const build = "20260701_home_fx_v2";
+  const build = "20260701_page_headers_v1";
 
   assert.match(index, new RegExp(`modules/store\\.js\\?v=${build}`));
   assert.match(sw, /`\.\/modules\/store\.js\?v=\$\{BUILD_ID\}`/);

--- a/test/customerAppRecovery.test.js
+++ b/test/customerAppRecovery.test.js
@@ -236,7 +236,7 @@ test("Customer App build id is consistent across shell and service worker", () =
   const sw = read("customer-app/sw.js");
   const app = read("customer-app/assets/customer-app.js");
   const manifest = read("customer-app/manifest.webmanifest");
-  const build = "20260701_fb_timeline_v1";
+  const build = "20260701_home_fx_v2";
 
   assert.match(index, new RegExp(`customer-app\\.css\\?v=${build}`));
   assert.match(index, new RegExp(`modules\\/api\\.js\\?v=${build}`));
@@ -254,7 +254,7 @@ test("Customer App build id is consistent across shell and service worker", () =
 test("store module is loaded in index.html and precached in the service worker app shell", () => {
   const index = read("customer-app/index.html");
   const sw = read("customer-app/sw.js");
-  const build = "20260701_fb_timeline_v1";
+  const build = "20260701_home_fx_v2";
 
   assert.match(index, new RegExp(`modules/store\\.js\\?v=${build}`));
   assert.match(sw, /`\.\/modules\/store\.js\?v=\$\{BUILD_ID\}`/);

--- a/test/customerSameDayTiming.test.js
+++ b/test/customerSameDayTiming.test.js
@@ -160,7 +160,7 @@ test("customer app disables availability HTTP cache and refreshes same-day slots
 });
 
 test("customer app build and service worker cache IDs changed", () => {
-  const id = "20260701_home_fx_v2";
+  const id = "20260701_page_headers_v1";
   for (const file of [
     "customer-app/index.html",
     "customer-app/sw.js",

--- a/test/customerSameDayTiming.test.js
+++ b/test/customerSameDayTiming.test.js
@@ -160,7 +160,7 @@ test("customer app disables availability HTTP cache and refreshes same-day slots
 });
 
 test("customer app build and service worker cache IDs changed", () => {
-  const id = "20260701_fb_timeline_v1";
+  const id = "20260701_home_fx_v2";
   for (const file of [
     "customer-app/index.html",
     "customer-app/sw.js",

--- a/test/homepageCms.test.js
+++ b/test/homepageCms.test.js
@@ -278,7 +278,7 @@ test("customer homepage has no admin control, bottom nav is fixed five-tab, and 
   const sw = read("customer-app/sw.js");
   const app = read("customer-app/assets/customer-app.js");
   const manifest = read("customer-app/manifest.webmanifest");
-  const build = "20260701_fb_timeline_v1";
+  const build = "20260701_home_fx_v2";
 
   assert.doesNotMatch(index + ui, /โหมดแอดมิน|openCms|localStorage\.getItem\('cwfHomeCmsDemo'/);
   assert.match(index, /data-route="store"[\s\S]*ร้านค้า/);

--- a/test/homepageCms.test.js
+++ b/test/homepageCms.test.js
@@ -4,7 +4,7 @@ const fs = require("node:fs");
 const path = require("node:path");
 const express = require("express");
 
-const { DEFAULT_CONFIG, createHomepageRoutes, validateConfig, activeNow } = require("../server/routes/homepage");
+const { DEFAULT_CONFIG, createHomepageRoutes, validateConfig, activeNow, stripPublicConfig } = require("../server/routes/homepage");
 
 const REPO_ROOT = path.resolve(__dirname, "..");
 
@@ -278,7 +278,7 @@ test("customer homepage has no admin control, bottom nav is fixed five-tab, and 
   const sw = read("customer-app/sw.js");
   const app = read("customer-app/assets/customer-app.js");
   const manifest = read("customer-app/manifest.webmanifest");
-  const build = "20260701_home_fx_v2";
+  const build = "20260701_page_headers_v1";
 
   assert.doesNotMatch(index + ui, /โหมดแอดมิน|openCms|localStorage\.getItem\('cwfHomeCmsDemo'/);
   assert.match(index, /data-route="store"[\s\S]*ร้านค้า/);
@@ -903,6 +903,39 @@ test("social validation defaults platform, requires a matching-host url, and enf
   });
   assert.equal(tooMany.ok, false);
   assert.ok(tooMany.errors.includes("social.items too many"));
+});
+
+test("per-page headers (store/booking/tracking) normalize as hero-like banners and are stripped/filtered for the public config", () => {
+  const result = validateConfig({
+    sections: [{ id: "hero", type: "hero", enabled: true, sort_order: 10, title: "Hero", items: [] }],
+    page_headers: {
+      store: {
+        enabled: true, kicker: "ร้านค้า", title: "โปรร้านค้า", body: "ลดราคา", focal_position: "bottom",
+        items: [
+          { title: "สไลด์ 1", image_url: "https://res.cloudinary.com/demo/a.jpg", image_public_id: "cwf/a", route: "store", enabled: true },
+          { title: "สไลด์ 2", image_url: "https://res.cloudinary.com/demo/b.jpg", enabled: false },
+        ],
+      },
+      tracking: { enabled: false, title: "ปิดอยู่", items: [{ title: "x", image_url: "https://res.cloudinary.com/demo/t.jpg" }] },
+      bogus: { enabled: true, items: [] },
+    },
+  });
+  assert.equal(result.ok, true, JSON.stringify(result.errors));
+  const ph = result.config.page_headers;
+  // Only the three known page keys are kept; unknown keys are dropped.
+  assert.deepEqual(Object.keys(ph).sort(), ["store", "tracking"].sort());
+  assert.equal(ph.store.focal_position, "bottom");
+  assert.equal(ph.store.items.length, 2);
+  assert.equal(ph.store.items[0].image_public_id, "cwf/a");
+
+  // Public config: admin image_public_id stripped, disabled slide and disabled
+  // header dropped, so tracking (enabled:false) disappears entirely.
+  const pub = stripPublicConfig(result.config);
+  assert.ok(pub.page_headers, "public config must carry page_headers");
+  assert.deepEqual(Object.keys(pub.page_headers), ["store"]);
+  assert.equal(pub.page_headers.store.items.length, 1);
+  assert.equal(pub.page_headers.store.items[0].image_public_id, undefined);
+  assert.equal(pub.page_headers.store.items[0].route, "store");
 });
 
 test("updates items are savable with only an image/caption (no URL required); articles still require a URL", () => {


### PR DESCRIPTION
## Summary

A batch of customer-app improvements, each verified by booting the real app end-to-end (customer pages + admin CMS) with Playwright.

### Per-page header banners (main feature)
Admins can manage an independent auto-sliding, clickable **header banner** for the **store**, **booking/scheduled**, and **tracking** pages — separate from the homepage hero, each editable on its own.
- **Backend**: `config.page_headers { store, booking, tracking }`, each a hero-shaped banner (kicker/title/body/focal + image slides). `normalizePageHeaders` reuses the hero item normalizer; `validateConfig` includes it; `stripPublicConfig` carries it to the public config, stripping `image_public_id` and dropping disabled/expired slides and disabled headers.
- **Customer app**: `renderPageHeader(pageKey)`/`bindPageHeader` reuse the hero markup + auto-slide binding; rendered at the top of store, booking mode, the scheduled wizard, and tracking.
- **Admin CMS**: a new "แบนเนอร์หัวหน้า" nav group with 3 entries; selecting one opens a hero-style editor (kicker/title/body/focal + image slides with upload, CTA, reorder), reusing the existing slide editor/handlers. Saved & published with the config.

### LINE fixes
- The LINE quick action now shows the **real LINE app logo** (green rounded square + white speech balloon + LINE wordmark), not a generic chat bubble.
- Replaced the broken deep link `line.me/R/ti/p/@cwfair` with the official `lin.ee/fG1Oq7y` add-friend link in the contact sheet and booking toolbar.

### Effects & polish
- **Shimmer loading skeletons** and **gentle image zoom** on card tap (both respect `prefers-reduced-motion`).
- **Facebook Page timeline** now sizes its embed to the real container width (was clipping the cover/name/posts on the right).

### Verification
- Real app booted: page headers render full-width and auto-slide on store/booking/scheduled/tracking; admin Head editor lists 3 headers, opens the slide editor, uploads wired, no JS errors.
- Backend round-trip test for `page_headers` (normalize → strip → public filter).
- All 718 tests pass. `BUILD_ID` bumped.

## Test plan
- [ ] Admin CMS → "แบนเนอร์หัวหน้า" → add image slides to store/booking/tracking → save & publish
- [ ] Store / booking / tracking pages show the header banner, auto-sliding, slides clickable
- [ ] LINE button shows the real logo and opens LINE
- [ ] `npm test` green
