### PR TITLE
fix(catalog): allow booking_mode 'purchase' so products can be saved

### DIFF
--- a/migrations/20260702_catalog_booking_mode_purchase.sql
+++ b/migrations/20260702_catalog_booking_mode_purchase.sql
@@ -1,0 +1,15 @@
+-- Allow booking_mode = 'purchase' on catalog_items (buy flow).
+--
+-- The original marketplace migration added a CHECK constraint limiting
+-- booking_mode to ('bookable','contact_admin'). The buy flow introduced a third
+-- mode, 'purchase', for physical products — without this the INSERT/UPDATE of a
+-- product item fails the constraint. This only WIDENS the allowed set, so every
+-- existing row (all bookable/contact_admin) stays valid; nothing is deleted or
+-- altered destructively. Idempotent: the constraint is dropped-if-exists then
+-- recreated with the full set.
+
+ALTER TABLE public.catalog_items DROP CONSTRAINT IF EXISTS catalog_items_booking_mode_check;
+
+ALTER TABLE public.catalog_items
+  ADD CONSTRAINT catalog_items_booking_mode_check
+  CHECK (booking_mode IN ('bookable', 'contact_admin', 'purchase'));

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "migrate:homepage-cms": "node scripts/run-homepage-cms-migration.js",
     "migrate:homepage-article-sync": "node scripts/run-homepage-article-sync-migration.js",
     "migrate:customer-orders": "node scripts/run-customer-orders-migration.js",
+    "migrate:catalog-booking-mode-purchase": "node scripts/run-catalog-booking-mode-purchase-migration.js",
     "test": "node --test test/*.test.js"
   },
   "dependencies": {

--- a/scripts/run-catalog-booking-mode-purchase-migration.js
+++ b/scripts/run-catalog-booking-mode-purchase-migration.js
@@ -1,0 +1,119 @@
+"use strict";
+
+// Applies migrations/20260702_catalog_booking_mode_purchase.sql, which widens
+// the catalog_items.booking_mode CHECK constraint to allow 'purchase' (buy
+// flow). Additive only — every existing row stays valid — so it cannot break
+// the running app. Advisory-locked + verified (the constraint must include
+// 'purchase' afterward).
+
+const fs = require("fs");
+const path = require("path");
+const { Client } = require("pg");
+
+const MIGRATION_RELATIVE_PATH = "migrations/20260702_catalog_booking_mode_purchase.sql";
+const ADVISORY_LOCK_KEY = "202607020202";
+
+function clean(value) {
+  return String(value == null ? "" : value).trim();
+}
+
+function safeErrorMessage(error) {
+  return clean(error && error.message ? error.message : error)
+    .replace(/postgres(?:ql)?:\/\/[^\s"'<>]+/gi, "[REDACTED_DATABASE_URL]")
+    .replace(/(password|passwd|pwd|secret|token)=([^&\s]+)/gi, "$1=[REDACTED]");
+}
+
+function resolveMigrationPath(repoRoot = path.resolve(__dirname, "..")) {
+  const root = path.resolve(repoRoot);
+  const migrationPath = path.resolve(root, MIGRATION_RELATIVE_PATH);
+  const expected = path.resolve(root, "migrations", "20260702_catalog_booking_mode_purchase.sql");
+  if (migrationPath !== expected || !migrationPath.startsWith(root + path.sep)) {
+    throw new Error("migration path rejected");
+  }
+  return migrationPath;
+}
+
+function readMigrationSql(repoRoot) {
+  return fs.readFileSync(resolveMigrationPath(repoRoot), "utf8");
+}
+
+function createClientConfig(env = process.env) {
+  const databaseUrl = clean(env.DATABASE_URL);
+  if (databaseUrl) {
+    return {
+      connectionString: databaseUrl,
+      options: "-c timezone=Asia/Bangkok",
+      ssl: { rejectUnauthorized: false },
+    };
+  }
+  return {
+    host: clean(env.DB_HOST),
+    port: Number(env.DB_PORT || 5432),
+    user: clean(env.DB_USER),
+    password: env.DB_PASSWORD,
+    database: clean(env.DB_NAME),
+    options: "-c timezone=Asia/Bangkok",
+    ssl: { rejectUnauthorized: false },
+  };
+}
+
+async function verifySchema(client) {
+  const res = await client.query(
+    "SELECT pg_get_constraintdef(oid) AS def FROM pg_constraint WHERE conname = 'catalog_items_booking_mode_check' LIMIT 1"
+  );
+  const def = res.rows?.[0]?.def || "";
+  if (!def) throw new Error("catalog_items_booking_mode_check constraint missing after migration");
+  if (!/purchase/.test(def)) throw new Error("catalog_items_booking_mode_check does not allow 'purchase' after migration");
+}
+
+async function runMigration(options = {}) {
+  const env = options.env || process.env;
+  const logger = options.logger || console;
+  const repoRoot = options.repoRoot || path.resolve(__dirname, "..");
+  const clientFactory = options.clientFactory || ((config) => new Client(config));
+  const client = clientFactory(createClientConfig(env));
+  const sql = readMigrationSql(repoRoot);
+  let locked = false;
+
+  logger.log("CATALOG_BOOKING_MODE_PURCHASE_MIGRATION_START");
+  try {
+    await client.connect();
+    await client.query("SELECT pg_advisory_lock($1::bigint)", [ADVISORY_LOCK_KEY]);
+    locked = true;
+    await client.query(sql);
+    await verifySchema(client);
+    logger.log("CATALOG_BOOKING_MODE_PURCHASE_MIGRATION_OK");
+  } finally {
+    if (locked) await client.query("SELECT pg_advisory_unlock($1::bigint)", [ADVISORY_LOCK_KEY]).catch(() => {});
+    await client.end();
+  }
+}
+
+async function runCli(options = {}) {
+  const logger = options.logger || console;
+  try {
+    await runMigration(options);
+    return 0;
+  } catch (error) {
+    logger.error(`CATALOG_BOOKING_MODE_PURCHASE_MIGRATION_FAILED: ${safeErrorMessage(error)}`);
+    return 1;
+  }
+}
+
+if (require.main === module) {
+  runCli().then((code) => {
+    process.exitCode = code;
+  });
+}
+
+module.exports = {
+  ADVISORY_LOCK_KEY,
+  MIGRATION_RELATIVE_PATH,
+  createClientConfig,
+  readMigrationSql,
+  resolveMigrationPath,
+  runCli,
+  runMigration,
+  safeErrorMessage,
+  verifySchema,
+};

--- a/test/catalogBookingModePurchaseMigration.test.js
+++ b/test/catalogBookingModePurchaseMigration.test.js
@@ -1,0 +1,100 @@
+"use strict";
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("fs");
+const path = require("path");
+const runner = require("../scripts/run-catalog-booking-mode-purchase-migration");
+
+const REPO_ROOT = path.resolve(__dirname, "..");
+const DATABASE_URL = "postgres://user:super-secret-password@db.example.invalid:5432/cwf";
+
+class FakeClient {
+  constructor(options = {}) {
+    this.options = options;
+    this.ended = false;
+    this.queries = [];
+  }
+  async connect() { if (this.options.failConnect) throw new Error(this.options.failConnect); }
+  async query(sql, params) {
+    this.queries.push({ sql, params });
+    if (String(sql).includes("pg_get_constraintdef")) {
+      if (this.options.missingConstraint) return { rows: [] };
+      const modes = this.options.withoutPurchase ? "'bookable', 'contact_admin'" : "'bookable', 'contact_admin', 'purchase'";
+      return { rows: [{ def: `CHECK ((booking_mode = ANY (ARRAY[${modes}])))` }] };
+    }
+    return { rows: [] };
+  }
+  async end() { this.ended = true; }
+}
+
+function makeLogger() {
+  const lines = [];
+  return { lines, log: (m) => lines.push(String(m)), error: (m) => lines.push(String(m)) };
+}
+
+test("booking-mode-purchase migration runs the exact SQL under an advisory lock and verifies the constraint allows 'purchase'", async () => {
+  let client;
+  const logger = makeLogger();
+  await runner.runMigration({
+    env: { DATABASE_URL }, repoRoot: REPO_ROOT, logger,
+    clientFactory() { client = new FakeClient(); return client; },
+  });
+  const sql = fs.readFileSync(path.join(REPO_ROOT, runner.MIGRATION_RELATIVE_PATH), "utf8");
+  assert.equal(client.queries[0].sql, "SELECT pg_advisory_lock($1::bigint)");
+  assert.equal(client.queries[1].sql, sql);
+  assert.equal(client.queries.at(-1).sql, "SELECT pg_advisory_unlock($1::bigint)");
+  assert.equal(client.ended, true);
+  assert.deepEqual(logger.lines, ["CATALOG_BOOKING_MODE_PURCHASE_MIGRATION_START", "CATALOG_BOOKING_MODE_PURCHASE_MIGRATION_OK"]);
+});
+
+test("booking-mode-purchase migration fails if the constraint still does not allow 'purchase'", async () => {
+  const logger = makeLogger();
+  const code = await runner.runCli({
+    env: { DATABASE_URL }, repoRoot: REPO_ROOT, logger,
+    clientFactory() { return new FakeClient({ withoutPurchase: true }); },
+  });
+  assert.equal(code, 1);
+  assert.match(logger.lines.join("\n"), /does not allow 'purchase'/);
+});
+
+test("booking-mode-purchase migration fails if the constraint is missing", async () => {
+  const logger = makeLogger();
+  const code = await runner.runCli({
+    env: { DATABASE_URL }, repoRoot: REPO_ROOT, logger,
+    clientFactory() { return new FakeClient({ missingConstraint: true }); },
+  });
+  assert.equal(code, 1);
+  assert.match(logger.lines.join("\n"), /constraint missing after migration/);
+});
+
+test("booking-mode-purchase migration only widens the constraint (no destructive statements) and is idempotent", () => {
+  const sql = fs.readFileSync(path.join(REPO_ROOT, runner.MIGRATION_RELATIVE_PATH), "utf8");
+  const executable = sql.split("\n").filter((l) => !l.trim().startsWith("--")).join("\n");
+  assert.doesNotMatch(executable, /\bDROP\s+TABLE\b/i);
+  assert.doesNotMatch(executable, /\bDROP\s+COLUMN\b/i);
+  assert.doesNotMatch(executable, /\bDELETE\s+FROM\b/i);
+  assert.doesNotMatch(executable, /\bTRUNCATE\b/i);
+  // Widens the allowed set to include all three modes.
+  assert.match(executable, /DROP CONSTRAINT IF EXISTS catalog_items_booking_mode_check/);
+  assert.match(executable, /CHECK \(booking_mode IN \('bookable', 'contact_admin', 'purchase'\)\)/);
+});
+
+test("booking-mode-purchase migration runner never leaks database secrets", async () => {
+  const logger = makeLogger();
+  const code = await runner.runCli({
+    env: { DATABASE_URL }, repoRoot: REPO_ROOT, logger,
+    clientFactory() { return new FakeClient({ failConnect: `cannot connect ${DATABASE_URL}` }); },
+  });
+  assert.equal(code, 1);
+  const out = logger.lines.join("\n");
+  assert.doesNotMatch(out, /super-secret-password/);
+  assert.match(out, /\[REDACTED_DATABASE_URL\]/);
+});
+
+test("booking-mode-purchase migration runner uses a distinct advisory lock", () => {
+  const orders = require("../scripts/run-customer-orders-migration");
+  const homepageCms = require("../scripts/run-homepage-cms-migration");
+  assert.notEqual(runner.ADVISORY_LOCK_KEY, orders.ADVISORY_LOCK_KEY);
+  assert.notEqual(runner.ADVISORY_LOCK_KEY, homepageCms.ADVISORY_LOCK_KEY);
+});


### PR DESCRIPTION
## Problem

Adding a product in the admin catalog failed with **"เพิ่มรายการไม่สำเร็จ"** (HTTP 500).

## Root cause

`catalog_items` has a DB CHECK constraint `catalog_items_booking_mode_check` that only allowed `'bookable'` and `'contact_admin'`. The buy flow added a third mode, `'purchase'`, in the app code (validation + admin UI) but **not** in this constraint — so the INSERT/UPDATE of a product violated it and the route returned 500.

## Fix

- **Migration** `migrations/20260702_catalog_booking_mode_purchase.sql` — widens the constraint to `('bookable','contact_admin','purchase')`. **Additive only**: every existing row (all bookable/contact_admin) stays valid; nothing is dropped or altered destructively; idempotent (drop-if-exists then recreate).
- **Runner** `scripts/run-catalog-booking-mode-purchase-migration.js` + npm script `migrate:catalog-booking-mode-purchase` — advisory-locked, and **verifies** the constraint actually allows `'purchase'` after running.

Run in production:

```
npm run migrate:catalog-booking-mode-purchase
```

## Verification

- Full suite green (742 passing, 11 skipped). New `test/catalogBookingModePurchaseMigration.test.js`: runner executes the SQL under an advisory lock and verifies the constraint now allows `purchase`; **fails** if the constraint is missing or still excludes `purchase`; redacts DB secrets; uses a distinct advisory lock; and the SQL contains **no destructive statements** (only widens the constraint).

## Note

This is the DB half of the buy flow's `purchase` mode — the app code (PR #129/#130) was already merged. After this migration runs, saving a product-mode catalog item succeeds. (The `*` marks on the service-classification fields — ประเภทงาน / ประเภทแอร์ / ลักษณะการล้าง / BTU — are cosmetic; none are actually required by the client or server, so a product saves with them left blank.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LmdP3TGN5uQrfT8ZYefNco)_