### PR TITLE
Store buy flow: fix item_category save + add Omise online payment (PromptPay + card)

### DIFF
--- a/admin-store-catalog.html
+++ b/admin-store-catalog.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
   <title>Admin • รายการบริการในร้านค้า</title>
   <link rel="stylesheet" href="/style.css"/>
-  <link rel="stylesheet" href="/admin-store-catalog.css?v=20260702_buy_v1"/>
+  <link rel="stylesheet" href="/admin-store-catalog.css?v=20260702_cat_v2"/>
 </head>
 <body>
   <div class="topbar">
@@ -76,6 +76,6 @@
   </div>
 
   <script src="/admin-v2-common.js?v=20260622_admin_menu_catalog_entry"></script>
-  <script src="/admin-store-catalog.js?v=20260702_buy_v1"></script>
+  <script src="/admin-store-catalog.js?v=20260702_cat_v2"></script>
 </body>
 </html>

--- a/admin-store-catalog.js
+++ b/admin-store-catalog.js
@@ -68,7 +68,12 @@ function ensureCatalogModal() {
           <div class="asc-section-title">1) ข้อมูลหลัก</div>
           <div class="asc-field"><label>ชื่อรายการ *</label><input id="cm_item_name" placeholder="เช่น ล้างแอร์ผนัง"></div>
           <div class="asc-grid2">
-            <div class="asc-field"><label>หมวดหมู่ *</label><input id="cm_item_category" placeholder="เช่น ล้างแอร์"></div>
+            <div class="asc-field"><label>ประเภท *</label>
+              <select id="cm_item_category">
+                <option value="service">บริการ</option>
+                <option value="product">สินค้า</option>
+              </select>
+            </div>
             <div class="asc-field"><label>หน่วย *</label><input id="cm_unit_label" placeholder="เช่น เครื่อง, งาน"></div>
           </div>
         </div>
@@ -296,7 +301,7 @@ function onCatalogImageDeleteClick() {
 
 function resetCatalogModalFields() {
   el("cm_item_name").value = "";
-  el("cm_item_category").value = "";
+  el("cm_item_category").value = "service";
   el("cm_unit_label").value = "";
   el("cm_job_category").value = "";
   el("cm_ac_type").value = "";

--- a/customer-app/assets/customer-app.css
+++ b/customer-app/assets/customer-app.css
@@ -3547,6 +3547,25 @@ textarea.purchase-input { min-height: 66px; resize: vertical; }
 .purchase-summary strong { color: var(--ink); text-align: right; }
 .store-badge-buy { background: #fff3d6; color: #92600a; }
 
+/* ---- Online payment step (Omise: PromptPay + card) ---- */
+.pay-methods { display: flex; gap: 8px; margin: 14px 0 12px; }
+.pay-method-btn {
+  flex: 1; padding: 10px 8px; border-radius: 12px;
+  border: 2px solid var(--line); background: #fff; color: var(--muted);
+  font-size: 13px; font-weight: 800; cursor: pointer; transition: all .15s;
+}
+.pay-method-btn.is-active { border-color: var(--blue); color: var(--blue); background: var(--soft-blue); }
+.pay-body { min-height: 56px; }
+.pay-card-form { display: grid; gap: 8px; margin-bottom: 10px; }
+.pay-card-row { display: grid; grid-template-columns: 1fr 1fr; gap: 8px; }
+.pay-qr { text-align: center; padding: 8px 0; }
+.pay-qr-img {
+  width: 220px; max-width: 100%; height: auto; margin: 0 auto 8px;
+  border-radius: 12px; border: 2px solid var(--line); background: #fff;
+}
+.pay-qr-hint { font-size: 13px; font-weight: 700; color: var(--ink); margin: 4px 0; }
+.pay-qr-wait { font-size: 12.5px; color: var(--muted); }
+
 .commerce-category-card.is-contact-only small {
   color: var(--warning);
   background: var(--soft-yellow);

--- a/customer-app/assets/customer-app.js
+++ b/customer-app/assets/customer-app.js
@@ -3,7 +3,7 @@
 
   const App = window.CWFCustomerAppV2;
   const BOOT_TIMEOUT_MS = 3500;
-  const BUILD_ID = "20260702_orders_v1";
+  const BUILD_ID = "20260702_pay_v1";
 
   function withTimeout(promise, timeoutMs) {
     return Promise.race([

--- a/customer-app/index.html
+++ b/customer-app/index.html
@@ -17,10 +17,10 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Noto+Sans+Thai:wght@400;500;600;700;800;900&display=swap" media="print" onload="this.media='all'">
   <noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Noto+Sans+Thai:wght@400;500;600;700;800;900&display=swap"></noscript>
-  <link rel="manifest" href="./manifest.webmanifest?v=20260702_orders_v1">
+  <link rel="manifest" href="./manifest.webmanifest?v=20260702_pay_v1">
   <link rel="icon" type="image/png" sizes="192x192" href="./assets/icons/cwf-customer-192.png">
   <link rel="apple-touch-icon" sizes="180x180" href="./assets/icons/cwf-customer-180.png">
-  <link rel="stylesheet" href="./assets/customer-app.css?v=20260702_orders_v1">
+  <link rel="stylesheet" href="./assets/customer-app.css?v=20260702_pay_v1">
 </head>
 <body class="is-app-booting">
   <div class="app-shell" data-app-shell>
@@ -58,21 +58,21 @@
     </nav>
   </div>
 
-  <script src="./modules/state.js?v=20260702_orders_v1"></script>
-  <script src="./modules/utils.js?v=20260702_orders_v1"></script>
-  <script src="./modules/analytics.js?v=20260702_orders_v1"></script>
-  <script src="./modules/api.js?v=20260702_orders_v1"></script>
-  <script src="./modules/services.js?v=20260702_orders_v1"></script>
-  <script src="./modules/ui.js?v=20260702_orders_v1"></script>
-  <script src="./modules/store.js?v=20260702_orders_v1"></script>
-  <script src="./modules/auth.js?v=20260702_orders_v1"></script>
-  <script src="./modules/pricing.js?v=20260702_orders_v1"></script>
-  <script src="./modules/availability.js?v=20260702_orders_v1"></script>
-  <script src="./modules/bookingScheduled.js?v=20260702_orders_v1"></script>
-  <script src="./modules/bookingUrgent.js?v=20260702_orders_v1"></script>
-  <script src="./modules/tracking.js?v=20260702_orders_v1"></script>
-  <script src="./modules/profile.js?v=20260702_orders_v1"></script>
-  <script src="./modules/router.js?v=20260702_orders_v1"></script>
-  <script src="./assets/customer-app.js?v=20260702_orders_v1"></script>
+  <script src="./modules/state.js?v=20260702_pay_v1"></script>
+  <script src="./modules/utils.js?v=20260702_pay_v1"></script>
+  <script src="./modules/analytics.js?v=20260702_pay_v1"></script>
+  <script src="./modules/api.js?v=20260702_pay_v1"></script>
+  <script src="./modules/services.js?v=20260702_pay_v1"></script>
+  <script src="./modules/ui.js?v=20260702_pay_v1"></script>
+  <script src="./modules/store.js?v=20260702_pay_v1"></script>
+  <script src="./modules/auth.js?v=20260702_pay_v1"></script>
+  <script src="./modules/pricing.js?v=20260702_pay_v1"></script>
+  <script src="./modules/availability.js?v=20260702_pay_v1"></script>
+  <script src="./modules/bookingScheduled.js?v=20260702_pay_v1"></script>
+  <script src="./modules/bookingUrgent.js?v=20260702_pay_v1"></script>
+  <script src="./modules/tracking.js?v=20260702_pay_v1"></script>
+  <script src="./modules/profile.js?v=20260702_pay_v1"></script>
+  <script src="./modules/router.js?v=20260702_pay_v1"></script>
+  <script src="./assets/customer-app.js?v=20260702_pay_v1"></script>
 </body>
 </html>

--- a/customer-app/manifest.webmanifest
+++ b/customer-app/manifest.webmanifest
@@ -2,7 +2,7 @@
   "name": "CWF Customer Service",
   "short_name": "CWF Service",
   "description": "แอปลูกค้า Coldwindflow สำหรับเลือกบริการ จองคิว และติดตามงาน",
-  "start_url": "/customer-app/index.html?v=20260702_orders_v1#home",
+  "start_url": "/customer-app/index.html?v=20260702_pay_v1#home",
   "scope": "/customer-app/",
   "id": "/customer-app/",
   "display": "standalone",

--- a/customer-app/modules/api.js
+++ b/customer-app/modules/api.js
@@ -122,6 +122,14 @@
       return requestJson(`/public/orders/${encodeURIComponent(code)}`, { cache: "no-store" });
     },
 
+    async getPaymentConfig() {
+      return requestJson("/public/payment-config", { cache: "no-store" });
+    },
+
+    async payOrder(code, payload) {
+      return requestJson(`/public/orders/${encodeURIComponent(code)}/pay`, { method: "POST", body: payload || {} });
+    },
+
     async loadCatalogItems(query) {
       return requestJson("/catalog/items", { query: { customer: 1, ...(query || {}) }, cache: "no-store" });
     },

--- a/customer-app/modules/store.js
+++ b/customer-app/modules/store.js
@@ -1720,9 +1720,88 @@
         </div>
         <p class="purchase-error" data-buy-error hidden>กรุณากรอกชื่อและเบอร์โทร</p>
         <div class="purchase-total"><span>ยอดสินค้า</span><strong data-buy-total>${esc(priceStr)}</strong></div>
-        <p class="purchase-note">* ค่าติดตั้ง/ค่าจัดส่ง แอดมินจะยืนยันอีกครั้ง · ระบบชำระเงินออนไลน์กำลังจะเปิดเร็ว ๆ นี้</p>
-        <button class="primary-btn" type="button" data-buy-submit>ยืนยันสั่งซื้อ</button>
+        <p class="purchase-note">* ค่าติดตั้ง/ค่าจัดส่ง แอดมินจะยืนยันอีกครั้งหลังชำระค่าสินค้า</p>
+        <button class="primary-btn" type="button" data-buy-submit>ไปหน้าชำระเงิน</button>
       </section>
+    `;
+  }
+
+  // ---- Online payment (Omise: PromptPay + card) ----------------------------
+
+  let paymentConfigCache = null;
+  async function loadPaymentConfig() {
+    if (paymentConfigCache) return paymentConfigCache;
+    paymentConfigCache = await root.api.getPaymentConfig();
+    return paymentConfigCache;
+  }
+
+  // Load Omise.js once, on demand (only when the customer picks the card tab).
+  // The script is fetched from Omise's CDN by the browser, not our server.
+  let omiseJsPromise = null;
+  function ensureOmiseJs(publicKey) {
+    if (window.Omise) { window.Omise.setPublicKey(publicKey); return Promise.resolve(window.Omise); }
+    if (!omiseJsPromise) {
+      omiseJsPromise = new Promise((resolve, reject) => {
+        const s = document.createElement("script");
+        s.src = "https://cdn.omise.co/omise.js";
+        s.async = true;
+        s.onload = () => { if (window.Omise) resolve(window.Omise); else reject(new Error("omise.js unavailable")); };
+        s.onerror = () => reject(new Error("omise.js failed to load"));
+        document.head.appendChild(s);
+      });
+    }
+    return omiseJsPromise.then((Omise) => { Omise.setPublicKey(publicKey); return Omise; });
+  }
+
+  function paymentStepHtml(item, o) {
+    const totalStr = root.utils.formatBaht(o.amount);
+    return `
+      <button class="contact-sheet-close" type="button" data-purchase-close aria-label="ปิด">×</button>
+      <span class="section-kicker">ชำระเงิน</span>
+      <h2>ชำระค่าสินค้า</h2>
+      <div class="purchase-total"><span>ยอดชำระ</span><strong>${esc(totalStr)}</strong></div>
+      <div class="pay-methods" role="tablist">
+        <button class="pay-method-btn is-active" type="button" data-pay-method="promptpay" role="tab">พร้อมเพย์ (PromptPay)</button>
+        <button class="pay-method-btn" type="button" data-pay-method="card" role="tab">บัตรเครดิต/เดบิต</button>
+      </div>
+      <div class="pay-body" data-pay-body></div>
+      <p class="purchase-error" data-pay-error hidden></p>
+      <p class="purchase-note">ชำระเงินอย่างปลอดภัยผ่าน Omise · ข้อมูลบัตรไม่ถูกเก็บบนเซิร์ฟเวอร์ของเรา</p>
+    `;
+  }
+
+  function promptPayBodyHtml() {
+    return `<button class="primary-btn" type="button" data-pp-start>สร้าง QR พร้อมเพย์</button>`;
+  }
+
+  function cardBodyHtml() {
+    return `
+      <div class="pay-card-form">
+        <input class="purchase-input" data-card-number inputmode="numeric" autocomplete="cc-number" placeholder="หมายเลขบัตร">
+        <div class="pay-card-row">
+          <input class="purchase-input" data-card-exp inputmode="numeric" autocomplete="cc-exp" placeholder="เดือน/ปี (MM/YY)">
+          <input class="purchase-input" data-card-cvc inputmode="numeric" autocomplete="cc-csc" placeholder="CVC">
+        </div>
+        <input class="purchase-input" data-card-name autocomplete="cc-name" placeholder="ชื่อบนบัตร">
+      </div>
+      <button class="primary-btn" type="button" data-card-pay>ชำระด้วยบัตร</button>
+    `;
+  }
+
+  function paidConfirmHtml(item, o) {
+    return `
+      <button class="contact-sheet-close" type="button" data-purchase-close aria-label="ปิด">×</button>
+      <span class="section-kicker">ชำระเงินสำเร็จ</span>
+      <h2>ชำระเงินสำเร็จ 🎉</h2>
+      <div class="purchase-summary">
+        ${o.orderCode ? `<div><span>เลขคำสั่งซื้อ</span><strong>${esc(o.orderCode)}</strong></div>` : ""}
+        <div><span>สินค้า</span><strong>${esc(item.item_name || "")} × ${o.qty}</strong></div>
+        <div><span>ยอดชำระ</span><strong>${esc(root.utils.formatBaht(o.amount))}</strong></div>
+      </div>
+      <p>แอดมินจะติดต่อกลับเพื่อยืนยันการจัดส่ง/ติดตั้ง และค่าใช้จ่ายเพิ่มเติม (ถ้ามี)</p>
+      <div class="contact-sheet-actions">
+        <a class="primary-btn" href="https://lin.ee/fG1Oq7y" target="_blank" rel="noopener noreferrer">แจ้งแอดมินทาง LINE</a>
+      </div>
     `;
   }
 
@@ -1741,7 +1820,7 @@
         <div><span>ผู้สั่งซื้อ</span><strong>${esc(o.name)} · ${esc(o.phone)}</strong></div>
       </div>
       ${o.orderCode ? `<p class="purchase-note">บันทึกเลขคำสั่งซื้อไว้เพื่อสอบถามสถานะได้ที่แอดมิน</p>` : ""}
-      <p>แอดมินจะติดต่อกลับเพื่อยืนยันค่าติดตั้ง/ค่าส่ง และช่องทางชำระเงิน (ระบบชำระเงินออนไลน์กำลังจะเปิดใช้เร็ว ๆ นี้)</p>
+      <p>แอดมินจะติดต่อกลับเพื่อยืนยันค่าติดตั้ง/ค่าส่ง และแจ้งช่องทางชำระเงิน</p>
       <div class="contact-sheet-actions">
         <a class="primary-btn" href="https://lin.ee/fG1Oq7y" target="_blank" rel="noopener noreferrer">แจ้งแอดมินทาง LINE</a>
       </div>
@@ -1756,8 +1835,119 @@
     trackItemEvent("cwf_store_purchase_open", item, { source: "store" });
     const unitPrice = effectiveSalePrice(item);
     let qty = 1;
-    const close = () => { mount.innerHTML = ""; document.body.classList.remove("has-contact-sheet"); };
+    let pollTimer = null;
+    const close = () => {
+      if (pollTimer) { clearInterval(pollTimer); pollTimer = null; }
+      mount.innerHTML = "";
+      document.body.classList.remove("has-contact-sheet");
+    };
     const bindClose = () => mount.querySelectorAll("[data-purchase-close]").forEach((b) => b.addEventListener("click", close, { once: true }));
+
+    // Poll an order until its payment resolves (PromptPay confirms via webhook,
+    // so the QR screen watches the server). Stops on paid/failed or timeout.
+    const startPolling = (code, onResolved) => {
+      let attempts = 0;
+      if (pollTimer) clearInterval(pollTimer);
+      pollTimer = setInterval(async () => {
+        attempts += 1;
+        if (attempts > 60) { clearInterval(pollTimer); pollTimer = null; return; } // ~3 min
+        let status = "";
+        try { const r = await root.api.getOrder(code); status = r?.order?.status || ""; } catch (_) { return; }
+        if (status === "paid" || status === "payment_failed") {
+          clearInterval(pollTimer); pollTimer = null; onResolved(status);
+        }
+      }, 3000);
+    };
+
+    // The payment step: choose PromptPay (QR + poll) or card (Omise.js token).
+    const renderPaymentStep = (o, config) => {
+      const sheet = mount.querySelector(".purchase-sheet");
+      if (!sheet) return;
+      sheet.innerHTML = paymentStepHtml(item, o);
+      bindClose();
+      const body = sheet.querySelector("[data-pay-body]");
+      const errEl = sheet.querySelector("[data-pay-error]");
+      const showError = (msg) => { if (errEl) { errEl.textContent = msg; errEl.hidden = false; } };
+      const clearError = () => { if (errEl) errEl.hidden = true; };
+      const goPaid = () => {
+        if (pollTimer) { clearInterval(pollTimer); pollTimer = null; }
+        sheet.innerHTML = paidConfirmHtml(item, o);
+        bindClose();
+        trackItemEvent("cwf_store_purchase_paid", item, { method: o.lastMethod, amount: o.amount });
+      };
+
+      const renderMethod = (method) => {
+        clearError();
+        o.lastMethod = method;
+        sheet.querySelectorAll("[data-pay-method]").forEach((b) => b.classList.toggle("is-active", b.getAttribute("data-pay-method") === method));
+        if (!body) return;
+        body.innerHTML = method === "card" ? cardBodyHtml() : promptPayBodyHtml();
+        if (method === "promptpay") {
+          body.querySelector("[data-pp-start]")?.addEventListener("click", async () => {
+            clearError();
+            const btn = body.querySelector("[data-pp-start]");
+            if (btn) { btn.disabled = true; btn.textContent = "กำลังสร้าง QR..."; }
+            try {
+              const res = await root.api.payOrder(o.order.order_code, { method: "promptpay" });
+              const qr = res?.payment?.qr_uri;
+              if (!qr) throw new Error("no qr");
+              body.innerHTML = `
+                <div class="pay-qr">
+                  <img class="pay-qr-img" src="${esc(qr)}" alt="PromptPay QR" width="220" height="220">
+                  <p class="pay-qr-hint">สแกน QR นี้ด้วยแอปธนาคารเพื่อชำระ ${esc(root.utils.formatBaht(o.amount))}</p>
+                  <p class="pay-qr-wait" data-pp-wait>กำลังรอการชำระเงิน...</p>
+                </div>`;
+              startPolling(o.order.order_code, (status) => {
+                if (status === "paid") goPaid();
+                else { const w = body.querySelector("[data-pp-wait]"); if (w) w.textContent = "การชำระเงินไม่สำเร็จ กรุณาลองใหม่"; }
+              });
+            } catch (_) {
+              showError("สร้าง QR ไม่สำเร็จ กรุณาลองใหม่");
+              if (btn) { btn.disabled = false; btn.textContent = "สร้าง QR พร้อมเพย์"; }
+            }
+          });
+        } else {
+          body.querySelector("[data-card-pay]")?.addEventListener("click", async () => {
+            clearError();
+            const number = (body.querySelector("[data-card-number]")?.value || "").replace(/\s+/g, "");
+            const exp = (body.querySelector("[data-card-exp]")?.value || "").trim();
+            const cvc = (body.querySelector("[data-card-cvc]")?.value || "").trim();
+            const holder = (body.querySelector("[data-card-name]")?.value || "").trim();
+            const m = exp.match(/^(\d{1,2})\s*\/\s*(\d{2,4})$/);
+            if (!number || !m || !cvc) { showError("กรุณากรอกข้อมูลบัตรให้ครบถ้วน"); return; }
+            const btn = body.querySelector("[data-card-pay]");
+            if (btn) { btn.disabled = true; btn.textContent = "กำลังชำระเงิน..."; }
+            const reset = () => { if (btn) { btn.disabled = false; btn.textContent = "ชำระด้วยบัตร"; } };
+            try {
+              const Omise = await ensureOmiseJs(config.public_key);
+              const token = await new Promise((resolve, reject) => {
+                Omise.createToken("card", {
+                  name: holder || o.name,
+                  number,
+                  expiration_month: m[1],
+                  expiration_year: m[2].length === 2 ? `20${m[2]}` : m[2],
+                  security_code: cvc,
+                }, (statusCode, response) => {
+                  if (statusCode === 200 && response && response.id) resolve(response.id);
+                  else reject(new Error((response && response.message) || "tokenize failed"));
+                });
+              });
+              const res = await root.api.payOrder(o.order.order_code, { method: "card", token });
+              if (res?.order?.status === "paid") goPaid();
+              else { showError("การชำระเงินไม่สำเร็จ กรุณาตรวจสอบบัตรแล้วลองใหม่"); reset(); }
+            } catch (err) {
+              showError(err && err.message ? "ชำระเงินไม่สำเร็จ: " + err.message : "ชำระเงินไม่สำเร็จ กรุณาลองใหม่");
+              reset();
+            }
+          });
+        }
+      };
+
+      sheet.querySelectorAll("[data-pay-method]").forEach((b) =>
+        b.addEventListener("click", () => renderMethod(b.getAttribute("data-pay-method")))
+      );
+      renderMethod("promptpay");
+    };
     const qtyVal = mount.querySelector("[data-qty-val]");
     const totalEl = mount.querySelector("[data-buy-total]");
     const syncTotal = () => {
@@ -1779,8 +1969,8 @@
       const address = (mount.querySelector("[data-buy-address]")?.value || "").trim();
       trackItemEvent("cwf_store_purchase_request", item, { qty, delivery, install });
       submitBtn.disabled = true;
-      submitBtn.textContent = "กำลังส่งคำสั่งซื้อ...";
-      let orderCode = "";
+      submitBtn.textContent = "กำลังสร้างคำสั่งซื้อ...";
+      let order = null;
       try {
         const res = await root.api.createOrder({
           customer_name: name,
@@ -1790,13 +1980,24 @@
           address,
           items: [{ item_id: item.item_id, name: item.item_name, qty, unit_price: unitPrice || 0 }],
         });
-        orderCode = res?.order?.order_code || "";
+        order = res?.order || null;
       } catch (_error) {
-        // Order couldn't be saved (offline / schema not ready) — still confirm
-        // with the LINE hand-off so the sale isn't lost.
+        // Order couldn't be saved (offline / schema not ready) — fall through to
+        // the LINE hand-off below so the sale isn't lost.
       }
       const sheet = mount.querySelector(".purchase-sheet");
-      if (sheet) sheet.innerHTML = purchaseConfirmHtml(item, { qty, delivery, install, name, phone, orderCode });
+      const amount = Number(order?.subtotal) || (unitPrice || 0) * qty;
+      // Try online payment; gracefully fall back to the LINE hand-off when the
+      // order didn't save or payment isn't configured on the server.
+      let config = null;
+      if (order && order.order_code) {
+        try { config = await loadPaymentConfig(); } catch (_) { config = null; }
+      }
+      if (order && order.order_code && config && config.enabled) {
+        renderPaymentStep({ order, qty, delivery, install, name, phone, amount }, config);
+        return;
+      }
+      if (sheet) sheet.innerHTML = purchaseConfirmHtml(item, { qty, delivery, install, name, phone, orderCode: order?.order_code || "" });
       bindClose();
     });
     requestAnimationFrame(() => mount.querySelector(".contact-sheet-close")?.focus());

--- a/customer-app/sw.js
+++ b/customer-app/sw.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const BUILD_ID = "20260702_orders_v1";
+const BUILD_ID = "20260702_pay_v1";
 const CACHE_NAME = `cwf-customer-app-v2-${BUILD_ID}`;
 const APP_SHELL = [
   `./index.html?v=${BUILD_ID}`,

--- a/docs/OMISE_PAYMENT_SETUP.md
+++ b/docs/OMISE_PAYMENT_SETUP.md
@@ -1,0 +1,85 @@
+# Online payment (Omise / Opn) — store buy flow
+
+The store buy flow lets a customer pay for a `purchase`-mode catalog item
+online via **Omise (Opn Payments)** with either **PromptPay QR** or a
+**credit/debit card**. This document is the operator's guide: which environment
+variables to set, how the pieces fit together, and how to run the live test
+once keys are in place.
+
+> The app never sees raw card numbers. The browser tokenizes the card with
+> Omise.js using the **public** key; our server only ever receives a one-time
+> token and charges it with the **secret** key.
+
+## 1. Environment variables (required)
+
+Set these on the server (e.g. in the deployment environment / `.env`). Get the
+values from the Omise dashboard → **Keys**. Never commit them; never paste a
+secret key into chat, code, or a PR.
+
+| Variable            | Example            | Notes                                  |
+| ------------------- | ------------------ | -------------------------------------- |
+| `OMISE_PUBLIC_KEY`  | `pkey_test_xxxxx`  | Safe to expose to the browser.         |
+| `OMISE_SECRET_KEY`  | `skey_test_xxxxx`  | **Secret.** Server only. Never ships.  |
+
+- Test-mode keys are prefixed `pkey_test_` / `skey_test_`; live keys are
+  `pkey_...` / `skey_...` without `_test_`. Start with **test** keys.
+- If `OMISE_SECRET_KEY` is unset, payment is simply **off**: the buy flow falls
+  back to the existing LINE hand-off, and `GET /public/payment-config` returns
+  `{ enabled: false }`. Nothing breaks.
+
+## 2. Database
+
+The buy-flow migrations are additive and auto-apply on boot (no manual step).
+To run them by hand:
+
+```
+npm run migrate:store-buy         # runs all three buy-flow migrations in order
+# or just the payment columns:
+npm run migrate:customer-orders-payment
+```
+
+The payment migration only adds nullable `payment_*` columns to
+`customer_orders` — it never rewrites existing rows.
+
+## 3. Webhook
+
+In the Omise dashboard → **Webhooks**, add an endpoint pointing at:
+
+```
+https://<your-host>/webhooks/omise
+```
+
+This is how **PromptPay** payments are confirmed (the customer scans the QR and
+pays asynchronously). Omise webhooks are unsigned, so the handler does **not**
+trust the payload: it takes the charge id, re-fetches the charge from the Omise
+API, and only then updates the order. Replays are idempotent.
+
+## 4. How the flow works
+
+1. Customer fills the purchase sheet → `POST /public/orders` creates an order
+   with status `pending_payment` (subtotal computed server-side).
+2. App calls `GET /public/payment-config`; if enabled it shows the payment step.
+3. **Card:** browser tokenizes via Omise.js → `POST /public/orders/:code/pay`
+   with `{ method: "card", token }`. The charge is captured immediately; the
+   order becomes `paid` (or `payment_failed`).
+4. **PromptPay:** `POST /public/orders/:code/pay` with `{ method: "promptpay" }`
+   returns a QR image URL. The order sits at `payment_processing`; the app polls
+   `GET /public/orders/:code` until the webhook flips it to `paid`.
+
+The amount charged is **always** the server-stored `subtotal` — the client
+cannot influence it.
+
+## 5. Live test (must run where Omise is reachable)
+
+The CI/dev sandbox blocks outbound traffic to `api.omise.co`, so the live test
+runs in your **staging/production** environment with test keys set.
+
+1. Set `OMISE_PUBLIC_KEY` / `OMISE_SECRET_KEY` to your **test** keys; deploy.
+2. `GET /public/payment-config` → expect `{ enabled: true, test_mode: true }`.
+3. **Card:** in the app, buy a `purchase` item and pay with an Omise test card
+   (e.g. `4242 4242 4242 4242`, any future expiry, any CVC). Expect the order to
+   reach `paid`; confirm the charge in the Omise dashboard (test mode).
+4. **PromptPay:** choose PromptPay, get the QR. In test mode Omise won't take a
+   real scan — mark the charge as paid from the dashboard (or use the test
+   webhook) and confirm the order flips to `paid` via polling.
+5. When satisfied, swap to **live** keys and repeat a small real charge.

--- a/migrations/20260702_customer_orders_payment.sql
+++ b/migrations/20260702_customer_orders_payment.sql
@@ -1,0 +1,17 @@
+-- Customer product orders — payment columns (buy flow, Omise online payment).
+-- Additive only: adds nullable payment_* columns to customer_orders. It never
+-- drops, rewrites, or backfills existing rows, so it is safe to run on a live
+-- database and safe to re-run (ADD COLUMN IF NOT EXISTS is idempotent).
+--
+-- Existing orders keep their status ('pending_payment'); nothing is migrated.
+
+ALTER TABLE public.customer_orders ADD COLUMN IF NOT EXISTS payment_provider   TEXT;      -- e.g. 'omise'
+ALTER TABLE public.customer_orders ADD COLUMN IF NOT EXISTS payment_method     TEXT;      -- 'card' | 'promptpay'
+ALTER TABLE public.customer_orders ADD COLUMN IF NOT EXISTS payment_charge_id  TEXT;      -- Omise charge id (chrg_...)
+ALTER TABLE public.customer_orders ADD COLUMN IF NOT EXISTS payment_status     TEXT;      -- raw Omise charge status
+ALTER TABLE public.customer_orders ADD COLUMN IF NOT EXISTS paid_at            TIMESTAMPTZ;
+
+-- Look up an order by its Omise charge id from the webhook (one charge per order).
+CREATE UNIQUE INDEX IF NOT EXISTS idx_customer_orders_charge
+  ON public.customer_orders (payment_charge_id)
+  WHERE payment_charge_id IS NOT NULL;

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "migrate:homepage-article-sync": "node scripts/run-homepage-article-sync-migration.js",
     "migrate:customer-orders": "node scripts/run-customer-orders-migration.js",
     "migrate:catalog-booking-mode-purchase": "node scripts/run-catalog-booking-mode-purchase-migration.js",
+    "migrate:customer-orders-payment": "node scripts/run-customer-orders-payment-migration.js",
     "migrate:store-buy": "node scripts/run-store-buy-migrations.js",
     "test": "node --test test/*.test.js"
   },

--- a/scripts/run-customer-orders-payment-migration.js
+++ b/scripts/run-customer-orders-payment-migration.js
@@ -1,0 +1,128 @@
+"use strict";
+
+// Applies migrations/20260702_customer_orders_payment.sql — the payment_* columns
+// on customer_orders needed for Omise online payment.
+//
+// Safe to run anytime, including repeatedly: the migration is ADD COLUMN /
+// CREATE INDEX "IF NOT EXISTS" only. It adds nullable columns and never touches
+// existing rows or other tables, so it cannot affect or break the running app.
+// An advisory lock prevents two concurrent runners from racing.
+
+const fs = require("fs");
+const path = require("path");
+const { Client } = require("pg");
+
+const MIGRATION_RELATIVE_PATH = "migrations/20260702_customer_orders_payment.sql";
+const ADVISORY_LOCK_KEY = "202607020102";
+
+function clean(value) {
+  return String(value == null ? "" : value).trim();
+}
+
+function safeErrorMessage(error) {
+  return clean(error && error.message ? error.message : error)
+    .replace(/postgres(?:ql)?:\/\/[^\s"'<>]+/gi, "[REDACTED_DATABASE_URL]")
+    .replace(/(password|passwd|pwd|secret|token)=([^&\s]+)/gi, "$1=[REDACTED]");
+}
+
+function resolveMigrationPath(repoRoot = path.resolve(__dirname, "..")) {
+  const root = path.resolve(repoRoot);
+  const migrationPath = path.resolve(root, MIGRATION_RELATIVE_PATH);
+  const expected = path.resolve(root, "migrations", "20260702_customer_orders_payment.sql");
+  if (migrationPath !== expected || !migrationPath.startsWith(root + path.sep)) {
+    throw new Error("migration path rejected");
+  }
+  return migrationPath;
+}
+
+function readMigrationSql(repoRoot) {
+  return fs.readFileSync(resolveMigrationPath(repoRoot), "utf8");
+}
+
+function createClientConfig(env = process.env) {
+  const databaseUrl = clean(env.DATABASE_URL);
+  if (databaseUrl) {
+    return {
+      connectionString: databaseUrl,
+      options: "-c timezone=Asia/Bangkok",
+      ssl: { rejectUnauthorized: false },
+    };
+  }
+  return {
+    host: clean(env.DB_HOST),
+    port: Number(env.DB_PORT || 5432),
+    user: clean(env.DB_USER),
+    password: env.DB_PASSWORD,
+    database: clean(env.DB_NAME),
+    options: "-c timezone=Asia/Bangkok",
+    ssl: { rejectUnauthorized: false },
+  };
+}
+
+async function verifySchema(client) {
+  const table = await client.query("SELECT to_regclass('public.customer_orders') AS orders");
+  if (!table.rows?.[0]?.orders) throw new Error("customer_orders table missing (run the base orders migration first)");
+  const columns = await client.query(`
+    SELECT column_name
+    FROM information_schema.columns
+    WHERE table_schema='public'
+      AND table_name='customer_orders'
+      AND column_name IN ('payment_provider','payment_method','payment_charge_id','payment_status','paid_at')
+  `);
+  const names = new Set((columns.rows || []).map((row) => row.column_name));
+  for (const required of ["payment_provider", "payment_method", "payment_charge_id", "payment_status", "paid_at"]) {
+    if (!names.has(required)) throw new Error(`customer_orders.${required} missing after migration`);
+  }
+}
+
+async function runMigration(options = {}) {
+  const env = options.env || process.env;
+  const logger = options.logger || console;
+  const repoRoot = options.repoRoot || path.resolve(__dirname, "..");
+  const clientFactory = options.clientFactory || ((config) => new Client(config));
+  const client = clientFactory(createClientConfig(env));
+  const sql = readMigrationSql(repoRoot);
+  let locked = false;
+
+  logger.log("CUSTOMER_ORDERS_PAYMENT_MIGRATION_START");
+  try {
+    await client.connect();
+    await client.query("SELECT pg_advisory_lock($1::bigint)", [ADVISORY_LOCK_KEY]);
+    locked = true;
+    await client.query(sql);
+    await verifySchema(client);
+    logger.log("CUSTOMER_ORDERS_PAYMENT_MIGRATION_OK");
+  } finally {
+    if (locked) await client.query("SELECT pg_advisory_unlock($1::bigint)", [ADVISORY_LOCK_KEY]).catch(() => {});
+    await client.end();
+  }
+}
+
+async function runCli(options = {}) {
+  const logger = options.logger || console;
+  try {
+    await runMigration(options);
+    return 0;
+  } catch (error) {
+    logger.error(`CUSTOMER_ORDERS_PAYMENT_MIGRATION_FAILED: ${safeErrorMessage(error)}`);
+    return 1;
+  }
+}
+
+if (require.main === module) {
+  runCli().then((code) => {
+    process.exitCode = code;
+  });
+}
+
+module.exports = {
+  ADVISORY_LOCK_KEY,
+  MIGRATION_RELATIVE_PATH,
+  createClientConfig,
+  readMigrationSql,
+  resolveMigrationPath,
+  runCli,
+  runMigration,
+  safeErrorMessage,
+  verifySchema,
+};

--- a/scripts/run-store-buy-migrations.js
+++ b/scripts/run-store-buy-migrations.js
@@ -3,6 +3,7 @@
 // One safe command to apply every migration the store buy-flow needs, in order:
 //   1. customer_orders table
 //   2. catalog_items.booking_mode CHECK widened to allow 'purchase'
+//   3. customer_orders payment_* columns (Omise online payment)
 //
 // Why this is safe to run (including on production, and repeatedly):
 //   - Each underlying migration is additive-only (CREATE ... IF NOT EXISTS /
@@ -19,10 +20,12 @@
 
 const ordersRunner = require("./run-customer-orders-migration");
 const bookingModeRunner = require("./run-catalog-booking-mode-purchase-migration");
+const ordersPaymentRunner = require("./run-customer-orders-payment-migration");
 
 const STEPS = [
   { name: "customer_orders table", runner: ordersRunner },
   { name: "catalog booking_mode 'purchase'", runner: bookingModeRunner },
+  { name: "customer_orders payment columns", runner: ordersPaymentRunner },
 ];
 
 async function runAll(options = {}) {

--- a/server/routes/catalog/items.js
+++ b/server/routes/catalog/items.js
@@ -221,13 +221,37 @@ function validateMarketplaceFields(merged) {
   };
 }
 
+// A short, safe Thai hint appended to the generic save error on the admin-only
+// catalog routes, so a failure is diagnosable without server-log access.
+function dbErrorHint(error) {
+  const code = error && error.code;
+  if (code === "23514") return " (ค่าบางช่องไม่ตรงกับที่ระบบอนุญาต เช่น หมวดหมู่/โหมดการขาย)";
+  if (code === "23505") return " (ข้อมูลซ้ำกับที่มีอยู่)";
+  if (code === "23502") return " (มีช่องจำเป็นที่ยังไม่ได้กรอก)";
+  if (code === "42P01" || code === "42703") return " (ฐานข้อมูลยังไม่อัปเดต — รอระบบอัปเดต schema แล้วลองใหม่)";
+  return code ? ` (รหัส ${code})` : "";
+}
+
+function normalizeItemCategory(rawCategory, bookingMode) {
+  const value = String(rawCategory == null ? "" : rawCategory).trim().toLowerCase();
+  if (value === "service" || value === "product") return value;
+  if (String(bookingMode || "").trim() === "purchase") return "product";
+  if (/สินค้า|product|อุปกรณ์/i.test(String(rawCategory || ""))) return "product";
+  return "service";
+}
+
 function validateMergedCatalogItem(merged) {
   const errors = [];
 
   const item_name = String(merged.item_name || "").trim();
   if (!item_name) errors.push("กรุณากรอกชื่อรายการ");
 
-  const item_category = String(merged.item_category || "").trim();
+  // catalog_items.item_category is constrained to 'service'/'product' in the DB
+  // and is not shown to customers. The admin "หมวดหมู่" field is free text, so a
+  // value like "สินค้า" would violate the CHECK and fail the whole insert.
+  // Coerce to a valid token: a product-mode item (or product-ish text) is a
+  // 'product', everything else a 'service'.
+  const item_category = normalizeItemCategory(merged.item_category, merged.booking_mode);
   const unit_label = String(merged.unit_label || "").trim();
   const job_category = String(merged.job_category || "").trim();
   const ac_type = String(merged.ac_type || "").trim();
@@ -1225,7 +1249,7 @@ module.exports = function createCatalogItemRoutes(deps = {}) {
     } catch (e) {
       await client.query("ROLLBACK").catch(() => {});
       console.error(e);
-      res.status(500).json({ error: "เพิ่มรายการไม่สำเร็จ" });
+      res.status(500).json({ error: `เพิ่มรายการไม่สำเร็จ${dbErrorHint(e)}` });
     } finally {
       client.release();
     }
@@ -1365,7 +1389,7 @@ module.exports = function createCatalogItemRoutes(deps = {}) {
     } catch (e) {
       await client.query("ROLLBACK").catch(() => {});
       console.error(e);
-      res.status(500).json({ error: "แก้ไขรายการไม่สำเร็จ" });
+      res.status(500).json({ error: `แก้ไขรายการไม่สำเร็จ${dbErrorHint(e)}` });
     } finally {
       client.release();
     }
@@ -1855,6 +1879,9 @@ module.exports.serializeAdminCatalogRow = serializeAdminCatalogRow;
 module.exports.serializeCatalogImage = serializeCatalogImage;
 module.exports.validatePricingInput = validatePricingInput;
 module.exports.validateMarketplaceFields = validateMarketplaceFields;
+module.exports.validateMergedCatalogItem = validateMergedCatalogItem;
+module.exports.normalizeItemCategory = normalizeItemCategory;
+module.exports.dbErrorHint = dbErrorHint;
 module.exports.buildCatalogSelect = buildCatalogSelect;
 module.exports.MAX_CATALOG_IMAGES_PER_ITEM = MAX_CATALOG_IMAGES_PER_ITEM;
 module.exports.validateHotField = validateHotField;

--- a/server/routes/customerOrders.js
+++ b/server/routes/customerOrders.js
@@ -9,9 +9,14 @@
 // booking, pricing, payout, or accounting logic.
 
 const express = require("express");
+const { createOmiseClient, chargeToOrderStatus, promptPayQrUri } = require("../services/omise");
 
 const DELIVERY_METHODS = new Set(["pickup", "ship"]);
 const INSTALL_OPTIONS = new Set(["none", "cwf"]);
+const PAYMENT_METHODS = new Set(["card", "promptpay"]);
+// An order can only START a payment from one of these states (a fresh order, or
+// one whose previous attempt failed). This blocks paying twice for one order.
+const PAYABLE_STATUSES = new Set(["pending_payment", "payment_failed"]);
 const MAX_ITEMS = 20;
 const MAX_QTY = 99;
 
@@ -106,6 +111,8 @@ function isSchemaError(error) {
 
 function createCustomerOrdersRoutes(deps = {}) {
   const { pool, requireAdminSession } = deps;
+  // Injectable so tests can drive a fake Omise; defaults to an env-keyed client.
+  const omise = deps.omiseClient || createOmiseClient({ env: deps.env || process.env });
   const router = express.Router();
   const adminGuard = typeof requireAdminSession === "function" ? requireAdminSession : (_req, _res, next) => next();
 
@@ -153,6 +160,131 @@ function createCustomerOrdersRoutes(deps = {}) {
       if (isSchemaError(error)) return res.status(503).json({ error: "ORDERS_SCHEMA_NOT_READY" });
       console.error("[orders/get] failed", error);
       return res.status(500).json({ error: "โหลดคำสั่งซื้อไม่สำเร็จ" });
+    }
+  });
+
+  // Public: what the customer app needs to render the payment step. Exposes the
+  // PUBLIC key only (safe to ship to the browser) — never the secret key.
+  router.get("/public/payment-config", (_req, res) => {
+    const enabled = omise.isConfigured();
+    return res.json({
+      enabled,
+      provider: "omise",
+      public_key: enabled ? omise.getPublicKey() : "",
+      test_mode: enabled ? omise.isTestMode() : false,
+      methods: ["promptpay", "card"],
+    });
+  });
+
+  // Pay for an order. The amount is ALWAYS the server-stored subtotal — the
+  // client cannot influence how much is charged. Card: pass a one-time token
+  // from Omise.js (card data never reaches us). PromptPay: we return a QR to
+  // scan; the actual payment is confirmed later by the Omise webhook.
+  router.post("/public/orders/:code/pay", async (req, res) => {
+    if (!omise.isConfigured()) return res.status(503).json({ error: "PAYMENT_NOT_CONFIGURED" });
+    const code = cleanText(req.params.code, 40);
+    if (!code) return res.status(400).json({ error: "order code required" });
+    const method = cleanText(req.body && req.body.method, 20);
+    if (!PAYMENT_METHODS.has(method)) return res.status(400).json({ error: "payment method invalid" });
+    const token = cleanText(req.body && req.body.token, 200);
+    if (method === "card" && !token) return res.status(400).json({ error: "card token required" });
+
+    let order;
+    try {
+      const found = await pool.query(
+        `SELECT order_code, subtotal, status FROM public.customer_orders WHERE order_code=$1 LIMIT 1`,
+        [code]
+      );
+      if (!found.rows.length) return res.status(404).json({ error: "ไม่พบคำสั่งซื้อนี้" });
+      order = found.rows[0];
+    } catch (error) {
+      if (isSchemaError(error)) return res.status(503).json({ error: "ORDERS_SCHEMA_NOT_READY" });
+      console.error("[orders/pay:lookup] failed", error);
+      return res.status(500).json({ error: "เริ่มการชำระเงินไม่สำเร็จ" });
+    }
+
+    if (!PAYABLE_STATUSES.has(order.status)) {
+      // Already paid or a payment is already in progress — tell the client so it
+      // can just poll the order status instead of charging again.
+      return res.status(409).json({ error: "ORDER_NOT_PAYABLE", status: order.status });
+    }
+    const amount = Number(order.subtotal) || 0;
+    if (amount <= 0) return res.status(400).json({ error: "ยอดชำระไม่ถูกต้อง" });
+
+    let charge;
+    try {
+      const metadata = { order_code: code };
+      charge = method === "card"
+        ? await omise.createCardCharge({ amount, token, metadata })
+        : await omise.createPromptPayCharge({ amount, metadata });
+    } catch (error) {
+      console.error("[orders/pay:charge] failed", error && error.code);
+      return res.status(502).json({ error: "ชำระเงินไม่สำเร็จ กรุณาลองใหม่", code: error && error.code });
+    }
+
+    const mapped = chargeToOrderStatus(charge);
+    try {
+      const updated = await pool.query(
+        `UPDATE public.customer_orders
+            SET payment_provider='omise', payment_method=$2, payment_charge_id=$3,
+                payment_status=$4, status=$5,
+                paid_at = CASE WHEN $5='paid' THEN now() ELSE paid_at END,
+                updated_at = now()
+          WHERE order_code=$1
+          RETURNING order_code, customer_name, customer_phone, delivery_method, install_option, address, items, subtotal, status, created_at`,
+        [code, method, charge.id || null, (charge && charge.status) || null, mapped]
+      );
+      return res.json({
+        ok: true,
+        order: publicOrder(updated.rows[0]),
+        payment: {
+          method,
+          status: mapped,
+          charge_id: charge.id || null,
+          // PromptPay only: the QR the customer scans in their banking app.
+          qr_uri: method === "promptpay" ? promptPayQrUri(charge) : null,
+          // The client should poll GET /public/orders/:code until status leaves
+          // 'payment_processing' (PromptPay) — card resolves synchronously.
+          requires_polling: mapped === "payment_processing",
+        },
+      });
+    } catch (error) {
+      if (isSchemaError(error)) return res.status(503).json({ error: "ORDERS_SCHEMA_NOT_READY" });
+      console.error("[orders/pay:update] failed", error);
+      return res.status(500).json({ error: "บันทึกผลการชำระเงินไม่สำเร็จ" });
+    }
+  });
+
+  // Omise webhook. Omise webhooks are NOT signed, so we never trust the payload:
+  // we take the charge id from it, re-fetch the charge from Omise (source of
+  // truth), then update the matching order. Idempotent — replays are no-ops.
+  // Always answer 200 so Omise stops retrying a delivered event.
+  router.post("/webhooks/omise", async (req, res) => {
+    try {
+      const event = req.body && typeof req.body === "object" ? req.body : {};
+      const data = event.data && typeof event.data === "object" ? event.data : {};
+      // The event data object may be the charge, or (for source events) carry it.
+      const chargeId = cleanText(data.object === "charge" ? data.id : (data.charge || ""), 80);
+      if (!chargeId || !omise.isConfigured()) return res.json({ ok: true, ignored: true });
+
+      const charge = await omise.retrieveCharge(chargeId).catch(() => null);
+      if (!charge || !charge.id) return res.json({ ok: true, ignored: true });
+      const mapped = chargeToOrderStatus(charge);
+
+      await pool.query(
+        `UPDATE public.customer_orders
+            SET payment_status=$2, status=$3,
+                paid_at = CASE WHEN $3='paid' AND paid_at IS NULL THEN now() ELSE paid_at END,
+                updated_at = now()
+          WHERE payment_charge_id=$1`,
+        [charge.id, charge.status || null, mapped]
+      );
+      return res.json({ ok: true });
+    } catch (error) {
+      if (isSchemaError(error)) return res.json({ ok: true, ignored: true });
+      console.error("[orders/webhook] failed", error);
+      // Still 200: a 500 makes Omise retry a payload we can't process anyway.
+      return res.json({ ok: false });
     }
   });
 

--- a/server/services/omise.js
+++ b/server/services/omise.js
@@ -1,0 +1,179 @@
+"use strict";
+
+// Omise (Opn Payments) API client for the store buy-flow.
+//
+// Scope: create a charge for an order (card token or PromptPay source) and read
+// a charge back to confirm its real status. Card data NEVER touches our server —
+// the browser tokenizes it with Omise.js using the PUBLIC key, and we only ever
+// see a one-time token here. All money-moving calls use the SECRET key, which is
+// read from the environment and never hardcoded or logged.
+//
+// Amounts are handled in the smallest currency unit (satang for THB): 1 THB =
+// 100 satang. Callers pass whole-baht amounts; we convert once, here.
+//
+// Everything is injectable (env + httpRequest) so the whole flow is unit-tested
+// without a network — see test/omiseService.test.js.
+
+const https = require("https");
+
+const OMISE_API_HOST = "api.omise.co";
+const DEFAULT_CURRENCY = "thb";
+
+// The real transport: one HTTPS request to api.omise.co with HTTP Basic auth
+// (secret key as the username, empty password). Resolves { status, body } where
+// body is the parsed JSON (or null). Rejects only on a transport-level error.
+function defaultHttpRequest({ method, path, secretKey, payload, timeoutMs = 20000 }) {
+  return new Promise((resolve, reject) => {
+    const data = payload ? JSON.stringify(payload) : null;
+    const auth = Buffer.from(`${secretKey}:`).toString("base64");
+    const req = https.request(
+      {
+        method,
+        hostname: OMISE_API_HOST,
+        path,
+        headers: {
+          Authorization: `Basic ${auth}`,
+          "Content-Type": "application/json",
+          ...(data ? { "Content-Length": Buffer.byteLength(data) } : {}),
+        },
+        timeout: timeoutMs,
+      },
+      (res) => {
+        let raw = "";
+        res.setEncoding("utf8");
+        res.on("data", (chunk) => { raw += chunk; });
+        res.on("end", () => {
+          let body = null;
+          try { body = raw ? JSON.parse(raw) : null; } catch (_) { body = null; }
+          resolve({ status: res.statusCode || 0, body });
+        });
+      }
+    );
+    req.on("timeout", () => req.destroy(new Error("omise request timed out")));
+    req.on("error", reject);
+    if (data) req.write(data);
+    req.end();
+  });
+}
+
+function cleanKey(value) {
+  return String(value == null ? "" : value).trim();
+}
+
+// Whole baht -> integer satang. Guards against floating dust (1499.99 * 100).
+function bahtToSatang(baht) {
+  const n = Number(baht);
+  if (!Number.isFinite(n) || n < 0) return 0;
+  return Math.round(n * 100);
+}
+
+function createOmiseClient(options = {}) {
+  const env = options.env || process.env;
+  const httpRequest = options.httpRequest || defaultHttpRequest;
+  const secretKey = cleanKey(env.OMISE_SECRET_KEY);
+  const publicKey = cleanKey(env.OMISE_PUBLIC_KEY);
+
+  // True only when a secret key is present. The routes use this to fail closed
+  // (503 "payment not configured") instead of making a doomed API call.
+  function isConfigured() {
+    return Boolean(secretKey);
+  }
+
+  function getPublicKey() {
+    return publicKey;
+  }
+
+  // Test-mode keys are prefixed pkey_test_ / skey_test_ by Omise. Handy for the
+  // client to show a "test mode" banner without another round-trip.
+  function isTestMode() {
+    return /_test_/.test(secretKey) || /_test_/.test(publicKey);
+  }
+
+  async function call(method, path, payload) {
+    if (!secretKey) {
+      const err = new Error("OMISE_NOT_CONFIGURED");
+      err.code = "OMISE_NOT_CONFIGURED";
+      throw err;
+    }
+    const { status, body } = await httpRequest({ method, path, secretKey, payload });
+    // Omise returns { object: "error", code, message } on failure.
+    if (status < 200 || status >= 300 || (body && body.object === "error")) {
+      const err = new Error((body && body.message) || `omise ${method} ${path} failed (${status})`);
+      err.code = (body && body.code) || "OMISE_REQUEST_FAILED";
+      err.status = status;
+      err.omise = body || null;
+      throw err;
+    }
+    return body;
+  }
+
+  // Charge a card token (from Omise.js in the browser). capture=true settles
+  // immediately; status comes back 'successful' or 'failed'.
+  function createCardCharge({ amount, currency = DEFAULT_CURRENCY, token, metadata }) {
+    return call("POST", "/charges", {
+      amount: bahtToSatang(amount),
+      currency,
+      card: token,
+      capture: true,
+      ...(metadata ? { metadata } : {}),
+    });
+  }
+
+  // PromptPay: create a source, then a charge on it. The returned charge is
+  // 'pending' and carries the QR (source.scannable_code.image.download_uri).
+  // Actual payment is confirmed asynchronously by an Omise webhook.
+  async function createPromptPayCharge({ amount, currency = DEFAULT_CURRENCY, metadata }) {
+    const satang = bahtToSatang(amount);
+    const source = await call("POST", "/sources", { type: "promptpay", amount: satang, currency });
+    return call("POST", "/charges", {
+      amount: satang,
+      currency,
+      source: source.id,
+      ...(metadata ? { metadata } : {}),
+    });
+  }
+
+  // Read a charge back from Omise. Used by the webhook handler to VERIFY status
+  // from source of truth rather than trusting the webhook payload.
+  function retrieveCharge(chargeId) {
+    const id = cleanKey(chargeId);
+    if (!id) return Promise.reject(new Error("charge id required"));
+    return call("GET", `/charges/${encodeURIComponent(id)}`, null);
+  }
+
+  return {
+    isConfigured,
+    isTestMode,
+    getPublicKey,
+    createCardCharge,
+    createPromptPayCharge,
+    retrieveCharge,
+  };
+}
+
+// Map an Omise charge to the order status we persist. Omise charge statuses:
+// 'successful' | 'pending' | 'failed' | 'expired' | 'reversed'.
+function chargeToOrderStatus(charge) {
+  const status = charge && charge.status;
+  if (charge && charge.paid === true) return "paid";
+  if (status === "successful") return "paid";
+  if (status === "pending") return "payment_processing";
+  if (status === "failed" || status === "expired" || status === "reversed") return "payment_failed";
+  return "payment_processing";
+}
+
+// The scannable PromptPay QR image URL, if present on a charge.
+function promptPayQrUri(charge) {
+  const source = charge && charge.source;
+  const image = source && source.scannable_code && source.scannable_code.image;
+  return (image && (image.download_uri || image.uri)) || null;
+}
+
+module.exports = {
+  createOmiseClient,
+  defaultHttpRequest,
+  bahtToSatang,
+  chargeToOrderStatus,
+  promptPayQrUri,
+  DEFAULT_CURRENCY,
+};

--- a/test/adminStoreCatalogUi.test.js
+++ b/test/adminStoreCatalogUi.test.js
@@ -369,8 +369,23 @@ test("gallery delete and set-primary actions ask for confirmation only on delete
 });
 
 test("admin-store-catalog.html script and stylesheet references share a consistent cache-bust build id", () => {
-  assert.match(catalogHtmlSource, /admin-store-catalog\.css\?v=20260702_buy_v1/);
-  assert.match(catalogHtmlSource, /admin-store-catalog\.js\?v=20260702_buy_v1/);
+  assert.match(catalogHtmlSource, /admin-store-catalog\.css\?v=20260702_cat_v2/);
+  assert.match(catalogHtmlSource, /admin-store-catalog\.js\?v=20260702_cat_v2/);
+});
+
+test("the item_category field is a service/product dropdown, not free text", () => {
+  // The DB constrains catalog_items.item_category to exactly service/product,
+  // so the admin field must be a select — a free-text value like "สินค้า"
+  // would violate the CHECK and fail the insert.
+  const selectMatch = catalogJsSource.match(/<select id="cm_item_category">[\s\S]*?<\/select>/);
+  assert.ok(selectMatch, "cm_item_category should be a <select>");
+  assert.match(selectMatch[0], /value="service"[^>]*>บริการ/);
+  assert.match(selectMatch[0], /value="product"[^>]*>สินค้า/);
+  assert.doesNotMatch(catalogJsSource, /<input id="cm_item_category"/);
+});
+
+test("resetCatalogModalFields defaults the category select to 'service'", () => {
+  assert.match(catalogJsSource, /el\("cm_item_category"\)\.value = "service";/);
 });
 
 test("admin-store-catalog.css defines gallery grid and badge styles for the marketplace UI", () => {

--- a/test/catalogItemsRoutes.test.js
+++ b/test/catalogItemsRoutes.test.js
@@ -3053,3 +3053,44 @@ test("has_queue_today reuses one cached eligibility check across multiple items 
     assert.equal(matrixQueries.length, 1);
   });
 });
+
+// ---------- item_category coercion + DB error hints ----------
+// The DB constrains catalog_items.item_category to 'service'/'product', so the
+// server coerces the admin's value before insert instead of letting a stray
+// label (e.g. Thai "สินค้า") violate the CHECK and fail the whole save.
+
+test("normalizeItemCategory passes through canonical tokens", () => {
+  assert.equal(createCatalogItemRoutes.normalizeItemCategory("service"), "service");
+  assert.equal(createCatalogItemRoutes.normalizeItemCategory("product"), "product");
+  assert.equal(createCatalogItemRoutes.normalizeItemCategory("  PRODUCT  "), "product");
+});
+
+test("normalizeItemCategory treats a purchase-mode item as a product", () => {
+  assert.equal(createCatalogItemRoutes.normalizeItemCategory("", "purchase"), "product");
+  assert.equal(createCatalogItemRoutes.normalizeItemCategory("อะไรก็ได้", "purchase"), "product");
+});
+
+test("normalizeItemCategory maps product-ish free text to 'product', else 'service'", () => {
+  assert.equal(createCatalogItemRoutes.normalizeItemCategory("สินค้า"), "product");
+  assert.equal(createCatalogItemRoutes.normalizeItemCategory("อุปกรณ์"), "product");
+  assert.equal(createCatalogItemRoutes.normalizeItemCategory("ล้างแอร์"), "service");
+  assert.equal(createCatalogItemRoutes.normalizeItemCategory(""), "service");
+  assert.equal(createCatalogItemRoutes.normalizeItemCategory(null), "service");
+});
+
+test("validateMergedCatalogItem never emits an item_category outside the DB CHECK set", () => {
+  for (const raw of ["สินค้า", "ล้างแอร์", "", "service", "product", "random"]) {
+    const result = createCatalogItemRoutes.validateMergedCatalogItem({
+      item_name: "x", item_category: raw, is_active: true, is_customer_visible: true,
+    });
+    assert.equal(result.ok, true, `expected ok for category=${raw}`);
+    assert.ok(["service", "product"].includes(result.value.item_category), `bad token for ${raw}: ${result.value.item_category}`);
+  }
+});
+
+test("dbErrorHint maps a CHECK-constraint violation to a Thai hint and is silent for unknown errors", () => {
+  assert.match(createCatalogItemRoutes.dbErrorHint({ code: "23514" }), /หมวดหมู่|โหมดการขาย/);
+  assert.match(createCatalogItemRoutes.dbErrorHint({ code: "42P01" }), /schema/);
+  assert.equal(createCatalogItemRoutes.dbErrorHint({}), "");
+  assert.equal(createCatalogItemRoutes.dbErrorHint(null), "");
+});

--- a/test/customerAppRecovery.test.js
+++ b/test/customerAppRecovery.test.js
@@ -236,7 +236,7 @@ test("Customer App build id is consistent across shell and service worker", () =
   const sw = read("customer-app/sw.js");
   const app = read("customer-app/assets/customer-app.js");
   const manifest = read("customer-app/manifest.webmanifest");
-  const build = "20260702_orders_v1";
+  const build = "20260702_pay_v1";
 
   assert.match(index, new RegExp(`customer-app\\.css\\?v=${build}`));
   assert.match(index, new RegExp(`modules\\/api\\.js\\?v=${build}`));
@@ -254,7 +254,7 @@ test("Customer App build id is consistent across shell and service worker", () =
 test("store module is loaded in index.html and precached in the service worker app shell", () => {
   const index = read("customer-app/index.html");
   const sw = read("customer-app/sw.js");
-  const build = "20260702_orders_v1";
+  const build = "20260702_pay_v1";
 
   assert.match(index, new RegExp(`modules/store\\.js\\?v=${build}`));
   assert.match(sw, /`\.\/modules\/store\.js\?v=\$\{BUILD_ID\}`/);

--- a/test/customerAppStorePayment.test.js
+++ b/test/customerAppStorePayment.test.js
@@ -1,0 +1,54 @@
+"use strict";
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("fs");
+const path = require("path");
+
+const REPO_ROOT = path.resolve(__dirname, "..");
+const read = (p) => fs.readFileSync(path.join(REPO_ROOT, p), "utf8");
+
+const storeSrc = read("customer-app/modules/store.js");
+const apiSrc = read("customer-app/modules/api.js");
+const cssSrc = read("customer-app/assets/customer-app.css");
+
+test("api module exposes getPaymentConfig and payOrder against the public endpoints", () => {
+  assert.match(apiSrc, /getPaymentConfig\(\)\s*\{[\s\S]*?\/public\/payment-config/);
+  assert.match(apiSrc, /payOrder\(code, payload\)\s*\{[\s\S]*?\/public\/orders\/\$\{encodeURIComponent\(code\)\}\/pay/);
+});
+
+test("store renders a payment step offering PromptPay and card after the order is created", () => {
+  assert.match(storeSrc, /paymentStepHtml/);
+  assert.match(storeSrc, /data-pay-method="promptpay"/);
+  assert.match(storeSrc, /data-pay-method="card"/);
+  // The order is created first, then the payment step is shown.
+  assert.match(storeSrc, /renderPaymentStep\(\{ order/);
+});
+
+test("store loads Omise.js lazily and tokenizes the card in the browser (card data never posted to us)", () => {
+  assert.match(storeSrc, /cdn\.omise\.co\/omise\.js/);
+  assert.match(storeSrc, /Omise\.createToken\("card"/);
+  // We only ever send the one-time token to our own endpoint, never raw PAN.
+  assert.match(storeSrc, /payOrder\(o\.order\.order_code, \{ method: "card", token \}\)/);
+  assert.doesNotMatch(storeSrc, /createOrder\([^)]*number/);
+});
+
+test("store shows the PromptPay QR and polls the order status until it resolves", () => {
+  assert.match(storeSrc, /payOrder\(o\.order\.order_code, \{ method: "promptpay" \}\)/);
+  assert.match(storeSrc, /pay-qr-img/);
+  assert.match(storeSrc, /startPolling\(o\.order\.order_code/);
+  // Polling stops on a terminal status.
+  assert.match(storeSrc, /status === "paid" \|\| status === "payment_failed"/);
+});
+
+test("store falls back to the LINE hand-off when payment is unconfigured or the order did not save", () => {
+  assert.match(storeSrc, /config && config\.enabled/);
+  assert.match(storeSrc, /purchaseConfirmHtml\(item, \{ qty, delivery, install, name, phone, orderCode/);
+});
+
+test("payment step styles exist and the Customer App payment build id is bumped", () => {
+  assert.match(cssSrc, /\.pay-method-btn/);
+  assert.match(cssSrc, /\.pay-qr-img/);
+  assert.match(read("customer-app/index.html"), /modules\/store\.js\?v=20260702_pay_v1/);
+  assert.match(read("customer-app/sw.js"), /BUILD_ID = "20260702_pay_v1"/);
+});

--- a/test/customerOrdersPayment.test.js
+++ b/test/customerOrdersPayment.test.js
@@ -1,0 +1,190 @@
+"use strict";
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const http = require("node:http");
+const express = require("express");
+
+const { createCustomerOrdersRoutes } = require("../server/routes/customerOrders");
+
+// The base order columns publicOrder() serializes.
+function baseRow(o) {
+  return {
+    order_code: o.order_code, customer_name: o.customer_name, customer_phone: o.customer_phone,
+    delivery_method: o.delivery_method, install_option: o.install_option, address: o.address,
+    items: o.items, subtotal: o.subtotal, status: o.status, created_at: o.created_at,
+  };
+}
+
+// In-memory pool handling the pay-lookup, pay-update, webhook-update and public
+// GET queries used by the payment routes.
+function makePool(seed, { schemaReady = true } = {}) {
+  const orders = new Map();
+  if (seed) orders.set(seed.order_code, { address: "", ...seed });
+  return {
+    orders,
+    async query(sql, params = []) {
+      if (!schemaReady) { const e = new Error("no table"); e.code = "42P01"; throw e; }
+      const s = String(sql).replace(/\s+/g, " ");
+      if (s.includes("SELECT order_code, subtotal, status FROM public.customer_orders WHERE order_code=$1")) {
+        const o = orders.get(params[0]);
+        return { rows: o ? [{ order_code: o.order_code, subtotal: o.subtotal, status: o.status }] : [] };
+      }
+      if (s.startsWith("UPDATE public.customer_orders") && s.includes("WHERE order_code=$1")) {
+        const o = orders.get(params[0]);
+        if (!o) return { rows: [] };
+        o.payment_method = params[1]; o.payment_charge_id = params[2]; o.payment_status = params[3]; o.status = params[4];
+        return { rows: [baseRow(o)] };
+      }
+      if (s.includes("WHERE payment_charge_id=$1")) {
+        for (const o of orders.values()) {
+          if (o.payment_charge_id === params[0]) { o.payment_status = params[1]; o.status = params[2]; }
+        }
+        return { rows: [] };
+      }
+      if (s.includes("FROM public.customer_orders WHERE order_code=$1")) {
+        const o = orders.get(params[0]);
+        return { rows: o ? [baseRow(o)] : [] };
+      }
+      return { rows: [] };
+    },
+  };
+}
+
+function fakeOmise(overrides = {}) {
+  const spy = { charges: [] };
+  return {
+    spy,
+    isConfigured: () => overrides.configured !== false,
+    isTestMode: () => true,
+    getPublicKey: () => overrides.publicKey || "pkey_test_123",
+    createCardCharge: overrides.createCardCharge || (async ({ amount, token }) => {
+      spy.charges.push({ method: "card", amount, token });
+      return { id: "chrg_card_1", status: "successful", paid: true };
+    }),
+    createPromptPayCharge: overrides.createPromptPayCharge || (async ({ amount }) => {
+      spy.charges.push({ method: "promptpay", amount });
+      return { id: "chrg_pp_1", status: "pending", paid: false, source: { scannable_code: { image: { download_uri: "https://cdn.omise.co/qr.png" } } } };
+    }),
+    retrieveCharge: overrides.retrieveCharge || (async (id) => ({ id, status: "successful", paid: true })),
+  };
+}
+
+function seedOrder(extra = {}) {
+  return {
+    order_code: "CWF-PAY1", customer_name: "คุณเอ", customer_phone: "0812345678",
+    delivery_method: "pickup", install_option: "none", address: "",
+    items: [{ item_id: "6", name: "แอร์ Daikin 12000 BTU", qty: 1, unit_price: 14900 }],
+    subtotal: 14900, status: "pending_payment", created_at: new Date().toISOString(), ...extra,
+  };
+}
+
+function startServer(pool, omiseClient) {
+  const app = express();
+  app.use(express.json());
+  app.use(createCustomerOrdersRoutes({ pool, omiseClient, requireAdminSession: (_q, _s, next) => next() }));
+  const server = http.createServer(app);
+  return new Promise((resolve) => server.listen(0, "127.0.0.1", () => resolve(server)));
+}
+const url = (s) => `http://127.0.0.1:${s.address().port}`;
+const postJson = (u, body) => fetch(u, { method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify(body || {}) });
+
+test("GET /public/payment-config exposes the public key but never a secret", async () => {
+  const server = await startServer(makePool(seedOrder()), fakeOmise());
+  try {
+    const body = await (await fetch(`${url(server)}/public/payment-config`)).json();
+    assert.equal(body.enabled, true);
+    assert.equal(body.provider, "omise");
+    assert.equal(body.public_key, "pkey_test_123");
+    assert.deepEqual(body.methods, ["promptpay", "card"]);
+    assert.ok(!("secret_key" in body) && !JSON.stringify(body).includes("skey_"));
+  } finally { server.close(); }
+});
+
+test("payment-config reports disabled when Omise is not configured", async () => {
+  const server = await startServer(makePool(seedOrder()), fakeOmise({ configured: false }));
+  try {
+    const body = await (await fetch(`${url(server)}/public/payment-config`)).json();
+    assert.equal(body.enabled, false);
+    assert.equal(body.public_key, "");
+  } finally { server.close(); }
+});
+
+test("card payment charges the SERVER-stored amount, marks the order paid", async () => {
+  const omise = fakeOmise();
+  const pool = makePool(seedOrder());
+  const server = await startServer(pool, omise);
+  try {
+    // The client sends amount:1 — it must be ignored; the charge uses 14900.
+    const res = await postJson(`${url(server)}/public/orders/CWF-PAY1/pay`, { method: "card", token: "tokn_x", amount: 1 });
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.equal(body.order.status, "paid");
+    assert.equal(body.payment.status, "paid");
+    assert.equal(body.payment.charge_id, "chrg_card_1");
+    assert.equal(omise.spy.charges[0].amount, 14900);
+    assert.equal(pool.orders.get("CWF-PAY1").status, "paid");
+  } finally { server.close(); }
+});
+
+test("PromptPay payment returns a QR and leaves the order awaiting the webhook", async () => {
+  const server = await startServer(makePool(seedOrder()), fakeOmise());
+  try {
+    const body = await (await postJson(`${url(server)}/public/orders/CWF-PAY1/pay`, { method: "promptpay" })).json();
+    assert.equal(body.order.status, "payment_processing");
+    assert.equal(body.payment.qr_uri, "https://cdn.omise.co/qr.png");
+    assert.equal(body.payment.requires_polling, true);
+  } finally { server.close(); }
+});
+
+test("pay rejects an invalid method, a missing card token, and a non-payable order", async () => {
+  const server = await startServer(makePool(seedOrder({ status: "paid" })), fakeOmise());
+  try {
+    assert.equal((await postJson(`${url(server)}/public/orders/CWF-PAY1/pay`, { method: "bitcoin" })).status, 400);
+    assert.equal((await postJson(`${url(server)}/public/orders/CWF-PAY1/pay`, { method: "card" })).status, 400);
+    const paidRes = await postJson(`${url(server)}/public/orders/CWF-PAY1/pay`, { method: "promptpay" });
+    assert.equal(paidRes.status, 409);
+    assert.equal((await paidRes.json()).status, "paid");
+  } finally { server.close(); }
+});
+
+test("pay returns 503 when Omise is not configured, and 404 for an unknown order", async () => {
+  const notConfigured = await startServer(makePool(seedOrder()), fakeOmise({ configured: false }));
+  try {
+    assert.equal((await postJson(`${url(notConfigured)}/public/orders/CWF-PAY1/pay`, { method: "promptpay" })).status, 503);
+  } finally { notConfigured.close(); }
+
+  const server = await startServer(makePool(seedOrder()), fakeOmise());
+  try {
+    assert.equal((await postJson(`${url(server)}/public/orders/CWF-NOPE/pay`, { method: "promptpay" })).status, 404);
+  } finally { server.close(); }
+});
+
+test("webhook verifies by re-fetching the charge and flips the matching order to paid, idempotently", async () => {
+  let retrieveCalls = 0;
+  const omise = fakeOmise({ retrieveCharge: async (id) => { retrieveCalls += 1; return { id, status: "successful", paid: true }; } });
+  const pool = makePool(seedOrder({ status: "payment_processing", payment_charge_id: "chrg_pp_1", payment_status: "pending" }));
+  const server = await startServer(pool, omise);
+  try {
+    const event = { key: "charge.complete", data: { object: "charge", id: "chrg_pp_1", status: "successful" } };
+    const first = await postJson(`${url(server)}/webhooks/omise`, event);
+    assert.equal(first.status, 200);
+    assert.equal((await first.json()).ok, true);
+    assert.equal(pool.orders.get("CWF-PAY1").status, "paid");
+    assert.equal(retrieveCalls, 1); // verified against Omise, not trusting the payload
+
+    // Replays are safe no-ops.
+    const second = await postJson(`${url(server)}/webhooks/omise`, event);
+    assert.equal(second.status, 200);
+    assert.equal(pool.orders.get("CWF-PAY1").status, "paid");
+  } finally { server.close(); }
+});
+
+test("webhook ignores an event with no charge id and always answers 200", async () => {
+  const server = await startServer(makePool(seedOrder()), fakeOmise());
+  try {
+    const res = await postJson(`${url(server)}/webhooks/omise`, { key: "ping", data: {} });
+    assert.equal(res.status, 200);
+    assert.equal((await res.json()).ignored, true);
+  } finally { server.close(); }
+});

--- a/test/customerOrdersPaymentMigration.test.js
+++ b/test/customerOrdersPaymentMigration.test.js
@@ -1,0 +1,94 @@
+"use strict";
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("fs");
+const path = require("path");
+const runner = require("../scripts/run-customer-orders-payment-migration");
+
+const REPO_ROOT = path.resolve(__dirname, "..");
+const DATABASE_URL = "postgres://user:super-secret-password@db.example.invalid:5432/cwf";
+
+const PAY_COLUMNS = ["payment_provider", "payment_method", "payment_charge_id", "payment_status", "paid_at"];
+
+class FakeClient {
+  constructor(options = {}) {
+    this.options = options;
+    this.ended = false;
+    this.queries = [];
+  }
+  async connect() { if (this.options.failConnect) throw new Error(this.options.failConnect); }
+  async query(sql) {
+    this.queries.push({ sql: String(sql) });
+    const s = String(sql);
+    if (s.includes("to_regclass('public.customer_orders')")) {
+      return { rows: [{ orders: this.options.missingTable ? null : "public.customer_orders" }] };
+    }
+    if (s.includes("information_schema.columns")) {
+      const cols = this.options.missingColumn ? PAY_COLUMNS.filter((c) => c !== "paid_at") : PAY_COLUMNS;
+      return { rows: cols.map((column_name) => ({ column_name })) };
+    }
+    return { rows: [] };
+  }
+  async end() { this.ended = true; }
+}
+
+function makeLogger() {
+  const lines = [];
+  return { lines, log: (m) => lines.push(String(m)), error: (m) => lines.push(String(m)) };
+}
+
+test("payment migration runner runs the SQL under an advisory lock, verifies, and unlocks", async () => {
+  let client;
+  const logger = makeLogger();
+  await runner.runMigration({
+    env: { DATABASE_URL }, repoRoot: REPO_ROOT, logger,
+    clientFactory() { client = new FakeClient(); return client; },
+  });
+  const sql = fs.readFileSync(path.join(REPO_ROOT, runner.MIGRATION_RELATIVE_PATH), "utf8");
+  assert.equal(client.queries[0].sql, "SELECT pg_advisory_lock($1::bigint)");
+  assert.equal(client.queries[1].sql, sql);
+  assert.equal(client.queries.at(-1).sql, "SELECT pg_advisory_unlock($1::bigint)");
+  assert.equal(client.ended, true);
+  assert.deepEqual(logger.lines, ["CUSTOMER_ORDERS_PAYMENT_MIGRATION_START", "CUSTOMER_ORDERS_PAYMENT_MIGRATION_OK"]);
+});
+
+test("payment migration runner fails non-zero when a payment column is missing after migration", async () => {
+  const logger = makeLogger();
+  const code = await runner.runCli({
+    env: { DATABASE_URL }, repoRoot: REPO_ROOT, logger,
+    clientFactory() { return new FakeClient({ missingColumn: true }); },
+  });
+  assert.equal(code, 1);
+  assert.match(logger.lines.join("\n"), /customer_orders\.paid_at missing after migration/);
+});
+
+test("payment migration runner never leaks database secrets", async () => {
+  const logger = makeLogger();
+  const code = await runner.runCli({
+    env: { DATABASE_URL }, repoRoot: REPO_ROOT, logger,
+    clientFactory() { return new FakeClient({ failConnect: `cannot connect ${DATABASE_URL}` }); },
+  });
+  assert.equal(code, 1);
+  const output = logger.lines.join("\n");
+  assert.doesNotMatch(output, /super-secret-password/);
+  assert.match(output, /\[REDACTED_DATABASE_URL\]/);
+});
+
+test("payment migration is additive only and idempotent (safe to re-run on a live DB)", () => {
+  const sql = fs.readFileSync(path.join(REPO_ROOT, runner.MIGRATION_RELATIVE_PATH), "utf8");
+  const executable = sql.split("\n").filter((l) => !l.trim().startsWith("--")).join("\n");
+  assert.doesNotMatch(executable, /\bDELETE\s+FROM\b/i);
+  assert.doesNotMatch(executable, /\bTRUNCATE\b/i);
+  assert.doesNotMatch(executable, /\bDROP\s+(TABLE|COLUMN)\b/i);
+  // Only additive ADD COLUMN IF NOT EXISTS on the existing table.
+  assert.match(sql, /ADD COLUMN IF NOT EXISTS payment_provider/);
+  assert.match(sql, /ADD COLUMN IF NOT EXISTS paid_at/);
+  assert.match(sql, /CREATE UNIQUE INDEX IF NOT EXISTS/);
+  assert.doesNotMatch(executable, /\bUPDATE\s+public/i); // never backfills/rewrites rows
+});
+
+test("payment migration runner uses an advisory lock distinct from the base orders runner", () => {
+  const base = require("../scripts/run-customer-orders-migration");
+  assert.notEqual(runner.ADVISORY_LOCK_KEY, base.ADVISORY_LOCK_KEY);
+});

--- a/test/customerSameDayTiming.test.js
+++ b/test/customerSameDayTiming.test.js
@@ -160,7 +160,7 @@ test("customer app disables availability HTTP cache and refreshes same-day slots
 });
 
 test("customer app build and service worker cache IDs changed", () => {
-  const id = "20260702_orders_v1";
+  const id = "20260702_pay_v1";
   for (const file of [
     "customer-app/index.html",
     "customer-app/sw.js",

--- a/test/homepageCms.test.js
+++ b/test/homepageCms.test.js
@@ -278,7 +278,7 @@ test("customer homepage has no admin control, bottom nav is fixed five-tab, and 
   const sw = read("customer-app/sw.js");
   const app = read("customer-app/assets/customer-app.js");
   const manifest = read("customer-app/manifest.webmanifest");
-  const build = "20260702_orders_v1";
+  const build = "20260702_pay_v1";
 
   assert.doesNotMatch(index + ui, /โหมดแอดมิน|openCms|localStorage\.getItem\('cwfHomeCmsDemo'/);
   assert.match(index, /data-route="store"[\s\S]*ร้านค้า/);

--- a/test/omiseService.test.js
+++ b/test/omiseService.test.js
@@ -1,0 +1,106 @@
+"use strict";
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const {
+  createOmiseClient,
+  bahtToSatang,
+  chargeToOrderStatus,
+  promptPayQrUri,
+} = require("../server/services/omise");
+
+// A fake transport that records requests and returns queued responses.
+function makeHttp(responses) {
+  const calls = [];
+  const queue = Array.isArray(responses) ? responses.slice() : [responses];
+  return {
+    calls,
+    request: async (opts) => {
+      calls.push(opts);
+      const next = queue.shift();
+      return next || { status: 200, body: {} };
+    },
+  };
+}
+
+test("bahtToSatang converts to integer satang and guards against float dust", () => {
+  assert.equal(bahtToSatang(14900), 1490000);
+  assert.equal(bahtToSatang(1499.99), 149999);
+  assert.equal(bahtToSatang(0), 0);
+  assert.equal(bahtToSatang(-5), 0);
+  assert.equal(bahtToSatang("abc"), 0);
+});
+
+test("createCardCharge posts a captured charge in satang with the card token", async () => {
+  const http = makeHttp({ status: 200, body: { id: "chrg_1", status: "successful", paid: true } });
+  const omise = createOmiseClient({ env: { OMISE_SECRET_KEY: "skey_test_x" }, httpRequest: http.request });
+  const charge = await omise.createCardCharge({ amount: 14900, token: "tokn_abc" });
+  assert.equal(charge.id, "chrg_1");
+  const req = http.calls[0];
+  assert.equal(req.method, "POST");
+  assert.equal(req.path, "/charges");
+  assert.equal(req.payload.amount, 1490000);
+  assert.equal(req.payload.currency, "thb");
+  assert.equal(req.payload.card, "tokn_abc");
+  assert.equal(req.payload.capture, true);
+  assert.equal(req.secretKey, "skey_test_x");
+});
+
+test("createPromptPayCharge creates a source then a charge on that source", async () => {
+  const http = makeHttp([
+    { status: 200, body: { id: "src_1", type: "promptpay" } },
+    { status: 200, body: { id: "chrg_pp", status: "pending", source: { scannable_code: { image: { download_uri: "https://cdn.omise.co/q.png" } } } } },
+  ]);
+  const omise = createOmiseClient({ env: { OMISE_SECRET_KEY: "skey_test_x" }, httpRequest: http.request });
+  const charge = await omise.createPromptPayCharge({ amount: 14900 });
+  assert.equal(http.calls[0].path, "/sources");
+  assert.equal(http.calls[0].payload.type, "promptpay");
+  assert.equal(http.calls[0].payload.amount, 1490000);
+  assert.equal(http.calls[1].path, "/charges");
+  assert.equal(http.calls[1].payload.source, "src_1");
+  assert.equal(promptPayQrUri(charge), "https://cdn.omise.co/q.png");
+});
+
+test("retrieveCharge does a GET on the charge id", async () => {
+  const http = makeHttp({ status: 200, body: { id: "chrg_9", status: "successful", paid: true } });
+  const omise = createOmiseClient({ env: { OMISE_SECRET_KEY: "skey_test_x" }, httpRequest: http.request });
+  const charge = await omise.retrieveCharge("chrg_9");
+  assert.equal(http.calls[0].method, "GET");
+  assert.equal(http.calls[0].path, "/charges/chrg_9");
+  assert.equal(charge.paid, true);
+});
+
+test("an Omise error response is turned into a thrown error carrying the code", async () => {
+  const http = makeHttp({ status: 402, body: { object: "error", code: "invalid_card", message: "card was declined" } });
+  const omise = createOmiseClient({ env: { OMISE_SECRET_KEY: "skey_test_x" }, httpRequest: http.request });
+  await assert.rejects(
+    () => omise.createCardCharge({ amount: 100, token: "tokn_bad" }),
+    (err) => { assert.equal(err.code, "invalid_card"); assert.equal(err.status, 402); return true; }
+  );
+});
+
+test("with no secret key the client is not configured and refuses to call out", async () => {
+  const http = makeHttp({ status: 200, body: {} });
+  const omise = createOmiseClient({ env: {}, httpRequest: http.request });
+  assert.equal(omise.isConfigured(), false);
+  await assert.rejects(() => omise.createCardCharge({ amount: 100, token: "t" }), /OMISE_NOT_CONFIGURED/);
+  assert.equal(http.calls.length, 0);
+});
+
+test("isTestMode and getPublicKey reflect the configured keys", () => {
+  const omise = createOmiseClient({ env: { OMISE_SECRET_KEY: "skey_test_x", OMISE_PUBLIC_KEY: "pkey_test_y" }, httpRequest: () => {} });
+  assert.equal(omise.isConfigured(), true);
+  assert.equal(omise.isTestMode(), true);
+  assert.equal(omise.getPublicKey(), "pkey_test_y");
+  const live = createOmiseClient({ env: { OMISE_SECRET_KEY: "skey_live_x", OMISE_PUBLIC_KEY: "pkey_live_y" }, httpRequest: () => {} });
+  assert.equal(live.isTestMode(), false);
+});
+
+test("chargeToOrderStatus maps Omise charge states to persisted order statuses", () => {
+  assert.equal(chargeToOrderStatus({ status: "successful", paid: true }), "paid");
+  assert.equal(chargeToOrderStatus({ status: "pending", paid: false }), "payment_processing");
+  assert.equal(chargeToOrderStatus({ status: "failed" }), "payment_failed");
+  assert.equal(chargeToOrderStatus({ status: "expired" }), "payment_failed");
+  assert.equal(chargeToOrderStatus({}), "payment_processing");
+});

--- a/test/storeBuyMigrations.test.js
+++ b/test/storeBuyMigrations.test.js
@@ -5,16 +5,18 @@ const assert = require("node:assert/strict");
 const orchestrator = require("../scripts/run-store-buy-migrations");
 const ordersRunner = require("../scripts/run-customer-orders-migration");
 const bookingModeRunner = require("../scripts/run-catalog-booking-mode-purchase-migration");
+const ordersPaymentRunner = require("../scripts/run-customer-orders-payment-migration");
 
 function makeLogger() {
   const lines = [];
   return { lines, log: (m) => lines.push(String(m)), error: (m) => lines.push(String(m)) };
 }
 
-test("STEPS wires the two buy-flow migration runners in the correct order", () => {
-  assert.equal(orchestrator.STEPS.length, 2);
+test("STEPS wires the buy-flow migration runners in the correct order", () => {
+  assert.equal(orchestrator.STEPS.length, 3);
   assert.equal(orchestrator.STEPS[0].runner, ordersRunner);
   assert.equal(orchestrator.STEPS[1].runner, bookingModeRunner);
+  assert.equal(orchestrator.STEPS[2].runner, ordersPaymentRunner);
 });
 
 test("runAll runs every step in order and returns 0 when all succeed", async () => {


### PR DESCRIPTION
Two related pieces of store buy-flow work on the same branch.

---

## Part 1 — Fix: saving a store item fails when หมวดหมู่ is free text

Adding a store item failed with a 500 (`เพิ่มรายการไม่สำเร็จ`) when the admin typed a free-text category such as `สินค้า`. `catalog_items.item_category` is constrained to `CHECK (item_category IN ('service','product'))`, so any other value aborts the insert.

- `normalizeItemCategory()` coerces the value to a valid token before insert (purchase-mode / product-ish → `product`, else `service`).
- `dbErrorHint()` appends a short Thai hint (constraint / duplicate / schema-not-ready) to the admin save error.
- The admin หมวดหมู่ field is now a `บริการ / สินค้า` dropdown, so an invalid value can't be entered.
- Additive only — no schema change.

## Part 2 — Feature: Omise online payment (PromptPay + card)

`purchase`-mode orders previously parked at `pending_payment` with no way to pay. This adds full online payment via Omise (Opn), supporting **PromptPay QR** and **credit/debit card**.

**Backend**
- `server/services/omise.js` — env-keyed Omise client (secret key from env, never hardcoded/logged). Card charge from a browser token, PromptPay source+charge, retrieveCharge. Amounts converted to satang; fully injectable for tests (no network).
- `GET /public/payment-config` exposes only the **public** key + methods.
- `POST /public/orders/:code/pay` charges the **server-stored** subtotal (client can't influence the amount). Card resolves synchronously; PromptPay returns a QR and awaits the webhook. Only `pending_payment` / `payment_failed` orders are payable (blocks double charge).
- `POST /webhooks/omise` verifies by **re-fetching** the charge (Omise webhooks are unsigned) and updates the order idempotently; always answers 200.
- Additive migration adding nullable `payment_*` columns to `customer_orders`, with a safe idempotent runner wired into the store-buy orchestrator (auto-applies on boot) + `npm run migrate:customer-orders-payment`.

**Customer app**
- Purchase sheet now shows a payment step: PromptPay (QR + status polling) or card (Omise.js tokenizes in the browser — only the one-time token reaches our server, never the raw card number).
- Graceful fallback to the existing LINE hand-off when the order didn't save or payment isn't configured.
- `api.getPaymentConfig` / `api.payOrder`, payment-step styles, cache-bust bumped to `20260702_pay_v1`.

**Docs** — `docs/OMISE_PAYMENT_SETUP.md`: required env keys, webhook endpoint, and the live-test steps.

### Security / safety
- Secret key lives only in `OMISE_SECRET_KEY` (env) — never in code, logs, or this PR. With no secret key set, payment reports **disabled** and the buy flow is unchanged.
- Server computes the charge amount; the client can't set it.
- All migrations are additive/idempotent; nothing existing is rewritten.

### Testing
- 27 new tests (Omise service with a mocked transport, pay/webhook routes, payment migration runner, customer-app payment contract). Full suite green: **780 pass, 11 pre-existing skips, 0 fail.**
- ⚠️ **No live Omise call was made** — this environment's network policy blocks `api.omise.co`. The live test must run in staging/production with your Omise **test** keys set; steps are in `docs/OMISE_PAYMENT_SETUP.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LmdP3TGN5uQrfT8ZYefNco