### PR TITLE
feat(store): collapse advanced filters into a togglable panel

### DIFF
--- a/customer-app/assets/customer-app.css
+++ b/customer-app/assets/customer-app.css
@@ -2154,6 +2154,7 @@ p { margin: 0; }
   --ico-book: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='%23000' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Crect x='3' y='4' width='18' height='18' rx='3'/%3E%3Cpath d='M16 2v4M8 2v4M3 10h18'/%3E%3Cpath d='M9 15l2 2 4-4'/%3E%3C/svg%3E");
   --ico-track: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='%23000' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M12 21s-7-5.6-7-11a7 7 0 0 1 14 0c0 5.4-7 11-7 11z'/%3E%3Ccircle cx='12' cy='10' r='2.5'/%3E%3C/svg%3E");
   --ico-user: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='%23000' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Ccircle cx='12' cy='8' r='4'/%3E%3Cpath d='M4 21c0-4 4-6 8-6s8 2 8 6'/%3E%3C/svg%3E");
+  --ico-filter: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='%23000' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M3 5h18M6 12h12M10 19h4'/%3E%3C/svg%3E");
 }
 
 /* ===================== Responsive guards ===================== */
@@ -3543,12 +3544,78 @@ body.has-contact-sheet { overflow: hidden; }
 }
 .store-filters {
   display: flex;
-  flex-wrap: wrap;
+  flex-direction: column;
   gap: 8px;
   margin-bottom: 14px;
 }
+.store-filter-head {
+  display: flex;
+  gap: 8px;
+  align-items: stretch;
+}
 .store-search-input {
-  flex: 1 1 100%;
+  flex: 1 1 auto;
+}
+.store-filter-toggle {
+  flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  height: 44px;
+  padding: 0 14px;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--line);
+  background: #fff;
+  color: var(--ink);
+  font-size: 14px;
+  font-weight: 600;
+  cursor: pointer;
+}
+.store-filter-toggle.is-open {
+  border-color: var(--accent, #1f7bff);
+  color: var(--accent, #1f7bff);
+  background: rgba(31, 123, 255, 0.06);
+}
+.store-filter-toggle-icon {
+  width: 16px;
+  height: 16px;
+  background: currentColor;
+  -webkit-mask: var(--ico-filter) center / contain no-repeat;
+  mask: var(--ico-filter) center / contain no-repeat;
+}
+.store-filter-count {
+  min-width: 18px;
+  height: 18px;
+  padding: 0 5px;
+  border-radius: 999px;
+  background: var(--accent, #1f7bff);
+  color: #fff;
+  font-size: 11px;
+  font-weight: 700;
+  line-height: 18px;
+  text-align: center;
+}
+.store-filter-count[hidden] {
+  display: none;
+}
+.store-filter-caret {
+  width: 0;
+  height: 0;
+  border-left: 4px solid transparent;
+  border-right: 4px solid transparent;
+  border-top: 5px solid currentColor;
+  transition: transform 0.18s ease;
+}
+.store-filter-toggle.is-open .store-filter-caret {
+  transform: rotate(180deg);
+}
+.store-filter-panel {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+.store-filter-panel[hidden] {
+  display: none;
 }
 .store-search-input,
 .store-category-select,

--- a/customer-app/assets/customer-app.js
+++ b/customer-app/assets/customer-app.js
@@ -3,7 +3,7 @@
 
   const App = window.CWFCustomerAppV2;
   const BOOT_TIMEOUT_MS = 3500;
-  const BUILD_ID = "20260701_pageheader_v1";
+  const BUILD_ID = "20260701_storefilter_v1";
 
   function withTimeout(promise, timeoutMs) {
     return Promise.race([

--- a/customer-app/index.html
+++ b/customer-app/index.html
@@ -17,10 +17,10 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Noto+Sans+Thai:wght@400;500;600;700;800;900&display=swap" media="print" onload="this.media='all'">
   <noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Noto+Sans+Thai:wght@400;500;600;700;800;900&display=swap"></noscript>
-  <link rel="manifest" href="./manifest.webmanifest?v=20260701_pageheader_v1">
+  <link rel="manifest" href="./manifest.webmanifest?v=20260701_storefilter_v1">
   <link rel="icon" type="image/png" sizes="192x192" href="./assets/icons/cwf-customer-192.png">
   <link rel="apple-touch-icon" sizes="180x180" href="./assets/icons/cwf-customer-180.png">
-  <link rel="stylesheet" href="./assets/customer-app.css?v=20260701_pageheader_v1">
+  <link rel="stylesheet" href="./assets/customer-app.css?v=20260701_storefilter_v1">
 </head>
 <body class="is-app-booting">
   <div class="app-shell" data-app-shell>
@@ -58,21 +58,21 @@
     </nav>
   </div>
 
-  <script src="./modules/state.js?v=20260701_pageheader_v1"></script>
-  <script src="./modules/utils.js?v=20260701_pageheader_v1"></script>
-  <script src="./modules/analytics.js?v=20260701_pageheader_v1"></script>
-  <script src="./modules/api.js?v=20260701_pageheader_v1"></script>
-  <script src="./modules/services.js?v=20260701_pageheader_v1"></script>
-  <script src="./modules/ui.js?v=20260701_pageheader_v1"></script>
-  <script src="./modules/store.js?v=20260701_pageheader_v1"></script>
-  <script src="./modules/auth.js?v=20260701_pageheader_v1"></script>
-  <script src="./modules/pricing.js?v=20260701_pageheader_v1"></script>
-  <script src="./modules/availability.js?v=20260701_pageheader_v1"></script>
-  <script src="./modules/bookingScheduled.js?v=20260701_pageheader_v1"></script>
-  <script src="./modules/bookingUrgent.js?v=20260701_pageheader_v1"></script>
-  <script src="./modules/tracking.js?v=20260701_pageheader_v1"></script>
-  <script src="./modules/profile.js?v=20260701_pageheader_v1"></script>
-  <script src="./modules/router.js?v=20260701_pageheader_v1"></script>
-  <script src="./assets/customer-app.js?v=20260701_pageheader_v1"></script>
+  <script src="./modules/state.js?v=20260701_storefilter_v1"></script>
+  <script src="./modules/utils.js?v=20260701_storefilter_v1"></script>
+  <script src="./modules/analytics.js?v=20260701_storefilter_v1"></script>
+  <script src="./modules/api.js?v=20260701_storefilter_v1"></script>
+  <script src="./modules/services.js?v=20260701_storefilter_v1"></script>
+  <script src="./modules/ui.js?v=20260701_storefilter_v1"></script>
+  <script src="./modules/store.js?v=20260701_storefilter_v1"></script>
+  <script src="./modules/auth.js?v=20260701_storefilter_v1"></script>
+  <script src="./modules/pricing.js?v=20260701_storefilter_v1"></script>
+  <script src="./modules/availability.js?v=20260701_storefilter_v1"></script>
+  <script src="./modules/bookingScheduled.js?v=20260701_storefilter_v1"></script>
+  <script src="./modules/bookingUrgent.js?v=20260701_storefilter_v1"></script>
+  <script src="./modules/tracking.js?v=20260701_storefilter_v1"></script>
+  <script src="./modules/profile.js?v=20260701_storefilter_v1"></script>
+  <script src="./modules/router.js?v=20260701_storefilter_v1"></script>
+  <script src="./assets/customer-app.js?v=20260701_storefilter_v1"></script>
 </body>
 </html>

--- a/customer-app/manifest.webmanifest
+++ b/customer-app/manifest.webmanifest
@@ -2,7 +2,7 @@
   "name": "CWF Customer Service",
   "short_name": "CWF Service",
   "description": "แอปลูกค้า Coldwindflow สำหรับเลือกบริการ จองคิว และติดตามงาน",
-  "start_url": "/customer-app/index.html?v=20260701_pageheader_v1#home",
+  "start_url": "/customer-app/index.html?v=20260701_storefilter_v1#home",
   "scope": "/customer-app/",
   "id": "/customer-app/",
   "display": "standalone",

--- a/customer-app/modules/store.js
+++ b/customer-app/modules/store.js
@@ -4,6 +4,9 @@
   const root = window.CWFCustomerAppV2 = window.CWFCustomerAppV2 || {};
 
   let filterState = { search: "", category: "", acType: "", washVariant: "", btu: "", queueToday: false, sort: "recommended" };
+  // Advanced filters (everything except the always-visible search box) collapse
+  // into a togglable panel so the store list is not buried under filter rows.
+  let filtersOpen = false;
   let detailLoadSeq = 0;
   let reviewsRequestSeq = 0;
   let eligibilityRequestSeq = 0;
@@ -560,6 +563,28 @@
     return `<div class="store-grid" data-store-grid>${filtered.map(renderCard).join("")}</div>`;
   }
 
+  // How many advanced filters are currently narrowing the list (search box is
+  // excluded — it stays visible). Drives the badge on the collapsed toggle so
+  // customers can tell filters are active without expanding the panel.
+  function activeFilterCount() {
+    let n = 0;
+    if (filterState.category) n += 1;
+    if (filterState.acType) n += 1;
+    if (filterState.washVariant) n += 1;
+    if (filterState.btu) n += 1;
+    if (filterState.queueToday) n += 1;
+    if (filterState.sort && filterState.sort !== "recommended") n += 1;
+    return n;
+  }
+
+  function refreshFilterCount(container) {
+    const badge = container.querySelector("[data-store-filter-count]");
+    if (!badge) return;
+    const n = activeFilterCount();
+    badge.textContent = String(n);
+    badge.hidden = n === 0;
+  }
+
   function renderBody() {
     const bucket = root.state.catalog || { status: "idle", items: [], error: "" };
     if (bucket.status === "idle" || bucket.status === "loading") {
@@ -576,32 +601,43 @@
       return root.utils.stateBox("", "ยังไม่มีรายการที่เปิดให้ลูกค้าดูในขณะนี้ กรุณาติดต่อแอดมินเพื่อสอบถามบริการ");
     }
     const categories = categoriesFromItems(items);
+    const activeCount = activeFilterCount();
     return `
       <div class="store-filters">
-        <input type="search" class="store-search-input" data-store-search placeholder="ค้นหาชื่อสินค้า/บริการ" aria-label="ค้นหาสินค้า" value="${root.utils.escapeHtml(filterState.search)}">
-        <select class="store-category-select" data-store-category aria-label="หมวดหมู่">
-          <option value="">ทั้งหมด</option>
-          ${categories.map((cat) => `<option value="${root.utils.escapeHtml(cat)}"${filterState.category === cat ? " selected" : ""}>${root.utils.escapeHtml(cat)}</option>`).join("")}
-        </select>
-        <select class="store-actype-select" data-store-actype aria-label="ชนิดแอร์">
-          <option value="">ชนิดแอร์ทั้งหมด</option>
-          ${FILTER_AC_TYPES.map((opt) => `<option value="${opt.value}"${filterState.acType === opt.value ? " selected" : ""}>${root.utils.escapeHtml(opt.label)}</option>`).join("")}
-        </select>
-        <select class="store-wash-select" data-store-wash aria-label="วิธีล้าง">
-          <option value="">วิธีล้างทั้งหมด</option>
-          ${FILTER_WASH_VARIANTS.map((opt) => `<option value="${opt.value}"${filterState.washVariant === opt.value ? " selected" : ""}>${root.utils.escapeHtml(opt.label)}</option>`).join("")}
-        </select>
-        <select class="store-btu-select" data-store-btu aria-label="ขนาด BTU">
-          <option value="">BTU ทั้งหมด</option>
-          ${FILTER_BTU_OPTIONS.map((btu) => `<option value="${btu}"${String(filterState.btu) === String(btu) ? " selected" : ""}>${btu.toLocaleString("th-TH")} BTU</option>`).join("")}
-        </select>
-        <label class="store-queue-today-chip">
-          <input type="checkbox" data-store-queue-today${filterState.queueToday ? " checked" : ""}>
-          <span>มีคิววันนี้</span>
-        </label>
-        <select class="store-sort-select" data-store-sort aria-label="เรียงตาม">
-          ${SORT_OPTIONS.map((opt) => `<option value="${opt.value}"${filterState.sort === opt.value ? " selected" : ""}>${root.utils.escapeHtml(opt.label)}</option>`).join("")}
-        </select>
+        <div class="store-filter-head">
+          <input type="search" class="store-search-input" data-store-search placeholder="ค้นหาชื่อสินค้า/บริการ" aria-label="ค้นหาสินค้า" value="${root.utils.escapeHtml(filterState.search)}">
+          <button type="button" class="store-filter-toggle${filtersOpen ? " is-open" : ""}" data-store-filter-toggle aria-expanded="${filtersOpen ? "true" : "false"}" aria-controls="store-filter-panel">
+            <span class="store-filter-toggle-icon" aria-hidden="true"></span>
+            <span>ตัวกรอง</span>
+            <span class="store-filter-count" data-store-filter-count${activeCount ? "" : " hidden"}>${activeCount}</span>
+            <span class="store-filter-caret" aria-hidden="true"></span>
+          </button>
+        </div>
+        <div class="store-filter-panel" id="store-filter-panel" data-store-filter-panel${filtersOpen ? "" : " hidden"}>
+          <select class="store-category-select" data-store-category aria-label="หมวดหมู่">
+            <option value="">ทั้งหมด</option>
+            ${categories.map((cat) => `<option value="${root.utils.escapeHtml(cat)}"${filterState.category === cat ? " selected" : ""}>${root.utils.escapeHtml(cat)}</option>`).join("")}
+          </select>
+          <select class="store-actype-select" data-store-actype aria-label="ชนิดแอร์">
+            <option value="">ชนิดแอร์ทั้งหมด</option>
+            ${FILTER_AC_TYPES.map((opt) => `<option value="${opt.value}"${filterState.acType === opt.value ? " selected" : ""}>${root.utils.escapeHtml(opt.label)}</option>`).join("")}
+          </select>
+          <select class="store-wash-select" data-store-wash aria-label="วิธีล้าง">
+            <option value="">วิธีล้างทั้งหมด</option>
+            ${FILTER_WASH_VARIANTS.map((opt) => `<option value="${opt.value}"${filterState.washVariant === opt.value ? " selected" : ""}>${root.utils.escapeHtml(opt.label)}</option>`).join("")}
+          </select>
+          <select class="store-btu-select" data-store-btu aria-label="ขนาด BTU">
+            <option value="">BTU ทั้งหมด</option>
+            ${FILTER_BTU_OPTIONS.map((btu) => `<option value="${btu}"${String(filterState.btu) === String(btu) ? " selected" : ""}>${btu.toLocaleString("th-TH")} BTU</option>`).join("")}
+          </select>
+          <label class="store-queue-today-chip">
+            <input type="checkbox" data-store-queue-today${filterState.queueToday ? " checked" : ""}>
+            <span>มีคิววันนี้</span>
+          </label>
+          <select class="store-sort-select" data-store-sort aria-label="เรียงตาม">
+            ${SORT_OPTIONS.map((opt) => `<option value="${opt.value}"${filterState.sort === opt.value ? " selected" : ""}>${root.utils.escapeHtml(opt.label)}</option>`).join("")}
+          </select>
+        </div>
       </div>
       <div data-store-grid-mount>${renderGrid(items)}</div>
     `;
@@ -774,9 +810,20 @@
     if (!mount) return;
     mount.innerHTML = renderGrid(root.state.catalog.items || []);
     bindGridActions(container);
+    refreshFilterCount(container);
   }
 
   function bindBody(container) {
+    const filterToggle = container.querySelector("[data-store-filter-toggle]");
+    const filterPanel = container.querySelector("[data-store-filter-panel]");
+    if (filterToggle && filterPanel) {
+      filterToggle.addEventListener("click", () => {
+        filtersOpen = !filtersOpen;
+        filterPanel.hidden = !filtersOpen;
+        filterToggle.classList.toggle("is-open", filtersOpen);
+        filterToggle.setAttribute("aria-expanded", filtersOpen ? "true" : "false");
+      });
+    }
     const search = container.querySelector("[data-store-search]");
     if (search) {
       search.addEventListener("input", () => {
@@ -1608,6 +1655,7 @@
   const store = {
     render(container) {
       filterState = { search: "", category: "", acType: "", washVariant: "", btu: "", queueToday: false, sort: "recommended" };
+      filtersOpen = false;
       track("cwf_store_view", {});
       container.innerHTML = `
         <section class="screen store-screen">

--- a/customer-app/sw.js
+++ b/customer-app/sw.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const BUILD_ID = "20260701_pageheader_v1";
+const BUILD_ID = "20260701_storefilter_v1";
 const CACHE_NAME = `cwf-customer-app-v2-${BUILD_ID}`;
 const APP_SHELL = [
   `./index.html?v=${BUILD_ID}`,

--- a/test/customerAppRecovery.test.js
+++ b/test/customerAppRecovery.test.js
@@ -236,7 +236,7 @@ test("Customer App build id is consistent across shell and service worker", () =
   const sw = read("customer-app/sw.js");
   const app = read("customer-app/assets/customer-app.js");
   const manifest = read("customer-app/manifest.webmanifest");
-  const build = "20260701_pageheader_v1";
+  const build = "20260701_storefilter_v1";
 
   assert.match(index, new RegExp(`customer-app\\.css\\?v=${build}`));
   assert.match(index, new RegExp(`modules\\/api\\.js\\?v=${build}`));
@@ -254,7 +254,7 @@ test("Customer App build id is consistent across shell and service worker", () =
 test("store module is loaded in index.html and precached in the service worker app shell", () => {
   const index = read("customer-app/index.html");
   const sw = read("customer-app/sw.js");
-  const build = "20260701_pageheader_v1";
+  const build = "20260701_storefilter_v1";
 
   assert.match(index, new RegExp(`modules/store\\.js\\?v=${build}`));
   assert.match(sw, /`\.\/modules\/store\.js\?v=\$\{BUILD_ID\}`/);

--- a/test/customerSameDayTiming.test.js
+++ b/test/customerSameDayTiming.test.js
@@ -160,7 +160,7 @@ test("customer app disables availability HTTP cache and refreshes same-day slots
 });
 
 test("customer app build and service worker cache IDs changed", () => {
-  const id = "20260701_pageheader_v1";
+  const id = "20260701_storefilter_v1";
   for (const file of [
     "customer-app/index.html",
     "customer-app/sw.js",

--- a/test/homepageCms.test.js
+++ b/test/homepageCms.test.js
@@ -278,7 +278,7 @@ test("customer homepage has no admin control, bottom nav is fixed five-tab, and 
   const sw = read("customer-app/sw.js");
   const app = read("customer-app/assets/customer-app.js");
   const manifest = read("customer-app/manifest.webmanifest");
-  const build = "20260701_pageheader_v1";
+  const build = "20260701_storefilter_v1";
 
   assert.doesNotMatch(index + ui, /โหมดแอดมิน|openCms|localStorage\.getItem\('cwfHomeCmsDemo'/);
   assert.match(index, /data-route="store"[\s\S]*ร้านค้า/);


### PR DESCRIPTION
## Summary

The store page (ร้านค้า) stacked **six** filter controls above the product grid — category, AC type (ชนิดแอร์), wash method (วิธีล้าง), BTU, "มีคิววันนี้", and sort. On mobile this pushed the actual products far down the page and read as cluttered ("ตัวกรอง มันดู รก").

This change keeps only the **search box** visible and tucks the six advanced filters into a collapsible panel behind a **"ตัวกรอง"** toggle.

## Changes

- **Collapsed by default** — the store opens showing search + a compact "ตัวกรอง" toggle button, so products appear immediately.
- **Toggle to expand** — tapping "ตัวกรอง" reveals the same six controls in the existing 2-column grid; the button highlights and the caret flips. No filter behavior changed.
- **Active-filter badge** — a count pill on the toggle shows how many advanced filters are active (search is excluded), so customers can tell filters are applied without expanding. Sort counts only when it's not the default "recommended".
- **State resets to collapsed** each time the store route is opened.
- Added a `--ico-filter` icon and bumped the customer-app `BUILD_ID` (`20260701_storefilter_v1`) so the CSS/JS change busts cache.

## Verification

- Full suite green (718 passing, 11 skipped).
- Playwright against the real homepage routes + static bundle at 390px: panel `hidden` on load → visible after toggle (6 controls present) → applying an AC-type filter and collapsing keeps the badge showing "1".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LmdP3TGN5uQrfT8ZYefNco)_