### PR TITLE
fix(store): auto-apply buy-flow migrations on boot (fixes เพิ่มสินค้าไม่ได้)

### DIFF
--- a/index.js
+++ b/index.js
@@ -26403,6 +26403,26 @@ const HOST = "0.0.0.0";
 const CERT_KEY_PATH = process.env.HTTPS_KEY_PATH || "./cert/192.168.1.105+2-key.pem";
 const CERT_CRT_PATH = process.env.HTTPS_CERT_PATH || "./cert/192.168.1.105+2.pem";
 
+// Auto-apply the additive store buy-flow migrations on boot so no manual CLI
+// step is needed — deploying/restarting the app is enough. Each migration is
+// idempotent, advisory-locked, additive-only (no drop/delete/rewrite of
+// existing data) and self-verified; any failure is logged and never blocks
+// serving (the affected routes already return 503 until the schema exists) and
+// is retried on the next boot.
+function ensureStoreBuyMigrationsApplied() {
+  try {
+    const { runAll } = require("./scripts/run-store-buy-migrations");
+    Promise.resolve(runAll())
+      .then((code) => {
+        if (code === 0) console.log("✅ store buy-flow migrations ensured");
+        else console.error("⚠️ store buy-flow migrations not fully applied (will retry next boot)");
+      })
+      .catch((e) => console.error("⚠️ store buy-flow migration error:", e && e.message));
+  } catch (e) {
+    console.error("⚠️ store buy-flow migration bootstrap skipped:", e && e.message);
+  }
+}
+
 function startServer() {
   try {
     if (fs.existsSync(CERT_KEY_PATH) && fs.existsSync(CERT_CRT_PATH)) {
@@ -26416,6 +26436,7 @@ function startServer() {
         console.log(`🔒 Local: https://localhost:${PORT}`);
         startUrgentFinalizerRunner();
         startArticleSyncRunner();
+        ensureStoreBuyMigrationsApplied();
       });
       return;
     }
@@ -26427,6 +26448,7 @@ function startServer() {
     console.log(`🌐 HTTP CWF Server running at http://localhost:${PORT}`);
     startUrgentFinalizerRunner();
     startArticleSyncRunner();
+    ensureStoreBuyMigrationsApplied();
   });
 }
 


### PR DESCRIPTION
## Problem

Adding a product still failed with **"เพิ่มรายการไม่สำเร็จ"** — because **merging the code does not run the DB migration**. On the production database the `catalog_items.booking_mode` CHECK constraint still excluded `'purchase'`, so the INSERT kept failing. The owner also can't easily run the `npm run migrate:*` CLI on the host.

## Fix

Run the (already safe) buy-flow migrations **automatically on server boot**, so a normal deploy/restart is all that's needed — no CLI step.

- `index.js` gains `ensureStoreBuyMigrationsApplied()`, called right after the server starts listening (the same place the existing urgent-finalizer and article-sync boot runners start). It runs the store-buy orchestrator (create `customer_orders` + widen `booking_mode` to allow `'purchase'`).

### Why it's safe
- The migrations are **additive-only** (create-if-not-exists / widen a CHECK), **idempotent**, **advisory-locked**, and **self-verifying** — they can't drop, delete, or rewrite existing data, so they can't break the app.
- The call is **fire-and-forget and fully guarded**: any failure is logged and **never blocks serving** (affected routes already return `503` until the schema exists) and is **retried on the next boot**.

## Result

After this deploys and the app restarts, the constraint is widened automatically and **product items save successfully** — no manual migration needed. (The `npm run migrate:store-buy` command still exists for anyone who prefers to run it by hand.)

## Verification

- Full suite green (746 passing, 11 skipped); `node --check index.js` passes. No test imports `index.js`, so the boot hook doesn't affect the test run.
- The boot hook reuses the orchestrator already verified in PRs #131–#133 (idempotent, stop-on-failure, exits/logs cleanly, safe with no DB).

## Note

This change itself must be deployed once for the auto-migration to take effect; after that restart, adding products works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LmdP3TGN5uQrfT8ZYefNco)_