### PR TITLE
feat(cms): testimonials + FAQ sections, and show 6 featured services

### DIFF
--- a/admin-homepage-cms.html
+++ b/admin-homepage-cms.html
@@ -331,6 +331,6 @@
   </div>
 
   <select id="sectionPicker" style="display:none"></select>
-  <script src="/admin-homepage-cms.js?v=20260702_reviews_faq_v1"></script>
+  <script src="/admin-homepage-cms.js?v=20260702_featured6_v1"></script>
 </body>
 </html>

--- a/admin-homepage-cms.html
+++ b/admin-homepage-cms.html
@@ -331,6 +331,6 @@
   </div>
 
   <select id="sectionPicker" style="display:none"></select>
-  <script src="/admin-homepage-cms.js?v=20260702_sections_v1"></script>
+  <script src="/admin-homepage-cms.js?v=20260702_reviews_faq_v1"></script>
 </body>
 </html>

--- a/admin-homepage-cms.js
+++ b/admin-homepage-cms.js
@@ -9,7 +9,7 @@
       { id: "promo_banner", type: "promo_banner", enabled: true, sort_order: 25, title: "", body: "", items: [] },
       { id: "active_job", type: "active_job", enabled: true, sort_order: 30, title: "Active job", body: "", items: [] },
       { id: "announcements", type: "announcements", enabled: true, sort_order: 40, title: "ข่าวและประกาศ CWF", body: "", items: [{ title: "ติดต่อทีม CWF", action: "contact", body: "สอบถามบริการหรือแจ้งข้อมูลเพิ่มเติมกับแอดมิน" }] },
-      { id: "featured_services", type: "featured_services", enabled: true, sort_order: 50, title: "บริการแนะนำ", body: "ราคาและรายละเอียดจาก Catalog", featured_mode: "auto", featured_limit: 4, show_price: true, show_badge: true, item_ids: [], items: [] },
+      { id: "featured_services", type: "featured_services", enabled: true, sort_order: 50, title: "บริการแนะนำ", body: "ราคาและรายละเอียดจาก Catalog", featured_mode: "auto", featured_limit: 6, show_price: true, show_badge: true, item_ids: [], items: [] },
       { id: "updates", type: "updates", enabled: true, sort_order: 60, title: "ภาพกิจกรรมและโพสต์", body: "", items: [] },
       { id: "articles", type: "articles", enabled: true, sort_order: 70, title: "บทความแนะนำ", body: "", items: [] },
       { id: "social", type: "social", enabled: true, sort_order: 75, title: "ติดตามเราบนโซเชียล", body: "อัปเดตล่าสุดจาก Facebook และ YouTube ของ Coldwindflow", items: [] },
@@ -678,7 +678,7 @@
     }
     return `
       <label class="field">แหล่งข้อมูล<select class="fi" data-featured-mode><option value="auto" ${mode === "auto" ? "selected" : ""}>ดึงจาก Catalog อัตโนมัติ (is_featured)</option><option value="manual" ${mode === "manual" ? "selected" : ""}>เลือกรายการเอง</option></select></label>
-      <label class="field">จำนวนสูงสุด<input class="fi" type="number" min="1" max="12" data-featured-limit value="${esc(section.featured_limit || 4)}"></label>
+      <label class="field">จำนวนสูงสุด<input class="fi" type="number" min="1" max="12" data-featured-limit value="${esc(section.featured_limit || 6)}"></label>
       <div style="display:flex;gap:14px;flex-wrap:wrap">
         <label class="switch"><input type="checkbox" data-featured-bool="show_price" ${section.show_price !== false ? "checked" : ""}> แสดงราคา</label>
         <label class="switch"><input type="checkbox" data-featured-bool="show_badge" ${section.show_badge !== false ? "checked" : ""}> แสดง Badge</label>
@@ -835,7 +835,7 @@
       if (target.dataset.prop === "url") { delete item[ctaName].route; delete item[ctaName].action; }
     }
     if (target.matches("[data-item]")) section.items[Number(target.dataset.item)][target.dataset.prop] = target.value;
-    if (target.matches("[data-featured-limit]")) section.featured_limit = Math.max(1, Math.min(12, Number(target.value) || 4));
+    if (target.matches("[data-featured-limit]")) section.featured_limit = Math.max(1, Math.min(12, Number(target.value) || 6));
     if (target.matches("[data-seed-urls]")) section.seed_urls = target.value.split("\n").map((l) => l.trim()).filter(Boolean).slice(0, 8);
     renderPreview();
   });

--- a/admin-homepage-cms.js
+++ b/admin-homepage-cms.js
@@ -21,12 +21,26 @@
     hero: "🏠", quick: "⚡", promo_banner: "🎨",
     active_job: "🔧", announcements: "📣", featured_services: "⭐",
     updates: "📸", articles: "📝", social: "📱", trust: "🛡️",
+    testimonials: "💬", faq: "❓",
   };
   // Thai labels for the "add section" picker.
   const SECTION_TYPE_LABELS = {
     hero: "Hero แบนเนอร์หลัก", quick: "เมนูด่วน", promo_banner: "แบนเนอร์โปรโมชัน",
     active_job: "งานที่กำลังทำ", announcements: "ข่าว/ประกาศ", featured_services: "บริการแนะนำ",
     updates: "ภาพกิจกรรม/โพสต์", articles: "บทความ", social: "โซเชียล", trust: "จุดเด่น/ความน่าเชื่อถือ",
+    testimonials: "รีวิวลูกค้า", faq: "คำถามที่พบบ่อย (FAQ)",
+  };
+  // Starter templates for section types not in the default homepage layout, so
+  // "add section" seeds them with useful example content.
+  const EXTRA_SECTION_TEMPLATES = {
+    testimonials: { title: "ลูกค้าพูดถึงเรา", body: "", items: [
+      { title: "คุณเอ", tag: "ลูกค้าคอนโด", rating: 5, body: "ช่างสุภาพ ทำงานสะอาด ประทับใจมากครับ" },
+      { title: "คุณบี", tag: "ลูกค้าบ้าน", rating: 5, body: "จองง่าย ตรงเวลา ราคาชัดเจน แนะนำเลย" },
+    ] },
+    faq: { title: "คำถามที่พบบ่อย", body: "", items: [
+      { title: "ล้างแอร์ใช้เวลานานไหม?", body: "โดยทั่วไปประมาณ 45–90 นาทีต่อเครื่อง ขึ้นกับชนิดและความสกปรก" },
+      { title: "มีรับประกันงานหรือไม่?", body: "รับประกันงานบริการ 7 วันหลังให้บริการ" },
+    ] },
   };
 
   let config = clone(DEFAULT_CONFIG);
@@ -98,7 +112,11 @@
   function addSection(type) {
     if (!SECTION_TYPE_LABELS[type]) return;
     if (config.sections.length >= MAX_SECTIONS) { setStatus(`จำกัดสูงสุด ${MAX_SECTIONS} Section`, "bad"); return; }
-    const template = clone(DEFAULT_CONFIG.sections.find((s) => s.type === type) || { type, title: "", items: [] });
+    const template = clone(
+      DEFAULT_CONFIG.sections.find((s) => s.type === type)
+      || EXTRA_SECTION_TEMPLATES[type]
+      || { type, title: "", items: [] });
+    template.type = type;
     template.id = uniqueSectionId(type);
     template.enabled = true;
     template.sort_order = Math.max(0, ...config.sections.map((s) => Number(s.sort_order || 0))) + 10;
@@ -328,6 +346,40 @@
       if (targetMode === "url") return `<label class="field">External URL<input class="fi" data-item="${index}" data-prop="url" value="${esc(item.url || "")}" placeholder="https://..."></label>`;
       return `<label class="field">Internal route<select class="fi" data-item="${index}" data-prop="route">${ROUTE_OPTIONS.map((r) => `<option value="${r}" ${String(item.route || "home") === r ? "selected" : ""}>${r}</option>`).join("")}</select></label>`;
     })();
+    // Shared card head (number, move, enable, delete) reused by the focused
+    // testimonials / FAQ editors below.
+    const itemHead = `
+      <div class="item-card-head">
+        <div style="display:flex;align-items:center;gap:8px">
+          <span class="item-num">${index + 1}</span>
+          <span style="font-weight:900;font-size:13px">${sectionType === "faq" ? "คำถาม" : sectionType === "testimonials" ? "รีวิว" : "รายการ"} ${index + 1}</span>
+          <button class="mini" type="button" data-move-item="${index}" data-dir="-1" ${index === 0 ? "disabled" : ""}>↑</button>
+          <button class="mini" type="button" data-move-item="${index}" data-dir="1" ${index === total - 1 ? "disabled" : ""}>↓</button>
+        </div>
+        <div style="display:flex;gap:8px;align-items:center">
+          <label class="switch"><input type="checkbox" data-item-enabled="${index}" ${item.enabled !== false ? "checked" : ""}> เปิด</label>
+          <button class="btn btn-danger btn-sm" type="button" data-remove-item="${index}">ลบ</button>
+        </div>
+      </div>`;
+    if (sectionType === "faq") {
+      return `<div class="item-card">${itemHead}<div class="item-card-body">
+        <label class="field">คำถาม<input class="fi" data-item="${index}" data-prop="title" value="${esc(item.title || "")}"></label>
+        <label class="field">คำตอบ<textarea class="fi" data-item="${index}" data-prop="body">${esc(item.body || "")}</textarea></label>
+      </div></div>`;
+    }
+    if (sectionType === "testimonials") {
+      const rating = Number(item.rating || 5);
+      return `<div class="item-card">${itemHead}<div class="item-card-body">
+        <div class="two">
+          <label class="field">ชื่อผู้รีวิว<input class="fi" data-item="${index}" data-prop="title" value="${esc(item.title || "")}"></label>
+          <label class="field">บทบาท/สถานที่ (ไม่บังคับ)<input class="fi" data-item="${index}" data-prop="tag" value="${esc(item.tag || "")}"></label>
+        </div>
+        <label class="field">คะแนนดาว<select class="fi" data-item="${index}" data-prop="rating">${[5, 4, 3, 2, 1].map((n) => `<option value="${n}" ${rating === n ? "selected" : ""}>${"★".repeat(n)} (${n})</option>`).join("")}</select></label>
+        <label class="field">ข้อความรีวิว<textarea class="fi" data-item="${index}" data-prop="body">${esc(item.body || "")}</textarea></label>
+        <label class="field">รูปโปรไฟล์ (ไม่บังคับ)<input class="fi" data-item="${index}" data-prop="image_url" value="${esc(item.image_url || "")}"></label>
+        <label class="field">อัปโหลดรูป<input class="fi" type="file" accept="image/jpeg,image/png,image/webp" data-upload="${index}"></label>
+      </div></div>`;
+    }
     return `
       <div class="item-card">
         <div class="item-card-head">
@@ -506,7 +558,7 @@
     if (headKey()) { renderHeadEditor(); return; }
     const section = current();
     if (!section) return;
-    const itemTypes = ["announcements", "updates", "articles", "social", "trust", "quick", "promo_banner"];
+    const itemTypes = ["announcements", "updates", "articles", "social", "trust", "quick", "promo_banner", "testimonials", "faq"];
     const hasViewAll = ["announcements", "updates", "articles", "social", "trust", "featured_services"].includes(section.type);
 
     let content = `

--- a/customer-app/assets/customer-app.css
+++ b/customer-app/assets/customer-app.css
@@ -5456,6 +5456,121 @@ body.has-contact-sheet { overflow: hidden; }
   line-height: 1.40;
 }
 
+/* ─── Testimonials (customer reviews) ───────────────────────────────── */
+.homepage-testimonials {
+  display: flex;
+  gap: 12px;
+  overflow-x: auto;
+  scroll-snap-type: x mandatory;
+  -webkit-overflow-scrolling: touch;
+  padding-bottom: 4px;
+}
+.homepage-testimonial-card {
+  flex: 0 0 min(82%, 300px);
+  scroll-snap-align: start;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 16px;
+  border: 1px solid var(--line);
+  border-radius: 18px;
+  background: linear-gradient(160deg, #fff 0%, var(--soft-blue) 220%);
+  box-shadow: 0 8px 22px rgba(6, 24, 47, 0.07);
+}
+.homepage-stars {
+  color: #ffb400;
+  font-size: 15px;
+  letter-spacing: 1px;
+}
+.homepage-testimonial-text {
+  color: var(--ink);
+  font-size: 13px;
+  line-height: 1.55;
+  margin: 0;
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 5;
+  overflow: hidden;
+}
+.homepage-testimonial-author {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-top: auto;
+}
+.homepage-testimonial-avatar {
+  width: 38px;
+  height: 38px;
+  border-radius: 50%;
+  object-fit: cover;
+  flex: 0 0 auto;
+}
+.homepage-testimonial-avatar.is-initial {
+  display: grid;
+  place-items: center;
+  background: linear-gradient(145deg, var(--blue), var(--cobalt));
+  color: #fff;
+  font-weight: 900;
+  font-size: 16px;
+}
+.homepage-testimonial-meta strong {
+  display: block;
+  color: var(--ink);
+  font-size: 13px;
+  font-weight: 800;
+}
+.homepage-testimonial-meta small {
+  color: var(--muted);
+  font-size: 11px;
+}
+
+/* ─── FAQ accordion ─────────────────────────────────────────────────── */
+.homepage-faq {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.homepage-faq-item {
+  border: 1px solid var(--line);
+  border-radius: 14px;
+  background: #fff;
+  overflow: hidden;
+}
+.homepage-faq-item summary {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 13px 15px;
+  cursor: pointer;
+  list-style: none;
+  color: var(--ink);
+  font-size: 13.5px;
+  font-weight: 800;
+  line-height: 1.4;
+}
+.homepage-faq-item summary::-webkit-details-marker { display: none; }
+.homepage-faq-chevron {
+  flex: 0 0 auto;
+  width: 0;
+  height: 0;
+  border-left: 5px solid transparent;
+  border-right: 5px solid transparent;
+  border-top: 6px solid var(--blue);
+  transition: transform 0.2s ease;
+}
+.homepage-faq-item[open] .homepage-faq-chevron { transform: rotate(180deg); }
+.homepage-faq-answer {
+  padding: 0 15px 14px;
+  color: var(--muted);
+  font-size: 13px;
+  line-height: 1.6;
+  white-space: pre-wrap;
+}
+@media (prefers-reduced-motion: reduce) {
+  .homepage-faq-chevron { transition: none; }
+}
+
 /* ─── Responsive guards ─────────────────────────────────────────────── */
 @media (max-width: 360px) {
   .homepage-screen { padding-inline: 10px; }

--- a/customer-app/assets/customer-app.js
+++ b/customer-app/assets/customer-app.js
@@ -3,7 +3,7 @@
 
   const App = window.CWFCustomerAppV2;
   const BOOT_TIMEOUT_MS = 3500;
-  const BUILD_ID = "20260702_sections_v1";
+  const BUILD_ID = "20260702_reviews_faq_v1";
 
   function withTimeout(promise, timeoutMs) {
     return Promise.race([

--- a/customer-app/assets/customer-app.js
+++ b/customer-app/assets/customer-app.js
@@ -3,7 +3,7 @@
 
   const App = window.CWFCustomerAppV2;
   const BOOT_TIMEOUT_MS = 3500;
-  const BUILD_ID = "20260702_reviews_faq_v1";
+  const BUILD_ID = "20260702_featured6_v1";
 
   function withTimeout(promise, timeoutMs) {
     return Promise.race([

--- a/customer-app/index.html
+++ b/customer-app/index.html
@@ -17,10 +17,10 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Noto+Sans+Thai:wght@400;500;600;700;800;900&display=swap" media="print" onload="this.media='all'">
   <noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Noto+Sans+Thai:wght@400;500;600;700;800;900&display=swap"></noscript>
-  <link rel="manifest" href="./manifest.webmanifest?v=20260702_reviews_faq_v1">
+  <link rel="manifest" href="./manifest.webmanifest?v=20260702_featured6_v1">
   <link rel="icon" type="image/png" sizes="192x192" href="./assets/icons/cwf-customer-192.png">
   <link rel="apple-touch-icon" sizes="180x180" href="./assets/icons/cwf-customer-180.png">
-  <link rel="stylesheet" href="./assets/customer-app.css?v=20260702_reviews_faq_v1">
+  <link rel="stylesheet" href="./assets/customer-app.css?v=20260702_featured6_v1">
 </head>
 <body class="is-app-booting">
   <div class="app-shell" data-app-shell>
@@ -58,21 +58,21 @@
     </nav>
   </div>
 
-  <script src="./modules/state.js?v=20260702_reviews_faq_v1"></script>
-  <script src="./modules/utils.js?v=20260702_reviews_faq_v1"></script>
-  <script src="./modules/analytics.js?v=20260702_reviews_faq_v1"></script>
-  <script src="./modules/api.js?v=20260702_reviews_faq_v1"></script>
-  <script src="./modules/services.js?v=20260702_reviews_faq_v1"></script>
-  <script src="./modules/ui.js?v=20260702_reviews_faq_v1"></script>
-  <script src="./modules/store.js?v=20260702_reviews_faq_v1"></script>
-  <script src="./modules/auth.js?v=20260702_reviews_faq_v1"></script>
-  <script src="./modules/pricing.js?v=20260702_reviews_faq_v1"></script>
-  <script src="./modules/availability.js?v=20260702_reviews_faq_v1"></script>
-  <script src="./modules/bookingScheduled.js?v=20260702_reviews_faq_v1"></script>
-  <script src="./modules/bookingUrgent.js?v=20260702_reviews_faq_v1"></script>
-  <script src="./modules/tracking.js?v=20260702_reviews_faq_v1"></script>
-  <script src="./modules/profile.js?v=20260702_reviews_faq_v1"></script>
-  <script src="./modules/router.js?v=20260702_reviews_faq_v1"></script>
-  <script src="./assets/customer-app.js?v=20260702_reviews_faq_v1"></script>
+  <script src="./modules/state.js?v=20260702_featured6_v1"></script>
+  <script src="./modules/utils.js?v=20260702_featured6_v1"></script>
+  <script src="./modules/analytics.js?v=20260702_featured6_v1"></script>
+  <script src="./modules/api.js?v=20260702_featured6_v1"></script>
+  <script src="./modules/services.js?v=20260702_featured6_v1"></script>
+  <script src="./modules/ui.js?v=20260702_featured6_v1"></script>
+  <script src="./modules/store.js?v=20260702_featured6_v1"></script>
+  <script src="./modules/auth.js?v=20260702_featured6_v1"></script>
+  <script src="./modules/pricing.js?v=20260702_featured6_v1"></script>
+  <script src="./modules/availability.js?v=20260702_featured6_v1"></script>
+  <script src="./modules/bookingScheduled.js?v=20260702_featured6_v1"></script>
+  <script src="./modules/bookingUrgent.js?v=20260702_featured6_v1"></script>
+  <script src="./modules/tracking.js?v=20260702_featured6_v1"></script>
+  <script src="./modules/profile.js?v=20260702_featured6_v1"></script>
+  <script src="./modules/router.js?v=20260702_featured6_v1"></script>
+  <script src="./assets/customer-app.js?v=20260702_featured6_v1"></script>
 </body>
 </html>

--- a/customer-app/index.html
+++ b/customer-app/index.html
@@ -17,10 +17,10 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Noto+Sans+Thai:wght@400;500;600;700;800;900&display=swap" media="print" onload="this.media='all'">
   <noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Noto+Sans+Thai:wght@400;500;600;700;800;900&display=swap"></noscript>
-  <link rel="manifest" href="./manifest.webmanifest?v=20260702_sections_v1">
+  <link rel="manifest" href="./manifest.webmanifest?v=20260702_reviews_faq_v1">
   <link rel="icon" type="image/png" sizes="192x192" href="./assets/icons/cwf-customer-192.png">
   <link rel="apple-touch-icon" sizes="180x180" href="./assets/icons/cwf-customer-180.png">
-  <link rel="stylesheet" href="./assets/customer-app.css?v=20260702_sections_v1">
+  <link rel="stylesheet" href="./assets/customer-app.css?v=20260702_reviews_faq_v1">
 </head>
 <body class="is-app-booting">
   <div class="app-shell" data-app-shell>
@@ -58,21 +58,21 @@
     </nav>
   </div>
 
-  <script src="./modules/state.js?v=20260702_sections_v1"></script>
-  <script src="./modules/utils.js?v=20260702_sections_v1"></script>
-  <script src="./modules/analytics.js?v=20260702_sections_v1"></script>
-  <script src="./modules/api.js?v=20260702_sections_v1"></script>
-  <script src="./modules/services.js?v=20260702_sections_v1"></script>
-  <script src="./modules/ui.js?v=20260702_sections_v1"></script>
-  <script src="./modules/store.js?v=20260702_sections_v1"></script>
-  <script src="./modules/auth.js?v=20260702_sections_v1"></script>
-  <script src="./modules/pricing.js?v=20260702_sections_v1"></script>
-  <script src="./modules/availability.js?v=20260702_sections_v1"></script>
-  <script src="./modules/bookingScheduled.js?v=20260702_sections_v1"></script>
-  <script src="./modules/bookingUrgent.js?v=20260702_sections_v1"></script>
-  <script src="./modules/tracking.js?v=20260702_sections_v1"></script>
-  <script src="./modules/profile.js?v=20260702_sections_v1"></script>
-  <script src="./modules/router.js?v=20260702_sections_v1"></script>
-  <script src="./assets/customer-app.js?v=20260702_sections_v1"></script>
+  <script src="./modules/state.js?v=20260702_reviews_faq_v1"></script>
+  <script src="./modules/utils.js?v=20260702_reviews_faq_v1"></script>
+  <script src="./modules/analytics.js?v=20260702_reviews_faq_v1"></script>
+  <script src="./modules/api.js?v=20260702_reviews_faq_v1"></script>
+  <script src="./modules/services.js?v=20260702_reviews_faq_v1"></script>
+  <script src="./modules/ui.js?v=20260702_reviews_faq_v1"></script>
+  <script src="./modules/store.js?v=20260702_reviews_faq_v1"></script>
+  <script src="./modules/auth.js?v=20260702_reviews_faq_v1"></script>
+  <script src="./modules/pricing.js?v=20260702_reviews_faq_v1"></script>
+  <script src="./modules/availability.js?v=20260702_reviews_faq_v1"></script>
+  <script src="./modules/bookingScheduled.js?v=20260702_reviews_faq_v1"></script>
+  <script src="./modules/bookingUrgent.js?v=20260702_reviews_faq_v1"></script>
+  <script src="./modules/tracking.js?v=20260702_reviews_faq_v1"></script>
+  <script src="./modules/profile.js?v=20260702_reviews_faq_v1"></script>
+  <script src="./modules/router.js?v=20260702_reviews_faq_v1"></script>
+  <script src="./assets/customer-app.js?v=20260702_reviews_faq_v1"></script>
 </body>
 </html>

--- a/customer-app/manifest.webmanifest
+++ b/customer-app/manifest.webmanifest
@@ -2,7 +2,7 @@
   "name": "CWF Customer Service",
   "short_name": "CWF Service",
   "description": "แอปลูกค้า Coldwindflow สำหรับเลือกบริการ จองคิว และติดตามงาน",
-  "start_url": "/customer-app/index.html?v=20260702_sections_v1#home",
+  "start_url": "/customer-app/index.html?v=20260702_reviews_faq_v1#home",
   "scope": "/customer-app/",
   "id": "/customer-app/",
   "display": "standalone",

--- a/customer-app/manifest.webmanifest
+++ b/customer-app/manifest.webmanifest
@@ -2,7 +2,7 @@
   "name": "CWF Customer Service",
   "short_name": "CWF Service",
   "description": "แอปลูกค้า Coldwindflow สำหรับเลือกบริการ จองคิว และติดตามงาน",
-  "start_url": "/customer-app/index.html?v=20260702_reviews_faq_v1#home",
+  "start_url": "/customer-app/index.html?v=20260702_featured6_v1#home",
   "scope": "/customer-app/",
   "id": "/customer-app/",
   "display": "standalone",

--- a/customer-app/modules/ui.js
+++ b/customer-app/modules/ui.js
@@ -122,7 +122,7 @@
         title: "บริการแนะนำ",
         body: "ราคาและรายละเอียดดึงจาก Catalog",
         featured_mode: "auto",
-        featured_limit: 4,
+        featured_limit: 6,
         show_price: true,
         show_badge: true,
         item_ids: [],
@@ -229,7 +229,7 @@
     const rows = root.state.catalog?.items || [];
     const cfg = section || {};
     const limitRaw = Number(cfg.featured_limit);
-    const limit = Number.isFinite(limitRaw) ? Math.max(1, Math.min(12, Math.round(limitRaw))) : 4;
+    const limit = Number.isFinite(limitRaw) ? Math.max(1, Math.min(12, Math.round(limitRaw))) : 6;
     if (cfg.featured_mode === "manual" && Array.isArray(cfg.item_ids) && cfg.item_ids.length) {
       const byId = new Map(rows.map((item) => [String(item.item_id), item]));
       return cfg.item_ids.map((id) => byId.get(String(id))).filter(Boolean).slice(0, limit);

--- a/customer-app/modules/ui.js
+++ b/customer-app/modules/ui.js
@@ -645,6 +645,72 @@
     `;
   }
 
+  function renderStars(rating) {
+    const r = Math.max(0, Math.min(5, Math.round(Number(rating) || 0)));
+    return `<span class="homepage-stars" role="img" aria-label="ให้คะแนน ${r} จาก 5 ดาว">${"★".repeat(r)}${"☆".repeat(5 - r)}</span>`;
+  }
+
+  // Customer testimonials — reviewer name (title), review text (body), optional
+  // role/place (tag) and avatar (image_url), plus a 1–5 star rating.
+  function renderHomepageTestimonials(section) {
+    if (!section) return "";
+    const items = (section.items || []).filter((item) => item && item.enabled !== false && item.title);
+    if (!items.length) return "";
+    return `
+      <section class="homepage-section">
+        <div class="homepage-section-head">
+          <div>
+            <h2>${root.utils.escapeHtml(section.title || "")}</h2>
+            ${section.body ? `<p>${root.utils.escapeHtml(section.body)}</p>` : ""}
+          </div>
+        </div>
+        <div class="homepage-carousel homepage-testimonials">
+          ${items.map((item) => `
+            <article class="homepage-testimonial-card">
+              ${renderStars(item.rating)}
+              ${item.body ? `<p class="homepage-testimonial-text">${root.utils.escapeHtml(item.body)}</p>` : ""}
+              <div class="homepage-testimonial-author">
+                ${item.image_url
+                  ? `<img class="homepage-testimonial-avatar" src="${root.utils.escapeHtml(item.image_url)}" alt="" loading="lazy">`
+                  : `<span class="homepage-testimonial-avatar is-initial" aria-hidden="true">${root.utils.escapeHtml((item.title || "?").trim().charAt(0) || "?")}</span>`}
+                <div class="homepage-testimonial-meta">
+                  <strong>${root.utils.escapeHtml(item.title || "")}</strong>
+                  ${item.tag ? `<small>${root.utils.escapeHtml(item.tag)}</small>` : ""}
+                </div>
+              </div>
+            </article>
+          `).join("")}
+        </div>
+      </section>
+    `;
+  }
+
+  // FAQ accordion — native <details>/<summary> so it expands with no JS and
+  // stays keyboard-accessible. title = question, body = answer.
+  function renderHomepageFaq(section) {
+    if (!section) return "";
+    const items = (section.items || []).filter((item) => item && item.enabled !== false && item.title);
+    if (!items.length) return "";
+    return `
+      <section class="homepage-section">
+        <div class="homepage-section-head">
+          <div>
+            <h2>${root.utils.escapeHtml(section.title || "")}</h2>
+            ${section.body ? `<p>${root.utils.escapeHtml(section.body)}</p>` : ""}
+          </div>
+        </div>
+        <div class="homepage-faq">
+          ${items.map((item) => `
+            <details class="homepage-faq-item">
+              <summary><span>${root.utils.escapeHtml(item.title || "")}</span><span class="homepage-faq-chevron" aria-hidden="true"></span></summary>
+              ${item.body ? `<div class="homepage-faq-answer">${root.utils.escapeHtml(item.body)}</div>` : ""}
+            </details>
+          `).join("")}
+        </div>
+      </section>
+    `;
+  }
+
   function renderHomepageSection(section) {
     if (!section) return "";
     if (section.type === "hero") return renderHomepageHero(section);
@@ -655,6 +721,8 @@
     if (["updates", "articles", "announcements"].includes(section.type)) return renderHomepageManualSection(section);
     if (section.type === "social") return renderHomepageSocial(section);
     if (section.type === "trust") return renderHomepageTrust(section);
+    if (section.type === "testimonials") return renderHomepageTestimonials(section);
+    if (section.type === "faq") return renderHomepageFaq(section);
     return "";
   }
 

--- a/customer-app/sw.js
+++ b/customer-app/sw.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const BUILD_ID = "20260702_reviews_faq_v1";
+const BUILD_ID = "20260702_featured6_v1";
 const CACHE_NAME = `cwf-customer-app-v2-${BUILD_ID}`;
 const APP_SHELL = [
   `./index.html?v=${BUILD_ID}`,

--- a/customer-app/sw.js
+++ b/customer-app/sw.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const BUILD_ID = "20260702_sections_v1";
+const BUILD_ID = "20260702_reviews_faq_v1";
 const CACHE_NAME = `cwf-customer-app-v2-${BUILD_ID}`;
 const APP_SHELL = [
   `./index.html?v=${BUILD_ID}`,

--- a/server/routes/homepage.js
+++ b/server/routes/homepage.js
@@ -20,6 +20,8 @@ const SECTION_TYPES = new Set([
   "articles",
   "social",
   "trust",
+  "testimonials",
+  "faq",
 ]);
 const INTERNAL_ROUTES = new Set(["home", "booking", "scheduled", "urgent", "tracking", "profile", "store"]);
 // Per-page header banners the admin manages independently of the homepage hero.
@@ -257,6 +259,12 @@ function normalizeItem(raw, sectionType, index, errors) {
   }
   if (sectionType === "social") {
     out.platform = SOCIAL_PLATFORMS.has(cleanText(item.platform, 10)) ? cleanText(item.platform, 10) : "youtube";
+  }
+  if (sectionType === "testimonials") {
+    // title = reviewer name, body = review text, tag = role/place (optional),
+    // image_url = optional avatar. rating is the only new field (1–5 stars).
+    const rating = Number(item.rating);
+    out.rating = Number.isFinite(rating) ? Math.max(1, Math.min(5, Math.round(rating))) : 5;
   }
   if (!out.title && sectionType !== "quick" && sectionType !== "promo_banner") errors.push(`${pathName}.title required`);
   validateUrlOrRoute(out, errors, pathName, {

--- a/server/routes/homepage.js
+++ b/server/routes/homepage.js
@@ -110,7 +110,7 @@ const DEFAULT_CONFIG = {
       title: "บริการแนะนำ",
       body: "ราคาและรายละเอียดดึงจาก Catalog",
       featured_mode: "auto",
-      featured_limit: 4,
+      featured_limit: 6,
       show_price: true,
       show_badge: true,
       item_ids: [],
@@ -327,7 +327,7 @@ function normalizeSection(raw, index, errors) {
     const mode = cleanText(section.featured_mode, 10) === "manual" ? "manual" : "auto";
     const limit = Number(section.featured_limit);
     out.featured_mode = mode;
-    out.featured_limit = Number.isFinite(limit) ? Math.max(1, Math.min(12, Math.round(limit))) : 4;
+    out.featured_limit = Number.isFinite(limit) ? Math.max(1, Math.min(12, Math.round(limit))) : 6;
     out.show_price = section.show_price !== false;
     out.show_badge = section.show_badge !== false;
     const itemIds = Array.isArray(section.item_ids) ? section.item_ids : [];

--- a/test/customerAppRecovery.test.js
+++ b/test/customerAppRecovery.test.js
@@ -236,7 +236,7 @@ test("Customer App build id is consistent across shell and service worker", () =
   const sw = read("customer-app/sw.js");
   const app = read("customer-app/assets/customer-app.js");
   const manifest = read("customer-app/manifest.webmanifest");
-  const build = "20260702_reviews_faq_v1";
+  const build = "20260702_featured6_v1";
 
   assert.match(index, new RegExp(`customer-app\\.css\\?v=${build}`));
   assert.match(index, new RegExp(`modules\\/api\\.js\\?v=${build}`));
@@ -254,7 +254,7 @@ test("Customer App build id is consistent across shell and service worker", () =
 test("store module is loaded in index.html and precached in the service worker app shell", () => {
   const index = read("customer-app/index.html");
   const sw = read("customer-app/sw.js");
-  const build = "20260702_reviews_faq_v1";
+  const build = "20260702_featured6_v1";
 
   assert.match(index, new RegExp(`modules/store\\.js\\?v=${build}`));
   assert.match(sw, /`\.\/modules\/store\.js\?v=\$\{BUILD_ID\}`/);

--- a/test/customerAppRecovery.test.js
+++ b/test/customerAppRecovery.test.js
@@ -236,7 +236,7 @@ test("Customer App build id is consistent across shell and service worker", () =
   const sw = read("customer-app/sw.js");
   const app = read("customer-app/assets/customer-app.js");
   const manifest = read("customer-app/manifest.webmanifest");
-  const build = "20260702_sections_v1";
+  const build = "20260702_reviews_faq_v1";
 
   assert.match(index, new RegExp(`customer-app\\.css\\?v=${build}`));
   assert.match(index, new RegExp(`modules\\/api\\.js\\?v=${build}`));
@@ -254,7 +254,7 @@ test("Customer App build id is consistent across shell and service worker", () =
 test("store module is loaded in index.html and precached in the service worker app shell", () => {
   const index = read("customer-app/index.html");
   const sw = read("customer-app/sw.js");
-  const build = "20260702_sections_v1";
+  const build = "20260702_reviews_faq_v1";
 
   assert.match(index, new RegExp(`modules/store\\.js\\?v=${build}`));
   assert.match(sw, /`\.\/modules\/store\.js\?v=\$\{BUILD_ID\}`/);

--- a/test/customerSameDayTiming.test.js
+++ b/test/customerSameDayTiming.test.js
@@ -160,7 +160,7 @@ test("customer app disables availability HTTP cache and refreshes same-day slots
 });
 
 test("customer app build and service worker cache IDs changed", () => {
-  const id = "20260702_reviews_faq_v1";
+  const id = "20260702_featured6_v1";
   for (const file of [
     "customer-app/index.html",
     "customer-app/sw.js",

--- a/test/customerSameDayTiming.test.js
+++ b/test/customerSameDayTiming.test.js
@@ -160,7 +160,7 @@ test("customer app disables availability HTTP cache and refreshes same-day slots
 });
 
 test("customer app build and service worker cache IDs changed", () => {
-  const id = "20260702_sections_v1";
+  const id = "20260702_reviews_faq_v1";
   for (const file of [
     "customer-app/index.html",
     "customer-app/sw.js",

--- a/test/homepageCms.test.js
+++ b/test/homepageCms.test.js
@@ -157,7 +157,7 @@ test("featured_services normalizes auto-mode defaults and validates manual selec
   assert.equal(auto.ok, true);
   const fs1 = auto.config.sections[0];
   assert.equal(fs1.featured_mode, "auto");
-  assert.equal(fs1.featured_limit, 4);
+  assert.equal(fs1.featured_limit, 6);
   assert.equal(fs1.show_price, true);
   assert.equal(fs1.show_badge, true);
   assert.deepEqual(fs1.item_ids, []);
@@ -195,7 +195,7 @@ test("legacy published config without featured_services fields gets safe default
   assert.equal(section.title, "บริการเก่าของแอดมิน");
   assert.equal(section.body, "คำอธิบายเดิม");
   assert.equal(section.featured_mode, "auto");
-  assert.equal(section.featured_limit, 4);
+  assert.equal(section.featured_limit, 6);
   assert.equal(section.show_price, true);
   assert.equal(section.show_badge, true);
 });
@@ -278,7 +278,7 @@ test("customer homepage has no admin control, bottom nav is fixed five-tab, and 
   const sw = read("customer-app/sw.js");
   const app = read("customer-app/assets/customer-app.js");
   const manifest = read("customer-app/manifest.webmanifest");
-  const build = "20260702_reviews_faq_v1";
+  const build = "20260702_featured6_v1";
 
   assert.doesNotMatch(index + ui, /โหมดแอดมิน|openCms|localStorage\.getItem\('cwfHomeCmsDemo'/);
   assert.match(index, /data-route="store"[\s\S]*ร้านค้า/);

--- a/test/homepageCms.test.js
+++ b/test/homepageCms.test.js
@@ -278,7 +278,7 @@ test("customer homepage has no admin control, bottom nav is fixed five-tab, and 
   const sw = read("customer-app/sw.js");
   const app = read("customer-app/assets/customer-app.js");
   const manifest = read("customer-app/manifest.webmanifest");
-  const build = "20260702_sections_v1";
+  const build = "20260702_reviews_faq_v1";
 
   assert.doesNotMatch(index + ui, /โหมดแอดมิน|openCms|localStorage\.getItem\('cwfHomeCmsDemo'/);
   assert.match(index, /data-route="store"[\s\S]*ร้านค้า/);
@@ -993,6 +993,36 @@ test("admins can add/duplicate sections: extra sections of a type are kept with 
   });
   assert.equal(many.ok, false);
   assert.ok(many.errors.some((e) => e.includes("sections too many")));
+});
+
+test("testimonials and faq are valid section types: star rating is clamped 1-5, faq Q/A persist and gate publicly", () => {
+  const result = validateConfig({
+    sections: [
+      { id: "hero", type: "hero", title: "H", sort_order: 10, items: [] },
+      { id: "testimonials", type: "testimonials", title: "รีวิวลูกค้า", sort_order: 20, items: [
+        { title: "คุณเอ", tag: "คอนโด", rating: 9, body: "ดีมาก" }, // over max → 5
+        { title: "คุณบี", rating: 0, body: "โอเค" },                 // under min → 1
+        { title: "คุณซี", body: "ไม่ได้ให้ดาว" },                    // missing → default 5
+      ] },
+      { id: "faq", type: "faq", title: "คำถามที่พบบ่อย", sort_order: 30, items: [
+        { title: "ล้างแอร์นานไหม?", body: "ประมาณ 45–90 นาทีต่อเครื่อง" },
+      ] },
+    ],
+  });
+  assert.equal(result.ok, true, JSON.stringify(result.errors));
+  const testimonials = result.config.sections.find((s) => s.type === "testimonials");
+  assert.deepEqual(testimonials.items.map((i) => i.rating), [5, 1, 5]);
+  const faq = result.config.sections.find((s) => s.type === "faq");
+  assert.equal(faq.items[0].title, "ล้างแอร์นานไหม?");
+  assert.equal(faq.items[0].body, "ประมาณ 45–90 นาทีต่อเครื่อง");
+  // Both new section types survive into the public config.
+  const pub = stripPublicConfig(result.config);
+  assert.deepEqual(pub.sections.map((s) => s.type), ["hero", "testimonials", "faq"]);
+  assert.equal(pub.sections.find((s) => s.type === "testimonials").items[0].rating, 5);
+
+  // A testimonial without a reviewer name (title) is rejected like other items.
+  const noName = validateConfig({ sections: [{ id: "t", type: "testimonials", title: "x", items: [{ rating: 5, body: "no name" }] }] });
+  assert.equal(noName.ok, false);
 });
 
 test("updates items are savable with only an image/caption (no URL required); articles still require a URL", () => {


### PR DESCRIPTION
Two related homepage changes on the same branch (PR #127 was not yet merged when the second was requested).

## 1. Customer testimonials + FAQ sections (new)

Two new admin-managed homepage section types:

- **testimonials (รีวิวลูกค้า)** — star-rated reviews. Reviewer name (title), review text (body), optional role/place (tag) and avatar (image_url), plus a **1–5 star rating** (clamped server-side). Rendered as a swipeable card carousel with a gold star row and a photo/initial avatar.
- **faq (คำถามที่พบบ่อย)** — a Q/A **accordion** on native `<details>/<summary>`: no JS, keyboard-accessible, chevron rotates on open.

Backend adds both to `SECTION_TYPES` and normalizes the `rating` field. Admin CMS gets focused item editors (star-rating picker for reviews; question/answer pair for FAQ), picker labels/icons, and starter templates for "add section". Neither is in the default layout — admins add them via the section picker.

## 2. Show 6 featured services, auto-rotating

Raised the default `featured_limit` from 4 to **6** so the homepage surfaces more services. The existing rotator paginates them **4 per view (2 pages)** and auto-cross-fades between pages, so customers see all six in a compact, non-tall layout. Admins can still tune "จำนวนสูงสุด" in the CMS.

## Verification

- Full suite green (721 passing, 11 skipped); tests cover rating clamping, required reviewer name, public-config gating, and the new featured default.
- **Real end-to-end** (fresh server, Playwright + live HTTP):
  - Testimonials/FAQ: admin add renders the star picker; published config returns `["hero", "testimonials", "faq"]`; customer shows 2 review cards with `★★★★★` and a working FAQ accordion.
  - Featured: 6 catalog items render as **2 pages × dots**, 4 cards per view, auto-rotating (active page advances on the interval).

## Roadmap

Section scheduling ✅ → add/remove/duplicate sections ✅ → **testimonials + FAQ ✅** → theme/brand colors (next).

🤖 Generated with [Claude Code](https://claude.com/claude-code)