### PR TITLE
feat: admin orders & payment dashboard

### DIFF
--- a/admin-orders.css
+++ b/admin-orders.css
@@ -1,0 +1,62 @@
+/* Admin orders & payment dashboard */
+
+.ao-summary {
+  display: grid;
+  grid-template-columns: repeat(5, 1fr);
+  gap: 10px;
+  text-align: center;
+}
+.ao-stat { display: flex; flex-direction: column; gap: 2px; padding: 6px 4px; }
+.ao-stat-num { font-size: 22px; font-weight: 900; color: #0f172a; }
+.ao-stat-label { font-size: 11px; color: #64748b; }
+.ao-stat-num.ao-paid { color: #0f9d76; }
+.ao-stat-num.ao-processing { color: #b7791f; }
+.ao-stat-num.ao-failed { color: #dc2626; }
+.ao-stat-num.ao-revenue { color: #2563eb; }
+
+.ao-toolbar-row {
+  display: flex; align-items: center; justify-content: space-between;
+  gap: 10px; flex-wrap: wrap;
+}
+.ao-toolbar-row + .ao-toolbar-row { margin-top: 10px; }
+.ao-search {
+  flex: 1 1 220px; min-width: 160px;
+  padding: 9px 12px; border: 1px solid #d5dae2; border-radius: 10px; font-size: 14px;
+}
+.ao-filter {
+  padding: 9px 10px; border: 1px solid #d5dae2; border-radius: 10px; font-size: 13px; background: #fff;
+}
+
+.ao-card-list { display: grid; gap: 10px; }
+.ao-loading, .ao-empty, .ao-error { padding: 24px 12px; text-align: center; color: #64748b; font-size: 14px; }
+.ao-error { color: #dc2626; }
+
+.ao-card {
+  border: 1px solid #e6e9ef; border-radius: 14px; padding: 12px 14px;
+  background: #fff; display: grid; gap: 6px;
+}
+.ao-card-head { display: flex; align-items: center; justify-content: space-between; gap: 8px; }
+.ao-code { font-weight: 800; font-size: 14px; color: #0f172a; letter-spacing: .3px; }
+.ao-card-amount { font-size: 17px; font-weight: 900; color: #0f172a; }
+.ao-method { font-size: 12px; font-weight: 700; color: #64748b; }
+.ao-card-items { font-size: 13px; color: #334155; }
+.ao-card-row { display: flex; align-items: center; justify-content: space-between; gap: 10px; font-size: 13px; }
+.ao-muted { color: #64748b; font-size: 12px; }
+.ao-phone { color: #2563eb; text-decoration: none; font-weight: 700; }
+.ao-card-address, .ao-card-note { font-size: 12px; }
+.ao-card-note { color: #334155; background: #f8fafc; border-radius: 8px; padding: 6px 8px; }
+.ao-pay-detail { flex-wrap: wrap; gap: 4px 12px; }
+.ao-charge { font-family: ui-monospace, monospace; font-size: 11px; }
+
+.ao-badge {
+  font-size: 11.5px; font-weight: 800; padding: 3px 10px; border-radius: 999px; white-space: nowrap;
+}
+.ao-badge-paid { background: #dcfce7; color: #15803d; }
+.ao-badge-processing { background: #fef3c7; color: #b7791f; }
+.ao-badge-pending { background: #eef2f7; color: #475569; }
+.ao-badge-failed { background: #fee2e2; color: #dc2626; }
+
+@media (max-width: 560px) {
+  .ao-summary { grid-template-columns: repeat(2, 1fr); }
+  .ao-stat-num { font-size: 19px; }
+}

--- a/admin-orders.html
+++ b/admin-orders.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html lang="th">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <title>Admin • คำสั่งซื้อและการชำระเงิน</title>
+  <link rel="stylesheet" href="/style.css"/>
+  <link rel="stylesheet" href="/admin-orders.css?v=20260702_orders_v1"/>
+</head>
+<body>
+  <div class="topbar">
+    <div><b>🧾 คำสั่งซื้อและการชำระเงิน (Admin)</b></div>
+  </div>
+
+  <div class="container">
+    <div class="card ao-summary" id="orders_summary">
+      <div class="ao-stat"><span class="ao-stat-num" data-sum-total>–</span><span class="ao-stat-label">ทั้งหมด</span></div>
+      <div class="ao-stat"><span class="ao-stat-num ao-paid" data-sum-paid>–</span><span class="ao-stat-label">จ่ายแล้ว</span></div>
+      <div class="ao-stat"><span class="ao-stat-num ao-processing" data-sum-processing>–</span><span class="ao-stat-label">รอชำระ</span></div>
+      <div class="ao-stat"><span class="ao-stat-num ao-failed" data-sum-failed>–</span><span class="ao-stat-label">ไม่สำเร็จ</span></div>
+      <div class="ao-stat"><span class="ao-stat-num ao-revenue" data-sum-revenue>–</span><span class="ao-stat-label">ยอดจ่ายแล้ว (บาท)</span></div>
+    </div>
+
+    <div class="card ao-toolbar" style="margin-top:12px">
+      <div class="ao-toolbar-row">
+        <div>
+          <b>รายการคำสั่งซื้อ</b>
+          <div class="muted2 mini">ข้อมูลจริงจาก /admin/orders · แสดง 200 รายการล่าสุด</div>
+        </div>
+        <button id="btnReloadOrders" class="secondary btn-small" type="button">รีเฟรช</button>
+      </div>
+      <div class="ao-toolbar-row">
+        <input id="orders_search" class="ao-search" placeholder="ค้นหาเลขคำสั่งซื้อ / ชื่อ / เบอร์โทร">
+        <select id="orders_filter_status" class="ao-filter">
+          <option value="">ทุกสถานะ</option>
+          <option value="paid">จ่ายแล้ว</option>
+          <option value="payment_processing">รอชำระ (พร้อมเพย์)</option>
+          <option value="pending_payment">ยังไม่ชำระ</option>
+          <option value="payment_failed">ไม่สำเร็จ</option>
+        </select>
+        <select id="orders_filter_method" class="ao-filter">
+          <option value="">ทุกช่องทาง</option>
+          <option value="promptpay">พร้อมเพย์</option>
+          <option value="card">บัตร</option>
+        </select>
+      </div>
+    </div>
+
+    <div class="card" style="margin-top:12px">
+      <div id="orders_list" class="ao-card-list">กำลังโหลดคำสั่งซื้อ...</div>
+    </div>
+  </div>
+
+  <script src="/admin-v2-common.js?v=20260622_admin_menu_catalog_entry"></script>
+  <script src="/admin-orders.js?v=20260702_orders_v1"></script>
+</body>
+</html>

--- a/admin-orders.js
+++ b/admin-orders.js
@@ -1,0 +1,130 @@
+// Admin orders & payment dashboard. Read-only view of customer_orders from the
+// real /admin/orders endpoint, with client-side search + status/method filters.
+// apiFetch(), el() and the shared admin menu come from admin-v2-common.js.
+
+let allOrders = [];
+let ordersSchemaReady = true;
+let filterState = { search: "", status: "", method: "" };
+
+function esc(value) {
+  return String(value == null ? "" : value)
+    .replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;");
+}
+
+function fmtMoney(n) {
+  const v = Number(n);
+  return Number.isFinite(v) ? v.toLocaleString("th-TH") : "0";
+}
+
+function fmtDateTime(value) {
+  if (!value) return "";
+  const d = new Date(value);
+  if (Number.isNaN(d.getTime())) return "";
+  return d.toLocaleString("th-TH", { day: "2-digit", month: "short", year: "2-digit", hour: "2-digit", minute: "2-digit" });
+}
+
+// The order's payment/fulfilment status drives the badge. We prefer the order
+// status; payment_status is shown as raw detail.
+const STATUS_META = {
+  paid: { label: "จ่ายแล้ว", cls: "ao-badge-paid" },
+  payment_processing: { label: "รอชำระ", cls: "ao-badge-processing" },
+  pending_payment: { label: "ยังไม่ชำระ", cls: "ao-badge-pending" },
+  payment_failed: { label: "ไม่สำเร็จ", cls: "ao-badge-failed" },
+};
+
+function statusMeta(status) {
+  return STATUS_META[status] || { label: status || "-", cls: "ao-badge-pending" };
+}
+
+const METHOD_LABEL = { promptpay: "พร้อมเพย์", card: "บัตร" };
+const DELIVERY_LABEL = { pickup: "รับที่ร้าน", ship: "จัดส่ง" };
+const INSTALL_LABEL = { none: "ไม่ติดตั้ง", cwf: "ติดตั้งโดยช่าง CWF" };
+
+function itemsSummary(items) {
+  if (!Array.isArray(items) || !items.length) return "";
+  return items.map((it) => `${esc(it.name || it.item_name || "")} × ${Number(it.qty) || 1}`).join(", ");
+}
+
+function orderCardHtml(o) {
+  const meta = statusMeta(o.status);
+  const method = o.payment_method ? (METHOD_LABEL[o.payment_method] || o.payment_method) : "";
+  const paidLine = o.paid_at ? `<span class="ao-muted">ชำระเมื่อ ${esc(fmtDateTime(o.paid_at))}</span>` : "";
+  const chargeLine = o.payment_charge_id ? `<span class="ao-muted ao-charge">${esc(o.payment_charge_id)}</span>` : "";
+  return `
+    <div class="ao-card">
+      <div class="ao-card-head">
+        <div class="ao-code">${esc(o.order_code)}</div>
+        <span class="ao-badge ${meta.cls}">${esc(meta.label)}</span>
+      </div>
+      <div class="ao-card-amount">฿${fmtMoney(o.subtotal)} ${method ? `<span class="ao-method">· ${esc(method)}</span>` : ""}</div>
+      <div class="ao-card-items">${itemsSummary(o.items) || "<span class=\"ao-muted\">ไม่มีรายการสินค้า</span>"}</div>
+      <div class="ao-card-row">
+        <span>${esc(o.customer_name || "")}</span>
+        <a class="ao-phone" href="tel:${esc(o.customer_phone || "")}">${esc(o.customer_phone || "")}</a>
+      </div>
+      <div class="ao-card-row ao-muted">
+        <span>${esc(DELIVERY_LABEL[o.delivery_method] || o.delivery_method || "")} · ${esc(INSTALL_LABEL[o.install_option] || o.install_option || "")}</span>
+        <span>${esc(fmtDateTime(o.created_at))}</span>
+      </div>
+      ${o.address ? `<div class="ao-card-address ao-muted">📍 ${esc(o.address)}</div>` : ""}
+      ${(paidLine || chargeLine) ? `<div class="ao-card-row ao-pay-detail">${paidLine}${chargeLine}</div>` : ""}
+      ${o.note ? `<div class="ao-card-note">📝 ${esc(o.note)}</div>` : ""}
+    </div>`;
+}
+
+function applyFilters(orders) {
+  const q = filterState.search.trim().toLowerCase();
+  return orders.filter((o) => {
+    if (filterState.status && o.status !== filterState.status) return false;
+    if (filterState.method && o.payment_method !== filterState.method) return false;
+    if (q) {
+      const hay = `${o.order_code} ${o.customer_name} ${o.customer_phone}`.toLowerCase();
+      if (!hay.includes(q)) return false;
+    }
+    return true;
+  });
+}
+
+function renderSummary(orders) {
+  const by = (s) => orders.filter((o) => o.status === s).length;
+  const revenue = orders.filter((o) => o.status === "paid").reduce((sum, o) => sum + (Number(o.subtotal) || 0), 0);
+  el("orders_summary").querySelector("[data-sum-total]").textContent = String(orders.length);
+  el("orders_summary").querySelector("[data-sum-paid]").textContent = String(by("paid"));
+  el("orders_summary").querySelector("[data-sum-processing]").textContent = String(by("payment_processing"));
+  el("orders_summary").querySelector("[data-sum-failed]").textContent = String(by("payment_failed"));
+  el("orders_summary").querySelector("[data-sum-revenue]").textContent = fmtMoney(revenue);
+}
+
+function renderList() {
+  const box = el("orders_list");
+  if (!ordersSchemaReady) {
+    box.innerHTML = `<div class="ao-empty">ยังไม่ได้ติดตั้งฐานข้อมูลคำสั่งซื้อ (schema) — ระบบจะอัปเดตอัตโนมัติเมื่อเปิดใช้งานฟีเจอร์ร้านค้า</div>`;
+    return;
+  }
+  const filtered = applyFilters(allOrders);
+  if (!allOrders.length) { box.innerHTML = `<div class="ao-empty">ยังไม่มีคำสั่งซื้อ</div>`; return; }
+  if (!filtered.length) { box.innerHTML = `<div class="ao-empty">ไม่พบคำสั่งซื้อที่ตรงกับตัวกรอง</div>`; return; }
+  box.innerHTML = filtered.map(orderCardHtml).join("");
+}
+
+async function loadOrders() {
+  const box = el("orders_list");
+  box.innerHTML = `<div class="ao-loading">กำลังโหลดคำสั่งซื้อ...</div>`;
+  try {
+    const data = await apiFetch("/admin/orders");
+    allOrders = Array.isArray(data && data.orders) ? data.orders : [];
+    ordersSchemaReady = data && data.schema_ready === false ? false : true;
+    renderSummary(allOrders);
+    renderList();
+  } catch (err) {
+    box.innerHTML = `<div class="ao-error">โหลดคำสั่งซื้อไม่สำเร็จ กรุณาลองใหม่</div>`;
+  }
+}
+
+document.addEventListener("DOMContentLoaded", () => {
+  el("btnReloadOrders")?.addEventListener("click", loadOrders);
+  el("orders_search")?.addEventListener("input", (e) => { filterState.search = e.target.value || ""; renderList(); });
+  el("orders_filter_status")?.addEventListener("change", (e) => { filterState.status = e.target.value || ""; renderList(); });
+  el("orders_filter_method")?.addEventListener("change", (e) => { filterState.method = e.target.value || ""; renderList(); });
+  loadOrders();
+});

--- a/admin-v2-common.js
+++ b/admin-v2-common.js
@@ -486,6 +486,7 @@ function injectAdminMenu(){
             <div class="cwf-link" data-href="/admin-review-v2.html">✅ อนุมัติงาน/รีวิว <small>Approvals</small></div>
             <div class="cwf-link" data-href="/admin-promotions-v2.html">🏷️ โปรโมชั่น/ราคา <small>Promotions</small></div>
             <div class="cwf-link" data-href="/admin-store-catalog.html">🗂️ รายการบริการในร้านค้า <small>Store Catalog</small></div>
+            <div class="cwf-link" data-href="/admin-orders.html">🧾 คำสั่งซื้อ/การชำระเงิน <small>Orders &amp; Payment</small></div>
             <div class="cwf-link" data-href="/admin-job-view-v2.html">🔎 ดูงาน <small>Job View</small></div>
           </div>
         </div>

--- a/server/routes/customerOrders.js
+++ b/server/routes/customerOrders.js
@@ -104,6 +104,25 @@ function publicOrder(row) {
   };
 }
 
+// Admin view: everything in publicOrder plus payment details (for the orders
+// dashboard). note is admin-only too.
+function adminOrder(row) {
+  const base = publicOrder(row);
+  if (!base) return null;
+  return {
+    ...base,
+    note: row.note || "",
+    payment_method: row.payment_method || "",
+    payment_status: row.payment_status || "",
+    payment_charge_id: row.payment_charge_id || "",
+    paid_at: row.paid_at || null,
+  };
+}
+
+function isUndefinedColumn(error) {
+  return error && error.code === "42703";
+}
+
 function isSchemaError(error) {
   const code = error && error.code;
   return code === "42P01" || code === "42703"; // undefined_table / undefined_column
@@ -288,14 +307,27 @@ function createCustomerOrdersRoutes(deps = {}) {
     }
   });
 
-  // Admin: list recent orders (read-only).
+  // Admin: list recent orders (read-only). Includes payment details when the
+  // payment columns exist; on a DB that has orders but not yet the payment
+  // migration, it falls back to the base columns so the list still loads.
+  const ADMIN_BASE_COLUMNS = "order_code, customer_name, customer_phone, delivery_method, install_option, address, items, subtotal, status, note, created_at";
+  const ADMIN_PAYMENT_COLUMNS = "payment_method, payment_status, payment_charge_id, paid_at";
   router.get("/admin/orders", adminGuard, async (_req, res) => {
     try {
-      const rows = await pool.query(
-        `SELECT order_code, customer_name, customer_phone, delivery_method, install_option, address, items, subtotal, status, created_at
-           FROM public.customer_orders ORDER BY created_at DESC LIMIT 200`
-      );
-      return res.json({ ok: true, orders: rows.rows.map(publicOrder) });
+      let rows;
+      try {
+        rows = await pool.query(
+          `SELECT ${ADMIN_BASE_COLUMNS}, ${ADMIN_PAYMENT_COLUMNS}
+             FROM public.customer_orders ORDER BY created_at DESC LIMIT 200`
+        );
+      } catch (inner) {
+        if (!isUndefinedColumn(inner)) throw inner; // real error → outer catch
+        rows = await pool.query(
+          `SELECT ${ADMIN_BASE_COLUMNS}
+             FROM public.customer_orders ORDER BY created_at DESC LIMIT 200`
+        );
+      }
+      return res.json({ ok: true, orders: rows.rows.map(adminOrder) });
     } catch (error) {
       if (isSchemaError(error)) return res.json({ ok: true, orders: [], schema_ready: false });
       console.error("[orders/admin-list] failed", error);
@@ -306,4 +338,4 @@ function createCustomerOrdersRoutes(deps = {}) {
   return router;
 }
 
-module.exports = { createCustomerOrdersRoutes, normalizeOrder, generateOrderCode, publicOrder };
+module.exports = { createCustomerOrdersRoutes, normalizeOrder, generateOrderCode, publicOrder, adminOrder };

--- a/test/adminOrdersRoute.test.js
+++ b/test/adminOrdersRoute.test.js
@@ -1,0 +1,93 @@
+"use strict";
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const http = require("node:http");
+const express = require("express");
+
+const { createCustomerOrdersRoutes, adminOrder } = require("../server/routes/customerOrders");
+
+const SAMPLE = {
+  order_code: "CWF-A1", customer_name: "คุณเอ", customer_phone: "0812345678",
+  delivery_method: "ship", install_option: "cwf", address: "123 ถนนทดสอบ",
+  items: [{ item_id: "6", name: "แอร์ Daikin", qty: 1, unit_price: 14900 }],
+  subtotal: 14900, status: "paid", note: "ด่วน", created_at: new Date().toISOString(),
+  payment_method: "promptpay", payment_status: "successful", payment_charge_id: "chrg_1", paid_at: new Date().toISOString(),
+};
+
+// Pool whose admin SELECT behaviour is configurable: with payment columns, or
+// throwing undefined_column (42703) on the rich query to exercise the fallback.
+function makePool({ hasPaymentColumns = true, tableMissing = false } = {}) {
+  return {
+    calls: [],
+    async query(sql) {
+      const s = String(sql).replace(/\s+/g, " ");
+      this.calls.push(s);
+      if (tableMissing) { const e = new Error("no table"); e.code = "42P01"; throw e; }
+      const isRich = s.includes("payment_method, payment_status");
+      if (isRich && !hasPaymentColumns) { const e = new Error("no column"); e.code = "42703"; throw e; }
+      const row = { ...SAMPLE };
+      if (!isRich) { delete row.payment_method; delete row.payment_status; delete row.payment_charge_id; delete row.paid_at; }
+      return { rows: [row] };
+    },
+  };
+}
+
+function startServer(pool) {
+  const app = express();
+  app.use(express.json());
+  app.use(createCustomerOrdersRoutes({ pool, requireAdminSession: (_q, _s, next) => next() }));
+  const server = http.createServer(app);
+  return new Promise((resolve) => server.listen(0, "127.0.0.1", () => resolve(server)));
+}
+const url = (s) => `http://127.0.0.1:${s.address().port}`;
+
+test("adminOrder serializer includes payment + note fields on top of the public fields", () => {
+  const a = adminOrder(SAMPLE);
+  assert.equal(a.order_code, "CWF-A1");
+  assert.equal(a.payment_method, "promptpay");
+  assert.equal(a.payment_status, "successful");
+  assert.equal(a.payment_charge_id, "chrg_1");
+  assert.equal(a.note, "ด่วน");
+  assert.ok(a.paid_at);
+  // Missing payment fields degrade to empty strings, never undefined.
+  const bare = adminOrder({ order_code: "CWF-B", items: [], subtotal: 0, status: "pending_payment" });
+  assert.equal(bare.payment_method, "");
+  assert.equal(bare.paid_at, null);
+});
+
+test("GET /admin/orders returns payment details when the columns exist", async () => {
+  const server = await startServer(makePool({ hasPaymentColumns: true }));
+  try {
+    const body = await (await fetch(`${url(server)}/admin/orders`)).json();
+    assert.equal(body.ok, true);
+    assert.equal(body.orders.length, 1);
+    assert.equal(body.orders[0].payment_method, "promptpay");
+    assert.equal(body.orders[0].status, "paid");
+  } finally { server.close(); }
+});
+
+test("GET /admin/orders falls back to base columns when the payment migration has not run", async () => {
+  const pool = makePool({ hasPaymentColumns: false });
+  const server = await startServer(pool);
+  try {
+    const res = await fetch(`${url(server)}/admin/orders`);
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.equal(body.orders.length, 1); // list still loads
+    assert.equal(body.orders[0].payment_method, ""); // gracefully absent
+    // It retried without the payment columns.
+    assert.ok(pool.calls.some((s) => s.includes("payment_method, payment_status")));
+    assert.ok(pool.calls.some((s) => !s.includes("payment_method") && s.includes("FROM public.customer_orders")));
+  } finally { server.close(); }
+});
+
+test("GET /admin/orders reports schema_ready:false (200, empty) when the table itself is missing", async () => {
+  const server = await startServer(makePool({ tableMissing: true }));
+  try {
+    const body = await (await fetch(`${url(server)}/admin/orders`)).json();
+    assert.equal(body.ok, true);
+    assert.equal(body.schema_ready, false);
+    assert.deepEqual(body.orders, []);
+  } finally { server.close(); }
+});

--- a/test/adminOrdersUi.test.js
+++ b/test/adminOrdersUi.test.js
@@ -1,0 +1,68 @@
+"use strict";
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("fs");
+const path = require("path");
+
+const REPO_ROOT = path.resolve(__dirname, "..");
+const read = (p) => fs.readFileSync(path.join(REPO_ROOT, p), "utf8");
+
+const htmlSrc = read("admin-orders.html");
+const jsSrc = read("admin-orders.js");
+const cssSrc = read("admin-orders.css");
+const commonSrc = read("admin-v2-common.js");
+
+test("the shared admin menu links to the orders dashboard exactly once", () => {
+  const matches = commonSrc.match(/data-href="\/admin-orders\.html"/g) || [];
+  assert.equal(matches.length, 1);
+  assert.match(commonSrc, /data-href="\/admin-orders\.html">[^<]*คำสั่งซื้อ/);
+});
+
+test("admin-orders.html loads the shared menu, its own script and stylesheet with a consistent cache-bust", () => {
+  assert.match(htmlSrc, /<script src="\/admin-v2-common\.js\?v=[^"]+"><\/script>/);
+  assert.match(htmlSrc, /admin-orders\.js\?v=20260702_orders_v1/);
+  assert.match(htmlSrc, /admin-orders\.css\?v=20260702_orders_v1/);
+});
+
+test("the page has a summary strip, search, status + method filters and a list container", () => {
+  assert.match(htmlSrc, /data-sum-total/);
+  assert.match(htmlSrc, /data-sum-paid/);
+  assert.match(htmlSrc, /data-sum-revenue/);
+  assert.match(htmlSrc, /id="orders_search"/);
+  assert.match(htmlSrc, /id="orders_filter_status"/);
+  assert.match(htmlSrc, /id="orders_filter_method"/);
+  assert.match(htmlSrc, /id="orders_list"/);
+});
+
+test("the dashboard reads the real /admin/orders endpoint (read-only, no mutation calls)", () => {
+  assert.match(jsSrc, /apiFetch\("\/admin\/orders"\)/);
+  assert.doesNotMatch(jsSrc, /method:\s*"(POST|PATCH|DELETE|PUT)"/);
+});
+
+test("orders are rendered with a status badge and payment method, and money/dates are formatted", () => {
+  assert.match(jsSrc, /STATUS_META/);
+  assert.match(jsSrc, /ao-badge-paid/);
+  assert.match(jsSrc, /ao-badge-processing/);
+  assert.match(jsSrc, /ao-badge-failed/);
+  assert.match(jsSrc, /payment_method/);
+  assert.match(jsSrc, /toLocaleString\("th-TH"/);
+});
+
+test("client-side search + status + method filters are wired to re-render the list", () => {
+  assert.match(jsSrc, /orders_search[\s\S]*?filterState\.search/);
+  assert.match(jsSrc, /orders_filter_status[\s\S]*?filterState\.status/);
+  assert.match(jsSrc, /orders_filter_method[\s\S]*?filterState\.method/);
+  assert.match(jsSrc, /function applyFilters/);
+});
+
+test("the dashboard shows a friendly message when the orders schema is not ready", () => {
+  assert.match(jsSrc, /schema_ready === false/);
+  assert.match(jsSrc, /ordersSchemaReady/);
+});
+
+test("badge and summary styles exist in the stylesheet", () => {
+  assert.match(cssSrc, /\.ao-badge-paid/);
+  assert.match(cssSrc, /\.ao-summary/);
+  assert.match(cssSrc, /\.ao-card/);
+});


### PR DESCRIPTION
Adds an admin dashboard to monitor store orders and their Omise payment status (follows the payment feature merged in #135).

## Backend
- `GET /admin/orders` now returns payment details via a new `adminOrder` serializer: `payment_method`, raw `payment_status`, `payment_charge_id`, `paid_at`, plus the admin-only `note`.
- The query fetches the `payment_*` columns when present and **falls back to the base columns** if the payment migration hasn't run yet, so the list always loads. A missing table still reports `schema_ready:false` (200, empty).

## Admin page (`/admin-orders.html`)
- **Summary strip:** total / paid / awaiting / failed counts + paid revenue.
- **Card list:** colour-coded status badge (จ่ายแล้ว / รอชำระ / ยังไม่ชำระ / ไม่สำเร็จ), payment method, charge id, amount, customer, delivery/install, address, note.
- **Filters:** client-side search (code / name / phone) + status + method.
- Friendly message when the orders schema isn't applied yet.
- Wired into the shared admin menu beside Store Catalog; served by the existing static route; **read-only** (no mutation calls).

## Safety
- Read-only dashboard; no schema change, no migration. The admin route degrades gracefully before/after the payment migration.

## Testing
- 12 new tests (admin route serializer + payment-column fallback + schema-not-ready; dashboard UI contract). Full suite green: **792 pass, 11 pre-existing skips, 0 fail.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LmdP3TGN5uQrfT8ZYefNco

---
_Generated by [Claude Code](https://claude.ai/code/session_01LmdP3TGN5uQrfT8ZYefNco)_