### PR TITLE
feat(cms): add, duplicate, and delete homepage sections

### DIFF
--- a/admin-homepage-cms.html
+++ b/admin-homepage-cms.html
@@ -308,6 +308,10 @@
   <div class="cms-layout">
     <nav class="cms-nav tab-active" data-panel="sections">
       <div class="nav-hd">Sections</div>
+      <div class="toolbar" style="padding:0 4px 10px">
+        <select id="newSectionType" class="fi" style="flex:1;min-width:0"></select>
+        <button class="btn btn-ghost btn-sm" id="addSectionBtn" type="button">+ เพิ่ม</button>
+      </div>
       <div id="sectionList"></div>
     </nav>
 
@@ -327,6 +331,6 @@
   </div>
 
   <select id="sectionPicker" style="display:none"></select>
-  <script src="/admin-homepage-cms.js?v=20260702_section_sched_v1"></script>
+  <script src="/admin-homepage-cms.js?v=20260702_sections_v1"></script>
 </body>
 </html>

--- a/admin-homepage-cms.js
+++ b/admin-homepage-cms.js
@@ -22,6 +22,12 @@
     active_job: "🔧", announcements: "📣", featured_services: "⭐",
     updates: "📸", articles: "📝", social: "📱", trust: "🛡️",
   };
+  // Thai labels for the "add section" picker.
+  const SECTION_TYPE_LABELS = {
+    hero: "Hero แบนเนอร์หลัก", quick: "เมนูด่วน", promo_banner: "แบนเนอร์โปรโมชัน",
+    active_job: "งานที่กำลังทำ", announcements: "ข่าว/ประกาศ", featured_services: "บริการแนะนำ",
+    updates: "ภาพกิจกรรม/โพสต์", articles: "บทความ", social: "โซเชียล", trust: "จุดเด่น/ความน่าเชื่อถือ",
+  };
 
   let config = clone(DEFAULT_CONFIG);
   let selected = "hero";
@@ -40,13 +46,22 @@
   function clone(value) { return JSON.parse(JSON.stringify(value)); }
   function standardSections() { return clone(DEFAULT_CONFIG).sections; }
   function normalizeAdminConfig(value) {
-    const next = value && Array.isArray(value.sections) ? clone(value) : clone(DEFAULT_CONFIG);
-    const standard = standardSections();
-    const existingTypes = new Set(next.sections.map((section) => section.type));
-    standard.forEach((section) => {
-      if (!existingTypes.has(section.type)) next.sections.push(section);
+    const next = value && Array.isArray(value.sections) && value.sections.length ? clone(value) : clone(DEFAULT_CONFIG);
+    const validTypes = new Set(standardSections().map((std) => std.type));
+    // Respect exactly what was saved (so admin add/duplicate/delete stick) —
+    // only drop sections of unknown types, and fall back to defaults if empty.
+    next.sections = next.sections.filter((section) => section && validTypes.has(section.type));
+    if (!next.sections.length) next.sections = standardSections();
+    // Ensure ids are unique so per-id lookups (edit/move/duplicate/delete) are
+    // unambiguous even if an imported config had collisions.
+    const seen = new Set();
+    next.sections.forEach((section) => {
+      let id = section.id || section.type;
+      let n = 2;
+      while (seen.has(id)) id = `${section.type}-${n++}`;
+      section.id = id;
+      seen.add(id);
     });
-    next.sections = next.sections.filter((section) => standard.some((std) => std.type === section.type));
     const rawHeaders = next.page_headers && typeof next.page_headers === "object" ? next.page_headers : {};
     next.page_headers = {};
     PAGE_HEADER_META.forEach(([key]) => {
@@ -64,6 +79,65 @@
   }
   function setStatus(text, kind) { $("status").textContent = text; $("status").className = `status-chip ${kind || ""}`; }
   function sections() { return config.sections.sort((a, b) => Number(a.sort_order || 0) - Number(b.sort_order || 0)); }
+
+  const MAX_SECTIONS = 24;
+  // A fresh id for a new/duplicated section: the type itself when free, else
+  // type-2, type-3, ... so per-id lookups stay unambiguous.
+  function uniqueSectionId(type) {
+    const ids = new Set(config.sections.map((s) => s.id));
+    if (!ids.has(type)) return type;
+    let n = 2;
+    while (ids.has(`${type}-${n}`)) n += 1;
+    return `${type}-${n}`;
+  }
+  // Re-space sort_order to clean multiples of 10 in current visual order, so
+  // inserts/duplicates land predictably and the move buttons keep working.
+  function renumberSections() {
+    sections().forEach((section, index) => { section.sort_order = (index + 1) * 10; });
+  }
+  function addSection(type) {
+    if (!SECTION_TYPE_LABELS[type]) return;
+    if (config.sections.length >= MAX_SECTIONS) { setStatus(`จำกัดสูงสุด ${MAX_SECTIONS} Section`, "bad"); return; }
+    const template = clone(DEFAULT_CONFIG.sections.find((s) => s.type === type) || { type, title: "", items: [] });
+    template.id = uniqueSectionId(type);
+    template.enabled = true;
+    template.sort_order = Math.max(0, ...config.sections.map((s) => Number(s.sort_order || 0))) + 10;
+    config.sections.push(template);
+    renumberSections();
+    selected = template.id;
+    render();
+    setStatus(`เพิ่ม Section: ${SECTION_TYPE_LABELS[type]}`, "ok");
+  }
+  function duplicateSection(id) {
+    const src = config.sections.find((s) => s.id === id);
+    if (!src) return;
+    if (config.sections.length >= MAX_SECTIONS) { setStatus(`จำกัดสูงสุด ${MAX_SECTIONS} Section`, "bad"); return; }
+    const copy = clone(src);
+    copy.id = uniqueSectionId(src.type);
+    if (src.title) copy.title = `${src.title} (สำเนา)`;
+    copy.sort_order = Number(src.sort_order || 0) + 1;
+    config.sections.push(copy);
+    renumberSections();
+    selected = copy.id;
+    render();
+    setStatus("ทำซ้ำ Section แล้ว", "ok");
+  }
+  function deleteSection(id) {
+    if (config.sections.length <= 1) { setStatus("ต้องมีอย่างน้อย 1 Section", "bad"); return; }
+    const idx = config.sections.findIndex((s) => s.id === id);
+    if (idx === -1) return;
+    config.sections.splice(idx, 1);
+    if (selected === id) selected = config.sections[Math.max(0, idx - 1)].id;
+    renumberSections();
+    render();
+    setStatus("ลบ Section แล้ว", "ok");
+  }
+  function populateSectionTypePicker() {
+    const el = $("newSectionType");
+    if (!el) return;
+    el.innerHTML = Object.keys(SECTION_TYPE_LABELS).map((type) =>
+      `<option value="${type}">${TYPE_ICONS[type] || "📄"} ${esc(SECTION_TYPE_LABELS[type])}</option>`).join("");
+  }
   function headKey() { return typeof selected === "string" && selected.startsWith("head:") ? selected.slice(5) : null; }
   function currentHead() { const key = headKey(); return key && config.page_headers ? config.page_headers[key] || null : null; }
   // current() resolves to the selected page-header object when a "head:*" entry
@@ -213,9 +287,13 @@
     $("editorHeader").innerHTML = `
       <div class="editor-hd">
         <div class="editor-hd-icon">${TYPE_ICONS[section.type] || "📄"}</div>
-        <div>
+        <div style="flex:1;min-width:0">
           <div class="editor-hd-title">${esc(section.title || section.type)}</div>
           <div class="editor-hd-sub">${section.type} · ${section.enabled !== false ? "เปิดใช้งานอยู่" : "ปิดอยู่"}</div>
+        </div>
+        <div class="toolbar">
+          <button class="btn btn-ghost btn-sm" type="button" data-duplicate-section="${esc(section.id)}">⧉ ทำซ้ำ</button>
+          <button class="btn btn-danger btn-sm" type="button" data-delete-section="${esc(section.id)}">🗑 ลบ Section</button>
         </div>
       </div>
     `;
@@ -612,6 +690,7 @@
   }
 
   function render() {
+    populateSectionTypePicker();
     renderSectionList();
     renderEditorHeader();
     renderEditor();
@@ -626,6 +705,15 @@
 
   /* ── event handlers ── */
   document.addEventListener("click", (event) => {
+    if (event.target.id === "addSectionBtn") { const el = $("newSectionType"); if (el) addSection(el.value); return; }
+    const dupSection = event.target.closest("[data-duplicate-section]");
+    if (dupSection) { duplicateSection(dupSection.dataset.duplicateSection); return; }
+    const delSection = event.target.closest("[data-delete-section]");
+    if (delSection) {
+      const sec = config.sections.find((s) => s.id === delSection.dataset.deleteSection);
+      if (sec && window.confirm(`ลบ Section "${sec.title || sec.type}" ?`)) deleteSection(sec.id);
+      return;
+    }
     const moveBtn = event.target.closest("[data-move]");
     if (moveBtn) move(moveBtn.dataset.move, Number(moveBtn.dataset.dir));
     const edit = event.target.closest("[data-edit]");

--- a/customer-app/assets/customer-app.js
+++ b/customer-app/assets/customer-app.js
@@ -3,7 +3,7 @@
 
   const App = window.CWFCustomerAppV2;
   const BOOT_TIMEOUT_MS = 3500;
-  const BUILD_ID = "20260701_featured4_v1";
+  const BUILD_ID = "20260702_sections_v1";
 
   function withTimeout(promise, timeoutMs) {
     return Promise.race([

--- a/customer-app/index.html
+++ b/customer-app/index.html
@@ -17,10 +17,10 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Noto+Sans+Thai:wght@400;500;600;700;800;900&display=swap" media="print" onload="this.media='all'">
   <noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Noto+Sans+Thai:wght@400;500;600;700;800;900&display=swap"></noscript>
-  <link rel="manifest" href="./manifest.webmanifest?v=20260701_featured4_v1">
+  <link rel="manifest" href="./manifest.webmanifest?v=20260702_sections_v1">
   <link rel="icon" type="image/png" sizes="192x192" href="./assets/icons/cwf-customer-192.png">
   <link rel="apple-touch-icon" sizes="180x180" href="./assets/icons/cwf-customer-180.png">
-  <link rel="stylesheet" href="./assets/customer-app.css?v=20260701_featured4_v1">
+  <link rel="stylesheet" href="./assets/customer-app.css?v=20260702_sections_v1">
 </head>
 <body class="is-app-booting">
   <div class="app-shell" data-app-shell>
@@ -58,21 +58,21 @@
     </nav>
   </div>
 
-  <script src="./modules/state.js?v=20260701_featured4_v1"></script>
-  <script src="./modules/utils.js?v=20260701_featured4_v1"></script>
-  <script src="./modules/analytics.js?v=20260701_featured4_v1"></script>
-  <script src="./modules/api.js?v=20260701_featured4_v1"></script>
-  <script src="./modules/services.js?v=20260701_featured4_v1"></script>
-  <script src="./modules/ui.js?v=20260701_featured4_v1"></script>
-  <script src="./modules/store.js?v=20260701_featured4_v1"></script>
-  <script src="./modules/auth.js?v=20260701_featured4_v1"></script>
-  <script src="./modules/pricing.js?v=20260701_featured4_v1"></script>
-  <script src="./modules/availability.js?v=20260701_featured4_v1"></script>
-  <script src="./modules/bookingScheduled.js?v=20260701_featured4_v1"></script>
-  <script src="./modules/bookingUrgent.js?v=20260701_featured4_v1"></script>
-  <script src="./modules/tracking.js?v=20260701_featured4_v1"></script>
-  <script src="./modules/profile.js?v=20260701_featured4_v1"></script>
-  <script src="./modules/router.js?v=20260701_featured4_v1"></script>
-  <script src="./assets/customer-app.js?v=20260701_featured4_v1"></script>
+  <script src="./modules/state.js?v=20260702_sections_v1"></script>
+  <script src="./modules/utils.js?v=20260702_sections_v1"></script>
+  <script src="./modules/analytics.js?v=20260702_sections_v1"></script>
+  <script src="./modules/api.js?v=20260702_sections_v1"></script>
+  <script src="./modules/services.js?v=20260702_sections_v1"></script>
+  <script src="./modules/ui.js?v=20260702_sections_v1"></script>
+  <script src="./modules/store.js?v=20260702_sections_v1"></script>
+  <script src="./modules/auth.js?v=20260702_sections_v1"></script>
+  <script src="./modules/pricing.js?v=20260702_sections_v1"></script>
+  <script src="./modules/availability.js?v=20260702_sections_v1"></script>
+  <script src="./modules/bookingScheduled.js?v=20260702_sections_v1"></script>
+  <script src="./modules/bookingUrgent.js?v=20260702_sections_v1"></script>
+  <script src="./modules/tracking.js?v=20260702_sections_v1"></script>
+  <script src="./modules/profile.js?v=20260702_sections_v1"></script>
+  <script src="./modules/router.js?v=20260702_sections_v1"></script>
+  <script src="./assets/customer-app.js?v=20260702_sections_v1"></script>
 </body>
 </html>

--- a/customer-app/manifest.webmanifest
+++ b/customer-app/manifest.webmanifest
@@ -2,7 +2,7 @@
   "name": "CWF Customer Service",
   "short_name": "CWF Service",
   "description": "แอปลูกค้า Coldwindflow สำหรับเลือกบริการ จองคิว และติดตามงาน",
-  "start_url": "/customer-app/index.html?v=20260701_featured4_v1#home",
+  "start_url": "/customer-app/index.html?v=20260702_sections_v1#home",
   "scope": "/customer-app/",
   "id": "/customer-app/",
   "display": "standalone",

--- a/customer-app/modules/ui.js
+++ b/customer-app/modules/ui.js
@@ -441,10 +441,11 @@
   function renderHomepageActiveJob(section) {
     const bucket = root.state.homeActiveJob || { status: "idle", data: null };
     const job = bucket.data;
-    if (!job || bucket.status !== "success") return `<div data-home-active-job></div>`;
+    const sid = root.utils.escapeHtml(section.id || "active_job");
+    if (!job || bucket.status !== "success") return `<div data-home-active-job data-section-id="${sid}"></div>`;
     const dateLabel = job.appointment_datetime ? root.utils.formatDateTime(job.appointment_datetime) : "";
     return `
-      <section class="homepage-section homepage-active-job" data-home-active-job>
+      <section class="homepage-section homepage-active-job" data-home-active-job data-section-id="${sid}">
         <div class="homepage-section-head">
           <div>
             <h2>${root.utils.escapeHtml(section.title || "")}</h2>
@@ -467,10 +468,10 @@
       // No valid items after resolving against real Catalog data (e.g. every
       // manually-selected item became inactive/hidden) — hide the section
       // entirely rather than show admin-authored copy with an empty body.
-      return `<div data-home-featured-section></div>`;
+      return `<div data-home-featured-section data-section-id="${root.utils.escapeHtml(section.id || "featured_services")}"></div>`;
     }
     return `
-      <section class="homepage-section" data-home-featured-section>
+      <section class="homepage-section" data-home-featured-section data-section-id="${root.utils.escapeHtml(section.id || "featured_services")}">
         <div class="homepage-section-head">
           <div>
             <h2>${root.utils.escapeHtml(section.title || "")}</h2>
@@ -1194,12 +1195,19 @@
       account.innerHTML = renderAccountShortcut();
       root.auth?.bindAvatarFallbacks?.(account);
     }
-    const featuredSection = container.querySelector("[data-home-featured-section]");
-    const featuredCfg = sectionByType("featured_services");
-    if (featuredSection && featuredCfg) featuredSection.outerHTML = renderHomepageFeaturedSection(featuredCfg);
-    const activeJob = container.querySelector("[data-home-active-job]");
-    const activeSection = sectionByType("active_job");
-    if (activeJob && activeSection) activeJob.outerHTML = renderHomepageActiveJob(activeSection);
+    // Re-render each featured/active-job mount from its own section config (by
+    // id), so duplicated sections of these types all refresh — not just the
+    // first one — once catalog/active-job data arrives.
+    const sectionById = (id, type) =>
+      homepageSections().find((section) => section.id === id) || sectionByType(type);
+    container.querySelectorAll("[data-home-featured-section]").forEach((mount) => {
+      const cfg = sectionById(mount.getAttribute("data-section-id"), "featured_services");
+      if (cfg) mount.outerHTML = renderHomepageFeaturedSection(cfg);
+    });
+    container.querySelectorAll("[data-home-active-job]").forEach((mount) => {
+      const cfg = sectionById(mount.getAttribute("data-section-id"), "active_job");
+      if (cfg) mount.outerHTML = renderHomepageActiveJob(cfg);
+    });
     container.querySelectorAll("[data-quick-price]").forEach((mount) => {
       const card = root.services.quickServices.find((item) => item.id === mount.getAttribute("data-quick-price"));
       if (card) mount.innerHTML = renderQuickPrice(card);

--- a/customer-app/sw.js
+++ b/customer-app/sw.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const BUILD_ID = "20260701_featured4_v1";
+const BUILD_ID = "20260702_sections_v1";
 const CACHE_NAME = `cwf-customer-app-v2-${BUILD_ID}`;
 const APP_SHELL = [
   `./index.html?v=${BUILD_ID}`,

--- a/server/routes/homepage.js
+++ b/server/routes/homepage.js
@@ -29,6 +29,9 @@ const ASPECT_MODES = new Set(["contain", "cover"]);
 const MAX_PROMO_BANNERS = 8;
 const MAX_SOCIAL_ITEMS = 8;
 const MAX_SEED_URLS = 8;
+// Upper bound on total homepage sections. Higher than the original fixed set of
+// ten so admins can add and duplicate sections, while still bounding growth.
+const MAX_SECTIONS = 24;
 const SOCIAL_PLATFORMS = new Set(["facebook", "youtube"]);
 // Admin pastes a public post/video URL; no Graph/YouTube Data API calls are
 // made server-side, so the only safety check we can do is confirm the URL
@@ -383,11 +386,24 @@ function validateConfig(input) {
   if (jsonSize(input) > MAX_JSON_BYTES) errors.push("payload too large");
   const sections = Array.isArray(input?.sections) ? input.sections : [];
   if (!sections.length) errors.push("sections required");
-  if (sections.length > 10) errors.push("sections too many");
+  // Admins can add/duplicate sections, so allow more than the original fixed
+  // set while still bounding payload growth.
+  if (sections.length > MAX_SECTIONS) errors.push("sections too many");
+  const normalizedSections = sections.map((section, index) => normalizeSection(section, index, errors));
+  // Defensive id uniqueness: duplicated sections must not share an id, or the
+  // customer/admin lookups (sectionByType, move/toggle/edit by id) would target
+  // the wrong instance. Suffix any collision in input order before sorting.
+  const seenIds = new Set();
+  for (const section of normalizedSections) {
+    let uid = section.id;
+    let n = 2;
+    while (seenIds.has(uid)) uid = `${section.id}-${n++}`;
+    section.id = uid;
+    seenIds.add(uid);
+  }
   const normalized = {
     version: 1,
-    sections: sections.map((section, index) => normalizeSection(section, index, errors))
-      .sort((a, b) => a.sort_order - b.sort_order),
+    sections: normalizedSections.sort((a, b) => a.sort_order - b.sort_order),
     page_headers: normalizePageHeaders(input?.page_headers, errors),
   };
   return { ok: errors.length === 0, errors, config: normalized };

--- a/test/customerAppRecovery.test.js
+++ b/test/customerAppRecovery.test.js
@@ -236,7 +236,7 @@ test("Customer App build id is consistent across shell and service worker", () =
   const sw = read("customer-app/sw.js");
   const app = read("customer-app/assets/customer-app.js");
   const manifest = read("customer-app/manifest.webmanifest");
-  const build = "20260701_featured4_v1";
+  const build = "20260702_sections_v1";
 
   assert.match(index, new RegExp(`customer-app\\.css\\?v=${build}`));
   assert.match(index, new RegExp(`modules\\/api\\.js\\?v=${build}`));
@@ -254,7 +254,7 @@ test("Customer App build id is consistent across shell and service worker", () =
 test("store module is loaded in index.html and precached in the service worker app shell", () => {
   const index = read("customer-app/index.html");
   const sw = read("customer-app/sw.js");
-  const build = "20260701_featured4_v1";
+  const build = "20260702_sections_v1";
 
   assert.match(index, new RegExp(`modules/store\\.js\\?v=${build}`));
   assert.match(sw, /`\.\/modules\/store\.js\?v=\$\{BUILD_ID\}`/);

--- a/test/customerSameDayTiming.test.js
+++ b/test/customerSameDayTiming.test.js
@@ -160,7 +160,7 @@ test("customer app disables availability HTTP cache and refreshes same-day slots
 });
 
 test("customer app build and service worker cache IDs changed", () => {
-  const id = "20260701_featured4_v1";
+  const id = "20260702_sections_v1";
   for (const file of [
     "customer-app/index.html",
     "customer-app/sw.js",

--- a/test/homepageCms.test.js
+++ b/test/homepageCms.test.js
@@ -278,7 +278,7 @@ test("customer homepage has no admin control, bottom nav is fixed five-tab, and 
   const sw = read("customer-app/sw.js");
   const app = read("customer-app/assets/customer-app.js");
   const manifest = read("customer-app/manifest.webmanifest");
-  const build = "20260701_featured4_v1";
+  const build = "20260702_sections_v1";
 
   assert.doesNotMatch(index + ui, /โหมดแอดมิน|openCms|localStorage\.getItem\('cwfHomeCmsDemo'/);
   assert.match(index, /data-route="store"[\s\S]*ร้านค้า/);
@@ -967,6 +967,32 @@ test("section-level active_from/active_to are persisted and gate the whole secti
   });
   assert.equal(bad.ok, false);
   assert.ok(bad.errors.some((e) => e.includes("active range invalid")));
+});
+
+test("admins can add/duplicate sections: extra sections of a type are kept with unique ids, and the total is capped", () => {
+  // Two promo_banner sections (a duplicate) — both survive, ids de-duplicated.
+  const dup = validateConfig({
+    sections: [
+      { id: "hero", type: "hero", title: "H", sort_order: 10, items: [] },
+      { id: "promo_banner", type: "promo_banner", title: "โปร A", sort_order: 20, items: [{ image_url: "https://res.cloudinary.com/demo/a.jpg", alt_text: "a" }] },
+      { id: "promo_banner", type: "promo_banner", title: "โปร B", sort_order: 30, items: [{ image_url: "https://res.cloudinary.com/demo/b.jpg", alt_text: "b" }] },
+    ],
+  });
+  assert.equal(dup.ok, true, JSON.stringify(dup.errors));
+  const promos = dup.config.sections.filter((s) => s.type === "promo_banner");
+  assert.equal(promos.length, 2);
+  assert.equal(new Set(promos.map((s) => s.id)).size, 2, "duplicate section ids must be made unique");
+  assert.ok(promos.some((s) => s.id === "promo_banner") && promos.some((s) => s.id === "promo_banner-2"));
+  // Both survive stripPublicConfig and render order follows sort_order.
+  const pub = stripPublicConfig(dup.config);
+  assert.deepEqual(pub.sections.map((s) => s.id), ["hero", "promo_banner", "promo_banner-2"]);
+
+  // More than the section cap is rejected.
+  const many = validateConfig({
+    sections: Array.from({ length: 25 }, (_, i) => ({ id: `trust-${i}`, type: "trust", title: "x", items: [{ title: "a", body: "b" }] })),
+  });
+  assert.equal(many.ok, false);
+  assert.ok(many.errors.some((e) => e.includes("sections too many")));
 });
 
 test("updates items are savable with only an image/caption (no URL required); articles still require a URL", () => {


### PR DESCRIPTION
## Summary

Feature 2 of 4 for admin customization. The section list could previously only be **reordered** and **toggled** — the set of sections was fixed at ten. Admins can now **build their own homepage layout** by adding, duplicating, and deleting sections (e.g. run two promo banners, or drop a section they don't use).

## Changes

**Admin CMS (`admin-homepage-cms.js` / `.html`)**
- **"+ เพิ่ม"** section picker (all section types) adds a new section seeded from its default template.
- **"⧉ ทำซ้ำ"** duplicates the current section; **"🗑 ลบ Section"** deletes it (guards against removing the last one, and confirms first).
- New/duplicated sections receive a unique id (`type`, `type-2`, …); `sort_order` is renumbered so inserts land predictably and the ↑/↓ move buttons keep working.
- `normalizeAdminConfig` now respects exactly what was saved — it only drops unknown types and falls back to defaults when empty — instead of force-re-adding every standard type, so **deletes persist across reloads**.

**Backend (`server/routes/homepage.js`)**
- Raised the section cap from 10 to `MAX_SECTIONS` (24).
- `validateConfig` defensively enforces **unique section ids**, so duplicated sections never collide for the customer/admin per-id lookups.

**Customer (`customer-app/modules/ui.js`)**
- The homepage already renders sections by iterating the array, so duplicates display. Made `patchHomeData` robust to multiple `featured_services` / `active_job` sections by tagging each mount with its section id and re-rendering **every** matching mount (not just the first) once catalog/active-job data loads.

## Verification

- Full suite green (720 passing, 11 skipped); new test covers duplicate-id de-duplication, the section cap, and public-config render order.
- **Real end-to-end** (fresh server, Playwright + live HTTP):
  - Admin UI: 10 → add → 11 → duplicate → 12 → delete → 11 sections, no JS errors.
  - Published a config with a duplicated promo banner → `GET /public/homepage` returns `["hero", "promo_banner", "promo_banner-2"]` (unique ids).
  - Customer app renders **2** promo-banner sections in the DOM.

## Roadmap

Step 2 of 4 requested by the owner: section scheduling ✅ → **add/remove/duplicate sections ✅** → testimonials + FAQ blocks → theme/brand colors. Each ships as its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LmdP3TGN5uQrfT8ZYefNco)_