### PR TITLE
chore(migrations): one safe command to apply the store buy-flow migrations

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "migrate:homepage-article-sync": "node scripts/run-homepage-article-sync-migration.js",
     "migrate:customer-orders": "node scripts/run-customer-orders-migration.js",
     "migrate:catalog-booking-mode-purchase": "node scripts/run-catalog-booking-mode-purchase-migration.js",
+    "migrate:store-buy": "node scripts/run-store-buy-migrations.js",
     "test": "node --test test/*.test.js"
   },
   "dependencies": {

--- a/scripts/run-store-buy-migrations.js
+++ b/scripts/run-store-buy-migrations.js
@@ -1,0 +1,52 @@
+"use strict";
+
+// One safe command to apply every migration the store buy-flow needs, in order:
+//   1. customer_orders table
+//   2. catalog_items.booking_mode CHECK widened to allow 'purchase'
+//
+// Why this is safe to run (including on production, and repeatedly):
+//   - Each underlying migration is additive-only (CREATE ... IF NOT EXISTS /
+//     widen a CHECK constraint) — it never drops, deletes, or rewrites existing
+//     data, so it cannot break the running app.
+//   - Each step is idempotent, so re-running is a no-op.
+//   - Each step takes its own advisory lock (safe against concurrent runs) and
+//     verifies the resulting schema, failing loudly if something is off.
+//   - Steps run in order and STOP at the first failure — a later step never
+//     runs on top of a failed earlier one.
+//
+// Usage (on the server, where DATABASE_URL / DB_* env vars are set):
+//   npm run migrate:store-buy
+
+const ordersRunner = require("./run-customer-orders-migration");
+const bookingModeRunner = require("./run-catalog-booking-mode-purchase-migration");
+
+const STEPS = [
+  { name: "customer_orders table", runner: ordersRunner },
+  { name: "catalog booking_mode 'purchase'", runner: bookingModeRunner },
+];
+
+async function runAll(options = {}) {
+  const logger = options.logger || console;
+  const steps = options.steps || STEPS;
+  logger.log("STORE_BUY_MIGRATIONS_START");
+  for (const step of steps) {
+    logger.log(`--> ${step.name}`);
+    // Each runner catches its own errors and returns 0 (ok) / 1 (failed),
+    // logging its own START/OK/FAILED lines.
+    const code = await step.runner.runCli(options);
+    if (code !== 0) {
+      logger.error(`STORE_BUY_MIGRATIONS_ABORTED at: ${step.name}`);
+      return code;
+    }
+  }
+  logger.log("STORE_BUY_MIGRATIONS_OK");
+  return 0;
+}
+
+if (require.main === module) {
+  runAll().then((code) => {
+    process.exitCode = code;
+  });
+}
+
+module.exports = { runAll, STEPS };

--- a/test/storeBuyMigrations.test.js
+++ b/test/storeBuyMigrations.test.js
@@ -1,0 +1,55 @@
+"use strict";
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const orchestrator = require("../scripts/run-store-buy-migrations");
+const ordersRunner = require("../scripts/run-customer-orders-migration");
+const bookingModeRunner = require("../scripts/run-catalog-booking-mode-purchase-migration");
+
+function makeLogger() {
+  const lines = [];
+  return { lines, log: (m) => lines.push(String(m)), error: (m) => lines.push(String(m)) };
+}
+
+test("STEPS wires the two buy-flow migration runners in the correct order", () => {
+  assert.equal(orchestrator.STEPS.length, 2);
+  assert.equal(orchestrator.STEPS[0].runner, ordersRunner);
+  assert.equal(orchestrator.STEPS[1].runner, bookingModeRunner);
+});
+
+test("runAll runs every step in order and returns 0 when all succeed", async () => {
+  const calls = [];
+  const logger = makeLogger();
+  const steps = [
+    { name: "one", runner: { async runCli() { calls.push("one"); return 0; } } },
+    { name: "two", runner: { async runCli() { calls.push("two"); return 0; } } },
+  ];
+  const code = await orchestrator.runAll({ logger, steps });
+  assert.equal(code, 0);
+  assert.deepEqual(calls, ["one", "two"]);
+  assert.equal(logger.lines[0], "STORE_BUY_MIGRATIONS_START");
+  assert.equal(logger.lines.at(-1), "STORE_BUY_MIGRATIONS_OK");
+});
+
+test("runAll stops at the first failing step and never runs later steps", async () => {
+  const calls = [];
+  const logger = makeLogger();
+  const steps = [
+    { name: "one", runner: { async runCli() { calls.push("one"); return 1; } } },
+    { name: "two", runner: { async runCli() { calls.push("two"); return 0; } } },
+  ];
+  const code = await orchestrator.runAll({ logger, steps });
+  assert.equal(code, 1);
+  assert.deepEqual(calls, ["one"]); // second step never ran
+  assert.match(logger.lines.join("\n"), /STORE_BUY_MIGRATIONS_ABORTED at: one/);
+  assert.doesNotMatch(logger.lines.join("\n"), /STORE_BUY_MIGRATIONS_OK/);
+});
+
+test("runAll forwards options (env / clientFactory) to each underlying runner", async () => {
+  const seen = [];
+  const steps = [
+    { name: "s", runner: { async runCli(opts) { seen.push(opts.marker); return 0; } } },
+  ];
+  await orchestrator.runAll({ logger: makeLogger(), steps, marker: "abc" });
+  assert.deepEqual(seen, ["abc"]);
+});


### PR DESCRIPTION
## Summary

A single, safe command to apply the two migrations the store buy-flow needs — so it's one step, not two, and hard to get wrong.

```
npm run migrate:store-buy
```

It runs, in order:
1. `customer_orders` table
2. `catalog_items.booking_mode` CHECK widened to allow `'purchase'`

## Why it's safe (production, repeatable)

- Each underlying migration is **additive-only** — it never drops, deletes, or rewrites existing data — so it **cannot break the running app**.
- Each step is **idempotent**, so re-running the command is a no-op.
- Each step takes its own **advisory lock** and **verifies** the resulting schema, failing loudly if anything is off.
- Steps run **in order and STOP at the first failure** — a later step never runs on top of a failed earlier one.
- **Exits non-zero on failure** so a deploy/CI pipeline can detect it.

## How to run it safely (runbook)

1. (Recommended) take a routine DB backup / snapshot first — standard practice, though these migrations are additive-only.
2. On the server (where `DATABASE_URL` or `DB_*` env vars are set):
   ```
   npm run migrate:store-buy
   ```
3. Success looks like `STORE_BUY_MIGRATIONS_OK`. On failure it prints `STORE_BUY_MIGRATIONS_ABORTED at: <step>` and exits non-zero — fix and re-run (safe to repeat).

Individual steps are still available (`npm run migrate:customer-orders`, `npm run migrate:catalog-booking-mode-purchase`) if you prefer to run them one at a time.

## Verification

- Full suite green (746 passing, 11 skipped). New `test/storeBuyMigrations.test.js` covers ordered execution, **stop-on-first-failure** (later steps never run), option forwarding, and that the real two runners are wired in order.
- Ran the CLI with no DB configured: it starts, fails safely at step 1, **aborts before step 2**, and exits non-zero — no crash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LmdP3TGN5uQrfT8ZYefNco)_