### PR TITLE
fix: online-purchase items reverting to "contact admin"

### DIFF
--- a/server/routes/catalog/items.js
+++ b/server/routes/catalog/items.js
@@ -785,7 +785,7 @@ function serializeCatalogRow(row) {
     images,
     short_description: row.short_description || null,
     highlights: Array.isArray(row.highlights) ? row.highlights : [],
-    booking_mode: row.booking_mode === "bookable" ? "bookable" : "contact_admin",
+    booking_mode: BOOKING_MODES.has(row.booking_mode) ? row.booking_mode : "contact_admin",
     // Needed on the list endpoint so the Store card's "book" button can build a
     // real booking draft without a follow-up detail fetch. booking_service_key is
     // intentionally omitted here: the frontend never uses it for booking, only

--- a/test/catalogItemsRoutes.test.js
+++ b/test/catalogItemsRoutes.test.js
@@ -2265,6 +2265,22 @@ test("public GET /catalog/items suppresses booking_ac_type/booking_btu/booking_w
   });
 });
 
+test("public GET /catalog/items preserves booking_mode 'purchase' (must not collapse to contact_admin)", async () => {
+  // Regression: the read serializer used to map anything != 'bookable' to
+  // 'contact_admin', silently downgrading a saved 'purchase' product so the
+  // customer app showed the admin-contact CTA instead of the buy button.
+  const items = sampleItems();
+  items[0].booking_mode = "purchase";
+  const pool = makePool(items, [], { marketplaceReady: true });
+  const router = createCatalogItemRoutes({ pool, requireAdminSession: allowAdmin });
+  await withServer(router, async (base) => {
+    const list = await (await fetch(`${base}/catalog/items?customer=1`)).json();
+    assert.equal(list.find((x) => x.item_id === 1).booking_mode, "purchase");
+    const detail = await (await fetch(`${base}/catalog/items/1`)).json();
+    assert.equal(detail.booking_mode, "purchase");
+  });
+});
+
 test("public GET /catalog/items/:itemId puts the Primary image first even when it is not sort_order 0", async () => {
   const items = sampleItems();
   const pool = makePool(items, [], { marketplaceReady: true });


### PR DESCRIPTION
## Problem

Setting a store item to **ซื้อออนไลน์ (purchase)** in the admin saved fine, but after saving it always came back as **ติดต่อแอดมิน (contact_admin)** — in both the admin Edit form and the customer app (which showed the "สอบถามแอดมิน" button instead of a buy button). Items could never actually be sold online.

## Root cause

The read serializer `serializeCatalogRow` collapsed the value:

```js
booking_mode: row.booking_mode === "bookable" ? "bookable" : "contact_admin",
```

Anything that wasn't `bookable` — including a correctly-saved `purchase` — was mapped to `contact_admin` on the way out. The DB stored `purchase` fine; every read downgraded it.

## Fix

```js
booking_mode: BOOKING_MODES.has(row.booking_mode) ? row.booking_mode : "contact_admin",
```

Preserves any valid mode (`bookable` / `purchase` / `contact_admin`) and only defaults to `contact_admin` for an unknown/undefined value (e.g. before the marketplace migration). This one serializer feeds the public list, public detail, and admin DTOs, so it corrects all three at once. The bookable-only fields (`booking_ac_type` / `booking_btu` / `booking_wash_variant`) stay gated on `bookable` as before.

## Testing
- New regression test: a `purchase` item read via the public list and detail endpoints stays `purchase`.
- Existing `contact_admin` suppression tests still pass (`contact_admin` maps to itself).
- Full suite green: **793 pass, 11 pre-existing skips, 0 fail.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LmdP3TGN5uQrfT8ZYefNco

---
_Generated by [Claude Code](https://claude.ai/code/session_01LmdP3TGN5uQrfT8ZYefNco)_