### PR TITLE
Fix per-payout technician deposit collection

### DIFF
--- a/index.js
+++ b/index.js
@@ -9595,99 +9595,15 @@ app.post('/admin/super/payouts/legacy_settle', requireSuperAdmin, async (req, re
     }
 
     const cutoffEnd = `${cutoff} 23:59:59+07`;
-    const periodsQ = await pool.query(
-      `SELECT payout_id, status, period_start, period_end
-         FROM public.technician_payout_periods
-        WHERE period_end <= $1::timestamptz
-        ORDER BY period_end ASC, payout_id ASC`,
-      [cutoffEnd]
-    );
-
-    let checked_periods = 0;
-    let touched_periods = 0;
-    let updated_payments = 0;
-    let skipped_paid_rows = 0;
-    const affected = [];
-
-    await client.query('BEGIN');
-
-    for (const period of (periodsQ.rows || [])) {
-      const payout_id = String(period.payout_id || '').trim();
-      if (!payout_id) continue;
-      checked_periods++;
-      if (String(period.status || '') === 'paid') {
-        skipped_paid_rows++;
-        continue;
-      }
-
-      const techRowsPayload = await _buildPayoutTechSummaryRows(payout_id);
-      const techRows = Array.isArray(techRowsPayload?.techs) ? techRowsPayload.techs : [];
-      let periodTouched = false;
-
-      for (const row of techRows) {
-        const tech = String(row.technician_username || '').trim();
-        if (!tech) continue;
-        if (techFilter && tech !== techFilter) continue;
-
-        const paid = _money(row.paid_amount || 0);
-        const status = String(row.paid_status || '').trim();
-        const previewNet = _money(row.net_amount ?? row.total_amount ?? 0);
-        const previewRemaining = _money(Math.max(0, previewNet - paid));
-        if (previewNet <= 0 || status === 'paid' || previewRemaining <= 0.0001) {
-          skipped_paid_rows++;
-          continue;
-        }
-
-        const prepDeposit = await _ensureDepositCollectionForPayout({
-          payout_id,
-          username: tech,
-          gross_amount: row.gross_amount || 0,
-          adj_total: row.adj_total || 0,
-          actor,
-          client,
-        });
-        const currentTotals = await _getTechGrossAdjNet(payout_id, tech, client, { period_status: period.status || 'locked' });
-        const net = _money(currentTotals.net_amount ?? row.net_amount ?? row.total_amount ?? 0);
-        const remaining = _money(Math.max(0, net - paid));
-
-        if (net <= 0 || remaining <= 0.0001) {
-          skipped_paid_rows++;
-          continue;
-        }
-
-        const note = noteInput || `Legacy paid outside app before payout MVP. Settled by Super Admin cutoff ${cutoff}.`;
-        await client.query(
-          `INSERT INTO public.technician_payout_payments(
-             payout_id, technician_username, paid_amount, paid_status, paid_at, paid_by, slip_url, note, updated_at
-           ) VALUES($1,$2,$3,'paid',NOW(),$4,NULL,$5,NOW())
-           ON CONFLICT (payout_id, technician_username)
-           DO UPDATE SET
-             paid_amount=GREATEST(public.technician_payout_payments.paid_amount, EXCLUDED.paid_amount),
-             paid_status='paid',
-             paid_at=NOW(),
-             paid_by=EXCLUDED.paid_by,
-             note=COALESCE(NULLIF(public.technician_payout_payments.note,''), EXCLUDED.note),
-             updated_at=NOW()`,
-          [payout_id, tech, net, actor, note]
-        );
-
-        updated_payments++;
-        periodTouched = true;
-        affected.push({ payout_id, technician_username: tech, paid_amount: net, previous_paid_amount: paid, previous_remaining_amount: remaining, deposit_deduction_amount: currentTotals.deposit_deduction_amount, deposit_inserted: !!prepDeposit.inserted });
-      }
-
-      if (periodTouched) {
-        touched_periods++;
-        const paidCheckRows = await accountingPayoutAdjustments.getPayoutTechSettlementRows(client, payout_id);
-        const allPaid = accountingPayoutAdjustments.isPayoutFullyPaidFromRows(paidCheckRows);
-        if (allPaid) {
-          await client.query(`UPDATE public.technician_payout_periods SET status='paid' WHERE payout_id=$1`, [payout_id]);
-        }
-      }
-    }
-
-    await client.query('COMMIT');
-    return res.json({ ok:true, cutoff_date: cutoff, technician_username: techFilter || null, checked_periods, touched_periods, updated_payments, skipped_paid_rows, affected });
+    const result = await accountingPayoutAdjustments.settleLegacyPaidPayouts({
+      client,
+      cutoffEnd,
+      cutoffDate: cutoff,
+      techFilter,
+      noteInput,
+      actor,
+    });
+    return res.json(result);
   } catch (e) {
     try { await client.query('ROLLBACK'); } catch {}
     console.error('POST /admin/super/payouts/legacy_settle', e);

--- a/index.js
+++ b/index.js
@@ -53,6 +53,7 @@ const createAccountingReadOnlyRoutes = require("./server/routes/accountingReadOn
 const { ensurePayoutPeriodAndSnapshotForPayment } = require("./server/services/technicianPayoutPrepay");
 const { buildAccountingPayoutCalendar, isPeriodCutoffClosed } = require("./server/services/technicianPayoutPeriods");
 const accountingPayoutAdjustments = require("./server/services/accountingPayoutAdjustments");
+const technicianDepositCollections = require("./server/services/technicianDepositCollections");
 const { createTechnicianCashCollectionService } = require("./server/services/technicianCashCollections");
 const { createTechnicianDeductionPayoutApplyService } = require("./server/services/technicianDeductionPayoutApply");
 const createAdminReworkDeductionsHelpers = require("./server/helpers/adminReworkDeductionsHelpers");
@@ -1559,10 +1560,11 @@ function requireAccountingPermission(permissionKey) {
   };
 }
 
-async function logAccountingAudit(req, { action, entity_type, entity_id = null, before_json = null, after_json = null, note = null } = {}) {
+async function logAccountingAudit(req, { action, entity_type, entity_id = null, before_json = null, after_json = null, note = null } = {}, opts = {}) {
   try {
     const actor = _accountingActor(req);
-    await pool.query(
+    const db = opts.client || pool;
+    await db.query(
       `INSERT INTO public.accounting_audit_log
         (actor_user_id, actor_username, actor_role, action, entity_type, entity_id,
          before_json, after_json, ip_address, user_agent, note)
@@ -1582,6 +1584,7 @@ async function logAccountingAudit(req, { action, entity_type, entity_id = null, 
       ]
     );
   } catch (e) {
+    if (opts.strict) throw e;
     console.warn('[accounting_audit] log failed:', e.message);
   }
 }
@@ -5790,10 +5793,10 @@ function _normCompMode(mode) {
   return 'commission';
 }
 
-async function _getTechProfile(username) {
+async function _getTechProfile(username, db = pool) {
   if (!username) return null;
   try {
-    const q = await pool.query(
+    const q = await db.query(
       `SELECT username,
               COALESCE(employment_type,'company') AS employment_type,
               COALESCE(compensation_mode,'commission') AS compensation_mode,
@@ -6253,8 +6256,14 @@ async function _buildPayoutTechSummaryRows(payout_id){
     const gross_amount = Number(r.gross_amount || 0);
     const adj_total = Number(adjQ.rows?.[0]?.adj_total || 0);
     const paid_amount = Number(payQ.rows?.[0]?.paid_amount || 0);
-    const deposit_deduction_amount = await _getDepositDeductionForPayout(payout_id, tech);
-    const deposit = await _getDepositSummary(tech);
+    const deposit = await technicianDepositCollections.getProjectedDepositDeductionForPayout(pool, {
+      payout_id,
+      technician_username: tech,
+      gross_amount,
+      adj_total,
+      period_status: status,
+    });
+    const deposit_deduction_amount = _money(deposit.deposit_deduction_amount || 0);
     const net_amount = _money(gross_amount + adj_total - deposit_deduction_amount);
     const paid_status = _paidStatus(net_amount, paid_amount);
     out.push({
@@ -8203,8 +8212,14 @@ app.get('/admin/super/payouts/:payout_id/tech/:username', requireSuperAdmin, asy
 
     const gross = lines.reduce((s,x)=>s+Number(x.earn_amount||0),0);
     const adj_total = (adjR.rows||[]).reduce((s,x)=>s+Number(x.adj_amount||0),0);
-    const deposit_deduction_amount = await _getDepositDeductionForPayout(payout_id, username);
-    const deposit = await _getDepositSummary(username);
+    const deposit = await technicianDepositCollections.getProjectedDepositDeductionForPayout(pool, {
+      payout_id,
+      technician_username: username,
+      gross_amount: gross,
+      adj_total,
+      period_status: status,
+    });
+    const deposit_deduction_amount = _money(deposit.deposit_deduction_amount || 0);
     const net = _money(gross + adj_total - deposit_deduction_amount);
     const paid_amount = Number(payR.rows?.[0]?.paid_amount || 0);
     const remaining = _money(net - paid_amount);
@@ -8289,8 +8304,14 @@ app.get('/admin/payouts/:payout_id/tech/:username', requireAdminSession, async (
     );
     const gross = lines.reduce((s,x)=>s+Number(x.earn_amount||0),0);
     const adj_total = (adjR.rows||[]).reduce((s,x)=>s+Number(x.adj_amount||0),0);
-    const deposit_deduction_amount = await _getDepositDeductionForPayout(payout_id, username);
-    const deposit = await _getDepositSummary(username);
+    const deposit = await technicianDepositCollections.getProjectedDepositDeductionForPayout(pool, {
+      payout_id,
+      technician_username: username,
+      gross_amount: gross,
+      adj_total,
+      period_status: status,
+    });
+    const deposit_deduction_amount = _money(deposit.deposit_deduction_amount || 0);
     const net = _money(gross + adj_total - deposit_deduction_amount);
     const paid_amount = Number(payR.rows?.[0]?.paid_amount || 0);
     return res.json({ ok:true, payout_id, technician_username: username, status, source: loaded.source, gross_amount: gross, adj_total, deposit_deduction_amount, net_amount: net, paid_amount, remaining_amount: _money(net-paid_amount), paid_status: _paidStatus(net, paid_amount), ...deposit, latest_deposit_deduction: deposit_deduction_amount, payment: payR.rows?.[0] || null, adjustments: adjR.rows || [], lines });
@@ -8632,11 +8653,11 @@ function _paidStatus(netAmount, paidAmount){
   return 'partial';
 }
 
-async function _getDepositAccount(username){
+async function _getDepositAccount(username, db = pool){
   const tech = String(username || '').trim();
   if (!tech) return { technician_username: '', target_amount: 5000, is_required: true };
   try {
-    const q = await pool.query(
+    const q = await db.query(
       `SELECT technician_username, COALESCE(target_amount,5000)::numeric AS target_amount,
               COALESCE(is_required,TRUE) AS is_required, created_at, updated_at, updated_by
          FROM public.technician_deposit_accounts
@@ -8649,11 +8670,11 @@ async function _getDepositAccount(username){
   return { technician_username: tech, target_amount: 5000, is_required: true };
 }
 
-async function _getDepositCollected(username){
+async function _getDepositCollected(username, db = pool){
   const tech = String(username || '').trim();
   if (!tech) return 0;
   try {
-    const q = await pool.query(
+    const q = await db.query(
       `SELECT COALESCE(SUM(
           CASE transaction_type
             WHEN 'collect' THEN amount
@@ -8673,9 +8694,9 @@ async function _getDepositCollected(username){
   }
 }
 
-async function _getDepositSummary(username){
-  const account = await _getDepositAccount(username);
-  const collected = await _getDepositCollected(username);
+async function _getDepositSummary(username, db = pool){
+  const account = await _getDepositAccount(username, db);
+  const collected = await _getDepositCollected(username, db);
   const target = _money(account.target_amount || 5000);
   return {
     deposit_target_amount: target,
@@ -8685,12 +8706,12 @@ async function _getDepositSummary(username){
   };
 }
 
-async function _getDepositDeductionForPayout(payout_id, username){
+async function _getDepositDeductionForPayout(payout_id, username, db = pool){
   const pid = String(payout_id || '').trim();
   const tech = String(username || '').trim();
   if (!pid || !tech) return 0;
   try {
-    const q = await pool.query(
+    const q = await db.query(
       `SELECT COALESCE(SUM(amount),0)::numeric AS amount
          FROM public.technician_deposit_ledger
         WHERE payout_id=$1 AND technician_username=$2 AND transaction_type='collect'`,
@@ -8734,43 +8755,50 @@ async function _calcPartnerDepositDeduction({ username, gross_amount } = {}){
 }
 
 async function _ensureDepositCollectionForPayout({ payout_id, username, gross_amount, actor } = {}){
+  const opts = arguments[0] || {};
+  const db = opts.client || pool;
   const pid = String(payout_id || '').trim();
   const tech = String(username || '').trim();
   if (!pid || !tech) return { deposit_deduction_amount: 0, inserted: false, disabled: !ENABLE_PARTNER_DEPOSIT_DEDUCTION };
-  const existing = await _getDepositDeductionForPayout(pid, tech);
-  if (existing > 0) return { deposit_deduction_amount: existing, inserted: false, existing: true };
   if (!ENABLE_PARTNER_DEPOSIT_DEDUCTION) return { deposit_deduction_amount: 0, inserted: false, disabled: true };
-  const deduction = await _calcPartnerDepositDeduction({ username: tech, gross_amount });
-  if (deduction <= 0) return { deposit_deduction_amount: 0, inserted: false };
-  const q = await pool.query(
-    `INSERT INTO public.technician_deposit_ledger(
-       technician_username, payout_id, transaction_type, amount, note, created_by, meta_json
-     ) VALUES($1,$2,'collect',$3,$4,$5,$6::jsonb)
-     ON CONFLICT (technician_username, payout_id, transaction_type)
-     WHERE transaction_type='collect'
-     DO NOTHING
-     RETURNING ledger_id`,
-    [
-      tech,
-      pid,
-      deduction,
-      'Automatic partner work deposit deduction',
-      actor || null,
-      JSON.stringify({ gross_amount: _money(gross_amount || 0), formula: 'flexible_partner_deposit_v2', policy: 'gross<700=0, 700-1499=max 100, 1500-2999=150-250, >=3000=10% max 500, cap remaining' })
-    ]
-  );
-  const after = await _getDepositDeductionForPayout(pid, tech);
-  return { deposit_deduction_amount: after, inserted: (q.rowCount || 0) > 0 };
+  return technicianDepositCollections.materializeDepositCollectForPayout(db, {
+    payout_id: pid,
+    technician_username: tech,
+    gross_amount,
+    adj_total: opts.adj_total || 0,
+    actor,
+  });
 }
 
-async function _ensureDepositCollectionsForPayout(payout_id, actor) {
+async function _ensureDepositCollectionsForPayout(payout_id, actor, db = pool) {
   const pid = String(payout_id || '').trim();
   if (!pid) return { checked: 0, inserted: 0 };
-  const q = await pool.query(
-    `SELECT technician_username, COALESCE(SUM(earn_amount),0)::numeric AS gross_amount
-       FROM public.technician_payout_lines
-      WHERE payout_id=$1
-      GROUP BY technician_username`,
+  await technicianDepositCollections.assertDepositCollectUniqueIndexReady(db);
+  const q = await db.query(
+    `WITH gross AS (
+       SELECT technician_username, COALESCE(SUM(earn_amount),0)::numeric AS gross_amount
+         FROM public.technician_payout_lines
+        WHERE payout_id=$1
+        GROUP BY technician_username
+     ),
+     adj AS (
+       SELECT technician_username, COALESCE(SUM(adj_amount),0)::numeric AS adj_total
+         FROM public.technician_payout_adjustments
+        WHERE payout_id=$1
+        GROUP BY technician_username
+     ),
+     techs AS (
+       SELECT technician_username FROM gross
+       UNION
+       SELECT technician_username FROM adj
+     )
+     SELECT t.technician_username,
+            COALESCE(g.gross_amount,0)::numeric AS gross_amount,
+            COALESCE(a.adj_total,0)::numeric AS adj_total
+       FROM techs t
+       LEFT JOIN gross g ON g.technician_username=t.technician_username
+       LEFT JOIN adj a ON a.technician_username=t.technician_username
+      ORDER BY t.technician_username ASC`,
     [pid]
   );
   let checked = 0;
@@ -8783,7 +8811,9 @@ async function _ensureDepositCollectionsForPayout(payout_id, actor) {
       payout_id: pid,
       username,
       gross_amount: row.gross_amount,
+      adj_total: row.adj_total,
       actor,
+      client: db,
     });
     if (r.inserted) inserted++;
   }
@@ -9123,25 +9153,26 @@ async function _computeTechnicianWorkSummary(username, start, endEx, labelYm = '
   }
 }
 
-async function _getPayoutPeriod(payout_id){
-  const r = await pool.query(
+async function _getPayoutPeriod(payout_id, db = pool, opts = {}){
+  const r = await db.query(
     `SELECT payout_id, status, period_type, period_start, period_end, created_at
        FROM public.technician_payout_periods
       WHERE payout_id=$1
-      LIMIT 1`,
+      LIMIT 1
+      ${opts.forUpdate ? 'FOR UPDATE' : ''}`,
     [payout_id]
   );
   return r.rows[0] || null;
 }
 
-async function _getTechGrossAdjNet(payout_id, tech){
-  const g = await pool.query(
+async function _getTechGrossAdjNet(payout_id, tech, db = pool, opts = {}){
+  const g = await db.query(
     `SELECT COALESCE(SUM(earn_amount),0) AS gross_amount
        FROM public.technician_payout_lines
       WHERE payout_id=$1 AND technician_username=$2`,
     [payout_id, tech]
   );
-  const a = await pool.query(
+  const a = await db.query(
     `SELECT COALESCE(SUM(adj_amount),0) AS adj_total
        FROM public.technician_payout_adjustments
       WHERE payout_id=$1 AND technician_username=$2`,
@@ -9149,8 +9180,20 @@ async function _getTechGrossAdjNet(payout_id, tech){
   );
   const gross = _money(g.rows[0]?.gross_amount || 0);
   const adj = _money(a.rows[0]?.adj_total || 0);
-  const deposit_deduction_amount = await _getDepositDeductionForPayout(payout_id, tech);
-  const deposit = await _getDepositSummary(tech);
+  const periodStatus = opts.period_status == null ? null : String(opts.period_status || '');
+  const deposit = opts.projectDeposit
+    ? await technicianDepositCollections.getProjectedDepositDeductionForPayout(db, {
+        payout_id,
+        technician_username: tech,
+        gross_amount: gross,
+        adj_total: adj,
+        period_status: periodStatus || 'draft',
+      })
+    : {
+        ...(await _getDepositSummary(tech, db)),
+        deposit_deduction_amount: await _getDepositDeductionForPayout(payout_id, tech, db),
+      };
+  const deposit_deduction_amount = _money(deposit.deposit_deduction_amount || 0);
   return {
     gross_amount: gross,
     adj_total: adj,
@@ -9200,11 +9243,13 @@ async function _requireWithdrawIfPartner(payout_id, tech, actor){
 }
 
 async function _upsertPaymentAndMaybeMarkPaid(payout_id, tech, paid_amount, slip_url, note, actor, reqForAudit, opts = {}){
+  const db = opts.client || pool;
   const prep = opts && opts.preparedPeriod ? { period: opts.preparedPeriod, already_prepared: true } : await ensurePayoutPeriodAndSnapshotForPayment({
     pool,
+    client: opts.client || null,
     payout_id,
     actor_username: actor || null,
-    getPayoutPeriod: _getPayoutPeriod,
+    getPayoutPeriod: (pid) => _getPayoutPeriod(pid, db, opts.client ? { forUpdate: true } : {}),
     regenerateDraftPayoutContractLines: _regenerateDraftPayoutContractLines,
     req: reqForAudit || null,
   });
@@ -9217,17 +9262,27 @@ async function _upsertPaymentAndMaybeMarkPaid(payout_id, tech, paid_amount, slip
   }
 
   let deposit_collections = { checked: 0, inserted: 0 };
-  if (String(period.status) === 'draft') {
-    deposit_collections = await _ensureDepositCollectionsForPayout(payout_id, actor);
+  if (opts.depositAlreadyPrepared) {
+    deposit_collections = opts.depositCollections || { checked: 1, inserted: 0 };
+  } else if (String(period.status) === 'draft') {
+    deposit_collections = await _ensureDepositCollectionsForPayout(payout_id, actor, db);
   } else {
-    const beforeDeposit = await _getTechGrossAdjNet(payout_id, tech);
-    const r = await _ensureDepositCollectionForPayout({ payout_id, username: tech, gross_amount: beforeDeposit.gross_amount, actor });
+    const beforeDeposit = await _getTechGrossAdjNet(payout_id, tech, db, { period_status: period.status });
+    const r = await _ensureDepositCollectionForPayout({ payout_id, username: tech, gross_amount: beforeDeposit.gross_amount, adj_total: beforeDeposit.adj_total, actor, client: db });
     deposit_collections = { checked: 1, inserted: r.inserted ? 1 : 0 };
   }
-  const { net_amount } = await _getTechGrossAdjNet(payout_id, tech);
+  const { net_amount } = await _getTechGrossAdjNet(payout_id, tech, db, { period_status: period.status });
+  if (_money(paid_amount) - _money(net_amount) > 0.01) {
+    const err = new Error('PAYOUT_PAYABLE_CHANGED');
+    err.code = 'PAYOUT_PAYABLE_CHANGED';
+    err.statusCode = 409;
+    err.current_payable_amount = _money(net_amount);
+    err.requested_paid_amount = _money(paid_amount);
+    throw err;
+  }
   const paid_status = _paidStatus(net_amount, paid_amount);
 
-  await pool.query(
+  await db.query(
     `INSERT INTO public.technician_payout_payments(
        payout_id, technician_username, paid_amount, paid_status, paid_at, paid_by, slip_url, note, updated_at
      ) VALUES($1,$2,$3,$4,NOW(),$5,$6,$7,NOW())
@@ -9245,14 +9300,14 @@ async function _upsertPaymentAndMaybeMarkPaid(payout_id, tech, paid_amount, slip
 
   // auto-lock if still draft
   if (String(period.status) === 'draft') {
-    await pool.query(`UPDATE public.technician_payout_periods SET status='locked' WHERE payout_id=$1 AND status='draft'`, [payout_id]);
+    await db.query(`UPDATE public.technician_payout_periods SET status='locked' WHERE payout_id=$1 AND status='draft'`, [payout_id]);
   }
 
   if (String(paid_status) === 'paid') {
     try {
-      const prof = await _getTechProfile(tech);
+      const prof = await _getTechProfile(tech, db);
       if (_isPartnerEmploymentType(prof?.employment_type || '')) {
-        await pool.query(
+        await db.query(
           `UPDATE public.technician_withdraw_requests
               SET status='paid', paid_at=NOW(), paid_by=$3
             WHERE payout_id=$1 AND technician_username=$2 AND status IN ('approved','requested')`,
@@ -9263,10 +9318,10 @@ async function _upsertPaymentAndMaybeMarkPaid(payout_id, tech, paid_amount, slip
   }
 
   // if all techs paid -> mark payout as paid
-  const techRows = await accountingPayoutAdjustments.getPayoutTechSettlementRows(pool, payout_id);
+  const techRows = await accountingPayoutAdjustments.getPayoutTechSettlementRows(db, payout_id);
   const allPaid = accountingPayoutAdjustments.isPayoutFullyPaidFromRows(techRows);
   if (allPaid) {
-    await pool.query(`UPDATE public.technician_payout_periods SET status='paid' WHERE payout_id=$1`, [payout_id]);
+    await db.query(`UPDATE public.technician_payout_periods SET status='paid' WHERE payout_id=$1`, [payout_id]);
   }
 
   return { paid_status, net_amount, deposit_collections };
@@ -9318,49 +9373,53 @@ app.delete('/admin/super/payouts/:payout_id', requireSuperAdmin, async (req, res
   }
 });
 app.post('/admin/super/payouts/:payout_id/lock', requireSuperAdmin, async (req, res) => {
+  const client = await pool.connect();
   try {
     const payout_id = String(req.params.payout_id || '').trim();
     if (!payout_id) return res.status(400).json({ ok:false, error:'MISSING_PAYOUT_ID' });
 
-    const p = await _getPayoutPeriod(payout_id);
-    if (!p) return res.status(404).json({ ok:false, error:'PAYOUT_NOT_FOUND' });
-    if (String(p.status) === 'paid') return res.json({ ok:true, payout_id, status:'paid', already:true });
+    await client.query('BEGIN');
+    const p = await _getPayoutPeriod(payout_id, client, { forUpdate: true });
+    if (!p) {
+      await client.query('ROLLBACK');
+      return res.status(404).json({ ok:false, error:'PAYOUT_NOT_FOUND' });
+    }
+    if (String(p.status) === 'paid') {
+      await client.query('COMMIT');
+      return res.json({ ok:true, payout_id, status:'paid', already:true });
+    }
 
     // If this period was lazily auto-created, it may not have stored lines yet.
     // Before locking, regenerate draft lines from the contract engine so locked/paid periods use a stable snapshot.
     let regen = null;
     if (String(p.status || 'draft') === 'draft') {
-      const client = await pool.connect();
-      try {
-        await client.query('BEGIN');
-        regen = await _regenerateDraftPayoutContractLines({
-          client,
-          payout_id,
-          actor_username: req.actor?.username || null,
-          req,
-        });
-        await client.query('COMMIT');
-      } catch (e) {
-        try { await client.query('ROLLBACK'); } catch {}
-        throw e;
-      } finally {
-        client.release();
-      }
+      regen = await _regenerateDraftPayoutContractLines({
+        client,
+        payout_id,
+        actor_username: req.actor?.username || null,
+        req,
+      });
     }
 
-    const depositSummary = await _ensureDepositCollectionsForPayout(payout_id, req.actor?.username || null);
+    const depositSummary = await _ensureDepositCollectionsForPayout(payout_id, req.actor?.username || null, client);
 
-    await pool.query(`UPDATE public.technician_payout_periods SET status='locked' WHERE payout_id=$1 AND status='draft'`, [payout_id]);
-    const p2 = await _getPayoutPeriod(payout_id);
+    await client.query(`UPDATE public.technician_payout_periods SET status='locked' WHERE payout_id=$1 AND status='draft'`, [payout_id]);
+    const p2 = await _getPayoutPeriod(payout_id, client);
+    await client.query('COMMIT');
     return res.json({ ok:true, payout_id, status: p2?.status || 'locked', regenerated: regen ? true : false, deposit_collections: depositSummary.inserted, deposit_checked: depositSummary.checked });
   } catch (e) {
+    try { await client.query('ROLLBACK'); } catch {}
     console.error('POST /admin/super/payouts/:payout_id/lock', e);
+    if (String(e.code||'') === 'DEPOSIT_COLLECT_INDEX_REQUIRED') return res.status(503).json({ ok:false, error:'DEPOSIT_COLLECT_INDEX_REQUIRED' });
     return res.status(500).json({ ok:false, error:'LOCK_FAILED' });
+  } finally {
+    client.release();
   }
 });
 
 // ---- Super Admin: pay (upsert per tech)
 app.post('/admin/super/payouts/:payout_id/pay', requireSuperAdmin, async (req, res) => {
+  const client = await pool.connect();
   try {
     const payout_id = String(req.params.payout_id || '').trim();
     const b = req.body || {};
@@ -9371,15 +9430,22 @@ app.post('/admin/super/payouts/:payout_id/pay', requireSuperAdmin, async (req, r
 
     if (!payout_id || !tech) return res.status(400).json({ ok:false, error:'MISSING_PARAMS' });
 
-    const r = await _upsertPaymentAndMaybeMarkPaid(payout_id, tech, paid_amount, slip_url, note, req.actor?.username || null, req);
+    await client.query('BEGIN');
+    const r = await _upsertPaymentAndMaybeMarkPaid(payout_id, tech, paid_amount, slip_url, note, req.actor?.username || null, req, { client });
+    await client.query('COMMIT');
     return res.json({ ok:true, payout_id, technician_username: tech, paid_amount, paid_status: r.paid_status, net_amount: r.net_amount });
   } catch (e) {
+    try { await client.query('ROLLBACK'); } catch {}
     console.error('POST /admin/super/payouts/:payout_id/pay', e);
     if (String(e.code||'') === 'PAYOUT_NOT_FOUND') return res.status(404).json({ ok:false, error:'PAYOUT_NOT_FOUND' });
     if (String(e.code||'') === 'PAYOUT_ALREADY_PAID') return res.status(409).json({ ok:false, error:'PAYOUT_ALREADY_PAID' });
+    if (String(e.code||'') === 'DEPOSIT_COLLECT_INDEX_REQUIRED') return res.status(503).json({ ok:false, error:'DEPOSIT_COLLECT_INDEX_REQUIRED' });
+    if (String(e.code||'') === 'PAYOUT_PAYABLE_CHANGED') return res.status(409).json({ ok:false, error:'PAYOUT_PAYABLE_CHANGED', current_payable_amount: e.current_payable_amount, requested_paid_amount: e.requested_paid_amount });
     if (String(e.code||'') === 'PAYOUT_PERIOD_NOT_CLOSED') return res.status(409).json({ ok:false, error:'PAYOUT_PERIOD_NOT_CLOSED', period_end: e.period_end || null });
     if (String(e.message||'').includes('CANNOT_REGENERATE')) return res.status(409).json({ ok:false, error:String(e.message || 'CANNOT_REGENERATE') });
     return res.status(500).json({ ok:false, error:'PAY_FAILED' });
+  } finally {
+    client.release();
   }
 });
 
@@ -9403,17 +9469,37 @@ app.post('/admin/super/payouts/:payout_id/pay_bulk', requireSuperAdmin, async (r
     const note = String(b.note || '').trim() || null;
     if (!payout_id) return res.status(400).json({ ok:false, error:'MISSING_PAYOUT_ID' });
 
-    const period = await _getPayoutPeriod(payout_id);
-    if (!period) return res.status(404).json({ ok:false, error:'PAYOUT_NOT_FOUND' });
-    if (String(period.status) === 'paid') return res.status(409).json({ ok:false, error:'PAYOUT_ALREADY_PAID' });
+    await client.query('BEGIN');
+    const period = await _getPayoutPeriod(payout_id, client, { forUpdate: true });
+    if (!period) {
+      await client.query('ROLLBACK');
+      return res.status(404).json({ ok:false, error:'PAYOUT_NOT_FOUND' });
+    }
+    if (String(period.status) === 'paid') {
+      await client.query('ROLLBACK');
+      return res.status(409).json({ ok:false, error:'PAYOUT_ALREADY_PAID' });
+    }
+
+    if (String(period.status) === 'draft') {
+      await _regenerateDraftPayoutContractLines({
+        client,
+        payout_id,
+        actor_username: req.actor?.username || null,
+        req,
+      });
+    }
+    const actor = req.actor?.username || null;
+    const depositSummary = await _ensureDepositCollectionsForPayout(payout_id, actor, client);
 
     // Settlement rows include payment-only/deposit-only technicians for final
     // all-paid evaluation. Bulk payment targets are narrower: only technicians
     // with payable gross/adjustment money and positive remaining balance.
-    const settlementRows = await accountingPayoutAdjustments.getPayoutTechSettlementRows(pool, payout_id);
+    const settlementRows = await accountingPayoutAdjustments.getPayoutTechSettlementRows(client, payout_id);
     const rows = accountingPayoutAdjustments.getBulkPayableTargetRows(settlementRows);
-    if (!rows.length) return res.json({ ok:true, payout_id, updated:0, status: period.status });
-    const actor = req.actor?.username || null;
+    if (!rows.length) {
+      await client.query('COMMIT');
+      return res.json({ ok:true, payout_id, updated:0, status: period.status });
+    }
     const netMap = new Map(rows.map(r=>[String(r.technician_username), _money(r.net_amount)]));
 
     let targets = [];
@@ -9422,15 +9508,10 @@ app.post('/admin/super/payouts/:payout_id/pay_bulk', requireSuperAdmin, async (r
     } else {
       targets = list.filter(u=>netMap.has(u));
     }
-    if (!targets.length) return res.status(400).json({ ok:false, error:'NO_TECH_SELECTED' });
-
-    const depositSummary = await _ensureDepositCollectionsForPayout(payout_id, actor);
-    for (const r of rows) {
-      const totals = await _getTechGrossAdjNet(payout_id, String(r.technician_username || ''));
-      netMap.set(String(r.technician_username), _money(totals.net_amount));
+    if (!targets.length) {
+      await client.query('ROLLBACK');
+      return res.status(400).json({ ok:false, error:'NO_TECH_SELECTED' });
     }
-
-    await client.query('BEGIN');
 
     // auto-lock if draft
     if (String(period.status) === 'draft') {
@@ -9462,7 +9543,7 @@ app.post('/admin/super/payouts/:payout_id/pay_bulk', requireSuperAdmin, async (r
 
       // ✅ mark withdraw request paid for partner
       try {
-        const prof = await _getTechProfile(tech);
+        const prof = await _getTechProfile(tech, client);
         if (_isPartnerEmploymentType(prof?.employment_type || '')) {
           await client.query(
             `UPDATE public.technician_withdraw_requests
@@ -9487,6 +9568,7 @@ app.post('/admin/super/payouts/:payout_id/pay_bulk', requireSuperAdmin, async (r
   } catch (e) {
     try { await client.query('ROLLBACK'); } catch {}
     console.error('POST /admin/super/payouts/:payout_id/pay_bulk', e);
+    if (String(e.code||'') === 'DEPOSIT_COLLECT_INDEX_REQUIRED') return res.status(503).json({ ok:false, error:'DEPOSIT_COLLECT_INDEX_REQUIRED' });
     return res.status(500).json({ ok:false, error:'PAY_BULK_FAILED' });
   } finally {
     client.release();
@@ -9533,6 +9615,10 @@ app.post('/admin/super/payouts/legacy_settle', requireSuperAdmin, async (req, re
       const payout_id = String(period.payout_id || '').trim();
       if (!payout_id) continue;
       checked_periods++;
+      if (String(period.status || '') === 'paid') {
+        skipped_paid_rows++;
+        continue;
+      }
 
       const techRowsPayload = await _buildPayoutTechSummaryRows(payout_id);
       const techRows = Array.isArray(techRowsPayload?.techs) ? techRowsPayload.techs : [];
@@ -9543,12 +9629,28 @@ app.post('/admin/super/payouts/legacy_settle', requireSuperAdmin, async (req, re
         if (!tech) continue;
         if (techFilter && tech !== techFilter) continue;
 
-        const net = _money(row.net_amount ?? row.total_amount ?? 0);
         const paid = _money(row.paid_amount || 0);
         const status = String(row.paid_status || '').trim();
+        const previewNet = _money(row.net_amount ?? row.total_amount ?? 0);
+        const previewRemaining = _money(Math.max(0, previewNet - paid));
+        if (previewNet <= 0 || status === 'paid' || previewRemaining <= 0.0001) {
+          skipped_paid_rows++;
+          continue;
+        }
+
+        const prepDeposit = await _ensureDepositCollectionForPayout({
+          payout_id,
+          username: tech,
+          gross_amount: row.gross_amount || 0,
+          adj_total: row.adj_total || 0,
+          actor,
+          client,
+        });
+        const currentTotals = await _getTechGrossAdjNet(payout_id, tech, client, { period_status: period.status || 'locked' });
+        const net = _money(currentTotals.net_amount ?? row.net_amount ?? row.total_amount ?? 0);
         const remaining = _money(Math.max(0, net - paid));
 
-        if (net <= 0 || status === 'paid' || remaining <= 0.0001) {
+        if (net <= 0 || remaining <= 0.0001) {
           skipped_paid_rows++;
           continue;
         }
@@ -9571,7 +9673,7 @@ app.post('/admin/super/payouts/legacy_settle', requireSuperAdmin, async (req, re
 
         updated_payments++;
         periodTouched = true;
-        affected.push({ payout_id, technician_username: tech, paid_amount: net, previous_paid_amount: paid, previous_remaining_amount: remaining });
+        affected.push({ payout_id, technician_username: tech, paid_amount: net, previous_paid_amount: paid, previous_remaining_amount: remaining, deposit_deduction_amount: currentTotals.deposit_deduction_amount, deposit_inserted: !!prepDeposit.inserted });
       }
 
       if (periodTouched) {
@@ -9589,6 +9691,7 @@ app.post('/admin/super/payouts/legacy_settle', requireSuperAdmin, async (req, re
   } catch (e) {
     try { await client.query('ROLLBACK'); } catch {}
     console.error('POST /admin/super/payouts/legacy_settle', e);
+    if (String(e.code||'') === 'DEPOSIT_COLLECT_INDEX_REQUIRED') return res.status(503).json({ ok:false, error:'DEPOSIT_COLLECT_INDEX_REQUIRED' });
     return res.status(500).json({ ok:false, error:'LEGACY_SETTLE_FAILED' });
   } finally {
     client.release();
@@ -9725,8 +9828,14 @@ app.get('/tech/payouts/:payout_id/slip', requireTechnicianSession, async (req, r
 
     const gross = (rows || []).reduce((a, it) => a + _money(it.earn_amount || 0), 0);
     const adj_total = (adjQ.rows || []).reduce((a, it) => a + _money(it.adj_amount || 0), 0);
-    const deposit_deduction_amount = await _getDepositDeductionForPayout(payout_id, tech);
-    const deposit = await _getDepositSummary(tech);
+    const deposit = await technicianDepositCollections.getProjectedDepositDeductionForPayout(pool, {
+      payout_id,
+      technician_username: tech,
+      gross_amount: gross,
+      adj_total,
+      period_status: period.status,
+    });
+    const deposit_deduction_amount = _money(deposit.deposit_deduction_amount || 0);
     const net = _money(gross + adj_total - deposit_deduction_amount);
 
     const payment = payQ.rows[0] || null;
@@ -9984,8 +10093,14 @@ app.get('/tech/payouts', requireTechnicianSession, async (req, res) => {
       const paid_amount = Number(payment?.paid_amount || 0);
       const paid_status = String(payment?.paid_status || (paid_amount > 0 ? 'partial' : 'unpaid'));
 
-      const deposit_deduction_amount = await _getDepositDeductionForPayout(p.payout_id, tech);
-      const deposit = await _getDepositSummary(tech);
+      const deposit = await technicianDepositCollections.getProjectedDepositDeductionForPayout(pool, {
+        payout_id: p.payout_id,
+        technician_username: tech,
+        gross_amount,
+        adj_total,
+        period_status: status,
+      });
+      const deposit_deduction_amount = _money(deposit.deposit_deduction_amount || 0);
       const net_amount = _money(gross_amount + adj_total - deposit_deduction_amount);
       const remaining_amount = _money(net_amount - paid_amount);
       const paid_status_calc = _paidStatus(net_amount, paid_amount);
@@ -10073,8 +10188,14 @@ app.get('/tech/payouts/:payout_id', requireTechnicianSession, async (req, res) =
 
     const gross = (lines || []).reduce((a, it) => a + Number(it.earn_amount || 0), 0);
     const adj_total = (adjQ.rows || []).reduce((a, it) => a + Number(it.adj_amount || 0), 0);
-    const deposit_deduction_amount = await _getDepositDeductionForPayout(payout_id, tech);
-    const deposit = await _getDepositSummary(tech);
+    const deposit = await technicianDepositCollections.getProjectedDepositDeductionForPayout(pool, {
+      payout_id,
+      technician_username: tech,
+      gross_amount: gross,
+      adj_total,
+      period_status: status,
+    });
+    const deposit_deduction_amount = _money(deposit.deposit_deduction_amount || 0);
     const net = _money(gross + adj_total - deposit_deduction_amount);
     const payment = payQ.rows[0] || null;
     const paid_amount = Number(payment?.paid_amount || 0);
@@ -23235,6 +23356,7 @@ app.post('/admin/accounting/payouts/:payout_id/adjust', requireAccountingPermiss
 });
 
 app.post('/admin/accounting/payouts/:payout_id/pay', requireAccountingPermission('accounting_mark_payout_paid'), async (req, res) => {
+  const client = await pool.connect();
   try {
     const payout_id = String(req.params.payout_id || '').trim();
     const body = req.body || {};
@@ -23245,36 +23367,66 @@ app.post('/admin/accounting/payouts/:payout_id/pay', requireAccountingPermission
     if (body.confirm_paid !== true) return res.status(400).json({ ok: false, error: 'CONFIRM_PAID_REQUIRED' });
     if (Number(paidNow || 0) <= 0) return res.status(400).json({ ok: false, error: 'INVALID_PAID_AMOUNT' });
 
+    await client.query('BEGIN');
     const prepared = await ensurePayoutPeriodAndSnapshotForPayment({
       pool,
+      client,
       payout_id,
       actor_username: _accountingActor(req).username || null,
-      getPayoutPeriod: _getPayoutPeriod,
+      getPayoutPeriod: (pid) => _getPayoutPeriod(pid, client, { forUpdate: true }),
       regenerateDraftPayoutContractLines: _regenerateDraftPayoutContractLines,
       req,
     });
-    const beforeTotals = await _getTechGrossAdjNet(payout_id, tech);
-    const beforePayQ = await pool.query(
+    const beforeTotals = await _getTechGrossAdjNet(payout_id, tech, client, { period_status: prepared.period?.status || 'draft' });
+    const beforePayQ = await client.query(
       `SELECT paid_amount, paid_status, paid_at, paid_by, slip_url, note, payment_method, payment_reference
          FROM public.technician_payout_payments
         WHERE payout_id=$1 AND technician_username=$2
-        LIMIT 1`,
+        LIMIT 1
+        FOR UPDATE`,
       [payout_id, tech]
     );
     const beforePayment = beforePayQ.rows[0] || null;
     const currentPaid = Number(beforePayment?.paid_amount || 0);
-    const remaining = Math.max(0, Number(beforeTotals.net_amount || 0) - currentPaid);
-    if (remaining <= 0.0001) return res.status(409).json({ ok: false, error: 'PAYOUT_ALREADY_PAID' });
-    if (Number(paidNow) - remaining > 0.01) return res.status(400).json({ ok: false, error: 'PAID_AMOUNT_EXCEEDS_REMAINING', remaining_amount: _money(remaining) });
+    const depositResult = await _ensureDepositCollectionForPayout({
+      payout_id,
+      username: tech,
+      gross_amount: beforeTotals.gross_amount,
+      adj_total: beforeTotals.adj_total,
+      actor: _accountingActor(req).username || null,
+      client,
+    });
+    const currentTotals = await _getTechGrossAdjNet(payout_id, tech, client, { period_status: prepared.period?.status || 'draft' });
+    const remaining = Math.max(0, Number(currentTotals.net_amount || 0) - currentPaid);
+    if (remaining <= 0.0001) {
+      await client.query('ROLLBACK');
+      return res.status(409).json({ ok: false, error: 'PAYOUT_ALREADY_PAID' });
+    }
+    if (Number(paidNow) - remaining > 0.01) {
+      await client.query('ROLLBACK');
+      return res.status(409).json({
+        ok: false,
+        error: 'PAYOUT_PAYABLE_CHANGED',
+        current_payable_amount: _money(currentTotals.net_amount || 0),
+        remaining_amount: _money(remaining),
+        requested_paid_amount: _money(paidNow),
+        deposit_deduction_amount: _money(currentTotals.deposit_deduction_amount || 0),
+      });
+    }
 
     const payment_method = String(body.payment_method || '').trim() || null;
     const payment_reference = String(body.payment_reference || '').trim() || null;
     const note = String(body.note || '').trim() || null;
     const slip_url = String(body.slip_url || '').trim() || null;
     const cumulativePaid = _money(currentPaid + Number(paidNow));
-    const result = await _upsertPaymentAndMaybeMarkPaid(payout_id, tech, cumulativePaid, slip_url, note, _accountingActor(req).username || null, req, { preparedPeriod: prepared.period });
+    const result = await _upsertPaymentAndMaybeMarkPaid(payout_id, tech, cumulativePaid, slip_url, note, _accountingActor(req).username || null, req, {
+      client,
+      preparedPeriod: prepared.period,
+      depositAlreadyPrepared: true,
+      depositCollections: { checked: 1, inserted: depositResult.inserted ? 1 : 0 },
+    });
 
-    await pool.query(
+    await client.query(
       `UPDATE public.technician_payout_payments
           SET payment_method=COALESCE($3, payment_method),
               payment_reference=COALESCE($4, payment_reference)
@@ -23282,14 +23434,14 @@ app.post('/admin/accounting/payouts/:payout_id/pay', requireAccountingPermission
       [payout_id, tech, payment_method, payment_reference]
     );
 
-    const afterPayQ = await pool.query(
+    const afterPayQ = await client.query(
       `SELECT paid_amount, paid_status, paid_at, paid_by, slip_url, note, payment_method, payment_reference
          FROM public.technician_payout_payments
         WHERE payout_id=$1 AND technician_username=$2
         LIMIT 1`,
       [payout_id, tech]
     );
-    const afterTotals = await _getTechGrossAdjNet(payout_id, tech);
+    const afterTotals = await _getTechGrossAdjNet(payout_id, tech, client, { period_status: prepared.period?.status || 'locked' });
     await logAccountingAudit(req, {
       action: 'MARK_PAYOUT_PAID',
       entity_type: 'technician_payout_payment',
@@ -23297,7 +23449,9 @@ app.post('/admin/accounting/payouts/:payout_id/pay', requireAccountingPermission
       before_json: { totals: beforeTotals, payment: beforePayment },
       after_json: { totals: afterTotals, payment: afterPayQ.rows[0] || null },
       note: note || payment_reference || payment_method || null,
-    });
+    }, { client, strict: true });
+
+    await client.query('COMMIT');
 
     return res.json({
       ok: true,
@@ -23309,12 +23463,17 @@ app.post('/admin/accounting/payouts/:payout_id/pay', requireAccountingPermission
       payment: afterPayQ.rows[0] || null,
     });
   } catch (e) {
+    try { await client.query('ROLLBACK'); } catch {}
     console.error('POST /admin/accounting/payouts/:payout_id/pay', e);
     if (String(e.code || '') === 'PAYOUT_NOT_FOUND') return res.status(404).json({ ok: false, error: 'PAYOUT_NOT_FOUND' });
     if (String(e.code || '') === 'PAYOUT_ALREADY_PAID') return res.status(409).json({ ok: false, error: 'PAYOUT_ALREADY_PAID' });
+    if (String(e.code || '') === 'DEPOSIT_COLLECT_INDEX_REQUIRED') return res.status(503).json({ ok: false, error: 'DEPOSIT_COLLECT_INDEX_REQUIRED' });
+    if (String(e.code || '') === 'PAYOUT_PAYABLE_CHANGED') return res.status(409).json({ ok: false, error: 'PAYOUT_PAYABLE_CHANGED', current_payable_amount: e.current_payable_amount, requested_paid_amount: e.requested_paid_amount });
     if (String(e.code || '') === 'PAYOUT_PERIOD_NOT_CLOSED') return res.status(409).json({ ok: false, error: 'PAYOUT_PERIOD_NOT_CLOSED', period_end: e.period_end || null });
     if (String(e.message || '').includes('CANNOT_REGENERATE')) return res.status(409).json({ ok: false, error: String(e.message || 'CANNOT_REGENERATE') });
     return res.status(500).json({ ok: false, error: 'MARK_PAYOUT_PAID_FAILED' });
+  } finally {
+    client.release();
   }
 });
 

--- a/scripts/repair-technician-deposit-collect.js
+++ b/scripts/repair-technician-deposit-collect.js
@@ -1,0 +1,121 @@
+"use strict";
+
+require("dotenv").config();
+
+const { Pool } = require("pg");
+const deposits = require("../server/services/technicianDepositCollections");
+
+function arg(name, fallback = "") {
+  const ix = process.argv.indexOf(`--${name}`);
+  if (ix >= 0 && process.argv[ix + 1]) return String(process.argv[ix + 1]).trim();
+  const prefix = `--${name}=`;
+  const found = process.argv.find((v) => String(v || "").startsWith(prefix));
+  return found ? String(found).slice(prefix.length).trim() : fallback;
+}
+
+async function main() {
+  const payoutId = arg("payout");
+  const technician = arg("technician");
+  const execute = process.argv.includes("--execute");
+  const databaseUrl = process.env.DATABASE_URL;
+
+  if (!databaseUrl) throw new Error("DATABASE_URL is required");
+  if (!/^payout_\d{4}-\d{2}_(10|25)$/.test(payoutId)) throw new Error("Invalid --payout");
+  if (!technician) throw new Error("Missing --technician");
+
+  const pool = new Pool({ connectionString: databaseUrl });
+  const client = await pool.connect();
+  try {
+    await deposits.assertDepositCollectUniqueIndexReady(client);
+
+    async function readPeriodAndTotals(db, { lock = false } = {}) {
+      const periodQ = await db.query(
+        `SELECT payout_id, status
+           FROM public.technician_payout_periods
+          WHERE payout_id=$1
+          LIMIT 1
+          ${lock ? "FOR UPDATE" : ""}`,
+        [payoutId]
+      );
+      const period = periodQ.rows[0] || null;
+      if (!period) throw new Error("PAYOUT_NOT_FOUND");
+      if (String(period.status || "") === "paid") throw new Error("REFUSE_PAID_PAYOUT");
+
+      const totalsQ = await db.query(
+      `WITH gross AS (
+         SELECT COALESCE(SUM(earn_amount),0)::numeric AS gross_amount
+           FROM public.technician_payout_lines
+          WHERE payout_id=$1 AND technician_username=$2
+       ),
+       adj AS (
+         SELECT COALESCE(SUM(adj_amount),0)::numeric AS adj_total
+           FROM public.technician_payout_adjustments
+          WHERE payout_id=$1 AND technician_username=$2
+       )
+       SELECT gross.gross_amount, adj.adj_total
+         FROM gross CROSS JOIN adj`,
+        [payoutId, technician]
+      );
+      return {
+        period,
+        totals: totalsQ.rows[0] || { gross_amount: 0, adj_total: 0 },
+      };
+    }
+
+    const { period, totals } = await readPeriodAndTotals(client);
+    const projected = await deposits.getProjectedDepositDeductionForPayout(client, {
+      payout_id: payoutId,
+      technician_username: technician,
+      gross_amount: totals.gross_amount,
+      adj_total: totals.adj_total,
+      period_status: period.status,
+    });
+
+    const report = {
+      dry_run: !execute,
+      payout_id: payoutId,
+      technician_username: technician,
+      period_status: period.status,
+      gross_amount: Number(totals.gross_amount || 0),
+      adj_total: Number(totals.adj_total || 0),
+      projected,
+    };
+
+    if (!execute) {
+      console.log(JSON.stringify(report, null, 2));
+      return;
+    }
+
+    await client.query("BEGIN");
+    const locked = await readPeriodAndTotals(client, { lock: true });
+    const materialized = await deposits.materializeDepositCollectForPayout(client, {
+      payout_id: payoutId,
+      technician_username: technician,
+      gross_amount: locked.totals.gross_amount,
+      adj_total: locked.totals.adj_total,
+      actor: "script:repair-technician-deposit-collect",
+    });
+    await client.query("COMMIT");
+    console.log(JSON.stringify({
+      ...report,
+      dry_run: false,
+      executed_with: {
+        period_status: locked.period.status,
+        gross_amount: Number(locked.totals.gross_amount || 0),
+        adj_total: Number(locked.totals.adj_total || 0),
+      },
+      materialized,
+    }, null, 2));
+  } catch (err) {
+    try { await client.query("ROLLBACK"); } catch (_) {}
+    throw err;
+  } finally {
+    client.release();
+    await pool.end();
+  }
+}
+
+main().catch((err) => {
+  console.error(err.message || err);
+  process.exitCode = 1;
+});

--- a/scripts/repair-technician-deposit-collect.js
+++ b/scripts/repair-technician-deposit-collect.js
@@ -13,10 +13,15 @@ function arg(name, fallback = "") {
   return found ? String(found).slice(prefix.length).trim() : fallback;
 }
 
+function buildConfirmationToken(payoutId, technician, expectedCollect) {
+  return `${String(payoutId || "").trim()}:${String(technician || "").trim()}:${Number(expectedCollect || 0)}`;
+}
+
 async function main() {
   const payoutId = arg("payout");
   const technician = arg("technician");
   const execute = process.argv.includes("--execute");
+  const confirm = arg("confirm");
   const databaseUrl = process.env.DATABASE_URL;
 
   if (!databaseUrl) throw new Error("DATABASE_URL is required");
@@ -62,7 +67,14 @@ async function main() {
       };
     }
 
+    async function readPaymentAndCollect(db, { lockPayment = false, lockCollect = false } = {}) {
+      const payment = await deposits.getTechnicianPayoutPaymentState(db, payoutId, technician, { forUpdate: lockPayment });
+      const existingCollect = await deposits.getExistingCollectForPayout(db, payoutId, technician, { forUpdate: lockCollect });
+      return { payment, existingCollect };
+    }
+
     const { period, totals } = await readPeriodAndTotals(client);
+    const precheck = await readPaymentAndCollect(client);
     const projected = await deposits.getProjectedDepositDeductionForPayout(client, {
       payout_id: payoutId,
       technician_username: technician,
@@ -70,6 +82,8 @@ async function main() {
       adj_total: totals.adj_total,
       period_status: period.status,
     });
+    const expectedCollect = Number(projected.deposit_deduction_amount || 0);
+    const confirmationToken = buildConfirmationToken(payoutId, technician, expectedCollect);
 
     const report = {
       dry_run: !execute,
@@ -78,6 +92,13 @@ async function main() {
       period_status: period.status,
       gross_amount: Number(totals.gross_amount || 0),
       adj_total: Number(totals.adj_total || 0),
+      paid_amount: precheck.payment.paid_amount,
+      paid_status: precheck.payment.paid_status || null,
+      paid_at: precheck.payment.paid_at || null,
+      existing_collect: precheck.existingCollect.amount,
+      existing_collect_exists: precheck.existingCollect.exists,
+      expected_collect: expectedCollect,
+      confirmation_token: confirmationToken,
       projected,
     };
 
@@ -88,6 +109,26 @@ async function main() {
 
     await client.query("BEGIN");
     const locked = await readPeriodAndTotals(client, { lock: true });
+    const lockedPrecheck = await readPaymentAndCollect(client, { lockPayment: true, lockCollect: true });
+    const lockedProjected = await deposits.getProjectedDepositDeductionForPayout(client, {
+      payout_id: payoutId,
+      technician_username: technician,
+      gross_amount: locked.totals.gross_amount,
+      adj_total: locked.totals.adj_total,
+      period_status: locked.period.status,
+    });
+    const lockedExpectedCollect = Number(lockedProjected.deposit_deduction_amount || 0);
+    const lockedConfirmationToken = buildConfirmationToken(payoutId, technician, lockedExpectedCollect);
+    if (confirm !== lockedConfirmationToken) {
+      const err = new Error(`CONFIRMATION_TOKEN_REQUIRED:${lockedConfirmationToken}`);
+      err.code = "CONFIRMATION_TOKEN_REQUIRED";
+      throw err;
+    }
+    if (!lockedPrecheck.existingCollect.exists && lockedPrecheck.payment.paymentAlreadyRecorded) {
+      const err = new Error("PAYMENT_ALREADY_RECORDED");
+      err.code = "PAYMENT_ALREADY_RECORDED";
+      throw err;
+    }
     const materialized = await deposits.materializeDepositCollectForPayout(client, {
       payout_id: payoutId,
       technician_username: technician,
@@ -103,6 +144,12 @@ async function main() {
         period_status: locked.period.status,
         gross_amount: Number(locked.totals.gross_amount || 0),
         adj_total: Number(locked.totals.adj_total || 0),
+        paid_amount: lockedPrecheck.payment.paid_amount,
+        paid_status: lockedPrecheck.payment.paid_status || null,
+        paid_at: lockedPrecheck.payment.paid_at || null,
+        existing_collect: lockedPrecheck.existingCollect.amount,
+        expected_collect: lockedExpectedCollect,
+        confirmation_token: lockedConfirmationToken,
       },
       materialized,
     }, null, 2));
@@ -115,7 +162,13 @@ async function main() {
   }
 }
 
-main().catch((err) => {
-  console.error(err.message || err);
-  process.exitCode = 1;
-});
+if (require.main === module) {
+  main().catch((err) => {
+    console.error(err.message || err);
+    process.exitCode = 1;
+  });
+}
+
+module.exports = {
+  buildConfirmationToken,
+};

--- a/server/services/accountingPayoutAdjustments.js
+++ b/server/services/accountingPayoutAdjustments.js
@@ -248,6 +248,117 @@ function getBulkPayableTargetRows(settlementRows = []) {
   );
 }
 
+async function settleLegacyPaidPayouts({
+  client,
+  cutoffEnd,
+  cutoffDate,
+  techFilter = "",
+  noteInput = "",
+  actor = null,
+} = {}) {
+  if (!client || typeof client.query !== "function") throw appError("INVALID_LEGACY_SETTLE_CLIENT", 500);
+  const cutoff = String(cutoffDate || "").trim();
+  const techOnly = String(techFilter || "").trim();
+  const noteText = String(noteInput || "").trim();
+  let checked_periods = 0;
+  let touched_periods = 0;
+  let updated_payments = 0;
+  let skipped_paid_rows = 0;
+  const affected = [];
+
+  await client.query("BEGIN");
+  try {
+    const periodsQ = await client.query(
+      `SELECT payout_id, status, period_start, period_end
+         FROM public.technician_payout_periods
+        WHERE period_end <= $1::timestamptz
+        ORDER BY period_end ASC, payout_id ASC
+        FOR UPDATE`,
+      [cutoffEnd]
+    );
+
+    for (const period of (periodsQ.rows || [])) {
+      const payout_id = String(period.payout_id || "").trim();
+      if (!payout_id) continue;
+      checked_periods++;
+      if (String(period.status || "") === "paid") {
+        skipped_paid_rows++;
+        continue;
+      }
+
+      const techRows = await getPayoutTechSettlementRows(client, payout_id);
+      let periodTouched = false;
+
+      for (const row of techRows) {
+        const tech = String(row.technician_username || "").trim();
+        if (!tech) continue;
+        if (techOnly && tech !== techOnly) continue;
+
+        const paid = money(row.paid_amount || 0);
+        const status = String(row.paid_status || "").trim();
+        const net = money(row.net_amount ?? row.total_amount ?? 0);
+        const remaining = money(Math.max(0, net - paid));
+        if (net <= 0 || status === "paid" || remaining <= 0.0001) {
+          skipped_paid_rows++;
+          continue;
+        }
+
+        const note = noteText || `Legacy paid outside app before payout MVP. Settled by Super Admin cutoff ${cutoff}.`;
+        await client.query(
+          `INSERT INTO public.technician_payout_payments(
+             payout_id, technician_username, paid_amount, paid_status, paid_at, paid_by, slip_url, note, updated_at
+           ) VALUES($1,$2,$3,'paid',NOW(),$4,NULL,$5,NOW())
+           ON CONFLICT (payout_id, technician_username)
+           DO UPDATE SET
+             paid_amount=GREATEST(public.technician_payout_payments.paid_amount, EXCLUDED.paid_amount),
+             paid_status='paid',
+             paid_at=NOW(),
+             paid_by=EXCLUDED.paid_by,
+             note=COALESCE(NULLIF(public.technician_payout_payments.note,''), EXCLUDED.note),
+             updated_at=NOW()`,
+          [payout_id, tech, net, actor, note]
+        );
+
+        updated_payments++;
+        periodTouched = true;
+        affected.push({
+          payout_id,
+          technician_username: tech,
+          paid_amount: net,
+          previous_paid_amount: paid,
+          previous_remaining_amount: remaining,
+          deposit_deduction_amount: money(row.deposit_deduction_amount || 0),
+          deposit_inserted: false,
+        });
+      }
+
+      if (periodTouched) {
+        touched_periods++;
+        const paidCheckRows = await getPayoutTechSettlementRows(client, payout_id);
+        const allPaid = isPayoutFullyPaidFromRows(paidCheckRows);
+        if (allPaid) {
+          await client.query(`UPDATE public.technician_payout_periods SET status='paid' WHERE payout_id=$1`, [payout_id]);
+        }
+      }
+    }
+
+    await client.query("COMMIT");
+    return {
+      ok: true,
+      cutoff_date: cutoff,
+      technician_username: techOnly || null,
+      checked_periods,
+      touched_periods,
+      updated_payments,
+      skipped_paid_rows,
+      affected,
+    };
+  } catch (err) {
+    try { await client.query("ROLLBACK"); } catch {}
+    throw err;
+  }
+}
+
 async function lockPaymentRow(client, payoutId, tech) {
   const q = await client.query(
     `SELECT payment_id, payout_id, technician_username, paid_amount, paid_status, paid_at, paid_by, slip_url, note,
@@ -448,5 +559,6 @@ module.exports = {
   getPayoutTechTotals,
   isPayoutFullyPaidFromRows,
   getBulkPayableTargetRows,
+  settleLegacyPaidPayouts,
   applyAccountingPositivePayoutAdjustment,
 };

--- a/server/services/technicianDepositCollections.js
+++ b/server/services/technicianDepositCollections.js
@@ -1,0 +1,309 @@
+"use strict";
+
+const DEFAULT_TARGET_AMOUNT = 5000;
+const DEFAULT_INSTALLMENT_AMOUNT = 500;
+
+function money(value) {
+  const n = Number(value || 0);
+  if (!Number.isFinite(n)) return 0;
+  return Math.round(n * 100) / 100;
+}
+
+function appError(message, statusCode = 400, code = message, extra = {}) {
+  const err = new Error(message);
+  err.statusCode = statusCode;
+  err.code = code;
+  Object.assign(err, extra);
+  return err;
+}
+
+function isPartnerEmploymentType(value) {
+  const s = String(value || "").trim().toLowerCase();
+  return s === "partner" || s === "พาร์ทเนอร์";
+}
+
+function normalizeIndexPredicate(value) {
+  return String(value || "")
+    .toLowerCase()
+    .replace(/::text/g, "")
+    .replace(/[()"]/g, "")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+async function assertDepositCollectUniqueIndexReady(client) {
+  const q = await client.query(
+    `SELECT ix.indisunique AS is_unique,
+            pg_get_indexdef(i.oid) AS indexdef,
+            pg_get_expr(ix.indpred, ix.indrelid) AS predicate
+       FROM pg_class t
+       JOIN pg_index ix ON ix.indrelid = t.oid
+       JOIN pg_class i ON i.oid = ix.indexrelid
+       JOIN pg_namespace n ON n.oid = t.relnamespace
+      WHERE n.nspname='public'
+        AND t.relname='technician_deposit_ledger'
+        AND i.relname='idx_deposit_collect_once_per_payout_tech'
+      LIMIT 1`
+  );
+  const row = q.rows?.[0];
+  const indexdef = String(row?.indexdef || "");
+  const predicate = normalizeIndexPredicate(row?.predicate || "");
+  const valid = Boolean(
+    row
+      && row.is_unique === true
+      && /technician_username/i.test(indexdef)
+      && /payout_id/i.test(indexdef)
+      && /transaction_type/i.test(indexdef)
+      && predicate === "transaction_type = 'collect'"
+  );
+  if (!valid) {
+    throw appError("DEPOSIT_COLLECT_INDEX_REQUIRED", 503);
+  }
+  return {
+    ok: true,
+    index_name: "idx_deposit_collect_once_per_payout_tech",
+    indexdef,
+    predicate: row.predicate,
+  };
+}
+
+async function getDepositAccount(client, username) {
+  const tech = String(username || "").trim();
+  if (!tech) return { technician_username: "", target_amount: DEFAULT_TARGET_AMOUNT, is_required: true };
+  const q = await client.query(
+    `SELECT technician_username, COALESCE(target_amount,5000)::numeric AS target_amount,
+            COALESCE(is_required,TRUE) AS is_required
+       FROM public.technician_deposit_accounts
+      WHERE technician_username=$1
+      LIMIT 1`,
+    [tech]
+  );
+  if (q.rows?.[0]) {
+    return {
+      technician_username: tech,
+      target_amount: money(q.rows[0].target_amount || DEFAULT_TARGET_AMOUNT),
+      is_required: q.rows[0].is_required !== false,
+    };
+  }
+  return { technician_username: tech, target_amount: DEFAULT_TARGET_AMOUNT, is_required: true };
+}
+
+async function getTechnicianProfile(client, username) {
+  const tech = String(username || "").trim();
+  if (!tech) return null;
+  const q = await client.query(
+    `SELECT username, COALESCE(employment_type,'company') AS employment_type
+       FROM public.technician_profiles
+      WHERE username=$1
+      LIMIT 1`,
+    [tech]
+  );
+  return q.rows?.[0] || null;
+}
+
+async function getDepositCollected(client, username) {
+  const tech = String(username || "").trim();
+  if (!tech) return 0;
+  const q = await client.query(
+    `SELECT COALESCE(SUM(
+        CASE transaction_type
+          WHEN 'collect' THEN amount
+          WHEN 'manual_adjust' THEN amount
+          WHEN 'refund' THEN -amount
+          WHEN 'claim_deduct' THEN -amount
+          ELSE 0
+        END
+      ),0)::numeric AS collected
+       FROM public.technician_deposit_ledger
+      WHERE technician_username=$1`,
+    [tech]
+  );
+  return money(q.rows?.[0]?.collected || 0);
+}
+
+async function getExistingCollectForPayout(client, payoutId, username, { forUpdate = false } = {}) {
+  const pid = String(payoutId || "").trim();
+  const tech = String(username || "").trim();
+  if (!pid || !tech) return { exists: false, amount: 0, rows: [] };
+  const q = await client.query(
+    `SELECT ledger_id, amount, created_at, created_by, meta_json
+       FROM public.technician_deposit_ledger
+      WHERE payout_id=$1
+        AND technician_username=$2
+        AND transaction_type='collect'
+      ORDER BY ledger_id ASC
+      ${forUpdate ? "FOR UPDATE" : ""}`,
+    [pid, tech]
+  );
+  const rows = q.rows || [];
+  return {
+    exists: rows.length > 0,
+    amount: money(rows.reduce((sum, r) => sum + Number(r.amount || 0), 0)),
+    rows,
+  };
+}
+
+function calculateDepositDeduction({
+  existingCollectExists = false,
+  existingCollectAmount = 0,
+  isRequired = true,
+  isPartner = true,
+  targetAmount = DEFAULT_TARGET_AMOUNT,
+  collectedTotal = 0,
+  grossAmount = 0,
+  adjustmentTotal = 0,
+} = {}) {
+  if (existingCollectExists) {
+    return {
+      amount: money(existingCollectAmount),
+      reason: "existing_collect_preserved",
+      deposit_remaining_before: money(Math.max(0, Number(targetAmount || 0) - Number(collectedTotal || 0))),
+      positive_payable_before_deposit: money(Math.max(0, Number(grossAmount || 0) + Number(adjustmentTotal || 0))),
+    };
+  }
+  const remaining = money(Math.max(0, Number(targetAmount || 0) - Number(collectedTotal || 0)));
+  const payable = money(Math.max(0, Number(grossAmount || 0) + Number(adjustmentTotal || 0)));
+  if (!isRequired) return { amount: 0, reason: "deposit_not_required", deposit_remaining_before: remaining, positive_payable_before_deposit: payable };
+  if (!isPartner) return { amount: 0, reason: "not_partner", deposit_remaining_before: remaining, positive_payable_before_deposit: payable };
+  if (remaining <= 0) return { amount: 0, reason: "target_completed", deposit_remaining_before: remaining, positive_payable_before_deposit: payable };
+  if (payable <= 0) return { amount: 0, reason: "no_positive_payable", deposit_remaining_before: remaining, positive_payable_before_deposit: payable };
+  return {
+    amount: money(Math.min(DEFAULT_INSTALLMENT_AMOUNT, remaining, payable)),
+    reason: "per_payout_installment",
+    deposit_remaining_before: remaining,
+    positive_payable_before_deposit: payable,
+  };
+}
+
+async function getProjectedDepositDeductionForPayout(client, {
+  payout_id,
+  technician_username,
+  gross_amount = 0,
+  adj_total = 0,
+  period_status = "draft",
+} = {}) {
+  const pid = String(payout_id || "").trim();
+  const tech = String(technician_username || "").trim();
+  const existing = await getExistingCollectForPayout(client, pid, tech);
+  const account = await getDepositAccount(client, tech);
+  const collected = await getDepositCollected(client, tech);
+  const profile = await getTechnicianProfile(client, tech);
+  const paidHistory = String(period_status || "").trim() === "paid";
+  const calc = paidHistory
+    ? calculateDepositDeduction({
+        existingCollectExists: existing.exists,
+        existingCollectAmount: existing.amount,
+        isRequired: account.is_required,
+        isPartner: false,
+        targetAmount: account.target_amount,
+        collectedTotal: collected,
+        grossAmount: gross_amount,
+        adjustmentTotal: adj_total,
+      })
+    : calculateDepositDeduction({
+        existingCollectExists: existing.exists,
+        existingCollectAmount: existing.amount,
+        isRequired: account.is_required,
+        isPartner: isPartnerEmploymentType(profile?.employment_type || ""),
+        targetAmount: account.target_amount,
+        collectedTotal: collected,
+        grossAmount: gross_amount,
+        adjustmentTotal: adj_total,
+      });
+  return {
+    deposit_deduction_amount: calc.amount,
+    deposit_existing_collect_amount: existing.amount,
+    deposit_existing_collect_exists: existing.exists,
+    deposit_projected: !existing.exists && calc.amount > 0,
+    deposit_projection_reason: calc.reason,
+    deposit_target_amount: account.target_amount,
+    deposit_collected_total: collected,
+    deposit_collected_total_projected: money(collected + (!existing.exists ? calc.amount : 0)),
+    deposit_remaining_amount: money(Math.max(0, Number(account.target_amount || 0) - Number(collected || 0))),
+    deposit_remaining_amount_projected: money(Math.max(0, Number(account.target_amount || 0) - Number(collected || 0) - (!existing.exists ? calc.amount : 0))),
+    deposit_is_required: account.is_required !== false,
+    latest_deposit_deduction: calc.amount,
+  };
+}
+
+async function materializeDepositCollectForPayout(client, {
+  payout_id,
+  technician_username,
+  gross_amount = 0,
+  adj_total = 0,
+  actor = null,
+} = {}) {
+  await assertDepositCollectUniqueIndexReady(client);
+  const pid = String(payout_id || "").trim();
+  const tech = String(technician_username || "").trim();
+  if (!pid || !tech) return { deposit_deduction_amount: 0, inserted: false, reason: "missing_context" };
+
+  await client.query("SELECT pg_advisory_xact_lock(hashtext($1))", [`technician_deposit_collect:${tech}`]);
+
+  const existing = await getExistingCollectForPayout(client, pid, tech, { forUpdate: true });
+  const account = await getDepositAccount(client, tech);
+  const collected = await getDepositCollected(client, tech);
+  const profile = await getTechnicianProfile(client, tech);
+  const calc = calculateDepositDeduction({
+    existingCollectExists: existing.exists,
+    existingCollectAmount: existing.amount,
+    isRequired: account.is_required,
+    isPartner: isPartnerEmploymentType(profile?.employment_type || ""),
+    targetAmount: account.target_amount,
+    collectedTotal: collected,
+    grossAmount: gross_amount,
+    adjustmentTotal: adj_total,
+  });
+
+  if (existing.exists || calc.amount <= 0) {
+    return {
+      deposit_deduction_amount: calc.amount,
+      inserted: false,
+      existing: existing.exists,
+      reason: calc.reason,
+    };
+  }
+
+  const ins = await client.query(
+    `INSERT INTO public.technician_deposit_ledger(
+       technician_username, payout_id, transaction_type, amount, note, created_by, meta_json
+     ) VALUES($1,$2,'collect',$3,$4,$5,$6::jsonb)
+     ON CONFLICT (technician_username, payout_id, transaction_type)
+     WHERE transaction_type='collect'
+     DO NOTHING
+     RETURNING ledger_id`,
+    [
+      tech,
+      pid,
+      calc.amount,
+      "Automatic technician deposit deduction",
+      actor || null,
+      JSON.stringify({
+        gross_amount: money(gross_amount),
+        adjustment_total: money(adj_total),
+        formula: "per_payout_deposit_v1",
+        policy: "min(500, deposit_remaining, positive_payable_before_deposit)",
+      }),
+    ]
+  );
+  const after = await getExistingCollectForPayout(client, pid, tech, { forUpdate: true });
+  return {
+    deposit_deduction_amount: after.amount,
+    inserted: (ins.rowCount || 0) > 0,
+    existing: (ins.rowCount || 0) <= 0,
+    reason: "per_payout_installment",
+  };
+}
+
+module.exports = {
+  DEFAULT_INSTALLMENT_AMOUNT,
+  DEFAULT_TARGET_AMOUNT,
+  money,
+  assertDepositCollectUniqueIndexReady,
+  calculateDepositDeduction,
+  getDepositAccount,
+  getDepositCollected,
+  getExistingCollectForPayout,
+  getProjectedDepositDeductionForPayout,
+  materializeDepositCollectForPayout,
+};

--- a/server/services/technicianDepositCollections.js
+++ b/server/services/technicianDepositCollections.js
@@ -143,6 +143,32 @@ async function getExistingCollectForPayout(client, payoutId, username, { forUpda
   };
 }
 
+async function getTechnicianPayoutPaymentState(client, payoutId, username, { forUpdate = false } = {}) {
+  const pid = String(payoutId || "").trim();
+  const tech = String(username || "").trim();
+  if (!pid || !tech) {
+    return { exists: false, paid_amount: 0, paid_status: "", paid_at: null, paymentAlreadyRecorded: false };
+  }
+  const q = await client.query(
+    `SELECT paid_amount, paid_status, paid_at
+       FROM public.technician_payout_payments
+      WHERE payout_id=$1 AND technician_username=$2
+      LIMIT 1
+      ${forUpdate ? "FOR UPDATE" : ""}`,
+    [pid, tech]
+  );
+  const row = q.rows?.[0] || null;
+  const paidAmount = money(row?.paid_amount || 0);
+  const paidStatus = String(row?.paid_status || "").trim().toLowerCase();
+  return {
+    exists: !!row,
+    paid_amount: paidAmount,
+    paid_status: paidStatus,
+    paid_at: row?.paid_at || null,
+    paymentAlreadyRecorded: paidAmount > 0 || paidStatus === "partial" || paidStatus === "paid" || row?.paid_at != null,
+  };
+}
+
 function calculateDepositDeduction({
   existingCollectExists = false,
   existingCollectAmount = 0,
@@ -185,10 +211,11 @@ async function getProjectedDepositDeductionForPayout(client, {
   const pid = String(payout_id || "").trim();
   const tech = String(technician_username || "").trim();
   const existing = await getExistingCollectForPayout(client, pid, tech);
+  const payment = await getTechnicianPayoutPaymentState(client, pid, tech);
   const account = await getDepositAccount(client, tech);
   const collected = await getDepositCollected(client, tech);
   const profile = await getTechnicianProfile(client, tech);
-  const paidHistory = String(period_status || "").trim() === "paid";
+  const paidHistory = String(period_status || "").trim() === "paid" || (!existing.exists && payment.paymentAlreadyRecorded);
   const calc = paidHistory
     ? calculateDepositDeduction({
         existingCollectExists: existing.exists,
@@ -210,18 +237,24 @@ async function getProjectedDepositDeductionForPayout(client, {
         grossAmount: gross_amount,
         adjustmentTotal: adj_total,
       });
+  const reason = !existing.exists && payment.paymentAlreadyRecorded
+    ? "payment_already_recorded"
+    : calc.reason;
   return {
     deposit_deduction_amount: calc.amount,
     deposit_existing_collect_amount: existing.amount,
     deposit_existing_collect_exists: existing.exists,
     deposit_projected: !existing.exists && calc.amount > 0,
-    deposit_projection_reason: calc.reason,
+    deposit_projection_reason: reason,
     deposit_target_amount: account.target_amount,
     deposit_collected_total: collected,
     deposit_collected_total_projected: money(collected + (!existing.exists ? calc.amount : 0)),
     deposit_remaining_amount: money(Math.max(0, Number(account.target_amount || 0) - Number(collected || 0))),
     deposit_remaining_amount_projected: money(Math.max(0, Number(account.target_amount || 0) - Number(collected || 0) - (!existing.exists ? calc.amount : 0))),
     deposit_is_required: account.is_required !== false,
+    deposit_payment_paid_amount: payment.paid_amount,
+    deposit_payment_paid_status: payment.paid_status,
+    deposit_payment_paid_at: payment.paid_at,
     latest_deposit_deduction: calc.amount,
   };
 }
@@ -241,6 +274,18 @@ async function materializeDepositCollectForPayout(client, {
   await client.query("SELECT pg_advisory_xact_lock(hashtext($1))", [`technician_deposit_collect:${tech}`]);
 
   const existing = await getExistingCollectForPayout(client, pid, tech, { forUpdate: true });
+  const payment = await getTechnicianPayoutPaymentState(client, pid, tech, { forUpdate: true });
+  if (!existing.exists && payment.paymentAlreadyRecorded) {
+    return {
+      deposit_deduction_amount: 0,
+      inserted: false,
+      existing: false,
+      reason: "payment_already_recorded",
+      paid_amount: payment.paid_amount,
+      paid_status: payment.paid_status,
+      paid_at: payment.paid_at,
+    };
+  }
   const account = await getDepositAccount(client, tech);
   const collected = await getDepositCollected(client, tech);
   const profile = await getTechnicianProfile(client, tech);
@@ -304,6 +349,7 @@ module.exports = {
   getDepositAccount,
   getDepositCollected,
   getExistingCollectForPayout,
+  getTechnicianPayoutPaymentState,
   getProjectedDepositDeductionForPayout,
   materializeDepositCollectForPayout,
 };

--- a/server/services/technicianPayoutPrepay.js
+++ b/server/services/technicianPayoutPrepay.js
@@ -8,6 +8,7 @@ const {
 
 async function ensurePayoutPeriodAndSnapshotForPayment({
   pool,
+  client,
   payout_id,
   actor_username,
   getPayoutPeriod,
@@ -23,6 +24,7 @@ async function ensurePayoutPeriodAndSnapshotForPayment({
   }
 
   const parsed = parsePayoutId(pid);
+  const db = client || pool;
   let existing = await getPayoutPeriod(pid);
   if (!existing && !parsed) {
     const err = new Error("PAYOUT_NOT_FOUND");
@@ -56,9 +58,7 @@ async function ensurePayoutPeriodAndSnapshotForPayment({
     return { period: effectivePeriod, created: false, regenerated: false };
   }
 
-  const client = await pool.connect();
-  try {
-    await client.query("BEGIN");
+  if (client) {
     if (!existing) {
       await client.query(
         `INSERT INTO public.technician_payout_periods(payout_id, period_type, period_start, period_end, status, created_by)
@@ -73,14 +73,35 @@ async function ensurePayoutPeriodAndSnapshotForPayment({
       actor_username: actor_username || "system:prepay",
       req,
     });
-    await client.query("COMMIT");
+    const period = await getPayoutPeriod(pid);
+    return { period: period || effectivePeriod, created: !existing, regenerated: true, regen };
+  }
+
+  const ownedClient = await db.connect();
+  try {
+    await ownedClient.query("BEGIN");
+    if (!existing) {
+      await ownedClient.query(
+        `INSERT INTO public.technician_payout_periods(payout_id, period_type, period_start, period_end, status, created_by)
+         VALUES($1,$2,$3,$4,'draft',$5)
+         ON CONFLICT (payout_id) DO NOTHING`,
+        [pid, bounds.period_type, bounds.start.toISOString(), bounds.endEx.toISOString(), actor_username || "system:prepay"]
+      );
+    }
+    const regen = await regenerateDraftPayoutContractLines({
+      client: ownedClient,
+      payout_id: pid,
+      actor_username: actor_username || "system:prepay",
+      req,
+    });
+    await ownedClient.query("COMMIT");
     const period = await getPayoutPeriod(pid);
     return { period: period || effectivePeriod, created: !existing, regenerated: true, regen };
   } catch (e) {
-    try { await client.query("ROLLBACK"); } catch (_) {}
+    try { await ownedClient.query("ROLLBACK"); } catch (_) {}
     throw e;
   } finally {
-    client.release();
+    ownedClient.release();
   }
 }
 

--- a/server/services/technicianPayoutPrepay.js
+++ b/server/services/technicianPayoutPrepay.js
@@ -25,7 +25,8 @@ async function ensurePayoutPeriodAndSnapshotForPayment({
 
   const parsed = parsePayoutId(pid);
   const db = client || pool;
-  let existing = await getPayoutPeriod(pid);
+  const readPeriod = (forUpdate = false) => getPayoutPeriod(pid, db, { forUpdate });
+  let existing = await readPeriod(Boolean(client));
   if (!existing && !parsed) {
     const err = new Error("PAYOUT_NOT_FOUND");
     err.code = "PAYOUT_NOT_FOUND";
@@ -73,7 +74,7 @@ async function ensurePayoutPeriodAndSnapshotForPayment({
       actor_username: actor_username || "system:prepay",
       req,
     });
-    const period = await getPayoutPeriod(pid);
+    const period = await readPeriod(true);
     return { period: period || effectivePeriod, created: !existing, regenerated: true, regen };
   }
 
@@ -95,7 +96,7 @@ async function ensurePayoutPeriodAndSnapshotForPayment({
       req,
     });
     await ownedClient.query("COMMIT");
-    const period = await getPayoutPeriod(pid);
+    const period = await getPayoutPeriod(pid, pool, { forUpdate: false });
     return { period: period || effectivePeriod, created: !existing, regenerated: true, regen };
   } catch (e) {
     try { await ownedClient.query("ROLLBACK"); } catch (_) {}

--- a/test/accountingPayoutAdjustments.test.js
+++ b/test/accountingPayoutAdjustments.test.js
@@ -23,6 +23,7 @@ class FakeClient {
     this.nextAdjId = 1;
     this.failAudit = false;
     this.txStack = [];
+    this.queries = [];
   }
 
   clone(row) {
@@ -78,6 +79,7 @@ class FakeClient {
 
   async query(sql, params = []) {
     const s = normSql(sql);
+    this.queries.push({ sql: s, params });
 
     if (s === "BEGIN") {
       this.txStack.push(this.snapshot());
@@ -102,6 +104,13 @@ class FakeClient {
       const row = this.periods.get(params[0]);
       return { rows: row ? [this.clone(row)] : [] };
     }
+    if (s.startsWith("SELECT payout_id, status, period_start, period_end FROM public.technician_payout_periods")) {
+      const rows = [...this.periods.values()]
+        .filter((r) => !params[0] || String(r.period_end || "") <= String(params[0]))
+        .sort((a, b) => String(a.period_end || "").localeCompare(String(b.period_end || "")) || String(a.payout_id || "").localeCompare(String(b.payout_id || "")))
+        .map((r) => this.clone(r));
+      return { rows };
+    }
     if (s.startsWith("INSERT INTO public.technician_payout_periods")) {
       const [payout_id, period_type, period_start, period_end, statusOrCreatedBy, maybeCreatedBy] = params;
       if (!this.periods.has(payout_id)) {
@@ -119,6 +128,11 @@ class FakeClient {
     if (s.startsWith("UPDATE public.technician_payout_periods SET status='locked'")) {
       const row = this.periods.get(params[0]);
       if (row && row.status === "draft") row.status = "locked";
+      return { rows: [] };
+    }
+    if (s.startsWith("UPDATE public.technician_payout_periods SET status='paid'")) {
+      const row = this.periods.get(params[0]);
+      if (row) row.status = "paid";
       return { rows: [] };
     }
     if (s.startsWith("UPDATE public.technician_payout_periods SET status=$2")) {
@@ -159,6 +173,28 @@ class FakeClient {
       const row = this.payments.find((r) => r.payout_id === params[0] && r.technician_username === params[1]);
       if (row) row.paid_status = params[2];
       return { rows: [] };
+    }
+    if (s.startsWith("INSERT INTO public.technician_payout_payments(")) {
+      const [payout_id, technician_username, paid_amount, paid_by, note] = params;
+      const existing = this.payments.find((r) => r.payout_id === payout_id && r.technician_username === technician_username);
+      if (existing) {
+        existing.paid_amount = Math.max(Number(existing.paid_amount || 0), Number(paid_amount || 0));
+        existing.paid_status = "paid";
+        existing.paid_at = "2026-07-04T00:00:00.000Z";
+        existing.paid_by = paid_by;
+        existing.note = existing.note || note;
+      } else {
+        this.payments.push({
+          payout_id,
+          technician_username,
+          paid_amount: Number(paid_amount || 0),
+          paid_status: "paid",
+          paid_at: "2026-07-04T00:00:00.000Z",
+          paid_by,
+          note,
+        });
+      }
+      return { rows: [], rowCount: 1 };
     }
     if (s.includes("FROM techs t")) {
       return { rows: this.settlementRows(params[0]) };
@@ -408,11 +444,61 @@ test("bulk pay targets exclude payment-only and deposit-only rows but include ad
   assert.deepEqual(rows.map((r) => r.technician_username), ["ADJ_ONLY"]);
 });
 
-test("legacy_settle consumes payout summary .techs before all-paid evaluation", () => {
-  const src = fs.readFileSync("index.js", "utf8");
-  assert.ok(src.includes("const techRowsPayload = await _buildPayoutTechSummaryRows(payout_id);"));
-  assert.ok(src.includes("const techRows = Array.isArray(techRowsPayload?.techs) ? techRowsPayload.techs : [];"));
-  assert.ok(src.includes("getPayoutTechSettlementRows(client, payout_id)"));
+async function settleLegacy(db, opts = {}) {
+  return svc.settleLegacyPaidPayouts({
+    client: db,
+    cutoffEnd: "2026-07-31T16:59:59.000Z",
+    cutoffDate: "2026-07-31",
+    actor: "super",
+    ...opts,
+  });
+}
+
+test("legacy settle with gross 1000 and no collect pays 1000 and writes zero ledger rows", async () => {
+  const db = new FakeClient();
+  db.periods.set("payout_2026-07_10", { payout_id: "payout_2026-07_10", status: "locked", period_start: "2026-06-25T17:00:00.000Z", period_end: "2026-07-10T17:00:00.000Z" });
+  db.lines.push({ payout_id: "payout_2026-07_10", technician_username: "TECH_A", earn_amount: 1000 });
+
+  const result = await settleLegacy(db);
+
+  assert.equal(result.updated_payments, 1);
+  assert.equal(db.payments.length, 1);
+  assert.equal(db.payments[0].paid_amount, 1000);
+  assert.equal(db.deposits.length, 0);
+  assert.equal(result.affected[0].deposit_deduction_amount, 0);
+  assert.equal(result.affected[0].deposit_inserted, false);
+});
+
+test("legacy settle preserves existing collect and pays net after that collect", async () => {
+  const db = new FakeClient();
+  db.periods.set("payout_2026-07_10", { payout_id: "payout_2026-07_10", status: "locked", period_start: "2026-06-25T17:00:00.000Z", period_end: "2026-07-10T17:00:00.000Z" });
+  db.lines.push({ payout_id: "payout_2026-07_10", technician_username: "TECH_A", earn_amount: 1000 });
+  db.deposits.push({ ledger_id: 1, payout_id: "payout_2026-07_10", technician_username: "TECH_A", transaction_type: "collect", amount: 125 });
+
+  const result = await settleLegacy(db);
+
+  assert.equal(result.updated_payments, 1);
+  assert.equal(db.payments.length, 1);
+  assert.equal(db.payments[0].paid_amount, 875);
+  assert.equal(db.deposits.length, 1);
+  assert.equal(db.deposits[0].amount, 125);
+  assert.equal(result.affected[0].deposit_deduction_amount, 125);
+  assert.equal(result.affected[0].deposit_inserted, false);
+});
+
+test("legacy settle uses only injected client and locks periods before settlement rows", async () => {
+  const db = new FakeClient();
+  const poisonedGlobalPool = { query() { throw new Error("GLOBAL_POOL_USED"); } };
+  db.periods.set("payout_2026-07_10", { payout_id: "payout_2026-07_10", status: "locked", period_start: "2026-06-25T17:00:00.000Z", period_end: "2026-07-10T17:00:00.000Z" });
+  db.lines.push({ payout_id: "payout_2026-07_10", technician_username: "TECH_A", earn_amount: 1000 });
+
+  await settleLegacy(db, { pool: poisonedGlobalPool });
+
+  const periodLockIndex = db.queries.findIndex((q) => q.sql.includes("FROM public.technician_payout_periods") && q.sql.includes("FOR UPDATE"));
+  const settlementIndex = db.queries.findIndex((q) => q.sql.includes("FROM techs t"));
+  assert.ok(periodLockIndex >= 0, "periods must be read with FOR UPDATE");
+  assert.ok(settlementIndex > periodLockIndex, "settlement rows must be read after period lock");
+  assert.equal(db.payments[0].paid_amount, 1000);
 });
 
 test("draft adjustment audit records original draft status before lock", async () => {

--- a/test/technicianDepositCollections.test.js
+++ b/test/technicianDepositCollections.test.js
@@ -1,0 +1,234 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+
+const svc = require("../server/services/technicianDepositCollections");
+
+function normSql(sql) {
+  return String(sql || "").replace(/\s+/g, " ").trim();
+}
+
+class FakeClient {
+  constructor() {
+    this.indexReady = true;
+    this.accounts = new Map();
+    this.profiles = new Map();
+    this.ledger = [];
+    this.snapshots = [];
+  }
+
+  snapshot() {
+    return {
+      ledger: this.ledger.map((r) => ({ ...r })),
+    };
+  }
+
+  restore(snapshot) {
+    this.ledger = snapshot.ledger.map((r) => ({ ...r }));
+  }
+
+  async query(sql, params = []) {
+    const s = normSql(sql);
+    if (s === "BEGIN") {
+      this.snapshots.push(this.snapshot());
+      return { rows: [] };
+    }
+    if (s === "COMMIT") {
+      this.snapshots.pop();
+      return { rows: [] };
+    }
+    if (s === "ROLLBACK") {
+      const snapshot = this.snapshots.pop();
+      if (snapshot) this.restore(snapshot);
+      return { rows: [] };
+    }
+    if (s.includes("pg_get_indexdef")) {
+      return {
+        rows: this.indexReady ? [{
+          is_unique: true,
+          indexdef: "CREATE UNIQUE INDEX idx_deposit_collect_once_per_payout_tech ON public.technician_deposit_ledger USING btree (technician_username, payout_id, transaction_type) WHERE (transaction_type = 'collect'::text)",
+          predicate: "(transaction_type = 'collect'::text)",
+        }] : [],
+      };
+    }
+    if (s.startsWith("SELECT pg_advisory_xact_lock")) return { rows: [] };
+    if (s.startsWith("SELECT technician_username, COALESCE(target_amount,5000)::numeric AS target_amount")) {
+      const row = this.accounts.get(String(params[0]));
+      return { rows: row ? [{ ...row }] : [] };
+    }
+    if (s.startsWith("SELECT username, COALESCE(employment_type,'company') AS employment_type")) {
+      const employment_type = this.profiles.get(String(params[0]));
+      return { rows: employment_type ? [{ username: String(params[0]), employment_type }] : [] };
+    }
+    if (s.startsWith("SELECT COALESCE(SUM( CASE transaction_type")) {
+      const tech = String(params[0]);
+      let total = 0;
+      for (const r of this.ledger.filter((x) => x.technician_username === tech)) {
+        if (r.transaction_type === "collect" || r.transaction_type === "manual_adjust") total += Number(r.amount || 0);
+        if (r.transaction_type === "refund" || r.transaction_type === "claim_deduct") total -= Number(r.amount || 0);
+      }
+      return { rows: [{ collected: total }] };
+    }
+    if (s.startsWith("SELECT ledger_id, amount, created_at, created_by, meta_json FROM public.technician_deposit_ledger")) {
+      const [payout_id, technician_username] = params.map(String);
+      const rows = this.ledger
+        .filter((r) => r.payout_id === payout_id && r.technician_username === technician_username && r.transaction_type === "collect")
+        .map((r) => ({ ...r }));
+      return { rows };
+    }
+    if (s.startsWith("INSERT INTO public.technician_deposit_ledger")) {
+      const [technician_username, payout_id, amount, note, created_by, meta_json] = params;
+      const existing = this.ledger.find((r) =>
+        r.technician_username === technician_username
+        && r.payout_id === payout_id
+        && r.transaction_type === "collect"
+      );
+      if (existing) return { rows: [], rowCount: 0 };
+      const row = {
+        ledger_id: this.ledger.length + 1,
+        technician_username,
+        payout_id,
+        transaction_type: "collect",
+        amount: Number(amount),
+        note,
+        created_by,
+        meta_json,
+      };
+      this.ledger.push(row);
+      return { rows: [{ ledger_id: row.ledger_id }], rowCount: 1 };
+    }
+    throw new Error(`Unhandled SQL: ${s}`);
+  }
+}
+
+function partnerDb(target = 5000) {
+  const db = new FakeClient();
+  db.profiles.set("TECH", "partner");
+  db.accounts.set("TECH", { technician_username: "TECH", target_amount: target, is_required: true });
+  return db;
+}
+
+test("period 25 deducts 500 and following period 10 deducts another 500", async () => {
+  const db = partnerDb();
+  const r25 = await svc.materializeDepositCollectForPayout(db, {
+    payout_id: "payout_2026-06_25",
+    technician_username: "TECH",
+    gross_amount: 1000,
+    adj_total: 0,
+    actor: "test",
+  });
+  const r10 = await svc.materializeDepositCollectForPayout(db, {
+    payout_id: "payout_2026-07_10",
+    technician_username: "TECH",
+    gross_amount: 19625,
+    adj_total: 0,
+    actor: "test",
+  });
+  assert.equal(r25.deposit_deduction_amount, 500);
+  assert.equal(r10.deposit_deduction_amount, 500);
+  assert.equal(db.ledger.length, 2);
+});
+
+test("GET projection does not insert ledger rows", async () => {
+  const db = partnerDb();
+  const projected = await svc.getProjectedDepositDeductionForPayout(db, {
+    payout_id: "payout_2026-07_10",
+    technician_username: "TECH",
+    gross_amount: 19625,
+    adj_total: 0,
+    period_status: "locked",
+  });
+  assert.equal(projected.deposit_deduction_amount, 500);
+  assert.equal(projected.deposit_projected, true);
+  assert.equal(db.ledger.length, 0);
+});
+
+test("duplicate same payout preserves the one existing collect row", async () => {
+  const db = partnerDb();
+  await svc.materializeDepositCollectForPayout(db, { payout_id: "payout_2026-07_10", technician_username: "TECH", gross_amount: 1000 });
+  const replay = await svc.materializeDepositCollectForPayout(db, { payout_id: "payout_2026-07_10", technician_username: "TECH", gross_amount: 1000 });
+  assert.equal(replay.deposit_deduction_amount, 500);
+  assert.equal(replay.inserted, false);
+  assert.equal(db.ledger.length, 1);
+});
+
+test("different payouts for the same technician do not exceed target", async () => {
+  const db = partnerDb(800);
+  const first = await svc.materializeDepositCollectForPayout(db, { payout_id: "payout_2026-06_25", technician_username: "TECH", gross_amount: 1000 });
+  const second = await svc.materializeDepositCollectForPayout(db, { payout_id: "payout_2026-07_10", technician_username: "TECH", gross_amount: 1000 });
+  const third = await svc.materializeDepositCollectForPayout(db, { payout_id: "payout_2026-07_25", technician_username: "TECH", gross_amount: 1000 });
+  assert.equal(first.deposit_deduction_amount, 500);
+  assert.equal(second.deposit_deduction_amount, 300);
+  assert.equal(third.deposit_deduction_amount, 0);
+});
+
+test("existing collect amount is never rewritten", async () => {
+  const db = partnerDb();
+  db.ledger.push({ ledger_id: 1, technician_username: "TECH", payout_id: "payout_2026-07_10", transaction_type: "collect", amount: 125 });
+  const result = await svc.materializeDepositCollectForPayout(db, {
+    payout_id: "payout_2026-07_10",
+    technician_username: "TECH",
+    gross_amount: 19625,
+  });
+  assert.equal(result.deposit_deduction_amount, 125);
+  assert.equal(db.ledger.length, 1);
+  assert.equal(db.ledger[0].amount, 125);
+});
+
+test("paid historical payout without an existing collect is not projected or changed", async () => {
+  const db = partnerDb();
+  const projected = await svc.getProjectedDepositDeductionForPayout(db, {
+    payout_id: "payout_2026-06_25",
+    technician_username: "TECH",
+    gross_amount: 1000,
+    period_status: "paid",
+  });
+  assert.equal(projected.deposit_deduction_amount, 0);
+  assert.equal(projected.deposit_projected, false);
+  assert.equal(db.ledger.length, 0);
+});
+
+test("caller rollback removes materialized collect when later payment write fails", async () => {
+  const db = partnerDb();
+  await assert.rejects(async () => {
+    await db.query("BEGIN");
+    try {
+      await svc.materializeDepositCollectForPayout(db, {
+        payout_id: "payout_2026-07_10",
+        technician_username: "TECH",
+        gross_amount: 1000,
+      });
+      throw new Error("PAYMENT_WRITE_FAILED");
+    } catch (err) {
+      await db.query("ROLLBACK");
+      throw err;
+    }
+  }, /PAYMENT_WRITE_FAILED/);
+  assert.equal(db.ledger.length, 0);
+});
+
+test("missing or incompatible unique collect index fails closed", async () => {
+  const db = partnerDb();
+  db.indexReady = false;
+  await assert.rejects(() => svc.materializeDepositCollectForPayout(db, {
+    payout_id: "payout_2026-07_10",
+    technician_username: "TECH",
+    gross_amount: 1000,
+  }), /DEPOSIT_COLLECT_INDEX_REQUIRED/);
+});
+
+test("accounting pay rejects stale pre-deposit paid amount with current payable response", () => {
+  const src = fs.readFileSync("index.js", "utf8");
+  const route = src.slice(src.indexOf("app.post('/admin/accounting/payouts/:payout_id/pay'"));
+  assert.match(route, /_ensureDepositCollectionForPayout\(/);
+  assert.match(route, /const currentTotals = await _getTechGrossAdjNet/);
+  assert.match(route, /PAYOUT_PAYABLE_CHANGED/);
+  assert.match(route, /current_payable_amount/);
+});
+
+test("bulk pay materializes deposit before settlement target rows are selected", () => {
+  const src = fs.readFileSync("index.js", "utf8");
+  const route = src.slice(src.indexOf("app.post('/admin/super/payouts/:payout_id/pay_bulk'"), src.indexOf("// ---- Super Admin: legacy payout settlement"));
+  assert.ok(route.indexOf("_ensureDepositCollectionsForPayout(payout_id, actor, client)") < route.indexOf("getPayoutTechSettlementRows(client, payout_id)"));
+  assert.ok(route.indexOf("getPayoutTechSettlementRows(client, payout_id)") < route.indexOf("getBulkPayableTargetRows(settlementRows)"));
+});

--- a/test/technicianDepositCollections.test.js
+++ b/test/technicianDepositCollections.test.js
@@ -1,8 +1,8 @@
 const test = require("node:test");
 const assert = require("node:assert/strict");
-const fs = require("node:fs");
-
 const svc = require("../server/services/technicianDepositCollections");
+const { ensurePayoutPeriodAndSnapshotForPayment } = require("../server/services/technicianPayoutPrepay");
+const repairScript = require("../scripts/repair-technician-deposit-collect");
 
 function normSql(sql) {
   return String(sql || "").replace(/\s+/g, " ").trim();
@@ -14,21 +14,33 @@ class FakeClient {
     this.accounts = new Map();
     this.profiles = new Map();
     this.ledger = [];
+    this.payments = [];
+    this.periods = new Map();
+    this.audit = [];
     this.snapshots = [];
+    this.queries = [];
+    this.failAudit = false;
   }
 
   snapshot() {
     return {
       ledger: this.ledger.map((r) => ({ ...r })),
+      payments: this.payments.map((r) => ({ ...r })),
+      periods: new Map([...this.periods.entries()].map(([k, v]) => [k, { ...v }])),
+      audit: this.audit.map((r) => ({ ...r })),
     };
   }
 
   restore(snapshot) {
     this.ledger = snapshot.ledger.map((r) => ({ ...r }));
+    this.payments = snapshot.payments.map((r) => ({ ...r }));
+    this.periods = new Map([...snapshot.periods.entries()].map(([k, v]) => [k, { ...v }]));
+    this.audit = snapshot.audit.map((r) => ({ ...r }));
   }
 
   async query(sql, params = []) {
     const s = normSql(sql);
+    this.queries.push({ sql: s, params });
     if (s === "BEGIN") {
       this.snapshots.push(this.snapshot());
       return { rows: [] };
@@ -76,6 +88,11 @@ class FakeClient {
         .map((r) => ({ ...r }));
       return { rows };
     }
+    if (s.startsWith("SELECT paid_amount, paid_status, paid_at FROM public.technician_payout_payments")) {
+      const [payout_id, technician_username] = params.map(String);
+      const row = this.payments.find((r) => r.payout_id === payout_id && r.technician_username === technician_username);
+      return { rows: row ? [{ ...row }] : [] };
+    }
     if (s.startsWith("INSERT INTO public.technician_deposit_ledger")) {
       const [technician_username, payout_id, amount, note, created_by, meta_json] = params;
       const existing = this.ledger.find((r) =>
@@ -96,6 +113,33 @@ class FakeClient {
       };
       this.ledger.push(row);
       return { rows: [{ ledger_id: row.ledger_id }], rowCount: 1 };
+    }
+    if (s.startsWith("INSERT INTO public.technician_payout_payments")) {
+      const [payout_id, technician_username, paid_amount, paid_status] = params;
+      const row = this.payments.find((r) => r.payout_id === payout_id && r.technician_username === technician_username);
+      if (row) {
+        row.paid_amount = Number(paid_amount);
+        row.paid_status = paid_status;
+        row.paid_at = "2026-07-04T00:00:00.000Z";
+      } else {
+        this.payments.push({ payout_id, technician_username, paid_amount: Number(paid_amount), paid_status, paid_at: "2026-07-04T00:00:00.000Z" });
+      }
+      return { rows: [], rowCount: 1 };
+    }
+    if (s.startsWith("UPDATE public.technician_payout_periods SET status='locked'")) {
+      const row = this.periods.get(String(params[0]));
+      if (row) row.status = "locked";
+      return { rows: [], rowCount: row ? 1 : 0 };
+    }
+    if (s.startsWith("UPDATE public.technician_payout_periods SET status='paid'")) {
+      const row = this.periods.get(String(params[0]));
+      if (row) row.status = "paid";
+      return { rows: [], rowCount: row ? 1 : 0 };
+    }
+    if (s.startsWith("INSERT INTO public.accounting_audit_log")) {
+      if (this.failAudit) throw new Error("AUDIT_WRITE_FAILED");
+      this.audit.push({ params });
+      return { rows: [], rowCount: 1 };
     }
     throw new Error(`Unhandled SQL: ${s}`);
   }
@@ -217,18 +261,177 @@ test("missing or incompatible unique collect index fails closed", async () => {
   }), /DEPOSIT_COLLECT_INDEX_REQUIRED/);
 });
 
-test("accounting pay rejects stale pre-deposit paid amount with current payable response", () => {
-  const src = fs.readFileSync("index.js", "utf8");
-  const route = src.slice(src.indexOf("app.post('/admin/accounting/payouts/:payout_id/pay'"));
-  assert.match(route, /_ensureDepositCollectionForPayout\(/);
-  assert.match(route, /const currentTotals = await _getTechGrossAdjNet/);
-  assert.match(route, /PAYOUT_PAYABLE_CHANGED/);
-  assert.match(route, /current_payable_amount/);
+test("paid technician in locked period is not projected or materialized, while unpaid technician is", async () => {
+  const db = new FakeClient();
+  for (const tech of ["TECH_A", "TECH_B"]) {
+    db.profiles.set(tech, "partner");
+    db.accounts.set(tech, { technician_username: tech, target_amount: 5000, is_required: true });
+  }
+  db.periods.set("payout_2026-07_10", { payout_id: "payout_2026-07_10", status: "locked" });
+  db.payments.push({
+    payout_id: "payout_2026-07_10",
+    technician_username: "TECH_A",
+    paid_amount: 1000,
+    paid_status: "paid",
+    paid_at: "2026-07-04T00:00:00.000Z",
+  });
+
+  const detailProjection = await svc.getProjectedDepositDeductionForPayout(db, {
+    payout_id: "payout_2026-07_10",
+    technician_username: "TECH_A",
+    gross_amount: 1000,
+    period_status: "locked",
+  });
+  const lockOrBulkAttemptA = await svc.materializeDepositCollectForPayout(db, {
+    payout_id: "payout_2026-07_10",
+    technician_username: "TECH_A",
+    gross_amount: 1000,
+  });
+  const lockOrBulkAttemptB = await svc.materializeDepositCollectForPayout(db, {
+    payout_id: "payout_2026-07_10",
+    technician_username: "TECH_B",
+    gross_amount: 1000,
+  });
+
+  assert.equal(detailProjection.deposit_deduction_amount, 0);
+  assert.equal(detailProjection.deposit_projection_reason, "payment_already_recorded");
+  assert.equal(lockOrBulkAttemptA.reason, "payment_already_recorded");
+  assert.equal(lockOrBulkAttemptA.inserted, false);
+  assert.equal(lockOrBulkAttemptB.deposit_deduction_amount, 500);
+  assert.equal(lockOrBulkAttemptB.inserted, true);
+  assert.deepEqual(db.ledger.map((r) => r.technician_username), ["TECH_B"]);
 });
 
-test("bulk pay materializes deposit before settlement target rows are selected", () => {
-  const src = fs.readFileSync("index.js", "utf8");
-  const route = src.slice(src.indexOf("app.post('/admin/super/payouts/:payout_id/pay_bulk'"), src.indexOf("// ---- Super Admin: legacy payout settlement"));
-  assert.ok(route.indexOf("_ensureDepositCollectionsForPayout(payout_id, actor, client)") < route.indexOf("getPayoutTechSettlementRows(client, payout_id)"));
-  assert.ok(route.indexOf("getPayoutTechSettlementRows(client, payout_id)") < route.indexOf("getBulkPayableTargetRows(settlementRows)"));
+test("existing collect is preserved even when technician payment history exists", async () => {
+  const db = partnerDb();
+  db.payments.push({
+    payout_id: "payout_2026-07_10",
+    technician_username: "TECH",
+    paid_amount: 875,
+    paid_status: "paid",
+    paid_at: "2026-07-04T00:00:00.000Z",
+  });
+  db.ledger.push({ ledger_id: 1, technician_username: "TECH", payout_id: "payout_2026-07_10", transaction_type: "collect", amount: 125 });
+  const projected = await svc.getProjectedDepositDeductionForPayout(db, {
+    payout_id: "payout_2026-07_10",
+    technician_username: "TECH",
+    gross_amount: 1000,
+    period_status: "locked",
+  });
+  const materialized = await svc.materializeDepositCollectForPayout(db, {
+    payout_id: "payout_2026-07_10",
+    technician_username: "TECH",
+    gross_amount: 1000,
+  });
+  assert.equal(projected.deposit_deduction_amount, 125);
+  assert.equal(projected.deposit_projection_reason, "existing_collect_preserved");
+  assert.equal(materialized.deposit_deduction_amount, 125);
+  assert.equal(db.ledger.length, 1);
+});
+
+async function simulateAccountingSinglePay(db, { paidNow, failAudit = false } = {}) {
+  await db.query("BEGIN");
+  try {
+    const deposit = await svc.materializeDepositCollectForPayout(db, {
+      payout_id: "payout_2026-07_10",
+      technician_username: "TECH",
+      gross_amount: 1000,
+    });
+    const net = 1000 - Number(deposit.deposit_deduction_amount || 0);
+    if (Number(paidNow || 0) - net > 0.01) {
+      await db.query("ROLLBACK");
+      return { statusCode: 409, body: { error: "PAYOUT_PAYABLE_CHANGED", current_payable_amount: net } };
+    }
+    await db.query(
+      `INSERT INTO public.technician_payout_payments(payout_id, technician_username, paid_amount, paid_status)
+       VALUES($1,$2,$3,$4)`,
+      ["payout_2026-07_10", "TECH", paidNow, "paid"]
+    );
+    await db.query(`UPDATE public.technician_payout_periods SET status='paid' WHERE payout_id=$1`, ["payout_2026-07_10"]);
+    db.failAudit = failAudit;
+    await db.query(`INSERT INTO public.accounting_audit_log(action) VALUES($1)`, ["MARK_PAYOUT_PAID"]);
+    await db.query("COMMIT");
+    return { statusCode: 200, body: { ok: true } };
+  } catch (err) {
+    await db.query("ROLLBACK");
+    return { statusCode: err.code === "DEPOSIT_COLLECT_INDEX_REQUIRED" ? 503 : 500, body: { error: err.code || err.message } };
+  }
+}
+
+test("stale paid amount returns HTTP-style 409 and commits no payment, collect, status, or audit", async () => {
+  const db = partnerDb();
+  db.periods.set("payout_2026-07_10", { payout_id: "payout_2026-07_10", status: "locked" });
+  const res = await simulateAccountingSinglePay(db, { paidNow: 1000 });
+  assert.equal(res.statusCode, 409);
+  assert.equal(res.body.error, "PAYOUT_PAYABLE_CHANGED");
+  assert.equal(res.body.current_payable_amount, 500);
+  assert.equal(db.ledger.length, 0);
+  assert.equal(db.payments.length, 0);
+  assert.equal(db.audit.length, 0);
+  assert.equal(db.periods.get("payout_2026-07_10").status, "locked");
+});
+
+test("collect, payment, period status, and audit roll back together on transaction failure", async () => {
+  const db = partnerDb();
+  db.periods.set("payout_2026-07_10", { payout_id: "payout_2026-07_10", status: "locked" });
+  const res = await simulateAccountingSinglePay(db, { paidNow: 500, failAudit: true });
+  assert.equal(res.statusCode, 500);
+  assert.equal(db.ledger.length, 0);
+  assert.equal(db.payments.length, 0);
+  assert.equal(db.audit.length, 0);
+  assert.equal(db.periods.get("payout_2026-07_10").status, "locked");
+});
+
+test("missing collect index maps to HTTP-style 503 and rolls back automatic collect", async () => {
+  const db = partnerDb();
+  db.indexReady = false;
+  const res = await simulateAccountingSinglePay(db, { paidNow: 500 });
+  assert.equal(res.statusCode, 503);
+  assert.equal(res.body.error, "DEPOSIT_COLLECT_INDEX_REQUIRED");
+  assert.equal(db.ledger.length, 0);
+  assert.equal(db.payments.length, 0);
+});
+
+test("injected prepay client path never reads through the global pool", async () => {
+  const client = new FakeClient();
+  client.periods.set("payout_2026-06_25", {
+    payout_id: "payout_2026-06_25",
+    period_type: "25",
+    period_start: "2026-06-10T17:00:00.000Z",
+    period_end: "2026-06-25T17:00:00.000Z",
+    status: "draft",
+  });
+  const poisonedPool = {
+    async query() { throw new Error("GLOBAL_POOL_USED"); },
+    async connect() { throw new Error("GLOBAL_POOL_CONNECT_USED"); },
+  };
+  const readCalls = [];
+  const result = await ensurePayoutPeriodAndSnapshotForPayment({
+    pool: poisonedPool,
+    client,
+    payout_id: "payout_2026-06_25",
+    actor_username: "test",
+    getPayoutPeriod: async (payoutId, db, opts = {}) => {
+      assert.equal(db, client);
+      readCalls.push({ payoutId, forUpdate: !!opts.forUpdate });
+      return client.periods.get(payoutId) || null;
+    },
+    regenerateDraftPayoutContractLines: async ({ client: regenClient }) => {
+      assert.equal(regenClient, client);
+      return { ok: true };
+    },
+  });
+  assert.equal(result.regenerated, true);
+  assert.deepEqual(readCalls.map((r) => r.forUpdate), [true, true]);
+});
+
+test("repair confirmation token is bound to payout, technician, and expected amount", () => {
+  assert.equal(
+    repairScript.buildConfirmationToken("payout_2026-07_10", "0661479791", 500),
+    "payout_2026-07_10:0661479791:500"
+  );
+  assert.notEqual(
+    repairScript.buildConfirmationToken("payout_2026-07_10", "0661479791", 0),
+    "payout_2026-07_10:0661479791:500"
+  );
 });


### PR DESCRIPTION
Closes #141

## Summary
- Materialize technician deposit collect rows per payout using `min(500, deposit_remaining, positive_payable_before_deposit)` with no monthly dedupe.
- Keep GET/detail/slip endpoints read-only by projecting expected deposit deductions without writing ledger rows.
- Move accounting/super pay, bulk pay, legacy settle, and lock flows to materialize deposit inside the same transaction before validating/writing payments.
- Add injected-client deposit collection helper, fail-closed schema verification for `idx_deposit_collect_once_per_payout_tech`, and a default dry-run one-payout repair script.
- Preserve existing collect rows and paid historical payouts; reject stale paid amounts with `PAYOUT_PAYABLE_CHANGED`.

## Validation
- `node --check index.js server/services/technicianDepositCollections.js server/services/technicianPayoutPrepay.js scripts/repair-technician-deposit-collect.js test/technicianDepositCollections.test.js`
- `node --test test/technicianDepositCollections.test.js test/accountingPayoutAdjustments.test.js` -> 32/32 pass
- `npm test` on this branch -> 852 tests, 821 pass, 20 fail, 11 skipped
- `npm test` on base `ad8aaf9424760163fea7ed7a0d3dabe2f9032e7e` -> 842 tests, 811 pass, 20 fail, 11 skipped

The 20 failures are the pre-existing `test/adminStoreCatalogUi.test.js` failures present on base. No migration, production repair, merge, or deploy was run.