### PR TITLE
[codex] Fix customer order payment security

### DIFF
--- a/customer-app/assets/customer-app.js
+++ b/customer-app/assets/customer-app.js
@@ -3,7 +3,7 @@
 
   const App = window.CWFCustomerAppV2;
   const BOOT_TIMEOUT_MS = 3500;
-  const BUILD_ID = "20260703_lifecycle_v1";
+  const BUILD_ID = "20260705_payment_security_v1";
 
   function withTimeout(promise, timeoutMs) {
     return Promise.race([

--- a/customer-app/index.html
+++ b/customer-app/index.html
@@ -17,10 +17,10 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Noto+Sans+Thai:wght@400;500;600;700;800;900&display=swap" media="print" onload="this.media='all'">
   <noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Noto+Sans+Thai:wght@400;500;600;700;800;900&display=swap"></noscript>
-  <link rel="manifest" href="./manifest.webmanifest?v=20260703_lifecycle_v1">
+  <link rel="manifest" href="./manifest.webmanifest?v=20260705_payment_security_v1">
   <link rel="icon" type="image/png" sizes="192x192" href="./assets/icons/cwf-customer-192.png">
   <link rel="apple-touch-icon" sizes="180x180" href="./assets/icons/cwf-customer-180.png">
-  <link rel="stylesheet" href="./assets/customer-app.css?v=20260703_lifecycle_v1">
+  <link rel="stylesheet" href="./assets/customer-app.css?v=20260705_payment_security_v1">
 </head>
 <body class="is-app-booting">
   <div class="app-shell" data-app-shell>
@@ -58,21 +58,21 @@
     </nav>
   </div>
 
-  <script src="./modules/state.js?v=20260703_lifecycle_v1"></script>
-  <script src="./modules/utils.js?v=20260703_lifecycle_v1"></script>
-  <script src="./modules/analytics.js?v=20260703_lifecycle_v1"></script>
-  <script src="./modules/api.js?v=20260703_lifecycle_v1"></script>
-  <script src="./modules/services.js?v=20260703_lifecycle_v1"></script>
-  <script src="./modules/ui.js?v=20260703_lifecycle_v1"></script>
-  <script src="./modules/store.js?v=20260703_lifecycle_v1"></script>
-  <script src="./modules/auth.js?v=20260703_lifecycle_v1"></script>
-  <script src="./modules/pricing.js?v=20260703_lifecycle_v1"></script>
-  <script src="./modules/availability.js?v=20260703_lifecycle_v1"></script>
-  <script src="./modules/bookingScheduled.js?v=20260703_lifecycle_v1"></script>
-  <script src="./modules/bookingUrgent.js?v=20260703_lifecycle_v1"></script>
-  <script src="./modules/tracking.js?v=20260703_lifecycle_v1"></script>
-  <script src="./modules/profile.js?v=20260703_lifecycle_v1"></script>
-  <script src="./modules/router.js?v=20260703_lifecycle_v1"></script>
-  <script src="./assets/customer-app.js?v=20260703_lifecycle_v1"></script>
+  <script src="./modules/state.js?v=20260705_payment_security_v1"></script>
+  <script src="./modules/utils.js?v=20260705_payment_security_v1"></script>
+  <script src="./modules/analytics.js?v=20260705_payment_security_v1"></script>
+  <script src="./modules/api.js?v=20260705_payment_security_v1"></script>
+  <script src="./modules/services.js?v=20260705_payment_security_v1"></script>
+  <script src="./modules/ui.js?v=20260705_payment_security_v1"></script>
+  <script src="./modules/store.js?v=20260705_payment_security_v1"></script>
+  <script src="./modules/auth.js?v=20260705_payment_security_v1"></script>
+  <script src="./modules/pricing.js?v=20260705_payment_security_v1"></script>
+  <script src="./modules/availability.js?v=20260705_payment_security_v1"></script>
+  <script src="./modules/bookingScheduled.js?v=20260705_payment_security_v1"></script>
+  <script src="./modules/bookingUrgent.js?v=20260705_payment_security_v1"></script>
+  <script src="./modules/tracking.js?v=20260705_payment_security_v1"></script>
+  <script src="./modules/profile.js?v=20260705_payment_security_v1"></script>
+  <script src="./modules/router.js?v=20260705_payment_security_v1"></script>
+  <script src="./assets/customer-app.js?v=20260705_payment_security_v1"></script>
 </body>
 </html>

--- a/customer-app/manifest.webmanifest
+++ b/customer-app/manifest.webmanifest
@@ -2,7 +2,7 @@
   "name": "CWF Customer Service",
   "short_name": "CWF Service",
   "description": "แอปลูกค้า Coldwindflow สำหรับเลือกบริการ จองคิว และติดตามงาน",
-  "start_url": "/customer-app/index.html?v=20260703_lifecycle_v1#home",
+  "start_url": "/customer-app/index.html?v=20260705_payment_security_v1#home",
   "scope": "/customer-app/",
   "id": "/customer-app/",
   "display": "standalone",

--- a/customer-app/modules/store.js
+++ b/customer-app/modules/store.js
@@ -12,7 +12,7 @@
   let eligibilityRequestSeq = 0;
   let reviewSubmitSeq = 0;
 
-  console.info("[customer-store] store-card-spacing-review-privacy 20260629 loaded");
+  console.info("[customer-store] payment-security 20260705 loaded");
 
   const FILTER_AC_TYPES = [
     { value: "wall", label: "แอร์ผนัง" },
@@ -1755,18 +1755,38 @@
 
   function paymentStepHtml(item, o) {
     const totalStr = root.utils.formatBaht(o.amount);
+    const methods = Array.isArray(o.methods) && o.methods.length ? o.methods : ["promptpay"];
     return `
       <button class="contact-sheet-close" type="button" data-purchase-close aria-label="ปิด">×</button>
       <span class="section-kicker">ชำระเงิน</span>
       <h2>ชำระค่าสินค้า</h2>
       <div class="purchase-total"><span>ยอดชำระ</span><strong>${esc(totalStr)}</strong></div>
       <div class="pay-methods" role="tablist">
-        <button class="pay-method-btn is-active" type="button" data-pay-method="promptpay" role="tab">พร้อมเพย์ (PromptPay)</button>
-        <button class="pay-method-btn" type="button" data-pay-method="card" role="tab">บัตรเครดิต/เดบิต</button>
+        ${methods.includes("promptpay") ? `<button class="pay-method-btn is-active" type="button" data-pay-method="promptpay" role="tab">พร้อมเพย์ (PromptPay)</button>` : ""}
+        ${methods.includes("card") ? `<button class="pay-method-btn${methods.includes("promptpay") ? "" : " is-active"}" type="button" data-pay-method="card" role="tab">บัตรเครดิต/เดบิต</button>` : ""}
       </div>
       <div class="pay-body" data-pay-body></div>
       <p class="purchase-error" data-pay-error hidden></p>
       <p class="purchase-note">ชำระเงินอย่างปลอดภัยผ่าน Omise · ข้อมูลบัตรไม่ถูกเก็บบนเซิร์ฟเวอร์ของเรา</p>
+    `;
+  }
+
+  function processingPaymentHtml(item, o) {
+    const orderCode = (o.order && o.order.order_code) || o.orderCode || "";
+    return `
+      <button class="contact-sheet-close" type="button" data-purchase-close aria-label="ปิด">×</button>
+      <span class="section-kicker">กำลังตรวจสอบ</span>
+      <h2>กำลังตรวจสอบการชำระเงิน</h2>
+      <div class="purchase-summary">
+        ${orderCode ? `<div><span>เลขคำสั่งซื้อ</span><strong>${esc(orderCode)}</strong></div>` : ""}
+        <div><span>สินค้า</span><strong>${esc(item.item_name || "")} × ${o.qty}</strong></div>
+        <div><span>ยอดชำระ</span><strong>${esc(root.utils.formatBaht(o.amount))}</strong></div>
+      </div>
+      <p>ระบบได้รับคำขอชำระเงินแล้วและกำลังรอตรวจสอบผล กรุณาอย่ากดจ่ายซ้ำ</p>
+      <div class="contact-sheet-actions">
+        ${orderCode ? `<button class="secondary-btn" type="button" data-route="tracking" data-track-order="${esc(orderCode)}">ติดตามคำสั่งซื้อ</button>` : ""}
+        <a class="primary-btn" href="https://lin.ee/fG1Oq7y" target="_blank" rel="noopener noreferrer">แจ้งแอดมินทาง LINE</a>
+      </div>
     `;
   }
 
@@ -1865,12 +1885,24 @@
     const renderPaymentStep = (o, config) => {
       const sheet = mount.querySelector(".purchase-sheet");
       if (!sheet) return;
+      o.methods = Array.isArray(config.methods) && config.methods.length ? config.methods : ["promptpay"];
       sheet.innerHTML = paymentStepHtml(item, o);
       bindClose();
       const body = sheet.querySelector("[data-pay-body]");
       const errEl = sheet.querySelector("[data-pay-error]");
       const showError = (msg) => { if (errEl) { errEl.textContent = msg; errEl.hidden = false; } };
       const clearError = () => { if (errEl) errEl.hidden = true; };
+      const isProcessingResponse = (res) => {
+        const status = res?.order?.status || res?.payment?.status || "";
+        return status === "payment_processing" || res?.error === "PAYMENT_PROCESSING" || res?.error === "PAYMENT_RESULT_UNKNOWN";
+      };
+      const goProcessing = (res) => {
+        if (pollTimer) { clearInterval(pollTimer); pollTimer = null; }
+        const orderCode = (res?.order && res.order.order_code) || (o.order && o.order.order_code) || "";
+        if (orderCode) root.state.updateDraft?.("tracking", { trackingCode: orderCode });
+        sheet.innerHTML = processingPaymentHtml(item, { ...o, order: res?.order || o.order, orderCode });
+        bindClose();
+      };
       const goPaid = () => {
         if (pollTimer) { clearInterval(pollTimer); pollTimer = null; }
         const orderCode = (o.order && o.order.order_code) || "";
@@ -1890,11 +1922,14 @@
         body.innerHTML = method === "card" ? cardBodyHtml() : promptPayBodyHtml();
         if (method === "promptpay") {
           body.querySelector("[data-pp-start]")?.addEventListener("click", async () => {
+            if (o.paymentInFlight) return;
+            o.paymentInFlight = true;
             clearError();
             const btn = body.querySelector("[data-pp-start]");
             if (btn) { btn.disabled = true; btn.textContent = "กำลังสร้าง QR..."; }
             try {
               const res = await root.api.payOrder(o.order.order_code, { method: "promptpay" });
+              if (isProcessingResponse(res) && !res?.payment?.qr_uri) { goProcessing(res); return; }
               const qr = res?.payment?.qr_uri;
               if (!qr) throw new Error("no qr");
               body.innerHTML = `
@@ -1909,11 +1944,13 @@
               });
             } catch (_) {
               showError("สร้าง QR ไม่สำเร็จ กรุณาลองใหม่");
+              o.paymentInFlight = false;
               if (btn) { btn.disabled = false; btn.textContent = "สร้าง QR พร้อมเพย์"; }
             }
           });
         } else {
           body.querySelector("[data-card-pay]")?.addEventListener("click", async () => {
+            if (o.paymentInFlight) return;
             clearError();
             const number = (body.querySelector("[data-card-number]")?.value || "").replace(/\s+/g, "");
             const exp = (body.querySelector("[data-card-exp]")?.value || "").trim();
@@ -1925,6 +1962,7 @@
             if (btn) { btn.disabled = true; btn.textContent = "กำลังชำระเงิน..."; }
             const reset = () => { if (btn) { btn.disabled = false; btn.textContent = "ชำระด้วยบัตร"; } };
             try {
+              o.paymentInFlight = true;
               const Omise = await ensureOmiseJs(config.public_key);
               const token = await new Promise((resolve, reject) => {
                 Omise.createToken("card", {
@@ -1940,9 +1978,11 @@
               });
               const res = await root.api.payOrder(o.order.order_code, { method: "card", token });
               if (res?.order?.status === "paid") goPaid();
-              else { showError("การชำระเงินไม่สำเร็จ กรุณาตรวจสอบบัตรแล้วลองใหม่"); reset(); }
+              else if (isProcessingResponse(res)) goProcessing(res);
+              else { showError("การชำระเงินไม่สำเร็จ กรุณาตรวจสอบบัตรแล้วลองใหม่"); o.paymentInFlight = false; reset(); }
             } catch (err) {
               showError(err && err.message ? "ชำระเงินไม่สำเร็จ: " + err.message : "ชำระเงินไม่สำเร็จ กรุณาลองใหม่");
+              o.paymentInFlight = false;
               reset();
             }
           });
@@ -1952,7 +1992,7 @@
       sheet.querySelectorAll("[data-pay-method]").forEach((b) =>
         b.addEventListener("click", () => renderMethod(b.getAttribute("data-pay-method")))
       );
-      renderMethod("promptpay");
+      renderMethod((o.methods || []).includes("promptpay") ? "promptpay" : "card");
     };
     const qtyVal = mount.querySelector("[data-qty-val]");
     const totalEl = mount.querySelector("[data-buy-total]");
@@ -1984,7 +2024,7 @@
           delivery_method: delivery,
           install_option: install,
           address,
-          items: [{ item_id: item.item_id, name: item.item_name, qty, unit_price: unitPrice || 0 }],
+          items: [{ item_id: item.item_id, qty }],
         });
         order = res?.order || null;
       } catch (_error) {

--- a/customer-app/sw.js
+++ b/customer-app/sw.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const BUILD_ID = "20260703_lifecycle_v1";
+const BUILD_ID = "20260705_payment_security_v1";
 const CACHE_NAME = `cwf-customer-app-v2-${BUILD_ID}`;
 const APP_SHELL = [
   `./index.html?v=${BUILD_ID}`,

--- a/docs/OMISE_PAYMENT_SETUP.md
+++ b/docs/OMISE_PAYMENT_SETUP.md
@@ -1,85 +1,146 @@
-# Online payment (Omise / Opn) — store buy flow
+# Online payment (Omise / Opn) - store buy flow
 
 The store buy flow lets a customer pay for a `purchase`-mode catalog item
 online via **Omise (Opn Payments)** with either **PromptPay QR** or a
-**credit/debit card**. This document is the operator's guide: which environment
-variables to set, how the pieces fit together, and how to run the live test
-once keys are in place.
+**credit/debit card**.
 
-> The app never sees raw card numbers. The browser tokenizes the card with
-> Omise.js using the **public** key; our server only ever receives a one-time
-> token and charges it with the **secret** key.
+The app never sees raw card numbers. The browser tokenizes the card with
+Omise.js using the **public** key; our server only receives a one-time token and
+charges it with the **secret** key.
 
-## 1. Environment variables (required)
+## 1. Environment variables
 
-Set these on the server (e.g. in the deployment environment / `.env`). Get the
-values from the Omise dashboard → **Keys**. Never commit them; never paste a
-secret key into chat, code, or a PR.
+Set these on the server, for example in the deployment environment or `.env`.
+Never commit them and never paste secrets into chat, code, or a PR.
 
-| Variable            | Example            | Notes                                  |
-| ------------------- | ------------------ | -------------------------------------- |
-| `OMISE_PUBLIC_KEY`  | `pkey_test_xxxxx`  | Safe to expose to the browser.         |
-| `OMISE_SECRET_KEY`  | `skey_test_xxxxx`  | **Secret.** Server only. Never ships.  |
+| Variable | Example | Notes |
+| --- | --- | --- |
+| `OMISE_SECRET_KEY` | `skey_test_xxxxx` | **Secret.** Server only. Required for charge/retrieve. |
+| `OMISE_WEBHOOK_SECRET` | `whsec_xxxxx` | **Secret.** Required before online payment is enabled. |
+| `OMISE_PUBLIC_KEY` | `pkey_test_xxxxx` | Safe to expose. Required only for card payment UI. |
 
-- Test-mode keys are prefixed `pkey_test_` / `skey_test_`; live keys are
-  `pkey_...` / `skey_...` without `_test_`. Start with **test** keys.
-- If `OMISE_SECRET_KEY` is unset, payment is simply **off**: the buy flow falls
-  back to the existing LINE hand-off, and `GET /public/payment-config` returns
-  `{ enabled: false }`. Nothing breaks.
+Readiness behavior:
+
+- Online payment is **off** unless both `OMISE_SECRET_KEY` and
+  `OMISE_WEBHOOK_SECRET` are set.
+- PromptPay can be advertised with only `OMISE_SECRET_KEY` and
+  `OMISE_WEBHOOK_SECRET`.
+- Card payment is advertised only when `OMISE_PUBLIC_KEY` is also set.
+- When config is incomplete, `GET /public/payment-config` returns
+  `enabled: false` or omits the unavailable method, and the Customer App keeps
+  the LINE fallback.
 
 ## 2. Database
 
-The buy-flow migrations are additive and auto-apply on boot (no manual step).
-To run them by hand:
+The existing buy-flow migrations are additive. Do not run migrations from
+application startup unless that behavior has been separately approved for the
+release.
 
-```
-npm run migrate:store-buy         # runs all three buy-flow migrations in order
-# or just the payment columns:
-npm run migrate:customer-orders-payment
-```
+Relevant existing schema:
 
-The payment migration only adds nullable `payment_*` columns to
-`customer_orders` — it never rewrites existing rows.
+- `public.customer_orders.status`
+- `payment_provider`
+- `payment_method`
+- `payment_charge_id`
+- `payment_status`
+- `paid_at`
+- unique partial index on non-null `payment_charge_id`
+
+No new migration is required for the payment security change. The current
+payment attempt is stored as `payment_status='processing:<attempt_id>'` until a
+charge id is safely persisted.
 
 ## 3. Webhook
 
-In the Omise dashboard → **Webhooks**, add an endpoint pointing at:
+In the Omise dashboard -> **Webhooks**, add an endpoint pointing at:
 
-```
+```text
 https://<your-host>/webhooks/omise
 ```
 
-This is how **PromptPay** payments are confirmed (the customer scans the QR and
-pays asynchronously). Omise webhooks are unsigned, so the handler does **not**
-trust the payload: it takes the charge id, re-fetches the charge from the Omise
-API, and only then updates the order. Replays are idempotent.
+The endpoint must be configured with HMAC-SHA256 signatures. The server verifies:
+
+- `Omise-Signature`
+- `Omise-Signature-Timestamp`
+- signed payload `<timestamp>.<raw request body>`
+
+The handler still does not trust webhook payload fields after signature
+verification. It extracts the charge id, retrieves the real charge from Omise,
+checks metadata (`order_code` and `attempt_id`), amount, and THB currency, and
+only then updates the order. Replays are idempotent.
 
 ## 4. How the flow works
 
-1. Customer fills the purchase sheet → `POST /public/orders` creates an order
-   with status `pending_payment` (subtotal computed server-side).
-2. App calls `GET /public/payment-config`; if enabled it shows the payment step.
-3. **Card:** browser tokenizes via Omise.js → `POST /public/orders/:code/pay`
-   with `{ method: "card", token }`. The charge is captured immediately; the
-   order becomes `paid` (or `payment_failed`).
-4. **PromptPay:** `POST /public/orders/:code/pay` with `{ method: "promptpay" }`
-   returns a QR image URL. The order sits at `payment_processing`; the app polls
-   `GET /public/orders/:code` until the webhook flips it to `paid`.
+1. Customer fills the purchase sheet.
+2. `POST /public/orders` creates an order with status `pending_payment`.
+   Product names and prices are loaded from the catalog database; client
+   `name`, `unit_price`, and `subtotal` are ignored.
+3. App calls `GET /public/payment-config`; if enabled it shows the payment step.
+4. Before calling Omise, the server locks the order, creates a cryptographically
+   random `attempt_id`, stores `payment_status='processing:<attempt_id>'`, moves
+   the order to `payment_processing`, and commits.
+5. **Card:** browser tokenizes via Omise.js, then calls
+   `POST /public/orders/:code/pay` with `{ method: "card", token }`.
+6. **PromptPay:** `POST /public/orders/:code/pay` with
+   `{ method: "promptpay" }` returns a QR image URL. The order stays at
+   `payment_processing` until webhook verification marks it paid or failed.
 
-The amount charged is **always** the server-stored `subtotal` — the client
-cannot influence it.
+The amount charged is always the server-stored `subtotal`; the client cannot
+influence it.
 
-## 5. Live test (must run where Omise is reachable)
+Ambiguous Omise failures (timeout, transport error, HTTP 408, HTTP 429, HTTP
+5xx) remain non-retryable and keep the order at `payment_processing`. Only a
+confirmed no-charge rejection or a verified terminal failed/expired/reversed
+charge may become `payment_failed`.
 
-The CI/dev sandbox blocks outbound traffic to `api.omise.co`, so the live test
-runs in your **staging/production** environment with test keys set.
+## 5. Release checklist
 
-1. Set `OMISE_PUBLIC_KEY` / `OMISE_SECRET_KEY` to your **test** keys; deploy.
-2. `GET /public/payment-config` → expect `{ enabled: true, test_mode: true }`.
-3. **Card:** in the app, buy a `purchase` item and pay with an Omise test card
-   (e.g. `4242 4242 4242 4242`, any future expiry, any CVC). Expect the order to
-   reach `paid`; confirm the charge in the Omise dashboard (test mode).
-4. **PromptPay:** choose PromptPay, get the QR. In test mode Omise won't take a
-   real scan — mark the charge as paid from the dashboard (or use the test
-   webhook) and confirm the order flips to `paid` via polling.
-5. When satisfied, swap to **live** keys and repeat a small real charge.
+Before enabling online payment in production:
+
+1. Confirm `OMISE_SECRET_KEY` is set for the intended Omise account.
+2. Confirm `OMISE_WEBHOOK_SECRET` is set and matches the Omise dashboard
+   webhook signing secret.
+3. Confirm `OMISE_PUBLIC_KEY` is set if card payment should be shown.
+4. Confirm `GET /public/payment-config` returns:
+   - `enabled: true`
+   - `methods` includes `promptpay`
+   - `methods` includes `card` only when the public key is present
+5. Create a test order with an approved test product and verify stored order
+   item name/unit price match the catalog, not the browser payload.
+6. Verify PromptPay webhook delivery reaches `paid`.
+
+## 6. Manual reconciliation for stuck `payment_processing`
+
+If an order remains `payment_processing`, do **not** reset it automatically to
+`pending_payment`. That state means Omise may already have created a charge and
+a retry could double-charge the customer.
+
+Manual process:
+
+1. Look up the order by `order_code`.
+2. Read the current attempt from `payment_status` when it has the form
+   `processing:<attempt_id>`.
+3. Search the Omise dashboard/API for charges whose metadata contains the same
+   `order_code` and `attempt_id`.
+4. If a matching charge is paid/successful and amount/currency match the order,
+   let the webhook process it or manually apply the same state update with owner
+   approval.
+5. If Omise confirms no charge exists or the matching charge is terminal
+   failed/expired/reversed, owner-approved manual reconciliation may set the
+   order to `payment_failed` so the customer can retry.
+6. Never change production data without an approved reconciliation ticket.
+
+## 7. Live test
+
+Run this only in an environment that is intentionally configured to reach Omise.
+
+1. Set `OMISE_SECRET_KEY`, `OMISE_WEBHOOK_SECRET`, and optionally
+   `OMISE_PUBLIC_KEY` to test-mode values; deploy.
+2. `GET /public/payment-config` should return enabled test mode and the expected
+   method list.
+3. Card: buy a `purchase` item and pay with an Omise test card. Expect the order
+   to reach `paid`; confirm the charge in the Omise dashboard test mode.
+4. PromptPay: choose PromptPay and get the QR. Use Omise test tooling/dashboard
+   to complete the charge and confirm the order flips to `paid` via webhook and
+   polling.
+5. Swap to live keys only after owner approval.

--- a/docs/OMISE_PAYMENT_SETUP.md
+++ b/docs/OMISE_PAYMENT_SETUP.md
@@ -16,13 +16,13 @@ Never commit them and never paste secrets into chat, code, or a PR.
 | Variable | Example | Notes |
 | --- | --- | --- |
 | `OMISE_SECRET_KEY` | `skey_test_xxxxx` | **Secret.** Server only. Required for charge/retrieve. |
-| `OMISE_WEBHOOK_SECRET` | `whsec_xxxxx` | **Secret.** Required before online payment is enabled. |
+| `OMISE_WEBHOOK_SECRET` | `base64-secret-from-dashboard` | **Secret.** Base64 webhook signing secret from the Omise dashboard. Required before online payment is enabled. |
 | `OMISE_PUBLIC_KEY` | `pkey_test_xxxxx` | Safe to expose. Required only for card payment UI. |
 
 Readiness behavior:
 
 - Online payment is **off** unless both `OMISE_SECRET_KEY` and
-  `OMISE_WEBHOOK_SECRET` are set.
+  `OMISE_WEBHOOK_SECRET` are set and the webhook secret is valid Base64.
 - PromptPay can be advertised with only `OMISE_SECRET_KEY` and
   `OMISE_WEBHOOK_SECRET`.
 - Card payment is advertised only when `OMISE_PUBLIC_KEY` is also set.
@@ -58,7 +58,12 @@ In the Omise dashboard -> **Webhooks**, add an endpoint pointing at:
 https://<your-host>/webhooks/omise
 ```
 
-The endpoint must be configured with HMAC-SHA256 signatures. The server verifies:
+The endpoint must be configured with HMAC-SHA256 signatures. Omise exposes the
+webhook signing secret as Base64 in the dashboard; set that exact Base64 value
+as `OMISE_WEBHOOK_SECRET`. The server decodes it to bytes before calculating the
+HMAC and fails closed if the value is empty or not valid Base64.
+
+The server verifies:
 
 - `Omise-Signature`
 - `Omise-Signature-Timestamp`
@@ -99,7 +104,7 @@ Before enabling online payment in production:
 
 1. Confirm `OMISE_SECRET_KEY` is set for the intended Omise account.
 2. Confirm `OMISE_WEBHOOK_SECRET` is set and matches the Omise dashboard
-   webhook signing secret.
+   webhook signing secret Base64 value.
 3. Confirm `OMISE_PUBLIC_KEY` is set if card payment should be shown.
 4. Confirm `GET /public/payment-config` returns:
    - `enabled: true`
@@ -130,7 +135,20 @@ Manual process:
    order to `payment_failed` so the customer can retry.
 6. Never change production data without an approved reconciliation ticket.
 
-## 7. Live test
+## 7. Rollback notes
+
+Do not remove `OMISE_WEBHOOK_SECRET` while there are `payment_processing` orders
+or PromptPay QR charges that may still send webhooks. Removing it disables both
+new payment readiness and the webhook receiver, so in-flight payments can no
+longer reconcile automatically.
+
+Before rollback, reconcile in-flight orders using the manual process above. The
+safest rollback is to revert the payment-security application change. If the
+system later supports disabling only the start of new online payments while
+keeping webhook reconciliation active, that is also acceptable; do not change
+production config destructively as part of rollback without owner approval.
+
+## 8. Live test
 
 Run this only in an environment that is intentionally configured to reach Omise.
 

--- a/index.js
+++ b/index.js
@@ -655,7 +655,12 @@ const app = express();
 app.set('trust proxy', 1);
 app.use(cors());
 app.use(createLineWebhookRoutes({ pool }));
-app.use(express.json());
+app.use(express.json({
+  verify: (req, _res, buf) => {
+    const pathOnly = String(req.originalUrl || req.url || "").split("?")[0];
+    if (pathOnly === "/webhooks/omise") req.rawBody = Buffer.from(buf);
+  },
+}));
 app.use(customerAuth.createCustomerAuthRoutes({ pool, env: process.env, logger: console }));
 
 // =======================================

--- a/server/routes/customerOrders.js
+++ b/server/routes/customerOrders.js
@@ -562,7 +562,7 @@ function createCustomerOrdersRoutes(deps = {}) {
       if (!updated.rows.length) {
         return res.status(202).json({
           ok: false,
-          error: "PAYMENT_PROCESSING",
+          error: "PAYMENT_RESULT_UNKNOWN",
           message: "กำลังตรวจสอบการชำระเงิน",
           order: publicOrder(claim.order),
           payment: { status: PROCESSING_STATUS, requires_polling: true },
@@ -580,7 +580,6 @@ function createCustomerOrdersRoutes(deps = {}) {
         },
       });
     } catch (error) {
-      if (isSchemaError(error)) return res.status(503).json({ error: "ORDERS_SCHEMA_NOT_READY" });
       console.error("[orders/pay:update] failed", error);
       return res.status(202).json({
         ok: false,

--- a/server/routes/customerOrders.js
+++ b/server/routes/customerOrders.js
@@ -1,25 +1,30 @@
 "use strict";
 
-// Customer product orders (buy flow — Phase 2).
+// Customer product orders (buy flow).
 //
-// Self-contained router: a customer places an order from the app's purchase
-// sheet (POST /public/orders), can look it up by code (GET /public/orders/:code),
-// and admins can list orders (GET /admin/orders). Payment is a later phase —
-// an order starts as "pending_payment". This module deliberately does NOT touch
-// booking, pricing, payout, or accounting logic.
+// Security invariants:
+// - Checkout snapshots product name/price from catalog tables only.
+// - Payment claims a unique attempt before any Omise call.
+// - Webhooks are verified, then reconciled against the real Omise charge.
 
 const express = require("express");
-const { createOmiseClient, chargeToOrderStatus, promptPayQrUri } = require("../services/omise");
+const crypto = require("crypto");
+const {
+  createOmiseClient,
+  chargeToOrderStatus,
+  promptPayQrUri,
+  bahtToSatang,
+  isAmbiguousOmiseError,
+  isRetryableOmiseRejection,
+} = require("../services/omise");
 
 const DELIVERY_METHODS = new Set(["pickup", "ship"]);
 const INSTALL_OPTIONS = new Set(["none", "cwf"]);
 const PAYMENT_METHODS = new Set(["card", "promptpay"]);
-// Admin-driven fulfilment lifecycle for a paid order (separate from the payment
-// `status`). Kept as a flat allow-list — the admin advances it manually.
 const FULFILLMENT_STATUSES = new Set(["confirmed", "preparing", "shipped", "installing", "completed", "cancelled"]);
-// An order can only START a payment from one of these states (a fresh order, or
-// one whose previous attempt failed). This blocks paying twice for one order.
 const PAYABLE_STATUSES = new Set(["pending_payment", "payment_failed"]);
+const PROCESSING_STATUS = "payment_processing";
+const PAYMENT_ATTEMPT_PREFIX = "processing:";
 const MAX_ITEMS = 20;
 const MAX_QTY = 99;
 
@@ -27,8 +32,11 @@ function cleanText(value, max) {
   return String(value == null ? "" : value).trim().slice(0, max);
 }
 
-// A short human-friendly order code, e.g. "CWF-LM= K3F9" without spaces:
-// CWF + base36(time) + 3 random chars. Uppercased, easy to read back to staff.
+function money(value) {
+  const n = Number(value);
+  return Number.isFinite(n) ? Number(n.toFixed(2)) : 0;
+}
+
 function generateOrderCode() {
   const t = Date.now().toString(36).toUpperCase();
   let rand = "";
@@ -36,8 +44,24 @@ function generateOrderCode() {
   return `CWF-${t}${rand}`;
 }
 
-// Validate + normalize an incoming order payload. Prices/subtotal are computed
-// server-side from the submitted line items (never trust a client total).
+function newAttemptId() {
+  return crypto.randomBytes(16).toString("hex");
+}
+
+function currentAttemptId(value) {
+  const s = cleanText(value, 200);
+  return s.startsWith(PAYMENT_ATTEMPT_PREFIX) ? s.slice(PAYMENT_ATTEMPT_PREFIX.length) : "";
+}
+
+function paymentStatusForOutput(value) {
+  const s = cleanText(value, 200);
+  return s.startsWith(PAYMENT_ATTEMPT_PREFIX) ? "processing" : s;
+}
+
+function isPaymentInFlight(row) {
+  return row && (row.status === PROCESSING_STATUS || Boolean(currentAttemptId(row.payment_status)));
+}
+
 function normalizeOrder(input) {
   const errors = [];
   const body = input && typeof input === "object" ? input : {};
@@ -57,21 +81,27 @@ function normalizeOrder(input) {
 
   const rawItems = Array.isArray(body.items) ? body.items : [];
   if (!rawItems.length) errors.push("items required");
-  if (rawItems.length > MAX_ITEMS) errors.push("too many items");
 
-  let subtotal = 0;
-  const items = rawItems.slice(0, MAX_ITEMS).map((raw, index) => {
+  const aggregate = new Map();
+  rawItems.forEach((raw, index) => {
     const item = raw && typeof raw === "object" ? raw : {};
     const itemId = cleanText(item.item_id, 80);
-    const itemName = cleanText(item.name || item.item_name, 200);
-    const qty = Math.max(1, Math.min(MAX_QTY, Math.round(Number(item.qty) || 0)));
-    const unitPrice = Number(item.unit_price);
     if (!itemId) errors.push(`items.${index}.item_id required`);
-    if (!itemName) errors.push(`items.${index}.name required`);
-    if (!Number.isFinite(unitPrice) || unitPrice < 0) errors.push(`items.${index}.unit_price invalid`);
-    const safePrice = Number.isFinite(unitPrice) && unitPrice >= 0 ? Math.round(unitPrice * 100) / 100 : 0;
-    subtotal += safePrice * qty;
-    return { item_id: itemId, name: itemName, qty, unit_price: safePrice };
+    if (itemId && !/^\d+$/.test(itemId)) errors.push(`items.${index}.item_id invalid`);
+
+    const qty = Number(item.qty);
+    if (!Number.isInteger(qty) || qty < 1 || qty > MAX_QTY) {
+      errors.push(`items.${index}.qty invalid`);
+      return;
+    }
+    if (!itemId || !/^\d+$/.test(itemId)) return;
+    aggregate.set(itemId, (aggregate.get(itemId) || 0) + qty);
+  });
+
+  const items = Array.from(aggregate.entries()).map(([item_id, qty]) => ({ item_id, qty }));
+  if (items.length > MAX_ITEMS) errors.push("too many items");
+  items.forEach((item) => {
+    if (item.qty > MAX_QTY) errors.push(`items.${item.item_id}.qty exceeds max`);
   });
 
   return {
@@ -84,13 +114,94 @@ function normalizeOrder(input) {
       install_option: install,
       address,
       items,
-      subtotal: Math.round(subtotal * 100) / 100,
       note: cleanText(body.note, 500),
     },
   };
 }
 
-// Only fields safe to return to the customer for an order.
+function catalogRuleCurrentlyActive(row, nowMs = Date.now()) {
+  if (row.price_rule_id == null || !row.rule_is_active) return false;
+  const from = row.rule_effective_from ? new Date(row.rule_effective_from).getTime() : null;
+  const to = row.rule_effective_to ? new Date(row.rule_effective_to).getTime() : null;
+  const afterStart = from === null || Number.isNaN(from) || nowMs >= from;
+  const beforeEnd = to === null || Number.isNaN(to) || nowMs <= to;
+  return afterStart && beforeEnd;
+}
+
+function catalogEffectiveUnitPrice(row, nowMs = Date.now()) {
+  return money(catalogRuleCurrentlyActive(row, nowMs) ? row.rule_active_price : row.base_price);
+}
+
+async function withDbClient(pool, fn) {
+  if (pool && typeof pool.connect === "function") {
+    const client = await pool.connect();
+    try {
+      return await fn(client);
+    } finally {
+      if (client && typeof client.release === "function") client.release();
+    }
+  }
+  return fn(pool);
+}
+
+async function inTransaction(pool, fn) {
+  return withDbClient(pool, async (client) => {
+    await client.query("BEGIN");
+    try {
+      const result = await fn(client);
+      await client.query("COMMIT");
+      return result;
+    } catch (error) {
+      try { await client.query("ROLLBACK"); } catch (_) {}
+      throw error;
+    }
+  });
+}
+
+async function buildServerOrderSnapshot(client, normalized) {
+  const itemIds = normalized.items.map((item) => Number(item.item_id));
+  const result = await client.query(
+    `SELECT ci.item_id, ci.item_name, ci.base_price, ci.is_active, ci.is_customer_visible,
+            ci.booking_mode, ci.price_rule_id,
+            pr.active_price AS rule_active_price, pr.is_active AS rule_is_active,
+            pr.effective_from AS rule_effective_from, pr.effective_to AS rule_effective_to
+       FROM public.catalog_items ci
+       LEFT JOIN public.customer_service_price_rules pr ON pr.rule_id = ci.price_rule_id
+      WHERE ci.item_id = ANY($1::bigint[])`,
+    [itemIds]
+  );
+  const byId = new Map((result.rows || []).map((row) => [String(row.item_id), row]));
+  const errors = [];
+  let subtotal = 0;
+  const items = [];
+  for (const requested of normalized.items) {
+    const row = byId.get(String(requested.item_id));
+    if (!row) { errors.push(`items.${requested.item_id} not found`); continue; }
+    if (row.is_active !== true) errors.push(`items.${requested.item_id} inactive`);
+    if (row.is_customer_visible !== true) errors.push(`items.${requested.item_id} hidden`);
+    if (row.booking_mode !== "purchase") errors.push(`items.${requested.item_id} not purchase`);
+    const unitPrice = catalogEffectiveUnitPrice(row);
+    if (!(unitPrice > 0)) errors.push(`items.${requested.item_id} price invalid`);
+    const lineTotal = money(unitPrice * requested.qty);
+    subtotal = money(subtotal + lineTotal);
+    items.push({
+      item_id: String(row.item_id),
+      name: row.item_name,
+      item_name: row.item_name,
+      qty: requested.qty,
+      unit_price: unitPrice,
+      line_total: lineTotal,
+    });
+  }
+  if (errors.length) {
+    const err = new Error("ORDER_ITEM_VALIDATION_FAILED");
+    err.code = "ORDER_ITEM_VALIDATION_FAILED";
+    err.details = errors;
+    throw err;
+  }
+  return { items, subtotal };
+}
+
 function publicOrder(row) {
   if (!row) return null;
   return {
@@ -103,16 +214,12 @@ function publicOrder(row) {
     items: Array.isArray(row.items) ? row.items : (row.items || []),
     subtotal: Number(row.subtotal) || 0,
     status: row.status,
-    // Fulfilment is undefined until the fulfilment migration/columns exist; a
-    // paid-but-not-yet-handled order simply has an empty fulfilment_status.
     fulfillment_status: row.fulfillment_status || "",
     admin_note: row.admin_note || "",
     created_at: row.created_at,
   };
 }
 
-// Admin view: everything in publicOrder plus payment details (for the orders
-// dashboard). note is admin-only too.
 function adminOrder(row) {
   const base = publicOrder(row);
   if (!base) return null;
@@ -120,7 +227,7 @@ function adminOrder(row) {
     ...base,
     note: row.note || "",
     payment_method: row.payment_method || "",
-    payment_status: row.payment_status || "",
+    payment_status: paymentStatusForOutput(row.payment_status),
     payment_charge_id: row.payment_charge_id || "",
     paid_at: row.paid_at || null,
   };
@@ -132,36 +239,152 @@ function isUndefinedColumn(error) {
 
 function isSchemaError(error) {
   const code = error && error.code;
-  return code === "42P01" || code === "42703"; // undefined_table / undefined_column
+  return code === "42P01" || code === "42703";
+}
+
+function getWebhookSecret(env) {
+  return cleanText(env && env.OMISE_WEBHOOK_SECRET, 500);
+}
+
+function paymentReadiness(omise, env) {
+  const webhookReady = Boolean(getWebhookSecret(env));
+  const secretReady = omise.isConfigured();
+  const publicKey = cleanText(omise.getPublicKey && omise.getPublicKey(), 200);
+  const enabled = secretReady && webhookReady;
+  return {
+    enabled,
+    secretReady,
+    webhookReady,
+    publicKey,
+    methods: enabled ? ["promptpay", ...(publicKey ? ["card"] : [])] : [],
+  };
+}
+
+function safeHeader(req, name) {
+  return (typeof req.get === "function" ? req.get(name) : (req.headers && req.headers[name.toLowerCase()])) || "";
+}
+
+function signatureCandidates(value) {
+  return String(value || "")
+    .split(",")
+    .map((part) => part.trim())
+    .map((part) => part.includes("=") ? part.split("=").pop().trim() : part)
+    .filter(Boolean);
+}
+
+function verifyOmiseWebhookSignature(req, secret) {
+  const timestamp = cleanText(safeHeader(req, "Omise-Signature-Timestamp"), 80);
+  const header = safeHeader(req, "Omise-Signature");
+  const raw = Buffer.isBuffer(req.rawBody) ? req.rawBody : Buffer.from(req.rawBody || "");
+  if (!timestamp || !header || !raw.length) return { ok: false };
+  const signed = Buffer.concat([Buffer.from(`${timestamp}.`, "utf8"), raw]);
+  const expected = crypto.createHmac("sha256", secret).update(signed).digest();
+  for (const candidate of signatureCandidates(header)) {
+    if (!/^[0-9a-f]{64}$/i.test(candidate)) continue;
+    const actual = Buffer.from(candidate, "hex");
+    if (actual.length === expected.length && crypto.timingSafeEqual(actual, expected)) return { ok: true };
+  }
+  return { ok: false };
+}
+
+function chargeMetadata(charge) {
+  return charge && charge.metadata && typeof charge.metadata === "object" ? charge.metadata : {};
+}
+
+function chargeAmountMatchesOrder(charge, order) {
+  return Number(charge && charge.amount) === bahtToSatang(order && order.subtotal);
+}
+
+function chargeCurrencyIsThb(charge) {
+  return String(charge && charge.currency || "").toLowerCase() === "thb";
+}
+
+async function applyVerifiedCharge(pool, charge) {
+  return inTransaction(pool, async (client) => {
+    const metadata = chargeMetadata(charge);
+    const metaOrderCode = cleanText(metadata.order_code, 40);
+    const metaAttemptId = cleanText(metadata.attempt_id, 120);
+    let found = await client.query(
+      `SELECT order_code, subtotal, status, payment_status, payment_charge_id, paid_at
+         FROM public.customer_orders
+        WHERE payment_charge_id=$1
+        FOR UPDATE`,
+      [charge.id]
+    );
+    let order = found.rows[0] || null;
+    let matchedBy = order ? "charge_id" : "";
+
+    if (!order && metaOrderCode && metaAttemptId) {
+      found = await client.query(
+        `SELECT order_code, subtotal, status, payment_status, payment_charge_id, paid_at
+           FROM public.customer_orders
+          WHERE order_code=$1
+          FOR UPDATE`,
+        [metaOrderCode]
+      );
+      const candidate = found.rows[0] || null;
+      if (candidate && candidate.status === PROCESSING_STATUS && currentAttemptId(candidate.payment_status) === metaAttemptId) {
+        order = candidate;
+        matchedBy = "metadata";
+      }
+    }
+
+    if (!order) return { status: 200, body: { ok: true, ignored: true } };
+    if (metaOrderCode && metaOrderCode !== order.order_code) return { status: 200, body: { ok: true, ignored: true } };
+    if (matchedBy === "metadata" && currentAttemptId(order.payment_status) !== metaAttemptId) {
+      return { status: 200, body: { ok: true, ignored: true } };
+    }
+    if (!chargeAmountMatchesOrder(charge, order) || !chargeCurrencyIsThb(charge)) {
+      return { status: 200, body: { ok: true, ignored: true } };
+    }
+    if (order.status === "paid") return { status: 200, body: { ok: true, replayed: true } };
+
+    const mapped = chargeToOrderStatus(charge);
+    await client.query(
+      `UPDATE public.customer_orders
+          SET payment_charge_id=COALESCE(payment_charge_id, $2),
+              payment_status=$3,
+              status=$4,
+              paid_at = CASE WHEN $4='paid' AND paid_at IS NULL THEN now() ELSE paid_at END,
+              updated_at=now()
+        WHERE order_code=$1`,
+      [order.order_code, charge.id, charge.status || null, mapped]
+    );
+    return { status: 200, body: { ok: true } };
+  });
 }
 
 function createCustomerOrdersRoutes(deps = {}) {
   const { pool, requireAdminSession } = deps;
-  // Injectable so tests can drive a fake Omise; defaults to an env-keyed client.
-  const omise = deps.omiseClient || createOmiseClient({ env: deps.env || process.env });
+  const env = deps.env || process.env;
+  const omise = deps.omiseClient || createOmiseClient({ env });
   const router = express.Router();
   const adminGuard = typeof requireAdminSession === "function" ? requireAdminSession : (_req, _res, next) => next();
 
-  // Create an order (public — customer may be a guest).
   router.post("/public/orders", async (req, res) => {
     const result = normalizeOrder(req.body);
     if (!result.ok) return res.status(400).json({ error: "VALIDATION_FAILED", details: result.errors });
     const o = result.value;
-    // A few attempts in the unlikely event of an order_code collision.
     for (let attempt = 0; attempt < 5; attempt += 1) {
       const code = generateOrderCode();
       try {
-        const inserted = await pool.query(
-          `INSERT INTO public.customer_orders
-             (order_code, customer_name, customer_phone, delivery_method, install_option, address, items, subtotal, status, note)
-           VALUES ($1,$2,$3,$4,$5,$6,$7::jsonb,$8,'pending_payment',$9)
-           RETURNING order_code, customer_name, customer_phone, delivery_method, install_option, address, items, subtotal, status, created_at`,
-          [code, o.customer_name, o.customer_phone, o.delivery_method, o.install_option, o.address || null,
-            JSON.stringify(o.items), o.subtotal, o.note || null]
-        );
+        const inserted = await inTransaction(pool, async (client) => {
+          const snapshot = await buildServerOrderSnapshot(client, o);
+          return client.query(
+            `INSERT INTO public.customer_orders
+               (order_code, customer_name, customer_phone, delivery_method, install_option, address, items, subtotal, status, note)
+             VALUES ($1,$2,$3,$4,$5,$6,$7::jsonb,$8,'pending_payment',$9)
+             RETURNING order_code, customer_name, customer_phone, delivery_method, install_option, address, items, subtotal, status, created_at`,
+            [code, o.customer_name, o.customer_phone, o.delivery_method, o.install_option, o.address || null,
+              JSON.stringify(snapshot.items), snapshot.subtotal, o.note || null]
+          );
+        });
         return res.status(201).json({ ok: true, order: publicOrder(inserted.rows[0]) });
       } catch (error) {
-        if (error && error.code === "23505") continue; // unique_violation on order_code → retry
+        if (error && error.code === "23505") continue;
+        if (error && error.code === "ORDER_ITEM_VALIDATION_FAILED") {
+          return res.status(400).json({ error: "ORDER_ITEM_VALIDATION_FAILED", details: error.details || [] });
+        }
         if (isSchemaError(error)) return res.status(503).json({ error: "ORDERS_SCHEMA_NOT_READY" });
         console.error("[orders/create] failed", error);
         return res.status(500).json({ error: "สร้างคำสั่งซื้อไม่สำเร็จ" });
@@ -170,7 +393,6 @@ function createCustomerOrdersRoutes(deps = {}) {
     return res.status(500).json({ error: "สร้างคำสั่งซื้อไม่สำเร็จ" });
   });
 
-  // Look up one order by its code (public — the code is the access token).
   router.get("/public/orders/:code", async (req, res) => {
     const code = cleanText(req.params.code, 40);
     if (!code) return res.status(400).json({ error: "order code required" });
@@ -178,8 +400,6 @@ function createCustomerOrdersRoutes(deps = {}) {
     try {
       let found;
       try {
-        // Include fulfilment fields so the customer can track their order. If the
-        // fulfilment migration hasn't run yet, fall back to the base columns.
         found = await pool.query(
           `SELECT ${base}, fulfillment_status, admin_note FROM public.customer_orders WHERE order_code=$1 LIMIT 1`,
           [code]
@@ -197,77 +417,146 @@ function createCustomerOrdersRoutes(deps = {}) {
     }
   });
 
-  // Public: what the customer app needs to render the payment step. Exposes the
-  // PUBLIC key only (safe to ship to the browser) — never the secret key.
   router.get("/public/payment-config", (_req, res) => {
-    const enabled = omise.isConfigured();
+    const ready = paymentReadiness(omise, env);
     return res.json({
-      enabled,
+      enabled: ready.enabled,
       provider: "omise",
-      public_key: enabled ? omise.getPublicKey() : "",
-      test_mode: enabled ? omise.isTestMode() : false,
-      methods: ["promptpay", "card"],
+      public_key: ready.enabled && ready.publicKey ? ready.publicKey : "",
+      test_mode: ready.enabled ? omise.isTestMode() : false,
+      methods: ready.methods,
     });
   });
 
-  // Pay for an order. The amount is ALWAYS the server-stored subtotal — the
-  // client cannot influence how much is charged. Card: pass a one-time token
-  // from Omise.js (card data never reaches us). PromptPay: we return a QR to
-  // scan; the actual payment is confirmed later by the Omise webhook.
   router.post("/public/orders/:code/pay", async (req, res) => {
-    if (!omise.isConfigured()) return res.status(503).json({ error: "PAYMENT_NOT_CONFIGURED" });
+    const ready = paymentReadiness(omise, env);
+    if (!ready.enabled) return res.status(503).json({ error: "PAYMENT_NOT_CONFIGURED" });
     const code = cleanText(req.params.code, 40);
     if (!code) return res.status(400).json({ error: "order code required" });
     const method = cleanText(req.body && req.body.method, 20);
     if (!PAYMENT_METHODS.has(method)) return res.status(400).json({ error: "payment method invalid" });
+    if (method === "card" && !ready.publicKey) return res.status(503).json({ error: "CARD_PAYMENT_NOT_CONFIGURED" });
     const token = cleanText(req.body && req.body.token, 200);
     if (method === "card" && !token) return res.status(400).json({ error: "card token required" });
 
-    let order;
+    let claim;
     try {
-      const found = await pool.query(
-        `SELECT order_code, subtotal, status FROM public.customer_orders WHERE order_code=$1 LIMIT 1`,
-        [code]
-      );
-      if (!found.rows.length) return res.status(404).json({ error: "ไม่พบคำสั่งซื้อนี้" });
-      order = found.rows[0];
+      claim = await inTransaction(pool, async (client) => {
+        const found = await client.query(
+          `SELECT order_code, customer_name, customer_phone, delivery_method, install_option, address, items, subtotal,
+                  status, payment_status, payment_charge_id, paid_at
+             FROM public.customer_orders
+            WHERE order_code=$1
+            FOR UPDATE`,
+          [code]
+        );
+        if (!found.rows.length) return { type: "missing" };
+        const order = found.rows[0];
+        if (order.status === "paid") return { type: "already_paid", order };
+        if (isPaymentInFlight(order)) return { type: "processing", order };
+        if (!PAYABLE_STATUSES.has(order.status)) return { type: "not_payable", order };
+        const amount = money(order.subtotal);
+        if (amount <= 0) return { type: "invalid_amount", order };
+        const attemptId = newAttemptId();
+        const updated = await client.query(
+          `UPDATE public.customer_orders
+              SET payment_provider='omise', payment_method=$2, payment_charge_id=NULL,
+                  payment_status=$3, status='payment_processing',
+                  updated_at=now()
+            WHERE order_code=$1
+            RETURNING order_code, customer_name, customer_phone, delivery_method, install_option, address, items, subtotal,
+                      status, payment_status, payment_charge_id, paid_at`,
+          [code, method, `${PAYMENT_ATTEMPT_PREFIX}${attemptId}`]
+        );
+        return { type: "claimed", order: updated.rows[0], amount, attemptId };
+      });
     } catch (error) {
       if (isSchemaError(error)) return res.status(503).json({ error: "ORDERS_SCHEMA_NOT_READY" });
-      console.error("[orders/pay:lookup] failed", error);
+      console.error("[orders/pay:claim] failed", error);
       return res.status(500).json({ error: "เริ่มการชำระเงินไม่สำเร็จ" });
     }
 
-    if (!PAYABLE_STATUSES.has(order.status)) {
-      // Already paid or a payment is already in progress — tell the client so it
-      // can just poll the order status instead of charging again.
-      return res.status(409).json({ error: "ORDER_NOT_PAYABLE", status: order.status });
+    if (claim.type === "missing") return res.status(404).json({ error: "ไม่พบคำสั่งซื้อนี้" });
+    if (claim.type === "already_paid") return res.status(409).json({ error: "ORDER_ALREADY_PAID", status: "paid", order: publicOrder(claim.order) });
+    if (claim.type === "processing") {
+      return res.status(202).json({
+        ok: false,
+        error: "PAYMENT_PROCESSING",
+        message: "กำลังตรวจสอบการชำระเงิน",
+        order: publicOrder(claim.order),
+        payment: { status: PROCESSING_STATUS, requires_polling: true },
+      });
     }
-    const amount = Number(order.subtotal) || 0;
-    if (amount <= 0) return res.status(400).json({ error: "ยอดชำระไม่ถูกต้อง" });
+    if (claim.type === "not_payable") return res.status(409).json({ error: "ORDER_NOT_PAYABLE", status: claim.order.status });
+    if (claim.type === "invalid_amount") return res.status(400).json({ error: "ยอดชำระไม่ถูกต้อง" });
 
     let charge;
     try {
-      const metadata = { order_code: code };
+      const metadata = { order_code: code, attempt_id: claim.attemptId };
       charge = method === "card"
-        ? await omise.createCardCharge({ amount, token, metadata })
-        : await omise.createPromptPayCharge({ amount, metadata });
+        ? await omise.createCardCharge({ amount: claim.amount, token, metadata })
+        : await omise.createPromptPayCharge({ amount: claim.amount, metadata });
     } catch (error) {
       console.error("[orders/pay:charge] failed", error && error.code);
-      return res.status(502).json({ error: "ชำระเงินไม่สำเร็จ กรุณาลองใหม่", code: error && error.code });
+      if (isRetryableOmiseRejection(error)) {
+        let markedFailed = false;
+        try {
+          await inTransaction(pool, async (client) => {
+            await client.query(
+              `UPDATE public.customer_orders
+                  SET payment_status=$3, status='payment_failed', updated_at=now()
+                WHERE order_code=$1 AND payment_status=$2`,
+              [code, `${PAYMENT_ATTEMPT_PREFIX}${claim.attemptId}`, error.code || "omise_rejected"]
+            );
+          });
+          markedFailed = true;
+        } catch (updateError) {
+          console.error("[orders/pay:failure-update] failed", updateError);
+        }
+        if (!markedFailed) {
+          return res.status(202).json({
+            ok: false,
+            error: "PAYMENT_RESULT_UNKNOWN",
+            message: "กำลังตรวจสอบการชำระเงิน",
+            order: publicOrder(claim.order),
+            payment: { status: PROCESSING_STATUS, requires_polling: true },
+          });
+        }
+        return res.status(502).json({ error: "ชำระเงินไม่สำเร็จ กรุณาลองใหม่", code: error && error.code });
+      }
+      if (isAmbiguousOmiseError(error)) {
+        return res.status(202).json({
+          ok: false,
+          error: "PAYMENT_RESULT_UNKNOWN",
+          message: "กำลังตรวจสอบการชำระเงิน",
+          order: publicOrder(claim.order),
+          payment: { status: PROCESSING_STATUS, requires_polling: true },
+        });
+      }
+      return res.status(502).json({ error: "ชำระเงินไม่สำเร็จ", code: error && error.code });
     }
 
     const mapped = chargeToOrderStatus(charge);
     try {
-      const updated = await pool.query(
+      const updated = await inTransaction(pool, async (client) => client.query(
         `UPDATE public.customer_orders
             SET payment_provider='omise', payment_method=$2, payment_charge_id=$3,
                 payment_status=$4, status=$5,
-                paid_at = CASE WHEN $5='paid' THEN now() ELSE paid_at END,
+                paid_at = CASE WHEN $5='paid' AND paid_at IS NULL THEN now() ELSE paid_at END,
                 updated_at = now()
-          WHERE order_code=$1
+          WHERE order_code=$1 AND payment_status=$6
           RETURNING order_code, customer_name, customer_phone, delivery_method, install_option, address, items, subtotal, status, created_at`,
-        [code, method, charge.id || null, (charge && charge.status) || null, mapped]
-      );
+        [code, method, charge.id || null, (charge && charge.status) || null, mapped, `${PAYMENT_ATTEMPT_PREFIX}${claim.attemptId}`]
+      ));
+      if (!updated.rows.length) {
+        return res.status(202).json({
+          ok: false,
+          error: "PAYMENT_PROCESSING",
+          message: "กำลังตรวจสอบการชำระเงิน",
+          order: publicOrder(claim.order),
+          payment: { status: PROCESSING_STATUS, requires_polling: true },
+        });
+      }
       return res.json({
         ok: true,
         order: publicOrder(updated.rows[0]),
@@ -275,11 +564,8 @@ function createCustomerOrdersRoutes(deps = {}) {
           method,
           status: mapped,
           charge_id: charge.id || null,
-          // PromptPay only: the QR the customer scans in their banking app.
           qr_uri: method === "promptpay" ? promptPayQrUri(charge) : null,
-          // The client should poll GET /public/orders/:code until status leaves
-          // 'payment_processing' (PromptPay) — card resolves synchronously.
-          requires_polling: mapped === "payment_processing",
+          requires_polling: mapped === PROCESSING_STATUS,
         },
       });
     } catch (error) {
@@ -289,42 +575,29 @@ function createCustomerOrdersRoutes(deps = {}) {
     }
   });
 
-  // Omise webhook. Omise webhooks are NOT signed, so we never trust the payload:
-  // we take the charge id from it, re-fetch the charge from Omise (source of
-  // truth), then update the matching order. Idempotent — replays are no-ops.
-  // Always answer 200 so Omise stops retrying a delivered event.
   router.post("/webhooks/omise", async (req, res) => {
     try {
+      const webhookSecret = getWebhookSecret(env);
+      if (!webhookSecret) return res.status(503).json({ error: "OMISE_WEBHOOK_NOT_CONFIGURED" });
+      const signature = verifyOmiseWebhookSignature(req, webhookSecret);
+      if (!signature.ok) return res.status(401).json({ error: "OMISE_WEBHOOK_SIGNATURE_INVALID" });
+
       const event = req.body && typeof req.body === "object" ? req.body : {};
       const data = event.data && typeof event.data === "object" ? event.data : {};
-      // The event data object may be the charge, or (for source events) carry it.
       const chargeId = cleanText(data.object === "charge" ? data.id : (data.charge || ""), 80);
       if (!chargeId || !omise.isConfigured()) return res.json({ ok: true, ignored: true });
 
-      const charge = await omise.retrieveCharge(chargeId).catch(() => null);
+      const charge = await omise.retrieveCharge(chargeId);
       if (!charge || !charge.id) return res.json({ ok: true, ignored: true });
-      const mapped = chargeToOrderStatus(charge);
-
-      await pool.query(
-        `UPDATE public.customer_orders
-            SET payment_status=$2, status=$3,
-                paid_at = CASE WHEN $3='paid' AND paid_at IS NULL THEN now() ELSE paid_at END,
-                updated_at = now()
-          WHERE payment_charge_id=$1`,
-        [charge.id, charge.status || null, mapped]
-      );
-      return res.json({ ok: true });
+      const result = await applyVerifiedCharge(pool, charge);
+      return res.status(result.status || 200).json(result.body || { ok: true });
     } catch (error) {
-      if (isSchemaError(error)) return res.json({ ok: true, ignored: true });
-      console.error("[orders/webhook] failed", error);
-      // Still 200: a 500 makes Omise retry a payload we can't process anyway.
-      return res.json({ ok: false });
+      if (isSchemaError(error)) return res.status(503).json({ ok: false, error: "ORDERS_SCHEMA_NOT_READY" });
+      console.error("[orders/webhook] failed", error && error.code);
+      return res.status(502).json({ ok: false, error: "OMISE_WEBHOOK_PROCESSING_FAILED" });
     }
   });
 
-  // Admin: list recent orders (read-only). Includes payment details when the
-  // payment columns exist; on a DB that has orders but not yet the payment
-  // migration, it falls back to the base columns so the list still loads.
   const ADMIN_BASE_COLUMNS = "order_code, customer_name, customer_phone, delivery_method, install_option, address, items, subtotal, status, note, created_at";
   const ADMIN_EXTRA_COLUMNS = "payment_method, payment_status, payment_charge_id, paid_at, fulfillment_status, admin_note";
   router.get("/admin/orders", adminGuard, async (_req, res) => {
@@ -336,7 +609,7 @@ function createCustomerOrdersRoutes(deps = {}) {
              FROM public.customer_orders ORDER BY created_at DESC LIMIT 200`
         );
       } catch (inner) {
-        if (!isUndefinedColumn(inner)) throw inner; // real error → outer catch
+        if (!isUndefinedColumn(inner)) throw inner;
         rows = await pool.query(
           `SELECT ${ADMIN_BASE_COLUMNS}
              FROM public.customer_orders ORDER BY created_at DESC LIMIT 200`
@@ -350,8 +623,6 @@ function createCustomerOrdersRoutes(deps = {}) {
     }
   });
 
-  // Admin: advance an order's fulfilment status and/or leave a customer-visible
-  // note. Payment `status` is never touched here — this is the fulfilment lane.
   router.post("/admin/orders/:code/status", adminGuard, async (req, res) => {
     const code = cleanText(req.params.code, 40);
     if (!code) return res.status(400).json({ error: "order code required" });
@@ -385,4 +656,14 @@ function createCustomerOrdersRoutes(deps = {}) {
   return router;
 }
 
-module.exports = { createCustomerOrdersRoutes, normalizeOrder, generateOrderCode, publicOrder, adminOrder };
+module.exports = {
+  createCustomerOrdersRoutes,
+  normalizeOrder,
+  generateOrderCode,
+  publicOrder,
+  adminOrder,
+  catalogRuleCurrentlyActive,
+  catalogEffectiveUnitPrice,
+  verifyOmiseWebhookSignature,
+  applyVerifiedCharge,
+};

--- a/server/routes/customerOrders.js
+++ b/server/routes/customerOrders.js
@@ -242,8 +242,18 @@ function isSchemaError(error) {
   return code === "42P01" || code === "42703";
 }
 
+function decodeOmiseWebhookSecret(secret) {
+  const raw = cleanText(secret, 1000);
+  if (!raw || raw.length % 4 !== 0 || !/^[A-Za-z0-9+/]+={0,2}$/.test(raw)) return null;
+  const decoded = Buffer.from(raw, "base64");
+  if (!decoded.length) return null;
+  const normalizedInput = raw.replace(/=+$/, "");
+  const normalizedOutput = decoded.toString("base64").replace(/=+$/, "");
+  return normalizedInput === normalizedOutput ? decoded : null;
+}
+
 function getWebhookSecret(env) {
-  return cleanText(env && env.OMISE_WEBHOOK_SECRET, 500);
+  return decodeOmiseWebhookSecret(env && env.OMISE_WEBHOOK_SECRET);
 }
 
 function paymentReadiness(omise, env) {
@@ -272,13 +282,13 @@ function signatureCandidates(value) {
     .filter(Boolean);
 }
 
-function verifyOmiseWebhookSignature(req, secret) {
+function verifyOmiseWebhookSignature(req, secretKey) {
   const timestamp = cleanText(safeHeader(req, "Omise-Signature-Timestamp"), 80);
   const header = safeHeader(req, "Omise-Signature");
   const raw = Buffer.isBuffer(req.rawBody) ? req.rawBody : Buffer.from(req.rawBody || "");
-  if (!timestamp || !header || !raw.length) return { ok: false };
+  if (!Buffer.isBuffer(secretKey) || !secretKey.length || !timestamp || !header || !raw.length) return { ok: false };
   const signed = Buffer.concat([Buffer.from(`${timestamp}.`, "utf8"), raw]);
-  const expected = crypto.createHmac("sha256", secret).update(signed).digest();
+  const expected = crypto.createHmac("sha256", secretKey).update(signed).digest();
   for (const candidate of signatureCandidates(header)) {
     if (!/^[0-9a-f]{64}$/i.test(candidate)) continue;
     const actual = Buffer.from(candidate, "hex");
@@ -502,14 +512,15 @@ function createCustomerOrdersRoutes(deps = {}) {
         let markedFailed = false;
         try {
           await inTransaction(pool, async (client) => {
-            await client.query(
+            const failed = await client.query(
               `UPDATE public.customer_orders
                   SET payment_status=$3, status='payment_failed', updated_at=now()
-                WHERE order_code=$1 AND payment_status=$2`,
+                WHERE order_code=$1 AND payment_status=$2
+                RETURNING order_code`,
               [code, `${PAYMENT_ATTEMPT_PREFIX}${claim.attemptId}`, error.code || "omise_rejected"]
             );
+            markedFailed = Boolean((failed.rowCount || (failed.rows && failed.rows.length) || 0) > 0);
           });
-          markedFailed = true;
         } catch (updateError) {
           console.error("[orders/pay:failure-update] failed", updateError);
         }
@@ -571,7 +582,13 @@ function createCustomerOrdersRoutes(deps = {}) {
     } catch (error) {
       if (isSchemaError(error)) return res.status(503).json({ error: "ORDERS_SCHEMA_NOT_READY" });
       console.error("[orders/pay:update] failed", error);
-      return res.status(500).json({ error: "บันทึกผลการชำระเงินไม่สำเร็จ" });
+      return res.status(202).json({
+        ok: false,
+        error: "PAYMENT_RESULT_UNKNOWN",
+        message: "กำลังตรวจสอบการชำระเงิน",
+        order: publicOrder(claim.order),
+        payment: { status: PROCESSING_STATUS, requires_polling: true },
+      });
     }
   });
 

--- a/server/services/omise.js
+++ b/server/services/omise.js
@@ -162,6 +162,26 @@ function chargeToOrderStatus(charge) {
   return "payment_processing";
 }
 
+function isTerminalFailedCharge(charge) {
+  const status = charge && charge.status;
+  return status === "failed" || status === "expired" || status === "reversed";
+}
+
+function isAmbiguousOmiseError(error) {
+  if (!error) return true;
+  const status = Number(error.status || 0);
+  if (!status) return true;
+  if (status === 408 || status === 429 || status >= 500) return true;
+  const code = String(error.code || "").toUpperCase();
+  return code === "ETIMEDOUT" || code === "ECONNRESET" || code === "ECONNABORTED";
+}
+
+function isRetryableOmiseRejection(error) {
+  if (!error || isAmbiguousOmiseError(error)) return false;
+  const status = Number(error.status || 0);
+  return status >= 400 && status < 500 && status !== 408 && status !== 429;
+}
+
 // The scannable PromptPay QR image URL, if present on a charge.
 function promptPayQrUri(charge) {
   const source = charge && charge.source;
@@ -174,6 +194,9 @@ module.exports = {
   defaultHttpRequest,
   bahtToSatang,
   chargeToOrderStatus,
+  isAmbiguousOmiseError,
+  isRetryableOmiseRejection,
+  isTerminalFailedCharge,
   promptPayQrUri,
   DEFAULT_CURRENCY,
 };

--- a/test/customerAppRecovery.test.js
+++ b/test/customerAppRecovery.test.js
@@ -236,7 +236,7 @@ test("Customer App build id is consistent across shell and service worker", () =
   const sw = read("customer-app/sw.js");
   const app = read("customer-app/assets/customer-app.js");
   const manifest = read("customer-app/manifest.webmanifest");
-  const build = "20260703_lifecycle_v1";
+  const build = "20260705_payment_security_v1";
 
   assert.match(index, new RegExp(`customer-app\\.css\\?v=${build}`));
   assert.match(index, new RegExp(`modules\\/api\\.js\\?v=${build}`));
@@ -254,7 +254,7 @@ test("Customer App build id is consistent across shell and service worker", () =
 test("store module is loaded in index.html and precached in the service worker app shell", () => {
   const index = read("customer-app/index.html");
   const sw = read("customer-app/sw.js");
-  const build = "20260703_lifecycle_v1";
+  const build = "20260705_payment_security_v1";
 
   assert.match(index, new RegExp(`modules/store\\.js\\?v=${build}`));
   assert.match(sw, /`\.\/modules\/store\.js\?v=\$\{BUILD_ID\}`/);

--- a/test/customerAppStorePayment.test.js
+++ b/test/customerAppStorePayment.test.js
@@ -21,6 +21,7 @@ test("store renders a payment step offering PromptPay and card after the order i
   assert.match(storeSrc, /paymentStepHtml/);
   assert.match(storeSrc, /data-pay-method="promptpay"/);
   assert.match(storeSrc, /data-pay-method="card"/);
+  assert.match(storeSrc, /config\.methods/);
   // The order is created first, then the payment step is shown.
   assert.match(storeSrc, /renderPaymentStep\(\{ order/);
 });
@@ -37,8 +38,16 @@ test("store shows the PromptPay QR and polls the order status until it resolves"
   assert.match(storeSrc, /payOrder\(o\.order\.order_code, \{ method: "promptpay" \}\)/);
   assert.match(storeSrc, /pay-qr-img/);
   assert.match(storeSrc, /startPolling\(o\.order\.order_code/);
+  assert.match(storeSrc, /processingPaymentHtml/);
   // Polling stops on a terminal status.
   assert.match(storeSrc, /status === "paid" \|\| status === "payment_failed"/);
+});
+
+test("store sends only item_id and qty for order items and guards duplicate payment clicks", () => {
+  assert.match(storeSrc, /items: \[\{ item_id: item\.item_id, qty \}\]/);
+  assert.doesNotMatch(storeSrc, /items: \[\{ item_id: item\.item_id, name:/);
+  assert.doesNotMatch(storeSrc, /unit_price: unitPrice/);
+  assert.match(storeSrc, /paymentInFlight/);
 });
 
 test("store falls back to the LINE hand-off when payment is unconfigured or the order did not save", () => {
@@ -49,6 +58,7 @@ test("store falls back to the LINE hand-off when payment is unconfigured or the 
 test("payment step styles exist and the Customer App payment build id is bumped", () => {
   assert.match(cssSrc, /\.pay-method-btn/);
   assert.match(cssSrc, /\.pay-qr-img/);
-  assert.match(read("customer-app/index.html"), /modules\/store\.js\?v=20260703_lifecycle_v1/);
-  assert.match(read("customer-app/sw.js"), /BUILD_ID = "20260703_lifecycle_v1"/);
+  assert.match(read("customer-app/index.html"), /modules\/store\.js\?v=20260705_payment_security_v1/);
+  assert.match(read("customer-app/sw.js"), /BUILD_ID = "20260705_payment_security_v1"/);
+  assert.match(storeSrc, /payment-security 20260705 loaded/);
 });

--- a/test/customerOrders.test.js
+++ b/test/customerOrders.test.js
@@ -1,18 +1,35 @@
+"use strict";
+
 const test = require("node:test");
 const assert = require("node:assert/strict");
 const http = require("node:http");
 const express = require("express");
 
-const { createCustomerOrdersRoutes, normalizeOrder, generateOrderCode } = require("../server/routes/customerOrders");
+const { createCustomerOrdersRoutes, normalizeOrder, generateOrderCode, catalogEffectiveUnitPrice } = require("../server/routes/customerOrders");
 
-// In-memory pool that emulates the customer_orders table for INSERT/SELECT.
-function makePool({ schemaReady = true } = {}) {
+function makePool({ schemaReady = true, items = [], rules = [] } = {}) {
   const rows = [];
-  return {
+  const pool = {
     rows,
     async query(sql, params = []) {
       const s = String(sql).replace(/\s+/g, " ");
-      if (!schemaReady) { const e = new Error("relation does not exist"); e.code = "42P01"; throw e; }
+      if (["BEGIN", "COMMIT", "ROLLBACK"].includes(s)) return { rows: [] };
+      if (!schemaReady) { const e = new Error("schema missing"); e.code = "42703"; throw e; }
+      if (s.includes("FROM public.catalog_items ci")) {
+        const ids = new Set((params[0] || []).map((x) => String(x)));
+        return {
+          rows: items.filter((item) => ids.has(String(item.item_id))).map((item) => {
+            const rule = item.price_rule_id ? rules.find((r) => String(r.rule_id) === String(item.price_rule_id)) : null;
+            return {
+              ...item,
+              rule_active_price: rule ? rule.active_price : null,
+              rule_is_active: rule ? rule.is_active : null,
+              rule_effective_from: rule ? rule.effective_from : null,
+              rule_effective_to: rule ? rule.effective_to : null,
+            };
+          }),
+        };
+      }
       if (s.includes("INSERT INTO public.customer_orders")) {
         const row = {
           order_code: params[0], customer_name: params[1], customer_phone: params[2],
@@ -23,7 +40,7 @@ function makePool({ schemaReady = true } = {}) {
         rows.push(row);
         return { rows: [row] };
       }
-      if (s.includes("WHERE order_code=$1")) {
+      if (s.includes("FROM public.customer_orders WHERE order_code=$1")) {
         const found = rows.find((r) => r.order_code === params[0]);
         return { rows: found ? [found] : [] };
       }
@@ -31,110 +48,159 @@ function makePool({ schemaReady = true } = {}) {
       return { rows: [] };
     },
   };
+  return pool;
 }
 
-function startServer(pool) {
+function sampleItem(extra = {}) {
+  return {
+    item_id: 6,
+    item_name: "Server AC 12000 BTU",
+    base_price: 14900,
+    is_active: true,
+    is_customer_visible: true,
+    booking_mode: "purchase",
+    price_rule_id: null,
+    ...extra,
+  };
+}
+
+function validPayload(extra = {}) {
+  return {
+    customer_name: "Customer A",
+    customer_phone: "0812345678",
+    delivery_method: "ship",
+    install_option: "cwf",
+    address: "123 Test Road",
+    items: [{ item_id: "6", qty: 2, name: "Fake", unit_price: 1 }],
+    ...extra,
+  };
+}
+
+async function startServer(pool) {
   const app = express();
   app.use(express.json());
   app.use(createCustomerOrdersRoutes({ pool, requireAdminSession: (_q, _s, next) => next() }));
   const server = http.createServer(app);
-  return new Promise((resolve) => server.listen(0, "127.0.0.1", () => resolve(server)));
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  return server;
 }
-function baseUrl(server) { return `http://127.0.0.1:${server.address().port}`; }
 
-const validPayload = {
-  customer_name: "คุณเอ",
-  customer_phone: "0812345678",
-  delivery_method: "ship",
-  install_option: "cwf",
-  address: "123 ถนนทดสอบ",
-  items: [{ item_id: "6", name: "แอร์ Daikin 12000 BTU", qty: 2, unit_price: 14900 }],
-};
+function baseUrl(server) {
+  return `http://127.0.0.1:${server.address().port}`;
+}
 
-test("normalizeOrder computes subtotal server-side and ignores any client-sent total", () => {
-  const r = normalizeOrder({ ...validPayload, subtotal: 1 });
-  assert.equal(r.ok, true, JSON.stringify(r.errors));
-  assert.equal(r.value.subtotal, 29800); // 14900 * 2, not the client's 1
-  assert.equal(r.value.items[0].qty, 2);
+async function postOrder(server, payload) {
+  return fetch(`${baseUrl(server)}/public/orders`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(payload),
+  });
+}
+
+test("normalizeOrder rejects malformed quantities instead of coercing to one", () => {
+  assert.equal(normalizeOrder(validPayload({ items: [{ item_id: "6", qty: "abc" }] })).ok, false);
+  assert.equal(normalizeOrder(validPayload({ items: [{ item_id: "6", qty: 1.5 }] })).ok, false);
+  assert.equal(normalizeOrder(validPayload({ items: [{ item_id: "6", qty: 0 }] })).ok, false);
 });
 
-test("normalizeOrder requires name, phone, items, and address when shipping", () => {
-  assert.equal(normalizeOrder({ items: validPayload.items }).ok, false);
-  assert.equal(normalizeOrder({ customer_name: "x", customer_phone: "y", items: [] }).ok, false);
-  const noAddr = normalizeOrder({ ...validPayload, address: "" });
-  assert.equal(noAddr.ok, false);
-  assert.ok(noAddr.errors.some((e) => e.includes("address")));
-  // Pickup needs no address.
-  assert.equal(normalizeOrder({ ...validPayload, delivery_method: "pickup", address: "" }).ok, true);
+test("generateOrderCode produces a CWF-prefixed code", () => {
+  assert.match(generateOrderCode(), /^CWF-[0-9A-Z]+$/);
 });
 
-test("normalizeOrder clamps quantity and rejects invalid delivery/install/price", () => {
-  const clamped = normalizeOrder({ ...validPayload, items: [{ item_id: "1", name: "x", qty: 999, unit_price: 100 }] });
-  assert.equal(clamped.value.items[0].qty, 99);
-  assert.equal(normalizeOrder({ ...validPayload, delivery_method: "teleport" }).ok, false);
-  assert.equal(normalizeOrder({ ...validPayload, install_option: "magic" }).ok, false);
-  assert.equal(normalizeOrder({ ...validPayload, items: [{ item_id: "1", name: "x", qty: 1, unit_price: -5 }] }).ok, false);
-});
-
-test("generateOrderCode produces a unique-ish CWF-prefixed code", () => {
-  const a = generateOrderCode();
-  assert.match(a, /^CWF-[0-9A-Z]+$/);
-  assert.notEqual(a, generateOrderCode());
-});
-
-test("POST /public/orders creates an order and GET returns it; admin lists it", async () => {
-  const pool = makePool();
+test("POST /public/orders ignores client price/name and stores server catalog snapshot", async () => {
+  const pool = makePool({ items: [sampleItem()] });
   const server = await startServer(pool);
   try {
-    const url = baseUrl(server);
-    const created = await fetch(`${url}/public/orders`, {
-      method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify(validPayload),
-    });
-    assert.equal(created.status, 201);
-    const body = await created.json();
-    assert.equal(body.ok, true);
-    assert.match(body.order.order_code, /^CWF-/);
-    assert.equal(body.order.subtotal, 29800);
-    assert.equal(body.order.status, "pending_payment");
-
-    const code = body.order.order_code;
-    const got = await fetch(`${url}/public/orders/${encodeURIComponent(code)}`);
-    assert.equal(got.status, 200);
-    assert.equal((await got.json()).order.order_code, code);
-
-    const missing = await fetch(`${url}/public/orders/CWF-DOESNOTEXIST`);
-    assert.equal(missing.status, 404);
-
-    const admin = await fetch(`${url}/admin/orders`);
-    const adminBody = await admin.json();
-    assert.equal(adminBody.orders.length, 1);
-    assert.equal(adminBody.orders[0].order_code, code);
-  } finally {
-    server.close();
-  }
-});
-
-test("POST /public/orders rejects an invalid payload with 400 and details", async () => {
-  const server = await startServer(makePool());
-  try {
-    const res = await fetch(`${baseUrl(server)}/public/orders`, {
-      method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify({ items: [] }),
-    });
-    assert.equal(res.status, 400);
+    const res = await postOrder(server, validPayload());
+    assert.equal(res.status, 201);
     const body = await res.json();
-    assert.equal(body.error, "VALIDATION_FAILED");
-    assert.ok(Array.isArray(body.details) && body.details.length);
+    assert.equal(body.order.subtotal, 29800);
+    assert.equal(body.order.items[0].name, "Server AC 12000 BTU");
+    assert.equal(body.order.items[0].unit_price, 14900);
+    assert.equal(pool.rows[0].items[0].name, "Server AC 12000 BTU");
   } finally {
     server.close();
   }
 });
 
-test("routes report 503 (not 500) before the orders table migration is applied", async () => {
-  const server = await startServer(makePool({ schemaReady: false }));
+test("POST /public/orders rejects missing, inactive, hidden, and non-purchase items", async () => {
+  for (const [label, items] of [
+    ["missing", []],
+    ["inactive", [sampleItem({ is_active: false })]],
+    ["hidden", [sampleItem({ is_customer_visible: false })]],
+    ["non-purchase", [sampleItem({ booking_mode: "contact_admin" })]],
+  ]) {
+    const server = await startServer(makePool({ items }));
+    try {
+      const res = await postOrder(server, validPayload());
+      assert.equal(res.status, 400, label);
+      assert.equal((await res.json()).error, "ORDER_ITEM_VALIDATION_FAILED");
+    } finally {
+      server.close();
+    }
+  }
+});
+
+test("checkout pricing matches public catalog rule for active/expired/future/inactive promotion", async () => {
+  const now = Date.now();
+  const cases = [
+    [{ is_active: true, effective_from: null, effective_to: null }, 12000],
+    [{ is_active: true, effective_from: "2000-01-01T00:00:00Z", effective_to: "2000-02-01T00:00:00Z" }, 14900],
+    [{ is_active: true, effective_from: "2999-01-01T00:00:00Z", effective_to: null }, 14900],
+    [{ is_active: false, effective_from: null, effective_to: null }, 14900],
+  ];
+  for (const [ruleFields, expected] of cases) {
+    assert.equal(catalogEffectiveUnitPrice({
+      ...sampleItem({ price_rule_id: 9 }),
+      rule_active_price: 12000,
+      rule_is_active: ruleFields.is_active,
+      rule_effective_from: ruleFields.effective_from,
+      rule_effective_to: ruleFields.effective_to,
+    }, now), expected);
+  }
+});
+
+test("POST /public/orders uses active promotion price and falls back to base when inactive", async () => {
+  const active = await startServer(makePool({
+    items: [sampleItem({ price_rule_id: 1 })],
+    rules: [{ rule_id: 1, active_price: 12000, is_active: true, effective_from: null, effective_to: null }],
+  }));
   try {
-    const res = await fetch(`${baseUrl(server)}/public/orders`, {
-      method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify(validPayload),
-    });
+    const body = await (await postOrder(active, validPayload({ items: [{ item_id: "6", qty: 1, unit_price: 1 }] }))).json();
+    assert.equal(body.order.subtotal, 12000);
+  } finally {
+    active.close();
+  }
+
+  const inactive = await startServer(makePool({
+    items: [sampleItem({ price_rule_id: 1 })],
+    rules: [{ rule_id: 1, active_price: 12000, is_active: false, effective_from: null, effective_to: null }],
+  }));
+  try {
+    const body = await (await postOrder(inactive, validPayload({ items: [{ item_id: "6", qty: 1, unit_price: 1 }] }))).json();
+    assert.equal(body.order.subtotal, 14900);
+  } finally {
+    inactive.close();
+  }
+});
+
+test("duplicate item lines aggregate before max quantity enforcement", async () => {
+  const server = await startServer(makePool({ items: [sampleItem()] }));
+  try {
+    const res = await postOrder(server, validPayload({
+      items: [{ item_id: "6", qty: 60 }, { item_id: "6", qty: 40 }],
+    }));
+    assert.equal(res.status, 400);
+    assert.match(JSON.stringify((await res.json()).details), /exceeds max/);
+  } finally {
+    server.close();
+  }
+});
+
+test("purchase/pricing schema not ready fails closed instead of trusting client price", async () => {
+  const server = await startServer(makePool({ schemaReady: false, items: [sampleItem()] }));
+  try {
+    const res = await postOrder(server, validPayload());
     assert.equal(res.status, 503);
     assert.equal((await res.json()).error, "ORDERS_SCHEMA_NOT_READY");
   } finally {

--- a/test/customerOrdersPayment.test.js
+++ b/test/customerOrdersPayment.test.js
@@ -77,7 +77,12 @@ function makePool(seed, options = {}) {
         return { rows: [], rowCount: 0 };
       }
       if (s.includes("WHERE order_code=$1 AND payment_status=$6")) {
-        if (options.failFinalPaymentUpdate) throw new Error("simulated final payment update failure");
+        if (options.failFinalPaymentUpdate || options.failFinalPaymentUpdateCode) {
+          const e = new Error("simulated final payment update failure");
+          if (options.failFinalPaymentUpdateCode) e.code = options.failFinalPaymentUpdateCode;
+          throw e;
+        }
+        if (options.finalPaymentUpdateNoRows) return { rows: [], rowCount: 0 };
         const o = orders.get(params[0]);
         if (!o || o.payment_status !== params[5]) return { rows: [], rowCount: 0 };
         o.payment_method = params[1];
@@ -285,6 +290,49 @@ test("provider success with final DB update failure returns unknown and blocks d
     const second = await postJson(`${url(server)}/public/orders/CWF-PAY1/pay`, { method: "card", token: "tokn_x" });
     assert.equal(second.status, 202);
     assert.equal((await second.json()).error, "PAYMENT_PROCESSING");
+    assert.equal(omise.spy.charges.length, 1);
+  } finally { server.close(); }
+});
+
+test("schema-classified final DB update failure after charge returns unknown and blocks duplicate charge", async () => {
+  const pool = makePool(seedOrder(), { failFinalPaymentUpdateCode: "42703" });
+  const omise = fakeOmise();
+  const server = await startServer(pool, omise);
+  try {
+    const first = await postJson(`${url(server)}/public/orders/CWF-PAY1/pay`, { method: "card", token: "tokn_x" });
+    const firstBody = await first.json();
+    assert.equal(first.status, 202);
+    assert.equal(firstBody.error, "PAYMENT_RESULT_UNKNOWN");
+    assert.equal(firstBody.payment.status, "payment_processing");
+    assert.equal(firstBody.payment.requires_polling, true);
+    assert.equal(firstBody.order.order_code, "CWF-PAY1");
+    assert.equal(pool.orders.get("CWF-PAY1").status, "payment_processing");
+    assert.equal(omise.spy.charges.length, 1);
+
+    const second = await postJson(`${url(server)}/public/orders/CWF-PAY1/pay`, { method: "card", token: "tokn_x" });
+    assert.equal(second.status, 202);
+    assert.ok(["PAYMENT_PROCESSING", "PAYMENT_RESULT_UNKNOWN"].includes((await second.json()).error));
+    assert.equal(omise.spy.charges.length, 1);
+  } finally { server.close(); }
+});
+
+test("final DB update zero rows after charge returns unknown and blocks duplicate charge", async () => {
+  const pool = makePool(seedOrder(), { finalPaymentUpdateNoRows: true });
+  const omise = fakeOmise();
+  const server = await startServer(pool, omise);
+  try {
+    const first = await postJson(`${url(server)}/public/orders/CWF-PAY1/pay`, { method: "card", token: "tokn_x" });
+    const firstBody = await first.json();
+    assert.equal(first.status, 202);
+    assert.equal(firstBody.error, "PAYMENT_RESULT_UNKNOWN");
+    assert.equal(firstBody.payment.status, "payment_processing");
+    assert.equal(firstBody.payment.requires_polling, true);
+    assert.equal(pool.orders.get("CWF-PAY1").status, "payment_processing");
+    assert.equal(omise.spy.charges.length, 1);
+
+    const second = await postJson(`${url(server)}/public/orders/CWF-PAY1/pay`, { method: "card", token: "tokn_x" });
+    assert.equal(second.status, 202);
+    assert.ok(["PAYMENT_PROCESSING", "PAYMENT_RESULT_UNKNOWN"].includes((await second.json()).error));
     assert.equal(omise.spy.charges.length, 1);
   } finally { server.close(); }
 });

--- a/test/customerOrdersPayment.test.js
+++ b/test/customerOrdersPayment.test.js
@@ -3,42 +3,96 @@
 const test = require("node:test");
 const assert = require("node:assert/strict");
 const http = require("node:http");
+const crypto = require("node:crypto");
 const express = require("express");
 
 const { createCustomerOrdersRoutes } = require("../server/routes/customerOrders");
 
-// The base order columns publicOrder() serializes.
+const WEBHOOK_SECRET = "whsec_test";
+
 function baseRow(o) {
   return {
     order_code: o.order_code, customer_name: o.customer_name, customer_phone: o.customer_phone,
     delivery_method: o.delivery_method, install_option: o.install_option, address: o.address,
-    items: o.items, subtotal: o.subtotal, status: o.status, created_at: o.created_at,
+    items: o.items, subtotal: o.subtotal, status: o.status, payment_status: o.payment_status,
+    payment_charge_id: o.payment_charge_id, paid_at: o.paid_at, created_at: o.created_at,
   };
 }
 
-// In-memory pool handling the pay-lookup, pay-update, webhook-update and public
-// GET queries used by the payment routes.
-function makePool(seed, { schemaReady = true } = {}) {
-  const orders = new Map();
-  if (seed) orders.set(seed.order_code, { address: "", ...seed });
+function seedOrder(extra = {}) {
   return {
+    order_code: "CWF-PAY1",
+    customer_name: "Customer A",
+    customer_phone: "0812345678",
+    delivery_method: "pickup",
+    install_option: "none",
+    address: "",
+    items: [{ item_id: "6", name: "AC", qty: 1, unit_price: 14900 }],
+    subtotal: 14900,
+    status: "pending_payment",
+    payment_status: null,
+    payment_charge_id: null,
+    paid_at: null,
+    created_at: new Date().toISOString(),
+    ...extra,
+  };
+}
+
+function makePool(seed, options = {}) {
+  const orders = new Map();
+  if (seed) orders.set(seed.order_code, { ...seed });
+  const calls = [];
+  const pool = {
     orders,
+    calls,
+    failWebhookUpdate: false,
     async query(sql, params = []) {
-      if (!schemaReady) { const e = new Error("no table"); e.code = "42P01"; throw e; }
-      const s = String(sql).replace(/\s+/g, " ");
-      if (s.includes("SELECT order_code, subtotal, status FROM public.customer_orders WHERE order_code=$1")) {
+      const s = String(sql).replace(/\s+/g, " ").trim();
+      calls.push(s);
+      if (["BEGIN", "COMMIT", "ROLLBACK"].includes(s)) return { rows: [] };
+      if (options.schemaReady === false) { const e = new Error("schema missing"); e.code = "42P01"; throw e; }
+      if (s.includes("WHERE order_code=$1") && s.includes("FOR UPDATE")) {
         const o = orders.get(params[0]);
-        return { rows: o ? [{ order_code: o.order_code, subtotal: o.subtotal, status: o.status }] : [] };
+        return { rows: o ? [baseRow(o)] : [] };
       }
-      if (s.startsWith("UPDATE public.customer_orders") && s.includes("WHERE order_code=$1")) {
+      if (s.includes("SET payment_provider='omise'") && s.includes("payment_status=$3") && s.includes("payment_charge_id=NULL")) {
         const o = orders.get(params[0]);
-        if (!o) return { rows: [] };
-        o.payment_method = params[1]; o.payment_charge_id = params[2]; o.payment_status = params[3]; o.status = params[4];
+        o.payment_method = params[1];
+        o.payment_charge_id = null;
+        o.payment_status = params[2];
+        o.status = "payment_processing";
         return { rows: [baseRow(o)] };
       }
-      if (s.includes("WHERE payment_charge_id=$1")) {
-        for (const o of orders.values()) {
-          if (o.payment_charge_id === params[0]) { o.payment_status = params[1]; o.status = params[2]; }
+      if (s.includes("SET payment_status=$3, status='payment_failed'")) {
+        const o = orders.get(params[0]);
+        if (o && o.payment_status === params[1]) {
+          o.payment_status = params[2];
+          o.status = "payment_failed";
+        }
+        return { rows: [] };
+      }
+      if (s.includes("WHERE order_code=$1 AND payment_status=$6")) {
+        const o = orders.get(params[0]);
+        if (!o || o.payment_status !== params[5]) return { rows: [] };
+        o.payment_method = params[1];
+        o.payment_charge_id = params[2];
+        o.payment_status = params[3];
+        o.status = params[4];
+        if (o.status === "paid" && !o.paid_at) o.paid_at = new Date().toISOString();
+        return { rows: [baseRow(o)] };
+      }
+      if (s.includes("WHERE payment_charge_id=$1") && s.includes("FOR UPDATE")) {
+        const row = Array.from(orders.values()).find((o) => o.payment_charge_id === params[0]);
+        return { rows: row ? [baseRow(row)] : [] };
+      }
+      if (s.includes("SET payment_charge_id=COALESCE")) {
+        if (pool.failWebhookUpdate) throw new Error("simulated db failure");
+        const o = orders.get(params[0]);
+        if (o) {
+          o.payment_charge_id = o.payment_charge_id || params[1];
+          o.payment_status = params[2];
+          o.status = params[3];
+          if (o.status === "paid" && !o.paid_at) o.paid_at = new Date().toISOString();
         }
         return { rows: [] };
       }
@@ -49,142 +103,264 @@ function makePool(seed, { schemaReady = true } = {}) {
       return { rows: [] };
     },
   };
+  return pool;
 }
 
 function fakeOmise(overrides = {}) {
-  const spy = { charges: [] };
+  const spy = { charges: [], retrieve: [] };
   return {
     spy,
     isConfigured: () => overrides.configured !== false,
     isTestMode: () => true,
-    getPublicKey: () => overrides.publicKey || "pkey_test_123",
-    createCardCharge: overrides.createCardCharge || (async ({ amount, token }) => {
-      spy.charges.push({ method: "card", amount, token });
-      return { id: "chrg_card_1", status: "successful", paid: true };
+    getPublicKey: () => overrides.publicKey === undefined ? "pkey_test_123" : overrides.publicKey,
+    createCardCharge: overrides.createCardCharge || (async ({ amount, token, metadata }) => {
+      spy.charges.push({ method: "card", amount, token, metadata });
+      return { id: `chrg_${spy.charges.length}`, status: "successful", paid: true, amount: amount * 100, currency: "thb", metadata };
     }),
-    createPromptPayCharge: overrides.createPromptPayCharge || (async ({ amount }) => {
-      spy.charges.push({ method: "promptpay", amount });
-      return { id: "chrg_pp_1", status: "pending", paid: false, source: { scannable_code: { image: { download_uri: "https://cdn.omise.co/qr.png" } } } };
+    createPromptPayCharge: overrides.createPromptPayCharge || (async ({ amount, metadata }) => {
+      spy.charges.push({ method: "promptpay", amount, metadata });
+      return {
+        id: `chrg_${spy.charges.length}`,
+        status: "pending",
+        paid: false,
+        amount: amount * 100,
+        currency: "thb",
+        metadata,
+        source: { scannable_code: { image: { download_uri: "https://cdn.omise.co/qr.png" } } },
+      };
     }),
-    retrieveCharge: overrides.retrieveCharge || (async (id) => ({ id, status: "successful", paid: true })),
+    retrieveCharge: overrides.retrieveCharge || (async (id) => {
+      spy.retrieve.push(id);
+      return { id, status: "successful", paid: true, amount: 1490000, currency: "thb", metadata: { order_code: "CWF-PAY1", attempt_id: "attempt" } };
+    }),
   };
 }
 
-function seedOrder(extra = {}) {
-  return {
-    order_code: "CWF-PAY1", customer_name: "คุณเอ", customer_phone: "0812345678",
-    delivery_method: "pickup", install_option: "none", address: "",
-    items: [{ item_id: "6", name: "แอร์ Daikin 12000 BTU", qty: 1, unit_price: 14900 }],
-    subtotal: 14900, status: "pending_payment", created_at: new Date().toISOString(), ...extra,
-  };
-}
-
-function startServer(pool, omiseClient) {
+async function startServer(pool, omiseClient, env = {}) {
   const app = express();
-  app.use(express.json());
-  app.use(createCustomerOrdersRoutes({ pool, omiseClient, requireAdminSession: (_q, _s, next) => next() }));
+  app.use(express.json({
+    verify: (req, _res, buf) => {
+      if (String(req.originalUrl || "").split("?")[0] === "/webhooks/omise") req.rawBody = Buffer.from(buf);
+    },
+  }));
+  app.use(createCustomerOrdersRoutes({
+    pool,
+    omiseClient,
+    env: { OMISE_WEBHOOK_SECRET: WEBHOOK_SECRET, ...env },
+    requireAdminSession: (_q, _s, next) => next(),
+  }));
   const server = http.createServer(app);
-  return new Promise((resolve) => server.listen(0, "127.0.0.1", () => resolve(server)));
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  return server;
 }
-const url = (s) => `http://127.0.0.1:${s.address().port}`;
-const postJson = (u, body) => fetch(u, { method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify(body || {}) });
 
-test("GET /public/payment-config exposes the public key but never a secret", async () => {
-  const server = await startServer(makePool(seedOrder()), fakeOmise());
-  try {
-    const body = await (await fetch(`${url(server)}/public/payment-config`)).json();
-    assert.equal(body.enabled, true);
-    assert.equal(body.provider, "omise");
-    assert.equal(body.public_key, "pkey_test_123");
-    assert.deepEqual(body.methods, ["promptpay", "card"]);
-    assert.ok(!("secret_key" in body) && !JSON.stringify(body).includes("skey_"));
-  } finally { server.close(); }
-});
+function url(server) {
+  return `http://127.0.0.1:${server.address().port}`;
+}
 
-test("payment-config reports disabled when Omise is not configured", async () => {
-  const server = await startServer(makePool(seedOrder()), fakeOmise({ configured: false }));
+function postJson(u, body) {
+  return fetch(u, { method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify(body || {}) });
+}
+
+function signedHeaders(raw, secret = WEBHOOK_SECRET, extraSignature = "") {
+  const timestamp = "1770000000";
+  const sig = crypto.createHmac("sha256", secret).update(`${timestamp}.${raw}`).digest("hex");
+  return {
+    "content-type": "application/json",
+    "Omise-Signature-Timestamp": timestamp,
+    "Omise-Signature": extraSignature ? `${extraSignature},${sig}` : sig,
+  };
+}
+
+async function postWebhook(server, payload, headers) {
+  const raw = JSON.stringify(payload);
+  return fetch(`${url(server)}/webhooks/omise`, {
+    method: "POST",
+    headers: headers || signedHeaders(raw),
+    body: raw,
+  });
+}
+
+test("GET /public/payment-config fails closed without webhook secret and omits card without public key", async () => {
+  const noWebhook = await startServer(makePool(seedOrder()), fakeOmise(), { OMISE_WEBHOOK_SECRET: "" });
   try {
-    const body = await (await fetch(`${url(server)}/public/payment-config`)).json();
+    const body = await (await fetch(`${url(noWebhook)}/public/payment-config`)).json();
     assert.equal(body.enabled, false);
+    assert.deepEqual(body.methods, []);
+  } finally { noWebhook.close(); }
+
+  const noPublic = await startServer(makePool(seedOrder()), fakeOmise({ publicKey: "" }));
+  try {
+    const body = await (await fetch(`${url(noPublic)}/public/payment-config`)).json();
+    assert.equal(body.enabled, true);
+    assert.deepEqual(body.methods, ["promptpay"]);
     assert.equal(body.public_key, "");
-  } finally { server.close(); }
+  } finally { noPublic.close(); }
 });
 
-test("card payment charges the SERVER-stored amount, marks the order paid", async () => {
-  const omise = fakeOmise();
+test("card payment claims an attempt before charging and uses stored amount with metadata", async () => {
   const pool = makePool(seedOrder());
+  const omise = fakeOmise();
   const server = await startServer(pool, omise);
   try {
-    // The client sends amount:1 — it must be ignored; the charge uses 14900.
     const res = await postJson(`${url(server)}/public/orders/CWF-PAY1/pay`, { method: "card", token: "tokn_x", amount: 1 });
     assert.equal(res.status, 200);
-    const body = await res.json();
-    assert.equal(body.order.status, "paid");
-    assert.equal(body.payment.status, "paid");
-    assert.equal(body.payment.charge_id, "chrg_card_1");
+    assert.equal(omise.spy.charges.length, 1);
     assert.equal(omise.spy.charges[0].amount, 14900);
+    assert.equal(omise.spy.charges[0].metadata.order_code, "CWF-PAY1");
+    assert.match(omise.spy.charges[0].metadata.attempt_id, /^[0-9a-f]{32}$/);
     assert.equal(pool.orders.get("CWF-PAY1").status, "paid");
   } finally { server.close(); }
 });
 
-test("PromptPay payment returns a QR and leaves the order awaiting the webhook", async () => {
-  const server = await startServer(makePool(seedOrder()), fakeOmise());
-  try {
-    const body = await (await postJson(`${url(server)}/public/orders/CWF-PAY1/pay`, { method: "promptpay" })).json();
-    assert.equal(body.order.status, "payment_processing");
-    assert.equal(body.payment.qr_uri, "https://cdn.omise.co/qr.png");
-    assert.equal(body.payment.requires_polling, true);
-  } finally { server.close(); }
-});
-
-test("pay rejects an invalid method, a missing card token, and a non-payable order", async () => {
-  const server = await startServer(makePool(seedOrder({ status: "paid" })), fakeOmise());
-  try {
-    assert.equal((await postJson(`${url(server)}/public/orders/CWF-PAY1/pay`, { method: "bitcoin" })).status, 400);
-    assert.equal((await postJson(`${url(server)}/public/orders/CWF-PAY1/pay`, { method: "card" })).status, 400);
-    const paidRes = await postJson(`${url(server)}/public/orders/CWF-PAY1/pay`, { method: "promptpay" });
-    assert.equal(paidRes.status, 409);
-    assert.equal((await paidRes.json()).status, "paid");
-  } finally { server.close(); }
-});
-
-test("pay returns 503 when Omise is not configured, and 404 for an unknown order", async () => {
-  const notConfigured = await startServer(makePool(seedOrder()), fakeOmise({ configured: false }));
-  try {
-    assert.equal((await postJson(`${url(notConfigured)}/public/orders/CWF-PAY1/pay`, { method: "promptpay" })).status, 503);
-  } finally { notConfigured.close(); }
-
-  const server = await startServer(makePool(seedOrder()), fakeOmise());
-  try {
-    assert.equal((await postJson(`${url(server)}/public/orders/CWF-NOPE/pay`, { method: "promptpay" })).status, 404);
-  } finally { server.close(); }
-});
-
-test("webhook verifies by re-fetching the charge and flips the matching order to paid, idempotently", async () => {
-  let retrieveCalls = 0;
-  const omise = fakeOmise({ retrieveCharge: async (id) => { retrieveCalls += 1; return { id, status: "successful", paid: true }; } });
-  const pool = makePool(seedOrder({ status: "payment_processing", payment_charge_id: "chrg_pp_1", payment_status: "pending" }));
+test("concurrent duplicate pay requests create at most one charge", async () => {
+  const pool = makePool(seedOrder());
+  const omise = fakeOmise({ createPromptPayCharge: async ({ amount, metadata }) => {
+    omise.spy.charges.push({ method: "promptpay", amount, metadata });
+    await new Promise((resolve) => setTimeout(resolve, 40));
+    return { id: "chrg_pp", status: "pending", paid: false, amount: amount * 100, currency: "thb", metadata, source: { scannable_code: { image: { download_uri: "qr" } } } };
+  } });
   const server = await startServer(pool, omise);
   try {
-    const event = { key: "charge.complete", data: { object: "charge", id: "chrg_pp_1", status: "successful" } };
-    const first = await postJson(`${url(server)}/webhooks/omise`, event);
-    assert.equal(first.status, 200);
-    assert.equal((await first.json()).ok, true);
-    assert.equal(pool.orders.get("CWF-PAY1").status, "paid");
-    assert.equal(retrieveCalls, 1); // verified against Omise, not trusting the payload
-
-    // Replays are safe no-ops.
-    const second = await postJson(`${url(server)}/webhooks/omise`, event);
-    assert.equal(second.status, 200);
-    assert.equal(pool.orders.get("CWF-PAY1").status, "paid");
+    const [a, b] = await Promise.all([
+      postJson(`${url(server)}/public/orders/CWF-PAY1/pay`, { method: "promptpay" }),
+      postJson(`${url(server)}/public/orders/CWF-PAY1/pay`, { method: "promptpay" }),
+    ]);
+    assert.equal(omise.spy.charges.length, 1);
+    assert.ok([200, 202].includes(a.status));
+    assert.ok([200, 202].includes(b.status));
   } finally { server.close(); }
 });
 
-test("webhook ignores an event with no charge id and always answers 200", async () => {
-  const server = await startServer(makePool(seedOrder()), fakeOmise());
+test("deterministic failure becomes retryable and creates a new attempt B", async () => {
+  const pool = makePool(seedOrder());
+  let calls = 0;
+  const omise = fakeOmise({ createCardCharge: async ({ metadata }) => {
+    calls += 1;
+    omise.spy.charges.push({ metadata });
+    if (calls === 1) {
+      const e = new Error("bad token"); e.status = 400; e.code = "bad_request"; throw e;
+    }
+    return { id: "chrg_ok", status: "successful", paid: true, amount: 1490000, currency: "thb", metadata };
+  } });
+  const server = await startServer(pool, omise);
   try {
-    const res = await postJson(`${url(server)}/webhooks/omise`, { key: "ping", data: {} });
+    assert.equal((await postJson(`${url(server)}/public/orders/CWF-PAY1/pay`, { method: "card", token: "bad" })).status, 502);
+    assert.equal(pool.orders.get("CWF-PAY1").status, "payment_failed");
+    const second = await postJson(`${url(server)}/public/orders/CWF-PAY1/pay`, { method: "card", token: "ok" });
+    assert.equal(second.status, 200);
+    assert.notEqual(omise.spy.charges[0].metadata.attempt_id, omise.spy.charges[1].metadata.attempt_id);
+  } finally { server.close(); }
+});
+
+test("timeout, HTTP 429, and HTTP 5xx remain non-retryable in payment_processing", async () => {
+  for (const err of [
+    Object.assign(new Error("timeout"), { code: "ETIMEDOUT" }),
+    Object.assign(new Error("rate limited"), { status: 429, code: "rate_limit" }),
+    Object.assign(new Error("server error"), { status: 500, code: "server_error" }),
+  ]) {
+    const pool = makePool(seedOrder());
+    const omise = fakeOmise({ createPromptPayCharge: async () => { throw err; } });
+    const server = await startServer(pool, omise);
+    try {
+      const first = await postJson(`${url(server)}/public/orders/CWF-PAY1/pay`, { method: "promptpay" });
+      assert.equal(first.status, 202);
+      assert.equal(pool.orders.get("CWF-PAY1").status, "payment_processing");
+      const second = await postJson(`${url(server)}/public/orders/CWF-PAY1/pay`, { method: "promptpay" });
+      assert.equal(second.status, 202);
+      assert.equal(omise.spy.charges.length, 0);
+    } finally { server.close(); }
+  }
+});
+
+test("webhook validates missing, invalid, valid, dual signatures and raw tampering", async () => {
+  const pool = makePool(seedOrder({ status: "payment_processing", payment_status: "processing:attempt" }));
+  const omise = fakeOmise();
+  const server = await startServer(pool, omise);
+  const payload = { data: { object: "charge", id: "chrg_sig" } };
+  const raw = JSON.stringify(payload);
+  try {
+    assert.equal((await fetch(`${url(server)}/webhooks/omise`, { method: "POST", headers: { "content-type": "application/json" }, body: raw })).status, 401);
+    assert.equal((await postWebhook(server, payload, signedHeaders(raw, "wrong"))).status, 401);
+    assert.equal((await postWebhook(server, payload, signedHeaders(raw))).status, 200);
+
+    pool.orders.set("CWF-PAY1", seedOrder({ status: "payment_processing", payment_status: "processing:attempt" }));
+    const dual = signedHeaders(raw, WEBHOOK_SECRET, "0".repeat(64));
+    assert.equal((await postWebhook(server, payload, dual)).status, 200);
+
+    const tamperedHeaders = signedHeaders(raw);
+    assert.equal((await postWebhook(server, { data: { object: "charge", id: "different" } }, tamperedHeaders)).status, 401);
+  } finally { server.close(); }
+});
+
+test("webhook recovery requires matching order, attempt, amount and THB currency", async () => {
+  const pool = makePool(seedOrder({ status: "payment_processing", payment_status: "processing:attemptA" }));
+  const omise = fakeOmise({ retrieveCharge: async (id) => ({ id, status: "successful", paid: true, amount: 1490000, currency: "thb", metadata: { order_code: "CWF-PAY1", attempt_id: "attemptA" } }) });
+  const server = await startServer(pool, omise);
+  try {
+    const res = await postWebhook(server, { data: { object: "charge", id: "chrg_recover" } });
     assert.equal(res.status, 200);
-    assert.equal((await res.json()).ignored, true);
+    const order = pool.orders.get("CWF-PAY1");
+    assert.equal(order.status, "paid");
+    assert.equal(order.payment_charge_id, "chrg_recover");
+  } finally { server.close(); }
+});
+
+test("webhook amount or currency mismatch is ignored without mutating the order", async () => {
+  for (const charge of [
+    { id: "chrg_bad_amount", status: "successful", paid: true, amount: 100, currency: "thb", metadata: { order_code: "CWF-PAY1", attempt_id: "attemptA" } },
+    { id: "chrg_bad_currency", status: "successful", paid: true, amount: 1490000, currency: "usd", metadata: { order_code: "CWF-PAY1", attempt_id: "attemptA" } },
+  ]) {
+    const pool = makePool(seedOrder({ status: "payment_processing", payment_status: "processing:attemptA" }));
+    const omise = fakeOmise({ retrieveCharge: async () => charge });
+    const server = await startServer(pool, omise);
+    try {
+      const res = await postWebhook(server, { data: { object: "charge", id: charge.id } });
+      assert.equal(res.status, 200);
+      const order = pool.orders.get("CWF-PAY1");
+      assert.equal(order.status, "payment_processing");
+      assert.equal(order.payment_charge_id, null);
+    } finally { server.close(); }
+  }
+});
+
+test("webhook attempt mismatch and old attempt A cannot mutate newer attempt B", async () => {
+  const pool = makePool(seedOrder({ status: "payment_processing", payment_status: "processing:attemptB" }));
+  const omise = fakeOmise({ retrieveCharge: async (id) => ({ id, status: "failed", paid: false, amount: 1490000, currency: "thb", metadata: { order_code: "CWF-PAY1", attempt_id: "attemptA" } }) });
+  const server = await startServer(pool, omise);
+  try {
+    const res = await postWebhook(server, { data: { object: "charge", id: "chrg_old" } });
+    assert.equal(res.status, 200);
+    const order = pool.orders.get("CWF-PAY1");
+    assert.equal(order.status, "payment_processing");
+    assert.equal(order.payment_status, "processing:attemptB");
+    assert.equal(order.payment_charge_id, null);
+  } finally { server.close(); }
+});
+
+test("webhook replay is idempotent and paid order is not downgraded", async () => {
+  const paidAt = "2026-07-05T00:00:00.000Z";
+  const pool = makePool(seedOrder({ status: "paid", payment_status: "successful", payment_charge_id: "chrg_paid", paid_at: paidAt }));
+  const omise = fakeOmise({ retrieveCharge: async (id) => ({ id, status: "failed", paid: false, amount: 1490000, currency: "thb", metadata: { order_code: "CWF-PAY1", attempt_id: "old" } }) });
+  const server = await startServer(pool, omise);
+  try {
+    const first = await postWebhook(server, { data: { object: "charge", id: "chrg_paid" } });
+    const second = await postWebhook(server, { data: { object: "charge", id: "chrg_paid" } });
+    assert.equal(first.status, 200);
+    assert.equal(second.status, 200);
+    const order = pool.orders.get("CWF-PAY1");
+    assert.equal(order.status, "paid");
+    assert.equal(order.paid_at, paidAt);
+  } finally { server.close(); }
+});
+
+test("webhook transient DB failure is not acknowledged as successful", async () => {
+  const pool = makePool(seedOrder({ status: "payment_processing", payment_status: "processing:attempt" }));
+  pool.failWebhookUpdate = true;
+  const omise = fakeOmise({ retrieveCharge: async (id) => ({ id, status: "successful", paid: true, amount: 1490000, currency: "thb", metadata: { order_code: "CWF-PAY1", attempt_id: "attempt" } }) });
+  const server = await startServer(pool, omise);
+  try {
+    const res = await postWebhook(server, { data: { object: "charge", id: "chrg_fail" } });
+    assert.equal(res.status, 502);
   } finally { server.close(); }
 });

--- a/test/customerOrdersPayment.test.js
+++ b/test/customerOrdersPayment.test.js
@@ -4,11 +4,14 @@ const test = require("node:test");
 const assert = require("node:assert/strict");
 const http = require("node:http");
 const crypto = require("node:crypto");
+const fs = require("node:fs");
+const path = require("node:path");
 const express = require("express");
 
 const { createCustomerOrdersRoutes } = require("../server/routes/customerOrders");
 
-const WEBHOOK_SECRET = "whsec_test";
+const WEBHOOK_SECRET_BYTES = Buffer.from("omise webhook secret fixture", "utf8");
+const WEBHOOK_SECRET = WEBHOOK_SECRET_BYTES.toString("base64");
 
 function baseRow(o) {
   return {
@@ -49,11 +52,11 @@ function makePool(seed, options = {}) {
     async query(sql, params = []) {
       const s = String(sql).replace(/\s+/g, " ").trim();
       calls.push(s);
-      if (["BEGIN", "COMMIT", "ROLLBACK"].includes(s)) return { rows: [] };
+      if (["BEGIN", "COMMIT", "ROLLBACK"].includes(s)) return { rows: [], rowCount: 0 };
       if (options.schemaReady === false) { const e = new Error("schema missing"); e.code = "42P01"; throw e; }
       if (s.includes("WHERE order_code=$1") && s.includes("FOR UPDATE")) {
         const o = orders.get(params[0]);
-        return { rows: o ? [baseRow(o)] : [] };
+        return { rows: o ? [baseRow(o)] : [], rowCount: o ? 1 : 0 };
       }
       if (s.includes("SET payment_provider='omise'") && s.includes("payment_status=$3") && s.includes("payment_charge_id=NULL")) {
         const o = orders.get(params[0]);
@@ -61,29 +64,32 @@ function makePool(seed, options = {}) {
         o.payment_charge_id = null;
         o.payment_status = params[2];
         o.status = "payment_processing";
-        return { rows: [baseRow(o)] };
+        return { rows: [baseRow(o)], rowCount: 1 };
       }
       if (s.includes("SET payment_status=$3, status='payment_failed'")) {
+        if (options.failureUpdateNoMatch) return { rows: [], rowCount: 0 };
         const o = orders.get(params[0]);
         if (o && o.payment_status === params[1]) {
           o.payment_status = params[2];
           o.status = "payment_failed";
+          return { rows: [baseRow(o)], rowCount: 1 };
         }
-        return { rows: [] };
+        return { rows: [], rowCount: 0 };
       }
       if (s.includes("WHERE order_code=$1 AND payment_status=$6")) {
+        if (options.failFinalPaymentUpdate) throw new Error("simulated final payment update failure");
         const o = orders.get(params[0]);
-        if (!o || o.payment_status !== params[5]) return { rows: [] };
+        if (!o || o.payment_status !== params[5]) return { rows: [], rowCount: 0 };
         o.payment_method = params[1];
         o.payment_charge_id = params[2];
         o.payment_status = params[3];
         o.status = params[4];
         if (o.status === "paid" && !o.paid_at) o.paid_at = new Date().toISOString();
-        return { rows: [baseRow(o)] };
+        return { rows: [baseRow(o)], rowCount: 1 };
       }
       if (s.includes("WHERE payment_charge_id=$1") && s.includes("FOR UPDATE")) {
         const row = Array.from(orders.values()).find((o) => o.payment_charge_id === params[0]);
-        return { rows: row ? [baseRow(row)] : [] };
+        return { rows: row ? [baseRow(row)] : [], rowCount: row ? 1 : 0 };
       }
       if (s.includes("SET payment_charge_id=COALESCE")) {
         if (pool.failWebhookUpdate) throw new Error("simulated db failure");
@@ -94,13 +100,13 @@ function makePool(seed, options = {}) {
           o.status = params[3];
           if (o.status === "paid" && !o.paid_at) o.paid_at = new Date().toISOString();
         }
-        return { rows: [] };
+        return { rows: [], rowCount: o ? 1 : 0 };
       }
       if (s.includes("FROM public.customer_orders WHERE order_code=$1")) {
         const o = orders.get(params[0]);
-        return { rows: o ? [baseRow(o)] : [] };
+        return { rows: o ? [baseRow(o)] : [], rowCount: o ? 1 : 0 };
       }
-      return { rows: [] };
+      return { rows: [], rowCount: 0 };
     },
   };
   return pool;
@@ -162,9 +168,9 @@ function postJson(u, body) {
   return fetch(u, { method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify(body || {}) });
 }
 
-function signedHeaders(raw, secret = WEBHOOK_SECRET, extraSignature = "") {
+function signedHeaders(raw, secretBytes = WEBHOOK_SECRET_BYTES, extraSignature = "") {
   const timestamp = "1770000000";
-  const sig = crypto.createHmac("sha256", secret).update(`${timestamp}.${raw}`).digest("hex");
+  const sig = crypto.createHmac("sha256", secretBytes).update(`${timestamp}.${raw}`).digest("hex");
   return {
     "content-type": "application/json",
     "Omise-Signature-Timestamp": timestamp,
@@ -198,6 +204,23 @@ test("GET /public/payment-config fails closed without webhook secret and omits c
   } finally { noPublic.close(); }
 });
 
+test("invalid Base64 webhook secret disables payment and rejects webhooks", async () => {
+  const server = await startServer(makePool(seedOrder()), fakeOmise(), { OMISE_WEBHOOK_SECRET: "not-base64%%%" });
+  try {
+    const config = await (await fetch(`${url(server)}/public/payment-config`)).json();
+    assert.equal(config.enabled, false);
+    assert.deepEqual(config.methods, []);
+    const raw = JSON.stringify({ data: { object: "charge", id: "chrg_invalid_secret" } });
+    const res = await fetch(`${url(server)}/webhooks/omise`, {
+      method: "POST",
+      headers: signedHeaders(raw),
+      body: raw,
+    });
+    assert.equal(res.status, 503);
+    assert.equal((await res.json()).error, "OMISE_WEBHOOK_NOT_CONFIGURED");
+  } finally { server.close(); }
+});
+
 test("card payment claims an attempt before charging and uses stored amount with metadata", async () => {
   const pool = makePool(seedOrder());
   const omise = fakeOmise();
@@ -210,6 +233,18 @@ test("card payment claims an attempt before charging and uses stored amount with
     assert.equal(omise.spy.charges[0].metadata.order_code, "CWF-PAY1");
     assert.match(omise.spy.charges[0].metadata.attempt_id, /^[0-9a-f]{32}$/);
     assert.equal(pool.orders.get("CWF-PAY1").status, "paid");
+  } finally { server.close(); }
+});
+
+test("paid order is non-payable and does not create an Omise charge", async () => {
+  const pool = makePool(seedOrder({ status: "paid", payment_status: "successful", payment_charge_id: "chrg_paid", paid_at: new Date().toISOString() }));
+  const omise = fakeOmise();
+  const server = await startServer(pool, omise);
+  try {
+    const res = await postJson(`${url(server)}/public/orders/CWF-PAY1/pay`, { method: "card", token: "tokn_x" });
+    assert.equal(res.status, 409);
+    assert.equal((await res.json()).error, "ORDER_ALREADY_PAID");
+    assert.equal(omise.spy.charges.length, 0);
   } finally { server.close(); }
 });
 
@@ -232,6 +267,28 @@ test("concurrent duplicate pay requests create at most one charge", async () => 
   } finally { server.close(); }
 });
 
+test("provider success with final DB update failure returns unknown and blocks duplicate charge", async () => {
+  const pool = makePool(seedOrder(), { failFinalPaymentUpdate: true });
+  const omise = fakeOmise();
+  const server = await startServer(pool, omise);
+  try {
+    const first = await postJson(`${url(server)}/public/orders/CWF-PAY1/pay`, { method: "card", token: "tokn_x" });
+    const firstBody = await first.json();
+    assert.equal(first.status, 202);
+    assert.equal(firstBody.error, "PAYMENT_RESULT_UNKNOWN");
+    assert.equal(firstBody.payment.status, "payment_processing");
+    assert.equal(firstBody.payment.requires_polling, true);
+    assert.equal(firstBody.order.order_code, "CWF-PAY1");
+    assert.equal(pool.orders.get("CWF-PAY1").status, "payment_processing");
+    assert.equal(omise.spy.charges.length, 1);
+
+    const second = await postJson(`${url(server)}/public/orders/CWF-PAY1/pay`, { method: "card", token: "tokn_x" });
+    assert.equal(second.status, 202);
+    assert.equal((await second.json()).error, "PAYMENT_PROCESSING");
+    assert.equal(omise.spy.charges.length, 1);
+  } finally { server.close(); }
+});
+
 test("deterministic failure becomes retryable and creates a new attempt B", async () => {
   const pool = makePool(seedOrder());
   let calls = 0;
@@ -250,6 +307,27 @@ test("deterministic failure becomes retryable and creates a new attempt B", asyn
     const second = await postJson(`${url(server)}/public/orders/CWF-PAY1/pay`, { method: "card", token: "ok" });
     assert.equal(second.status, 200);
     assert.notEqual(omise.spy.charges[0].metadata.attempt_id, omise.spy.charges[1].metadata.attempt_id);
+  } finally { server.close(); }
+});
+
+test("deterministic failure update no-match returns unknown without opening retry", async () => {
+  const pool = makePool(seedOrder(), { failureUpdateNoMatch: true });
+  const omise = fakeOmise({ createCardCharge: async ({ metadata }) => {
+    omise.spy.charges.push({ metadata });
+    const e = new Error("bad token"); e.status = 400; e.code = "bad_request"; throw e;
+  } });
+  const server = await startServer(pool, omise);
+  try {
+    const first = await postJson(`${url(server)}/public/orders/CWF-PAY1/pay`, { method: "card", token: "bad" });
+    const body = await first.json();
+    assert.equal(first.status, 202);
+    assert.equal(body.error, "PAYMENT_RESULT_UNKNOWN");
+    assert.equal(pool.orders.get("CWF-PAY1").status, "payment_processing");
+
+    const second = await postJson(`${url(server)}/public/orders/CWF-PAY1/pay`, { method: "card", token: "bad" });
+    assert.equal(second.status, 202);
+    assert.equal((await second.json()).error, "PAYMENT_PROCESSING");
+    assert.equal(omise.spy.charges.length, 1);
   } finally { server.close(); }
 });
 
@@ -281,16 +359,27 @@ test("webhook validates missing, invalid, valid, dual signatures and raw tamperi
   const raw = JSON.stringify(payload);
   try {
     assert.equal((await fetch(`${url(server)}/webhooks/omise`, { method: "POST", headers: { "content-type": "application/json" }, body: raw })).status, 401);
-    assert.equal((await postWebhook(server, payload, signedHeaders(raw, "wrong"))).status, 401);
+    assert.equal((await postWebhook(server, payload, signedHeaders(raw, Buffer.from("wrong")))).status, 401);
     assert.equal((await postWebhook(server, payload, signedHeaders(raw))).status, 200);
 
     pool.orders.set("CWF-PAY1", seedOrder({ status: "payment_processing", payment_status: "processing:attempt" }));
-    const dual = signedHeaders(raw, WEBHOOK_SECRET, "0".repeat(64));
+    const dual = signedHeaders(raw, WEBHOOK_SECRET_BYTES, "0".repeat(64));
     assert.equal((await postWebhook(server, payload, dual)).status, 200);
 
     const tamperedHeaders = signedHeaders(raw);
     assert.equal((await postWebhook(server, { data: { object: "charge", id: "different" } }, tamperedHeaders)).status, 401);
   } finally { server.close(); }
+});
+
+test("backend pay route accepts only token and Customer App tokenizes card before backend pay", () => {
+  const routeSource = fs.readFileSync(path.join(__dirname, "..", "server", "routes", "customerOrders.js"), "utf8");
+  assert.match(routeSource, /const token = cleanText\(req\.body && req\.body\.token, 200\)/);
+  assert.doesNotMatch(routeSource, /card_number|cardNumber|expiration_month|expiration_year|security_code|cvc/i);
+  assert.doesNotMatch(routeSource, /console\.(log|warn|error)\([^;\n]*(token|req\.body)/i);
+
+  const storeSource = fs.readFileSync(path.join(__dirname, "..", "customer-app", "modules", "store.js"), "utf8");
+  assert.match(storeSource, /Omise\.createToken\("card"/);
+  assert.match(storeSource, /payOrder\(o\.order\.order_code, \{ method: "card", token \}\)/);
 });
 
 test("webhook recovery requires matching order, attempt, amount and THB currency", async () => {

--- a/test/customerSameDayTiming.test.js
+++ b/test/customerSameDayTiming.test.js
@@ -160,7 +160,7 @@ test("customer app disables availability HTTP cache and refreshes same-day slots
 });
 
 test("customer app build and service worker cache IDs changed", () => {
-  const id = "20260703_lifecycle_v1";
+  const id = "20260705_payment_security_v1";
   for (const file of [
     "customer-app/index.html",
     "customer-app/sw.js",

--- a/test/homepageCms.test.js
+++ b/test/homepageCms.test.js
@@ -278,7 +278,7 @@ test("customer homepage has no admin control, bottom nav is fixed five-tab, and 
   const sw = read("customer-app/sw.js");
   const app = read("customer-app/assets/customer-app.js");
   const manifest = read("customer-app/manifest.webmanifest");
-  const build = "20260703_lifecycle_v1";
+  const build = "20260705_payment_security_v1";
 
   assert.doesNotMatch(index + ui, /โหมดแอดมิน|openCms|localStorage\.getItem\('cwfHomeCmsDemo'/);
   assert.match(index, /data-route="store"[\s\S]*ร้านค้า/);

--- a/test/omiseService.test.js
+++ b/test/omiseService.test.js
@@ -8,6 +8,8 @@ const {
   bahtToSatang,
   chargeToOrderStatus,
   promptPayQrUri,
+  isAmbiguousOmiseError,
+  isRetryableOmiseRejection,
 } = require("../server/services/omise");
 
 // A fake transport that records requests and returns queued responses.
@@ -103,4 +105,15 @@ test("chargeToOrderStatus maps Omise charge states to persisted order statuses",
   assert.equal(chargeToOrderStatus({ status: "failed" }), "payment_failed");
   assert.equal(chargeToOrderStatus({ status: "expired" }), "payment_failed");
   assert.equal(chargeToOrderStatus({}), "payment_processing");
+});
+
+test("Omise error classification keeps ambiguous outcomes non-retryable", () => {
+  assert.equal(isAmbiguousOmiseError(Object.assign(new Error("timeout"), { code: "ETIMEDOUT" })), true);
+  assert.equal(isAmbiguousOmiseError(Object.assign(new Error("reset"), { code: "ECONNRESET" })), true);
+  assert.equal(isAmbiguousOmiseError(Object.assign(new Error("408"), { status: 408 })), true);
+  assert.equal(isAmbiguousOmiseError(Object.assign(new Error("429"), { status: 429 })), true);
+  assert.equal(isAmbiguousOmiseError(Object.assign(new Error("500"), { status: 500 })), true);
+  assert.equal(isRetryableOmiseRejection(Object.assign(new Error("bad request"), { status: 400, code: "bad_request" })), true);
+  assert.equal(isRetryableOmiseRejection(Object.assign(new Error("declined"), { status: 402, code: "failed_capture" })), true);
+  assert.equal(isRetryableOmiseRejection(Object.assign(new Error("429"), { status: 429 })), false);
 });


### PR DESCRIPTION
## Summary

Draft PR for Issue #143.

Fixes the Customer App buy-flow security issues found on `main@610d81a9c5f08d9408d76dccb605868e26668f4b`:

- checkout snapshots catalog item name and price from the server/database only
- client `name`, `item_name`, `unit_price`, and `subtotal` are ignored
- duplicate item ids are aggregated and quantity is strictly validated
- payment claims a cryptographically random attempt before calling Omise
- duplicate/concurrent/retry payment calls cannot create another charge while an order is `payment_processing`
- Omise webhook signatures are verified with the Base64-decoded dashboard signing secret
- webhook handling retrieves the real charge from Omise and correlates by charge id or matching `order_code + attempt_id + amount + currency`
- provider-success plus any final DB persistence failure now returns `202 PAYMENT_RESULT_UNKNOWN` and keeps the order non-retryable, including schema-classified DB errors and zero-row final updates
- deterministic provider failure only opens retry when the attempt-specific DB update actually matches
- online payment fails closed when Omise config is incomplete or webhook secret is invalid

## Root Cause

`POST /public/orders` previously computed `subtotal` from browser-supplied `items[].unit_price` and stored browser-supplied product names. `POST /public/orders/:code/pay` read the order without a durable attempt claim before calling Omise, so retries/concurrency could risk more than one external charge. The webhook path also needed verified-charge recovery by metadata for the case where Omise creates a charge but final DB persistence fails.

The review also found that `OMISE_WEBHOOK_SECRET` was used as a raw string HMAC key. Omise documents the webhook signing secret as Base64 and requires decoding before HMAC over `<timestamp>.<raw request body>`.

## Changed Files

Implementation and docs:

- `server/routes/customerOrders.js`
- `server/services/omise.js`
- `index.js`
- `customer-app/modules/store.js`
- `customer-app/index.html`
- `customer-app/sw.js`
- `customer-app/assets/customer-app.js`
- `customer-app/manifest.webmanifest`
- `docs/OMISE_PAYMENT_SETUP.md`

Tests:

- `test/customerOrders.test.js`
- `test/customerOrdersPayment.test.js`
- `test/customerAppStorePayment.test.js`
- `test/omiseService.test.js`
- `test/customerAppRecovery.test.js`
- `test/customerSameDayTiming.test.js`
- `test/homepageCms.test.js`

## Routes Changed

- `POST /public/orders`
  - validates item identity/qty only from client
  - loads catalog rows in a transaction
  - requires active, customer-visible, `booking_mode='purchase'`, positive effective price
  - stores server name/price snapshots

- `GET /public/payment-config`
  - requires `OMISE_SECRET_KEY` + valid Base64 `OMISE_WEBHOOK_SECRET` before enabling online payment
  - advertises card only when `OMISE_PUBLIC_KEY` exists

- `POST /public/orders/:code/pay`
  - claims `payment_status='processing:<attempt_id>'` under `SELECT ... FOR UPDATE` before Omise
  - commits before the network call
  - keeps ambiguous or unknown outcomes non-retryable
  - returns `202 PAYMENT_RESULT_UNKNOWN` after charge creation if final persistence throws, including `42P01` / `42703`, or if the final update matches zero rows

- `POST /webhooks/omise`
  - verifies HMAC-SHA256 over raw body using the decoded Base64 webhook secret
  - supports comma-separated signatures for secret rotation
  - retrieves charge from Omise before trusting status
  - correlates with current attempt and validates amount/currency

## DB / Schema Impact

No migration. No new column/index/table.

Uses existing fields:

- `customer_orders.status`
- `payment_provider`
- `payment_method`
- `payment_charge_id`
- `payment_status`
- `paid_at`

Current in-flight attempt is stored as `payment_status='processing:<attempt_id>'`; once charge id is safely stored, `payment_charge_id` is the primary correlation key.

## Config Requirements

- `OMISE_SECRET_KEY`: required for charge/retrieve
- `OMISE_WEBHOOK_SECRET`: required before online payment is enabled; must be the Base64 webhook signing secret from the Omise dashboard
- `OMISE_PUBLIC_KEY`: required only to advertise card payment

PromptPay can be shown without public key, but not without secret + valid webhook secret.

## Cache Bust

- `customer-app/index.html`: bumped to `20260705_payment_security_v1`
- `customer-app/sw.js`: bumped `BUILD_ID` to `20260705_payment_security_v1`
- `customer-app/assets/customer-app.js`: bumped `BUILD_ID` to `20260705_payment_security_v1`
- `customer-app/manifest.webmanifest`: bumped `start_url` to `20260705_payment_security_v1`
- `customer-app/modules/store.js`: console marker `[customer-store] payment-security 20260705 loaded`

## Tests Performed

`node --check` passed for the latest changed JS files:

- `server/routes/customerOrders.js`
- `test/customerOrdersPayment.test.js`

Focused payment test passed:

```text
node --test test/customerOrdersPayment.test.js
# 18 tests, 18 pass, 0 fail
```

Focused suite passed:

```text
node --test test/customerOrders.test.js test/customerOrdersPayment.test.js test/customerAppStorePayment.test.js test/omiseService.test.js test/customerAppRecovery.test.js test/customerSameDayTiming.test.js test/homepageCms.test.js
# 196 tests, 196 pass, 0 fail
```

Full suite comparison:

```text
base 610d81a: npm test -> 859 tests, 828 pass, 20 fail, 11 skipped
branch:       npm test -> 872 tests, 841 pass, 20 fail, 11 skipped
additional failures caused by branch: 0
```

The 20 failures are pre-existing `test/adminStoreCatalogUi.test.js` failures present on base and branch.

## Remaining Risks

- If Omise creates a charge and neither final DB update nor webhook delivery succeeds, the order intentionally remains `payment_processing` until manual reconciliation. This is fail-closed to avoid duplicate charges.
- Existing schema stores only the current attempt marker, not a historical payment-attempt ledger. That is enough for one active attempt per order, but not a full audit trail.

## Manual Reconciliation

For stuck `payment_processing`:

1. Inspect `customer_orders.payment_status` for `processing:<attempt_id>`.
2. Search Omise dashboard/API for a charge with matching `metadata.order_code` and `metadata.attempt_id`.
3. Verify amount equals order subtotal in satang and currency is THB.
4. If paid/successful, let webhook process it or apply owner-approved manual correction.
5. If no charge exists or charge is terminal failed/expired/reversed, owner-approved reconciliation may set the order to `payment_failed` so the customer can retry.
6. Do not reset automatically and do not mutate production data without approval.

## Rollback

Safest rollback is to revert this PR. No schema rollback is needed because no migration or data backfill is included.

Do **not** remove `OMISE_WEBHOOK_SECRET` while there are in-flight `payment_processing` orders or PromptPay QR charges. Removing it disables both new payment readiness and webhook verification, so in-flight payments can no longer reconcile automatically. Reconcile in-flight orders before any rollback/config change. If the platform later supports disabling only new payment starts while keeping webhook reconciliation active, that is acceptable; do not make production config changes in this PR.

## Safety Confirmation

No production data mutation, no migration creation/execution, no Omise live/test charge, no production config change, no merge, and no deploy.