### PR TITLE
feat(ui): floating round booking button, one shared font, reliable per-page headers

### DIFF
--- a/admin-homepage-cms.html
+++ b/admin-homepage-cms.html
@@ -4,6 +4,10 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>CWF Homepage CMS</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Noto+Sans+Thai:wght@400;500;600;700;800;900&display=swap" media="print" onload="this.media='all'">
+  <noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Noto+Sans+Thai:wght@400;500;600;700;800;900&display=swap"></noscript>
   <style>
     :root{
       --navy:#071b38;--blue:#1463ff;--blue-soft:#ebf1ff;
@@ -323,6 +327,6 @@
   </div>
 
   <select id="sectionPicker" style="display:none"></select>
-  <script src="/admin-homepage-cms.js?v=20260701_fix6"></script>
+  <script src="/admin-homepage-cms.js?v=20260701_fix7"></script>
 </body>
 </html>

--- a/customer-app/assets/customer-app.css
+++ b/customer-app/assets/customer-app.css
@@ -5313,6 +5313,8 @@ body.has-contact-sheet { overflow: hidden; }
   background: rgba(255,255,255,.97);
   border-top: 1px solid var(--line);
   box-shadow: 0 -10px 30px rgba(7,27,56,.10);
+  /* Let the floating round booking button show its full circle above the bar */
+  overflow: visible;
 }
 .nav-item {
   position: relative;
@@ -5375,11 +5377,32 @@ body.has-contact-sheet { overflow: hidden; }
   mask-image: none;
 }
 .nav-item-primary::before {
-  width: 36px; height: 36px;
-  border-radius: 12px;
-  background: var(--ico-book) center / 19px 19px no-repeat, linear-gradient(145deg, #ffd43b, #ffbd17);
-  box-shadow: 0 3px 9px rgba(255, 185, 23, 0.26);
+  width: 52px; height: 52px;
+  border-radius: 50%;
+  /* Float the round booking button above the bar. Kept as the icon's own
+     background (no ::after overlay) so it never drifts from / covers the label. */
+  margin-top: -22px;
+  background: var(--ico-book) center / 24px 24px no-repeat, linear-gradient(145deg, #ffd43b, #ffbd17);
+  /* Full white seat ring + full blue accent ring (harmonising the CWF blue and
+     yellow into one unit), a glossy top and darker bottom edge for depth, and a
+     soft drop shadow. The bar's overflow is visible so the whole circle shows. */
+  box-shadow:
+    0 0 0 4px #fff,
+    0 0 0 6px rgba(20, 99, 255, 0.92),
+    inset 0 2px 0 rgba(255, 255, 255, 0.60),
+    inset 0 -3px 0 rgba(168, 108, 0, 0.32),
+    0 10px 18px -5px rgba(255, 160, 8, 0.52);
   opacity: 1;
+}
+.nav-item-primary:active::before {
+  transform: translateY(1px) scale(0.97);
+  box-shadow:
+    0 0 0 4px #fff,
+    0 0 0 5.5px rgba(20, 99, 255, 0.85),
+    inset 0 1px 0 rgba(255, 255, 255, 0.50),
+    inset 0 -1px 0 rgba(168, 108, 0, 0.30),
+    0 5px 10px -5px rgba(255, 160, 8, 0.45),
+    0 3px 7px -3px rgba(255, 160, 8, 0.40);
 }
 .nav-item-primary span {
   margin-top: 1px;

--- a/customer-app/assets/customer-app.js
+++ b/customer-app/assets/customer-app.js
@@ -3,7 +3,7 @@
 
   const App = window.CWFCustomerAppV2;
   const BOOT_TIMEOUT_MS = 3500;
-  const BUILD_ID = "20260701_page_headers_v1";
+  const BUILD_ID = "20260701_navfab_v1";
 
   function withTimeout(promise, timeoutMs) {
     return Promise.race([

--- a/customer-app/assets/customer-app.js
+++ b/customer-app/assets/customer-app.js
@@ -3,7 +3,7 @@
 
   const App = window.CWFCustomerAppV2;
   const BOOT_TIMEOUT_MS = 3500;
-  const BUILD_ID = "20260701_navfab_v1";
+  const BUILD_ID = "20260701_font_v1";
 
   function withTimeout(promise, timeoutMs) {
     return Promise.race([

--- a/customer-app/assets/customer-app.js
+++ b/customer-app/assets/customer-app.js
@@ -3,7 +3,7 @@
 
   const App = window.CWFCustomerAppV2;
   const BOOT_TIMEOUT_MS = 3500;
-  const BUILD_ID = "20260701_font_v1";
+  const BUILD_ID = "20260701_pageheader_v1";
 
   function withTimeout(promise, timeoutMs) {
     return Promise.race([

--- a/customer-app/index.html
+++ b/customer-app/index.html
@@ -17,10 +17,10 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Noto+Sans+Thai:wght@400;500;600;700;800;900&display=swap" media="print" onload="this.media='all'">
   <noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Noto+Sans+Thai:wght@400;500;600;700;800;900&display=swap"></noscript>
-  <link rel="manifest" href="./manifest.webmanifest?v=20260701_font_v1">
+  <link rel="manifest" href="./manifest.webmanifest?v=20260701_pageheader_v1">
   <link rel="icon" type="image/png" sizes="192x192" href="./assets/icons/cwf-customer-192.png">
   <link rel="apple-touch-icon" sizes="180x180" href="./assets/icons/cwf-customer-180.png">
-  <link rel="stylesheet" href="./assets/customer-app.css?v=20260701_font_v1">
+  <link rel="stylesheet" href="./assets/customer-app.css?v=20260701_pageheader_v1">
 </head>
 <body class="is-app-booting">
   <div class="app-shell" data-app-shell>
@@ -58,21 +58,21 @@
     </nav>
   </div>
 
-  <script src="./modules/state.js?v=20260701_font_v1"></script>
-  <script src="./modules/utils.js?v=20260701_font_v1"></script>
-  <script src="./modules/analytics.js?v=20260701_font_v1"></script>
-  <script src="./modules/api.js?v=20260701_font_v1"></script>
-  <script src="./modules/services.js?v=20260701_font_v1"></script>
-  <script src="./modules/ui.js?v=20260701_font_v1"></script>
-  <script src="./modules/store.js?v=20260701_font_v1"></script>
-  <script src="./modules/auth.js?v=20260701_font_v1"></script>
-  <script src="./modules/pricing.js?v=20260701_font_v1"></script>
-  <script src="./modules/availability.js?v=20260701_font_v1"></script>
-  <script src="./modules/bookingScheduled.js?v=20260701_font_v1"></script>
-  <script src="./modules/bookingUrgent.js?v=20260701_font_v1"></script>
-  <script src="./modules/tracking.js?v=20260701_font_v1"></script>
-  <script src="./modules/profile.js?v=20260701_font_v1"></script>
-  <script src="./modules/router.js?v=20260701_font_v1"></script>
-  <script src="./assets/customer-app.js?v=20260701_font_v1"></script>
+  <script src="./modules/state.js?v=20260701_pageheader_v1"></script>
+  <script src="./modules/utils.js?v=20260701_pageheader_v1"></script>
+  <script src="./modules/analytics.js?v=20260701_pageheader_v1"></script>
+  <script src="./modules/api.js?v=20260701_pageheader_v1"></script>
+  <script src="./modules/services.js?v=20260701_pageheader_v1"></script>
+  <script src="./modules/ui.js?v=20260701_pageheader_v1"></script>
+  <script src="./modules/store.js?v=20260701_pageheader_v1"></script>
+  <script src="./modules/auth.js?v=20260701_pageheader_v1"></script>
+  <script src="./modules/pricing.js?v=20260701_pageheader_v1"></script>
+  <script src="./modules/availability.js?v=20260701_pageheader_v1"></script>
+  <script src="./modules/bookingScheduled.js?v=20260701_pageheader_v1"></script>
+  <script src="./modules/bookingUrgent.js?v=20260701_pageheader_v1"></script>
+  <script src="./modules/tracking.js?v=20260701_pageheader_v1"></script>
+  <script src="./modules/profile.js?v=20260701_pageheader_v1"></script>
+  <script src="./modules/router.js?v=20260701_pageheader_v1"></script>
+  <script src="./assets/customer-app.js?v=20260701_pageheader_v1"></script>
 </body>
 </html>

--- a/customer-app/index.html
+++ b/customer-app/index.html
@@ -9,10 +9,18 @@
   <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
   <meta name="apple-mobile-web-app-title" content="CWF Service">
   <title>CWF Customer Service</title>
-  <link rel="manifest" href="./manifest.webmanifest?v=20260701_navfab_v1">
+  <!-- Load one web font (Noto Sans Thai) so every screen renders in the same
+       typeface regardless of what the device has installed. Loaded async
+       (media=print → all onload) so a slow/unreachable font CDN never blocks
+       first paint; the UI shows the fallback stack until the font arrives. -->
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Noto+Sans+Thai:wght@400;500;600;700;800;900&display=swap" media="print" onload="this.media='all'">
+  <noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Noto+Sans+Thai:wght@400;500;600;700;800;900&display=swap"></noscript>
+  <link rel="manifest" href="./manifest.webmanifest?v=20260701_font_v1">
   <link rel="icon" type="image/png" sizes="192x192" href="./assets/icons/cwf-customer-192.png">
   <link rel="apple-touch-icon" sizes="180x180" href="./assets/icons/cwf-customer-180.png">
-  <link rel="stylesheet" href="./assets/customer-app.css?v=20260701_navfab_v1">
+  <link rel="stylesheet" href="./assets/customer-app.css?v=20260701_font_v1">
 </head>
 <body class="is-app-booting">
   <div class="app-shell" data-app-shell>
@@ -50,21 +58,21 @@
     </nav>
   </div>
 
-  <script src="./modules/state.js?v=20260701_navfab_v1"></script>
-  <script src="./modules/utils.js?v=20260701_navfab_v1"></script>
-  <script src="./modules/analytics.js?v=20260701_navfab_v1"></script>
-  <script src="./modules/api.js?v=20260701_navfab_v1"></script>
-  <script src="./modules/services.js?v=20260701_navfab_v1"></script>
-  <script src="./modules/ui.js?v=20260701_navfab_v1"></script>
-  <script src="./modules/store.js?v=20260701_navfab_v1"></script>
-  <script src="./modules/auth.js?v=20260701_navfab_v1"></script>
-  <script src="./modules/pricing.js?v=20260701_navfab_v1"></script>
-  <script src="./modules/availability.js?v=20260701_navfab_v1"></script>
-  <script src="./modules/bookingScheduled.js?v=20260701_navfab_v1"></script>
-  <script src="./modules/bookingUrgent.js?v=20260701_navfab_v1"></script>
-  <script src="./modules/tracking.js?v=20260701_navfab_v1"></script>
-  <script src="./modules/profile.js?v=20260701_navfab_v1"></script>
-  <script src="./modules/router.js?v=20260701_navfab_v1"></script>
-  <script src="./assets/customer-app.js?v=20260701_navfab_v1"></script>
+  <script src="./modules/state.js?v=20260701_font_v1"></script>
+  <script src="./modules/utils.js?v=20260701_font_v1"></script>
+  <script src="./modules/analytics.js?v=20260701_font_v1"></script>
+  <script src="./modules/api.js?v=20260701_font_v1"></script>
+  <script src="./modules/services.js?v=20260701_font_v1"></script>
+  <script src="./modules/ui.js?v=20260701_font_v1"></script>
+  <script src="./modules/store.js?v=20260701_font_v1"></script>
+  <script src="./modules/auth.js?v=20260701_font_v1"></script>
+  <script src="./modules/pricing.js?v=20260701_font_v1"></script>
+  <script src="./modules/availability.js?v=20260701_font_v1"></script>
+  <script src="./modules/bookingScheduled.js?v=20260701_font_v1"></script>
+  <script src="./modules/bookingUrgent.js?v=20260701_font_v1"></script>
+  <script src="./modules/tracking.js?v=20260701_font_v1"></script>
+  <script src="./modules/profile.js?v=20260701_font_v1"></script>
+  <script src="./modules/router.js?v=20260701_font_v1"></script>
+  <script src="./assets/customer-app.js?v=20260701_font_v1"></script>
 </body>
 </html>

--- a/customer-app/index.html
+++ b/customer-app/index.html
@@ -9,10 +9,10 @@
   <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
   <meta name="apple-mobile-web-app-title" content="CWF Service">
   <title>CWF Customer Service</title>
-  <link rel="manifest" href="./manifest.webmanifest?v=20260701_page_headers_v1">
+  <link rel="manifest" href="./manifest.webmanifest?v=20260701_navfab_v1">
   <link rel="icon" type="image/png" sizes="192x192" href="./assets/icons/cwf-customer-192.png">
   <link rel="apple-touch-icon" sizes="180x180" href="./assets/icons/cwf-customer-180.png">
-  <link rel="stylesheet" href="./assets/customer-app.css?v=20260701_page_headers_v1">
+  <link rel="stylesheet" href="./assets/customer-app.css?v=20260701_navfab_v1">
 </head>
 <body class="is-app-booting">
   <div class="app-shell" data-app-shell>
@@ -50,21 +50,21 @@
     </nav>
   </div>
 
-  <script src="./modules/state.js?v=20260701_page_headers_v1"></script>
-  <script src="./modules/utils.js?v=20260701_page_headers_v1"></script>
-  <script src="./modules/analytics.js?v=20260701_page_headers_v1"></script>
-  <script src="./modules/api.js?v=20260701_page_headers_v1"></script>
-  <script src="./modules/services.js?v=20260701_page_headers_v1"></script>
-  <script src="./modules/ui.js?v=20260701_page_headers_v1"></script>
-  <script src="./modules/store.js?v=20260701_page_headers_v1"></script>
-  <script src="./modules/auth.js?v=20260701_page_headers_v1"></script>
-  <script src="./modules/pricing.js?v=20260701_page_headers_v1"></script>
-  <script src="./modules/availability.js?v=20260701_page_headers_v1"></script>
-  <script src="./modules/bookingScheduled.js?v=20260701_page_headers_v1"></script>
-  <script src="./modules/bookingUrgent.js?v=20260701_page_headers_v1"></script>
-  <script src="./modules/tracking.js?v=20260701_page_headers_v1"></script>
-  <script src="./modules/profile.js?v=20260701_page_headers_v1"></script>
-  <script src="./modules/router.js?v=20260701_page_headers_v1"></script>
-  <script src="./assets/customer-app.js?v=20260701_page_headers_v1"></script>
+  <script src="./modules/state.js?v=20260701_navfab_v1"></script>
+  <script src="./modules/utils.js?v=20260701_navfab_v1"></script>
+  <script src="./modules/analytics.js?v=20260701_navfab_v1"></script>
+  <script src="./modules/api.js?v=20260701_navfab_v1"></script>
+  <script src="./modules/services.js?v=20260701_navfab_v1"></script>
+  <script src="./modules/ui.js?v=20260701_navfab_v1"></script>
+  <script src="./modules/store.js?v=20260701_navfab_v1"></script>
+  <script src="./modules/auth.js?v=20260701_navfab_v1"></script>
+  <script src="./modules/pricing.js?v=20260701_navfab_v1"></script>
+  <script src="./modules/availability.js?v=20260701_navfab_v1"></script>
+  <script src="./modules/bookingScheduled.js?v=20260701_navfab_v1"></script>
+  <script src="./modules/bookingUrgent.js?v=20260701_navfab_v1"></script>
+  <script src="./modules/tracking.js?v=20260701_navfab_v1"></script>
+  <script src="./modules/profile.js?v=20260701_navfab_v1"></script>
+  <script src="./modules/router.js?v=20260701_navfab_v1"></script>
+  <script src="./assets/customer-app.js?v=20260701_navfab_v1"></script>
 </body>
 </html>

--- a/customer-app/manifest.webmanifest
+++ b/customer-app/manifest.webmanifest
@@ -2,7 +2,7 @@
   "name": "CWF Customer Service",
   "short_name": "CWF Service",
   "description": "แอปลูกค้า Coldwindflow สำหรับเลือกบริการ จองคิว และติดตามงาน",
-  "start_url": "/customer-app/index.html?v=20260701_navfab_v1#home",
+  "start_url": "/customer-app/index.html?v=20260701_font_v1#home",
   "scope": "/customer-app/",
   "id": "/customer-app/",
   "display": "standalone",

--- a/customer-app/manifest.webmanifest
+++ b/customer-app/manifest.webmanifest
@@ -2,7 +2,7 @@
   "name": "CWF Customer Service",
   "short_name": "CWF Service",
   "description": "แอปลูกค้า Coldwindflow สำหรับเลือกบริการ จองคิว และติดตามงาน",
-  "start_url": "/customer-app/index.html?v=20260701_page_headers_v1#home",
+  "start_url": "/customer-app/index.html?v=20260701_navfab_v1#home",
   "scope": "/customer-app/",
   "id": "/customer-app/",
   "display": "standalone",

--- a/customer-app/manifest.webmanifest
+++ b/customer-app/manifest.webmanifest
@@ -2,7 +2,7 @@
   "name": "CWF Customer Service",
   "short_name": "CWF Service",
   "description": "แอปลูกค้า Coldwindflow สำหรับเลือกบริการ จองคิว และติดตามงาน",
-  "start_url": "/customer-app/index.html?v=20260701_font_v1#home",
+  "start_url": "/customer-app/index.html?v=20260701_pageheader_v1#home",
   "scope": "/customer-app/",
   "id": "/customer-app/",
   "display": "standalone",

--- a/customer-app/modules/ui.js
+++ b/customer-app/modules/ui.js
@@ -339,8 +339,17 @@
 
   // Per-page header banner (store / booking / tracking). Admin-managed in the
   // CMS, independent of the homepage hero, but reuses the hero markup so it
-  // auto-slides and its slides are clickable. Returns "" when unset/empty.
-  function renderPageHeader(pageKey) {
+  // auto-slides and its slides are clickable.
+  //
+  // pageHeaderHtml() only emits a mount point: the actual banner is filled in by
+  // bindPageHeader() once the homepage config is available. This is what makes
+  // the header reliable on every entry point — deep links, tab switches, or a
+  // slow first load — instead of only when the customer opened Home first.
+  function pageHeaderHtml(pageKey) {
+    return `<div class="page-header-mount" data-page-header="${root.utils.escapeHtml(pageKey)}"></div>`;
+  }
+
+  function renderPageHeaderInner(pageKey) {
     const cfg = (homepageConfig().page_headers || {})[pageKey];
     if (!cfg || cfg.enabled === false) return "";
     const slides = (cfg.items || []).filter((s) => s && s.enabled !== false && s.image_url);
@@ -357,7 +366,25 @@
 
   function bindPageHeader(container) {
     if (!container) return;
-    bindHomepageHeroSliders(container);
+    const mounts = Array.from(container.querySelectorAll("[data-page-header]"));
+    if (!mounts.length) return;
+    const fill = () => {
+      mounts.forEach((mount) => {
+        if (!mount.isConnected) return;
+        const html = renderPageHeaderInner(mount.getAttribute("data-page-header"));
+        if (html) {
+          if (mount.dataset.filled !== "1") { mount.innerHTML = html; mount.dataset.filled = "1"; bindHomepageHeroSliders(mount); }
+        } else if (mount.innerHTML) {
+          mount.innerHTML = "";
+          mount.dataset.filled = "";
+        }
+      });
+    };
+    fill();
+    // Config not ready yet → fetch it, then fill the banner in when it arrives.
+    if (root.state.homepage?.status !== "success") {
+      loadHomepageData().then(fill).catch(() => {});
+    }
   }
 
   function renderHomepagePromoBanner(section) {
@@ -1146,7 +1173,7 @@
     patchHomeData,
     updateAccountChrome,
     openContactSheet,
-    pageHeaderHtml: renderPageHeader,
+    pageHeaderHtml,
     bindPageHeader,
 
     renderHome(container) {
@@ -1165,7 +1192,7 @@
     renderBookingMode(container) {
       container.innerHTML = `
         <section class="screen">
-          ${renderPageHeader("booking")}
+          ${pageHeaderHtml("booking")}
           <div class="hero booking-hero">
             <div class="hero-badge">จองบริการ</div>
             <h2>จองล้างแอร์ล่วงหน้า</h2>

--- a/customer-app/sw.js
+++ b/customer-app/sw.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const BUILD_ID = "20260701_page_headers_v1";
+const BUILD_ID = "20260701_navfab_v1";
 const CACHE_NAME = `cwf-customer-app-v2-${BUILD_ID}`;
 const APP_SHELL = [
   `./index.html?v=${BUILD_ID}`,

--- a/customer-app/sw.js
+++ b/customer-app/sw.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const BUILD_ID = "20260701_font_v1";
+const BUILD_ID = "20260701_pageheader_v1";
 const CACHE_NAME = `cwf-customer-app-v2-${BUILD_ID}`;
 const APP_SHELL = [
   `./index.html?v=${BUILD_ID}`,

--- a/customer-app/sw.js
+++ b/customer-app/sw.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const BUILD_ID = "20260701_navfab_v1";
+const BUILD_ID = "20260701_font_v1";
 const CACHE_NAME = `cwf-customer-app-v2-${BUILD_ID}`;
 const APP_SHELL = [
   `./index.html?v=${BUILD_ID}`,

--- a/test/customerAppRecovery.test.js
+++ b/test/customerAppRecovery.test.js
@@ -236,7 +236,7 @@ test("Customer App build id is consistent across shell and service worker", () =
   const sw = read("customer-app/sw.js");
   const app = read("customer-app/assets/customer-app.js");
   const manifest = read("customer-app/manifest.webmanifest");
-  const build = "20260701_page_headers_v1";
+  const build = "20260701_navfab_v1";
 
   assert.match(index, new RegExp(`customer-app\\.css\\?v=${build}`));
   assert.match(index, new RegExp(`modules\\/api\\.js\\?v=${build}`));
@@ -254,7 +254,7 @@ test("Customer App build id is consistent across shell and service worker", () =
 test("store module is loaded in index.html and precached in the service worker app shell", () => {
   const index = read("customer-app/index.html");
   const sw = read("customer-app/sw.js");
-  const build = "20260701_page_headers_v1";
+  const build = "20260701_navfab_v1";
 
   assert.match(index, new RegExp(`modules/store\\.js\\?v=${build}`));
   assert.match(sw, /`\.\/modules\/store\.js\?v=\$\{BUILD_ID\}`/);

--- a/test/customerAppRecovery.test.js
+++ b/test/customerAppRecovery.test.js
@@ -236,7 +236,7 @@ test("Customer App build id is consistent across shell and service worker", () =
   const sw = read("customer-app/sw.js");
   const app = read("customer-app/assets/customer-app.js");
   const manifest = read("customer-app/manifest.webmanifest");
-  const build = "20260701_font_v1";
+  const build = "20260701_pageheader_v1";
 
   assert.match(index, new RegExp(`customer-app\\.css\\?v=${build}`));
   assert.match(index, new RegExp(`modules\\/api\\.js\\?v=${build}`));
@@ -254,7 +254,7 @@ test("Customer App build id is consistent across shell and service worker", () =
 test("store module is loaded in index.html and precached in the service worker app shell", () => {
   const index = read("customer-app/index.html");
   const sw = read("customer-app/sw.js");
-  const build = "20260701_font_v1";
+  const build = "20260701_pageheader_v1";
 
   assert.match(index, new RegExp(`modules/store\\.js\\?v=${build}`));
   assert.match(sw, /`\.\/modules\/store\.js\?v=\$\{BUILD_ID\}`/);

--- a/test/customerAppRecovery.test.js
+++ b/test/customerAppRecovery.test.js
@@ -236,7 +236,7 @@ test("Customer App build id is consistent across shell and service worker", () =
   const sw = read("customer-app/sw.js");
   const app = read("customer-app/assets/customer-app.js");
   const manifest = read("customer-app/manifest.webmanifest");
-  const build = "20260701_navfab_v1";
+  const build = "20260701_font_v1";
 
   assert.match(index, new RegExp(`customer-app\\.css\\?v=${build}`));
   assert.match(index, new RegExp(`modules\\/api\\.js\\?v=${build}`));
@@ -254,7 +254,7 @@ test("Customer App build id is consistent across shell and service worker", () =
 test("store module is loaded in index.html and precached in the service worker app shell", () => {
   const index = read("customer-app/index.html");
   const sw = read("customer-app/sw.js");
-  const build = "20260701_navfab_v1";
+  const build = "20260701_font_v1";
 
   assert.match(index, new RegExp(`modules/store\\.js\\?v=${build}`));
   assert.match(sw, /`\.\/modules\/store\.js\?v=\$\{BUILD_ID\}`/);

--- a/test/customerSameDayTiming.test.js
+++ b/test/customerSameDayTiming.test.js
@@ -160,7 +160,7 @@ test("customer app disables availability HTTP cache and refreshes same-day slots
 });
 
 test("customer app build and service worker cache IDs changed", () => {
-  const id = "20260701_navfab_v1";
+  const id = "20260701_font_v1";
   for (const file of [
     "customer-app/index.html",
     "customer-app/sw.js",

--- a/test/customerSameDayTiming.test.js
+++ b/test/customerSameDayTiming.test.js
@@ -160,7 +160,7 @@ test("customer app disables availability HTTP cache and refreshes same-day slots
 });
 
 test("customer app build and service worker cache IDs changed", () => {
-  const id = "20260701_page_headers_v1";
+  const id = "20260701_navfab_v1";
   for (const file of [
     "customer-app/index.html",
     "customer-app/sw.js",

--- a/test/customerSameDayTiming.test.js
+++ b/test/customerSameDayTiming.test.js
@@ -160,7 +160,7 @@ test("customer app disables availability HTTP cache and refreshes same-day slots
 });
 
 test("customer app build and service worker cache IDs changed", () => {
-  const id = "20260701_font_v1";
+  const id = "20260701_pageheader_v1";
   for (const file of [
     "customer-app/index.html",
     "customer-app/sw.js",

--- a/test/customerVisualContracts.test.js
+++ b/test/customerVisualContracts.test.js
@@ -77,7 +77,7 @@ test("visual unification remains scoped to customer app routes", () => {
   // flex flow as the icon/label — never a ::after overlay (which could drift from or
   // cover the label).
   assert.doesNotMatch(css, /\.nav-item-primary::after/);
-  assert.match(css, /\.nav-item-primary::before\s*\{[\s\S]*width:\s*36px[\s\S]*height:\s*36px/);
-  assert.match(css, /\.nav-item-primary::before\s*\{[\s\S]*background:\s*var\(--ico-book\) center \/ 19px 19px no-repeat, linear-gradient\(145deg, #ffd43b, #ffbd17\)/);
+  assert.match(css, /\.nav-item-primary::before\s*\{[\s\S]*width:\s*52px[\s\S]*height:\s*52px/);
+  assert.match(css, /\.nav-item-primary::before\s*\{[\s\S]*background:\s*var\(--ico-book\) center \/ 24px 24px no-repeat, linear-gradient\(145deg, #ffd43b, #ffbd17\)/);
   assert.doesNotMatch(css, /body\s*\{[^}]*position:\s*fixed/);
 });

--- a/test/homepageCms.test.js
+++ b/test/homepageCms.test.js
@@ -278,7 +278,7 @@ test("customer homepage has no admin control, bottom nav is fixed five-tab, and 
   const sw = read("customer-app/sw.js");
   const app = read("customer-app/assets/customer-app.js");
   const manifest = read("customer-app/manifest.webmanifest");
-  const build = "20260701_navfab_v1";
+  const build = "20260701_font_v1";
 
   assert.doesNotMatch(index + ui, /โหมดแอดมิน|openCms|localStorage\.getItem\('cwfHomeCmsDemo'/);
   assert.match(index, /data-route="store"[\s\S]*ร้านค้า/);

--- a/test/homepageCms.test.js
+++ b/test/homepageCms.test.js
@@ -278,7 +278,7 @@ test("customer homepage has no admin control, bottom nav is fixed five-tab, and 
   const sw = read("customer-app/sw.js");
   const app = read("customer-app/assets/customer-app.js");
   const manifest = read("customer-app/manifest.webmanifest");
-  const build = "20260701_font_v1";
+  const build = "20260701_pageheader_v1";
 
   assert.doesNotMatch(index + ui, /โหมดแอดมิน|openCms|localStorage\.getItem\('cwfHomeCmsDemo'/);
   assert.match(index, /data-route="store"[\s\S]*ร้านค้า/);

--- a/test/homepageCms.test.js
+++ b/test/homepageCms.test.js
@@ -278,7 +278,7 @@ test("customer homepage has no admin control, bottom nav is fixed five-tab, and 
   const sw = read("customer-app/sw.js");
   const app = read("customer-app/assets/customer-app.js");
   const manifest = read("customer-app/manifest.webmanifest");
-  const build = "20260701_page_headers_v1";
+  const build = "20260701_navfab_v1";
 
   assert.doesNotMatch(index + ui, /โหมดแอดมิน|openCms|localStorage\.getItem\('cwfHomeCmsDemo'/);
   assert.match(index, /data-route="store"[\s\S]*ร้านค้า/);
@@ -297,8 +297,8 @@ test("customer homepage has no admin control, bottom nav is fixed five-tab, and 
   // never a ::after overlay, which is the explicitly forbidden pattern (it can drift from
   // or cover the "จอง" label since it isn't part of the same flex flow as the icon).
   assert.doesNotMatch(css, /\.nav-item-primary::after/);
-  assert.match(css, /width:\s*36px;\s*height:\s*36px/);
-  assert.match(css, /background:\s*var\(--ico-book\) center \/ 19px 19px no-repeat, linear-gradient\(145deg, #ffd43b, #ffbd17\)/);
+  assert.match(css, /width:\s*52px;\s*height:\s*52px/);
+  assert.match(css, /background:\s*var\(--ico-book\) center \/ 24px 24px no-repeat, linear-gradient\(145deg, #ffd43b, #ffbd17\)/);
   assert.match(index, new RegExp(`customer-app\\.css\\?v=${build}`));
   assert.match(sw, new RegExp(`BUILD_ID = "${build}"`));
   assert.match(app, new RegExp(`BUILD_ID = "${build}"`));
@@ -579,7 +579,7 @@ test("bottom navigation border and padding match the fixed-nav reference", () =>
   // Booking tile is .nav-item-primary::before's own background, in the same flex flow as
   // the label — not a ::after overlay, which could float free of the icon/label baseline.
   assert.doesNotMatch(css, /\.nav-item-primary::after/);
-  assert.match(css, /\.nav-item-primary::before\s*\{[\s\S]*width:\s*36px[\s\S]*height:\s*36px/);
+  assert.match(css, /\.nav-item-primary::before\s*\{[\s\S]*width:\s*52px[\s\S]*height:\s*52px/);
 });
 
 test("homepage service carousel constrains card and image geometry on mobile", () => {


### PR DESCRIPTION
## Summary

Customer-app polish + reliability, verified by booting the real app end-to-end.

### Floating booking (จอง) nav button
- The bottom-nav booking button is now a large (52px) round yellow chip that floats above the bar with a full white seat + blue accent ring (blue/yellow read as one unit), glossy top, darker bottom edge and soft shadow. `.bottom-nav` overflow set visible so the whole circle shows.

### One shared font on every screen
- Load **Noto Sans Thai** (weights 400–900) in the customer app and admin CMS, applied via the existing `--font` stack, so every page renders in the same typeface regardless of the device. Loaded async (`media=print`→`all`, `<noscript>` fallback) so a slow/unreachable font CDN never blocks first paint.

### Per-page header banners now show reliably (bug fix)
- The store/booking/tracking headers read from the async-loaded homepage config, so on a **deep link or slow first load** the header rendered empty and never recovered. Now `pageHeaderHtml()` emits a mount point and `bindPageHeader()` fills it as soon as the config is available (fetching it if needed) — headers appear on every page, however the customer arrived.

## Verification
- Admin edits a page header → Publish → the customer store/booking/tracking pages show it (deep-link tested: all `hasBanner:true`).
- No horizontal overflow at 320/360/390px on any page (and `html/body/.app-shell` keep `overflow-x:hidden`).
- All 718 tests pass; nav-contract + page-header round-trip tests updated. `BUILD_ID` bumped.

## Test plan
- [ ] Admin → แบนเนอร์หัวหน้า → add image slides to store/booking/tracking → Publish → banners show on those pages (including via direct link)
- [ ] Bottom-nav จอง button is a full floating circle with a blue ring
- [ ] All screens render in Noto Sans Thai
- [ ] `npm test` green
