### PR TITLE
feat(cms): schedule whole homepage sections with a date window

### DIFF
--- a/admin-homepage-cms.html
+++ b/admin-homepage-cms.html
@@ -327,6 +327,6 @@
   </div>
 
   <select id="sectionPicker" style="display:none"></select>
-  <script src="/admin-homepage-cms.js?v=20260701_featured4_v1"></script>
+  <script src="/admin-homepage-cms.js?v=20260702_section_sched_v1"></script>
 </body>
 </html>

--- a/admin-homepage-cms.js
+++ b/admin-homepage-cms.js
@@ -438,6 +438,11 @@
           ${field("ชื่อ Section", "title")}
           ${field("คำอธิบาย", "body", "textarea")}
           ${hasViewAll ? `<div class="two">${field("ข้อความปุ่ม ดูทั้งหมด", "view_all_label")}${selectField("Route ปุ่ม ดูทั้งหมด", "view_all_route", [["", "ไม่แสดงปุ่ม"], ...ROUTE_OPTIONS.map((r) => [r, r])])}</div>` : ""}
+          <div class="two">
+            <label class="field">แสดงตั้งแต่วันที่ (ไม่บังคับ)<input class="fi" data-field="active_from" value="${esc(section.active_from || "")}" placeholder="YYYY-MM-DD"></label>
+            <label class="field">แสดงถึงวันที่ (ไม่บังคับ)<input class="fi" data-field="active_to" value="${esc(section.active_to || "")}" placeholder="YYYY-MM-DD"></label>
+          </div>
+          <p style="font-size:12px;color:var(--muted);line-height:1.5">เว้นว่าง = แสดงตลอด · ตั้งช่วงวันเพื่อให้ทั้ง Section แสดงเฉพาะช่วงเวลานั้น (เช่น โปรเทศกาล)</p>
         </div>
       </div>
     `;

--- a/server/routes/homepage.js
+++ b/server/routes/homepage.js
@@ -300,6 +300,12 @@ function normalizeSection(raw, index, errors) {
   if (cleanText(section.view_all_label, 60)) out.view_all_label = cleanText(section.view_all_label, 60);
   const _viewAllRoute = cleanText(section.view_all_route, 40);
   if (_viewAllRoute && INTERNAL_ROUTES.has(_viewAllRoute)) out.view_all_route = _viewAllRoute;
+  // Section-level scheduling: an admin can set a date window so a whole section
+  // (e.g. a seasonal promo block) shows only between active_from and active_to.
+  // stripPublicConfig already gates sections through activeNow(); persisting the
+  // dates here is what makes that window take effect.
+  if (cleanText(section.active_from, 32)) out.active_from = cleanText(section.active_from, 32);
+  if (cleanText(section.active_to, 32)) out.active_to = cleanText(section.active_to, 32);
   validateImageUrl(out.image_url, errors, `${id}.image_url`);
   validateDateRange(out, errors, id);
   if (type === "hero") {

--- a/test/homepageCms.test.js
+++ b/test/homepageCms.test.js
@@ -938,6 +938,37 @@ test("per-page headers (store/booking/tracking) normalize as hero-like banners a
   assert.equal(pub.page_headers.store.items[0].route, "store");
 });
 
+test("section-level active_from/active_to are persisted and gate the whole section in the public config", () => {
+  const result = validateConfig({
+    sections: [
+      { id: "hero", type: "hero", title: "หน้าหลัก", items: [] },
+      // A seasonal promo block scheduled for a past window — should be dropped.
+      { id: "promo_banner", type: "promo_banner", title: "โปรสงกรานต์", active_from: "2026-04-01", active_to: "2026-04-30", items: [{ image_url: "https://res.cloudinary.com/demo/songkran.jpg", alt_text: "โปร" }] },
+      // A trust block scheduled to start in the future — should also be dropped now.
+      { id: "trust", type: "trust", title: "เร็วๆ นี้", active_from: "2026-12-01", items: [{ title: "x", body: "y" }] },
+    ],
+  });
+  assert.equal(result.ok, true, JSON.stringify(result.errors));
+  // Dates survive normalization (draft/admin config keeps them).
+  const promo = result.config.sections.find((s) => s.id === "promo_banner");
+  assert.equal(promo.active_from, "2026-04-01");
+  assert.equal(promo.active_to, "2026-04-30");
+
+  // Public config in July 2026: the expired promo and the not-yet-started trust
+  // block are both gated out; only the always-on hero remains.
+  const pub = stripPublicConfig(result.config);
+  assert.ok(activeNow(result.config.sections[0], new Date("2026-07-02T05:00:00Z")));
+  const ids = pub.sections.map((s) => s.id);
+  assert.deepEqual(ids, ["hero"]);
+
+  // An invalid range (from after to) is rejected at validation time.
+  const bad = validateConfig({
+    sections: [{ id: "trust", type: "trust", title: "x", active_from: "2026-05-10", active_to: "2026-05-01", items: [{ title: "a", body: "b" }] }],
+  });
+  assert.equal(bad.ok, false);
+  assert.ok(bad.errors.some((e) => e.includes("active range invalid")));
+});
+
 test("updates items are savable with only an image/caption (no URL required); articles still require a URL", () => {
   // Activity-photo post: image + caption, no link. Must validate OK so admins
   // can publish work photos without inventing a URL.


### PR DESCRIPTION
## Summary

First of the admin-customization improvements: admins can now **schedule an entire homepage section** to appear only within a date window — not just individual items.

The plumbing was 90% there: `stripPublicConfig` already filtered sections through `activeNow()`, and `normalizeSection` already validated a section date range — but the `active_from`/`active_to` values were never persisted onto the saved section, so the window never took effect. This wires up the last step and exposes it in the CMS.

## Changes

- **`server/routes/homepage.js`** — `normalizeSection` now carries `active_from`/`active_to` onto the section, so the existing `activeNow()` gate applies to the whole section (e.g. a Songkran promo block that appears on 1 Apr and disappears after 30 Apr on its own).
- **`admin-homepage-cms.js`** — every section's "ข้อมูลทั่วไป" block gains optional **"แสดงตั้งแต่วันที่ / แสดงถึงวันที่"** fields with a short hint (blank = always on).
- **Test** — covers date persistence, public-config gating of an expired section and a not-yet-started section, and rejection of an inverted range.
- Bumped the admin CMS cache-bust.

## Verification

- Full suite green (719 passing, 11 skipped).
- Playwright admin smoke at 1100px: the new fields render in the editor, accept and retain a `2026-12-01 → 2026-12-31` window, and the page throws no JS errors.

## Note

This is step 1 of 4 the owner requested for admin customization (section scheduling → add/remove/duplicate sections → testimonials + FAQ blocks → theme/brand colors). Each ships as its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LmdP3TGN5uQrfT8ZYefNco)_