### PR TITLE
feat(home): default featured services to 4 cards

### DIFF
--- a/admin-homepage-cms.html
+++ b/admin-homepage-cms.html
@@ -327,6 +327,6 @@
   </div>
 
   <select id="sectionPicker" style="display:none"></select>
-  <script src="/admin-homepage-cms.js?v=20260701_fix7"></script>
+  <script src="/admin-homepage-cms.js?v=20260701_featured4_v1"></script>
 </body>
 </html>

--- a/admin-homepage-cms.js
+++ b/admin-homepage-cms.js
@@ -9,7 +9,7 @@
       { id: "promo_banner", type: "promo_banner", enabled: true, sort_order: 25, title: "", body: "", items: [] },
       { id: "active_job", type: "active_job", enabled: true, sort_order: 30, title: "Active job", body: "", items: [] },
       { id: "announcements", type: "announcements", enabled: true, sort_order: 40, title: "ข่าวและประกาศ CWF", body: "", items: [{ title: "ติดต่อทีม CWF", action: "contact", body: "สอบถามบริการหรือแจ้งข้อมูลเพิ่มเติมกับแอดมิน" }] },
-      { id: "featured_services", type: "featured_services", enabled: true, sort_order: 50, title: "บริการแนะนำ", body: "ราคาและรายละเอียดจาก Catalog", featured_mode: "auto", featured_limit: 8, show_price: true, show_badge: true, item_ids: [], items: [] },
+      { id: "featured_services", type: "featured_services", enabled: true, sort_order: 50, title: "บริการแนะนำ", body: "ราคาและรายละเอียดจาก Catalog", featured_mode: "auto", featured_limit: 4, show_price: true, show_badge: true, item_ids: [], items: [] },
       { id: "updates", type: "updates", enabled: true, sort_order: 60, title: "ภาพกิจกรรมและโพสต์", body: "", items: [] },
       { id: "articles", type: "articles", enabled: true, sort_order: 70, title: "บทความแนะนำ", body: "", items: [] },
       { id: "social", type: "social", enabled: true, sort_order: 75, title: "ติดตามเราบนโซเชียล", body: "อัปเดตล่าสุดจาก Facebook และ YouTube ของ Coldwindflow", items: [] },
@@ -543,7 +543,7 @@
     }
     return `
       <label class="field">แหล่งข้อมูล<select class="fi" data-featured-mode><option value="auto" ${mode === "auto" ? "selected" : ""}>ดึงจาก Catalog อัตโนมัติ (is_featured)</option><option value="manual" ${mode === "manual" ? "selected" : ""}>เลือกรายการเอง</option></select></label>
-      <label class="field">จำนวนสูงสุด<input class="fi" type="number" min="1" max="12" data-featured-limit value="${esc(section.featured_limit || 8)}"></label>
+      <label class="field">จำนวนสูงสุด<input class="fi" type="number" min="1" max="12" data-featured-limit value="${esc(section.featured_limit || 4)}"></label>
       <div style="display:flex;gap:14px;flex-wrap:wrap">
         <label class="switch"><input type="checkbox" data-featured-bool="show_price" ${section.show_price !== false ? "checked" : ""}> แสดงราคา</label>
         <label class="switch"><input type="checkbox" data-featured-bool="show_badge" ${section.show_badge !== false ? "checked" : ""}> แสดง Badge</label>
@@ -690,7 +690,7 @@
       if (target.dataset.prop === "url") { delete item[ctaName].route; delete item[ctaName].action; }
     }
     if (target.matches("[data-item]")) section.items[Number(target.dataset.item)][target.dataset.prop] = target.value;
-    if (target.matches("[data-featured-limit]")) section.featured_limit = Math.max(1, Math.min(12, Number(target.value) || 8));
+    if (target.matches("[data-featured-limit]")) section.featured_limit = Math.max(1, Math.min(12, Number(target.value) || 4));
     if (target.matches("[data-seed-urls]")) section.seed_urls = target.value.split("\n").map((l) => l.trim()).filter(Boolean).slice(0, 8);
     renderPreview();
   });

--- a/customer-app/assets/customer-app.js
+++ b/customer-app/assets/customer-app.js
@@ -3,7 +3,7 @@
 
   const App = window.CWFCustomerAppV2;
   const BOOT_TIMEOUT_MS = 3500;
-  const BUILD_ID = "20260701_featured_v1";
+  const BUILD_ID = "20260701_featured4_v1";
 
   function withTimeout(promise, timeoutMs) {
     return Promise.race([

--- a/customer-app/index.html
+++ b/customer-app/index.html
@@ -17,10 +17,10 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Noto+Sans+Thai:wght@400;500;600;700;800;900&display=swap" media="print" onload="this.media='all'">
   <noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Noto+Sans+Thai:wght@400;500;600;700;800;900&display=swap"></noscript>
-  <link rel="manifest" href="./manifest.webmanifest?v=20260701_featured_v1">
+  <link rel="manifest" href="./manifest.webmanifest?v=20260701_featured4_v1">
   <link rel="icon" type="image/png" sizes="192x192" href="./assets/icons/cwf-customer-192.png">
   <link rel="apple-touch-icon" sizes="180x180" href="./assets/icons/cwf-customer-180.png">
-  <link rel="stylesheet" href="./assets/customer-app.css?v=20260701_featured_v1">
+  <link rel="stylesheet" href="./assets/customer-app.css?v=20260701_featured4_v1">
 </head>
 <body class="is-app-booting">
   <div class="app-shell" data-app-shell>
@@ -58,21 +58,21 @@
     </nav>
   </div>
 
-  <script src="./modules/state.js?v=20260701_featured_v1"></script>
-  <script src="./modules/utils.js?v=20260701_featured_v1"></script>
-  <script src="./modules/analytics.js?v=20260701_featured_v1"></script>
-  <script src="./modules/api.js?v=20260701_featured_v1"></script>
-  <script src="./modules/services.js?v=20260701_featured_v1"></script>
-  <script src="./modules/ui.js?v=20260701_featured_v1"></script>
-  <script src="./modules/store.js?v=20260701_featured_v1"></script>
-  <script src="./modules/auth.js?v=20260701_featured_v1"></script>
-  <script src="./modules/pricing.js?v=20260701_featured_v1"></script>
-  <script src="./modules/availability.js?v=20260701_featured_v1"></script>
-  <script src="./modules/bookingScheduled.js?v=20260701_featured_v1"></script>
-  <script src="./modules/bookingUrgent.js?v=20260701_featured_v1"></script>
-  <script src="./modules/tracking.js?v=20260701_featured_v1"></script>
-  <script src="./modules/profile.js?v=20260701_featured_v1"></script>
-  <script src="./modules/router.js?v=20260701_featured_v1"></script>
-  <script src="./assets/customer-app.js?v=20260701_featured_v1"></script>
+  <script src="./modules/state.js?v=20260701_featured4_v1"></script>
+  <script src="./modules/utils.js?v=20260701_featured4_v1"></script>
+  <script src="./modules/analytics.js?v=20260701_featured4_v1"></script>
+  <script src="./modules/api.js?v=20260701_featured4_v1"></script>
+  <script src="./modules/services.js?v=20260701_featured4_v1"></script>
+  <script src="./modules/ui.js?v=20260701_featured4_v1"></script>
+  <script src="./modules/store.js?v=20260701_featured4_v1"></script>
+  <script src="./modules/auth.js?v=20260701_featured4_v1"></script>
+  <script src="./modules/pricing.js?v=20260701_featured4_v1"></script>
+  <script src="./modules/availability.js?v=20260701_featured4_v1"></script>
+  <script src="./modules/bookingScheduled.js?v=20260701_featured4_v1"></script>
+  <script src="./modules/bookingUrgent.js?v=20260701_featured4_v1"></script>
+  <script src="./modules/tracking.js?v=20260701_featured4_v1"></script>
+  <script src="./modules/profile.js?v=20260701_featured4_v1"></script>
+  <script src="./modules/router.js?v=20260701_featured4_v1"></script>
+  <script src="./assets/customer-app.js?v=20260701_featured4_v1"></script>
 </body>
 </html>

--- a/customer-app/manifest.webmanifest
+++ b/customer-app/manifest.webmanifest
@@ -2,7 +2,7 @@
   "name": "CWF Customer Service",
   "short_name": "CWF Service",
   "description": "แอปลูกค้า Coldwindflow สำหรับเลือกบริการ จองคิว และติดตามงาน",
-  "start_url": "/customer-app/index.html?v=20260701_featured_v1#home",
+  "start_url": "/customer-app/index.html?v=20260701_featured4_v1#home",
   "scope": "/customer-app/",
   "id": "/customer-app/",
   "display": "standalone",

--- a/customer-app/modules/ui.js
+++ b/customer-app/modules/ui.js
@@ -122,7 +122,7 @@
         title: "บริการแนะนำ",
         body: "ราคาและรายละเอียดดึงจาก Catalog",
         featured_mode: "auto",
-        featured_limit: 8,
+        featured_limit: 4,
         show_price: true,
         show_badge: true,
         item_ids: [],
@@ -229,7 +229,7 @@
     const rows = root.state.catalog?.items || [];
     const cfg = section || {};
     const limitRaw = Number(cfg.featured_limit);
-    const limit = Number.isFinite(limitRaw) ? Math.max(1, Math.min(12, Math.round(limitRaw))) : 8;
+    const limit = Number.isFinite(limitRaw) ? Math.max(1, Math.min(12, Math.round(limitRaw))) : 4;
     if (cfg.featured_mode === "manual" && Array.isArray(cfg.item_ids) && cfg.item_ids.length) {
       const byId = new Map(rows.map((item) => [String(item.item_id), item]));
       return cfg.item_ids.map((id) => byId.get(String(id))).filter(Boolean).slice(0, limit);

--- a/customer-app/sw.js
+++ b/customer-app/sw.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const BUILD_ID = "20260701_featured_v1";
+const BUILD_ID = "20260701_featured4_v1";
 const CACHE_NAME = `cwf-customer-app-v2-${BUILD_ID}`;
 const APP_SHELL = [
   `./index.html?v=${BUILD_ID}`,

--- a/server/routes/homepage.js
+++ b/server/routes/homepage.js
@@ -105,7 +105,7 @@ const DEFAULT_CONFIG = {
       title: "บริการแนะนำ",
       body: "ราคาและรายละเอียดดึงจาก Catalog",
       featured_mode: "auto",
-      featured_limit: 8,
+      featured_limit: 4,
       show_price: true,
       show_badge: true,
       item_ids: [],
@@ -310,7 +310,7 @@ function normalizeSection(raw, index, errors) {
     const mode = cleanText(section.featured_mode, 10) === "manual" ? "manual" : "auto";
     const limit = Number(section.featured_limit);
     out.featured_mode = mode;
-    out.featured_limit = Number.isFinite(limit) ? Math.max(1, Math.min(12, Math.round(limit))) : 8;
+    out.featured_limit = Number.isFinite(limit) ? Math.max(1, Math.min(12, Math.round(limit))) : 4;
     out.show_price = section.show_price !== false;
     out.show_badge = section.show_badge !== false;
     const itemIds = Array.isArray(section.item_ids) ? section.item_ids : [];

--- a/test/customerAppRecovery.test.js
+++ b/test/customerAppRecovery.test.js
@@ -236,7 +236,7 @@ test("Customer App build id is consistent across shell and service worker", () =
   const sw = read("customer-app/sw.js");
   const app = read("customer-app/assets/customer-app.js");
   const manifest = read("customer-app/manifest.webmanifest");
-  const build = "20260701_featured_v1";
+  const build = "20260701_featured4_v1";
 
   assert.match(index, new RegExp(`customer-app\\.css\\?v=${build}`));
   assert.match(index, new RegExp(`modules\\/api\\.js\\?v=${build}`));
@@ -254,7 +254,7 @@ test("Customer App build id is consistent across shell and service worker", () =
 test("store module is loaded in index.html and precached in the service worker app shell", () => {
   const index = read("customer-app/index.html");
   const sw = read("customer-app/sw.js");
-  const build = "20260701_featured_v1";
+  const build = "20260701_featured4_v1";
 
   assert.match(index, new RegExp(`modules/store\\.js\\?v=${build}`));
   assert.match(sw, /`\.\/modules\/store\.js\?v=\$\{BUILD_ID\}`/);

--- a/test/customerSameDayTiming.test.js
+++ b/test/customerSameDayTiming.test.js
@@ -160,7 +160,7 @@ test("customer app disables availability HTTP cache and refreshes same-day slots
 });
 
 test("customer app build and service worker cache IDs changed", () => {
-  const id = "20260701_featured_v1";
+  const id = "20260701_featured4_v1";
   for (const file of [
     "customer-app/index.html",
     "customer-app/sw.js",

--- a/test/homepageCms.test.js
+++ b/test/homepageCms.test.js
@@ -157,7 +157,7 @@ test("featured_services normalizes auto-mode defaults and validates manual selec
   assert.equal(auto.ok, true);
   const fs1 = auto.config.sections[0];
   assert.equal(fs1.featured_mode, "auto");
-  assert.equal(fs1.featured_limit, 8);
+  assert.equal(fs1.featured_limit, 4);
   assert.equal(fs1.show_price, true);
   assert.equal(fs1.show_badge, true);
   assert.deepEqual(fs1.item_ids, []);
@@ -195,7 +195,7 @@ test("legacy published config without featured_services fields gets safe default
   assert.equal(section.title, "บริการเก่าของแอดมิน");
   assert.equal(section.body, "คำอธิบายเดิม");
   assert.equal(section.featured_mode, "auto");
-  assert.equal(section.featured_limit, 8);
+  assert.equal(section.featured_limit, 4);
   assert.equal(section.show_price, true);
   assert.equal(section.show_badge, true);
 });
@@ -278,7 +278,7 @@ test("customer homepage has no admin control, bottom nav is fixed five-tab, and 
   const sw = read("customer-app/sw.js");
   const app = read("customer-app/assets/customer-app.js");
   const manifest = read("customer-app/manifest.webmanifest");
-  const build = "20260701_featured_v1";
+  const build = "20260701_featured4_v1";
 
   assert.doesNotMatch(index + ui, /โหมดแอดมิน|openCms|localStorage\.getItem\('cwfHomeCmsDemo'/);
   assert.match(index, /data-route="store"[\s\S]*ร้านค้า/);


### PR DESCRIPTION
## Summary

Follow-up to the compact featured-services redesign — the **"บริการแนะนำ"** section now recommends **4 cards** by default instead of 8.

With four featured items it renders a single clean 2×2 set (no rotation). Admins who want to page through more can still raise the **"จำนวนสูงสุด"** (max count) field in the CMS, and the auto-rotating pages return.

## Changes

Lowered the `featured_limit` default from **8 → 4** everywhere it is seeded or normalized, so the value is consistent across the stack:

- `server/routes/homepage.js` — default config + `validateConfig` normalize fallback
- `customer-app/modules/ui.js` — `DEFAULT_HOME_CONFIG` and the `featuredCatalogItems` render fallback
- `admin-homepage-cms.js` — default section, editor input default, and change-handler fallback

Updated the two `homepageCms` tests that assert the normalized default, and bumped the customer `BUILD_ID` + admin CMS cache-bust.

## Note on existing configs

`validateConfig` only applies the default when `featured_limit` is absent; a config that already stored an explicit `8` keeps it. If the live homepage still shows more than four, lower **"จำนวนสูงสุด"** to `4` in the CMS and re-publish (the field now defaults to 4).

## Verification

- Full suite green (718 passing, 11 skipped).
- Playwright against the real homepage routes + static bundle at 390px with 6 featured catalog items: renders **1 page, 4 cards, no rotation dots** — image / name / price / จอง on each.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LmdP3TGN5uQrfT8ZYefNco)_