### PR TITLE
feat(cms): admin-configurable brand theme colors

### DIFF
--- a/admin-homepage-cms.html
+++ b/admin-homepage-cms.html
@@ -331,6 +331,6 @@
   </div>
 
   <select id="sectionPicker" style="display:none"></select>
-  <script src="/admin-homepage-cms.js?v=20260702_featured6_v1"></script>
+  <script src="/admin-homepage-cms.js?v=20260702_theme_v1"></script>
 </body>
 </html>

--- a/admin-homepage-cms.js
+++ b/admin-homepage-cms.js
@@ -89,6 +89,7 @@
         items: Array.isArray(header.items) ? header.items : [],
       };
     });
+    next.theme = next.theme && typeof next.theme === "object" && !Array.isArray(next.theme) ? next.theme : {};
     return next;
   }
   function setStatus(text, kind) { $("status").textContent = text; $("status").className = `status-chip ${kind || ""}`; }
@@ -277,14 +278,37 @@
         </div>
       </div>`;
     }).join("");
-    $("sectionList").innerHTML += `<div class="nav-hd" style="margin-top:8px">แบนเนอร์หัวหน้า (แยกแต่ละหน้า)</div>${headerRows}`;
+    const themeRow = `
+      <div class="sec-row ${selected === "theme" ? "is-active" : ""}">
+        <div class="sec-row-body" data-edit="theme">
+          <div class="sec-icon">🎨</div>
+          <div class="sec-info">
+            <div class="sec-name">ธีม / สีแบรนด์</div>
+            <div class="sec-type">สีทั้งแอป</div>
+          </div>
+        </div>
+      </div>`;
+    $("sectionList").innerHTML += `<div class="nav-hd" style="margin-top:8px">แบนเนอร์หัวหน้า (แยกแต่ละหน้า)</div>${headerRows}`
+      + `<div class="nav-hd" style="margin-top:8px">รูปลักษณ์</div>${themeRow}`;
     $("sectionPicker").innerHTML = list.map((section) => `<option value="${esc(section.id)}">${esc(section.title || section.type)}</option>`).join("")
-      + PAGE_HEADER_META.map(([key, label]) => `<option value="head:${key}">${esc(label)}</option>`).join("");
+      + PAGE_HEADER_META.map(([key, label]) => `<option value="head:${key}">${esc(label)}</option>`).join("")
+      + `<option value="theme">ธีม / สีแบรนด์</option>`;
     $("sectionPicker").value = selected;
   }
 
   /* ── editor header ── */
   function renderEditorHeader() {
+    if (selected === "theme") {
+      $("editorHeader").innerHTML = `
+        <div class="editor-hd">
+          <div class="editor-hd-icon">🎨</div>
+          <div>
+            <div class="editor-hd-title">ธีม / สีแบรนด์</div>
+            <div class="editor-hd-sub">เปลี่ยนสีของทั้งแอปลูกค้า</div>
+          </div>
+        </div>`;
+      return;
+    }
     const key = headKey();
     if (key) {
       const meta = PAGE_HEADER_META.find(([k]) => k === key) || [key, key, "📄"];
@@ -554,7 +578,59 @@
     `;
   }
 
+  const THEME_PRESETS = [
+    { label: "CWF น้ำเงิน (ค่าเริ่มต้น)", primary: "#1659e0", accent: "#3d8bff", highlight: "#ffd23b" },
+    { label: "เขียวมินต์", primary: "#0f9d76", accent: "#33c39a", highlight: "#ffd23b" },
+    { label: "ม่วงพรีเมียม", primary: "#5b3bd4", accent: "#8a6cff", highlight: "#ffcf3b" },
+    { label: "ส้มพลังงาน", primary: "#e0562a", accent: "#ff8a3d", highlight: "#ffd23b" },
+    { label: "ชมพูสดใส", primary: "#d6296e", accent: "#ff5c9a", highlight: "#ffd23b" },
+    { label: "เทาเข้มหรู", primary: "#2b3a55", accent: "#5a6b8c", highlight: "#f4b740" },
+  ];
+  function themeColorRow(key, label, hint) {
+    const value = (config.theme || {})[key] || "";
+    return `
+      <label class="field">${esc(label)}
+        <div style="display:flex;gap:10px;align-items:center">
+          <input type="color" data-theme-color="${key}" value="${esc(value || "#1659e0")}" style="width:52px;height:40px;padding:2px;border-radius:10px;border:1.5px solid var(--line);background:#fff;cursor:pointer">
+          <input class="fi" data-theme-hex="${key}" value="${esc(value)}" placeholder="ค่าเริ่มต้น (เว้นว่าง)" style="flex:1" maxlength="7">
+        </div>
+        <span style="font-size:11px;color:var(--muted)">${esc(hint)}</span>
+      </label>`;
+  }
+  function renderThemeEditor() {
+    const theme = config.theme || {};
+    $("editor").innerHTML = `
+      <div class="ep">
+        <div class="ep-head">สีแบรนด์ (มีผลทั้งแอปลูกค้า)</div>
+        <div class="ep-body">
+          <p style="font-size:12.5px;color:var(--muted);line-height:1.6;margin:0 0 6px">เว้นว่างทุกช่อง = ใช้สีเริ่มต้นของ CWF · ระบบจะสร้างเฉดอ่อนให้อัตโนมัติจากสีหลัก</p>
+          ${themeColorRow("primary", "สีหลัก (ปุ่ม/ลิงก์/ไฮไลต์)", "ใช้กับปุ่มจอง ลิงก์ และองค์ประกอบหลัก")}
+          ${themeColorRow("accent", "สีเสริม (ไล่เฉด/ไอคอน)", "ใช้ไล่โทนกับสีหลัก เว้นว่าง = สร้างจากสีหลัก")}
+          ${themeColorRow("highlight", "สีเน้น (ปุ่มจองวงกลม/ป้าย)", "สีเหลืองปุ่มจองลอยและ kicker")}
+          <div class="toolbar" style="margin-top:8px">
+            <button class="btn btn-ghost btn-sm" type="button" id="resetTheme">↺ กลับค่าเริ่มต้น</button>
+          </div>
+        </div>
+      </div>
+      <div class="ep">
+        <div class="ep-head">ธีมสำเร็จรูป</div>
+        <div class="ep-body">
+          <div style="display:flex;flex-wrap:wrap;gap:8px">
+            ${THEME_PRESETS.map((p, i) => `
+              <button class="btn btn-ghost btn-sm" type="button" data-theme-preset="${i}" style="display:flex;align-items:center;gap:8px">
+                <span style="display:inline-flex;gap:2px">
+                  <span style="width:14px;height:14px;border-radius:4px;background:${p.primary}"></span>
+                  <span style="width:14px;height:14px;border-radius:4px;background:${p.accent}"></span>
+                  <span style="width:14px;height:14px;border-radius:4px;background:${p.highlight}"></span>
+                </span>${esc(p.label)}
+              </button>`).join("")}
+          </div>
+        </div>
+      </div>`;
+  }
+
   function renderEditor() {
+    if (selected === "theme") { renderThemeEditor(); return; }
     if (headKey()) { renderHeadEditor(); return; }
     const section = current();
     if (!section) return;
@@ -758,6 +834,13 @@
   /* ── event handlers ── */
   document.addEventListener("click", (event) => {
     if (event.target.id === "addSectionBtn") { const el = $("newSectionType"); if (el) addSection(el.value); return; }
+    const preset = event.target.closest("[data-theme-preset]");
+    if (preset) {
+      const p = THEME_PRESETS[Number(preset.dataset.themePreset)];
+      if (p) { config.theme = { primary: p.primary, accent: p.accent, highlight: p.highlight }; render(); setStatus(`ใช้ธีม: ${p.label}`, "ok"); }
+      return;
+    }
+    if (event.target.id === "resetTheme") { config.theme = {}; render(); setStatus("กลับไปใช้สีเริ่มต้น", "ok"); return; }
     const dupSection = event.target.closest("[data-duplicate-section]");
     if (dupSection) { duplicateSection(dupSection.dataset.duplicateSection); return; }
     const delSection = event.target.closest("[data-delete-section]");
@@ -822,6 +905,25 @@
 
   document.addEventListener("input", (event) => {
     const target = event.target;
+    // Theme color fields live outside any section — handle first and bail.
+    if (target.matches("[data-theme-color]") || target.matches("[data-theme-hex]")) {
+      const key = target.dataset.themeColor || target.dataset.themeHex;
+      config.theme = config.theme || {};
+      const raw = String(target.value || "").trim().toLowerCase();
+      if (target.matches("[data-theme-color]")) {
+        config.theme[key] = raw; // native color input is always #rrggbb
+        const hex = document.querySelector(`[data-theme-hex="${key}"]`);
+        if (hex) hex.value = raw;
+      } else if (!raw) {
+        delete config.theme[key];
+      } else if (/^#[0-9a-fA-F]{6}$/.test(raw)) {
+        config.theme[key] = raw;
+        const picker = document.querySelector(`[data-theme-color="${key}"]`);
+        if (picker) picker.value = raw;
+      }
+      renderPreview();
+      return;
+    }
     const section = current();
     if (target.matches("[data-field]")) section[target.dataset.field] = target.value;
     if (target.matches("[data-cta]")) { section[target.dataset.cta] = section[target.dataset.cta] || {}; section[target.dataset.cta][target.dataset.prop] = target.value; }

--- a/customer-app/assets/customer-app.js
+++ b/customer-app/assets/customer-app.js
@@ -3,7 +3,7 @@
 
   const App = window.CWFCustomerAppV2;
   const BOOT_TIMEOUT_MS = 3500;
-  const BUILD_ID = "20260702_featured6_v1";
+  const BUILD_ID = "20260702_theme_v1";
 
   function withTimeout(promise, timeoutMs) {
     return Promise.race([

--- a/customer-app/index.html
+++ b/customer-app/index.html
@@ -17,10 +17,10 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Noto+Sans+Thai:wght@400;500;600;700;800;900&display=swap" media="print" onload="this.media='all'">
   <noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Noto+Sans+Thai:wght@400;500;600;700;800;900&display=swap"></noscript>
-  <link rel="manifest" href="./manifest.webmanifest?v=20260702_featured6_v1">
+  <link rel="manifest" href="./manifest.webmanifest?v=20260702_theme_v1">
   <link rel="icon" type="image/png" sizes="192x192" href="./assets/icons/cwf-customer-192.png">
   <link rel="apple-touch-icon" sizes="180x180" href="./assets/icons/cwf-customer-180.png">
-  <link rel="stylesheet" href="./assets/customer-app.css?v=20260702_featured6_v1">
+  <link rel="stylesheet" href="./assets/customer-app.css?v=20260702_theme_v1">
 </head>
 <body class="is-app-booting">
   <div class="app-shell" data-app-shell>
@@ -58,21 +58,21 @@
     </nav>
   </div>
 
-  <script src="./modules/state.js?v=20260702_featured6_v1"></script>
-  <script src="./modules/utils.js?v=20260702_featured6_v1"></script>
-  <script src="./modules/analytics.js?v=20260702_featured6_v1"></script>
-  <script src="./modules/api.js?v=20260702_featured6_v1"></script>
-  <script src="./modules/services.js?v=20260702_featured6_v1"></script>
-  <script src="./modules/ui.js?v=20260702_featured6_v1"></script>
-  <script src="./modules/store.js?v=20260702_featured6_v1"></script>
-  <script src="./modules/auth.js?v=20260702_featured6_v1"></script>
-  <script src="./modules/pricing.js?v=20260702_featured6_v1"></script>
-  <script src="./modules/availability.js?v=20260702_featured6_v1"></script>
-  <script src="./modules/bookingScheduled.js?v=20260702_featured6_v1"></script>
-  <script src="./modules/bookingUrgent.js?v=20260702_featured6_v1"></script>
-  <script src="./modules/tracking.js?v=20260702_featured6_v1"></script>
-  <script src="./modules/profile.js?v=20260702_featured6_v1"></script>
-  <script src="./modules/router.js?v=20260702_featured6_v1"></script>
-  <script src="./assets/customer-app.js?v=20260702_featured6_v1"></script>
+  <script src="./modules/state.js?v=20260702_theme_v1"></script>
+  <script src="./modules/utils.js?v=20260702_theme_v1"></script>
+  <script src="./modules/analytics.js?v=20260702_theme_v1"></script>
+  <script src="./modules/api.js?v=20260702_theme_v1"></script>
+  <script src="./modules/services.js?v=20260702_theme_v1"></script>
+  <script src="./modules/ui.js?v=20260702_theme_v1"></script>
+  <script src="./modules/store.js?v=20260702_theme_v1"></script>
+  <script src="./modules/auth.js?v=20260702_theme_v1"></script>
+  <script src="./modules/pricing.js?v=20260702_theme_v1"></script>
+  <script src="./modules/availability.js?v=20260702_theme_v1"></script>
+  <script src="./modules/bookingScheduled.js?v=20260702_theme_v1"></script>
+  <script src="./modules/bookingUrgent.js?v=20260702_theme_v1"></script>
+  <script src="./modules/tracking.js?v=20260702_theme_v1"></script>
+  <script src="./modules/profile.js?v=20260702_theme_v1"></script>
+  <script src="./modules/router.js?v=20260702_theme_v1"></script>
+  <script src="./assets/customer-app.js?v=20260702_theme_v1"></script>
 </body>
 </html>

--- a/customer-app/manifest.webmanifest
+++ b/customer-app/manifest.webmanifest
@@ -2,7 +2,7 @@
   "name": "CWF Customer Service",
   "short_name": "CWF Service",
   "description": "แอปลูกค้า Coldwindflow สำหรับเลือกบริการ จองคิว และติดตามงาน",
-  "start_url": "/customer-app/index.html?v=20260702_featured6_v1#home",
+  "start_url": "/customer-app/index.html?v=20260702_theme_v1#home",
   "scope": "/customer-app/",
   "id": "/customer-app/",
   "display": "standalone",

--- a/customer-app/modules/ui.js
+++ b/customer-app/modules/ui.js
@@ -779,18 +779,68 @@
     }
   }
 
+  // ── Admin-configurable brand theme ──────────────────────────────────
+  // The admin can set primary / accent / highlight colors in the CMS. We map
+  // them onto the app's CSS custom properties (and derive soft tints), so the
+  // whole customer app recolors app-wide. Absent/invalid values fall back to
+  // the stylesheet defaults.
+  const THEME_HEX = /^#[0-9a-fA-F]{6}$/;
+  function themeHexToRgb(hex) {
+    const n = parseInt(hex.slice(1), 16);
+    return [(n >> 16) & 255, (n >> 8) & 255, n & 255];
+  }
+  function themeRgbToHex(r, g, b) {
+    return "#" + [r, g, b].map((x) => Math.max(0, Math.min(255, Math.round(x))).toString(16).padStart(2, "0")).join("");
+  }
+  function themeMixWhite(hex, whiteAmount) {
+    const [r, g, b] = themeHexToRgb(hex);
+    const w = whiteAmount;
+    return themeRgbToHex(r + (255 - r) * w, g + (255 - g) * w, b + (255 - b) * w);
+  }
+  function applyHomepageTheme(config) {
+    if (typeof document === "undefined" || !document.documentElement) return;
+    const rootEl = document.documentElement;
+    const theme = (config && config.theme && typeof config.theme === "object") ? config.theme : {};
+    const clean = (value) => (typeof value === "string" && THEME_HEX.test(value.trim()) ? value.trim().toLowerCase() : null);
+    const primary = clean(theme.primary);
+    const accent = clean(theme.accent);
+    const highlight = clean(theme.highlight);
+    // Clear previous overrides first so reverting to defaults works.
+    ["--blue", "--blue-2", "--accent", "--cobalt", "--yellow", "--yellow-2", "--soft-blue", "--soft-blue-2"]
+      .forEach((prop) => rootEl.style.removeProperty(prop));
+    if (primary) {
+      rootEl.style.setProperty("--blue", primary);
+      rootEl.style.setProperty("--accent", primary);
+      rootEl.style.setProperty("--soft-blue", themeMixWhite(primary, 0.90));
+      rootEl.style.setProperty("--soft-blue-2", themeMixWhite(primary, 0.82));
+      rootEl.style.setProperty("--blue-2", accent || themeMixWhite(primary, 0.18));
+      rootEl.style.setProperty("--cobalt", accent || themeMixWhite(primary, 0.30));
+    } else if (accent) {
+      rootEl.style.setProperty("--blue-2", accent);
+      rootEl.style.setProperty("--cobalt", accent);
+      rootEl.style.setProperty("--accent", accent);
+    }
+    if (highlight) {
+      rootEl.style.setProperty("--yellow", highlight);
+      rootEl.style.setProperty("--yellow-2", themeMixWhite(highlight, 0.35));
+    }
+  }
+
   async function loadHomepageData() {
     if (root.state.homepage?.status !== "idle") return;
     root.state.setHomepage({ status: "loading", error: "" });
     try {
       const data = await root.api.loadHomepage();
+      const config = data?.config || DEFAULT_HOME_CONFIG;
+      applyHomepageTheme(config);
       root.state.setHomepage({
         status: "success",
-        config: data?.config || DEFAULT_HOME_CONFIG,
+        config,
         fallback: Boolean(data?.fallback),
         error: "",
       });
     } catch (error) {
+      applyHomepageTheme(DEFAULT_HOME_CONFIG);
       root.state.setHomepage({
         status: "error",
         config: DEFAULT_HOME_CONFIG,

--- a/customer-app/sw.js
+++ b/customer-app/sw.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const BUILD_ID = "20260702_featured6_v1";
+const BUILD_ID = "20260702_theme_v1";
 const CACHE_NAME = `cwf-customer-app-v2-${BUILD_ID}`;
 const APP_SHELL = [
   `./index.html?v=${BUILD_ID}`,

--- a/server/routes/homepage.js
+++ b/server/routes/homepage.js
@@ -388,6 +388,23 @@ function normalizePageHeaders(raw, errors) {
   return out;
 }
 
+// Admin-configurable brand theme: up to three hex colors the customer app maps
+// onto its CSS variables (primary/accent/highlight). Invalid values are flagged
+// and dropped; an absent theme means "use the app's default palette".
+const THEME_KEYS = ["primary", "accent", "highlight"];
+const HEX_COLOR = /^#[0-9a-fA-F]{6}$/;
+function normalizeTheme(raw, errors) {
+  const src = raw && typeof raw === "object" && !Array.isArray(raw) ? raw : {};
+  const out = {};
+  for (const key of THEME_KEYS) {
+    const value = cleanText(src[key], 7);
+    if (!value) continue;
+    if (!HEX_COLOR.test(value)) { errors.push(`theme.${key} must be a 6-digit hex color`); continue; }
+    out[key] = value.toLowerCase();
+  }
+  return out;
+}
+
 function validateConfig(input) {
   const errors = [];
   if (!input || typeof input !== "object" || Array.isArray(input)) errors.push("payload must be object");
@@ -413,6 +430,7 @@ function validateConfig(input) {
     version: 1,
     sections: normalizedSections.sort((a, b) => a.sort_order - b.sort_order),
     page_headers: normalizePageHeaders(input?.page_headers, errors),
+    theme: normalizeTheme(input?.theme, errors),
   };
   return { ok: errors.length === 0, errors, config: normalized };
 }
@@ -493,7 +511,8 @@ function stripPublicConfig(config) {
     delete cleanHeader.updated_by;
     page_headers[key] = cleanHeader;
   }
-  return { version: 1, sections, page_headers };
+  const theme = config?.theme && typeof config.theme === "object" && !Array.isArray(config.theme) ? config.theme : {};
+  return { version: 1, sections, page_headers, theme };
 }
 
 async function hydrateAutoSyncArticles(pool, publicConfig) {

--- a/test/customerAppRecovery.test.js
+++ b/test/customerAppRecovery.test.js
@@ -236,7 +236,7 @@ test("Customer App build id is consistent across shell and service worker", () =
   const sw = read("customer-app/sw.js");
   const app = read("customer-app/assets/customer-app.js");
   const manifest = read("customer-app/manifest.webmanifest");
-  const build = "20260702_featured6_v1";
+  const build = "20260702_theme_v1";
 
   assert.match(index, new RegExp(`customer-app\\.css\\?v=${build}`));
   assert.match(index, new RegExp(`modules\\/api\\.js\\?v=${build}`));
@@ -254,7 +254,7 @@ test("Customer App build id is consistent across shell and service worker", () =
 test("store module is loaded in index.html and precached in the service worker app shell", () => {
   const index = read("customer-app/index.html");
   const sw = read("customer-app/sw.js");
-  const build = "20260702_featured6_v1";
+  const build = "20260702_theme_v1";
 
   assert.match(index, new RegExp(`modules/store\\.js\\?v=${build}`));
   assert.match(sw, /`\.\/modules\/store\.js\?v=\$\{BUILD_ID\}`/);

--- a/test/customerSameDayTiming.test.js
+++ b/test/customerSameDayTiming.test.js
@@ -160,7 +160,7 @@ test("customer app disables availability HTTP cache and refreshes same-day slots
 });
 
 test("customer app build and service worker cache IDs changed", () => {
-  const id = "20260702_featured6_v1";
+  const id = "20260702_theme_v1";
   for (const file of [
     "customer-app/index.html",
     "customer-app/sw.js",

--- a/test/homepageCms.test.js
+++ b/test/homepageCms.test.js
@@ -278,7 +278,7 @@ test("customer homepage has no admin control, bottom nav is fixed five-tab, and 
   const sw = read("customer-app/sw.js");
   const app = read("customer-app/assets/customer-app.js");
   const manifest = read("customer-app/manifest.webmanifest");
-  const build = "20260702_featured6_v1";
+  const build = "20260702_theme_v1";
 
   assert.doesNotMatch(index + ui, /โหมดแอดมิน|openCms|localStorage\.getItem\('cwfHomeCmsDemo'/);
   assert.match(index, /data-route="store"[\s\S]*ร้านค้า/);
@@ -1023,6 +1023,31 @@ test("testimonials and faq are valid section types: star rating is clamped 1-5, 
   // A testimonial without a reviewer name (title) is rejected like other items.
   const noName = validateConfig({ sections: [{ id: "t", type: "testimonials", title: "x", items: [{ rating: 5, body: "no name" }] }] });
   assert.equal(noName.ok, false);
+});
+
+test("brand theme colors validate as hex, drop invalid/empty, and carry to the public config", () => {
+  const ok = validateConfig({
+    sections: [{ id: "hero", type: "hero", title: "H", items: [] }],
+    theme: { primary: "#0F9D76", accent: "#33c39a", highlight: "", bogus: "#fff" },
+  });
+  assert.equal(ok.ok, true, JSON.stringify(ok.errors));
+  // Valid colors are lower-cased; empty highlight and unknown keys are dropped.
+  assert.deepEqual(ok.config.theme, { primary: "#0f9d76", accent: "#33c39a" });
+  const pub = stripPublicConfig(ok.config);
+  assert.deepEqual(pub.theme, { primary: "#0f9d76", accent: "#33c39a" });
+
+  // A malformed hex is rejected.
+  const bad = validateConfig({
+    sections: [{ id: "hero", type: "hero", title: "H", items: [] }],
+    theme: { primary: "blue" },
+  });
+  assert.equal(bad.ok, false);
+  assert.ok(bad.errors.some((e) => e.includes("theme.primary")));
+
+  // No theme = empty object (app uses default palette), still present in public config.
+  const none = validateConfig({ sections: [{ id: "hero", type: "hero", title: "H", items: [] }] });
+  assert.deepEqual(none.config.theme, {});
+  assert.deepEqual(stripPublicConfig(none.config).theme, {});
 });
 
 test("updates items are savable with only an image/caption (no URL required); articles still require a URL", () => {


### PR DESCRIPTION
## Summary

Final feature (4 of 4) for admin customization: a **"ธีม / สีแบรนด์"** editor that lets admins recolor the entire customer app without touching CSS — e.g. a seasonal palette.

## Changes

- **Config** gains an optional `theme` object with up to three hex colors: **primary** (buttons/links/highlights), **accent** (gradients/icons), and **highlight** (the floating booking button + kickers).
- **Backend (`server/routes/homepage.js`)** — validates the colors as 6-digit hex, lower-cases them, drops empty/unknown keys, and carries the theme into the public config (`stripPublicConfig`).
- **Customer (`customer-app/modules/ui.js`)** — maps the theme onto the app's CSS custom properties on `:root` and derives soft tints from the primary, so the whole app recolors app-wide. Absent/invalid values fall back to the default palette.
- **Admin CMS (`admin-homepage-cms.js` / `.html`)** — a theme panel with color pickers + hex inputs for the three colors, **six ready-made presets**, and a reset-to-default button.

## Verification

- Full suite green (722 passing, 11 skipped); new test covers hex validation, lower-casing, dropping empty/unknown keys, and public-config carry-through.
- **Real end-to-end** (fresh server, Playwright + live HTTP):
  - Admin: the theme editor renders 3 color pickers; applying the "green mint" preset sets `primary=#0f9d76`; no JS errors.
  - Published a green theme → `GET /public/homepage` returns `theme: { primary: "#0f9d76", ... }`.
  - Customer app: `--blue` resolves to `#0f9d76` and rendered elements (price text, "ดูทั้งหมด" link) compute to `rgb(15, 157, 118)` — the whole app is green, while the yellow highlight (จอง button/FAB) stays as set.

## Roadmap — all four admin-customization items complete

Section scheduling ✅ → add/remove/duplicate sections ✅ → testimonials + FAQ ✅ → **theme/brand colors ✅**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LmdP3TGN5uQrfT8ZYefNco)_