### PR TITLE
chore(orders): safe idempotent migration runner for customer_orders

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "migrate:catalog-hot-sale-reviews": "node scripts/run-catalog-store-hot-sale-reviews-migration.js",
     "migrate:homepage-cms": "node scripts/run-homepage-cms-migration.js",
     "migrate:homepage-article-sync": "node scripts/run-homepage-article-sync-migration.js",
+    "migrate:customer-orders": "node scripts/run-customer-orders-migration.js",
     "test": "node --test test/*.test.js"
   },
   "dependencies": {

--- a/scripts/run-customer-orders-migration.js
+++ b/scripts/run-customer-orders-migration.js
@@ -1,0 +1,127 @@
+"use strict";
+
+// Applies migrations/20260702_customer_orders.sql (buy flow — customer_orders).
+//
+// Safe to run anytime, including repeatedly: the migration is CREATE TABLE /
+// CREATE INDEX "IF NOT EXISTS" only and never touches existing tables, so it
+// cannot affect or break the running app. An advisory lock prevents two
+// concurrent runners from racing.
+
+const fs = require("fs");
+const path = require("path");
+const { Client } = require("pg");
+
+const MIGRATION_RELATIVE_PATH = "migrations/20260702_customer_orders.sql";
+const ADVISORY_LOCK_KEY = "202607020101";
+
+function clean(value) {
+  return String(value == null ? "" : value).trim();
+}
+
+function safeErrorMessage(error) {
+  return clean(error && error.message ? error.message : error)
+    .replace(/postgres(?:ql)?:\/\/[^\s"'<>]+/gi, "[REDACTED_DATABASE_URL]")
+    .replace(/(password|passwd|pwd|secret|token)=([^&\s]+)/gi, "$1=[REDACTED]");
+}
+
+function resolveMigrationPath(repoRoot = path.resolve(__dirname, "..")) {
+  const root = path.resolve(repoRoot);
+  const migrationPath = path.resolve(root, MIGRATION_RELATIVE_PATH);
+  const expected = path.resolve(root, "migrations", "20260702_customer_orders.sql");
+  if (migrationPath !== expected || !migrationPath.startsWith(root + path.sep)) {
+    throw new Error("migration path rejected");
+  }
+  return migrationPath;
+}
+
+function readMigrationSql(repoRoot) {
+  return fs.readFileSync(resolveMigrationPath(repoRoot), "utf8");
+}
+
+function createClientConfig(env = process.env) {
+  const databaseUrl = clean(env.DATABASE_URL);
+  if (databaseUrl) {
+    return {
+      connectionString: databaseUrl,
+      options: "-c timezone=Asia/Bangkok",
+      ssl: { rejectUnauthorized: false },
+    };
+  }
+  return {
+    host: clean(env.DB_HOST),
+    port: Number(env.DB_PORT || 5432),
+    user: clean(env.DB_USER),
+    password: env.DB_PASSWORD,
+    database: clean(env.DB_NAME),
+    options: "-c timezone=Asia/Bangkok",
+    ssl: { rejectUnauthorized: false },
+  };
+}
+
+async function verifySchema(client) {
+  const tables = await client.query("SELECT to_regclass('public.customer_orders') AS orders");
+  if (!tables.rows?.[0]?.orders) throw new Error("customer_orders table missing after migration");
+  const columns = await client.query(`
+    SELECT column_name
+    FROM information_schema.columns
+    WHERE table_schema='public'
+      AND table_name='customer_orders'
+      AND column_name IN ('order_code','customer_name','customer_phone','delivery_method','install_option','items','subtotal','status')
+  `);
+  const names = new Set((columns.rows || []).map((row) => row.column_name));
+  for (const required of ["order_code", "customer_name", "customer_phone", "delivery_method", "install_option", "items", "subtotal", "status"]) {
+    if (!names.has(required)) throw new Error(`customer_orders.${required} missing after migration`);
+  }
+}
+
+async function runMigration(options = {}) {
+  const env = options.env || process.env;
+  const logger = options.logger || console;
+  const repoRoot = options.repoRoot || path.resolve(__dirname, "..");
+  const clientFactory = options.clientFactory || ((config) => new Client(config));
+  const client = clientFactory(createClientConfig(env));
+  const sql = readMigrationSql(repoRoot);
+  let locked = false;
+
+  logger.log("CUSTOMER_ORDERS_MIGRATION_START");
+  try {
+    await client.connect();
+    await client.query("SELECT pg_advisory_lock($1::bigint)", [ADVISORY_LOCK_KEY]);
+    locked = true;
+    await client.query(sql);
+    await verifySchema(client);
+    logger.log("CUSTOMER_ORDERS_MIGRATION_OK");
+  } finally {
+    if (locked) await client.query("SELECT pg_advisory_unlock($1::bigint)", [ADVISORY_LOCK_KEY]).catch(() => {});
+    await client.end();
+  }
+}
+
+async function runCli(options = {}) {
+  const logger = options.logger || console;
+  try {
+    await runMigration(options);
+    return 0;
+  } catch (error) {
+    logger.error(`CUSTOMER_ORDERS_MIGRATION_FAILED: ${safeErrorMessage(error)}`);
+    return 1;
+  }
+}
+
+if (require.main === module) {
+  runCli().then((code) => {
+    process.exitCode = code;
+  });
+}
+
+module.exports = {
+  ADVISORY_LOCK_KEY,
+  MIGRATION_RELATIVE_PATH,
+  createClientConfig,
+  readMigrationSql,
+  resolveMigrationPath,
+  runCli,
+  runMigration,
+  safeErrorMessage,
+  verifySchema,
+};

--- a/test/customerOrdersMigration.test.js
+++ b/test/customerOrdersMigration.test.js
@@ -1,0 +1,119 @@
+"use strict";
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("fs");
+const path = require("path");
+const runner = require("../scripts/run-customer-orders-migration");
+
+const REPO_ROOT = path.resolve(__dirname, "..");
+const DATABASE_URL = "postgres://user:super-secret-password@db.example.invalid:5432/cwf";
+
+const ORDER_COLUMNS = ["order_code", "customer_name", "customer_phone", "delivery_method", "install_option", "items", "subtotal", "status"];
+
+class FakeClient {
+  constructor(options = {}) {
+    this.options = options;
+    this.connected = false;
+    this.ended = false;
+    this.queries = [];
+  }
+  async connect() {
+    this.connected = true;
+    if (this.options.failConnect) throw new Error(this.options.failConnect);
+  }
+  async query(sql, params) {
+    this.queries.push({ sql, params });
+    const s = String(sql);
+    if (s.includes("to_regclass('public.customer_orders')")) {
+      return { rows: [{ orders: this.options.missingTable ? null : "public.customer_orders" }] };
+    }
+    if (s.includes("information_schema.columns")) {
+      const cols = this.options.missingColumn ? ORDER_COLUMNS.filter((c) => c !== "status") : ORDER_COLUMNS;
+      return { rows: cols.map((column_name) => ({ column_name })) };
+    }
+    return { rows: [] };
+  }
+  async end() {
+    this.ended = true;
+    if (this.options.failEnd) throw new Error(this.options.failEnd);
+  }
+}
+
+function makeLogger() {
+  const lines = [];
+  return { lines, log: (m) => lines.push(String(m)), error: (m) => lines.push(String(m)) };
+}
+
+test("customer-orders migration runner runs the exact SQL under an advisory lock, verifies, and unlocks", async () => {
+  let client;
+  const logger = makeLogger();
+  await runner.runMigration({
+    env: { DATABASE_URL },
+    repoRoot: REPO_ROOT,
+    logger,
+    clientFactory(config) {
+      assert.equal(config.connectionString, DATABASE_URL);
+      client = new FakeClient();
+      return client;
+    },
+  });
+  const migrationSql = fs.readFileSync(path.join(REPO_ROOT, runner.MIGRATION_RELATIVE_PATH), "utf8");
+  assert.equal(client.queries[0].sql, "SELECT pg_advisory_lock($1::bigint)");
+  assert.deepEqual(client.queries[0].params, [runner.ADVISORY_LOCK_KEY]);
+  assert.equal(client.queries[1].sql, migrationSql);
+  assert.equal(client.queries.at(-1).sql, "SELECT pg_advisory_unlock($1::bigint)");
+  assert.equal(client.ended, true);
+  assert.deepEqual(logger.lines, ["CUSTOMER_ORDERS_MIGRATION_START", "CUSTOMER_ORDERS_MIGRATION_OK"]);
+});
+
+test("customer-orders migration runner fails non-zero when the table is missing after migration", async () => {
+  const logger = makeLogger();
+  const code = await runner.runCli({
+    env: { DATABASE_URL }, repoRoot: REPO_ROOT, logger,
+    clientFactory() { return new FakeClient({ missingTable: true }); },
+  });
+  assert.equal(code, 1);
+  assert.match(logger.lines.join("\n"), /customer_orders table missing after migration/);
+});
+
+test("customer-orders migration runner fails non-zero when a required column is missing", async () => {
+  const logger = makeLogger();
+  const code = await runner.runCli({
+    env: { DATABASE_URL }, repoRoot: REPO_ROOT, logger,
+    clientFactory() { return new FakeClient({ missingColumn: true }); },
+  });
+  assert.equal(code, 1);
+  assert.match(logger.lines.join("\n"), /customer_orders\.status missing after migration/);
+});
+
+test("customer-orders migration runner never leaks database secrets", async () => {
+  const logger = makeLogger();
+  const code = await runner.runCli({
+    env: { DATABASE_URL }, repoRoot: REPO_ROOT, logger,
+    clientFactory() { return new FakeClient({ failConnect: `cannot connect ${DATABASE_URL}` }); },
+  });
+  assert.equal(code, 1);
+  const output = logger.lines.join("\n");
+  assert.doesNotMatch(output, /super-secret-password/);
+  assert.match(output, /\[REDACTED_DATABASE_URL\]/);
+});
+
+test("customer-orders migration is additive only and idempotent (safe to re-run, cannot break the app)", () => {
+  const sql = fs.readFileSync(path.join(REPO_ROOT, runner.MIGRATION_RELATIVE_PATH), "utf8");
+  const executable = sql.split("\n").filter((l) => !l.trim().startsWith("--")).join("\n");
+  assert.doesNotMatch(executable, /\bDELETE\s+FROM\b/i);
+  assert.doesNotMatch(executable, /\bTRUNCATE\b/i);
+  assert.doesNotMatch(executable, /\bDROP\s+TABLE\b/i);
+  assert.doesNotMatch(executable, /\bDROP\s+COLUMN\b/i);
+  assert.doesNotMatch(executable, /\bALTER\s+TABLE\b/i); // touches no existing table
+  assert.match(sql, /CREATE TABLE IF NOT EXISTS public\.customer_orders/);
+  assert.match(sql, /CREATE INDEX IF NOT EXISTS/);
+});
+
+test("customer-orders migration runner uses an advisory lock distinct from other runners", () => {
+  const homepageCms = require("../scripts/run-homepage-cms-migration");
+  const customerAuth = require("../scripts/run-customer-auth-migration");
+  assert.notEqual(runner.ADVISORY_LOCK_KEY, homepageCms.ADVISORY_LOCK_KEY);
+  assert.notEqual(runner.ADVISORY_LOCK_KEY, customerAuth.ADVISORY_LOCK_KEY);
+});


### PR DESCRIPTION
## Summary

Makes the `customer_orders` migration (from the buy-flow PR 2) **ready to apply in production** the same way as every other migration in this repo, and proves it **cannot affect or break the running app**.

## Changes

- **`scripts/run-customer-orders-migration.js`** — mirrors the existing migration runners: connects, takes a **distinct advisory lock**, runs `migrations/20260702_customer_orders.sql`, **verifies** the table + required columns exist afterward, then unlocks. Any error has DB URLs/secrets redacted.
- **`package.json`** — adds the `migrate:customer-orders` script.

Run in production with:

```
npm run migrate:customer-orders
```

## Why it's safe (no impact / can't break the app)

The migration is **`CREATE TABLE` / `CREATE INDEX … IF NOT EXISTS` only** — it adds one brand-new `customer_orders` table and its indexes and touches **no existing table** (no `ALTER` / `DROP` / `DELETE` / `TRUNCATE`). It is therefore:

- **idempotent** — safe to run repeatedly,
- **isolated** — existing bookings/catalog/accounting are untouched,
- **fail-safe before it runs** — the app already returns `503 ORDERS_SCHEMA_NOT_READY` (not 500) until the table exists, and the customer still gets the LINE hand-off.

## Verification

- Full suite green (736 passing, 11 skipped). New `test/customerOrdersMigration.test.js` asserts: the runner executes the exact SQL under an advisory lock and verifies schema; fails non-zero if the table/column is missing; never leaks DB secrets; the SQL is **additive-only + idempotent** (no `ALTER`/`DROP`/`DELETE`/`TRUNCATE`); and uses an advisory-lock key distinct from other runners.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LmdP3TGN5uQrfT8ZYefNco)_