### PR TITLE
Fix admin job edit saved price stability

### DIFF
--- a/admin-job-edit-price-state.js
+++ b/admin-job-edit-price-state.js
@@ -1,0 +1,147 @@
+(function initAdminJobEditPriceState(root, factory) {
+  if (typeof module === "object" && module.exports) {
+    module.exports = factory();
+  } else {
+    root.CWFAdminJobEditPriceState = factory();
+  }
+})(typeof globalThis !== "undefined" ? globalThis : window, function buildAdminJobEditPriceState() {
+  "use strict";
+
+  const SNAPSHOT_FIELDS = [
+    "client_row_id",
+    "is_saved_row",
+    "item_id",
+    "item_name",
+    "job_type_key",
+    "job_type",
+    "ac_type_key",
+    "wash_type_key",
+    "repair_type_key",
+    "repair_detail",
+    "btu_tier",
+    "qty",
+    "unit_price",
+    "price_overridden",
+    "used_standard_price",
+    "duration_min",
+    "pricing_payload",
+    "auto_unit_price",
+    "auto_line_total",
+    "pricing_generation",
+    "latest_pricing_request_id",
+    "assigned_technician_username",
+    "is_standard",
+  ];
+
+  function cloneValue(value) {
+    if (Array.isArray(value)) return value.map(cloneValue);
+    if (value && typeof value === "object") return { ...value };
+    return value;
+  }
+
+  function snapshotRow(row) {
+    const out = {};
+    for (const key of SNAPSHOT_FIELDS) {
+      if (Object.prototype.hasOwnProperty.call(row || {}, key)) out[key] = cloneValue(row[key]);
+    }
+    return out;
+  }
+
+  function restoreRow(row, snapshot) {
+    if (!row || !snapshot) return row;
+    for (const key of Object.keys(row)) {
+      if (SNAPSHOT_FIELDS.includes(key) && !Object.prototype.hasOwnProperty.call(snapshot, key)) {
+        delete row[key];
+      }
+    }
+    for (const key of Object.keys(snapshot)) row[key] = cloneValue(snapshot[key]);
+    return row;
+  }
+
+  function parseMachineCountFromName(name) {
+    const match = String(name || "").match(/(\d+)\s*เครื่อง/);
+    const count = match ? Number(match[1]) : 0;
+    return Number.isFinite(count) && count > 1 ? count : 0;
+  }
+
+  function normalizeLegacyServiceRow(row) {
+    const next = { ...(row || {}) };
+    const machineCount = parseMachineCountFromName(next.item_name);
+    const qty = Number(next.qty || 0);
+    const unit = Number(next.unit_price || 0);
+    const total = (Number.isFinite(qty) ? qty : 0) * (Number.isFinite(unit) ? unit : 0);
+    if (machineCount >= 2 && qty === 1 && total > 0) {
+      next.qty = machineCount;
+      next.unit_price = Number((total / machineCount).toFixed(2));
+    }
+    return next;
+  }
+
+  function invalidatePricingRequests(row) {
+    if (!row) return 0;
+    row.pricing_generation = Number(row.pricing_generation || 0) + 1;
+    row.latest_pricing_request_id = null;
+    return row.pricing_generation;
+  }
+
+  function markManualPrice(row, unitPrice) {
+    if (!row) return row;
+    invalidatePricingRequests(row);
+    row.unit_price = Number(unitPrice || 0);
+    row.price_overridden = true;
+    row.used_standard_price = false;
+    return row;
+  }
+
+  function beginPricingRequest(row, requestId, payloadKey) {
+    if (!row) return null;
+    const generation = Number(row.pricing_generation || 0);
+    row.latest_pricing_request_id = requestId;
+    return {
+      rowId: row.client_row_id || null,
+      requestId,
+      generation,
+      payloadKey: String(payloadKey || ""),
+    };
+  }
+
+  function canApplyPricingResponse(row, token, currentPayloadKey) {
+    if (!row || !token) return false;
+    if (token.rowId && row.client_row_id !== token.rowId) return false;
+    if (Number(row.pricing_generation || 0) !== Number(token.generation || 0)) return false;
+    if (row.latest_pricing_request_id !== token.requestId) return false;
+    if (String(currentPayloadKey || "") !== String(token.payloadKey || "")) return false;
+    return true;
+  }
+
+  function makeSavedRow(input, clientRowId, inferAssignee) {
+    const row = input && typeof input === "object" ? input : {};
+    return {
+      client_row_id: clientRowId,
+      is_saved_row: true,
+      item_id: Number(row.item_id || 0) || null,
+      item_name: String(row.item_name || ""),
+      qty: Number(row.qty || 1) || 1,
+      unit_price: Number(row.unit_price || 0) || 0,
+      pricing_generation: 0,
+      assigned_technician_username: (
+        String(row.assigned_technician_username || "").trim() ||
+        (typeof inferAssignee === "function" ? inferAssignee(row.item_name) : "") ||
+        null
+      ),
+    };
+  }
+
+  return {
+    SNAPSHOT_FIELDS,
+    snapshotRow,
+    restoreRow,
+    parseMachineCountFromName,
+    normalizeLegacyServiceRow,
+    invalidatePricingRequests,
+    markManualPrice,
+    beginPricingRequest,
+    canApplyPricingResponse,
+    makeSavedRow,
+  };
+});

--- a/admin-job-edit-price-state.js
+++ b/admin-job-edit-price-state.js
@@ -114,6 +114,15 @@
     return true;
   }
 
+  function finishPricingRequestFailure(row, token) {
+    if (!row || !token) return false;
+    if (!token.rowId || row.client_row_id !== token.rowId) return false;
+    if (Number(row.pricing_generation || 0) !== Number(token.generation || 0)) return false;
+    if (row.latest_pricing_request_id !== token.requestId) return false;
+    row.latest_pricing_request_id = null;
+    return true;
+  }
+
   function makeSavedRow(input, clientRowId, inferAssignee) {
     const row = input && typeof input === "object" ? input : {};
     return {
@@ -142,6 +151,7 @@
     markManualPrice,
     beginPricingRequest,
     canApplyPricingResponse,
+    finishPricingRequestFailure,
     makeSavedRow,
   };
 });

--- a/admin-job-view-v2.html
+++ b/admin-job-view-v2.html
@@ -30,6 +30,7 @@
   </div>
 
   <script src="/admin-v2-common.js?v=20260428_allpages_ui1"></script>
-  <script src="/admin-job-view-v2.js?v=20260706_saved_price_stability"></script>
+  <script src="/admin-job-edit-price-state.js?v=20260706_price_state_v1"></script>
+  <script src="/admin-job-view-v2.js?v=20260706_saved_price_stability_review_fix"></script>
 </body>
 </html>

--- a/admin-job-view-v2.html
+++ b/admin-job-view-v2.html
@@ -30,6 +30,6 @@
   </div>
 
   <script src="/admin-v2-common.js?v=20260428_allpages_ui1"></script>
-  <script src="/admin-job-view-v2.js?v=20260617_ac_type_parser_fix"></script>
+  <script src="/admin-job-view-v2.js?v=20260706_saved_price_stability"></script>
 </body>
 </html>

--- a/admin-job-view-v2.html
+++ b/admin-job-view-v2.html
@@ -30,7 +30,7 @@
   </div>
 
   <script src="/admin-v2-common.js?v=20260428_allpages_ui1"></script>
-  <script src="/admin-job-edit-price-state.js?v=20260706_price_state_v1"></script>
-  <script src="/admin-job-view-v2.js?v=20260706_saved_price_stability_review_fix"></script>
+  <script src="/admin-job-edit-price-state.js?v=20260707_price_state_v2"></script>
+  <script src="/admin-job-view-v2.js?v=20260707_saved_price_stability_review_fix2"></script>
 </body>
 </html>

--- a/admin-job-view-v2.js
+++ b/admin-job-view-v2.js
@@ -17,6 +17,7 @@ console.info('[admin-job-view] rework UI v3 loaded');
 console.info('[admin-job-edit] service builder v2 loaded');
 console.info('[admin-job-edit] ac type parser fix 20260617 loaded');
 console.info('[admin-job-edit] saved price stability 20260706 loaded');
+console.info('[admin-job-edit] price state review fix 20260706 loaded');
 
 function safe(t){ return (t||'').toString(); }
 function fmtDT(iso){
@@ -485,7 +486,7 @@ async function loadJob(){
 
   const r = await apiFetch(`/admin/job_v2/${encodeURIComponent(jobId)}`);
   const job = r.job || {};
-  const items = Array.isArray(r.items) ? r.items.map(x=>normalizeLegacyQtyUnit(Object.assign({}, x))) : [];
+  const items = Array.isArray(r.items) ? r.items.map(x=>Object.assign({}, x)) : [];
   const photos = Array.isArray(r.photos) ? r.photos : [];
   const units = Array.isArray(r.units) ? r.units : [];
   const updates = Array.isArray(r.updates) ? r.updates : [];
@@ -876,6 +877,8 @@ async function loadJob(){
       if (m && m[1]) return String(m[1]).trim();
       return null;
     };
+    const priceState = window.CWFAdminJobEditPriceState;
+    if (!priceState) throw new Error('Admin job edit price state helper failed to load');
 
     // Auto-normalize legacy service rows:
     // - บางงานเก่าถูกเก็บเป็น qty=1 แต่ชื่อมี "... 5 เครื่อง" และ unit_price=ยอดรวม
@@ -887,20 +890,7 @@ async function loadJob(){
       const n = Number(m[1]);
       return Number.isFinite(n) ? n : 0;
     };
-    const normalizeLegacyServiceRow = (row) => {
-      try {
-        const nm = String(row.item_name || '');
-        const mc = parseMachineCountFromName(nm);
-        const q = Number(row.qty || 0);
-        const u = Number(row.unit_price || 0);
-        const total = (Number.isFinite(q) ? q : 0) * (Number.isFinite(u) ? u : 0);
-        if (mc >= 2 && q === 1 && total > 0) {
-          row.qty = mc;
-          row.unit_price = Number((total / mc).toFixed(2));
-        }
-      } catch(_e) {}
-      return row;
-    };
+    const normalizeLegacyServiceRow = (row) => priceState.normalizeLegacyServiceRow(row);
     const EDIT_JOB_TYPES = { wash:'ล้าง', repair:'ซ่อม', install:'ติดตั้ง' };
     const EDIT_REPAIR_TYPES = { standard:'ตรวจเช็ค/ซ่อมทั่วไป', leak:'ตรวจเช็ครั่ว', parts:'ซ่อมเปลี่ยนอะไหล่' };
     const EDIT_REPAIR_PAYLOAD = { standard:'', leak:'ตรวจเช็ครั่ว', parts:'ซ่อมเปลี่ยนอะไหล่' };
@@ -1059,15 +1049,9 @@ async function loadJob(){
     let editPricingRequestSeq = 0;
     const nextEditClientRowId = () => `edit-row-${Date.now().toString(36)}-${++editClientRowSeq}`;
 
-    let editorItems = (Array.isArray(items) ? items : []).map(it=>({
-      client_row_id: nextEditClientRowId(),
-      is_saved_row: true,
-      item_id: Number(it.item_id||0) || null,
-      item_name: safe(it.item_name||''),
-      qty: Number(it.qty||1) || 1,
-      unit_price: Number(it.unit_price||0) || 0,
-      assigned_technician_username: (String(it.assigned_technician_username||'').trim() || inferAssigneeFromItemName(it.item_name) || null),
-    })).map(normalizeLegacyServiceRow).map(row => {
+    let editorItems = (Array.isArray(items) ? items : []).map(it=>
+      priceState.makeSavedRow(it, nextEditClientRowId(), inferAssigneeFromItemName)
+    ).map(row => {
       const parsed = parseStandardItemName(row.item_name) || { is_standard:false };
       const merged = Object.assign(row, parsed);
       if (isPartsRepairRow(merged)) merged.price_overridden = true;
@@ -1167,13 +1151,12 @@ async function loadJob(){
       const rowId = row.client_row_id;
       const requestId = ++editPricingRequestSeq;
       const requestPayloadKey = JSON.stringify(getEditStandardPayload(row));
-      row.latest_pricing_request_id = requestId;
+      const pricingToken = priceState.beginPricingRequest(row, requestId, requestPayloadKey);
       const preview = await getEditPricingPreview(row, { allowFallback: opts.allowFallback !== false });
       const currentIdx = editorItems.findIndex((it)=>it && it.client_row_id === rowId);
       if (currentIdx < 0) return null;
       const currentRow = editorItems[currentIdx];
-      if (!currentRow || currentRow.latest_pricing_request_id !== requestId) return null;
-      if (JSON.stringify(getEditStandardPayload(currentRow)) !== requestPayloadKey) return null;
+      if (!priceState.canApplyPricingResponse(currentRow, pricingToken, JSON.stringify(getEditStandardPayload(currentRow)))) return null;
       const standardPrice = Math.max(0, Number(preview.standard_price || 0));
       const currentQty = Math.max(1, Math.round(Number(currentRow.qty || 1)));
       const unitPrice = currentQty > 0 ? Number((standardPrice / currentQty).toFixed(2)) : standardPrice;
@@ -1378,6 +1361,7 @@ async function loadJob(){
         const syncStandard = () => {
           const row = editorItems[idx];
           if (!row) return;
+          priceState.invalidatePricingRequests(row);
           row.is_standard = true;
           row.job_type_key = normalizeEditJobTypeKey(jobSel?.value || row.job_type_key || 'wash');
           row.job_type = jobTypePayload(row.job_type_key);
@@ -1405,6 +1389,7 @@ async function loadJob(){
           const row = editorItems[idx];
           if (!row) return;
           row.repair_detail = cleanRepairDetail(repairDetail.value || '');
+          priceState.invalidatePricingRequests(row);
           row.price_overridden = isPartsRepairRow(row) ? true : !!row.price_overridden;
           row.item_name = standardItemName(row);
           updatePriceStatusForRow(idx);
@@ -1416,6 +1401,7 @@ async function loadJob(){
         }
         if (qty) qty.oninput = ()=>{
           const row = editorItems[idx];
+          priceState.invalidatePricingRequests(row);
           row.qty = Math.max(1, Math.round(Number(qty.value||1)));
           if (row.is_standard) {
             row.item_name = standardItemName(row);
@@ -1424,30 +1410,48 @@ async function loadJob(){
           } else updatePriceStatusForRow(idx);
         };
         if (unit) unit.oninput = ()=>{
-          editorItems[idx].unit_price = Number(unit.value||0);
-          editorItems[idx].price_overridden = true;
-          editorItems[idx].used_standard_price = false;
+          priceState.markManualPrice(editorItems[idx], unit.value);
           updatePriceStatusForRow(idx);
         };
         if (useStandard) useStandard.onclick = async ()=>{
           const row = editorItems[idx];
           if (!row) return;
-          const before = {
-            unit_price: row.unit_price,
-            price_overridden: row.price_overridden,
-            used_standard_price: row.used_standard_price,
-          };
-          if (isPartsRepairRow(editorItems[idx])) {
-            editorItems[idx].repair_type_key = 'standard';
-            editorItems[idx].repair_detail = '';
+          const before = priceState.snapshotRow(row);
+          const candidate = priceState.snapshotRow(row);
+          if (isPartsRepairRow(candidate)) {
+            candidate.repair_type_key = 'standard';
+            candidate.repair_detail = '';
           }
-          editorItems[idx].price_overridden = false;
+          candidate.price_overridden = false;
+          candidate.used_standard_price = false;
+          candidate.item_name = standardItemName(candidate);
+          const rowId = row.client_row_id;
+          const requestId = ++editPricingRequestSeq;
+          const requestPayloadKey = JSON.stringify(getEditStandardPayload(candidate));
+          const pricingToken = priceState.beginPricingRequest(row, requestId, requestPayloadKey);
           try {
-            const preview = await updateEditItemPriceFromSelection(idx, { force:true, explicitStandard:true, allowFallback:false, rowId: row.client_row_id });
-            if (!preview) throw new Error('pricing preview stale');
+            const preview = await getEditPricingPreview(candidate, { allowFallback:false });
+            const currentIdx = editorItems.findIndex((it)=>it && it.client_row_id === rowId);
+            if (currentIdx < 0) return;
+            const currentRow = editorItems[currentIdx];
+            if (!priceState.canApplyPricingResponse(currentRow, pricingToken, JSON.stringify(getEditStandardPayload(candidate)))) return;
+            const q = Math.max(1, Math.round(Number(candidate.qty || 1)));
+            const standardPrice = Math.max(0, Number(preview.standard_price || 0));
+            const unitPrice = q > 0 ? Number((standardPrice / q).toFixed(2)) : standardPrice;
+            candidate.qty = q;
+            candidate.unit_price = unitPrice;
+            candidate.price_overridden = false;
+            candidate.used_standard_price = true;
+            candidate.auto_unit_price = unitPrice;
+            candidate.auto_line_total = standardPrice;
+            candidate.duration_min = Number(preview.duration_min || 0);
+            candidate.pricing_payload = preview.payload;
+            candidate.latest_pricing_request_id = currentRow.latest_pricing_request_id;
+            candidate.pricing_generation = currentRow.pricing_generation;
+            Object.assign(currentRow, candidate);
             renderEditor();
           } catch (e) {
-            Object.assign(row, before);
+            priceState.restoreRow(row, before);
             showToast('ดึงราคามาตรฐานไม่สำเร็จ ราคาปัจจุบันยังไม่ถูกเปลี่ยน', 'error');
             updatePriceStatusForRow(idx);
           }
@@ -1498,6 +1502,25 @@ async function loadJob(){
         editorItems.push({ client_row_id: rowId, is_saved_row: false, item_id: null, item_name: 'ล้างแอร์ผนัง • ล้างธรรมดา • 12000 BTU • 1 เครื่อง', qty: 1, unit_price: 0, job_type_key:'wash', job_type:'ล้าง', ac_type_key:'wall', wash_type_key:'normal', repair_type_key:'standard', btu_tier:'small', is_standard:true, price_overridden:false });
         renderEditor();
         setTimeout(()=>updateEditItemPriceFromSelection(idx, { force:true, rowId }), 0);
+      };
+    }
+
+    const btnNormalizeItems = el('btnNormalizeItems');
+    if (btnNormalizeItems) {
+      btnNormalizeItems.onclick = () => {
+        editorItems = editorItems.map((row) => {
+          const normalized = normalizeLegacyServiceRow(row);
+          normalized.client_row_id = row.client_row_id || normalized.client_row_id || nextEditClientRowId();
+          normalized.is_saved_row = !!row.is_saved_row;
+          normalized.price_overridden = row.price_overridden;
+          normalized.used_standard_price = row.used_standard_price;
+          normalized.assigned_technician_username = row.assigned_technician_username;
+          normalized.pricing_generation = Number(row.pricing_generation || 0) + 1;
+          normalized.latest_pricing_request_id = null;
+          return normalized;
+        });
+        renderEditor();
+        showToast('แปลงจำนวนเครื่องจากชื่อรายการแล้ว กรุณาตรวจสอบก่อนบันทึก', 'success');
       };
     }
 

--- a/admin-job-view-v2.js
+++ b/admin-job-view-v2.js
@@ -1416,7 +1416,6 @@ async function loadJob(){
         if (useStandard) useStandard.onclick = async ()=>{
           const row = editorItems[idx];
           if (!row) return;
-          const before = priceState.snapshotRow(row);
           const candidate = priceState.snapshotRow(row);
           if (isPartsRepairRow(candidate)) {
             candidate.repair_type_key = 'standard';
@@ -1451,23 +1450,34 @@ async function loadJob(){
             Object.assign(currentRow, candidate);
             renderEditor();
           } catch (e) {
-            priceState.restoreRow(row, before);
+            const currentIdx = editorItems.findIndex((it)=>it && it.client_row_id === rowId);
+            if (currentIdx < 0) return;
+            const currentRow = editorItems[currentIdx];
+            if (!priceState.finishPricingRequestFailure(currentRow, pricingToken)) return;
             showToast('ดึงราคามาตรฐานไม่สำเร็จ ราคาปัจจุบันยังไม่ถูกเปลี่ยน', 'error');
-            updatePriceStatusForRow(idx);
+            updatePriceStatusForRow(currentIdx);
           }
         };
         if (convert) convert.onclick = () => {
-          const parsed = parseStandardItemName(editorItems[idx].item_name) || { job_type_key:'wash', job_type:'ล้าง', ac_type_key:'wall', wash_type_key:'normal', repair_type_key:'standard', btu_tier:'small', is_standard:true };
-          Object.assign(editorItems[idx], parsed);
-          editorItems[idx].price_overridden = !!editorItems[idx].is_saved_row ? editorItems[idx].price_overridden : false;
-          editorItems[idx].item_name = standardItemName(editorItems[idx]);
+          const row = editorItems[idx];
+          if (!row) return;
+          priceState.invalidatePricingRequests(row);
+          const parsed = parseStandardItemName(row.item_name) || { job_type_key:'wash', job_type:'ล้าง', ac_type_key:'wall', wash_type_key:'normal', repair_type_key:'standard', btu_tier:'small', is_standard:true };
+          Object.assign(row, parsed);
+          row.price_overridden = !!row.is_saved_row ? row.price_overridden : false;
+          row.item_name = standardItemName(row);
           renderEditor();
-          if (!editorItems[idx]?.is_saved_row) {
-            const rowId = editorItems[idx]?.client_row_id;
+          if (!row.is_saved_row) {
+            const rowId = row.client_row_id;
             setTimeout(()=>updateEditItemPriceFromSelection(idx, { force:true, rowId }), 0);
           }
         };
-        if (name) name.oninput = ()=>{ editorItems[idx].item_name = name.value; };
+        if (name) name.oninput = ()=>{
+          const row = editorItems[idx];
+          if (!row) return;
+          priceState.invalidatePricingRequests(row);
+          row.item_name = name.value;
+        };
         if (del) del.onclick = ()=>{ editorItems.splice(idx,1); renderEditor(); };
         updatePriceStatusForRow(idx);
       });
@@ -1480,6 +1490,7 @@ async function loadJob(){
       editJobTypeEl.onchange = () => {
         editorItems.forEach((row, idx) => {
           if (row?.is_standard) {
+            priceState.invalidatePricingRequests(row);
             row.job_type_key = normalizeEditJobTypeKey(editJobTypeEl.value || row.job_type_key || 'wash');
             row.job_type = jobTypePayload(row.job_type_key);
             row.item_name = standardItemName(row);

--- a/admin-job-view-v2.js
+++ b/admin-job-view-v2.js
@@ -16,6 +16,7 @@
 console.info('[admin-job-view] rework UI v3 loaded');
 console.info('[admin-job-edit] service builder v2 loaded');
 console.info('[admin-job-edit] ac type parser fix 20260617 loaded');
+console.info('[admin-job-edit] saved price stability 20260706 loaded');
 
 function safe(t){ return (t||'').toString(); }
 function fmtDT(iso){
@@ -1054,7 +1055,13 @@ async function loadJob(){
       return 0;
     };
 
+    let editClientRowSeq = 0;
+    let editPricingRequestSeq = 0;
+    const nextEditClientRowId = () => `edit-row-${Date.now().toString(36)}-${++editClientRowSeq}`;
+
     let editorItems = (Array.isArray(items) ? items : []).map(it=>({
+      client_row_id: nextEditClientRowId(),
+      is_saved_row: true,
       item_id: Number(it.item_id||0) || null,
       item_name: safe(it.item_name||''),
       qty: Number(it.qty||1) || 1,
@@ -1088,10 +1095,14 @@ async function loadJob(){
       const row = editorItems[idx];
       const status = tr.querySelector('.it_price_status');
       if (status) {
-        status.textContent = row?.price_overridden
+        status.textContent = row?.is_saved_row && !row?.price_overridden && !row?.used_standard_price
+          ? 'ใช้ราคาที่บันทึกไว้'
+          : row?.used_standard_price
+            ? 'ใช้ราคามาตรฐาน'
+            : row?.price_overridden
           ? 'แก้ราคาเอง'
           : 'ระบบคำนวณราคาให้อัตโนมัติจากรายการที่เลือก';
-        status.style.color = row?.price_overridden ? '#b45309' : '#64748b';
+        status.style.color = row?.is_saved_row || row?.price_overridden || row?.used_standard_price ? '#b45309' : '#64748b';
       }
       const lineEl = tr.querySelector('.it_line');
       if (lineEl) {
@@ -1101,10 +1112,13 @@ async function loadJob(){
       updateEditorTotal();
     };
 
-    const getEditPricingPreview = async (row) => {
+    const getEditPricingPreview = async (row, opts = {}) => {
       const payload = getEditStandardPayload(row);
       const key = JSON.stringify(payload);
-      if (editPriceCache.has(key)) return editPriceCache.get(key);
+      if (editPriceCache.has(key)) {
+        const cached = editPriceCache.get(key);
+        if (opts.allowFallback !== false || cached?.source === 'public/pricing_preview') return cached;
+      }
       try {
         const r = await apiFetch('/public/pricing_preview', { method:'POST', body: JSON.stringify(payload) });
         const out = {
@@ -1116,6 +1130,7 @@ async function loadJob(){
         editPriceCache.set(key, out);
         return out;
       } catch (e) {
+        if (opts.allowFallback === false) throw e;
         const out = {
           standard_price: localEditStandardPrice(payload),
           duration_min: 0,
@@ -1128,8 +1143,17 @@ async function loadJob(){
     };
 
     const updateEditItemPriceFromSelection = async (idx, opts = {}) => {
+      if (opts.rowId) {
+        idx = editorItems.findIndex((it)=>it && it.client_row_id === opts.rowId);
+      }
       const row = editorItems[idx];
+      if (opts.rowId && (!row || row.client_row_id !== opts.rowId)) return null;
       if (!row || !row.is_standard) return null;
+      if (row.is_saved_row && !opts.explicitStandard) {
+        row.item_name = standardItemName(row);
+        updatePriceStatusForRow(idx);
+        return null;
+      }
       if (isPartsRepairRow(row)) {
         row.price_overridden = true;
         row.item_name = standardItemName(row);
@@ -1140,17 +1164,29 @@ async function loadJob(){
       row.item_name = standardItemName(row);
       const q = Math.max(1, Math.round(Number(row.qty || 1)));
       row.qty = q;
-      const preview = await getEditPricingPreview(row);
+      const rowId = row.client_row_id;
+      const requestId = ++editPricingRequestSeq;
+      const requestPayloadKey = JSON.stringify(getEditStandardPayload(row));
+      row.latest_pricing_request_id = requestId;
+      const preview = await getEditPricingPreview(row, { allowFallback: opts.allowFallback !== false });
+      const currentIdx = editorItems.findIndex((it)=>it && it.client_row_id === rowId);
+      if (currentIdx < 0) return null;
+      const currentRow = editorItems[currentIdx];
+      if (!currentRow || currentRow.latest_pricing_request_id !== requestId) return null;
+      if (JSON.stringify(getEditStandardPayload(currentRow)) !== requestPayloadKey) return null;
       const standardPrice = Math.max(0, Number(preview.standard_price || 0));
-      const unitPrice = q > 0 ? Number((standardPrice / q).toFixed(2)) : standardPrice;
-      row.auto_unit_price = unitPrice;
-      row.auto_line_total = standardPrice;
-      row.duration_min = Number(preview.duration_min || 0);
-      row.pricing_payload = preview.payload;
-      if (opts.force || !row.price_overridden) {
-        row.unit_price = unitPrice;
-        row.price_overridden = false;
-        const tr = tbody?.querySelector(`[data-idx="${idx}"]`);
+      const currentQty = Math.max(1, Math.round(Number(currentRow.qty || 1)));
+      const unitPrice = currentQty > 0 ? Number((standardPrice / currentQty).toFixed(2)) : standardPrice;
+      currentRow.auto_unit_price = unitPrice;
+      currentRow.auto_line_total = standardPrice;
+      currentRow.duration_min = Number(preview.duration_min || 0);
+      currentRow.pricing_payload = preview.payload;
+      if (opts.force || !currentRow.price_overridden) {
+        currentRow.unit_price = unitPrice;
+        currentRow.price_overridden = false;
+        currentRow.used_standard_price = !!opts.explicitStandard;
+        const tr = Array.from(tbody?.querySelectorAll('.editServiceCard') || [])
+          .find((card)=>String(card.getAttribute('data-row-id') || '') === String(rowId));
         const unit = tr?.querySelector('.it_unit');
         if (unit) unit.value = String(unitPrice);
       }
@@ -1159,12 +1195,12 @@ async function loadJob(){
         ac_type: preview.payload.ac_type,
         wash_variant: preview.payload.wash_variant,
         btu: preview.payload.btu,
-        qty: q,
-        unit_price: row.unit_price,
-        line_total: Number(row.unit_price || 0) * q,
+        qty: currentQty,
+        unit_price: currentRow.unit_price,
+        line_total: Number(currentRow.unit_price || 0) * currentQty,
         source: preview.source,
       });
-      updatePriceStatusForRow(idx);
+      updatePriceStatusForRow(currentIdx);
       return preview;
     };
 
@@ -1178,8 +1214,21 @@ async function loadJob(){
       const detail = await apiFetch(`/admin/job_v2/${encodeURIComponent(String(jobId))}`);
       const savedItems = Array.isArray(detail?.items) ? detail.items : [];
       const mismatches = [];
+      const remaining = savedItems.map((saved, index)=>({ saved, index }));
+      const takeSavedMatch = (expected, preferredIdx) => {
+        const itemId = expected.item_id ? Number(expected.item_id) : null;
+        let pos = -1;
+        if (itemId) pos = remaining.findIndex((entry)=>Number(entry.saved?.item_id || 0) === itemId);
+        if (pos < 0) {
+          const expectedName = String(expected.item_name || '').trim();
+          pos = remaining.findIndex((entry)=>String(entry.saved?.item_name || '').trim() === expectedName);
+        }
+        if (pos < 0 && remaining[preferredIdx]) pos = preferredIdx;
+        if (pos < 0) return null;
+        return remaining.splice(pos, 1)[0]?.saved || null;
+      };
       expectedItems.forEach((it, idx) => {
-        const saved = savedItems[idx];
+        const saved = takeSavedMatch(it, idx);
         if (!saved) {
           mismatches.push({ index: idx, field: 'item', expected: it.item_name, actual: null });
           return;
@@ -1187,8 +1236,19 @@ async function loadJob(){
         if (String(saved.item_name || '').trim() !== String(it.item_name || '').trim()) {
           mismatches.push({ index: idx, field: 'item_name', expected: it.item_name, actual: saved.item_name });
         }
-        if (!it.price_overridden && Math.abs(Number(saved.unit_price || 0) - Number(it.unit_price || 0)) > 0.01) {
+        if (Math.abs(Number(saved.unit_price || 0) - Number(it.unit_price || 0)) > 0.01) {
           mismatches.push({ index: idx, field: 'unit_price', expected: it.unit_price, actual: saved.unit_price });
+        }
+        if (Math.abs(Number(saved.qty || 0) - Number(it.qty || 0)) > 0.01) {
+          mismatches.push({ index: idx, field: 'qty', expected: it.qty, actual: saved.qty });
+        }
+        const expectedTotal = Number(it.qty || 0) * Number(it.unit_price || 0);
+        const savedTotal = Number(saved.line_total ?? (Number(saved.qty || 0) * Number(saved.unit_price || 0)));
+        if (Math.abs(savedTotal - expectedTotal) > 0.01) {
+          mismatches.push({ index: idx, field: 'line_total', expected: expectedTotal, actual: savedTotal });
+        }
+        if (String(saved.assigned_technician_username || '').trim() !== String(it.assigned_technician_username || '').trim()) {
+          mismatches.push({ index: idx, field: 'assigned_technician_username', expected: it.assigned_technician_username || null, actual: saved.assigned_technician_username || null });
         }
         if (String(it.item_name || '').includes('ล้างแอร์ผนัง') && String(it.item_name || '').includes('ล้างแขวนคอยล์')) {
           const name = String(saved.item_name || '');
@@ -1251,8 +1311,9 @@ async function loadJob(){
         const washOpts = Object.entries(STD_WASH_TYPES).map(([k,v])=>`<option value="${k}" ${washKey===k?'selected':''}>${escapeHtml(v)}</option>`).join('');
         const repairOpts = Object.entries(EDIT_REPAIR_TYPES).map(([k,v])=>`<option value="${k}" ${repairKey===k?'selected':''}>${escapeHtml(v)}</option>`).join('');
         const btuOpts = Object.entries(STD_BTU).filter(([k])=>acKey === 'wall' ? k !== 'all' : k === 'all').map(([k,v])=>`<option value="${k}" ${btuKey===k?'selected':''}>${escapeHtml(v)}</option>`).join('');
-        const previewName = isStd ? standardItemName({ ...it, job_type_key: jobKey, ac_type_key: acKey, wash_type_key: washKey, repair_type_key: repairKey, btu_tier: btuKey, qty:q }) : (it.item_name || 'รายการกำหนดเอง');
-        return `<div class="editServiceCard" data-idx="${idx}">
+        const previewName = it.is_saved_row ? (it.item_name || 'รายการที่บันทึกไว้') : (isStd ? standardItemName({ ...it, job_type_key: jobKey, ac_type_key: acKey, wash_type_key: washKey, repair_type_key: repairKey, btu_tier: btuKey, qty:q }) : (it.item_name || 'รายการกำหนดเอง'));
+        const rowId = it.client_row_id || `missing-row-${idx}`;
+        return `<div class="editServiceCard" data-idx="${idx}" data-row-id="${escapeHtml(rowId)}">
           <div class="editServiceCardHead">
             <div>
               <div class="editServiceTitle">รายการที่ ${idx+1}</div>
@@ -1273,12 +1334,18 @@ async function loadJob(){
           <div class="editLinePreview">${escapeHtml(previewName)}</div>
           <div class="editPriceBox">
             <div>
-              <div class="editPriceStatus it_price_status">${it.price_overridden ? 'แก้ราคาเอง' : 'ระบบคำนวณราคาให้อัตโนมัติจากรายการที่เลือก'}</div>
+              <div class="editPriceStatus it_price_status">${
+                it.is_saved_row && !it.price_overridden && !it.used_standard_price
+                  ? 'ใช้ราคาที่บันทึกไว้'
+                  : it.used_standard_price
+                    ? 'ใช้ราคามาตรฐาน'
+                    : it.price_overridden ? 'แก้ราคาเอง' : 'ระบบคำนวณราคาให้อัตโนมัติจากรายการที่เลือก'
+              }</div>
               <b><span class="it_line">${Number.isFinite(line) ? line.toLocaleString('th-TH') : '0'}</span> บาท</b>
             </div>
             <button type="button" class="secondary btn-small it_use_standard" style="width:auto">ใช้ราคามาตรฐาน</button>
           </div>
-          <details class="editManualPrice" ${it.price_overridden ? 'open' : ''}>
+          <details class="editManualPrice" ${it.price_overridden && !it.is_saved_row ? 'open' : ''}>
             <summary style="font-weight:1000;color:#92400e;cursor:pointer">แก้ราคาเอง / ราคาซ่อมตามจริง</summary>
             <label class="mini" style="display:block;margin-top:8px;font-weight:900;color:#92400e">ราคา/หน่วย</label>
             <input class="it_unit" type="number" min="0" step="1" value="${escapeHtml(String(unitPrice))}" />
@@ -1322,10 +1389,13 @@ async function loadJob(){
           row.repair_type_key = String(repairSel?.value || row.repair_type_key || 'standard');
           row.repair_detail = cleanRepairDetail(repairDetail?.value || row.repair_detail || '');
           row.qty = Math.max(1, Math.round(Number(qty?.value || row.qty || 1)));
-          row.price_overridden = isPartsRepairRow(row);
+          row.price_overridden = isPartsRepairRow(row) ? true : !!row.price_overridden;
           row.item_name = standardItemName(row);
           renderEditor();
-          if (!isPartsRepairRow(row)) setTimeout(()=>updateEditItemPriceFromSelection(idx, { force:true }), 0);
+          if (!row.is_saved_row && !isPartsRepairRow(row)) {
+            const rowId = row.client_row_id;
+            setTimeout(()=>updateEditItemPriceFromSelection(idx, { force:true, rowId }), 0);
+          }
         };
         if (jobSel) jobSel.onchange = syncStandard;
         if (acSel) acSel.onchange = syncStandard;
@@ -1349,31 +1419,49 @@ async function loadJob(){
           row.qty = Math.max(1, Math.round(Number(qty.value||1)));
           if (row.is_standard) {
             row.item_name = standardItemName(row);
-            if (!row.price_overridden) updateEditItemPriceFromSelection(idx);
+            if (!row.is_saved_row && !row.price_overridden) updateEditItemPriceFromSelection(idx, { rowId: row.client_row_id });
             else updatePriceStatusForRow(idx);
           } else updatePriceStatusForRow(idx);
         };
         if (unit) unit.oninput = ()=>{
           editorItems[idx].unit_price = Number(unit.value||0);
           editorItems[idx].price_overridden = true;
+          editorItems[idx].used_standard_price = false;
           updatePriceStatusForRow(idx);
         };
         if (useStandard) useStandard.onclick = async ()=>{
+          const row = editorItems[idx];
+          if (!row) return;
+          const before = {
+            unit_price: row.unit_price,
+            price_overridden: row.price_overridden,
+            used_standard_price: row.used_standard_price,
+          };
           if (isPartsRepairRow(editorItems[idx])) {
             editorItems[idx].repair_type_key = 'standard';
             editorItems[idx].repair_detail = '';
           }
           editorItems[idx].price_overridden = false;
-          await updateEditItemPriceFromSelection(idx, { force:true });
-          renderEditor();
+          try {
+            const preview = await updateEditItemPriceFromSelection(idx, { force:true, explicitStandard:true, allowFallback:false, rowId: row.client_row_id });
+            if (!preview) throw new Error('pricing preview stale');
+            renderEditor();
+          } catch (e) {
+            Object.assign(row, before);
+            showToast('ดึงราคามาตรฐานไม่สำเร็จ ราคาปัจจุบันยังไม่ถูกเปลี่ยน', 'error');
+            updatePriceStatusForRow(idx);
+          }
         };
         if (convert) convert.onclick = () => {
           const parsed = parseStandardItemName(editorItems[idx].item_name) || { job_type_key:'wash', job_type:'ล้าง', ac_type_key:'wall', wash_type_key:'normal', repair_type_key:'standard', btu_tier:'small', is_standard:true };
           Object.assign(editorItems[idx], parsed);
-          editorItems[idx].price_overridden = false;
+          editorItems[idx].price_overridden = !!editorItems[idx].is_saved_row ? editorItems[idx].price_overridden : false;
           editorItems[idx].item_name = standardItemName(editorItems[idx]);
           renderEditor();
-          setTimeout(()=>updateEditItemPriceFromSelection(idx, { force:true }), 0);
+          if (!editorItems[idx]?.is_saved_row) {
+            const rowId = editorItems[idx]?.client_row_id;
+            setTimeout(()=>updateEditItemPriceFromSelection(idx, { force:true, rowId }), 0);
+          }
         };
         if (name) name.oninput = ()=>{ editorItems[idx].item_name = name.value; };
         if (del) del.onclick = ()=>{ editorItems.splice(idx,1); renderEditor(); };
@@ -1390,8 +1478,13 @@ async function loadJob(){
           if (row?.is_standard) {
             row.job_type_key = normalizeEditJobTypeKey(editJobTypeEl.value || row.job_type_key || 'wash');
             row.job_type = jobTypePayload(row.job_type_key);
-            row.price_overridden = false;
-            updateEditItemPriceFromSelection(idx, { force:true });
+            row.item_name = standardItemName(row);
+            if (!row.is_saved_row) {
+              row.price_overridden = false;
+              updateEditItemPriceFromSelection(idx, { force:true, rowId: row.client_row_id });
+            } else {
+              updatePriceStatusForRow(idx);
+            }
           }
         });
       };
@@ -1401,9 +1494,10 @@ async function loadJob(){
     if (btnAddItem) {
       btnAddItem.onclick = ()=>{
         const idx = editorItems.length;
-        editorItems.push({ item_id: null, item_name: 'ล้างแอร์ผนัง • ล้างธรรมดา • 12000 BTU • 1 เครื่อง', qty: 1, unit_price: 0, job_type_key:'wash', job_type:'ล้าง', ac_type_key:'wall', wash_type_key:'normal', repair_type_key:'standard', btu_tier:'small', is_standard:true, price_overridden:false });
+        const rowId = nextEditClientRowId();
+        editorItems.push({ client_row_id: rowId, is_saved_row: false, item_id: null, item_name: 'ล้างแอร์ผนัง • ล้างธรรมดา • 12000 BTU • 1 เครื่อง', qty: 1, unit_price: 0, job_type_key:'wash', job_type:'ล้าง', ac_type_key:'wall', wash_type_key:'normal', repair_type_key:'standard', btu_tier:'small', is_standard:true, price_overridden:false });
         renderEditor();
-        setTimeout(()=>updateEditItemPriceFromSelection(idx, { force:true }), 0);
+        setTimeout(()=>updateEditItemPriceFromSelection(idx, { force:true, rowId }), 0);
       };
     }
 
@@ -1471,20 +1565,20 @@ async function loadJob(){
             technician_username: primaryU,
           };
           for (let i = 0; i < editorItems.length; i++) {
-            if (editorItems[i]?.is_standard && !editorItems[i]?.price_overridden) {
-              await updateEditItemPriceFromSelection(i);
+            if (editorItems[i]?.is_standard && !editorItems[i]?.is_saved_row && !editorItems[i]?.price_overridden) {
+              await updateEditItemPriceFromSelection(i, { rowId: editorItems[i].client_row_id });
             }
           }
           const cleanItems = editorItems
             .map(it=>({
               item_id: it.item_id ? Number(it.item_id) : null,
-              item_name: String(it.is_standard ? standardItemName(it) : (it.item_name||'')).trim(),
+              item_name: String(it.is_saved_row ? (it.item_name||'') : (it.is_standard ? standardItemName(it) : (it.item_name||''))).trim(),
               qty: Number(it.qty||0),
               unit_price: Number(it.unit_price||0),
               line_total: Number(it.qty||0) * Number(it.unit_price||0),
               assigned_technician_username: String(it.assigned_technician_username||'').trim() || null,
               is_service: true,
-              price_overridden: !!it.price_overridden || isPartsRepairRow(it),
+              price_overridden: !!it.price_overridden || !!it.is_saved_row || isPartsRepairRow(it),
               job_type: it.is_standard ? jobTypePayload(it.job_type_key || it.job_type || 'wash') : (String(it.job_type || payload.job_type || 'ล้าง').trim() || 'ล้าง'),
               ac_type: it.is_standard ? (STD_AC_PAYLOAD[String(it.ac_type_key || 'wall')] || 'ผนัง') : null,
               wash_variant: it.is_standard && normalizeEditJobTypeKey(it.job_type_key || it.job_type || 'wash') === 'wash' && String(it.ac_type_key || 'wall') === 'wall' ? normalizeEditWashVariant(STD_WASH_PAYLOAD[String(it.wash_type_key || 'normal')] || 'ล้างธรรมดา') : null,

--- a/test/adminJobEditPriceStability.test.js
+++ b/test/adminJobEditPriceStability.test.js
@@ -1,0 +1,146 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const test = require("node:test");
+
+const root = path.join(__dirname, "..");
+const jsPath = path.join(root, "admin-job-view-v2.js");
+const htmlPath = path.join(root, "admin-job-view-v2.html");
+const source = fs.readFileSync(jsPath, "utf8");
+const html = fs.readFileSync(htmlPath, "utf8");
+const { normalizeAdminJobItemsForSave } = require("../server/adminJobItems");
+
+test("existing saved item retains unit_price on initial load", () => {
+  assert.match(source, /is_saved_row:\s*true/);
+  assert.match(source, /unit_price:\s*Number\(it\.unit_price\|\|0\)\s*\|\|\s*0/);
+  assert.match(source, /ใช้ราคาที่บันทึกไว้/);
+});
+
+test("open edit page and save immediately retains exact saved price", () => {
+  assert.match(source, /!editorItems\[i\]\?\.is_saved_row/);
+  assert.match(source, /item_name:\s*String\(it\.is_saved_row\s*\?\s*\(it\.item_name\|\|''\)/);
+  assert.match(source, /price_overridden:\s*!!it\.price_overridden\s*\|\|\s*!!it\.is_saved_row/);
+});
+
+test("edit customer name retains price because saved rows are skipped during save-time repricing", () => {
+  assert.match(source, /if \(editorItems\[i\]\?\.is_standard && !editorItems\[i\]\?\.is_saved_row && !editorItems\[i\]\?\.price_overridden\)/);
+});
+
+test("edit phone address appointment and zone retain price", () => {
+  assert.doesNotMatch(source, /edit_customer_phone[\s\S]{0,300}updateEditItemPriceFromSelection/);
+  assert.doesNotMatch(source, /edit_address[\s\S]{0,300}updateEditItemPriceFromSelection/);
+  assert.doesNotMatch(source, /edit_appt[\s\S]{0,300}updateEditItemPriceFromSelection/);
+  assert.doesNotMatch(source, /edit_zone[\s\S]{0,300}updateEditItemPriceFromSelection/);
+});
+
+test("edit team and primary technician retain price", () => {
+  assert.match(source, /primarySel\.onchange = \(\)=>\{ renderTeamEditor\(getPrimaryTechFromUI\(primaryU\), curTeamUsers\); renderEditor\(\); \}/);
+  assert.doesNotMatch(source, /primarySel\.onchange[\s\S]{0,160}updateEditItemPriceFromSelection/);
+});
+
+test("edit item technician assignment retains price", () => {
+  assert.match(source, /assignee\.onchange = \(\)=>\{ editorItems\[idx\]\.assigned_technician_username/);
+  assert.doesNotMatch(source, /assignee\.onchange[\s\S]{0,180}updateEditItemPriceFromSelection/);
+});
+
+test("change job type retains saved unit_price", () => {
+  assert.match(source, /if \(!row\.is_saved_row\) \{\s*row\.price_overridden = false;\s*updateEditItemPriceFromSelection/);
+  assert.match(source, /else \{\s*updatePriceStatusForRow\(idx\);\s*\}/);
+});
+
+test("change AC type retains saved unit_price", () => {
+  assert.match(source, /if \(!row\.is_saved_row && !isPartsRepairRow\(row\)\)/);
+});
+
+test("change wash type retains saved unit_price", () => {
+  assert.match(source, /if \(!row\.is_saved_row && !isPartsRepairRow\(row\)\)/);
+});
+
+test("change BTU retains saved unit_price", () => {
+  assert.match(source, /if \(btuSel\) btuSel\.onchange = syncStandard/);
+  assert.match(source, /if \(!row\.is_saved_row && !isPartsRepairRow\(row\)\)/);
+});
+
+test("change qty retains unit_price and recalculates line total", () => {
+  assert.match(source, /if \(!row\.is_saved_row && !row\.price_overridden\) updateEditItemPriceFromSelection/);
+  assert.match(source, /else updatePriceStatusForRow\(idx\)/);
+  assert.match(source, /const line = Math\.max\(0, Number\(row\?\.qty \|\| 0\)\) \* Math\.max\(0, Number\(row\?\.unit_price \|\| 0\)\)/);
+});
+
+test("manually edit price, save, reload, price remains", () => {
+  assert.match(source, /editorItems\[idx\]\.unit_price = Number\(unit\.value\|\|0\)/);
+  assert.match(source, /editorItems\[idx\]\.price_overridden = true/);
+});
+
+test("saved price different from current Price Book remains unchanged", () => {
+  assert.match(source, /if \(row\.is_saved_row && !opts\.explicitStandard\)/);
+  assert.match(source, /return null/);
+});
+
+test("pricing preview failure does not overwrite saved price", () => {
+  assert.match(source, /allowFallback:false/);
+  assert.match(source, /Object\.assign\(row, before\)/);
+  assert.match(source, /ราคาปัจจุบันยังไม่ถูกเปลี่ยน/);
+});
+
+test("clicking use standard price explicitly changes price", () => {
+  assert.match(source, /explicitStandard:true/);
+  assert.match(source, /used_standard_price = !!opts\.explicitStandard/);
+  assert.match(source, /ใช้ราคามาตรฐาน/);
+});
+
+test("new item still receives automatic standard pricing", () => {
+  assert.match(source, /is_saved_row:\s*false/);
+  assert.match(source, /setTimeout\(\(\)=>updateEditItemPriceFromSelection\(idx, \{ force:true, rowId \}\), 0\)/);
+});
+
+test("delete row while pricing request is pending does not update another row", () => {
+  assert.match(source, /const currentIdx = editorItems\.findIndex\(\(it\)=>it && it\.client_row_id === rowId\)/);
+  assert.match(source, /if \(currentIdx < 0\) return null/);
+  assert.match(source, /latest_pricing_request_id !== requestId/);
+});
+
+test("stale pricing response does not overwrite latest selection", () => {
+  assert.match(source, /const requestPayloadKey = JSON\.stringify\(getEditStandardPayload\(row\)\)/);
+  assert.match(source, /JSON\.stringify\(getEditStandardPayload\(currentRow\)\) !== requestPayloadKey/);
+});
+
+test("post-save verification detects unit_price mismatch", () => {
+  assert.doesNotMatch(source, /!it\.price_overridden && Math\.abs\(Number\(saved\.unit_price/);
+  assert.match(source, /field:\s*'unit_price'/);
+  assert.match(source, /field:\s*'qty'/);
+  assert.match(source, /field:\s*'line_total'/);
+  assert.match(source, /field:\s*'assigned_technician_username'/);
+});
+
+test("HTML references the new JS cache version", () => {
+  assert.match(html, /admin-job-view-v2\.js\?v=20260706_saved_price_stability/);
+});
+
+test("backend helper preserves submitted saved prices when frontend marks the row overridden", () => {
+  const [row] = normalizeAdminJobItemsForSave([
+    {
+      item_name: "ล้างแอร์ผนัง • ล้างธรรมดา • 12000 BTU • 1 เครื่อง",
+      qty: 1,
+      unit_price: 550,
+      is_service: true,
+      price_overridden: true,
+    },
+  ]);
+  assert.equal(row.unit_price, 550);
+});
+
+test("backend helper preserves saved zero price when frontend marks the row overridden", () => {
+  const [row] = normalizeAdminJobItemsForSave([
+    {
+      item_name: "ล้างแอร์ผนัง • ล้างธรรมดา • 12000 BTU • 1 เครื่อง",
+      qty: 1,
+      unit_price: 0,
+      is_service: true,
+      price_overridden: true,
+    },
+  ]);
+  assert.equal(row.unit_price, 0);
+});

--- a/test/adminJobEditPriceStability.test.js
+++ b/test/adminJobEditPriceStability.test.js
@@ -121,7 +121,7 @@ test("a newer request supersedes an older request on the same row", () => {
   assert.equal(priceState.canApplyPricingResponse(row, newToken, "payload-a"), true);
 });
 
-test("parts-repair pricing failure restores the complete pre-click row state", () => {
+test("current pricing failure clears only request metadata", () => {
   const row = {
     client_row_id: "row-1",
     is_saved_row: true,
@@ -144,6 +144,94 @@ test("parts-repair pricing failure restores the complete pre-click row state", (
     pricing_generation: 0,
     latest_pricing_request_id: null,
   };
+  const token = priceState.beginPricingRequest(row, 1, "payload-standard");
+  const expected = priceState.snapshotRow(row);
+  expected.latest_pricing_request_id = null;
+  assert.equal(priceState.finishPricingRequestFailure(row, token), true);
+  assert.deepEqual(priceState.snapshotRow(row), expected);
+});
+
+test("failed stale pricing request after manual price edit does not restore old price", () => {
+  const row = { client_row_id: "row-1", pricing_generation: 0, unit_price: 550, latest_pricing_request_id: null };
+  const token = priceState.beginPricingRequest(row, 1, "payload-a");
+  priceState.markManualPrice(row, 777);
+  assert.equal(priceState.finishPricingRequestFailure(row, token), false);
+  assert.equal(row.unit_price, 777);
+  assert.equal(row.price_overridden, true);
+});
+
+test("failed older pricing request cannot overwrite newer successful pricing result", () => {
+  const row = { client_row_id: "row-1", pricing_generation: 0, unit_price: 550, latest_pricing_request_id: null };
+  const tokenA = priceState.beginPricingRequest(row, 1, "payload-a");
+  const tokenB = priceState.beginPricingRequest(row, 2, "payload-b");
+  if (priceState.canApplyPricingResponse(row, tokenB, "payload-b")) {
+    row.unit_price = 900;
+    row.used_standard_price = true;
+    row.price_overridden = false;
+  }
+  assert.equal(priceState.finishPricingRequestFailure(row, tokenA), false);
+  assert.equal(row.unit_price, 900);
+  assert.equal(row.used_standard_price, true);
+  assert.equal(row.price_overridden, false);
+});
+
+test("global job type mutation invalidates pending pricing responses before old result returns", () => {
+  const row = {
+    client_row_id: "row-1",
+    pricing_generation: 0,
+    latest_pricing_request_id: null,
+    job_type_key: "wash",
+    item_name: "wash old",
+    unit_price: 550,
+  };
+  const token = priceState.beginPricingRequest(row, 1, "payload-wash");
+  priceState.invalidatePricingRequests(row);
+  row.job_type_key = "repair";
+  row.item_name = "repair new";
+  if (priceState.canApplyPricingResponse(row, token, "payload-wash")) row.item_name = "stale old";
+  assert.equal(priceState.finishPricingRequestFailure(row, token), false);
+  assert.equal(row.job_type_key, "repair");
+  assert.equal(row.item_name, "repair new");
+});
+
+test("converting a row invalidates pending pricing responses before old result returns", () => {
+  const row = {
+    client_row_id: "row-1",
+    pricing_generation: 0,
+    latest_pricing_request_id: null,
+    is_standard: false,
+    item_name: "custom legacy",
+    unit_price: 500,
+  };
+  const token = priceState.beginPricingRequest(row, 1, "payload-custom");
+  priceState.invalidatePricingRequests(row);
+  Object.assign(row, { is_standard: true, job_type_key: "wash", item_name: "converted standard" });
+  if (priceState.canApplyPricingResponse(row, token, "payload-custom")) row.item_name = "stale custom";
+  assert.equal(priceState.finishPricingRequestFailure(row, token), false);
+  assert.equal(row.is_standard, true);
+  assert.equal(row.job_type_key, "wash");
+  assert.equal(row.item_name, "converted standard");
+});
+
+test("custom item name edit invalidates pending pricing responses before old result returns", () => {
+  const row = {
+    client_row_id: "row-1",
+    pricing_generation: 0,
+    latest_pricing_request_id: null,
+    is_standard: false,
+    item_name: "old custom",
+    unit_price: 500,
+  };
+  const token = priceState.beginPricingRequest(row, 1, "payload-custom");
+  priceState.invalidatePricingRequests(row);
+  row.item_name = "new custom";
+  if (priceState.canApplyPricingResponse(row, token, "payload-custom")) row.item_name = "stale custom";
+  assert.equal(priceState.finishPricingRequestFailure(row, token), false);
+  assert.equal(row.item_name, "new custom");
+});
+
+test("legacy restore helper remains available for explicit snapshots", () => {
+  const row = { client_row_id: "row-1", unit_price: 1 };
   const before = priceState.snapshotRow(row);
   const candidate = priceState.snapshotRow(row);
   candidate.repair_type_key = "standard";
@@ -196,9 +284,16 @@ test("explicit standard pricing uses candidate state and no fallback", () => {
   assert.match(source, /Object\.assign\(currentRow, candidate\)/);
 });
 
-test("pricing preview failure leaves all row data unchanged via snapshot restore", () => {
-  assert.match(source, /const before = priceState\.snapshotRow\(row\)/);
-  assert.match(source, /priceState\.restoreRow\(row, before\)/);
+test("pricing preview failure only finishes the current request metadata", () => {
+  assert.doesNotMatch(source, /const before = priceState\.snapshotRow\(row\)/);
+  assert.doesNotMatch(source, /priceState\.restoreRow\(row, before\)/);
+  assert.match(source, /priceState\.finishPricingRequestFailure\(currentRow, pricingToken\)/);
+});
+
+test("pricing-relevant UI mutations invalidate pending pricing requests before applying live changes", () => {
+  assert.match(source, /if \(convert\) convert\.onclick = \(\) => \{[\s\S]*?priceState\.invalidatePricingRequests\(row\);[\s\S]*?Object\.assign\(row, parsed\);/);
+  assert.match(source, /if \(name\) name\.oninput = \(\)=>\{[\s\S]*?priceState\.invalidatePricingRequests\(row\);[\s\S]*?row\.item_name = name\.value;/);
+  assert.match(source, /editJobTypeEl\.onchange = \(\) => \{[\s\S]*?if \(row\?\.is_standard\) \{[\s\S]*?priceState\.invalidatePricingRequests\(row\);[\s\S]*?row\.job_type_key = normalizeEditJobTypeKey/);
 });
 
 test("post-save verification detects unit_price, qty, line_total, and assignee mismatches", () => {
@@ -210,8 +305,8 @@ test("post-save verification detects unit_price, qty, line_total, and assignee m
 });
 
 test("HTML loads the shared helper and references the new JS cache version", () => {
-  assert.match(html, /admin-job-edit-price-state\.js\?v=20260706_price_state_v1/);
-  assert.match(html, /admin-job-view-v2\.js\?v=20260706_saved_price_stability_review_fix/);
+  assert.match(html, /admin-job-edit-price-state\.js\?v=20260707_price_state_v2/);
+  assert.match(html, /admin-job-view-v2\.js\?v=20260707_saved_price_stability_review_fix2/);
 });
 
 test("backend helper preserves submitted saved prices when frontend marks the row overridden", () => {

--- a/test/adminJobEditPriceStability.test.js
+++ b/test/adminJobEditPriceStability.test.js
@@ -10,104 +10,198 @@ const jsPath = path.join(root, "admin-job-view-v2.js");
 const htmlPath = path.join(root, "admin-job-view-v2.html");
 const source = fs.readFileSync(jsPath, "utf8");
 const html = fs.readFileSync(htmlPath, "utf8");
+const priceState = require("../admin-job-edit-price-state");
 const { normalizeAdminJobItemsForSave } = require("../server/adminJobItems");
 
-test("existing saved item retains unit_price on initial load", () => {
-  assert.match(source, /is_saved_row:\s*true/);
-  assert.match(source, /unit_price:\s*Number\(it\.unit_price\|\|0\)\s*\|\|\s*0/);
-  assert.match(source, /ใช้ราคาที่บันทึกไว้/);
+function savePayloadFromRow(row) {
+  return {
+    item_id: row.item_id ? Number(row.item_id) : null,
+    item_name: String(row.is_saved_row ? (row.item_name || "") : (row.item_name || "")).trim(),
+    qty: Number(row.qty || 0),
+    unit_price: Number(row.unit_price || 0),
+    line_total: Number(row.qty || 0) * Number(row.unit_price || 0),
+    assigned_technician_username: String(row.assigned_technician_username || "").trim() || null,
+    is_service: true,
+    price_overridden: !!row.price_overridden || !!row.is_saved_row,
+  };
+}
+
+test("saved legacy row initializes with exact DB qty and unit_price", () => {
+  const row = priceState.makeSavedRow({
+    item_id: 7,
+    item_name: "ล้างแอร์ผนัง • ล้างธรรมดา • 12000 BTU • 5 เครื่อง",
+    qty: 1,
+    unit_price: 2500,
+  }, "row-1");
+  assert.equal(row.is_saved_row, true);
+  assert.equal(row.qty, 1);
+  assert.equal(row.unit_price, 2500);
+  assert.equal(row.item_name, "ล้างแอร์ผนัง • ล้างธรรมดา • 12000 BTU • 5 เครื่อง");
 });
 
-test("open edit page and save immediately retains exact saved price", () => {
-  assert.match(source, /!editorItems\[i\]\?\.is_saved_row/);
-  assert.match(source, /item_name:\s*String\(it\.is_saved_row\s*\?\s*\(it\.item_name\|\|''\)/);
-  assert.match(source, /price_overridden:\s*!!it\.price_overridden\s*\|\|\s*!!it\.is_saved_row/);
+test("immediate save payload preserves exact saved legacy qty and price", () => {
+  const row = priceState.makeSavedRow({
+    item_name: "ล้างแอร์ผนัง • ล้างธรรมดา • 12000 BTU • 5 เครื่อง",
+    qty: 1,
+    unit_price: 2500,
+  }, "row-1");
+  const payload = savePayloadFromRow(row);
+  assert.equal(payload.qty, 1);
+  assert.equal(payload.unit_price, 2500);
+  assert.equal(payload.line_total, 2500);
+  assert.equal(payload.price_overridden, true);
 });
 
-test("edit customer name retains price because saved rows are skipped during save-time repricing", () => {
-  assert.match(source, /if \(editorItems\[i\]\?\.is_standard && !editorItems\[i\]\?\.is_saved_row && !editorItems\[i\]\?\.price_overridden\)/);
+test("explicit legacy normalize action may convert qty=1 total price into per-machine price", () => {
+  const row = priceState.makeSavedRow({
+    item_name: "ล้างแอร์ผนัง • ล้างธรรมดา • 12000 BTU • 5 เครื่อง",
+    qty: 1,
+    unit_price: 2500,
+  }, "row-1");
+  const normalized = priceState.normalizeLegacyServiceRow(row);
+  assert.equal(normalized.qty, 5);
+  assert.equal(normalized.unit_price, 500);
+  assert.equal(row.qty, 1, "normalizer returns a clone and does not mutate until explicit action applies it");
 });
 
-test("edit phone address appointment and zone retain price", () => {
-  assert.doesNotMatch(source, /edit_customer_phone[\s\S]{0,300}updateEditItemPriceFromSelection/);
-  assert.doesNotMatch(source, /edit_address[\s\S]{0,300}updateEditItemPriceFromSelection/);
-  assert.doesNotMatch(source, /edit_appt[\s\S]{0,300}updateEditItemPriceFromSelection/);
-  assert.doesNotMatch(source, /edit_zone[\s\S]{0,300}updateEditItemPriceFromSelection/);
+test("opening and reloading without explicit normalize never converts saved legacy rows", () => {
+  assert.match(source, /r\.items\.map\(x=>Object\.assign\(\{\}, x\)\)/);
+  assert.doesNotMatch(source, /\)\)\.map\(normalizeLegacyServiceRow\)\.map\(row =>/);
 });
 
-test("edit team and primary technician retain price", () => {
-  assert.match(source, /primarySel\.onchange = \(\)=>\{ renderTeamEditor\(getPrimaryTechFromUI\(primaryU\), curTeamUsers\); renderEditor\(\); \}/);
-  assert.doesNotMatch(source, /primarySel\.onchange[\s\S]{0,160}updateEditItemPriceFromSelection/);
+test("manual price input invalidates pending standard-price requests", () => {
+  const row = { client_row_id: "row-1", pricing_generation: 0, unit_price: 550, latest_pricing_request_id: null };
+  const token = priceState.beginPricingRequest(row, 1, "payload-a");
+  priceState.markManualPrice(row, 777);
+  assert.equal(row.unit_price, 777);
+  assert.equal(row.price_overridden, true);
+  assert.equal(row.used_standard_price, false);
+  assert.equal(priceState.canApplyPricingResponse(row, token, "payload-a"), false);
 });
 
-test("edit item technician assignment retains price", () => {
-  assert.match(source, /assignee\.onchange = \(\)=>\{ editorItems\[idx\]\.assigned_technician_username/);
-  assert.doesNotMatch(source, /assignee\.onchange[\s\S]{0,180}updateEditItemPriceFromSelection/);
+test("old standard-price response cannot overwrite a newer manual value or save payload", () => {
+  const row = { client_row_id: "row-1", pricing_generation: 0, qty: 2, unit_price: 550, latest_pricing_request_id: null };
+  const token = priceState.beginPricingRequest(row, 1, "payload-a");
+  priceState.markManualPrice(row, 1234);
+  if (priceState.canApplyPricingResponse(row, token, "payload-a")) row.unit_price = 500;
+  assert.equal(row.unit_price, 1234);
+  assert.equal(savePayloadFromRow(row).unit_price, 1234);
 });
 
-test("change job type retains saved unit_price", () => {
-  assert.match(source, /if \(!row\.is_saved_row\) \{\s*row\.price_overridden = false;\s*updateEditItemPriceFromSelection/);
-  assert.match(source, /else \{\s*updatePriceStatusForRow\(idx\);\s*\}/);
+test("row deletion makes pending pricing response a no-op", () => {
+  const row = { client_row_id: "row-1", pricing_generation: 0, latest_pricing_request_id: null };
+  const token = priceState.beginPricingRequest(row, 1, "payload-a");
+  const rows = [];
+  const current = rows.find((it) => it.client_row_id === token.rowId);
+  assert.equal(priceState.canApplyPricingResponse(current, token, "payload-a"), false);
 });
 
-test("change AC type retains saved unit_price", () => {
-  assert.match(source, /if \(!row\.is_saved_row && !isPartsRepairRow\(row\)\)/);
+test("row reorder still applies only to the matching client row id", () => {
+  const rowA = { client_row_id: "row-a", pricing_generation: 0, latest_pricing_request_id: null };
+  const rowB = { client_row_id: "row-b", pricing_generation: 0, latest_pricing_request_id: null };
+  const token = priceState.beginPricingRequest(rowA, 1, "payload-a");
+  const rows = [rowB, rowA];
+  const current = rows.find((it) => it.client_row_id === token.rowId);
+  assert.equal(current, rowA);
+  assert.equal(priceState.canApplyPricingResponse(current, token, "payload-a"), true);
+  assert.equal(priceState.canApplyPricingResponse(rowB, token, "payload-a"), false);
 });
 
-test("change wash type retains saved unit_price", () => {
-  assert.match(source, /if \(!row\.is_saved_row && !isPartsRepairRow\(row\)\)/);
+test("stale pricing response is rejected when selection payload changes", () => {
+  const row = { client_row_id: "row-1", pricing_generation: 0, latest_pricing_request_id: null };
+  const token = priceState.beginPricingRequest(row, 1, "payload-old");
+  assert.equal(priceState.canApplyPricingResponse(row, token, "payload-new"), false);
 });
 
-test("change BTU retains saved unit_price", () => {
-  assert.match(source, /if \(btuSel\) btuSel\.onchange = syncStandard/);
-  assert.match(source, /if \(!row\.is_saved_row && !isPartsRepairRow\(row\)\)/);
+test("a newer request supersedes an older request on the same row", () => {
+  const row = { client_row_id: "row-1", pricing_generation: 0, latest_pricing_request_id: null };
+  const oldToken = priceState.beginPricingRequest(row, 1, "payload-a");
+  const newToken = priceState.beginPricingRequest(row, 2, "payload-a");
+  assert.equal(priceState.canApplyPricingResponse(row, oldToken, "payload-a"), false);
+  assert.equal(priceState.canApplyPricingResponse(row, newToken, "payload-a"), true);
 });
 
-test("change qty retains unit_price and recalculates line total", () => {
-  assert.match(source, /if \(!row\.is_saved_row && !row\.price_overridden\) updateEditItemPriceFromSelection/);
-  assert.match(source, /else updatePriceStatusForRow\(idx\)/);
-  assert.match(source, /const line = Math\.max\(0, Number\(row\?\.qty \|\| 0\)\) \* Math\.max\(0, Number\(row\?\.unit_price \|\| 0\)\)/);
+test("parts-repair pricing failure restores the complete pre-click row state", () => {
+  const row = {
+    client_row_id: "row-1",
+    is_saved_row: true,
+    item_name: "ซ่อมแอร์ผนัง • ซ่อมเปลี่ยนอะไหล่ • เปลี่ยนแคป • 12000 BTU • 1 เครื่อง",
+    job_type_key: "repair",
+    job_type: "ซ่อม",
+    ac_type_key: "wall",
+    wash_type_key: "normal",
+    repair_type_key: "parts",
+    repair_detail: "เปลี่ยนแคป",
+    btu_tier: "small",
+    qty: 1,
+    unit_price: 1800,
+    price_overridden: true,
+    used_standard_price: false,
+    duration_min: 0,
+    pricing_payload: { before: true },
+    auto_unit_price: 0,
+    auto_line_total: 0,
+    pricing_generation: 0,
+    latest_pricing_request_id: null,
+  };
+  const before = priceState.snapshotRow(row);
+  const candidate = priceState.snapshotRow(row);
+  candidate.repair_type_key = "standard";
+  candidate.repair_detail = "";
+  candidate.item_name = "ซ่อมแอร์ผนัง • ตรวจเช็ค/ซ่อมทั่วไป • 12000 BTU • 1 เครื่อง";
+  priceState.beginPricingRequest(row, 1, "payload-standard");
+  priceState.restoreRow(row, before);
+  assert.deepEqual(priceState.snapshotRow(row), before);
 });
 
-test("manually edit price, save, reload, price remains", () => {
-  assert.match(source, /editorItems\[idx\]\.unit_price = Number\(unit\.value\|\|0\)/);
-  assert.match(source, /editorItems\[idx\]\.price_overridden = true/);
+test("successful explicit standard pricing can apply candidate state after token validation", () => {
+  const row = { client_row_id: "row-1", pricing_generation: 0, latest_pricing_request_id: null, qty: 2, unit_price: 550, price_overridden: true };
+  const candidate = priceState.snapshotRow(row);
+  const token = priceState.beginPricingRequest(row, 1, "payload-standard");
+  assert.equal(priceState.canApplyPricingResponse(row, token, "payload-standard"), true);
+  candidate.unit_price = 600;
+  candidate.price_overridden = false;
+  candidate.used_standard_price = true;
+  candidate.latest_pricing_request_id = row.latest_pricing_request_id;
+  candidate.pricing_generation = row.pricing_generation;
+  Object.assign(row, candidate);
+  assert.equal(row.unit_price, 600);
+  assert.equal(row.used_standard_price, true);
 });
 
-test("saved price different from current Price Book remains unchanged", () => {
-  assert.match(source, /if \(row\.is_saved_row && !opts\.explicitStandard\)/);
-  assert.match(source, /return null/);
+test("new row automatic pricing remains possible with request token validation", () => {
+  const row = { client_row_id: "new-1", is_saved_row: false, pricing_generation: 0, latest_pricing_request_id: null };
+  const token = priceState.beginPricingRequest(row, 1, "new-payload");
+  assert.equal(priceState.canApplyPricingResponse(row, token, "new-payload"), true);
 });
 
-test("pricing preview failure does not overwrite saved price", () => {
-  assert.match(source, /allowFallback:false/);
-  assert.match(source, /Object\.assign\(row, before\)/);
-  assert.match(source, /ราคาปัจจุบันยังไม่ถูกเปลี่ยน/);
+test("saved row non-price edits keep price because save-time repricing excludes saved rows", () => {
+  assert.match(source, /editorItems\[i\]\?\.is_standard && !editorItems\[i\]\?\.is_saved_row && !editorItems\[i\]\?\.price_overridden/);
 });
 
-test("clicking use standard price explicitly changes price", () => {
-  assert.match(source, /explicitStandard:true/);
-  assert.match(source, /used_standard_price = !!opts\.explicitStandard/);
-  assert.match(source, /ใช้ราคามาตรฐาน/);
+test("qty changes keep saved unit price and update line totals through existing row state", () => {
+  const row = priceState.makeSavedRow({ item_name: "ล้างแอร์ผนัง", qty: 2, unit_price: 550 }, "row-1");
+  row.qty = 3;
+  assert.equal(savePayloadFromRow(row).line_total, 1650);
+  assert.equal(row.unit_price, 550);
 });
 
-test("new item still receives automatic standard pricing", () => {
-  assert.match(source, /is_saved_row:\s*false/);
-  assert.match(source, /setTimeout\(\(\)=>updateEditItemPriceFromSelection\(idx, \{ force:true, rowId \}\), 0\)/);
+test("manual price edits use the shared helper in production code", () => {
+  assert.match(source, /priceState\.markManualPrice\(editorItems\[idx\], unit\.value\)/);
 });
 
-test("delete row while pricing request is pending does not update another row", () => {
-  assert.match(source, /const currentIdx = editorItems\.findIndex\(\(it\)=>it && it\.client_row_id === rowId\)/);
-  assert.match(source, /if \(currentIdx < 0\) return null/);
-  assert.match(source, /latest_pricing_request_id !== requestId/);
+test("explicit standard pricing uses candidate state and no fallback", () => {
+  assert.match(source, /const candidate = priceState\.snapshotRow\(row\)/);
+  assert.match(source, /getEditPricingPreview\(candidate, \{ allowFallback:false \}\)/);
+  assert.match(source, /Object\.assign\(currentRow, candidate\)/);
 });
 
-test("stale pricing response does not overwrite latest selection", () => {
-  assert.match(source, /const requestPayloadKey = JSON\.stringify\(getEditStandardPayload\(row\)\)/);
-  assert.match(source, /JSON\.stringify\(getEditStandardPayload\(currentRow\)\) !== requestPayloadKey/);
+test("pricing preview failure leaves all row data unchanged via snapshot restore", () => {
+  assert.match(source, /const before = priceState\.snapshotRow\(row\)/);
+  assert.match(source, /priceState\.restoreRow\(row, before\)/);
 });
 
-test("post-save verification detects unit_price mismatch", () => {
+test("post-save verification detects unit_price, qty, line_total, and assignee mismatches", () => {
   assert.doesNotMatch(source, /!it\.price_overridden && Math\.abs\(Number\(saved\.unit_price/);
   assert.match(source, /field:\s*'unit_price'/);
   assert.match(source, /field:\s*'qty'/);
@@ -115,8 +209,9 @@ test("post-save verification detects unit_price mismatch", () => {
   assert.match(source, /field:\s*'assigned_technician_username'/);
 });
 
-test("HTML references the new JS cache version", () => {
-  assert.match(html, /admin-job-view-v2\.js\?v=20260706_saved_price_stability/);
+test("HTML loads the shared helper and references the new JS cache version", () => {
+  assert.match(html, /admin-job-edit-price-state\.js\?v=20260706_price_state_v1/);
+  assert.match(html, /admin-job-view-v2\.js\?v=20260706_saved_price_stability_review_fix/);
 });
 
 test("backend helper preserves submitted saved prices when frontend marks the row overridden", () => {


### PR DESCRIPTION
## Root cause

Saved job service rows loaded from `GET /admin/job_v2/:id` were parsed back into standard editable rows and legacy-normalized on load. That allowed previously saved `qty` / `unit_price` to change before the admin did anything. Separately, pending pricing responses could overwrite newer manual/admin edits because failure and success paths did not consistently treat stale requests as no-ops.

## Fixes

- Saved rows now initialize through `admin-job-edit-price-state.js` and preserve exact DB `item_name`, `qty`, and `unit_price`.
- Automatic legacy quantity normalization no longer runs on initial load/reload/save.
- The existing `แปลงจำนวนเครื่องอัตโนมัติ` button is now the explicit path that may normalize legacy rows.
- Manual price input invalidates per-row pricing tokens/generations, so stale pricing responses cannot overwrite the latest manual price.
- Explicit `ใช้ราคามาตรฐาน` builds a candidate row, calls `/public/pricing_preview` without frontend fallback, and applies the candidate only after token/payload validation succeeds.
- Failed pricing requests no longer restore full live-row snapshots. The failure path clears only `latest_pricing_request_id`, and only when row id, generation, and request id still match the current request. Stale failures are no-ops.
- Pricing-relevant mutations now invalidate pending pricing requests before mutating live row state: global job type changes, converting legacy/custom rows, and custom item-name edits.
- Post-save verification still checks item name, qty, unit price, line total, and assigned technician for every row.

## Changed files

- `admin-job-edit-price-state.js` — small shared pure state helper for browser and executable tests
- `admin-job-view-v2.js`
- `admin-job-view-v2.html`
- `test/adminJobEditPriceStability.test.js`

## Backend findings

No backend change required. `PUT /jobs/:id/admin-edit` writes submitted items through `saveJobItemsAdminWithClient()`, which inserts submitted `unit_price` and computes `line_total = qty * unit_price`; it does not call Price Book or `/public/pricing_preview`. Saved/manual rows still submit `price_overridden` so backend normalization preserves exact submitted prices, including `0`.

## Tests

- `node --check admin-job-edit-price-state.js` -> pass
- `node --check admin-job-view-v2.js` -> pass
- `node --check test/adminJobEditPriceStability.test.js` -> pass
- `node --test test/adminJobEditPriceStability.test.js` -> 29 pass, 0 fail
- Related admin tests: `node --test test/adminOrdersRoute.test.js test/adminOrdersUi.test.js test/adminStoreCatalogUi.test.js test/adminJobEditPriceStability.test.js` -> 107 tests, 87 pass, 20 fail. The 20 failures are existing `adminStoreCatalogUi.test.js` catalog UI failures.

## Full-suite comparison

Base `main@3d491ec181cca85133a4dd7c59856940930f6011`:
- 872 tests
- 841 pass
- 20 fail
- 11 skipped

Branch head `d1b01d9565ebb7cf38ac0ccaec23a90c75c45785`:
- 901 tests
- 870 pass
- 20 fail
- 11 skipped

Additional failures caused by branch: 0.

## Cache bust

- `admin-job-view-v2.html` loads `admin-job-edit-price-state.js?v=20260707_price_state_v2`.
- `admin-job-view-v2.html` loads `admin-job-view-v2.js?v=20260707_saved_price_stability_review_fix2`.
- Existing console markers remain for this admin job edit price-state change.

## Remaining risks

- There is still no full Admin job edit browser/DOM harness in the repo, so the new coverage uses shared pure state-transition helpers plus targeted source integration assertions.
- Existing unrelated `adminStoreCatalogUi.test.js` failures remain pre-existing.

## Rollback

Revert this PR. No migration, schema change, production data mutation, backend change, merge, or deploy is included.