### PR TITLE
feat: order lifecycle — admin fulfilment + customer order tracking

### DIFF
--- a/admin-orders.css
+++ b/admin-orders.css
@@ -55,6 +55,19 @@
 .ao-badge-processing { background: #fef3c7; color: #b7791f; }
 .ao-badge-pending { background: #eef2f7; color: #475569; }
 .ao-badge-failed { background: #fee2e2; color: #dc2626; }
+.ao-badge-fulfil { background: #dbeafe; color: #1d4ed8; }
+
+.ao-fulfil {
+  margin-top: 8px; padding-top: 10px; border-top: 1px dashed #e6e9ef;
+  display: grid; gap: 8px;
+}
+.ao-fulfil-head { font-size: 13px; }
+.ao-fulfil-row { display: flex; gap: 8px; align-items: center; }
+.ao-fulfil-row .ao-filter { flex: 1; }
+.ao-fulfil-note { width: 100%; font-size: 13px; }
+.ao-fulfil-status { font-size: 12px; font-weight: 700; }
+.ao-fulfil-status.is-ok { color: #15803d; }
+.ao-fulfil-status.is-err { color: #dc2626; }
 
 @media (max-width: 560px) {
   .ao-summary { grid-template-columns: repeat(2, 1fr); }

--- a/admin-orders.html
+++ b/admin-orders.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
   <title>Admin • คำสั่งซื้อและการชำระเงิน</title>
   <link rel="stylesheet" href="/style.css"/>
-  <link rel="stylesheet" href="/admin-orders.css?v=20260702_orders_v1"/>
+  <link rel="stylesheet" href="/admin-orders.css?v=20260703_lifecycle_v1"/>
 </head>
 <body>
   <div class="topbar">
@@ -52,6 +52,6 @@
   </div>
 
   <script src="/admin-v2-common.js?v=20260622_admin_menu_catalog_entry"></script>
-  <script src="/admin-orders.js?v=20260702_orders_v1"></script>
+  <script src="/admin-orders.js?v=20260703_lifecycle_v1"></script>
 </body>
 </html>

--- a/admin-orders.js
+++ b/admin-orders.js
@@ -39,6 +39,18 @@ function statusMeta(status) {
 const METHOD_LABEL = { promptpay: "พร้อมเพย์", card: "บัตร" };
 const DELIVERY_LABEL = { pickup: "รับที่ร้าน", ship: "จัดส่ง" };
 const INSTALL_LABEL = { none: "ไม่ติดตั้ง", cwf: "ติดตั้งโดยช่าง CWF" };
+// Admin fulfilment lifecycle (must mirror FULFILLMENT_STATUSES in
+// server/routes/customerOrders.js).
+const FULFILLMENT_OPTIONS = [
+  { value: "", label: "— ยังไม่จัดการ —" },
+  { value: "confirmed", label: "ยืนยันคำสั่งซื้อ" },
+  { value: "preparing", label: "กำลังเตรียมสินค้า" },
+  { value: "shipped", label: "จัดส่งแล้ว" },
+  { value: "installing", label: "กำลังติดตั้ง" },
+  { value: "completed", label: "เสร็จสิ้น" },
+  { value: "cancelled", label: "ยกเลิก" },
+];
+const FULFILLMENT_LABEL = FULFILLMENT_OPTIONS.reduce((m, o) => { if (o.value) m[o.value] = o.label; return m; }, {});
 
 function itemsSummary(items) {
   if (!Array.isArray(items) || !items.length) return "";
@@ -69,6 +81,30 @@ function orderCardHtml(o) {
       ${o.address ? `<div class="ao-card-address ao-muted">📍 ${esc(o.address)}</div>` : ""}
       ${(paidLine || chargeLine) ? `<div class="ao-card-row ao-pay-detail">${paidLine}${chargeLine}</div>` : ""}
       ${o.note ? `<div class="ao-card-note">📝 ${esc(o.note)}</div>` : ""}
+      ${fulfillmentControlHtml(o)}
+    </div>`;
+}
+
+// Admin fulfilment control: current stage + a selector, a customer-visible note,
+// and a save button. Wired via event delegation on the list container.
+function fulfillmentControlHtml(o) {
+  const current = o.fulfillment_status || "";
+  const badge = current
+    ? `<span class="ao-badge ao-badge-fulfil">${esc(FULFILLMENT_LABEL[current] || current)}</span>`
+    : `<span class="ao-muted">ยังไม่จัดการ</span>`;
+  const options = FULFILLMENT_OPTIONS
+    .map((opt) => `<option value="${opt.value}"${opt.value === current ? " selected" : ""}>${esc(opt.label)}</option>`)
+    .join("");
+  return `
+    <div class="ao-fulfil" data-order-code="${esc(o.order_code)}">
+      <div class="ao-fulfil-head"><span class="ao-muted">การจัดการ:</span> ${badge}</div>
+      <div class="ao-fulfil-row">
+        <select class="ao-filter" data-fulfil-select>${options}</select>
+        <button class="secondary btn-small" type="button" data-fulfil-save>บันทึก</button>
+      </div>
+      <input class="ao-search ao-fulfil-note" data-fulfil-note maxlength="500"
+        placeholder="โน้ตถึงลูกค้า เช่น เลขพัสดุ / นัดติดตั้ง / ค่าส่งที่ยืนยัน" value="${esc(o.admin_note || "")}">
+      <span class="ao-fulfil-status" data-fulfil-msg hidden></span>
     </div>`;
 }
 
@@ -121,10 +157,45 @@ async function loadOrders() {
   }
 }
 
+async function saveFulfillment(wrap) {
+  const code = wrap.getAttribute("data-order-code");
+  const select = wrap.querySelector("[data-fulfil-select]");
+  const note = wrap.querySelector("[data-fulfil-note]");
+  const btn = wrap.querySelector("[data-fulfil-save]");
+  const msg = wrap.querySelector("[data-fulfil-msg]");
+  const showMsg = (text, ok) => { if (msg) { msg.textContent = text; msg.hidden = false; msg.classList.toggle("is-ok", !!ok); msg.classList.toggle("is-err", !ok); } };
+  if (btn) { btn.disabled = true; btn.textContent = "กำลังบันทึก..."; }
+  try {
+    const data = await apiFetch(`/admin/orders/${encodeURIComponent(code)}/status`, {
+      method: "POST",
+      body: JSON.stringify({ fulfillment_status: select ? select.value : "", admin_note: note ? note.value : "" }),
+    });
+    // Update the in-memory order so re-render keeps the change without a full reload.
+    const updated = data && data.order;
+    if (updated) {
+      const idx = allOrders.findIndex((o) => o.order_code === code);
+      if (idx >= 0) allOrders[idx] = updated;
+      renderSummary(allOrders);
+    }
+    showMsg("บันทึกแล้ว ✓", true);
+  } catch (_err) {
+    showMsg("บันทึกไม่สำเร็จ", false);
+  } finally {
+    if (btn) { btn.disabled = false; btn.textContent = "บันทึก"; }
+  }
+}
+
 document.addEventListener("DOMContentLoaded", () => {
   el("btnReloadOrders")?.addEventListener("click", loadOrders);
   el("orders_search")?.addEventListener("input", (e) => { filterState.search = e.target.value || ""; renderList(); });
   el("orders_filter_status")?.addEventListener("change", (e) => { filterState.status = e.target.value || ""; renderList(); });
   el("orders_filter_method")?.addEventListener("change", (e) => { filterState.method = e.target.value || ""; renderList(); });
+  // Delegated: fulfilment save buttons live inside re-rendered cards.
+  el("orders_list")?.addEventListener("click", (e) => {
+    const btn = e.target.closest("[data-fulfil-save]");
+    if (!btn) return;
+    const wrap = btn.closest("[data-order-code]");
+    if (wrap) saveFulfillment(wrap);
+  });
   loadOrders();
 });

--- a/customer-app/assets/customer-app.css
+++ b/customer-app/assets/customer-app.css
@@ -1067,6 +1067,26 @@ p { margin: 0; }
 /* ===================== Tracking ===================== */
 .lookup-card { border: 1.5px solid var(--soft-blue-2); }
 .tracking-result-card { display: flex; flex-direction: column; gap: 12px; }
+
+/* Store order tracking result */
+.order-status-line { font-size: 13.5px; color: var(--muted); }
+.order-status-line strong { color: var(--ink); }
+.order-steps { list-style: none; margin: 4px 0; padding: 0; display: grid; gap: 8px; }
+.order-step {
+  position: relative; padding-left: 26px; font-size: 13.5px; color: var(--muted);
+}
+.order-step::before {
+  content: ""; position: absolute; left: 0; top: 2px; width: 16px; height: 16px;
+  border-radius: 50%; border: 2px solid var(--line); background: #fff;
+}
+.order-step.is-done { color: var(--ink); font-weight: 700; }
+.order-step.is-done::before { background: var(--blue); border-color: var(--blue); }
+.order-items { display: grid; gap: 4px; }
+.order-total strong:last-child { color: var(--blue); }
+.order-admin-note {
+  font-size: 13px; color: var(--ink); background: var(--soft-blue);
+  border-radius: 10px; padding: 8px 10px;
+}
 .tracking-topline {
   display: flex;
   align-items: center;

--- a/customer-app/assets/customer-app.js
+++ b/customer-app/assets/customer-app.js
@@ -3,7 +3,7 @@
 
   const App = window.CWFCustomerAppV2;
   const BOOT_TIMEOUT_MS = 3500;
-  const BUILD_ID = "20260702_pay_v1";
+  const BUILD_ID = "20260703_lifecycle_v1";
 
   function withTimeout(promise, timeoutMs) {
     return Promise.race([

--- a/customer-app/index.html
+++ b/customer-app/index.html
@@ -17,10 +17,10 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Noto+Sans+Thai:wght@400;500;600;700;800;900&display=swap" media="print" onload="this.media='all'">
   <noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Noto+Sans+Thai:wght@400;500;600;700;800;900&display=swap"></noscript>
-  <link rel="manifest" href="./manifest.webmanifest?v=20260702_pay_v1">
+  <link rel="manifest" href="./manifest.webmanifest?v=20260703_lifecycle_v1">
   <link rel="icon" type="image/png" sizes="192x192" href="./assets/icons/cwf-customer-192.png">
   <link rel="apple-touch-icon" sizes="180x180" href="./assets/icons/cwf-customer-180.png">
-  <link rel="stylesheet" href="./assets/customer-app.css?v=20260702_pay_v1">
+  <link rel="stylesheet" href="./assets/customer-app.css?v=20260703_lifecycle_v1">
 </head>
 <body class="is-app-booting">
   <div class="app-shell" data-app-shell>
@@ -58,21 +58,21 @@
     </nav>
   </div>
 
-  <script src="./modules/state.js?v=20260702_pay_v1"></script>
-  <script src="./modules/utils.js?v=20260702_pay_v1"></script>
-  <script src="./modules/analytics.js?v=20260702_pay_v1"></script>
-  <script src="./modules/api.js?v=20260702_pay_v1"></script>
-  <script src="./modules/services.js?v=20260702_pay_v1"></script>
-  <script src="./modules/ui.js?v=20260702_pay_v1"></script>
-  <script src="./modules/store.js?v=20260702_pay_v1"></script>
-  <script src="./modules/auth.js?v=20260702_pay_v1"></script>
-  <script src="./modules/pricing.js?v=20260702_pay_v1"></script>
-  <script src="./modules/availability.js?v=20260702_pay_v1"></script>
-  <script src="./modules/bookingScheduled.js?v=20260702_pay_v1"></script>
-  <script src="./modules/bookingUrgent.js?v=20260702_pay_v1"></script>
-  <script src="./modules/tracking.js?v=20260702_pay_v1"></script>
-  <script src="./modules/profile.js?v=20260702_pay_v1"></script>
-  <script src="./modules/router.js?v=20260702_pay_v1"></script>
-  <script src="./assets/customer-app.js?v=20260702_pay_v1"></script>
+  <script src="./modules/state.js?v=20260703_lifecycle_v1"></script>
+  <script src="./modules/utils.js?v=20260703_lifecycle_v1"></script>
+  <script src="./modules/analytics.js?v=20260703_lifecycle_v1"></script>
+  <script src="./modules/api.js?v=20260703_lifecycle_v1"></script>
+  <script src="./modules/services.js?v=20260703_lifecycle_v1"></script>
+  <script src="./modules/ui.js?v=20260703_lifecycle_v1"></script>
+  <script src="./modules/store.js?v=20260703_lifecycle_v1"></script>
+  <script src="./modules/auth.js?v=20260703_lifecycle_v1"></script>
+  <script src="./modules/pricing.js?v=20260703_lifecycle_v1"></script>
+  <script src="./modules/availability.js?v=20260703_lifecycle_v1"></script>
+  <script src="./modules/bookingScheduled.js?v=20260703_lifecycle_v1"></script>
+  <script src="./modules/bookingUrgent.js?v=20260703_lifecycle_v1"></script>
+  <script src="./modules/tracking.js?v=20260703_lifecycle_v1"></script>
+  <script src="./modules/profile.js?v=20260703_lifecycle_v1"></script>
+  <script src="./modules/router.js?v=20260703_lifecycle_v1"></script>
+  <script src="./assets/customer-app.js?v=20260703_lifecycle_v1"></script>
 </body>
 </html>

--- a/customer-app/manifest.webmanifest
+++ b/customer-app/manifest.webmanifest
@@ -2,7 +2,7 @@
   "name": "CWF Customer Service",
   "short_name": "CWF Service",
   "description": "แอปลูกค้า Coldwindflow สำหรับเลือกบริการ จองคิว และติดตามงาน",
-  "start_url": "/customer-app/index.html?v=20260702_pay_v1#home",
+  "start_url": "/customer-app/index.html?v=20260703_lifecycle_v1#home",
   "scope": "/customer-app/",
   "id": "/customer-app/",
   "display": "standalone",

--- a/customer-app/modules/store.js
+++ b/customer-app/modules/store.js
@@ -1799,7 +1799,9 @@
         <div><span>ยอดชำระ</span><strong>${esc(root.utils.formatBaht(o.amount))}</strong></div>
       </div>
       <p>แอดมินจะติดต่อกลับเพื่อยืนยันการจัดส่ง/ติดตั้ง และค่าใช้จ่ายเพิ่มเติม (ถ้ามี)</p>
+      ${o.orderCode ? `<p class="purchase-note">ติดตามสถานะคำสั่งซื้อได้ที่เมนู "ติดตาม" โดยใส่เลข ${esc(o.orderCode)}</p>` : ""}
       <div class="contact-sheet-actions">
+        ${o.orderCode ? `<button class="secondary-btn" type="button" data-route="tracking" data-track-order="${esc(o.orderCode)}">ติดตามคำสั่งซื้อ</button>` : ""}
         <a class="primary-btn" href="https://lin.ee/fG1Oq7y" target="_blank" rel="noopener noreferrer">แจ้งแอดมินทาง LINE</a>
       </div>
     `;
@@ -1871,7 +1873,11 @@
       const clearError = () => { if (errEl) errEl.hidden = true; };
       const goPaid = () => {
         if (pollTimer) { clearInterval(pollTimer); pollTimer = null; }
-        sheet.innerHTML = paidConfirmHtml(item, o);
+        const orderCode = (o.order && o.order.order_code) || "";
+        // Prefill the tracking screen so the "ติดตามคำสั่งซื้อ" button lands on
+        // the live status of this exact order.
+        if (orderCode) root.state.updateDraft?.("tracking", { trackingCode: orderCode });
+        sheet.innerHTML = paidConfirmHtml(item, { ...o, orderCode });
         bindClose();
         trackItemEvent("cwf_store_purchase_paid", item, { method: o.lastMethod, amount: o.amount });
       };
@@ -1997,6 +2003,7 @@
         renderPaymentStep({ order, qty, delivery, install, name, phone, amount }, config);
         return;
       }
+      if (order?.order_code) root.state.updateDraft?.("tracking", { trackingCode: order.order_code });
       if (sheet) sheet.innerHTML = purchaseConfirmHtml(item, { qty, delivery, install, name, phone, orderCode: order?.order_code || "" });
       bindClose();
     });

--- a/customer-app/modules/tracking.js
+++ b/customer-app/modules/tracking.js
@@ -1012,6 +1012,60 @@
     return content || root.utils.stateBox("", "รูปงานจะแสดงหลังช่างอัปโหลดและงานเสร็จ");
   }
 
+  // ---- Store order tracking (codes like CWF-XXXX) --------------------------
+  const ORDER_PAYMENT_COPY = {
+    paid: { label: "ชำระเงินแล้ว", cls: "success" },
+    payment_processing: { label: "รอการชำระเงิน", cls: "loading" },
+    pending_payment: { label: "ยังไม่ได้ชำระเงิน", cls: "" },
+    payment_failed: { label: "การชำระเงินไม่สำเร็จ", cls: "error" },
+  };
+  const ORDER_FULFILMENT_STEPS = [
+    { key: "confirmed", label: "ยืนยันคำสั่งซื้อ" },
+    { key: "preparing", label: "กำลังเตรียมสินค้า" },
+    { key: "shipped", label: "จัดส่งแล้ว" },
+    { key: "installing", label: "กำลังติดตั้ง" },
+    { key: "completed", label: "เสร็จสิ้น" },
+  ];
+  const ORDER_FULFILMENT_LABEL = { cancelled: "ยกเลิกคำสั่งซื้อ", ...ORDER_FULFILMENT_STEPS.reduce((m, s) => { m[s.key] = s.label; return m; }, {}) };
+
+  function renderOrderResult(order) {
+    if (!order) return root.utils.stateBox("error", "ไม่พบคำสั่งซื้อนี้");
+    const pay = ORDER_PAYMENT_COPY[order.status] || { label: order.status || "-", cls: "" };
+    const fulfil = order.fulfillment_status || "";
+    const items = Array.isArray(order.items) ? order.items : [];
+    const itemsHtml = items.map((it) => `<div class="data-row"><span>${esc(it.name || it.item_name || "")} × ${Number(it.qty) || 1}</span><span class="muted">${root.utils.formatBaht((Number(it.unit_price) || 0) * (Number(it.qty) || 1))}</span></div>`).join("");
+    const steps = ORDER_FULFILMENT_STEPS;
+    const activeIndex = steps.findIndex((s) => s.key === fulfil);
+    const cancelled = fulfil === "cancelled";
+    const timeline = cancelled
+      ? `<div class="status-hero is-error"><strong>ยกเลิกคำสั่งซื้อ</strong></div>`
+      : `<ol class="order-steps">${steps.map((s, i) => `<li class="order-step ${activeIndex >= 0 && i <= activeIndex ? "is-done" : ""}">${esc(s.label)}</li>`).join("")}</ol>`;
+    return `
+      <div class="tracking-result-card order-result-card">
+        <div class="status-hero is-${pay.cls}">
+          <strong>${esc(pay.label)}</strong>
+          <span>คำสั่งซื้อ ${esc(order.order_code || "")}</span>
+        </div>
+        <div class="order-status-line">สถานะการจัดส่ง/ติดตั้ง: <strong>${esc(fulfil ? (ORDER_FULFILMENT_LABEL[fulfil] || fulfil) : "รอแอดมินยืนยัน")}</strong></div>
+        ${!cancelled ? timeline : timeline}
+        <div class="order-items">${itemsHtml}</div>
+        <div class="data-row order-total"><strong>ยอดชำระ</strong><strong>${root.utils.formatBaht(Number(order.subtotal) || 0)}</strong></div>
+        ${order.admin_note ? `<div class="order-admin-note">📌 ${esc(order.admin_note)}</div>` : ""}
+        <p class="muted mini">* ค่าจัดส่ง/ติดตั้งเพิ่มเติม (ถ้ามี) แอดมินจะแจ้งในโน้ตด้านบนหรือทาง LINE</p>
+      </div>`;
+  }
+
+  async function lookupOrder(container, code) {
+    const box = container.querySelector("[data-tracking-result]");
+    box.innerHTML = root.utils.stateBox("loading", "กำลังค้นหาคำสั่งซื้อ...");
+    try {
+      const res = await root.api.getOrder(code);
+      box.innerHTML = renderOrderResult(res && res.order);
+    } catch (_error) {
+      box.innerHTML = root.utils.stateBox("error", "ไม่พบคำสั่งซื้อนี้ กรุณาตรวจสอบเลขคำสั่งซื้ออีกครั้ง");
+    }
+  }
+
   function renderTrackingResult() {
     const state = root.state.tracking;
     if (state.status === "idle") return root.utils.stateBox("", "กรอกเลขงานหรือรหัสติดตามเพื่อดูสถานะจากระบบ");
@@ -1161,6 +1215,9 @@
       container.querySelector("[data-tracking-result]").innerHTML = renderTrackingResult();
       return;
     }
+    // Store order codes look like "CWF-XXXX" — route them to the order lookup
+    // instead of the job/booking tracker.
+    if (/^CWF-/i.test(q)) { await lookupOrder(container, q); return; }
     root.state.setTracking({ status: "loading", data: null, error: "" });
     container.querySelector("[data-tracking-result]").innerHTML = renderTrackingResult();
     try {
@@ -1275,9 +1332,9 @@
         <section class="screen">
           ${root.ui?.pageHeaderHtml ? root.ui.pageHeaderHtml("tracking") : ""}
           <div class="hero tracking-hero">
-            <div class="hero-badge">Live job status</div>
-            <h2>ติดตามงาน</h2>
-            <p>ใส่เลขงานหรือรหัสติดตาม เพื่อดูสถานะสำคัญตั้งแต่รับคำขอจนจบงาน</p>
+            <div class="hero-badge">Live status</div>
+            <h2>ติดตามงาน / คำสั่งซื้อ</h2>
+            <p>ใส่เลขงาน รหัสติดตาม หรือเลขคำสั่งซื้อ (CWF-...) เพื่อดูสถานะตั้งแต่ต้นจนจบ</p>
           </div>
           <section class="card lookup-card">
             <div class="section-head">
@@ -1285,11 +1342,11 @@
               <h2>ค้นหางานของคุณ</h2>
             </div>
             <div class="field">
-              <label for="tracking-code">เลขงาน / รหัสติดตาม</label>
-              <input id="tracking-code" class="input" placeholder="เช่น CWFXXXXXXX" value="${esc(code)}">
+              <label for="tracking-code">เลขงาน / รหัสติดตาม / เลขคำสั่งซื้อ</label>
+              <input id="tracking-code" class="input" placeholder="เช่น CWFXXXXXXX หรือ CWF-XXXX" value="${esc(code)}">
             </div>
             <div class="button-row">
-              <button class="primary-btn" type="button" data-action="track-read">ตรวจสอบสถานะงาน</button>
+              <button class="primary-btn" type="button" data-action="track-read">ตรวจสอบสถานะ</button>
             </div>
           </section>
           <section class="card">

--- a/customer-app/sw.js
+++ b/customer-app/sw.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const BUILD_ID = "20260702_pay_v1";
+const BUILD_ID = "20260703_lifecycle_v1";
 const CACHE_NAME = `cwf-customer-app-v2-${BUILD_ID}`;
 const APP_SHELL = [
   `./index.html?v=${BUILD_ID}`,

--- a/migrations/20260703_customer_orders_fulfillment.sql
+++ b/migrations/20260703_customer_orders_fulfillment.sql
@@ -1,0 +1,13 @@
+-- Customer product orders — fulfilment columns (buy flow, order lifecycle).
+-- Additive only: adds two nullable columns to customer_orders so an admin can
+-- move a paid order through fulfilment (confirmed → preparing → shipped/
+-- installing → completed / cancelled) and leave a customer-visible note (e.g.
+-- shipping details or a confirmed delivery/install fee). It never drops,
+-- rewrites, or backfills existing rows, so it is safe on a live DB and safe to
+-- re-run (ADD COLUMN IF NOT EXISTS is idempotent).
+--
+-- fulfilment is intentionally separate from `status` (the payment lifecycle):
+-- a paid order has status='paid' and its own fulfilment_status.
+
+ALTER TABLE public.customer_orders ADD COLUMN IF NOT EXISTS fulfillment_status TEXT;  -- confirmed|preparing|shipped|installing|completed|cancelled
+ALTER TABLE public.customer_orders ADD COLUMN IF NOT EXISTS admin_note         TEXT;  -- admin → customer note (visible in tracking)

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "migrate:customer-orders": "node scripts/run-customer-orders-migration.js",
     "migrate:catalog-booking-mode-purchase": "node scripts/run-catalog-booking-mode-purchase-migration.js",
     "migrate:customer-orders-payment": "node scripts/run-customer-orders-payment-migration.js",
+    "migrate:customer-orders-fulfillment": "node scripts/run-customer-orders-fulfillment-migration.js",
     "migrate:store-buy": "node scripts/run-store-buy-migrations.js",
     "test": "node --test test/*.test.js"
   },

--- a/scripts/run-customer-orders-fulfillment-migration.js
+++ b/scripts/run-customer-orders-fulfillment-migration.js
@@ -1,0 +1,129 @@
+"use strict";
+
+// Applies migrations/20260703_customer_orders_fulfillment.sql — the
+// fulfillment_status + admin_note columns on customer_orders for the order
+// lifecycle (admin fulfilment + customer tracking).
+//
+// Safe to run anytime, including repeatedly: ADD COLUMN IF NOT EXISTS only. It
+// adds nullable columns and never touches existing rows or other tables, so it
+// cannot affect or break the running app. An advisory lock prevents two
+// concurrent runners from racing.
+
+const fs = require("fs");
+const path = require("path");
+const { Client } = require("pg");
+
+const MIGRATION_RELATIVE_PATH = "migrations/20260703_customer_orders_fulfillment.sql";
+const ADVISORY_LOCK_KEY = "202607030101";
+
+function clean(value) {
+  return String(value == null ? "" : value).trim();
+}
+
+function safeErrorMessage(error) {
+  return clean(error && error.message ? error.message : error)
+    .replace(/postgres(?:ql)?:\/\/[^\s"'<>]+/gi, "[REDACTED_DATABASE_URL]")
+    .replace(/(password|passwd|pwd|secret|token)=([^&\s]+)/gi, "$1=[REDACTED]");
+}
+
+function resolveMigrationPath(repoRoot = path.resolve(__dirname, "..")) {
+  const root = path.resolve(repoRoot);
+  const migrationPath = path.resolve(root, MIGRATION_RELATIVE_PATH);
+  const expected = path.resolve(root, "migrations", "20260703_customer_orders_fulfillment.sql");
+  if (migrationPath !== expected || !migrationPath.startsWith(root + path.sep)) {
+    throw new Error("migration path rejected");
+  }
+  return migrationPath;
+}
+
+function readMigrationSql(repoRoot) {
+  return fs.readFileSync(resolveMigrationPath(repoRoot), "utf8");
+}
+
+function createClientConfig(env = process.env) {
+  const databaseUrl = clean(env.DATABASE_URL);
+  if (databaseUrl) {
+    return {
+      connectionString: databaseUrl,
+      options: "-c timezone=Asia/Bangkok",
+      ssl: { rejectUnauthorized: false },
+    };
+  }
+  return {
+    host: clean(env.DB_HOST),
+    port: Number(env.DB_PORT || 5432),
+    user: clean(env.DB_USER),
+    password: env.DB_PASSWORD,
+    database: clean(env.DB_NAME),
+    options: "-c timezone=Asia/Bangkok",
+    ssl: { rejectUnauthorized: false },
+  };
+}
+
+async function verifySchema(client) {
+  const table = await client.query("SELECT to_regclass('public.customer_orders') AS orders");
+  if (!table.rows?.[0]?.orders) throw new Error("customer_orders table missing (run the base orders migration first)");
+  const columns = await client.query(`
+    SELECT column_name
+    FROM information_schema.columns
+    WHERE table_schema='public'
+      AND table_name='customer_orders'
+      AND column_name IN ('fulfillment_status','admin_note')
+  `);
+  const names = new Set((columns.rows || []).map((row) => row.column_name));
+  for (const required of ["fulfillment_status", "admin_note"]) {
+    if (!names.has(required)) throw new Error(`customer_orders.${required} missing after migration`);
+  }
+}
+
+async function runMigration(options = {}) {
+  const env = options.env || process.env;
+  const logger = options.logger || console;
+  const repoRoot = options.repoRoot || path.resolve(__dirname, "..");
+  const clientFactory = options.clientFactory || ((config) => new Client(config));
+  const client = clientFactory(createClientConfig(env));
+  const sql = readMigrationSql(repoRoot);
+  let locked = false;
+
+  logger.log("CUSTOMER_ORDERS_FULFILLMENT_MIGRATION_START");
+  try {
+    await client.connect();
+    await client.query("SELECT pg_advisory_lock($1::bigint)", [ADVISORY_LOCK_KEY]);
+    locked = true;
+    await client.query(sql);
+    await verifySchema(client);
+    logger.log("CUSTOMER_ORDERS_FULFILLMENT_MIGRATION_OK");
+  } finally {
+    if (locked) await client.query("SELECT pg_advisory_unlock($1::bigint)", [ADVISORY_LOCK_KEY]).catch(() => {});
+    await client.end();
+  }
+}
+
+async function runCli(options = {}) {
+  const logger = options.logger || console;
+  try {
+    await runMigration(options);
+    return 0;
+  } catch (error) {
+    logger.error(`CUSTOMER_ORDERS_FULFILLMENT_MIGRATION_FAILED: ${safeErrorMessage(error)}`);
+    return 1;
+  }
+}
+
+if (require.main === module) {
+  runCli().then((code) => {
+    process.exitCode = code;
+  });
+}
+
+module.exports = {
+  ADVISORY_LOCK_KEY,
+  MIGRATION_RELATIVE_PATH,
+  createClientConfig,
+  readMigrationSql,
+  resolveMigrationPath,
+  runCli,
+  runMigration,
+  safeErrorMessage,
+  verifySchema,
+};

--- a/scripts/run-store-buy-migrations.js
+++ b/scripts/run-store-buy-migrations.js
@@ -4,6 +4,7 @@
 //   1. customer_orders table
 //   2. catalog_items.booking_mode CHECK widened to allow 'purchase'
 //   3. customer_orders payment_* columns (Omise online payment)
+//   4. customer_orders fulfilment columns (order lifecycle)
 //
 // Why this is safe to run (including on production, and repeatedly):
 //   - Each underlying migration is additive-only (CREATE ... IF NOT EXISTS /
@@ -21,11 +22,13 @@
 const ordersRunner = require("./run-customer-orders-migration");
 const bookingModeRunner = require("./run-catalog-booking-mode-purchase-migration");
 const ordersPaymentRunner = require("./run-customer-orders-payment-migration");
+const ordersFulfillmentRunner = require("./run-customer-orders-fulfillment-migration");
 
 const STEPS = [
   { name: "customer_orders table", runner: ordersRunner },
   { name: "catalog booking_mode 'purchase'", runner: bookingModeRunner },
   { name: "customer_orders payment columns", runner: ordersPaymentRunner },
+  { name: "customer_orders fulfilment columns", runner: ordersFulfillmentRunner },
 ];
 
 async function runAll(options = {}) {

--- a/server/routes/catalog/items.js
+++ b/server/routes/catalog/items.js
@@ -785,7 +785,7 @@ function serializeCatalogRow(row) {
     images,
     short_description: row.short_description || null,
     highlights: Array.isArray(row.highlights) ? row.highlights : [],
-    booking_mode: row.booking_mode === "bookable" ? "bookable" : "contact_admin",
+    booking_mode: BOOKING_MODES.has(row.booking_mode) ? row.booking_mode : "contact_admin",
     // Needed on the list endpoint so the Store card's "book" button can build a
     // real booking draft without a follow-up detail fetch. booking_service_key is
     // intentionally omitted here: the frontend never uses it for booking, only

--- a/server/routes/customerOrders.js
+++ b/server/routes/customerOrders.js
@@ -14,6 +14,9 @@ const { createOmiseClient, chargeToOrderStatus, promptPayQrUri } = require("../s
 const DELIVERY_METHODS = new Set(["pickup", "ship"]);
 const INSTALL_OPTIONS = new Set(["none", "cwf"]);
 const PAYMENT_METHODS = new Set(["card", "promptpay"]);
+// Admin-driven fulfilment lifecycle for a paid order (separate from the payment
+// `status`). Kept as a flat allow-list — the admin advances it manually.
+const FULFILLMENT_STATUSES = new Set(["confirmed", "preparing", "shipped", "installing", "completed", "cancelled"]);
 // An order can only START a payment from one of these states (a fresh order, or
 // one whose previous attempt failed). This blocks paying twice for one order.
 const PAYABLE_STATUSES = new Set(["pending_payment", "payment_failed"]);
@@ -100,6 +103,10 @@ function publicOrder(row) {
     items: Array.isArray(row.items) ? row.items : (row.items || []),
     subtotal: Number(row.subtotal) || 0,
     status: row.status,
+    // Fulfilment is undefined until the fulfilment migration/columns exist; a
+    // paid-but-not-yet-handled order simply has an empty fulfilment_status.
+    fulfillment_status: row.fulfillment_status || "",
+    admin_note: row.admin_note || "",
     created_at: row.created_at,
   };
 }
@@ -167,12 +174,20 @@ function createCustomerOrdersRoutes(deps = {}) {
   router.get("/public/orders/:code", async (req, res) => {
     const code = cleanText(req.params.code, 40);
     if (!code) return res.status(400).json({ error: "order code required" });
+    const base = "order_code, customer_name, customer_phone, delivery_method, install_option, address, items, subtotal, status, created_at";
     try {
-      const found = await pool.query(
-        `SELECT order_code, customer_name, customer_phone, delivery_method, install_option, address, items, subtotal, status, created_at
-           FROM public.customer_orders WHERE order_code=$1 LIMIT 1`,
-        [code]
-      );
+      let found;
+      try {
+        // Include fulfilment fields so the customer can track their order. If the
+        // fulfilment migration hasn't run yet, fall back to the base columns.
+        found = await pool.query(
+          `SELECT ${base}, fulfillment_status, admin_note FROM public.customer_orders WHERE order_code=$1 LIMIT 1`,
+          [code]
+        );
+      } catch (inner) {
+        if (!isUndefinedColumn(inner)) throw inner;
+        found = await pool.query(`SELECT ${base} FROM public.customer_orders WHERE order_code=$1 LIMIT 1`, [code]);
+      }
       if (!found.rows.length) return res.status(404).json({ error: "ไม่พบคำสั่งซื้อนี้" });
       return res.json({ ok: true, order: publicOrder(found.rows[0]) });
     } catch (error) {
@@ -311,13 +326,13 @@ function createCustomerOrdersRoutes(deps = {}) {
   // payment columns exist; on a DB that has orders but not yet the payment
   // migration, it falls back to the base columns so the list still loads.
   const ADMIN_BASE_COLUMNS = "order_code, customer_name, customer_phone, delivery_method, install_option, address, items, subtotal, status, note, created_at";
-  const ADMIN_PAYMENT_COLUMNS = "payment_method, payment_status, payment_charge_id, paid_at";
+  const ADMIN_EXTRA_COLUMNS = "payment_method, payment_status, payment_charge_id, paid_at, fulfillment_status, admin_note";
   router.get("/admin/orders", adminGuard, async (_req, res) => {
     try {
       let rows;
       try {
         rows = await pool.query(
-          `SELECT ${ADMIN_BASE_COLUMNS}, ${ADMIN_PAYMENT_COLUMNS}
+          `SELECT ${ADMIN_BASE_COLUMNS}, ${ADMIN_EXTRA_COLUMNS}
              FROM public.customer_orders ORDER BY created_at DESC LIMIT 200`
         );
       } catch (inner) {
@@ -332,6 +347,38 @@ function createCustomerOrdersRoutes(deps = {}) {
       if (isSchemaError(error)) return res.json({ ok: true, orders: [], schema_ready: false });
       console.error("[orders/admin-list] failed", error);
       return res.status(500).json({ error: "โหลดรายการคำสั่งซื้อไม่สำเร็จ" });
+    }
+  });
+
+  // Admin: advance an order's fulfilment status and/or leave a customer-visible
+  // note. Payment `status` is never touched here — this is the fulfilment lane.
+  router.post("/admin/orders/:code/status", adminGuard, async (req, res) => {
+    const code = cleanText(req.params.code, 40);
+    if (!code) return res.status(400).json({ error: "order code required" });
+    const body = req.body && typeof req.body === "object" ? req.body : {};
+    const fulfillment = cleanText(body.fulfillment_status, 20);
+    const hasNote = Object.prototype.hasOwnProperty.call(body, "admin_note");
+    const adminNote = hasNote ? cleanText(body.admin_note, 500) : null;
+    if (!fulfillment && !hasNote) return res.status(400).json({ error: "no changes" });
+    if (fulfillment && !FULFILLMENT_STATUSES.has(fulfillment)) {
+      return res.status(400).json({ error: "fulfillment_status invalid" });
+    }
+    try {
+      const updated = await pool.query(
+        `UPDATE public.customer_orders
+            SET fulfillment_status = COALESCE($2, fulfillment_status),
+                admin_note = CASE WHEN $3 THEN $4 ELSE admin_note END,
+                updated_at = now()
+          WHERE order_code=$1
+          RETURNING ${ADMIN_BASE_COLUMNS}, ${ADMIN_EXTRA_COLUMNS}`,
+        [code, fulfillment || null, hasNote, adminNote]
+      );
+      if (!updated.rows.length) return res.status(404).json({ error: "ไม่พบคำสั่งซื้อนี้" });
+      return res.json({ ok: true, order: adminOrder(updated.rows[0]) });
+    } catch (error) {
+      if (isSchemaError(error)) return res.status(503).json({ error: "ORDERS_SCHEMA_NOT_READY" });
+      console.error("[orders/admin-status] failed", error);
+      return res.status(500).json({ error: "อัปเดตสถานะไม่สำเร็จ" });
     }
   });
 

--- a/test/adminOrdersUi.test.js
+++ b/test/adminOrdersUi.test.js
@@ -21,8 +21,8 @@ test("the shared admin menu links to the orders dashboard exactly once", () => {
 
 test("admin-orders.html loads the shared menu, its own script and stylesheet with a consistent cache-bust", () => {
   assert.match(htmlSrc, /<script src="\/admin-v2-common\.js\?v=[^"]+"><\/script>/);
-  assert.match(htmlSrc, /admin-orders\.js\?v=20260702_orders_v1/);
-  assert.match(htmlSrc, /admin-orders\.css\?v=20260702_orders_v1/);
+  assert.match(htmlSrc, /admin-orders\.js\?v=20260703_lifecycle_v1/);
+  assert.match(htmlSrc, /admin-orders\.css\?v=20260703_lifecycle_v1/);
 });
 
 test("the page has a summary strip, search, status + method filters and a list container", () => {
@@ -35,9 +35,12 @@ test("the page has a summary strip, search, status + method filters and a list c
   assert.match(htmlSrc, /id="orders_list"/);
 });
 
-test("the dashboard reads the real /admin/orders endpoint (read-only, no mutation calls)", () => {
+test("the dashboard reads the real /admin/orders endpoint and only mutates via the status endpoint", () => {
   assert.match(jsSrc, /apiFetch\("\/admin\/orders"\)/);
-  assert.doesNotMatch(jsSrc, /method:\s*"(POST|PATCH|DELETE|PUT)"/);
+  // The only write is the fulfilment status update — no other mutating calls.
+  const posts = jsSrc.match(/\/admin\/orders\/[^`"]*/g) || [];
+  assert.ok(posts.some((p) => p.includes("/status")));
+  assert.doesNotMatch(jsSrc, /method:\s*"(PATCH|DELETE|PUT)"/);
 });
 
 test("orders are rendered with a status badge and payment method, and money/dates are formatted", () => {
@@ -65,4 +68,18 @@ test("badge and summary styles exist in the stylesheet", () => {
   assert.match(cssSrc, /\.ao-badge-paid/);
   assert.match(cssSrc, /\.ao-summary/);
   assert.match(cssSrc, /\.ao-card/);
+});
+
+test("admin can advance an order's fulfilment status and save a customer note", () => {
+  assert.match(jsSrc, /FULFILLMENT_OPTIONS/);
+  // Offers the lifecycle stages that mirror the backend allow-list.
+  for (const s of ["confirmed", "preparing", "shipped", "installing", "completed", "cancelled"]) {
+    assert.match(jsSrc, new RegExp(`value: "${s}"`));
+  }
+  assert.match(jsSrc, /data-fulfil-save/);
+  assert.match(jsSrc, /data-fulfil-note/);
+  // Posts to the real status endpoint.
+  assert.match(jsSrc, /\/admin\/orders\/\$\{encodeURIComponent\(code\)\}\/status/);
+  assert.match(jsSrc, /method:\s*"POST"/);
+  assert.match(cssSrc, /\.ao-fulfil/);
 });

--- a/test/catalogItemsRoutes.test.js
+++ b/test/catalogItemsRoutes.test.js
@@ -2265,6 +2265,22 @@ test("public GET /catalog/items suppresses booking_ac_type/booking_btu/booking_w
   });
 });
 
+test("public GET /catalog/items preserves booking_mode 'purchase' (must not collapse to contact_admin)", async () => {
+  // Regression: the read serializer used to map anything != 'bookable' to
+  // 'contact_admin', silently downgrading a saved 'purchase' product so the
+  // customer app showed the admin-contact CTA instead of the buy button.
+  const items = sampleItems();
+  items[0].booking_mode = "purchase";
+  const pool = makePool(items, [], { marketplaceReady: true });
+  const router = createCatalogItemRoutes({ pool, requireAdminSession: allowAdmin });
+  await withServer(router, async (base) => {
+    const list = await (await fetch(`${base}/catalog/items?customer=1`)).json();
+    assert.equal(list.find((x) => x.item_id === 1).booking_mode, "purchase");
+    const detail = await (await fetch(`${base}/catalog/items/1`)).json();
+    assert.equal(detail.booking_mode, "purchase");
+  });
+});
+
 test("public GET /catalog/items/:itemId puts the Primary image first even when it is not sort_order 0", async () => {
   const items = sampleItems();
   const pool = makePool(items, [], { marketplaceReady: true });

--- a/test/customerAppOrderTracking.test.js
+++ b/test/customerAppOrderTracking.test.js
@@ -1,0 +1,38 @@
+"use strict";
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("fs");
+const path = require("path");
+
+const REPO_ROOT = path.resolve(__dirname, "..");
+const read = (p) => fs.readFileSync(path.join(REPO_ROOT, p), "utf8");
+
+const trackingSrc = read("customer-app/modules/tracking.js");
+const storeSrc = read("customer-app/modules/store.js");
+const cssSrc = read("customer-app/assets/customer-app.css");
+
+test("tracking routes CWF- order codes to an order lookup instead of the job tracker", () => {
+  assert.match(trackingSrc, /\/\^CWF-\/i\.test\(q\)/);
+  assert.match(trackingSrc, /function lookupOrder/);
+  assert.match(trackingSrc, /root\.api\.getOrder\(code\)/);
+});
+
+test("the order result shows payment status, a fulfilment timeline and the admin note", () => {
+  assert.match(trackingSrc, /ORDER_PAYMENT_COPY/);
+  assert.match(trackingSrc, /ORDER_FULFILMENT_STEPS/);
+  assert.match(trackingSrc, /order\.admin_note/);
+  assert.match(trackingSrc, /function renderOrderResult/);
+});
+
+test("the tracking input invites an order code and its styles exist", () => {
+  assert.match(trackingSrc, /เลขคำสั่งซื้อ/);
+  assert.match(cssSrc, /\.order-steps/);
+  assert.match(cssSrc, /\.order-admin-note/);
+});
+
+test("the purchase confirmation prefills tracking and offers a track-order action", () => {
+  assert.match(storeSrc, /updateDraft\?\.\("tracking", \{ trackingCode: orderCode \}\)/);
+  assert.match(storeSrc, /data-route="tracking"/);
+  assert.match(storeSrc, /ติดตามคำสั่งซื้อ/);
+});

--- a/test/customerAppRecovery.test.js
+++ b/test/customerAppRecovery.test.js
@@ -236,7 +236,7 @@ test("Customer App build id is consistent across shell and service worker", () =
   const sw = read("customer-app/sw.js");
   const app = read("customer-app/assets/customer-app.js");
   const manifest = read("customer-app/manifest.webmanifest");
-  const build = "20260702_pay_v1";
+  const build = "20260703_lifecycle_v1";
 
   assert.match(index, new RegExp(`customer-app\\.css\\?v=${build}`));
   assert.match(index, new RegExp(`modules\\/api\\.js\\?v=${build}`));
@@ -254,7 +254,7 @@ test("Customer App build id is consistent across shell and service worker", () =
 test("store module is loaded in index.html and precached in the service worker app shell", () => {
   const index = read("customer-app/index.html");
   const sw = read("customer-app/sw.js");
-  const build = "20260702_pay_v1";
+  const build = "20260703_lifecycle_v1";
 
   assert.match(index, new RegExp(`modules/store\\.js\\?v=${build}`));
   assert.match(sw, /`\.\/modules\/store\.js\?v=\$\{BUILD_ID\}`/);

--- a/test/customerAppStorePayment.test.js
+++ b/test/customerAppStorePayment.test.js
@@ -49,6 +49,6 @@ test("store falls back to the LINE hand-off when payment is unconfigured or the 
 test("payment step styles exist and the Customer App payment build id is bumped", () => {
   assert.match(cssSrc, /\.pay-method-btn/);
   assert.match(cssSrc, /\.pay-qr-img/);
-  assert.match(read("customer-app/index.html"), /modules\/store\.js\?v=20260702_pay_v1/);
-  assert.match(read("customer-app/sw.js"), /BUILD_ID = "20260702_pay_v1"/);
+  assert.match(read("customer-app/index.html"), /modules\/store\.js\?v=20260703_lifecycle_v1/);
+  assert.match(read("customer-app/sw.js"), /BUILD_ID = "20260703_lifecycle_v1"/);
 });

--- a/test/customerOrdersFulfillmentMigration.test.js
+++ b/test/customerOrdersFulfillmentMigration.test.js
@@ -1,0 +1,88 @@
+"use strict";
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("fs");
+const path = require("path");
+const runner = require("../scripts/run-customer-orders-fulfillment-migration");
+
+const REPO_ROOT = path.resolve(__dirname, "..");
+const DATABASE_URL = "postgres://user:super-secret-password@db.example.invalid:5432/cwf";
+
+const COLUMNS = ["fulfillment_status", "admin_note"];
+
+class FakeClient {
+  constructor(options = {}) { this.options = options; this.ended = false; this.queries = []; }
+  async connect() { if (this.options.failConnect) throw new Error(this.options.failConnect); }
+  async query(sql) {
+    this.queries.push({ sql: String(sql) });
+    const s = String(sql);
+    if (s.includes("to_regclass('public.customer_orders')")) {
+      return { rows: [{ orders: this.options.missingTable ? null : "public.customer_orders" }] };
+    }
+    if (s.includes("information_schema.columns")) {
+      const cols = this.options.missingColumn ? COLUMNS.filter((c) => c !== "admin_note") : COLUMNS;
+      return { rows: cols.map((column_name) => ({ column_name })) };
+    }
+    return { rows: [] };
+  }
+  async end() { this.ended = true; }
+}
+
+function makeLogger() {
+  const lines = [];
+  return { lines, log: (m) => lines.push(String(m)), error: (m) => lines.push(String(m)) };
+}
+
+test("fulfilment migration runner runs the SQL under an advisory lock, verifies, and unlocks", async () => {
+  let client;
+  const logger = makeLogger();
+  await runner.runMigration({
+    env: { DATABASE_URL }, repoRoot: REPO_ROOT, logger,
+    clientFactory() { client = new FakeClient(); return client; },
+  });
+  const sql = fs.readFileSync(path.join(REPO_ROOT, runner.MIGRATION_RELATIVE_PATH), "utf8");
+  assert.equal(client.queries[0].sql, "SELECT pg_advisory_lock($1::bigint)");
+  assert.equal(client.queries[1].sql, sql);
+  assert.equal(client.queries.at(-1).sql, "SELECT pg_advisory_unlock($1::bigint)");
+  assert.deepEqual(logger.lines, ["CUSTOMER_ORDERS_FULFILLMENT_MIGRATION_START", "CUSTOMER_ORDERS_FULFILLMENT_MIGRATION_OK"]);
+});
+
+test("fulfilment migration runner fails non-zero when a column is missing after migration", async () => {
+  const logger = makeLogger();
+  const code = await runner.runCli({
+    env: { DATABASE_URL }, repoRoot: REPO_ROOT, logger,
+    clientFactory() { return new FakeClient({ missingColumn: true }); },
+  });
+  assert.equal(code, 1);
+  assert.match(logger.lines.join("\n"), /customer_orders\.admin_note missing after migration/);
+});
+
+test("fulfilment migration runner never leaks database secrets", async () => {
+  const logger = makeLogger();
+  const code = await runner.runCli({
+    env: { DATABASE_URL }, repoRoot: REPO_ROOT, logger,
+    clientFactory() { return new FakeClient({ failConnect: `cannot connect ${DATABASE_URL}` }); },
+  });
+  assert.equal(code, 1);
+  const output = logger.lines.join("\n");
+  assert.doesNotMatch(output, /super-secret-password/);
+  assert.match(output, /\[REDACTED_DATABASE_URL\]/);
+});
+
+test("fulfilment migration is additive only and idempotent", () => {
+  const sql = fs.readFileSync(path.join(REPO_ROOT, runner.MIGRATION_RELATIVE_PATH), "utf8");
+  const executable = sql.split("\n").filter((l) => !l.trim().startsWith("--")).join("\n");
+  assert.doesNotMatch(executable, /\bDELETE\s+FROM\b/i);
+  assert.doesNotMatch(executable, /\bDROP\s+(TABLE|COLUMN)\b/i);
+  assert.doesNotMatch(executable, /\bUPDATE\s+public/i);
+  assert.match(sql, /ADD COLUMN IF NOT EXISTS fulfillment_status/);
+  assert.match(sql, /ADD COLUMN IF NOT EXISTS admin_note/);
+});
+
+test("fulfilment migration runner uses a distinct advisory lock", () => {
+  const base = require("../scripts/run-customer-orders-migration");
+  const payment = require("../scripts/run-customer-orders-payment-migration");
+  assert.notEqual(runner.ADVISORY_LOCK_KEY, base.ADVISORY_LOCK_KEY);
+  assert.notEqual(runner.ADVISORY_LOCK_KEY, payment.ADVISORY_LOCK_KEY);
+});

--- a/test/customerSameDayTiming.test.js
+++ b/test/customerSameDayTiming.test.js
@@ -160,7 +160,7 @@ test("customer app disables availability HTTP cache and refreshes same-day slots
 });
 
 test("customer app build and service worker cache IDs changed", () => {
-  const id = "20260702_pay_v1";
+  const id = "20260703_lifecycle_v1";
   for (const file of [
     "customer-app/index.html",
     "customer-app/sw.js",

--- a/test/homepageCms.test.js
+++ b/test/homepageCms.test.js
@@ -278,7 +278,7 @@ test("customer homepage has no admin control, bottom nav is fixed five-tab, and 
   const sw = read("customer-app/sw.js");
   const app = read("customer-app/assets/customer-app.js");
   const manifest = read("customer-app/manifest.webmanifest");
-  const build = "20260702_pay_v1";
+  const build = "20260703_lifecycle_v1";
 
   assert.doesNotMatch(index + ui, /โหมดแอดมิน|openCms|localStorage\.getItem\('cwfHomeCmsDemo'/);
   assert.match(index, /data-route="store"[\s\S]*ร้านค้า/);

--- a/test/orderFulfillment.test.js
+++ b/test/orderFulfillment.test.js
@@ -1,0 +1,132 @@
+"use strict";
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const http = require("node:http");
+const express = require("express");
+
+const { createCustomerOrdersRoutes } = require("../server/routes/customerOrders");
+
+function baseRow(o) {
+  return {
+    order_code: o.order_code, customer_name: o.customer_name, customer_phone: o.customer_phone,
+    delivery_method: o.delivery_method, install_option: o.install_option, address: o.address,
+    items: o.items, subtotal: o.subtotal, status: o.status, note: o.note, created_at: o.created_at,
+    payment_method: o.payment_method, payment_status: o.payment_status, payment_charge_id: o.payment_charge_id,
+    paid_at: o.paid_at, fulfillment_status: o.fulfillment_status, admin_note: o.admin_note,
+  };
+}
+
+// Pool that supports the fulfilment UPDATE and the public GET (with fulfilment
+// columns). hasFulfilmentColumns=false makes the "rich" selects throw 42703 so
+// the defensive fallback is exercised.
+function makePool(seed, { hasFulfilmentColumns = true } = {}) {
+  const orders = new Map();
+  if (seed) orders.set(seed.order_code, { note: "", admin_note: "", fulfillment_status: "", ...seed });
+  return {
+    orders,
+    async query(sql, params = []) {
+      const s = String(sql).replace(/\s+/g, " ");
+      const wantsFulfil = s.includes("fulfillment_status");
+      if (wantsFulfil && !hasFulfilmentColumns && s.startsWith("SELECT")) {
+        const e = new Error("no column"); e.code = "42703"; throw e;
+      }
+      if (s.startsWith("UPDATE public.customer_orders") && s.includes("fulfillment_status = COALESCE")) {
+        const o = orders.get(params[0]);
+        if (!o) return { rows: [] };
+        if (params[1] != null) o.fulfillment_status = params[1];
+        if (params[2]) o.admin_note = params[3];
+        return { rows: [baseRow(o)] };
+      }
+      if (s.includes("FROM public.customer_orders WHERE order_code=$1")) {
+        const o = orders.get(params[0]);
+        if (!o) return { rows: [] };
+        const row = baseRow(o);
+        if (!wantsFulfil) { delete row.fulfillment_status; delete row.admin_note; }
+        return { rows: [row] };
+      }
+      return { rows: [] };
+    },
+  };
+}
+
+function seedOrder(extra = {}) {
+  return {
+    order_code: "CWF-F1", customer_name: "คุณเอ", customer_phone: "0812345678",
+    delivery_method: "ship", install_option: "cwf", address: "123",
+    items: [{ item_id: "6", name: "แอร์", qty: 1, unit_price: 14900 }],
+    subtotal: 14900, status: "paid", note: "", created_at: new Date().toISOString(),
+    payment_method: "promptpay", payment_status: "successful", payment_charge_id: "chrg_1", paid_at: new Date().toISOString(),
+    fulfillment_status: "", admin_note: "", ...extra,
+  };
+}
+
+function startServer(pool, { admin = true } = {}) {
+  const app = express();
+  app.use(express.json());
+  const guard = admin ? (_q, _s, next) => next() : (_q, res) => res.status(401).json({ error: "unauthorized" });
+  app.use(createCustomerOrdersRoutes({ pool, requireAdminSession: guard }));
+  const server = http.createServer(app);
+  return new Promise((resolve) => server.listen(0, "127.0.0.1", () => resolve(server)));
+}
+const url = (s) => `http://127.0.0.1:${s.address().port}`;
+const postJson = (u, body) => fetch(u, { method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify(body || {}) });
+
+test("admin can advance fulfilment status and leave a customer-visible note", async () => {
+  const pool = makePool(seedOrder());
+  const server = await startServer(pool);
+  try {
+    const res = await postJson(`${url(server)}/admin/orders/CWF-F1/status`, { fulfillment_status: "shipped", admin_note: "เลขพัสดุ TH123" });
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.equal(body.order.fulfillment_status, "shipped");
+    assert.equal(body.order.admin_note, "เลขพัสดุ TH123");
+    assert.equal(pool.orders.get("CWF-F1").fulfillment_status, "shipped");
+  } finally { server.close(); }
+});
+
+test("an invalid fulfilment status is rejected and an unknown order 404s", async () => {
+  const server = await startServer(makePool(seedOrder()));
+  try {
+    assert.equal((await postJson(`${url(server)}/admin/orders/CWF-F1/status`, { fulfillment_status: "teleported" })).status, 400);
+    assert.equal((await postJson(`${url(server)}/admin/orders/CWF-F1/status`, {})).status, 400); // no changes
+    assert.equal((await postJson(`${url(server)}/admin/orders/CWF-NOPE/status`, { fulfillment_status: "confirmed" })).status, 404);
+  } finally { server.close(); }
+});
+
+test("the status endpoint is behind the admin guard", async () => {
+  const server = await startServer(makePool(seedOrder()), { admin: false });
+  try {
+    assert.equal((await postJson(`${url(server)}/admin/orders/CWF-F1/status`, { fulfillment_status: "confirmed" })).status, 401);
+  } finally { server.close(); }
+});
+
+test("note can be updated without changing the fulfilment status", async () => {
+  const pool = makePool(seedOrder({ fulfillment_status: "confirmed" }));
+  const server = await startServer(pool);
+  try {
+    const body = await (await postJson(`${url(server)}/admin/orders/CWF-F1/status`, { admin_note: "ค่าส่ง 300 บาท" })).json();
+    assert.equal(body.order.fulfillment_status, "confirmed"); // unchanged
+    assert.equal(body.order.admin_note, "ค่าส่ง 300 บาท");
+  } finally { server.close(); }
+});
+
+test("public GET returns fulfilment status + admin note so the customer can track", async () => {
+  const server = await startServer(makePool(seedOrder({ fulfillment_status: "installing", admin_note: "ช่างถึง 14:00" })));
+  try {
+    const body = await (await fetch(`${url(server)}/public/orders/CWF-F1`)).json();
+    assert.equal(body.order.fulfillment_status, "installing");
+    assert.equal(body.order.admin_note, "ช่างถึง 14:00");
+  } finally { server.close(); }
+});
+
+test("public GET still works before the fulfilment migration (defensive column fallback)", async () => {
+  const server = await startServer(makePool(seedOrder(), { hasFulfilmentColumns: false }));
+  try {
+    const res = await fetch(`${url(server)}/public/orders/CWF-F1`);
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.equal(body.order.order_code, "CWF-F1");
+    assert.equal(body.order.fulfillment_status, ""); // absent, degrades to empty
+  } finally { server.close(); }
+});

--- a/test/storeBuyMigrations.test.js
+++ b/test/storeBuyMigrations.test.js
@@ -6,6 +6,7 @@ const orchestrator = require("../scripts/run-store-buy-migrations");
 const ordersRunner = require("../scripts/run-customer-orders-migration");
 const bookingModeRunner = require("../scripts/run-catalog-booking-mode-purchase-migration");
 const ordersPaymentRunner = require("../scripts/run-customer-orders-payment-migration");
+const ordersFulfillmentRunner = require("../scripts/run-customer-orders-fulfillment-migration");
 
 function makeLogger() {
   const lines = [];
@@ -13,10 +14,11 @@ function makeLogger() {
 }
 
 test("STEPS wires the buy-flow migration runners in the correct order", () => {
-  assert.equal(orchestrator.STEPS.length, 3);
+  assert.equal(orchestrator.STEPS.length, 4);
   assert.equal(orchestrator.STEPS[0].runner, ordersRunner);
   assert.equal(orchestrator.STEPS[1].runner, bookingModeRunner);
   assert.equal(orchestrator.STEPS[2].runner, ordersPaymentRunner);
+  assert.equal(orchestrator.STEPS[3].runner, ordersFulfillmentRunner);
 });
 
 test("runAll runs every step in order and returns 0 when all succeed", async () => {


### PR DESCRIPTION
Readiness pass on the customer app's buy flow. After the payment work (#135) and dashboard (#136), two gaps still blocked real end-to-end use — this closes both.

## Gaps fixed
1. **Admin couldn't fulfil an order.** A paid order was stuck at `paid` forever; `/admin/orders` was read-only.
2. **Customer couldn't track an order.** They got a `CWF-` code but the tracking screen only looked up jobs — the confirmation told them to ask the admin.

## Backend
- Additive migration: `fulfillment_status` + `admin_note` on `customer_orders` (nullable, no backfill), safe idempotent runner wired into the store-buy orchestrator (auto-applies on boot) + `npm run migrate:customer-orders-fulfillment`.
- `POST /admin/orders/:code/status` (admin-guarded): advance fulfilment through a validated set (`confirmed → preparing → shipped/installing → completed / cancelled`) and/or set a customer-visible `admin_note`. Payment `status` is a separate lane and is never touched here.
- `publicOrder` / `adminOrder` expose the new fields; the public GET and admin list fetch them defensively and **fall back to base columns before the migration runs**, so nothing breaks pre-migration.

## Admin dashboard
- Each order card gets a fulfilment-stage selector, a customer-visible note field (tracking number / confirmed shipping-install fee / appointment), and a save button. Order + summary update in place after saving.

## Customer app
- Tracking screen detects `CWF-` codes and shows the payment status, a fulfilment timeline, and the admin note.
- Purchase confirmation prefills the tracking code and offers a **"ติดตามคำสั่งซื้อ"** button.
- Customer-app cache-bust bumped to `20260703_lifecycle_v1`.

## Readiness audit — where the app stands
- ✅ Store browse, buy button, online payment (PromptPay + card), **admin fulfilment (this PR)**, **customer order tracking (this PR)**, job/booking tracking, guest checkout, auth (degrades gracefully).
- ⚠️ **Still requires operator setup for live payment:** set `OMISE_PUBLIC_KEY` / `OMISE_SECRET_KEY` in env and add the `/webhooks/omise` webhook (see `docs/OMISE_PAYMENT_SETUP.md`). Until then the buy flow falls back to the LINE hand-off.
- 💡 **Optional follow-ups (not blockers):** notify admin/LINE on a new paid order; capture the extra delivery/install fee as a second online charge instead of off-app. Happy to build these next if you want them.

## Safety
- All migrations additive/idempotent; routes degrade gracefully before/after the migration. Fulfilment is separate from payment status, so nothing about money handling changes.

## Testing
- 16 new tests (fulfilment migration runner, status endpoint incl. admin-guard/validation/404, public-GET fulfilment + pre-migration fallback, admin UI + customer tracking contracts). Full suite green: **809 pass, 11 pre-existing skips, 0 fail.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LmdP3TGN5uQrfT8ZYefNco

---
_Generated by [Claude Code](https://claude.ai/code/session_01LmdP3TGN5uQrfT8ZYefNco)_