### PR TITLE
feat(home): compact auto-rotating featured services

### DIFF
--- a/customer-app/assets/customer-app.css
+++ b/customer-app/assets/customer-app.css
@@ -4969,11 +4969,12 @@ body.has-contact-sheet { overflow: hidden; }
   content: "";
 }
 
-/* Featured service: ~2 cards visible at 390 px */
+/* Featured service: compact 2-column card (2×2 grid inside each rotator page) */
 .homepage-service-card {
   flex: 0 0 calc((100% - 10px) / 2);
   min-width: calc((100% - 10px) / 2);
   max-width: calc((100% - 10px) / 2);
+  position: relative;
 }
 
 /* Announcement: almost full-width  */
@@ -5083,27 +5084,133 @@ body.has-contact-sheet { overflow: hidden; }
 /* Promo label overrides colour */
 .homepage-promo-text { color: var(--danger) !important; font-size: 10px !important; font-weight: 800; }
 
-/* Booking-mode badge (sits between image and body) */
+/* Booking-mode badge — compact chip overlaid on the top-left of the image */
 .homepage-service-badge {
+  position: absolute;
+  top: 7px;
+  left: 7px;
+  z-index: 2;
   display: inline-flex;
-  align-self: flex-start;
-  margin: 9px 12px 0;
-  padding: 3px 9px;
+  padding: 2px 8px;
   border-radius: 999px;
-  background: linear-gradient(135deg, var(--soft-blue) 0%, var(--soft-blue-2) 100%);
+  background: rgba(255, 255, 255, 0.92);
   color: var(--blue-2);
-  font-size: 9.5px;
+  font-size: 9px;
   font-weight: 900;
+  box-shadow: 0 2px 6px rgba(6, 24, 47, 0.18);
+  backdrop-filter: blur(2px);
 }
-/* Featured card CTA button */
+/* Featured card CTA button — compact "จอง" pill */
 .homepage-service-action {
-  width: calc(100% - 24px) !important;
-  min-height: 40px !important;
-  margin: 0 12px 12px !important;
-  padding: 0 12px !important;
+  width: calc(100% - 20px) !important;
+  min-height: 36px !important;
+  margin: 0 10px 10px !important;
+  padding: 0 10px !important;
   font-size: 12px !important;
   font-weight: 900;
-  border-radius: 12px !important;
+  border-radius: 11px !important;
+}
+/* Compact featured body: just name + price, tighter than editorial cards */
+.homepage-service-card .homepage-card-body {
+  gap: 3px;
+  padding: 8px 10px 6px;
+}
+.homepage-service-card .homepage-card-body strong {
+  font-size: 12px;
+  -webkit-line-clamp: 2;
+}
+.homepage-service-card .homepage-card-body > span {
+  font-size: 12.5px;
+}
+
+/* ─── Featured services rotator (pages of 4 auto-cross-fade) ─────────── */
+.homepage-featured-rotator {
+  position: relative;
+}
+/* Pages are stacked in a single grid cell so they overlap for the cross-fade;
+   the cell sizes to the tallest page and the section never jumps height. */
+.homepage-featured-pages {
+  display: grid;
+}
+.homepage-featured-page {
+  grid-area: 1 / 1;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  align-content: start;
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+  transition: opacity 0.5s ease, visibility 0.5s ease;
+}
+.homepage-featured-page.is-active {
+  opacity: 1;
+  visibility: visible;
+  pointer-events: auto;
+}
+/* Eye-catching entrance: each active card rises + fades in, lightly staggered,
+   then a soft light sweep crosses it. Re-runs on every page change. */
+.homepage-featured-page.is-active .homepage-service-card:nth-child(-n+4) {
+  animation: featuredCardIn 0.5s cubic-bezier(0.22, 0.61, 0.36, 1) both;
+}
+.homepage-featured-page.is-active .homepage-service-card:nth-child(2) { animation-delay: 0.07s; }
+.homepage-featured-page.is-active .homepage-service-card:nth-child(3) { animation-delay: 0.14s; }
+.homepage-featured-page.is-active .homepage-service-card:nth-child(4) { animation-delay: 0.21s; }
+@keyframes featuredCardIn {
+  from { opacity: 0; transform: translateY(14px) scale(0.95); }
+  to   { opacity: 1; transform: none; }
+}
+/* Diagonal shine sweep — clipped to the card's rounded box (overflow:hidden). */
+.homepage-service-card::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  z-index: 3;
+  border-radius: inherit;
+  background: linear-gradient(115deg, transparent 32%, rgba(255, 255, 255, 0.55) 48%, transparent 64%);
+  transform: translateX(-130%);
+  opacity: 0;
+  pointer-events: none;
+}
+.homepage-featured-page.is-active .homepage-service-card::after {
+  animation: featuredShine 0.9s ease 0.18s both;
+}
+.homepage-featured-page.is-active .homepage-service-card:nth-child(2)::after { animation-delay: 0.25s; }
+.homepage-featured-page.is-active .homepage-service-card:nth-child(3)::after { animation-delay: 0.32s; }
+.homepage-featured-page.is-active .homepage-service-card:nth-child(4)::after { animation-delay: 0.39s; }
+@keyframes featuredShine {
+  0%   { transform: translateX(-130%); opacity: 0; }
+  22%  { opacity: 1; }
+  100% { transform: translateX(130%); opacity: 0; }
+}
+/* Progress dots — active dot stretches into a gold→blue pill */
+.homepage-featured-dots {
+  display: flex;
+  justify-content: center;
+  gap: 6px;
+  margin-top: 12px;
+}
+.homepage-featured-dots button {
+  width: 7px;
+  height: 7px;
+  padding: 0;
+  border: 0;
+  border-radius: 999px;
+  background: var(--line);
+  cursor: pointer;
+  transition: width 0.28s ease, background 0.28s ease;
+}
+.homepage-featured-dots button.is-active {
+  width: 20px;
+  background: linear-gradient(90deg, var(--yellow), var(--blue));
+}
+@media (prefers-reduced-motion: reduce) {
+  .homepage-featured-page { transition: opacity 0.2s ease; }
+  .homepage-featured-page.is-active .homepage-service-card,
+  .homepage-featured-page.is-active .homepage-service-card::after {
+    animation: none;
+  }
+  .homepage-service-card::after { display: none; }
 }
 
 /* ─── Distinct per-type card treatments ─────────────────────────────── */

--- a/customer-app/assets/customer-app.js
+++ b/customer-app/assets/customer-app.js
@@ -3,7 +3,7 @@
 
   const App = window.CWFCustomerAppV2;
   const BOOT_TIMEOUT_MS = 3500;
-  const BUILD_ID = "20260701_storefilter_v1";
+  const BUILD_ID = "20260701_featured_v1";
 
   function withTimeout(promise, timeoutMs) {
     return Promise.race([

--- a/customer-app/index.html
+++ b/customer-app/index.html
@@ -17,10 +17,10 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Noto+Sans+Thai:wght@400;500;600;700;800;900&display=swap" media="print" onload="this.media='all'">
   <noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Noto+Sans+Thai:wght@400;500;600;700;800;900&display=swap"></noscript>
-  <link rel="manifest" href="./manifest.webmanifest?v=20260701_storefilter_v1">
+  <link rel="manifest" href="./manifest.webmanifest?v=20260701_featured_v1">
   <link rel="icon" type="image/png" sizes="192x192" href="./assets/icons/cwf-customer-192.png">
   <link rel="apple-touch-icon" sizes="180x180" href="./assets/icons/cwf-customer-180.png">
-  <link rel="stylesheet" href="./assets/customer-app.css?v=20260701_storefilter_v1">
+  <link rel="stylesheet" href="./assets/customer-app.css?v=20260701_featured_v1">
 </head>
 <body class="is-app-booting">
   <div class="app-shell" data-app-shell>
@@ -58,21 +58,21 @@
     </nav>
   </div>
 
-  <script src="./modules/state.js?v=20260701_storefilter_v1"></script>
-  <script src="./modules/utils.js?v=20260701_storefilter_v1"></script>
-  <script src="./modules/analytics.js?v=20260701_storefilter_v1"></script>
-  <script src="./modules/api.js?v=20260701_storefilter_v1"></script>
-  <script src="./modules/services.js?v=20260701_storefilter_v1"></script>
-  <script src="./modules/ui.js?v=20260701_storefilter_v1"></script>
-  <script src="./modules/store.js?v=20260701_storefilter_v1"></script>
-  <script src="./modules/auth.js?v=20260701_storefilter_v1"></script>
-  <script src="./modules/pricing.js?v=20260701_storefilter_v1"></script>
-  <script src="./modules/availability.js?v=20260701_storefilter_v1"></script>
-  <script src="./modules/bookingScheduled.js?v=20260701_storefilter_v1"></script>
-  <script src="./modules/bookingUrgent.js?v=20260701_storefilter_v1"></script>
-  <script src="./modules/tracking.js?v=20260701_storefilter_v1"></script>
-  <script src="./modules/profile.js?v=20260701_storefilter_v1"></script>
-  <script src="./modules/router.js?v=20260701_storefilter_v1"></script>
-  <script src="./assets/customer-app.js?v=20260701_storefilter_v1"></script>
+  <script src="./modules/state.js?v=20260701_featured_v1"></script>
+  <script src="./modules/utils.js?v=20260701_featured_v1"></script>
+  <script src="./modules/analytics.js?v=20260701_featured_v1"></script>
+  <script src="./modules/api.js?v=20260701_featured_v1"></script>
+  <script src="./modules/services.js?v=20260701_featured_v1"></script>
+  <script src="./modules/ui.js?v=20260701_featured_v1"></script>
+  <script src="./modules/store.js?v=20260701_featured_v1"></script>
+  <script src="./modules/auth.js?v=20260701_featured_v1"></script>
+  <script src="./modules/pricing.js?v=20260701_featured_v1"></script>
+  <script src="./modules/availability.js?v=20260701_featured_v1"></script>
+  <script src="./modules/bookingScheduled.js?v=20260701_featured_v1"></script>
+  <script src="./modules/bookingUrgent.js?v=20260701_featured_v1"></script>
+  <script src="./modules/tracking.js?v=20260701_featured_v1"></script>
+  <script src="./modules/profile.js?v=20260701_featured_v1"></script>
+  <script src="./modules/router.js?v=20260701_featured_v1"></script>
+  <script src="./assets/customer-app.js?v=20260701_featured_v1"></script>
 </body>
 </html>

--- a/customer-app/manifest.webmanifest
+++ b/customer-app/manifest.webmanifest
@@ -2,7 +2,7 @@
   "name": "CWF Customer Service",
   "short_name": "CWF Service",
   "description": "แอปลูกค้า Coldwindflow สำหรับเลือกบริการ จองคิว และติดตามงาน",
-  "start_url": "/customer-app/index.html?v=20260701_storefilter_v1#home",
+  "start_url": "/customer-app/index.html?v=20260701_featured_v1#home",
   "scope": "/customer-app/",
   "id": "/customer-app/",
   "display": "standalone",

--- a/customer-app/modules/ui.js
+++ b/customer-app/modules/ui.js
@@ -237,6 +237,42 @@
     return rows.filter((item) => item && item.is_featured).slice(0, limit);
   }
 
+  // One compact featured card: image, name, price, book button — nothing else.
+  // The old card also carried a two-line description and a promo line, which
+  // made the homepage section very tall; customers asked for just the essentials
+  // shown as small cards.
+  function renderFeaturedMiniCard(item, showPrice, showBadge) {
+    const id = root.utils.escapeHtml(item.item_id);
+    const imageUrl = firstCatalogImage(item);
+    const bookable = item.booking_mode === "bookable";
+    const price = catalogDisplayPrice(item);
+    return `
+      <article class="homepage-service-card">
+        <button type="button" class="homepage-card-link" data-home-featured-detail="${id}">
+          <div class="homepage-card-image">
+            ${imageUrl
+              ? `<img src="${root.utils.escapeHtml(imageUrl)}" alt="${root.utils.escapeHtml(item.item_name || "บริการ CWF")}" loading="lazy">`
+              : root.utils.icon("sparkle", 28)}
+            ${showBadge ? `<span class="homepage-service-badge">${bookable ? "จองได้" : "สอบถาม"}</span>` : ""}
+          </div>
+          <div class="homepage-card-body">
+            <strong>${root.utils.escapeHtml(item.item_name || "-")}</strong>
+            ${showPrice ? `<span>${root.utils.escapeHtml(price)}${item.unit_label && price !== "สอบถามราคา" ? ` / ${root.utils.escapeHtml(item.unit_label)}` : ""}</span>` : ""}
+          </div>
+        </button>
+        <button type="button" class="${bookable ? "primary-btn" : "secondary-btn"} homepage-service-action" data-home-featured-action="${id}">
+          ${bookable ? "จอง" : "สอบถาม"}
+        </button>
+      </article>
+    `;
+  }
+
+  // Featured services render as a compact 2×2 grid of four small cards. When
+  // more than four featured items exist they are split into "pages" of four
+  // that auto-rotate (cross-fade + staggered rise-in), so customers can read
+  // one set before the next slides in — see bindHomepageFeaturedRotator.
+  const FEATURED_PAGE_SIZE = 4;
+
   function renderHomepageFeaturedServices(section) {
     const catalog = root.state.catalog || { status: "idle", items: [] };
     if (catalog.status === "loading" || catalog.status === "idle") {
@@ -248,34 +284,21 @@
     const showBadge = cfg.show_badge !== false;
     const items = featuredCatalogItems(cfg);
     if (!items.length) return root.utils.stateBox("", "ยังไม่มีบริการแนะนำที่เปิดแสดง");
+    const pages = [];
+    for (let i = 0; i < items.length; i += FEATURED_PAGE_SIZE) {
+      pages.push(items.slice(i, i + FEATURED_PAGE_SIZE));
+    }
+    const multi = pages.length > 1;
     return `
-      <div class="homepage-carousel homepage-featured-services">
-        ${items.map((item) => {
-          const id = root.utils.escapeHtml(item.item_id);
-          const imageUrl = firstCatalogImage(item);
-          const promo = item.has_active_promotion || item.has_promo;
-          return `
-            <article class="homepage-service-card">
-              <button type="button" class="homepage-card-link" data-home-featured-detail="${id}">
-                <div class="homepage-card-image">
-                  ${imageUrl
-                    ? `<img src="${root.utils.escapeHtml(imageUrl)}" alt="${root.utils.escapeHtml(item.item_name || "บริการ CWF")}" loading="lazy">`
-                    : root.utils.icon("sparkle", 28)}
-                </div>
-                ${showBadge ? `<span class="homepage-service-badge">${root.utils.escapeHtml(item.booking_mode === "bookable" ? "จองได้" : "สอบถามแอดมิน")}</span>` : ""}
-                <div class="homepage-card-body">
-                  <strong>${root.utils.escapeHtml(item.item_name || "-")}</strong>
-                  <small>${root.utils.escapeHtml(item.short_description || item.item_category || "")}</small>
-                  ${showPrice ? `<span>${root.utils.escapeHtml(catalogDisplayPrice(item))}${item.unit_label && catalogDisplayPrice(item) !== "สอบถามราคา" ? ` / ${root.utils.escapeHtml(item.unit_label)}` : ""}</span>` : ""}
-                  ${promo ? `<small class="homepage-promo-text">${root.utils.escapeHtml(item.campaign_name || item.price_label || "มีโปรโมชัน")}</small>` : ""}
-                </div>
-              </button>
-              <button type="button" class="${item.booking_mode === "bookable" ? "primary-btn" : "secondary-btn"} homepage-service-action" data-home-featured-action="${id}">
-                ${item.booking_mode === "bookable" ? "จองคิว" : "สอบถามแอดมิน"}
-              </button>
-            </article>
-          `;
-        }).join("")}
+      <div class="homepage-featured-rotator" data-featured-rotator>
+        <div class="homepage-featured-pages">
+          ${pages.map((pageItems, p) => `
+            <div class="homepage-featured-page${p === 0 ? " is-active" : ""}" data-featured-page aria-hidden="${p === 0 ? "false" : "true"}">
+              ${pageItems.map((item) => renderFeaturedMiniCard(item, showPrice, showBadge)).join("")}
+            </div>
+          `).join("")}
+        </div>
+        ${multi ? `<div class="homepage-featured-dots" role="tablist" aria-label="ชุดบริการแนะนำ">${pages.map((_, p) => `<button type="button" class="${p === 0 ? "is-active" : ""}" data-featured-dot="${p}" aria-label="ชุดบริการที่ ${p + 1}" aria-selected="${p === 0 ? "true" : "false"}"></button>`).join("")}</div>` : ""}
       </div>
     `;
   }
@@ -882,6 +905,49 @@
     });
     bindHomepageSocialCards(container);
     bindHomepageFbTimelines(container);
+    bindHomepageFeaturedRotator(container);
+  }
+
+  // Auto-rotate the pages of four featured cards. All pages stay in the DOM
+  // (so their book/detail buttons keep the handlers bound above) — only the
+  // active page is opaque and interactive; the rest fade out and turn off
+  // pointer events. Advances on a slow, readable interval, pauses while the
+  // customer is touching the section, and lets the dots jump directly.
+  function bindHomepageFeaturedRotator(container) {
+    container.querySelectorAll("[data-featured-rotator]").forEach((rotator) => {
+      if (rotator.dataset.bound === "1") return;
+      rotator.dataset.bound = "1";
+      const pages = Array.from(rotator.querySelectorAll("[data-featured-page]"));
+      const dots = Array.from(rotator.querySelectorAll("[data-featured-dot]"));
+      if (pages.length <= 1) return;
+      let index = 0;
+      let timer = 0;
+      let paused = false;
+      const setActive = (next) => {
+        index = (next % pages.length + pages.length) % pages.length;
+        pages.forEach((page, i) => {
+          const active = i === index;
+          page.classList.toggle("is-active", active);
+          page.setAttribute("aria-hidden", active ? "false" : "true");
+        });
+        dots.forEach((dot, i) => {
+          const active = i === index;
+          dot.classList.toggle("is-active", active);
+          dot.setAttribute("aria-selected", active ? "true" : "false");
+        });
+      };
+      const stop = () => { if (timer) { clearInterval(timer); timer = 0; } };
+      const start = () => { stop(); timer = setInterval(() => { if (!paused) setActive(index + 1); }, 4200); };
+      dots.forEach((dot, i) => {
+        dot.addEventListener("click", () => { setActive(i); start(); });
+      });
+      ["touchstart", "pointerdown"].forEach((ev) =>
+        rotator.addEventListener(ev, () => { paused = true; }, { passive: true }));
+      ["touchend", "pointerup", "mouseleave"].forEach((ev) =>
+        rotator.addEventListener(ev, () => { paused = false; }, { passive: true }));
+      setActive(0);
+      start();
+    });
   }
 
   // Size each Facebook Page Plugin to its real container width so its cover,

--- a/customer-app/sw.js
+++ b/customer-app/sw.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const BUILD_ID = "20260701_storefilter_v1";
+const BUILD_ID = "20260701_featured_v1";
 const CACHE_NAME = `cwf-customer-app-v2-${BUILD_ID}`;
 const APP_SHELL = [
   `./index.html?v=${BUILD_ID}`,

--- a/test/customerAppRecovery.test.js
+++ b/test/customerAppRecovery.test.js
@@ -236,7 +236,7 @@ test("Customer App build id is consistent across shell and service worker", () =
   const sw = read("customer-app/sw.js");
   const app = read("customer-app/assets/customer-app.js");
   const manifest = read("customer-app/manifest.webmanifest");
-  const build = "20260701_storefilter_v1";
+  const build = "20260701_featured_v1";
 
   assert.match(index, new RegExp(`customer-app\\.css\\?v=${build}`));
   assert.match(index, new RegExp(`modules\\/api\\.js\\?v=${build}`));
@@ -254,7 +254,7 @@ test("Customer App build id is consistent across shell and service worker", () =
 test("store module is loaded in index.html and precached in the service worker app shell", () => {
   const index = read("customer-app/index.html");
   const sw = read("customer-app/sw.js");
-  const build = "20260701_storefilter_v1";
+  const build = "20260701_featured_v1";
 
   assert.match(index, new RegExp(`modules/store\\.js\\?v=${build}`));
   assert.match(sw, /`\.\/modules\/store\.js\?v=\$\{BUILD_ID\}`/);

--- a/test/customerSameDayTiming.test.js
+++ b/test/customerSameDayTiming.test.js
@@ -160,7 +160,7 @@ test("customer app disables availability HTTP cache and refreshes same-day slots
 });
 
 test("customer app build and service worker cache IDs changed", () => {
-  const id = "20260701_storefilter_v1";
+  const id = "20260701_featured_v1";
   for (const file of [
     "customer-app/index.html",
     "customer-app/sw.js",

--- a/test/homepageCms.test.js
+++ b/test/homepageCms.test.js
@@ -278,7 +278,7 @@ test("customer homepage has no admin control, bottom nav is fixed five-tab, and 
   const sw = read("customer-app/sw.js");
   const app = read("customer-app/assets/customer-app.js");
   const manifest = read("customer-app/manifest.webmanifest");
-  const build = "20260701_storefilter_v1";
+  const build = "20260701_featured_v1";
 
   assert.doesNotMatch(index + ui, /โหมดแอดมิน|openCms|localStorage\.getItem\('cwfHomeCmsDemo'/);
   assert.match(index, /data-route="store"[\s\S]*ร้านค้า/);


### PR DESCRIPTION
## Summary

The homepage **"บริการแนะนำ"** (featured services) section was too long. Each card carried a full image, a two-line description, a promo line, and a large "จองคิว" button, so only two tall cards fit above the fold and everything below got pushed down.

Redesigned it into a **compact 2×2 grid of four small cards** showing only the essentials the customer asked for — **image, name, price, and a "จอง" button** — that **auto-rotates** through the rest of the featured items.

## Changes

- **Compact card** — dropped the description and promo lines; each card is now image + name + price + book button. The booking-mode badge (จองได้ / สอบถาม) moved to a small chip overlaid on the image.
- **Four at a time** — items render four per "page" in a 2×2 grid.
- **Auto-rotate** — when there are more than four featured items, the pages cross-fade automatically on a slow, readable ~4.2s interval so customers can finish reading one set before the next appears. Rotation **pauses while the section is being touched**, and **page dots** (gold→blue pill) let customers jump directly.
- **Eye-catching effects** — active cards rise + fade in with a light stagger, followed by a soft diagonal shine sweep. All motion is disabled under `prefers-reduced-motion`.
- Every card stays in the DOM (only the active page is opaque/interactive), so the existing detail + booking handlers stay bound. Bumped the customer-app `BUILD_ID` (`20260701_featured_v1`).

## Verification

- Full suite green (718 passing, 11 skipped); updated the CSS geometry-contract selector so it still resolves to the featured card block.
- Playwright against the real homepage routes + static bundle at 390px with 6 featured items: renders 2 pages × (4 + 2) cards with dots, auto-advances 0→1→0 on the interval, and each card shows image/name/price/CTA with **no description line**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LmdP3TGN5uQrfT8ZYefNco)_