### PR TITLE
feat(orders): persist customer product orders — buy flow PR 2

### DIFF
--- a/customer-app/assets/customer-app.js
+++ b/customer-app/assets/customer-app.js
@@ -3,7 +3,7 @@
 
   const App = window.CWFCustomerAppV2;
   const BOOT_TIMEOUT_MS = 3500;
-  const BUILD_ID = "20260702_buy_v1";
+  const BUILD_ID = "20260702_orders_v1";
 
   function withTimeout(promise, timeoutMs) {
     return Promise.race([

--- a/customer-app/index.html
+++ b/customer-app/index.html
@@ -17,10 +17,10 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Noto+Sans+Thai:wght@400;500;600;700;800;900&display=swap" media="print" onload="this.media='all'">
   <noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Noto+Sans+Thai:wght@400;500;600;700;800;900&display=swap"></noscript>
-  <link rel="manifest" href="./manifest.webmanifest?v=20260702_buy_v1">
+  <link rel="manifest" href="./manifest.webmanifest?v=20260702_orders_v1">
   <link rel="icon" type="image/png" sizes="192x192" href="./assets/icons/cwf-customer-192.png">
   <link rel="apple-touch-icon" sizes="180x180" href="./assets/icons/cwf-customer-180.png">
-  <link rel="stylesheet" href="./assets/customer-app.css?v=20260702_buy_v1">
+  <link rel="stylesheet" href="./assets/customer-app.css?v=20260702_orders_v1">
 </head>
 <body class="is-app-booting">
   <div class="app-shell" data-app-shell>
@@ -58,21 +58,21 @@
     </nav>
   </div>
 
-  <script src="./modules/state.js?v=20260702_buy_v1"></script>
-  <script src="./modules/utils.js?v=20260702_buy_v1"></script>
-  <script src="./modules/analytics.js?v=20260702_buy_v1"></script>
-  <script src="./modules/api.js?v=20260702_buy_v1"></script>
-  <script src="./modules/services.js?v=20260702_buy_v1"></script>
-  <script src="./modules/ui.js?v=20260702_buy_v1"></script>
-  <script src="./modules/store.js?v=20260702_buy_v1"></script>
-  <script src="./modules/auth.js?v=20260702_buy_v1"></script>
-  <script src="./modules/pricing.js?v=20260702_buy_v1"></script>
-  <script src="./modules/availability.js?v=20260702_buy_v1"></script>
-  <script src="./modules/bookingScheduled.js?v=20260702_buy_v1"></script>
-  <script src="./modules/bookingUrgent.js?v=20260702_buy_v1"></script>
-  <script src="./modules/tracking.js?v=20260702_buy_v1"></script>
-  <script src="./modules/profile.js?v=20260702_buy_v1"></script>
-  <script src="./modules/router.js?v=20260702_buy_v1"></script>
-  <script src="./assets/customer-app.js?v=20260702_buy_v1"></script>
+  <script src="./modules/state.js?v=20260702_orders_v1"></script>
+  <script src="./modules/utils.js?v=20260702_orders_v1"></script>
+  <script src="./modules/analytics.js?v=20260702_orders_v1"></script>
+  <script src="./modules/api.js?v=20260702_orders_v1"></script>
+  <script src="./modules/services.js?v=20260702_orders_v1"></script>
+  <script src="./modules/ui.js?v=20260702_orders_v1"></script>
+  <script src="./modules/store.js?v=20260702_orders_v1"></script>
+  <script src="./modules/auth.js?v=20260702_orders_v1"></script>
+  <script src="./modules/pricing.js?v=20260702_orders_v1"></script>
+  <script src="./modules/availability.js?v=20260702_orders_v1"></script>
+  <script src="./modules/bookingScheduled.js?v=20260702_orders_v1"></script>
+  <script src="./modules/bookingUrgent.js?v=20260702_orders_v1"></script>
+  <script src="./modules/tracking.js?v=20260702_orders_v1"></script>
+  <script src="./modules/profile.js?v=20260702_orders_v1"></script>
+  <script src="./modules/router.js?v=20260702_orders_v1"></script>
+  <script src="./assets/customer-app.js?v=20260702_orders_v1"></script>
 </body>
 </html>

--- a/customer-app/manifest.webmanifest
+++ b/customer-app/manifest.webmanifest
@@ -2,7 +2,7 @@
   "name": "CWF Customer Service",
   "short_name": "CWF Service",
   "description": "แอปลูกค้า Coldwindflow สำหรับเลือกบริการ จองคิว และติดตามงาน",
-  "start_url": "/customer-app/index.html?v=20260702_buy_v1#home",
+  "start_url": "/customer-app/index.html?v=20260702_orders_v1#home",
   "scope": "/customer-app/",
   "id": "/customer-app/",
   "display": "standalone",

--- a/customer-app/modules/api.js
+++ b/customer-app/modules/api.js
@@ -114,6 +114,14 @@
       return requestJson("/public/homepage/active-job", { cache: "no-store" });
     },
 
+    async createOrder(payload) {
+      return requestJson("/public/orders", { method: "POST", body: payload || {} });
+    },
+
+    async getOrder(code) {
+      return requestJson(`/public/orders/${encodeURIComponent(code)}`, { cache: "no-store" });
+    },
+
     async loadCatalogItems(query) {
       return requestJson("/catalog/items", { query: { customer: 1, ...(query || {}) }, cache: "no-store" });
     },

--- a/customer-app/modules/store.js
+++ b/customer-app/modules/store.js
@@ -1734,11 +1734,13 @@
       <span class="section-kicker">รับคำสั่งซื้อแล้ว</span>
       <h2>ขอบคุณสำหรับการสั่งซื้อ 🎉</h2>
       <div class="purchase-summary">
+        ${o.orderCode ? `<div><span>เลขคำสั่งซื้อ</span><strong>${esc(o.orderCode)}</strong></div>` : ""}
         <div><span>สินค้า</span><strong>${esc(item.item_name || "")} × ${o.qty}</strong></div>
         <div><span>การรับสินค้า</span><strong>${deliveryLabel}</strong></div>
         <div><span>การติดตั้ง</span><strong>${installLabel}</strong></div>
         <div><span>ผู้สั่งซื้อ</span><strong>${esc(o.name)} · ${esc(o.phone)}</strong></div>
       </div>
+      ${o.orderCode ? `<p class="purchase-note">บันทึกเลขคำสั่งซื้อไว้เพื่อสอบถามสถานะได้ที่แอดมิน</p>` : ""}
       <p>แอดมินจะติดต่อกลับเพื่อยืนยันค่าติดตั้ง/ค่าส่ง และช่องทางชำระเงิน (ระบบชำระเงินออนไลน์กำลังจะเปิดใช้เร็ว ๆ นี้)</p>
       <div class="contact-sheet-actions">
         <a class="primary-btn" href="https://lin.ee/fG1Oq7y" target="_blank" rel="noopener noreferrer">แจ้งแอดมินทาง LINE</a>
@@ -1765,16 +1767,36 @@
     bindClose();
     mount.querySelector("[data-qty-dec]")?.addEventListener("click", () => { qty = Math.max(1, qty - 1); syncTotal(); });
     mount.querySelector("[data-qty-inc]")?.addEventListener("click", () => { qty = Math.min(99, qty + 1); syncTotal(); });
-    mount.querySelector("[data-buy-submit]")?.addEventListener("click", () => {
+    const submitBtn = mount.querySelector("[data-buy-submit]");
+    submitBtn?.addEventListener("click", async () => {
       const name = (mount.querySelector("[data-buy-name]")?.value || "").trim();
       const phone = (mount.querySelector("[data-buy-phone]")?.value || "").trim();
       const errorEl = mount.querySelector("[data-buy-error]");
       if (!name || !phone) { if (errorEl) errorEl.hidden = false; return; }
+      if (errorEl) errorEl.hidden = true;
       const delivery = mount.querySelector("input[name='cwf-delivery']:checked")?.value || "pickup";
       const install = mount.querySelector("input[name='cwf-install']:checked")?.value || "none";
+      const address = (mount.querySelector("[data-buy-address]")?.value || "").trim();
       trackItemEvent("cwf_store_purchase_request", item, { qty, delivery, install });
+      submitBtn.disabled = true;
+      submitBtn.textContent = "กำลังส่งคำสั่งซื้อ...";
+      let orderCode = "";
+      try {
+        const res = await root.api.createOrder({
+          customer_name: name,
+          customer_phone: phone,
+          delivery_method: delivery,
+          install_option: install,
+          address,
+          items: [{ item_id: item.item_id, name: item.item_name, qty, unit_price: unitPrice || 0 }],
+        });
+        orderCode = res?.order?.order_code || "";
+      } catch (_error) {
+        // Order couldn't be saved (offline / schema not ready) — still confirm
+        // with the LINE hand-off so the sale isn't lost.
+      }
       const sheet = mount.querySelector(".purchase-sheet");
-      if (sheet) sheet.innerHTML = purchaseConfirmHtml(item, { qty, delivery, install, name, phone });
+      if (sheet) sheet.innerHTML = purchaseConfirmHtml(item, { qty, delivery, install, name, phone, orderCode });
       bindClose();
     });
     requestAnimationFrame(() => mount.querySelector(".contact-sheet-close")?.focus());

--- a/customer-app/sw.js
+++ b/customer-app/sw.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const BUILD_ID = "20260702_buy_v1";
+const BUILD_ID = "20260702_orders_v1";
 const CACHE_NAME = `cwf-customer-app-v2-${BUILD_ID}`;
 const APP_SHELL = [
   `./index.html?v=${BUILD_ID}`,

--- a/index.js
+++ b/index.js
@@ -44,6 +44,7 @@ const createTechnicianDirectoryRoutes = require("./server/routes/users/technicia
 const createCatalogItemRoutes = require("./server/routes/catalog/items");
 const createCatalogReviewRoutes = require("./server/routes/catalog/reviews");
 const { createHomepageRoutes, CONFIG_KEY: HOMEPAGE_CONFIG_KEY } = require("./server/routes/homepage");
+const { createCustomerOrdersRoutes } = require("./server/routes/customerOrders");
 const articleSync = require("./server/services/articleSync");
 const createServiceZoneRoutes = require("./server/routes/serviceZones");
 const createPageRoutes = require("./server/routes/pages");
@@ -13235,6 +13236,7 @@ app.use(createCatalogItemRoutes({
 }));
 app.use(createCatalogReviewRoutes({ pool, requireCustomerJwt, requireAdminSession }));
 app.use(createHomepageRoutes({ pool, requireAdminSession, requireCustomerJwt, upload, cloudinaryUploadBuffer, cloudinaryDestroyPublicId }));
+app.use(createCustomerOrdersRoutes({ pool, requireAdminSession }));
 
 
 app.post("/catalog/items", requireAdminSession, async (req, res) => {

--- a/migrations/20260702_customer_orders.sql
+++ b/migrations/20260702_customer_orders.sql
@@ -1,0 +1,24 @@
+-- Customer product orders (buy flow — Phase 2).
+-- Stores an order placed from the customer app's purchase sheet. Payment is
+-- handled in a later phase (Omise); an order starts as 'pending_payment'.
+-- This table is self-contained and does not touch existing booking/accounting
+-- tables.
+
+CREATE TABLE IF NOT EXISTS public.customer_orders (
+  order_id        BIGSERIAL PRIMARY KEY,
+  order_code      TEXT NOT NULL UNIQUE,
+  customer_name   TEXT NOT NULL,
+  customer_phone  TEXT NOT NULL,
+  delivery_method TEXT NOT NULL DEFAULT 'pickup',   -- 'pickup' | 'ship'
+  install_option  TEXT NOT NULL DEFAULT 'none',     -- 'none' | 'cwf'
+  address         TEXT,
+  items           JSONB NOT NULL DEFAULT '[]'::jsonb,
+  subtotal        NUMERIC(12,2) NOT NULL DEFAULT 0,
+  status          TEXT NOT NULL DEFAULT 'pending_payment',
+  note            TEXT,
+  created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at      TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_customer_orders_phone ON public.customer_orders (customer_phone);
+CREATE INDEX IF NOT EXISTS idx_customer_orders_created ON public.customer_orders (created_at DESC);

--- a/server/routes/customerOrders.js
+++ b/server/routes/customerOrders.js
@@ -1,0 +1,177 @@
+"use strict";
+
+// Customer product orders (buy flow — Phase 2).
+//
+// Self-contained router: a customer places an order from the app's purchase
+// sheet (POST /public/orders), can look it up by code (GET /public/orders/:code),
+// and admins can list orders (GET /admin/orders). Payment is a later phase —
+// an order starts as "pending_payment". This module deliberately does NOT touch
+// booking, pricing, payout, or accounting logic.
+
+const express = require("express");
+
+const DELIVERY_METHODS = new Set(["pickup", "ship"]);
+const INSTALL_OPTIONS = new Set(["none", "cwf"]);
+const MAX_ITEMS = 20;
+const MAX_QTY = 99;
+
+function cleanText(value, max) {
+  return String(value == null ? "" : value).trim().slice(0, max);
+}
+
+// A short human-friendly order code, e.g. "CWF-LM= K3F9" without spaces:
+// CWF + base36(time) + 3 random chars. Uppercased, easy to read back to staff.
+function generateOrderCode() {
+  const t = Date.now().toString(36).toUpperCase();
+  let rand = "";
+  for (let i = 0; i < 3; i += 1) rand += "ABCDEFGHJKLMNPQRSTUVWXYZ23456789"[Math.floor(Math.random() * 32)];
+  return `CWF-${t}${rand}`;
+}
+
+// Validate + normalize an incoming order payload. Prices/subtotal are computed
+// server-side from the submitted line items (never trust a client total).
+function normalizeOrder(input) {
+  const errors = [];
+  const body = input && typeof input === "object" ? input : {};
+
+  const name = cleanText(body.customer_name, 120);
+  const phone = cleanText(body.customer_phone, 40);
+  if (!name) errors.push("customer_name required");
+  if (!phone) errors.push("customer_phone required");
+
+  const delivery = cleanText(body.delivery_method, 20) || "pickup";
+  if (!DELIVERY_METHODS.has(delivery)) errors.push("delivery_method invalid");
+  const install = cleanText(body.install_option, 20) || "none";
+  if (!INSTALL_OPTIONS.has(install)) errors.push("install_option invalid");
+
+  const address = cleanText(body.address, 500);
+  if (delivery === "ship" && !address) errors.push("address required for shipping");
+
+  const rawItems = Array.isArray(body.items) ? body.items : [];
+  if (!rawItems.length) errors.push("items required");
+  if (rawItems.length > MAX_ITEMS) errors.push("too many items");
+
+  let subtotal = 0;
+  const items = rawItems.slice(0, MAX_ITEMS).map((raw, index) => {
+    const item = raw && typeof raw === "object" ? raw : {};
+    const itemId = cleanText(item.item_id, 80);
+    const itemName = cleanText(item.name || item.item_name, 200);
+    const qty = Math.max(1, Math.min(MAX_QTY, Math.round(Number(item.qty) || 0)));
+    const unitPrice = Number(item.unit_price);
+    if (!itemId) errors.push(`items.${index}.item_id required`);
+    if (!itemName) errors.push(`items.${index}.name required`);
+    if (!Number.isFinite(unitPrice) || unitPrice < 0) errors.push(`items.${index}.unit_price invalid`);
+    const safePrice = Number.isFinite(unitPrice) && unitPrice >= 0 ? Math.round(unitPrice * 100) / 100 : 0;
+    subtotal += safePrice * qty;
+    return { item_id: itemId, name: itemName, qty, unit_price: safePrice };
+  });
+
+  return {
+    ok: errors.length === 0,
+    errors,
+    value: {
+      customer_name: name,
+      customer_phone: phone,
+      delivery_method: delivery,
+      install_option: install,
+      address,
+      items,
+      subtotal: Math.round(subtotal * 100) / 100,
+      note: cleanText(body.note, 500),
+    },
+  };
+}
+
+// Only fields safe to return to the customer for an order.
+function publicOrder(row) {
+  if (!row) return null;
+  return {
+    order_code: row.order_code,
+    customer_name: row.customer_name,
+    customer_phone: row.customer_phone,
+    delivery_method: row.delivery_method,
+    install_option: row.install_option,
+    address: row.address || "",
+    items: Array.isArray(row.items) ? row.items : (row.items || []),
+    subtotal: Number(row.subtotal) || 0,
+    status: row.status,
+    created_at: row.created_at,
+  };
+}
+
+function isSchemaError(error) {
+  const code = error && error.code;
+  return code === "42P01" || code === "42703"; // undefined_table / undefined_column
+}
+
+function createCustomerOrdersRoutes(deps = {}) {
+  const { pool, requireAdminSession } = deps;
+  const router = express.Router();
+  const adminGuard = typeof requireAdminSession === "function" ? requireAdminSession : (_req, _res, next) => next();
+
+  // Create an order (public — customer may be a guest).
+  router.post("/public/orders", async (req, res) => {
+    const result = normalizeOrder(req.body);
+    if (!result.ok) return res.status(400).json({ error: "VALIDATION_FAILED", details: result.errors });
+    const o = result.value;
+    // A few attempts in the unlikely event of an order_code collision.
+    for (let attempt = 0; attempt < 5; attempt += 1) {
+      const code = generateOrderCode();
+      try {
+        const inserted = await pool.query(
+          `INSERT INTO public.customer_orders
+             (order_code, customer_name, customer_phone, delivery_method, install_option, address, items, subtotal, status, note)
+           VALUES ($1,$2,$3,$4,$5,$6,$7::jsonb,$8,'pending_payment',$9)
+           RETURNING order_code, customer_name, customer_phone, delivery_method, install_option, address, items, subtotal, status, created_at`,
+          [code, o.customer_name, o.customer_phone, o.delivery_method, o.install_option, o.address || null,
+            JSON.stringify(o.items), o.subtotal, o.note || null]
+        );
+        return res.status(201).json({ ok: true, order: publicOrder(inserted.rows[0]) });
+      } catch (error) {
+        if (error && error.code === "23505") continue; // unique_violation on order_code → retry
+        if (isSchemaError(error)) return res.status(503).json({ error: "ORDERS_SCHEMA_NOT_READY" });
+        console.error("[orders/create] failed", error);
+        return res.status(500).json({ error: "สร้างคำสั่งซื้อไม่สำเร็จ" });
+      }
+    }
+    return res.status(500).json({ error: "สร้างคำสั่งซื้อไม่สำเร็จ" });
+  });
+
+  // Look up one order by its code (public — the code is the access token).
+  router.get("/public/orders/:code", async (req, res) => {
+    const code = cleanText(req.params.code, 40);
+    if (!code) return res.status(400).json({ error: "order code required" });
+    try {
+      const found = await pool.query(
+        `SELECT order_code, customer_name, customer_phone, delivery_method, install_option, address, items, subtotal, status, created_at
+           FROM public.customer_orders WHERE order_code=$1 LIMIT 1`,
+        [code]
+      );
+      if (!found.rows.length) return res.status(404).json({ error: "ไม่พบคำสั่งซื้อนี้" });
+      return res.json({ ok: true, order: publicOrder(found.rows[0]) });
+    } catch (error) {
+      if (isSchemaError(error)) return res.status(503).json({ error: "ORDERS_SCHEMA_NOT_READY" });
+      console.error("[orders/get] failed", error);
+      return res.status(500).json({ error: "โหลดคำสั่งซื้อไม่สำเร็จ" });
+    }
+  });
+
+  // Admin: list recent orders (read-only).
+  router.get("/admin/orders", adminGuard, async (_req, res) => {
+    try {
+      const rows = await pool.query(
+        `SELECT order_code, customer_name, customer_phone, delivery_method, install_option, address, items, subtotal, status, created_at
+           FROM public.customer_orders ORDER BY created_at DESC LIMIT 200`
+      );
+      return res.json({ ok: true, orders: rows.rows.map(publicOrder) });
+    } catch (error) {
+      if (isSchemaError(error)) return res.json({ ok: true, orders: [], schema_ready: false });
+      console.error("[orders/admin-list] failed", error);
+      return res.status(500).json({ error: "โหลดรายการคำสั่งซื้อไม่สำเร็จ" });
+    }
+  });
+
+  return router;
+}
+
+module.exports = { createCustomerOrdersRoutes, normalizeOrder, generateOrderCode, publicOrder };

--- a/test/customerAppRecovery.test.js
+++ b/test/customerAppRecovery.test.js
@@ -236,7 +236,7 @@ test("Customer App build id is consistent across shell and service worker", () =
   const sw = read("customer-app/sw.js");
   const app = read("customer-app/assets/customer-app.js");
   const manifest = read("customer-app/manifest.webmanifest");
-  const build = "20260702_buy_v1";
+  const build = "20260702_orders_v1";
 
   assert.match(index, new RegExp(`customer-app\\.css\\?v=${build}`));
   assert.match(index, new RegExp(`modules\\/api\\.js\\?v=${build}`));
@@ -254,7 +254,7 @@ test("Customer App build id is consistent across shell and service worker", () =
 test("store module is loaded in index.html and precached in the service worker app shell", () => {
   const index = read("customer-app/index.html");
   const sw = read("customer-app/sw.js");
-  const build = "20260702_buy_v1";
+  const build = "20260702_orders_v1";
 
   assert.match(index, new RegExp(`modules/store\\.js\\?v=${build}`));
   assert.match(sw, /`\.\/modules\/store\.js\?v=\$\{BUILD_ID\}`/);

--- a/test/customerOrders.test.js
+++ b/test/customerOrders.test.js
@@ -1,0 +1,143 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const http = require("node:http");
+const express = require("express");
+
+const { createCustomerOrdersRoutes, normalizeOrder, generateOrderCode } = require("../server/routes/customerOrders");
+
+// In-memory pool that emulates the customer_orders table for INSERT/SELECT.
+function makePool({ schemaReady = true } = {}) {
+  const rows = [];
+  return {
+    rows,
+    async query(sql, params = []) {
+      const s = String(sql).replace(/\s+/g, " ");
+      if (!schemaReady) { const e = new Error("relation does not exist"); e.code = "42P01"; throw e; }
+      if (s.includes("INSERT INTO public.customer_orders")) {
+        const row = {
+          order_code: params[0], customer_name: params[1], customer_phone: params[2],
+          delivery_method: params[3], install_option: params[4], address: params[5],
+          items: JSON.parse(params[6]), subtotal: params[7], status: "pending_payment",
+          created_at: new Date().toISOString(),
+        };
+        rows.push(row);
+        return { rows: [row] };
+      }
+      if (s.includes("WHERE order_code=$1")) {
+        const found = rows.find((r) => r.order_code === params[0]);
+        return { rows: found ? [found] : [] };
+      }
+      if (s.includes("ORDER BY created_at DESC")) return { rows: rows.slice() };
+      return { rows: [] };
+    },
+  };
+}
+
+function startServer(pool) {
+  const app = express();
+  app.use(express.json());
+  app.use(createCustomerOrdersRoutes({ pool, requireAdminSession: (_q, _s, next) => next() }));
+  const server = http.createServer(app);
+  return new Promise((resolve) => server.listen(0, "127.0.0.1", () => resolve(server)));
+}
+function baseUrl(server) { return `http://127.0.0.1:${server.address().port}`; }
+
+const validPayload = {
+  customer_name: "คุณเอ",
+  customer_phone: "0812345678",
+  delivery_method: "ship",
+  install_option: "cwf",
+  address: "123 ถนนทดสอบ",
+  items: [{ item_id: "6", name: "แอร์ Daikin 12000 BTU", qty: 2, unit_price: 14900 }],
+};
+
+test("normalizeOrder computes subtotal server-side and ignores any client-sent total", () => {
+  const r = normalizeOrder({ ...validPayload, subtotal: 1 });
+  assert.equal(r.ok, true, JSON.stringify(r.errors));
+  assert.equal(r.value.subtotal, 29800); // 14900 * 2, not the client's 1
+  assert.equal(r.value.items[0].qty, 2);
+});
+
+test("normalizeOrder requires name, phone, items, and address when shipping", () => {
+  assert.equal(normalizeOrder({ items: validPayload.items }).ok, false);
+  assert.equal(normalizeOrder({ customer_name: "x", customer_phone: "y", items: [] }).ok, false);
+  const noAddr = normalizeOrder({ ...validPayload, address: "" });
+  assert.equal(noAddr.ok, false);
+  assert.ok(noAddr.errors.some((e) => e.includes("address")));
+  // Pickup needs no address.
+  assert.equal(normalizeOrder({ ...validPayload, delivery_method: "pickup", address: "" }).ok, true);
+});
+
+test("normalizeOrder clamps quantity and rejects invalid delivery/install/price", () => {
+  const clamped = normalizeOrder({ ...validPayload, items: [{ item_id: "1", name: "x", qty: 999, unit_price: 100 }] });
+  assert.equal(clamped.value.items[0].qty, 99);
+  assert.equal(normalizeOrder({ ...validPayload, delivery_method: "teleport" }).ok, false);
+  assert.equal(normalizeOrder({ ...validPayload, install_option: "magic" }).ok, false);
+  assert.equal(normalizeOrder({ ...validPayload, items: [{ item_id: "1", name: "x", qty: 1, unit_price: -5 }] }).ok, false);
+});
+
+test("generateOrderCode produces a unique-ish CWF-prefixed code", () => {
+  const a = generateOrderCode();
+  assert.match(a, /^CWF-[0-9A-Z]+$/);
+  assert.notEqual(a, generateOrderCode());
+});
+
+test("POST /public/orders creates an order and GET returns it; admin lists it", async () => {
+  const pool = makePool();
+  const server = await startServer(pool);
+  try {
+    const url = baseUrl(server);
+    const created = await fetch(`${url}/public/orders`, {
+      method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify(validPayload),
+    });
+    assert.equal(created.status, 201);
+    const body = await created.json();
+    assert.equal(body.ok, true);
+    assert.match(body.order.order_code, /^CWF-/);
+    assert.equal(body.order.subtotal, 29800);
+    assert.equal(body.order.status, "pending_payment");
+
+    const code = body.order.order_code;
+    const got = await fetch(`${url}/public/orders/${encodeURIComponent(code)}`);
+    assert.equal(got.status, 200);
+    assert.equal((await got.json()).order.order_code, code);
+
+    const missing = await fetch(`${url}/public/orders/CWF-DOESNOTEXIST`);
+    assert.equal(missing.status, 404);
+
+    const admin = await fetch(`${url}/admin/orders`);
+    const adminBody = await admin.json();
+    assert.equal(adminBody.orders.length, 1);
+    assert.equal(adminBody.orders[0].order_code, code);
+  } finally {
+    server.close();
+  }
+});
+
+test("POST /public/orders rejects an invalid payload with 400 and details", async () => {
+  const server = await startServer(makePool());
+  try {
+    const res = await fetch(`${baseUrl(server)}/public/orders`, {
+      method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify({ items: [] }),
+    });
+    assert.equal(res.status, 400);
+    const body = await res.json();
+    assert.equal(body.error, "VALIDATION_FAILED");
+    assert.ok(Array.isArray(body.details) && body.details.length);
+  } finally {
+    server.close();
+  }
+});
+
+test("routes report 503 (not 500) before the orders table migration is applied", async () => {
+  const server = await startServer(makePool({ schemaReady: false }));
+  try {
+    const res = await fetch(`${baseUrl(server)}/public/orders`, {
+      method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify(validPayload),
+    });
+    assert.equal(res.status, 503);
+    assert.equal((await res.json()).error, "ORDERS_SCHEMA_NOT_READY");
+  } finally {
+    server.close();
+  }
+});

--- a/test/customerSameDayTiming.test.js
+++ b/test/customerSameDayTiming.test.js
@@ -160,7 +160,7 @@ test("customer app disables availability HTTP cache and refreshes same-day slots
 });
 
 test("customer app build and service worker cache IDs changed", () => {
-  const id = "20260702_buy_v1";
+  const id = "20260702_orders_v1";
   for (const file of [
     "customer-app/index.html",
     "customer-app/sw.js",

--- a/test/homepageCms.test.js
+++ b/test/homepageCms.test.js
@@ -278,7 +278,7 @@ test("customer homepage has no admin control, bottom nav is fixed five-tab, and 
   const sw = read("customer-app/sw.js");
   const app = read("customer-app/assets/customer-app.js");
   const manifest = read("customer-app/manifest.webmanifest");
-  const build = "20260702_buy_v1";
+  const build = "20260702_orders_v1";
 
   assert.doesNotMatch(index + ui, /โหมดแอดมิน|openCms|localStorage\.getItem\('cwfHomeCmsDemo'/);
   assert.match(index, /data-route="store"[\s\S]*ร้านค้า/);


### PR DESCRIPTION
## Summary

Phase 2 of the buy flow. The purchase sheet from PR 1 now creates a **real, persisted order** and shows the customer an order code.

## Changes

- **Migration** `migrations/20260702_customer_orders.sql` — a self-contained `public.customer_orders` table (order_code, contact, delivery/install, `items` jsonb, subtotal, `status = 'pending_payment'`). Does not touch booking/accounting tables.
- **New route module** `server/routes/customerOrders.js` (mounted in `index.js`):
  - `POST /public/orders` — validates the payload and **computes the subtotal server-side** (never trusts a client total), generates a unique `CWF-` order code, inserts, and returns the order.
  - `GET /public/orders/:code` — look up an order by its code.
  - `GET /admin/orders` — admin read-only list of recent orders.
  - A missing table reports **503 (schema-not-ready)** rather than 500.
- **Customer app** — the purchase sheet submits to `/public/orders`, shows the returned **เลขคำสั่งซื้อ**, and falls back to the LINE hand-off if the call fails (a sale is never lost). `api.js` gains `createOrder` / `getOrder`.

## Verification

- Full suite green (730 passing, 11 skipped). New `test/customerOrders.test.js` exercises the routes end-to-end over HTTP with an in-memory pool: create → 201, lookup by code, admin list, invalid payload → 400, and pre-migration → 503; plus `normalizeOrder` units (server-side subtotal, required fields, qty clamp, address-required-for-shipping).
- **Real end-to-end** (fresh server, Playwright): buying 2× a ฿14,900 product creates order `CWF-…`, the confirmation shows the code, and the code resolves via `GET /public/orders/:code` (subtotal ฿29,800, server-computed) and appears in `GET /admin/orders`.

## Roadmap

buy UX ✅ → **persisted orders ✅** → **PR 3: Omise online payment** (PromptPay QR / card + webhook + stock). PR 3 needs the owner's **Omise keys as env** (never hardcoded), per the spec-lock rules on payment/secrets.

## Deployment note

The `customer_orders` migration must be applied before `/public/orders` works in production; until then the routes safely return `503 ORDERS_SCHEMA_NOT_READY` and the customer still gets the LINE hand-off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LmdP3TGN5uQrfT8ZYefNco)_