### PR TITLE
[codex] fix accounting payout adjustments

### DIFF
--- a/admin-accounting-v2.html
+++ b/admin-accounting-v2.html
@@ -187,6 +187,6 @@
   </main>
   <div id="accountingModal" class="acctModalBackdrop" aria-hidden="true"></div>
   <script src="admin-v2-common.js?v=accounting-entry-v3"></script>
-  <script src="admin-accounting-v2.js?v=accounting-company-settings-v40"></script>
+  <script src="admin-accounting-v2.js?v=accounting-payout-adjustment-v41"></script>
 </body>
 </html>

--- a/admin-accounting-v2.js
+++ b/admin-accounting-v2.js
@@ -141,6 +141,8 @@
     if (msg.includes('CONFIRM_ADJUSTMENT_REQUIRED')) return 'กรุณาติ๊กยืนยันก่อนเพิ่มเงินย้อนหลัง';
     if (msg.includes('IDEMPOTENCY_KEY_REQUIRED')) return 'ระบบยังไม่พร้อมบันทึกซ้ำอย่างปลอดภัย กรุณาปิดหน้าต่างแล้วลองใหม่';
     if (msg.includes('IDEMPOTENCY_KEY_REUSED')) return 'คำขอนี้ถูกใช้กับข้อมูลอื่นแล้ว กรุณาปิดหน้าต่างแล้วทำรายการใหม่';
+    if (msg.includes('INVALID_IDEMPOTENCY_KEY')) return 'รหัสป้องกันการกดซ้ำไม่ถูกต้อง กรุณาปิดหน้าต่างแล้วทำรายการใหม่';
+    if (msg.includes('PAYOUT_PAID_RECONCILIATION_REQUIRED')) return 'งวดนี้ถูกทำเครื่องหมายว่าจ่ายแล้ว แต่ยอด payment ในระบบไม่สอดคล้อง ต้องตรวจ reconciliation ก่อนเพิ่มย้อนหลัง';
     if (msg.includes('PAYOUT_ADJUSTMENT_MIGRATION_REQUIRED')) return 'ระบบยังไม่ได้รัน migration สำหรับป้องกันการกดซ้ำ จึงยังเพิ่มเงินย้อนหลังไม่ได้';
     if (msg.includes('INVALID_ADJUSTMENT_AMOUNT')) return 'ยอดเพิ่มย้อนหลังต้องมากกว่า 0';
     if (msg.includes('MISSING_REASON')) return 'กรุณาใส่เหตุผล';
@@ -718,7 +720,14 @@
     try {
       if (window.crypto && typeof window.crypto.randomUUID === 'function') return window.crypto.randomUUID();
     } catch (_) {}
-    return `acct-adj-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+    try {
+      if (window.crypto && typeof window.crypto.getRandomValues === 'function') {
+        const bytes = new Uint8Array(16);
+        window.crypto.getRandomValues(bytes);
+        return `acct-adj-${Array.from(bytes, (b) => b.toString(16).padStart(2, '0')).join('')}`;
+      }
+    } catch (_) {}
+    return '';
   }
 
   function openPayoutAdjustmentModal(payoutId, tech) {
@@ -735,6 +744,7 @@
         <div class="acctModalActions"><button class="acctGhostBtn" type="button" data-close>ยกเลิก</button><button class="acctPrimaryBtn" type="submit">บันทึกเพิ่มเงินย้อนหลัง</button></div>
       </form>`, async (fd, errEl) => {
         if (fd.get('confirm_adjustment') !== '1') { if (errEl) errEl.textContent = 'กรุณาติ๊กยืนยันก่อนเพิ่มเงินย้อนหลัง'; return; }
+        if (!idempotencyKey) { if (errEl) errEl.textContent = 'Browser นี้ไม่รองรับการสร้างรหัสป้องกันการกดซ้ำอย่างปลอดภัย'; return; }
         const guardKey = `${payoutId}:${tech}:${idempotencyKey}`;
         if (state.payoutAdjustmentInFlight.has(guardKey)) return;
         state.payoutAdjustmentInFlight.add(guardKey);

--- a/admin-accounting-v2.js
+++ b/admin-accounting-v2.js
@@ -1,5 +1,6 @@
 (() => {
   'use strict';
+  console.info('[admin-accounting-v2] payout-adjustment-v1 loaded');
 
   const TAB_META = {
     overview: { title: 'ภาพรวม', hint: 'สรุปงานบัญชีที่ต้องจัดการวันนี้', action: 'รีเฟรชข้อมูล' },
@@ -26,6 +27,7 @@
     payoutTechs: {},
     selectedPayoutId: null,
     payoutTechError: null,
+    payoutAdjustmentInFlight: new Set(),
     taxRequests: [],
     settings: null,
     loading: new Set(),
@@ -136,6 +138,14 @@
     const msg = String(e?.payload?.error || e?.message || e || '');
     if (msg.includes('CONFIRM_RECEIVED_REQUIRED')) return 'กรุณาติ๊กยืนยันว่าได้รับเงินจริงแล้ว';
     if (msg.includes('CONFIRM_PAID_REQUIRED')) return 'กรุณาติ๊กยืนยันว่าได้โอน/จ่ายเงินจริงแล้ว';
+    if (msg.includes('CONFIRM_ADJUSTMENT_REQUIRED')) return 'กรุณาติ๊กยืนยันก่อนเพิ่มเงินย้อนหลัง';
+    if (msg.includes('IDEMPOTENCY_KEY_REQUIRED')) return 'ระบบยังไม่พร้อมบันทึกซ้ำอย่างปลอดภัย กรุณาปิดหน้าต่างแล้วลองใหม่';
+    if (msg.includes('IDEMPOTENCY_KEY_REUSED')) return 'คำขอนี้ถูกใช้กับข้อมูลอื่นแล้ว กรุณาปิดหน้าต่างแล้วทำรายการใหม่';
+    if (msg.includes('PAYOUT_ADJUSTMENT_MIGRATION_REQUIRED')) return 'ระบบยังไม่ได้รัน migration สำหรับป้องกันการกดซ้ำ จึงยังเพิ่มเงินย้อนหลังไม่ได้';
+    if (msg.includes('INVALID_ADJUSTMENT_AMOUNT')) return 'ยอดเพิ่มย้อนหลังต้องมากกว่า 0';
+    if (msg.includes('MISSING_REASON')) return 'กรุณาใส่เหตุผล';
+    if (msg.includes('INVALID_JOB_ID')) return 'เลขงานไม่ถูกต้อง';
+    if (msg.includes('JOB_NOT_FOUND')) return 'ไม่พบเลขงานนี้';
     if (msg.includes('PAID_AMOUNT_EXCEEDS_REMAINING')) return 'ยอดที่จ่ายมากกว่ายอดคงเหลือ';
     if (msg.includes('PAYOUT_ALREADY_PAID')) return 'รายการนี้จ่ายครบแล้ว';
     if (msg.includes('PAYOUT_PERIOD_NOT_CLOSED')) return 'งวดนี้ยังไม่ปิดช่วงตัดยอด จึงยังบันทึกจ่ายก่อนไม่ได้';
@@ -406,6 +416,7 @@
                   ${payoutStatusBadge(t.paid_status)}
                   ${Number(t.cash_held_amount || 0) > 0 ? badge(`หักเงินสด ${money(t.cash_held_amount)} ฿`, 'warn') : ''}
                   ${paid ? `<button class="acctDisabledBtn" type="button" disabled>จ่ายช่างแล้ว</button>` : (t.can_pay === false ? `<button class="acctDisabledBtn" type="button" disabled>ยังไม่ปิดตัดยอด</button>` : `<button class="acctPrimaryBtn" type="button" data-pay-payout="${esc(payoutId)}" data-tech="${esc(t.technician_username)}" data-remaining="${esc(t.remaining_amount)}">บันทึกจ่ายแล้ว</button>`)}
+                  ${t.can_pay === false ? `<button class="acctDisabledBtn" type="button" disabled>เพิ่มหลังปิดยอด</button>` : `<button class="acctSecondaryBtn" type="button" data-adjust-payout="${esc(payoutId)}" data-tech="${esc(t.technician_username)}">เพิ่มเงินย้อนหลัง</button>`}
                   ${existingWht ? `<a class="acctSecondaryBtn" href="/admin/accounting/documents/${esc(existingWht.document_id)}/print" target="_blank" rel="noopener">พิมพ์ทวิ50 ${esc(existingWht.document_no || '')}</a>` : ''}
                   <button class="acctSecondaryBtn" type="button" data-edit-tech-tax="${esc(t.technician_username)}">เติมข้อมูลทวิ50</button>
                   ${whtReady && !existingWht ? `<button class="acctPrimaryBtn acctWhtBtn" type="button" data-issue-wht="${esc(payoutId)}" data-tech="${esc(t.technician_username)}">ออกทวิ50เดือนนี้</button>` : ''}
@@ -415,6 +426,7 @@
         </div>
       </div>`;
     el.querySelectorAll('[data-pay-payout]').forEach((btn) => btn.addEventListener('click', () => openPayoutPaidModal(btn.dataset.payPayout, btn.dataset.tech, btn.dataset.remaining)));
+    el.querySelectorAll('[data-adjust-payout]').forEach((btn) => btn.addEventListener('click', () => openPayoutAdjustmentModal(btn.dataset.adjustPayout, btn.dataset.tech)));
     el.querySelectorAll('[data-edit-tech-tax]').forEach((btn) => btn.addEventListener('click', () => openTechTaxProfileModal(btn.dataset.editTechTax)));
     el.querySelectorAll('[data-issue-wht]').forEach((btn) => btn.addEventListener('click', () => openIssueWithholdingModal(btn.dataset.issueWht, btn.dataset.tech)));
   }
@@ -699,6 +711,49 @@
         closeModal();
         await Promise.all([loadAudit(), loadPayoutTechs(payoutId, { keepPosition: true })]);
         if (r.print_url) window.open(r.print_url, '_blank', 'noopener');
+      });
+  }
+
+  function newIdempotencyKey() {
+    try {
+      if (window.crypto && typeof window.crypto.randomUUID === 'function') return window.crypto.randomUUID();
+    } catch (_) {}
+    return `acct-adj-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+  }
+
+  function openPayoutAdjustmentModal(payoutId, tech) {
+    const idempotencyKey = newIdempotencyKey();
+    openModal(`
+      <form class="acctFormGrid">
+        <h3>เพิ่มเงินย้อนหลัง</h3>
+        <p>ช่าง: <b>${esc(tech)}</b><br>งวด: <b>${esc(payoutId)}</b><br>ยอดที่เคยบันทึกว่าจ่ายแล้วจะไม่ถูกแก้ ระบบจะเพิ่มยอดคงเหลือเฉพาะส่วนต่าง</p>
+        <label>จำนวนเงินที่เพิ่ม<input class="acctInput" name="adj_amount" type="number" min="0.01" step="0.01" required></label>
+        <label>เหตุผล<textarea class="acctInput" name="reason" required placeholder="เช่น เพิ่มตกหล่นจากงานย้อนหลัง"></textarea></label>
+        <label>เลขงาน ถ้ามี<input class="acctInput" name="job_id" type="number" min="1" placeholder="ไม่บังคับ"></label>
+        <label class="acctCheckLine"><input type="checkbox" name="confirm_adjustment" value="1"><span>ยืนยันว่าเป็นยอดเพิ่มย้อนหลังจริง และเข้าใจว่ายอดเดิมที่จ่ายแล้วจะไม่ถูกแก้</span></label>
+        <div class="acctSoftErr" data-error style="display:block;min-height:0"></div>
+        <div class="acctModalActions"><button class="acctGhostBtn" type="button" data-close>ยกเลิก</button><button class="acctPrimaryBtn" type="submit">บันทึกเพิ่มเงินย้อนหลัง</button></div>
+      </form>`, async (fd, errEl) => {
+        if (fd.get('confirm_adjustment') !== '1') { if (errEl) errEl.textContent = 'กรุณาติ๊กยืนยันก่อนเพิ่มเงินย้อนหลัง'; return; }
+        const guardKey = `${payoutId}:${tech}:${idempotencyKey}`;
+        if (state.payoutAdjustmentInFlight.has(guardKey)) return;
+        state.payoutAdjustmentInFlight.add(guardKey);
+        try {
+          await postJson(`/admin/accounting/payouts/${encodeURIComponent(payoutId)}/adjust`, {
+            technician_username: tech,
+            adj_amount: fd.get('adj_amount'),
+            reason: fd.get('reason'),
+            job_id: fd.get('job_id') || null,
+            idempotency_key: idempotencyKey,
+            confirm_adjustment: true,
+          });
+          closeModal();
+          await Promise.all([loadSummary(), loadPayouts(), loadAudit()]);
+          await loadPayoutTechs(payoutId, { keepPosition: true });
+          showAccountingTab('payouts', { scroll: false, updateUrl: true });
+        } finally {
+          state.payoutAdjustmentInFlight.delete(guardKey);
+        }
       });
   }
 

--- a/index.js
+++ b/index.js
@@ -52,6 +52,7 @@ const createDocumentRoutes = require("./server/routes/docs");
 const createAccountingReadOnlyRoutes = require("./server/routes/accountingReadOnly");
 const { ensurePayoutPeriodAndSnapshotForPayment } = require("./server/services/technicianPayoutPrepay");
 const { buildAccountingPayoutCalendar, isPeriodCutoffClosed } = require("./server/services/technicianPayoutPeriods");
+const accountingPayoutAdjustments = require("./server/services/accountingPayoutAdjustments");
 const { createTechnicianCashCollectionService } = require("./server/services/technicianCashCollections");
 const { createTechnicianDeductionPayoutApplyService } = require("./server/services/technicianDeductionPayoutApply");
 const createAdminReworkDeductionsHelpers = require("./server/helpers/adminReworkDeductionsHelpers");
@@ -6218,6 +6219,18 @@ async function _buildPayoutTechSummaryRows(payout_id){
     if (!tech || rowMap.has(tech)) continue;
     rowMap.set(tech, { technician_username: tech, gross_amount: 0, jobs_count: 0, payment_only: true });
   }
+  const depTechsQ = await pool.query(
+    `SELECT technician_username
+       FROM public.technician_deposit_ledger
+      WHERE payout_id=$1 AND transaction_type='collect'
+      GROUP BY technician_username`,
+    [payout_id]
+  );
+  for (const r of (depTechsQ.rows || [])) {
+    const tech = String(r.technician_username || '').trim();
+    if (!tech || rowMap.has(tech)) continue;
+    rowMap.set(tech, { technician_username: tech, gross_amount: 0, jobs_count: 0, deposit_only: true });
+  }
   baseRows = Array.from(rowMap.values());
 
   const out = [];
@@ -6258,6 +6271,7 @@ async function _buildPayoutTechSummaryRows(payout_id){
       jobs_count: Number(r.jobs_count || 0),
       adjustment_only: !!r.adjustment_only,
       payment_only: !!r.payment_only,
+      deposit_only: !!r.deposit_only,
       source,
     });
   }
@@ -8320,7 +8334,7 @@ app.post('/admin/super/payouts/purge_draft_legacy', requireSuperAdmin, async (re
 // - draft only; locked/paid are never changed silently
 // - payout payments block regeneration
 // - adjustments are preserved separately and are not mixed into job income
-async function _regenerateDraftPayoutContractLines({ client, payout_id, actor_username, req }) {
+async function _regenerateDraftPayoutContractLines({ client, payout_id, actor_username, req, skipAudit = false }) {
   const metaQ = await client.query(
     `SELECT payout_id, period_type, period_start, period_end, status
        FROM public.technician_payout_periods
@@ -8425,21 +8439,23 @@ async function _regenerateDraftPayoutContractLines({ client, payout_id, actor_us
     newTotal += Number(ln.earn_amount || 0);
   }
 
-  try {
-    await auditLog(req || { actor: { username: actor_username || 'super_admin', role: 'super_admin' } }, { action: 'PAYOUT_CONTRACT_REGENERATE', target_username: null, target_role: null, meta: {
-      payout_id,
-      status,
-      old_lines: oldLines,
-      old_total: oldTotal,
-      new_lines: inserted,
-      new_total: Number(newTotal.toFixed(2)),
-      adjustments_count: adjustmentsCount,
-      adjustments_total: adjustmentsTotal,
-      errors: computed.errors || [],
-      engine: 'contract-v10-app-button',
-      ignored_legacy_fields: ['line_total','unit_price','total_price','paid_amount','final_price','special_bonus_amount','percentage','company_cut_percent','commission_percent'],
-    } });
-  } catch {}
+  if (!skipAudit) {
+    try {
+      await auditLog(req || { actor: { username: actor_username || 'super_admin', role: 'super_admin' } }, { action: 'PAYOUT_CONTRACT_REGENERATE', target_username: null, target_role: null, meta: {
+        payout_id,
+        status,
+        old_lines: oldLines,
+        old_total: oldTotal,
+        new_lines: inserted,
+        new_total: Number(newTotal.toFixed(2)),
+        adjustments_count: adjustmentsCount,
+        adjustments_total: adjustmentsTotal,
+        errors: computed.errors || [],
+        engine: 'contract-v10-app-button',
+        ignored_legacy_fields: ['line_total','unit_price','total_price','paid_amount','final_price','special_bonus_amount','percentage','company_cut_percent','commission_percent'],
+      } });
+    } catch {}
+  }
 
   return {
     ok: true,
@@ -9247,41 +9263,8 @@ async function _upsertPaymentAndMaybeMarkPaid(payout_id, tech, paid_amount, slip
   }
 
   // if all techs paid -> mark payout as paid
-  const techsQ = await pool.query(
-    `
-    WITH gross AS (
-      SELECT technician_username,
-             COALESCE(SUM(earn_amount),0) AS gross_amount
-        FROM public.technician_payout_lines
-       WHERE payout_id=$1
-       GROUP BY technician_username
-    ),
-    adj AS (
-      SELECT technician_username,
-             COALESCE(SUM(adj_amount),0) AS adj_total
-        FROM public.technician_payout_adjustments
-       WHERE payout_id=$1
-       GROUP BY technician_username
-    ),
-    dep AS (
-      SELECT technician_username,
-             COALESCE(SUM(amount),0) AS deposit_deduction_amount
-        FROM public.technician_deposit_ledger
-       WHERE payout_id=$1 AND transaction_type='collect'
-       GROUP BY technician_username
-    )
-    SELECT g.technician_username,
-           (g.gross_amount + COALESCE(a.adj_total,0) - COALESCE(d.deposit_deduction_amount,0)) AS net_amount,
-           COALESCE(p.paid_amount,0) AS paid_amount
-      FROM gross g
-      LEFT JOIN adj a ON a.technician_username=g.technician_username
-      LEFT JOIN dep d ON d.technician_username=g.technician_username
-      LEFT JOIN public.technician_payout_payments p ON p.payout_id=$1 AND p.technician_username=g.technician_username
-    `,
-    [payout_id]
-  );
-
-  const allPaid = (techsQ.rows || []).length > 0 && (techsQ.rows || []).every(r => _paidStatus(r.net_amount, r.paid_amount) === 'paid');
+  const techRows = await accountingPayoutAdjustments.getPayoutTechSettlementRows(pool, payout_id);
+  const allPaid = accountingPayoutAdjustments.isPayoutFullyPaidFromRows(techRows);
   if (allPaid) {
     await pool.query(`UPDATE public.technician_payout_periods SET status='paid' WHERE payout_id=$1`, [payout_id]);
   }
@@ -9424,34 +9407,9 @@ app.post('/admin/super/payouts/:payout_id/pay_bulk', requireSuperAdmin, async (r
     if (!period) return res.status(404).json({ ok:false, error:'PAYOUT_NOT_FOUND' });
     if (String(period.status) === 'paid') return res.status(409).json({ ok:false, error:'PAYOUT_ALREADY_PAID' });
 
-    // Load net amounts for all techs in this payout
-    const techsQ = await pool.query(
-      `
-      WITH gross AS (
-        SELECT technician_username,
-               COALESCE(SUM(earn_amount),0) AS gross_amount
-          FROM public.technician_payout_lines
-         WHERE payout_id=$1
-         GROUP BY technician_username
-      ),
-      adj AS (
-        SELECT technician_username,
-               COALESCE(SUM(adj_amount),0) AS adj_total
-          FROM public.technician_payout_adjustments
-         WHERE payout_id=$1
-         GROUP BY technician_username
-      )
-      SELECT g.technician_username,
-             g.gross_amount,
-             COALESCE(a.adj_total,0) AS adj_total,
-             (g.gross_amount + COALESCE(a.adj_total,0)) AS net_amount
-        FROM gross g
-        LEFT JOIN adj a ON a.technician_username=g.technician_username
-      ORDER BY g.technician_username ASC
-      `,
-      [payout_id]
-    );
-    const rows = techsQ.rows || [];
+    // Load net amounts for every technician touched by lines, adjustments,
+    // payments, or deposit collections in this payout.
+    const rows = await accountingPayoutAdjustments.getPayoutTechSettlementRows(pool, payout_id);
     if (!rows.length) return res.json({ ok:true, payout_id, updated:0, status: period.status });
     const actor = req.actor?.username || null;
     const netMap = new Map(rows.map(r=>[String(r.technician_username), _money(r.net_amount)]));
@@ -9513,41 +9471,9 @@ app.post('/admin/super/payouts/:payout_id/pay_bulk', requireSuperAdmin, async (r
       } catch {}
     }
 
-    // Mark paid if all techs are paid now
-    const paidCheck = await client.query(
-      `
-      WITH gross AS (
-        SELECT technician_username,
-               COALESCE(SUM(earn_amount),0) AS gross_amount
-          FROM public.technician_payout_lines
-         WHERE payout_id=$1
-         GROUP BY technician_username
-      ),
-      adj AS (
-        SELECT technician_username,
-               COALESCE(SUM(adj_amount),0) AS adj_total
-          FROM public.technician_payout_adjustments
-         WHERE payout_id=$1
-         GROUP BY technician_username
-      ),
-      dep AS (
-        SELECT technician_username,
-               COALESCE(SUM(amount),0) AS deposit_deduction_amount
-          FROM public.technician_deposit_ledger
-         WHERE payout_id=$1 AND transaction_type='collect'
-         GROUP BY technician_username
-      )
-      SELECT g.technician_username,
-             (g.gross_amount + COALESCE(a.adj_total,0) - COALESCE(d.deposit_deduction_amount,0)) AS net_amount,
-             COALESCE(p.paid_amount,0) AS paid_amount
-        FROM gross g
-        LEFT JOIN adj a ON a.technician_username=g.technician_username
-        LEFT JOIN dep d ON d.technician_username=g.technician_username
-        LEFT JOIN public.technician_payout_payments p ON p.payout_id=$1 AND p.technician_username=g.technician_username
-      `,
-      [payout_id]
-    );
-    const allPaid = (paidCheck.rows || []).length > 0 && (paidCheck.rows || []).every(r => _paidStatus(r.net_amount, r.paid_amount) === 'paid');
+    // Mark paid if all techs are paid now.
+    const paidCheckRows = await accountingPayoutAdjustments.getPayoutTechSettlementRows(client, payout_id);
+    const allPaid = accountingPayoutAdjustments.isPayoutFullyPaidFromRows(paidCheckRows);
     if (allPaid) {
       await client.query(`UPDATE public.technician_payout_periods SET status='paid' WHERE payout_id=$1`, [payout_id]);
     }
@@ -9646,36 +9572,8 @@ app.post('/admin/super/payouts/legacy_settle', requireSuperAdmin, async (req, re
 
       if (periodTouched) {
         touched_periods++;
-        const paidCheck = await client.query(
-          `WITH gross AS (
-             SELECT technician_username, COALESCE(SUM(earn_amount),0) AS gross_amount
-               FROM public.technician_payout_lines
-              WHERE payout_id=$1
-              GROUP BY technician_username
-           ),
-           adj AS (
-             SELECT technician_username, COALESCE(SUM(adj_amount),0) AS adj_total
-               FROM public.technician_payout_adjustments
-              WHERE payout_id=$1
-              GROUP BY technician_username
-           ),
-           dep AS (
-             SELECT technician_username, COALESCE(SUM(amount),0) AS deposit_deduction_amount
-               FROM public.technician_deposit_ledger
-              WHERE payout_id=$1 AND transaction_type='collect'
-              GROUP BY technician_username
-           )
-           SELECT g.technician_username,
-                  (g.gross_amount + COALESCE(a.adj_total,0) - COALESCE(d.deposit_deduction_amount,0)) AS net_amount,
-                  COALESCE(p.paid_amount,0) AS paid_amount
-             FROM gross g
-             LEFT JOIN adj a ON a.technician_username=g.technician_username
-             LEFT JOIN dep d ON d.technician_username=g.technician_username
-             LEFT JOIN public.technician_payout_payments p
-               ON p.payout_id=$1 AND p.technician_username=g.technician_username`,
-          [payout_id]
-        );
-        const allPaid = (paidCheck.rows || []).length > 0 && (paidCheck.rows || []).every(r => _paidStatus(r.net_amount, r.paid_amount) === 'paid');
+        const paidCheckRows = await accountingPayoutAdjustments.getPayoutTechSettlementRows(client, payout_id);
+        const allPaid = accountingPayoutAdjustments.isPayoutFullyPaidFromRows(paidCheckRows);
         if (allPaid) {
           await client.query(`UPDATE public.technician_payout_periods SET status='paid' WHERE payout_id=$1`, [payout_id]);
         }
@@ -23273,6 +23171,60 @@ app.get('/admin/accounting/documents/:document_id/print', requireAccountingPermi
   } catch (e) {
     console.error('GET /admin/accounting/documents/:document_id/print', e);
     return res.status(500).send('Print document failed');
+  }
+});
+
+app.post('/admin/accounting/payouts/:payout_id/adjust', requireAccountingPermission('accounting_mark_payout_paid'), async (req, res) => {
+  const client = await pool.connect();
+  let began = false;
+  try {
+    const payout_id = String(req.params.payout_id || '').trim();
+    await client.query('BEGIN');
+    began = true;
+    const result = await accountingPayoutAdjustments.applyAccountingPositivePayoutAdjustment({
+      client,
+      payout_id,
+      body: req.body || {},
+      actor: _accountingActor(req),
+      req,
+      regenerateDraftPayoutContractLines: _regenerateDraftPayoutContractLines,
+    });
+    await client.query('COMMIT');
+    began = false;
+    return res.json({
+      ok: true,
+      payout_id,
+      technician_username: result.adjustment?.technician_username || req.body?.technician_username || null,
+      adjustment: result.adjustment,
+      payment: result.payment || null,
+      totals: result.totals,
+      paid_status: result.totals?.paid_status || null,
+      period_status_before: result.period_status_before || null,
+      period_status_after: result.period_status_after || null,
+      regenerated: !!result.regenerated,
+      replayed: !!result.replayed,
+    });
+  } catch (e) {
+    if (began) { try { await client.query('ROLLBACK'); } catch {} }
+    console.error('POST /admin/accounting/payouts/:payout_id/adjust', e);
+    const code = Number(e.statusCode || 500);
+    const error = String(e.code || e.message || 'PAYOUT_ADJUSTMENT_FAILED');
+    if (error === 'PAYOUT_ADJUSTMENT_MIGRATION_REQUIRED') return res.status(503).json({ ok:false, error });
+    if (error === 'IDEMPOTENCY_KEY_REUSED') return res.status(409).json({ ok:false, error });
+    if (error === 'PAYOUT_PERIOD_NOT_CLOSED') return res.status(409).json({ ok:false, error, period_end: e.period_end || null });
+    if (['PAYOUT_NOT_FOUND','JOB_NOT_FOUND'].includes(error)) return res.status(code === 500 ? 404 : code).json({ ok:false, error });
+    if ([
+      'MISSING_PAYOUT_ID',
+      'MISSING_TECHNICIAN_USERNAME',
+      'INVALID_ADJUSTMENT_AMOUNT',
+      'MISSING_REASON',
+      'IDEMPOTENCY_KEY_REQUIRED',
+      'CONFIRM_ADJUSTMENT_REQUIRED',
+      'INVALID_JOB_ID',
+    ].includes(error)) return res.status(400).json({ ok:false, error });
+    return res.status(code >= 400 && code < 600 ? code : 500).json({ ok:false, error:'PAYOUT_ADJUSTMENT_FAILED' });
+  } finally {
+    client.release();
   }
 });
 

--- a/index.js
+++ b/index.js
@@ -9407,9 +9407,11 @@ app.post('/admin/super/payouts/:payout_id/pay_bulk', requireSuperAdmin, async (r
     if (!period) return res.status(404).json({ ok:false, error:'PAYOUT_NOT_FOUND' });
     if (String(period.status) === 'paid') return res.status(409).json({ ok:false, error:'PAYOUT_ALREADY_PAID' });
 
-    // Load net amounts for every technician touched by lines, adjustments,
-    // payments, or deposit collections in this payout.
-    const rows = await accountingPayoutAdjustments.getPayoutTechSettlementRows(pool, payout_id);
+    // Settlement rows include payment-only/deposit-only technicians for final
+    // all-paid evaluation. Bulk payment targets are narrower: only technicians
+    // with payable gross/adjustment money and positive remaining balance.
+    const settlementRows = await accountingPayoutAdjustments.getPayoutTechSettlementRows(pool, payout_id);
+    const rows = accountingPayoutAdjustments.getBulkPayableTargetRows(settlementRows);
     if (!rows.length) return res.json({ ok:true, payout_id, updated:0, status: period.status });
     const actor = req.actor?.username || null;
     const netMap = new Map(rows.map(r=>[String(r.technician_username), _money(r.net_amount)]));
@@ -9438,6 +9440,7 @@ app.post('/admin/super/payouts/:payout_id/pay_bulk', requireSuperAdmin, async (r
     let updated = 0;
     for (const tech of targets) {
       const net = _money(netMap.get(tech));
+      if (net <= 0) continue;
       const paid_amount = net;
       const paid_status = 'paid';
       await client.query(
@@ -9531,10 +9534,11 @@ app.post('/admin/super/payouts/legacy_settle', requireSuperAdmin, async (req, re
       if (!payout_id) continue;
       checked_periods++;
 
-      const techRows = await _buildPayoutTechSummaryRows(payout_id);
+      const techRowsPayload = await _buildPayoutTechSummaryRows(payout_id);
+      const techRows = Array.isArray(techRowsPayload?.techs) ? techRowsPayload.techs : [];
       let periodTouched = false;
 
-      for (const row of (techRows || [])) {
+      for (const row of techRows) {
         const tech = String(row.technician_username || '').trim();
         if (!tech) continue;
         if (techFilter && tech !== techFilter) continue;
@@ -23211,12 +23215,14 @@ app.post('/admin/accounting/payouts/:payout_id/adjust', requireAccountingPermiss
     const error = String(e.code || e.message || 'PAYOUT_ADJUSTMENT_FAILED');
     if (error === 'PAYOUT_ADJUSTMENT_MIGRATION_REQUIRED') return res.status(503).json({ ok:false, error });
     if (error === 'IDEMPOTENCY_KEY_REUSED') return res.status(409).json({ ok:false, error });
+    if (error === 'PAYOUT_PAID_RECONCILIATION_REQUIRED') return res.status(409).json({ ok:false, error });
     if (error === 'PAYOUT_PERIOD_NOT_CLOSED') return res.status(409).json({ ok:false, error, period_end: e.period_end || null });
     if (['PAYOUT_NOT_FOUND','JOB_NOT_FOUND'].includes(error)) return res.status(code === 500 ? 404 : code).json({ ok:false, error });
     if ([
       'MISSING_PAYOUT_ID',
       'MISSING_TECHNICIAN_USERNAME',
       'INVALID_ADJUSTMENT_AMOUNT',
+      'INVALID_IDEMPOTENCY_KEY',
       'MISSING_REASON',
       'IDEMPOTENCY_KEY_REQUIRED',
       'CONFIRM_ADJUSTMENT_REQUIRED',

--- a/migrations/20260703_technician_payout_adjustment_idempotency.sql
+++ b/migrations/20260703_technician_payout_adjustment_idempotency.sql
@@ -1,0 +1,9 @@
+-- Add durable idempotency for accounting-created payout adjustments.
+-- Additive only, safe to re-run, and intentionally does not backfill legacy rows.
+
+ALTER TABLE public.technician_payout_adjustments
+  ADD COLUMN IF NOT EXISTS idempotency_key TEXT;
+
+CREATE UNIQUE INDEX IF NOT EXISTS uq_tpa_idempotency_key
+  ON public.technician_payout_adjustments(idempotency_key)
+  WHERE idempotency_key IS NOT NULL;

--- a/server/services/accountingPayoutAdjustments.js
+++ b/server/services/accountingPayoutAdjustments.js
@@ -1,0 +1,431 @@
+"use strict";
+
+const {
+  parsePayoutId,
+  periodBoundsForYm,
+  isPeriodCutoffClosed,
+} = require("./technicianPayoutPeriods");
+
+function money(value) {
+  const n = Number(value || 0);
+  if (!Number.isFinite(n)) return 0;
+  return Math.round(n * 100) / 100;
+}
+
+function paidStatus(netAmount, paidAmount) {
+  const net = money(netAmount);
+  const paid = money(paidAmount);
+  if (net <= 0 && paid <= 0) return "paid";
+  if (paid >= net - 0.0001) return "paid";
+  if (paid > 0) return "partial";
+  return "unpaid";
+}
+
+function appError(message, statusCode = 400, code = message, extra = {}) {
+  const err = new Error(message);
+  err.statusCode = statusCode;
+  err.code = code;
+  Object.assign(err, extra);
+  return err;
+}
+
+function normalizePayload(payoutId, body = {}) {
+  const payout_id = String(payoutId || "").trim();
+  const technician_username = String(body.technician_username || "").trim();
+  const adj_amount = money(body.adj_amount);
+  const reason = String(body.reason || "").trim();
+  const job_id = body.job_id == null || String(body.job_id).trim() === "" ? null : String(body.job_id).trim();
+  const idempotency_key = String(body.idempotency_key || body.idempotencyKey || "").trim();
+  const confirm_adjustment = body.confirm_adjustment === true || String(body.confirm_adjustment || "").toLowerCase() === "true";
+
+  if (!payout_id) throw appError("MISSING_PAYOUT_ID", 400);
+  if (!technician_username) throw appError("MISSING_TECHNICIAN_USERNAME", 400);
+  if (!Number.isFinite(adj_amount) || adj_amount <= 0) throw appError("INVALID_ADJUSTMENT_AMOUNT", 400);
+  if (!reason) throw appError("MISSING_REASON", 400);
+  if (!idempotency_key) throw appError("IDEMPOTENCY_KEY_REQUIRED", 400);
+  if (!confirm_adjustment) throw appError("CONFIRM_ADJUSTMENT_REQUIRED", 400);
+
+  return { payout_id, technician_username, adj_amount, reason, job_id, idempotency_key };
+}
+
+function payloadMatches(row, payload) {
+  if (!row) return false;
+  return String(row.payout_id || "") === payload.payout_id
+    && String(row.technician_username || "") === payload.technician_username
+    && money(row.adj_amount) === money(payload.adj_amount)
+    && String(row.reason || "") === payload.reason
+    && (row.job_id == null || String(row.job_id).trim() === "" ? null : String(row.job_id).trim()) === payload.job_id;
+}
+
+async function assertAdjustmentMigrationReady(client) {
+  const col = await client.query(
+    `SELECT 1
+       FROM information_schema.columns
+      WHERE table_schema='public'
+        AND table_name='technician_payout_adjustments'
+        AND column_name='idempotency_key'
+      LIMIT 1`
+  );
+  if (!col.rows.length) {
+    throw appError("PAYOUT_ADJUSTMENT_MIGRATION_REQUIRED", 503);
+  }
+  const idx = await client.query(
+    `SELECT 1
+       FROM pg_indexes
+      WHERE schemaname='public'
+        AND tablename='technician_payout_adjustments'
+        AND indexname='uq_tpa_idempotency_key'
+      LIMIT 1`
+  );
+  if (!idx.rows.length) {
+    throw appError("PAYOUT_ADJUSTMENT_MIGRATION_REQUIRED", 503);
+  }
+}
+
+async function getPayoutPeriodForUpdate(client, payoutId) {
+  const q = await client.query(
+    `SELECT payout_id, status, period_type, period_start, period_end, created_at, created_by
+       FROM public.technician_payout_periods
+      WHERE payout_id=$1
+      FOR UPDATE`,
+    [payoutId]
+  );
+  return q.rows[0] || null;
+}
+
+async function ensureClosedDraftPeriodSnapshot({
+  client,
+  payout_id,
+  actor_username,
+  regenerateDraftPayoutContractLines,
+  req,
+}) {
+  let period = await getPayoutPeriodForUpdate(client, payout_id);
+  const parsed = parsePayoutId(payout_id);
+  if (!period) {
+    if (!parsed) throw appError("PAYOUT_NOT_FOUND", 404);
+    const bounds = periodBoundsForYm(parsed.type, parsed.y, parsed.m);
+    const virtual = {
+      payout_id,
+      period_type: bounds.period_type,
+      period_start: bounds.start.toISOString(),
+      period_end: bounds.endEx.toISOString(),
+      status: "draft",
+    };
+    if (!isPeriodCutoffClosed(virtual)) {
+      throw appError("PAYOUT_PERIOD_NOT_CLOSED", 409, "PAYOUT_PERIOD_NOT_CLOSED", { period_end: virtual.period_end });
+    }
+    await client.query(
+      `INSERT INTO public.technician_payout_periods(payout_id, period_type, period_start, period_end, status, created_by)
+       VALUES($1,$2,$3,$4,'draft',$5)
+       ON CONFLICT (payout_id) DO NOTHING`,
+      [payout_id, bounds.period_type, bounds.start.toISOString(), bounds.endEx.toISOString(), actor_username || null]
+    );
+    period = await getPayoutPeriodForUpdate(client, payout_id);
+  }
+  if (!period) throw appError("PAYOUT_NOT_FOUND", 404);
+
+  const status = String(period.status || "draft");
+  if (status === "draft") {
+    if (!isPeriodCutoffClosed(period)) {
+      throw appError("PAYOUT_PERIOD_NOT_CLOSED", 409, "PAYOUT_PERIOD_NOT_CLOSED", { period_end: period.period_end });
+    }
+    if (typeof regenerateDraftPayoutContractLines !== "function") {
+      throw appError("PAYOUT_SNAPSHOT_UNAVAILABLE", 500);
+    }
+    const regen = await regenerateDraftPayoutContractLines({
+      client,
+      payout_id,
+      actor_username: actor_username || null,
+      req,
+      skipAudit: true,
+    });
+    await client.query(
+      `UPDATE public.technician_payout_periods
+          SET status='locked'
+        WHERE payout_id=$1 AND status='draft'`,
+      [payout_id]
+    );
+    period = await getPayoutPeriodForUpdate(client, payout_id);
+    return { period, regenerated: true, regen };
+  }
+
+  if (status !== "locked" && status !== "paid") {
+    throw appError("UNSUPPORTED_PAYOUT_STATUS", 409);
+  }
+  return { period, regenerated: false, regen: null };
+}
+
+async function getPayoutTechSettlementRows(client, payoutId) {
+  const q = await client.query(
+    `WITH techs AS (
+       SELECT technician_username FROM public.technician_payout_lines WHERE payout_id=$1
+       UNION
+       SELECT technician_username FROM public.technician_payout_adjustments WHERE payout_id=$1
+       UNION
+       SELECT technician_username FROM public.technician_payout_payments WHERE payout_id=$1
+       UNION
+       SELECT technician_username FROM public.technician_deposit_ledger WHERE payout_id=$1 AND transaction_type='collect'
+     ),
+     gross AS (
+       SELECT technician_username, COALESCE(SUM(earn_amount),0)::numeric AS gross_amount
+         FROM public.technician_payout_lines
+        WHERE payout_id=$1
+        GROUP BY technician_username
+     ),
+     adj AS (
+       SELECT technician_username, COALESCE(SUM(adj_amount),0)::numeric AS adj_total
+         FROM public.technician_payout_adjustments
+        WHERE payout_id=$1
+        GROUP BY technician_username
+     ),
+     dep AS (
+       SELECT technician_username, COALESCE(SUM(amount),0)::numeric AS deposit_deduction_amount
+         FROM public.technician_deposit_ledger
+        WHERE payout_id=$1 AND transaction_type='collect'
+        GROUP BY technician_username
+     ),
+     pay AS (
+       SELECT technician_username, COALESCE(paid_amount,0)::numeric AS paid_amount
+         FROM public.technician_payout_payments
+        WHERE payout_id=$1
+     )
+     SELECT t.technician_username,
+            COALESCE(g.gross_amount,0)::numeric AS gross_amount,
+            COALESCE(a.adj_total,0)::numeric AS adj_total,
+            COALESCE(d.deposit_deduction_amount,0)::numeric AS deposit_deduction_amount,
+            (COALESCE(g.gross_amount,0) + COALESCE(a.adj_total,0) - COALESCE(d.deposit_deduction_amount,0))::numeric AS net_amount,
+            COALESCE(p.paid_amount,0)::numeric AS paid_amount
+       FROM techs t
+       LEFT JOIN gross g ON g.technician_username=t.technician_username
+       LEFT JOIN adj a ON a.technician_username=t.technician_username
+       LEFT JOIN dep d ON d.technician_username=t.technician_username
+       LEFT JOIN pay p ON p.technician_username=t.technician_username
+      ORDER BY t.technician_username ASC`,
+    [payoutId]
+  );
+  return (q.rows || []).map((r) => ({
+    technician_username: r.technician_username,
+    gross_amount: money(r.gross_amount),
+    adj_total: money(r.adj_total),
+    deposit_deduction_amount: money(r.deposit_deduction_amount),
+    net_amount: money(r.net_amount),
+    paid_amount: money(r.paid_amount),
+    remaining_amount: money(Math.max(0, Number(r.net_amount || 0) - Number(r.paid_amount || 0))),
+    paid_status: paidStatus(r.net_amount, r.paid_amount),
+  }));
+}
+
+async function getPayoutTechTotals(client, payoutId, tech) {
+  const rows = await getPayoutTechSettlementRows(client, payoutId);
+  return rows.find((r) => String(r.technician_username || "") === String(tech || "")) || {
+    technician_username: tech,
+    gross_amount: 0,
+    adj_total: 0,
+    deposit_deduction_amount: 0,
+    net_amount: 0,
+    paid_amount: 0,
+    remaining_amount: 0,
+    paid_status: "paid",
+  };
+}
+
+function isPayoutFullyPaidFromRows(rows = []) {
+  return rows.length > 0 && rows.every((r) => paidStatus(r.net_amount, r.paid_amount) === "paid");
+}
+
+async function lockPaymentRow(client, payoutId, tech) {
+  const q = await client.query(
+    `SELECT payment_id, payout_id, technician_username, paid_amount, paid_status, paid_at, paid_by, slip_url, note,
+            payment_method, payment_reference
+       FROM public.technician_payout_payments
+      WHERE payout_id=$1 AND technician_username=$2
+      FOR UPDATE`,
+    [payoutId, tech]
+  );
+  return q.rows[0] || null;
+}
+
+async function validateJobIdIfPresent(client, jobId) {
+  if (!jobId) return;
+  if (!/^\d+$/.test(String(jobId))) throw appError("INVALID_JOB_ID", 400);
+  const q = await client.query(
+    `SELECT 1 FROM public.jobs WHERE job_id=$1 LIMIT 1`,
+    [jobId]
+  );
+  if (!q.rows.length) throw appError("JOB_NOT_FOUND", 404);
+}
+
+async function findAdjustmentByIdempotencyKey(client, key) {
+  const q = await client.query(
+    `SELECT adj_id, payout_id, technician_username, job_id, adj_amount, reason, created_at, created_by, idempotency_key
+       FROM public.technician_payout_adjustments
+      WHERE idempotency_key=$1
+      FOR UPDATE`,
+    [key]
+  );
+  return q.rows[0] || null;
+}
+
+async function insertAccountingAudit(client, req, payload = {}) {
+  const actor = req?.actor || req?.auth || req?.effective || {};
+  await client.query(
+    `INSERT INTO public.accounting_audit_log
+      (actor_user_id, actor_username, actor_role, action, entity_type, entity_id,
+       before_json, after_json, ip_address, user_agent, note)
+     VALUES ($1,$2,$3,$4,$5,$6,$7::jsonb,$8::jsonb,$9,$10,$11)`,
+    [
+      actor.username || null,
+      actor.username || null,
+      actor.role || null,
+      payload.action || "PAYOUT_ADJUSTMENT_CREATE",
+      payload.entity_type || "technician_payout_adjustment",
+      payload.entity_id || null,
+      JSON.stringify(payload.before_json || null),
+      JSON.stringify(payload.after_json || null),
+      req?.ip || req?.headers?.["x-forwarded-for"] || null,
+      req?.headers?.["user-agent"] || null,
+      payload.note || null,
+    ]
+  );
+}
+
+async function applyAccountingPositivePayoutAdjustment({
+  client,
+  payout_id,
+  body,
+  actor,
+  req,
+  regenerateDraftPayoutContractLines,
+}) {
+  const payload = normalizePayload(payout_id, body);
+  await assertAdjustmentMigrationReady(client);
+
+  const snapshot = await ensureClosedDraftPeriodSnapshot({
+    client,
+    payout_id: payload.payout_id,
+    actor_username: actor?.username || null,
+    regenerateDraftPayoutContractLines,
+    req,
+  });
+  const periodBefore = { ...(snapshot.period || {}) };
+  const paymentBefore = await lockPaymentRow(client, payload.payout_id, payload.technician_username);
+  await validateJobIdIfPresent(client, payload.job_id);
+
+  const existing = await findAdjustmentByIdempotencyKey(client, payload.idempotency_key);
+  if (existing) {
+    if (!payloadMatches(existing, payload)) {
+      throw appError("IDEMPOTENCY_KEY_REUSED", 409);
+    }
+    const totals = await getPayoutTechTotals(client, payload.payout_id, payload.technician_username);
+    return {
+      replayed: true,
+      adjustment: existing,
+      payment: paymentBefore,
+      totals,
+      period_status_before: periodBefore.status,
+      period_status_after: snapshot.period?.status || periodBefore.status,
+      regenerated: snapshot.regenerated,
+    };
+  }
+
+  const totalsBefore = await getPayoutTechTotals(client, payload.payout_id, payload.technician_username);
+  const ins = await client.query(
+    `INSERT INTO public.technician_payout_adjustments
+       (payout_id, technician_username, job_id, adj_amount, reason, created_by, idempotency_key)
+     VALUES($1,$2,$3,$4,$5,$6,$7)
+     ON CONFLICT (idempotency_key) WHERE idempotency_key IS NOT NULL DO NOTHING
+     RETURNING adj_id, payout_id, technician_username, job_id, adj_amount, reason, created_at, created_by, idempotency_key`,
+    [
+      payload.payout_id,
+      payload.technician_username,
+      payload.job_id,
+      payload.adj_amount,
+      payload.reason,
+      actor?.username || null,
+      payload.idempotency_key,
+    ]
+  );
+  if (!ins.rows.length) {
+    const conflicted = await findAdjustmentByIdempotencyKey(client, payload.idempotency_key);
+    if (payloadMatches(conflicted, payload)) {
+      const totals = await getPayoutTechTotals(client, payload.payout_id, payload.technician_username);
+      return {
+        replayed: true,
+        adjustment: conflicted,
+        payment: paymentBefore,
+        totals,
+        period_status_before: periodBefore.status,
+        period_status_after: snapshot.period?.status || periodBefore.status,
+        regenerated: snapshot.regenerated,
+      };
+    }
+    throw appError("IDEMPOTENCY_KEY_REUSED", 409);
+  }
+  const adjustment = ins.rows[0];
+  const totalsAfter = await getPayoutTechTotals(client, payload.payout_id, payload.technician_username);
+  const nextPaidStatus = paidStatus(totalsAfter.net_amount, totalsAfter.paid_amount);
+
+  if (paymentBefore) {
+    await client.query(
+      `UPDATE public.technician_payout_payments
+          SET paid_status=$3, updated_at=NOW()
+        WHERE payout_id=$1 AND technician_username=$2`,
+      [payload.payout_id, payload.technician_username, nextPaidStatus]
+    );
+  }
+
+  const allRows = await getPayoutTechSettlementRows(client, payload.payout_id);
+  const allPaid = isPayoutFullyPaidFromRows(allRows);
+  let nextPeriodStatus = snapshot.period?.status || periodBefore.status || "locked";
+  if (allPaid) {
+    nextPeriodStatus = "paid";
+  } else if (String(nextPeriodStatus) === "paid") {
+    nextPeriodStatus = "locked";
+  }
+  if (nextPeriodStatus !== String(snapshot.period?.status || "")) {
+    await client.query(
+      `UPDATE public.technician_payout_periods
+          SET status=$2
+        WHERE payout_id=$1`,
+      [payload.payout_id, nextPeriodStatus]
+    );
+  }
+
+  const paymentAfter = await lockPaymentRow(client, payload.payout_id, payload.technician_username);
+  await insertAccountingAudit(client, req, {
+    action: "PAYOUT_ADJUSTMENT_CREATE",
+    entity_id: `${payload.payout_id}:${payload.technician_username}:${adjustment.adj_id}`,
+    before_json: { period: periodBefore, payment: paymentBefore, totals: totalsBefore },
+    after_json: {
+      adjustment,
+      period_status: nextPeriodStatus,
+      payment: paymentAfter,
+      totals: { ...totalsAfter, paid_status: nextPaidStatus },
+      regenerated: snapshot.regenerated,
+      regen: snapshot.regen,
+    },
+    note: payload.reason,
+  });
+
+  return {
+    replayed: false,
+    adjustment,
+    payment: paymentAfter,
+    totals: { ...totalsAfter, paid_status: nextPaidStatus },
+    period_status_before: periodBefore.status,
+    period_status_after: nextPeriodStatus,
+    regenerated: snapshot.regenerated,
+  };
+}
+
+module.exports = {
+  money,
+  paidStatus,
+  normalizePayload,
+  assertAdjustmentMigrationReady,
+  getPayoutTechSettlementRows,
+  getPayoutTechTotals,
+  isPayoutFullyPaidFromRows,
+  applyAccountingPositivePayoutAdjustment,
+};

--- a/server/services/accountingPayoutAdjustments.js
+++ b/server/services/accountingPayoutAdjustments.js
@@ -43,6 +43,9 @@ function normalizePayload(payoutId, body = {}) {
   if (!Number.isFinite(adj_amount) || adj_amount <= 0) throw appError("INVALID_ADJUSTMENT_AMOUNT", 400);
   if (!reason) throw appError("MISSING_REASON", 400);
   if (!idempotency_key) throw appError("IDEMPOTENCY_KEY_REQUIRED", 400);
+  if (idempotency_key.length > 120 || !/^[A-Za-z0-9._:-]+$/.test(idempotency_key)) {
+    throw appError("INVALID_IDEMPOTENCY_KEY", 400);
+  }
   if (!confirm_adjustment) throw appError("CONFIRM_ADJUSTMENT_REQUIRED", 400);
 
   return { payout_id, technician_username, adj_amount, reason, job_id, idempotency_key };
@@ -101,6 +104,7 @@ async function ensureClosedDraftPeriodSnapshot({
   req,
 }) {
   let period = await getPayoutPeriodForUpdate(client, payout_id);
+  let originalPeriod = period ? { ...period } : null;
   const parsed = parsePayoutId(payout_id);
   if (!period) {
     if (!parsed) throw appError("PAYOUT_NOT_FOUND", 404);
@@ -115,6 +119,7 @@ async function ensureClosedDraftPeriodSnapshot({
     if (!isPeriodCutoffClosed(virtual)) {
       throw appError("PAYOUT_PERIOD_NOT_CLOSED", 409, "PAYOUT_PERIOD_NOT_CLOSED", { period_end: virtual.period_end });
     }
+    originalPeriod = { ...virtual, status: "draft", is_virtual: true };
     await client.query(
       `INSERT INTO public.technician_payout_periods(payout_id, period_type, period_start, period_end, status, created_by)
        VALUES($1,$2,$3,$4,'draft',$5)
@@ -124,6 +129,7 @@ async function ensureClosedDraftPeriodSnapshot({
     period = await getPayoutPeriodForUpdate(client, payout_id);
   }
   if (!period) throw appError("PAYOUT_NOT_FOUND", 404);
+  if (!originalPeriod) originalPeriod = { ...period };
 
   const status = String(period.status || "draft");
   if (status === "draft") {
@@ -147,13 +153,13 @@ async function ensureClosedDraftPeriodSnapshot({
       [payout_id]
     );
     period = await getPayoutPeriodForUpdate(client, payout_id);
-    return { period, regenerated: true, regen };
+    return { period, originalPeriod, regenerated: true, regen };
   }
 
   if (status !== "locked" && status !== "paid") {
     throw appError("UNSUPPORTED_PAYOUT_STATUS", 409);
   }
-  return { period, regenerated: false, regen: null };
+  return { period, originalPeriod, regenerated: false, regen: null };
 }
 
 async function getPayoutTechSettlementRows(client, payoutId) {
@@ -234,6 +240,14 @@ function isPayoutFullyPaidFromRows(rows = []) {
   return rows.length > 0 && rows.every((r) => paidStatus(r.net_amount, r.paid_amount) === "paid");
 }
 
+function getBulkPayableTargetRows(settlementRows = []) {
+  return (settlementRows || []).filter((r) =>
+    (Number(r.gross_amount || 0) !== 0 || Number(r.adj_total || 0) !== 0) &&
+    Number(r.net_amount || 0) > 0 &&
+    Number(r.remaining_amount || 0) > 0.0001
+  );
+}
+
 async function lockPaymentRow(client, payoutId, tech) {
   const q = await client.query(
     `SELECT payment_id, payout_id, technician_username, paid_amount, paid_status, paid_at, paid_by, slip_url, note,
@@ -308,7 +322,7 @@ async function applyAccountingPositivePayoutAdjustment({
     regenerateDraftPayoutContractLines,
     req,
   });
-  const periodBefore = { ...(snapshot.period || {}) };
+  const periodBefore = { ...(snapshot.originalPeriod || snapshot.period || {}) };
   const paymentBefore = await lockPaymentRow(client, payload.payout_id, payload.technician_username);
   await validateJobIdIfPresent(client, payload.job_id);
 
@@ -330,6 +344,12 @@ async function applyAccountingPositivePayoutAdjustment({
   }
 
   const totalsBefore = await getPayoutTechTotals(client, payload.payout_id, payload.technician_username);
+  if (String(periodBefore.status || "") === "paid") {
+    const beforeStatus = paidStatus(totalsBefore.net_amount, paymentBefore?.paid_amount || 0);
+    if (money(totalsBefore.net_amount) > 0 && beforeStatus !== "paid") {
+      throw appError("PAYOUT_PAID_RECONCILIATION_REQUIRED", 409);
+    }
+  }
   const ins = await client.query(
     `INSERT INTO public.technician_payout_adjustments
        (payout_id, technician_username, job_id, adj_amount, reason, created_by, idempotency_key)
@@ -427,5 +447,6 @@ module.exports = {
   getPayoutTechSettlementRows,
   getPayoutTechTotals,
   isPayoutFullyPaidFromRows,
+  getBulkPayableTargetRows,
   applyAccountingPositivePayoutAdjustment,
 };

--- a/sw.js
+++ b/sw.js
@@ -1,7 +1,8 @@
 /* CWF root service worker: Tech App shell/cache refresh */
 const CWF_TECH_BUILD_ID = "20260622_urgent_offer_session_v1";
+const CWF_ACCOUNTING_CACHE_BUMP = "20260703_accounting_payout_adjustment_v1";
 const CACHE_PREFIX = "cwf-root-tech-app-";
-const CACHE_NAME = `${CACHE_PREFIX}${CWF_TECH_BUILD_ID}`;
+const CACHE_NAME = `${CACHE_PREFIX}${CWF_TECH_BUILD_ID}-${CWF_ACCOUNTING_CACHE_BUMP}`;
 const SHELL_ASSETS = [
   `/tech.html?v=${CWF_TECH_BUILD_ID}`,
   `/app.js?v=${CWF_TECH_BUILD_ID}`,

--- a/test/accountingPayoutAdjustments.test.js
+++ b/test/accountingPayoutAdjustments.test.js
@@ -1,6 +1,8 @@
 const test = require("node:test");
 const assert = require("node:assert/strict");
 const fs = require("node:fs");
+const http = require("node:http");
+const express = require("express");
 
 const svc = require("../server/services/accountingPayoutAdjustments");
 
@@ -19,10 +21,34 @@ class FakeClient {
     this.jobs = new Set();
     this.audit = [];
     this.nextAdjId = 1;
+    this.failAudit = false;
+    this.txStack = [];
   }
 
   clone(row) {
     return row ? { ...row } : row;
+  }
+
+  snapshot() {
+    return {
+      periods: new Map([...this.periods.entries()].map(([k, v]) => [k, this.clone(v)])),
+      lines: this.lines.map((r) => this.clone(r)),
+      adjustments: this.adjustments.map((r) => this.clone(r)),
+      payments: this.payments.map((r) => this.clone(r)),
+      deposits: this.deposits.map((r) => this.clone(r)),
+      audit: this.audit.map((r) => this.clone(r)),
+      nextAdjId: this.nextAdjId,
+    };
+  }
+
+  restore(snapshot) {
+    this.periods = new Map([...snapshot.periods.entries()].map(([k, v]) => [k, this.clone(v)]));
+    this.lines = snapshot.lines.map((r) => this.clone(r));
+    this.adjustments = snapshot.adjustments.map((r) => this.clone(r));
+    this.payments = snapshot.payments.map((r) => this.clone(r));
+    this.deposits = snapshot.deposits.map((r) => this.clone(r));
+    this.audit = snapshot.audit.map((r) => this.clone(r));
+    this.nextAdjId = snapshot.nextAdjId;
   }
 
   settlementRows(payoutId) {
@@ -53,6 +79,19 @@ class FakeClient {
   async query(sql, params = []) {
     const s = normSql(sql);
 
+    if (s === "BEGIN") {
+      this.txStack.push(this.snapshot());
+      return { rows: [] };
+    }
+    if (s === "COMMIT") {
+      this.txStack.pop();
+      return { rows: [] };
+    }
+    if (s === "ROLLBACK") {
+      const snapshot = this.txStack.pop();
+      if (snapshot) this.restore(snapshot);
+      return { rows: [] };
+    }
     if (s.includes("FROM information_schema.columns")) {
       return { rows: this.migrationReady ? [{ "?column?": 1 }] : [] };
     }
@@ -125,6 +164,7 @@ class FakeClient {
       return { rows: this.settlementRows(params[0]) };
     }
     if (s.startsWith("INSERT INTO public.accounting_audit_log")) {
+      if (this.failAudit) throw new Error("AUDIT_WRITE_FAILED");
       this.audit.push({ params });
       return { rows: [] };
     }
@@ -148,6 +188,21 @@ async function apply(db, body = {}, extra = {}) {
     req: { actor: { username: "acct", role: "admin" }, headers: {} },
     regenerateDraftPayoutContractLines: extra.regenerateDraftPayoutContractLines || (async () => ({ ok: true })),
   });
+}
+
+async function applyInsideRouteTransaction(db, body = {}) {
+  let began = false;
+  try {
+    await db.query("BEGIN");
+    began = true;
+    const result = await apply(db, body);
+    await db.query("COMMIT");
+    began = false;
+    return result;
+  } catch (err) {
+    if (began) await db.query("ROLLBACK");
+    throw err;
+  }
 }
 
 test("locked unpaid period accepts a positive adjustment and writes one audit row", async () => {
@@ -206,6 +261,34 @@ test("route uses accounting_mark_payout_paid permission", () => {
   assert.match(src, /app\.post\('\/admin\/accounting\/payouts\/:payout_id\/adjust', requireAccountingPermission\('accounting_mark_payout_paid'\)/);
 });
 
+test("HTTP permission middleware denies adjustment route before handler runs", async () => {
+  let handlerReached = false;
+  const app = express();
+  app.use(express.json());
+  app.post(
+    "/admin/accounting/payouts/:payout_id/adjust",
+    (_req, res) => res.status(403).json({ ok: false, error: "ACCOUNTING_PERMISSION_REQUIRED" }),
+    (_req, res) => {
+      handlerReached = true;
+      res.json({ ok: true });
+    }
+  );
+  const server = http.createServer(app);
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  try {
+    const port = server.address().port;
+    const response = await fetch(`http://127.0.0.1:${port}/admin/accounting/payouts/payout_2026-06_25/adjust`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({}),
+    });
+    assert.equal(response.status, 403);
+    assert.equal(handlerReached, false);
+  } finally {
+    await new Promise((resolve, reject) => server.close((err) => err ? reject(err) : resolve()));
+  }
+});
+
 test("invalid or missing job_id is rejected before insert", async () => {
   const db = new FakeClient();
   db.periods.set("payout_2026-06_25", { payout_id: "payout_2026-06_25", status: "locked", period_type: "25", period_start: "2026-06-01T00:00:00Z", period_end: "2026-06-16T00:00:00Z" });
@@ -244,21 +327,44 @@ test("same idempotency key with different payload returns conflict", async () =>
   assert.equal(db.adjustments.length, 1);
 });
 
+test("invalid idempotency keys are rejected before insert", async () => {
+  const db = new FakeClient();
+  db.periods.set("payout_2026-06_25", { payout_id: "payout_2026-06_25", status: "locked", period_type: "25", period_start: "2026-06-01T00:00:00Z", period_end: "2026-06-16T00:00:00Z" });
+
+  await assert.rejects(() => apply(db, { idempotency_key: "bad key" }), /INVALID_IDEMPOTENCY_KEY/);
+  await assert.rejects(() => apply(db, { idempotency_key: "x".repeat(121) }), /INVALID_IDEMPOTENCY_KEY/);
+  assert.equal(db.adjustments.length, 0);
+});
+
 test("missing migration returns PAYOUT_ADJUSTMENT_MIGRATION_REQUIRED", async () => {
   const db = new FakeClient();
   db.migrationReady = false;
   await assert.rejects(() => apply(db), /PAYOUT_ADJUSTMENT_MIGRATION_REQUIRED/);
 });
 
-test("paid period without payment row does not create a fake payment row", async () => {
+test("paid period with positive net and no payment row rejects reconciliation without mutation", async () => {
   const db = new FakeClient();
   db.periods.set("payout_2026-06_25", { payout_id: "payout_2026-06_25", status: "paid", period_type: "25", period_start: "2026-06-01T00:00:00Z", period_end: "2026-06-16T00:00:00Z" });
   db.lines.push({ payout_id: "payout_2026-06_25", technician_username: "TECH_A", earn_amount: 1000 });
 
-  await apply(db);
+  await assert.rejects(() => apply(db), /PAYOUT_PAID_RECONCILIATION_REQUIRED/);
 
   assert.equal(db.payments.length, 0);
-  assert.equal(db.periods.get("payout_2026-06_25").status, "locked");
+  assert.equal(db.adjustments.length, 0);
+  assert.equal(db.periods.get("payout_2026-06_25").status, "paid");
+  assert.equal(db.audit.length, 0);
+});
+
+test("paid period with non-positive prior net may be adjusted without a fake payment row", async () => {
+  const db = new FakeClient();
+  db.periods.set("payout_2026-06_25", { payout_id: "payout_2026-06_25", status: "paid", period_type: "25", period_start: "2026-06-01T00:00:00Z", period_end: "2026-06-16T00:00:00Z" });
+  db.deposits.push({ payout_id: "payout_2026-06_25", technician_username: "TECH_A", amount: 100, transaction_type: "collect" });
+
+  const result = await apply(db, { adj_amount: 50 });
+
+  assert.equal(db.payments.length, 0);
+  assert.equal(result.totals.net_amount, -50);
+  assert.equal(db.periods.get("payout_2026-06_25").status, "paid");
 });
 
 test("historical draft after cutoff snapshots and locks, but before-cutoff draft is rejected and not locked", async () => {
@@ -275,11 +381,50 @@ test("historical draft after cutoff snapshots and locks, but before-cutoff draft
   assert.equal(open.periods.get("payout_2999-01_25").status, "draft");
 });
 
-test("transaction failure point is inside caller transaction: route begins and rolls back on error", () => {
+test("audit failure inside route transaction rolls back adjustment, status, payment, and audit", async () => {
+  const db = new FakeClient();
+  db.failAudit = true;
+  db.periods.set("payout_2026-06_25", { payout_id: "payout_2026-06_25", status: "paid", period_type: "25", period_start: "2026-06-01T00:00:00Z", period_end: "2026-06-16T00:00:00Z" });
+  db.lines.push({ payout_id: "payout_2026-06_25", technician_username: "TECH_A", earn_amount: 1000 });
+  db.payments.push({ payment_id: 1, payout_id: "payout_2026-06_25", technician_username: "TECH_A", paid_amount: 1000, paid_status: "paid" });
+
+  await assert.rejects(() => applyInsideRouteTransaction(db, { adj_amount: 250 }), /AUDIT_WRITE_FAILED/);
+
+  assert.equal(db.adjustments.length, 0);
+  assert.equal(db.payments[0].paid_amount, 1000);
+  assert.equal(db.payments[0].paid_status, "paid");
+  assert.equal(db.periods.get("payout_2026-06_25").status, "paid");
+  assert.equal(db.audit.length, 0);
+  assert.equal(db.txStack.length, 0);
+});
+
+test("bulk pay targets exclude payment-only and deposit-only rows but include adjustment-only payable rows", () => {
+  const rows = svc.getBulkPayableTargetRows([
+    { technician_username: "PAY_ONLY", gross_amount: 0, adj_total: 0, deposit_deduction_amount: 0, net_amount: 0, paid_amount: 20, remaining_amount: 0 },
+    { technician_username: "DEP_ONLY", gross_amount: 0, adj_total: 0, deposit_deduction_amount: 10, net_amount: -10, paid_amount: 0, remaining_amount: 0 },
+    { technician_username: "ADJ_ONLY", gross_amount: 0, adj_total: 75, deposit_deduction_amount: 0, net_amount: 75, paid_amount: 0, remaining_amount: 75 },
+    { technician_username: "LINE_PAID", gross_amount: 100, adj_total: 0, deposit_deduction_amount: 0, net_amount: 100, paid_amount: 100, remaining_amount: 0 },
+  ]);
+  assert.deepEqual(rows.map((r) => r.technician_username), ["ADJ_ONLY"]);
+});
+
+test("legacy_settle consumes payout summary .techs before all-paid evaluation", () => {
   const src = fs.readFileSync("index.js", "utf8");
-  assert.match(src, /await client\.query\('BEGIN'\)[\s\S]*applyAccountingPositivePayoutAdjustment/);
-  assert.match(src, /catch \(e\) \{[\s\S]*await client\.query\('ROLLBACK'\)/);
-  assert.match(src, /INSERT INTO public\.accounting_audit_log/);
+  assert.ok(src.includes("const techRowsPayload = await _buildPayoutTechSummaryRows(payout_id);"));
+  assert.ok(src.includes("const techRows = Array.isArray(techRowsPayload?.techs) ? techRowsPayload.techs : [];"));
+  assert.ok(src.includes("getPayoutTechSettlementRows(client, payout_id)"));
+});
+
+test("draft adjustment audit records original draft status before lock", async () => {
+  const db = new FakeClient();
+  db.periods.set("payout_2000-01_25", { payout_id: "payout_2000-01_25", status: "draft", period_type: "25", period_start: "2000-01-01T00:00:00Z", period_end: "2000-01-16T00:00:00Z" });
+
+  const result = await apply(db, { payout_id: "payout_2000-01_25" }, { regenerateDraftPayoutContractLines: async () => ({ ok: true }) });
+
+  assert.equal(result.period_status_before, "draft");
+  assert.equal(result.period_status_after, "locked");
+  const beforeJson = JSON.parse(db.audit[0].params[6]);
+  assert.equal(beforeJson.period.status, "draft");
 });
 
 test("slip source includes adjustment rows and deposit totals", () => {

--- a/test/accountingPayoutAdjustments.test.js
+++ b/test/accountingPayoutAdjustments.test.js
@@ -1,0 +1,306 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+
+const svc = require("../server/services/accountingPayoutAdjustments");
+
+function normSql(sql) {
+  return String(sql || "").replace(/\s+/g, " ").trim();
+}
+
+class FakeClient {
+  constructor() {
+    this.migrationReady = true;
+    this.periods = new Map();
+    this.lines = [];
+    this.adjustments = [];
+    this.payments = [];
+    this.deposits = [];
+    this.jobs = new Set();
+    this.audit = [];
+    this.nextAdjId = 1;
+  }
+
+  clone(row) {
+    return row ? { ...row } : row;
+  }
+
+  settlementRows(payoutId) {
+    const techs = new Set();
+    for (const r of this.lines) if (r.payout_id === payoutId) techs.add(r.technician_username);
+    for (const r of this.adjustments) if (r.payout_id === payoutId) techs.add(r.technician_username);
+    for (const r of this.payments) if (r.payout_id === payoutId) techs.add(r.technician_username);
+    for (const r of this.deposits) if (r.payout_id === payoutId && r.transaction_type === "collect") techs.add(r.technician_username);
+    return [...techs].sort().map((technician_username) => {
+      const gross = this.lines.filter((r) => r.payout_id === payoutId && r.technician_username === technician_username)
+        .reduce((sum, r) => sum + Number(r.earn_amount || 0), 0);
+      const adj = this.adjustments.filter((r) => r.payout_id === payoutId && r.technician_username === technician_username)
+        .reduce((sum, r) => sum + Number(r.adj_amount || 0), 0);
+      const dep = this.deposits.filter((r) => r.payout_id === payoutId && r.technician_username === technician_username && r.transaction_type === "collect")
+        .reduce((sum, r) => sum + Number(r.amount || 0), 0);
+      const pay = this.payments.find((r) => r.payout_id === payoutId && r.technician_username === technician_username);
+      return {
+        technician_username,
+        gross_amount: gross,
+        adj_total: adj,
+        deposit_deduction_amount: dep,
+        net_amount: gross + adj - dep,
+        paid_amount: Number(pay?.paid_amount || 0),
+      };
+    });
+  }
+
+  async query(sql, params = []) {
+    const s = normSql(sql);
+
+    if (s.includes("FROM information_schema.columns")) {
+      return { rows: this.migrationReady ? [{ "?column?": 1 }] : [] };
+    }
+    if (s.includes("FROM pg_indexes")) {
+      return { rows: this.migrationReady ? [{ "?column?": 1 }] : [] };
+    }
+    if (s.startsWith("SELECT payout_id, status, period_type, period_start, period_end, created_at, created_by FROM public.technician_payout_periods")) {
+      const row = this.periods.get(params[0]);
+      return { rows: row ? [this.clone(row)] : [] };
+    }
+    if (s.startsWith("INSERT INTO public.technician_payout_periods")) {
+      const [payout_id, period_type, period_start, period_end, statusOrCreatedBy, maybeCreatedBy] = params;
+      if (!this.periods.has(payout_id)) {
+        this.periods.set(payout_id, {
+          payout_id,
+          period_type,
+          period_start,
+          period_end,
+          status: maybeCreatedBy === undefined ? "draft" : statusOrCreatedBy || "draft",
+          created_by: maybeCreatedBy === undefined ? statusOrCreatedBy : maybeCreatedBy,
+        });
+      }
+      return { rows: [] };
+    }
+    if (s.startsWith("UPDATE public.technician_payout_periods SET status='locked'")) {
+      const row = this.periods.get(params[0]);
+      if (row && row.status === "draft") row.status = "locked";
+      return { rows: [] };
+    }
+    if (s.startsWith("UPDATE public.technician_payout_periods SET status=$2")) {
+      const row = this.periods.get(params[0]);
+      if (row) row.status = params[1];
+      return { rows: [] };
+    }
+    if (s.startsWith("SELECT payment_id, payout_id, technician_username")) {
+      const row = this.payments.find((r) => r.payout_id === params[0] && r.technician_username === params[1]);
+      return { rows: row ? [this.clone(row)] : [] };
+    }
+    if (s.startsWith("SELECT 1 FROM public.jobs")) {
+      return { rows: this.jobs.has(String(params[0])) ? [{ "?column?": 1 }] : [] };
+    }
+    if (s.startsWith("SELECT adj_id, payout_id, technician_username")) {
+      const row = this.adjustments.find((r) => r.idempotency_key === params[0]);
+      return { rows: row ? [this.clone(row)] : [] };
+    }
+    if (s.startsWith("INSERT INTO public.technician_payout_adjustments")) {
+      const [payout_id, technician_username, job_id, adj_amount, reason, created_by, idempotency_key] = params;
+      const existing = this.adjustments.find((r) => r.idempotency_key && r.idempotency_key === idempotency_key);
+      if (existing) return { rows: [] };
+      const row = {
+        adj_id: this.nextAdjId++,
+        payout_id,
+        technician_username,
+        job_id,
+        adj_amount: Number(adj_amount),
+        reason,
+        created_by,
+        idempotency_key,
+        created_at: "2026-07-03T00:00:00.000Z",
+      };
+      this.adjustments.push(row);
+      return { rows: [this.clone(row)] };
+    }
+    if (s.startsWith("UPDATE public.technician_payout_payments")) {
+      const row = this.payments.find((r) => r.payout_id === params[0] && r.technician_username === params[1]);
+      if (row) row.paid_status = params[2];
+      return { rows: [] };
+    }
+    if (s.includes("FROM techs t")) {
+      return { rows: this.settlementRows(params[0]) };
+    }
+    if (s.startsWith("INSERT INTO public.accounting_audit_log")) {
+      this.audit.push({ params });
+      return { rows: [] };
+    }
+    throw new Error(`Unhandled SQL: ${s}`);
+  }
+}
+
+async function apply(db, body = {}, extra = {}) {
+  return svc.applyAccountingPositivePayoutAdjustment({
+    client: db,
+    payout_id: body.payout_id || "payout_2026-06_25",
+    body: {
+      technician_username: "TECH_A",
+      adj_amount: 100,
+      reason: "ย้อนหลัง",
+      idempotency_key: "idem-1",
+      confirm_adjustment: true,
+      ...body,
+    },
+    actor: { username: "acct", role: "admin" },
+    req: { actor: { username: "acct", role: "admin" }, headers: {} },
+    regenerateDraftPayoutContractLines: extra.regenerateDraftPayoutContractLines || (async () => ({ ok: true })),
+  });
+}
+
+test("locked unpaid period accepts a positive adjustment and writes one audit row", async () => {
+  const db = new FakeClient();
+  db.periods.set("payout_2026-06_25", { payout_id: "payout_2026-06_25", status: "locked", period_type: "25", period_start: "2026-06-01T00:00:00Z", period_end: "2026-06-16T00:00:00Z" });
+  db.lines.push({ payout_id: "payout_2026-06_25", technician_username: "TECH_A", earn_amount: 1000 });
+
+  const result = await apply(db);
+
+  assert.equal(result.replayed, false);
+  assert.equal(db.adjustments.length, 1);
+  assert.equal(result.totals.net_amount, 1100);
+  assert.equal(result.totals.remaining_amount, 1100);
+  assert.equal(db.periods.get("payout_2026-06_25").status, "locked");
+  assert.equal(db.audit.length, 1);
+});
+
+test("paid period positive adjustment preserves paid_amount and reopens as locked with remaining difference", async () => {
+  const db = new FakeClient();
+  db.periods.set("payout_2026-06_25", { payout_id: "payout_2026-06_25", status: "paid", period_type: "25", period_start: "2026-06-01T00:00:00Z", period_end: "2026-06-16T00:00:00Z" });
+  db.lines.push({ payout_id: "payout_2026-06_25", technician_username: "TECH_A", earn_amount: 1000 });
+  db.payments.push({ payment_id: 1, payout_id: "payout_2026-06_25", technician_username: "TECH_A", paid_amount: 1000, paid_status: "paid" });
+
+  const result = await apply(db, { adj_amount: 250 });
+
+  assert.equal(db.payments[0].paid_amount, 1000);
+  assert.equal(db.payments[0].paid_status, "partial");
+  assert.equal(result.totals.remaining_amount, 250);
+  assert.equal(db.periods.get("payout_2026-06_25").status, "locked");
+});
+
+test("paying the new difference makes union settlement fully paid again", async () => {
+  const db = new FakeClient();
+  db.periods.set("payout_2026-06_25", { payout_id: "payout_2026-06_25", status: "paid", period_type: "25", period_start: "2026-06-01T00:00:00Z", period_end: "2026-06-16T00:00:00Z" });
+  db.lines.push({ payout_id: "payout_2026-06_25", technician_username: "TECH_A", earn_amount: 1000 });
+  db.payments.push({ payment_id: 1, payout_id: "payout_2026-06_25", technician_username: "TECH_A", paid_amount: 1000, paid_status: "paid" });
+  await apply(db, { adj_amount: 250 });
+
+  db.payments[0].paid_amount = 1250;
+  const rows = await svc.getPayoutTechSettlementRows(db, "payout_2026-06_25");
+  assert.equal(svc.isPayoutFullyPaidFromRows(rows), true);
+});
+
+test("zero, negative, missing reason, and missing confirmation are rejected", async () => {
+  const db = new FakeClient();
+  db.periods.set("payout_2026-06_25", { payout_id: "payout_2026-06_25", status: "locked", period_type: "25", period_start: "2026-06-01T00:00:00Z", period_end: "2026-06-16T00:00:00Z" });
+
+  await assert.rejects(() => apply(db, { adj_amount: 0 }), /INVALID_ADJUSTMENT_AMOUNT/);
+  await assert.rejects(() => apply(db, { adj_amount: -1 }), /INVALID_ADJUSTMENT_AMOUNT/);
+  await assert.rejects(() => apply(db, { reason: "" }), /MISSING_REASON/);
+  await assert.rejects(() => apply(db, { confirm_adjustment: false }), /CONFIRM_ADJUSTMENT_REQUIRED/);
+});
+
+test("route uses accounting_mark_payout_paid permission", () => {
+  const src = fs.readFileSync("index.js", "utf8");
+  assert.match(src, /app\.post\('\/admin\/accounting\/payouts\/:payout_id\/adjust', requireAccountingPermission\('accounting_mark_payout_paid'\)/);
+});
+
+test("invalid or missing job_id is rejected before insert", async () => {
+  const db = new FakeClient();
+  db.periods.set("payout_2026-06_25", { payout_id: "payout_2026-06_25", status: "locked", period_type: "25", period_start: "2026-06-01T00:00:00Z", period_end: "2026-06-16T00:00:00Z" });
+
+  await assert.rejects(() => apply(db, { job_id: "abc" }), /INVALID_JOB_ID/);
+  await assert.rejects(() => apply(db, { job_id: "999" }), /JOB_NOT_FOUND/);
+  db.jobs.add("999");
+  await apply(db, { job_id: "999" });
+  assert.equal(db.adjustments[0].job_id, "999");
+});
+
+test("union settlement includes adjustment-only, payment-only, and deposit-only technicians", async () => {
+  const db = new FakeClient();
+  db.adjustments.push({ payout_id: "payout_2026-06_25", technician_username: "ADJ_ONLY", adj_amount: 75 });
+  db.payments.push({ payout_id: "payout_2026-06_25", technician_username: "PAY_ONLY", paid_amount: 20 });
+  db.deposits.push({ payout_id: "payout_2026-06_25", technician_username: "DEP_ONLY", amount: 10, transaction_type: "collect" });
+
+  const rows = await svc.getPayoutTechSettlementRows(db, "payout_2026-06_25");
+  assert.deepEqual(rows.map((r) => r.technician_username).sort(), ["ADJ_ONLY", "DEP_ONLY", "PAY_ONLY"]);
+});
+
+test("same idempotency key and same payload replays one row", async () => {
+  const db = new FakeClient();
+  db.periods.set("payout_2026-06_25", { payout_id: "payout_2026-06_25", status: "locked", period_type: "25", period_start: "2026-06-01T00:00:00Z", period_end: "2026-06-16T00:00:00Z" });
+  await apply(db);
+  const replay = await apply(db);
+  assert.equal(replay.replayed, true);
+  assert.equal(db.adjustments.length, 1);
+});
+
+test("same idempotency key with different payload returns conflict", async () => {
+  const db = new FakeClient();
+  db.periods.set("payout_2026-06_25", { payout_id: "payout_2026-06_25", status: "locked", period_type: "25", period_start: "2026-06-01T00:00:00Z", period_end: "2026-06-16T00:00:00Z" });
+  await apply(db);
+  await assert.rejects(() => apply(db, { adj_amount: 101 }), /IDEMPOTENCY_KEY_REUSED/);
+  assert.equal(db.adjustments.length, 1);
+});
+
+test("missing migration returns PAYOUT_ADJUSTMENT_MIGRATION_REQUIRED", async () => {
+  const db = new FakeClient();
+  db.migrationReady = false;
+  await assert.rejects(() => apply(db), /PAYOUT_ADJUSTMENT_MIGRATION_REQUIRED/);
+});
+
+test("paid period without payment row does not create a fake payment row", async () => {
+  const db = new FakeClient();
+  db.periods.set("payout_2026-06_25", { payout_id: "payout_2026-06_25", status: "paid", period_type: "25", period_start: "2026-06-01T00:00:00Z", period_end: "2026-06-16T00:00:00Z" });
+  db.lines.push({ payout_id: "payout_2026-06_25", technician_username: "TECH_A", earn_amount: 1000 });
+
+  await apply(db);
+
+  assert.equal(db.payments.length, 0);
+  assert.equal(db.periods.get("payout_2026-06_25").status, "locked");
+});
+
+test("historical draft after cutoff snapshots and locks, but before-cutoff draft is rejected and not locked", async () => {
+  const closed = new FakeClient();
+  closed.periods.set("payout_2000-01_25", { payout_id: "payout_2000-01_25", status: "draft", period_type: "25", period_start: "2000-01-01T00:00:00Z", period_end: "2000-01-16T00:00:00Z" });
+  let regenerated = false;
+  await apply(closed, { payout_id: "payout_2000-01_25" }, { regenerateDraftPayoutContractLines: async () => { regenerated = true; return { ok: true }; } });
+  assert.equal(regenerated, true);
+  assert.equal(closed.periods.get("payout_2000-01_25").status, "locked");
+
+  const open = new FakeClient();
+  open.periods.set("payout_2999-01_25", { payout_id: "payout_2999-01_25", status: "draft", period_type: "25", period_start: "2999-01-01T00:00:00Z", period_end: "2999-01-16T00:00:00Z" });
+  await assert.rejects(() => apply(open, { payout_id: "payout_2999-01_25" }), /PAYOUT_PERIOD_NOT_CLOSED/);
+  assert.equal(open.periods.get("payout_2999-01_25").status, "draft");
+});
+
+test("transaction failure point is inside caller transaction: route begins and rolls back on error", () => {
+  const src = fs.readFileSync("index.js", "utf8");
+  assert.match(src, /await client\.query\('BEGIN'\)[\s\S]*applyAccountingPositivePayoutAdjustment/);
+  assert.match(src, /catch \(e\) \{[\s\S]*await client\.query\('ROLLBACK'\)/);
+  assert.match(src, /INSERT INTO public\.accounting_audit_log/);
+});
+
+test("slip source includes adjustment rows and deposit totals", () => {
+  const src = fs.readFileSync("index.js", "utf8");
+  assert.match(src, /adjHtml/);
+  assert.match(src, /deposit_deduction_amount/);
+  assert.match(src, /ยอดสุทธิ/);
+  assert.match(src, /จ่ายแล้ว/);
+  assert.match(src, /คงเหลือ/);
+});
+
+test("super admin adjustment route remains separate and supports delete action", () => {
+  const src = fs.readFileSync("index.js", "utf8");
+  assert.match(src, /app\.post\('\/admin\/super\/payouts\/:payout_id\/adjust', requireSuperAdmin/);
+  assert.match(src, /if \(action === 'delete'\)/);
+  assert.match(src, /DELETE FROM public\.technician_payout_adjustments/);
+});
+
+test("migration SQL is additive and does not backfill", () => {
+  const sql = fs.readFileSync("migrations/20260703_technician_payout_adjustment_idempotency.sql", "utf8");
+  assert.match(sql, /ADD COLUMN IF NOT EXISTS idempotency_key TEXT/);
+  assert.match(sql, /CREATE UNIQUE INDEX IF NOT EXISTS uq_tpa_idempotency_key/);
+  assert.doesNotMatch(sql, /\bUPDATE\b|\bDELETE\b|\bINSERT\b/i);
+});


### PR DESCRIPTION
## Summary

Fixes #139 and addresses the latest Blocking Review on PR #140.

Adds an accounting-only positive payout adjustment flow so admins with `accounting_mark_payout_paid` can add retrospective money to the correct technician payout period, including periods that were already marked paid, without changing existing `paid_amount` records.

## What Changed

- Added `POST /admin/accounting/payouts/:payout_id/adjust`.
- Added durable idempotency support via a new additive migration for `technician_payout_adjustments.idempotency_key`.
- Added a focused payout adjustment service that keeps adjustment insert, payment status update, period status update, and accounting audit in one DB transaction.
- Split bulk-pay write targets from union settlement rows so payment-only/deposit-only technicians are used for all-paid evaluation but never written as payout payment targets.
- Reject paid-period positive-net reconciliation when the existing payment row is missing/inconsistent, avoiding accidental reopening of old debt.
- Updated `legacy_settle` to consume `_buildPayoutTechSummaryRows(...).techs` before all-paid checks.
- Added backend idempotency key format/length validation and cryptographic-only UI key fallback.
- Updated all-paid settlement calculations to use the union of payout lines, adjustments, payments, and deposit ledger collect rows.
- Added Accounting UI controls and modal for “เพิ่มเงินย้อนหลัง”.
- Kept Super Admin adjustment negative/delete behavior separate and unchanged.
- Bumped accounting JS cache version and root service worker cache name suffix.

## Safety Notes

- This PR does not run the migration.
- This PR does not backfill deposit ledger rows.
- This PR does not modify production data.
- Existing `paid_amount` values are preserved; paid periods reopen to `locked` only when the pre-adjustment payment state reconciles as paid and the new positive adjustment creates remaining payable.

## Validation

Passed:

- `node --check index.js`
- `node --check admin-accounting-v2.js`
- `node --check sw.js`
- `node --check server/services/accountingPayoutAdjustments.js`
- `node --check test/accountingPayoutAdjustments.test.js`
- `node --test test/accountingPayoutAdjustments.test.js` (22 passed)

Full suite comparison against base `3c2397bbce1b91e2f012d3c4d2252dde26995f72`:

- Branch `npm test`: 842 tests, 811 passed, 20 failed, 11 skipped.
- Base `npm test`: 820 tests, 789 passed, 20 failed, 11 skipped.
- The failure list is unchanged: all 20 failures are existing/out-of-scope `test/adminStoreCatalogUi.test.js` assertions about catalog UI functions/templates.

## Rollback

- Revert this PR commit range.
- Do not run the migration if rollback is needed before deploy.
- If the migration has already run in a later deployment, leaving the nullable column and partial unique index in place is safe; they are additive and no legacy rows are backfilled.