### PR TITLE
Fix customer booking flow and admin booking notifications

### DIFF
--- a/admin-review-ai-intake.js
+++ b/admin-review-ai-intake.js
@@ -33,6 +33,20 @@
     if (values.booking_card_alert_enabled === false) return false;
     return true;
   }
+  function sharedAdminAlertGate(){
+    window.__CWF_ADMIN_ALERT_GATE__ = window.__CWF_ADMIN_ALERT_GATE__ || {
+      lastPlayedAt: 0,
+      minGapMs: 1500,
+    };
+    return window.__CWF_ADMIN_ALERT_GATE__;
+  }
+  function claimSharedAdminAlertSound(){
+    const gate = sharedAdminAlertGate();
+    const now = Date.now();
+    if (now - Number(gate.lastPlayedAt || 0) < Number(gate.minGapMs || 1500)) return false;
+    gate.lastPlayedAt = now;
+    return true;
+  }
 
   function stageLabel(status){
     return ({
@@ -177,7 +191,7 @@
     STATE.lastReadyFingerprint = fp;
   }
   function playSoftAlert(){
-    try { const Ctx = window.AudioContext || window.webkitAudioContext; if (!Ctx) return; const ctx = new Ctx(); const osc = ctx.createOscillator(); const gain = ctx.createGain(); osc.frequency.value = 880; gain.gain.value = 0.035; osc.connect(gain); gain.connect(ctx.destination); osc.start(); setTimeout(()=>{ try { osc.stop(); ctx.close(); } catch(_){} }, 170); } catch(_) {}
+    try { if (!claimSharedAdminAlertSound()) return; const Ctx = window.AudioContext || window.webkitAudioContext; if (!Ctx) return; const ctx = new Ctx(); const osc = ctx.createOscillator(); const gain = ctx.createGain(); osc.frequency.value = 880; gain.gain.value = 0.035; osc.connect(gain); gain.connect(ctx.destination); osc.start(); setTimeout(()=>{ try { osc.stop(); ctx.close(); } catch(_){} }, 170); } catch(_) {}
   }
   document.addEventListener("click", (e)=>{
     const add = e.target.closest("[data-ai-open-add]");
@@ -187,6 +201,16 @@
     const card = e.target.closest("[data-ai-open-office]");
     if (card) return openOfficeFor(card.getAttribute("data-ai-open-office"));
   });
+  window.__CWF_AI_INTAKE_TEST__ = {
+    STATE,
+    render,
+    notifyAdmin,
+    playSoftAlert,
+    claimSharedAdminAlertSound,
+    sharedAdminAlertGate,
+  };
   function init(){ loadAiIntakes(); STATE.timer = setInterval(loadAiIntakes, 15000); }
-  if (document.readyState === "loading") document.addEventListener("DOMContentLoaded", init); else init();
+  if (!window.__CWF_AI_INTAKE_DISABLE_AUTO_INIT__) {
+    if (document.readyState === "loading") document.addEventListener("DOMContentLoaded", init); else init();
+  }
 })();

--- a/admin-review-v2.html
+++ b/admin-review-v2.html
@@ -174,7 +174,7 @@
   </div>
 
   <script src="admin-v2-common.js?v=20260428_allpages_ui1"></script>
-  <script src="admin-review-v2.js?v=20260707_customer_booking_notify_v2"></script>
+  <script src="admin-review-v2.js?v=20260707_customer_booking_notify_v3_xss_guard"></script>
   <script src="admin-review-ai-intake.js?v=ai-booking-intake-customer-cards-v11-admin-alert-gate"></script>
 </body>
 </html>

--- a/admin-review-v2.html
+++ b/admin-review-v2.html
@@ -69,7 +69,7 @@
           <option value="all" selected>ทั้งหมด</option>
           <option value="pending">รอตรวจสอบ</option>
           <option value="return">ตีกลับ</option>
-          <option value="waiting">??????????????</option>
+          <option value="waiting">กำลังรอช่างรับ</option>
           <option value="noaccept">ไม่พบช่างรับงาน</option>
           <option value="timeproposal">รอพิจารณาเวลาใหม่</option>
         </select>
@@ -98,6 +98,8 @@
       <div class="muted" id="mSub"></div>
 
       <div class="hr"></div>
+
+      <div id="mReadOnlyNotice" class="proposal-warning" style="display:none;margin-bottom:10px">งานนี้กำลังรอช่างรับ ระบบเปิดให้ดูรายละเอียดเท่านั้น</div>
 
       <div class="form">
         <div class="grid2">
@@ -172,7 +174,7 @@
   </div>
 
   <script src="admin-v2-common.js?v=20260428_allpages_ui1"></script>
-  <script src="admin-review-v2.js?v=20260707_customer_booking_notify_v1"></script>
+  <script src="admin-review-v2.js?v=20260707_customer_booking_notify_v2"></script>
   <script src="admin-review-ai-intake.js?v=ai-booking-intake-customer-cards-v10"></script>
 </body>
 </html>

--- a/admin-review-v2.html
+++ b/admin-review-v2.html
@@ -175,6 +175,6 @@
 
   <script src="admin-v2-common.js?v=20260428_allpages_ui1"></script>
   <script src="admin-review-v2.js?v=20260707_customer_booking_notify_v2"></script>
-  <script src="admin-review-ai-intake.js?v=ai-booking-intake-customer-cards-v10"></script>
+  <script src="admin-review-ai-intake.js?v=ai-booking-intake-customer-cards-v11-admin-alert-gate"></script>
 </body>
 </html>

--- a/admin-review-v2.html
+++ b/admin-review-v2.html
@@ -47,6 +47,7 @@
     .proposal-actions .btn{min-height:38px;padding:8px 10px}
     .approval-alert{margin-top:12px;padding:13px;border-radius:18px;background:linear-gradient(135deg,#fff7ed,#eff6ff);border:1px solid rgba(245,158,11,.30);font-weight:900;color:#0f172a}
     .review-card-hot{border:1px solid rgba(245,158,11,.35)!important;box-shadow:0 18px 44px rgba(15,23,42,.10)!important}
+    .review-card-new{outline:3px solid rgba(34,197,94,.45);background:linear-gradient(180deg,#f0fdf4,#fff)}
   </style>
 </head>
 <body class="theme-2">
@@ -68,6 +69,7 @@
           <option value="all" selected>ทั้งหมด</option>
           <option value="pending">รอตรวจสอบ</option>
           <option value="return">ตีกลับ</option>
+          <option value="waiting">??????????????</option>
           <option value="noaccept">ไม่พบช่างรับงาน</option>
           <option value="timeproposal">รอพิจารณาเวลาใหม่</option>
         </select>
@@ -170,7 +172,7 @@
   </div>
 
   <script src="admin-v2-common.js?v=20260428_allpages_ui1"></script>
-  <script src="admin-review-v2.js?v=20260621_draft_reservation_v1"></script>
+  <script src="admin-review-v2.js?v=20260707_customer_booking_notify_v1"></script>
   <script src="admin-review-ai-intake.js?v=ai-booking-intake-customer-cards-v10"></script>
 </body>
 </html>

--- a/admin-review-v2.js
+++ b/admin-review-v2.js
@@ -5,7 +5,7 @@
  * - Production-safe: fail-open, ไม่กระทบ endpoint เดิม
  */
 
-const ADMIN_REVIEW_V2_DEDUP_BUILD = "20260707_customer_booking_notify_v2";
+const ADMIN_REVIEW_V2_DEDUP_BUILD = "20260707_customer_booking_notify_v3_xss_guard";
 window.__CWF_ADMIN_REVIEW_V2_VERSION__ = ADMIN_REVIEW_V2_DEDUP_BUILD;
 
 let TECHS = [];
@@ -33,7 +33,39 @@ const REVIEW_QUEUE_NOTIFY = {
 const ADMIN_REVIEW_EXTERNAL_TOAST = typeof window.showToast === "function" ? window.showToast : null;
 
 function $(id){ return document.getElementById(id); }
-function safe(s){ return (s==null?'':String(s)); }
+function text(s){ return (s==null?'':String(s)); }
+function escapeHtml(value){
+  return text(value).replace(/[&<>"'=]/g, (char) => ({
+    "&": "&amp;",
+    "<": "&lt;",
+    ">": "&gt;",
+    '"': "&quot;",
+    "'": "&#39;",
+    "=": "&#61;",
+  })[char]);
+}
+function html(value){ return escapeHtml(value); }
+function attr(value){ return escapeHtml(value); }
+function jsString(value){
+  return text(value)
+    .replace(/\\/g, "\\\\")
+    .replace(/'/g, "\\'")
+    .replace(/\r/g, "\\r")
+    .replace(/\n/g, "\\n")
+    .replace(/\u2028/g, "\\u2028")
+    .replace(/\u2029/g, "\\u2029");
+}
+function safeExternalHttpUrl(value){
+  const raw = text(value).trim();
+  if (!raw) return "";
+  try {
+    const parsed = new URL(raw);
+    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") return "";
+    return parsed.href;
+  } catch (_) {
+    return "";
+  }
+}
 function pad2(x){ return String(x).padStart(2,'0'); }
 
 function loadNotifiedJobIds(){
@@ -53,7 +85,7 @@ function saveNotifiedJobIds(){
 }
 
 function queueBucket(row){
-  const status = safe(row?.job_status);
+  const status = text(row?.job_status);
   const mode = String(row?.booking_mode || "").toLowerCase();
   if (mode === "urgent" && status === REVIEW_WAITING_STATUS) return "waiting_technician";
   if (status === "pending_review" || status === "รอตรวจสอบ") return "pending_review";
@@ -160,9 +192,9 @@ function renderNotificationSummary(rows = []){
   }
   const needs = notificationRows(rows).filter((r) => isAdminActionAllowed(r));
   if (needs.length) {
-    const pending = needs.filter(r=>safe(r.job_status)==="รอตรวจสอบ").length;
-    const noaccept = needs.filter(r=>safe(r.job_status)==="ไม่พบช่างรับงาน" || safe(r.job_status)==="ตีกลับ").length;
-    const timep = needs.filter(r=>safe(r.job_status)==="รอพิจารณาเวลาใหม่").length;
+    const pending = needs.filter(r=>text(r.job_status)==="รอตรวจสอบ").length;
+    const noaccept = needs.filter(r=>text(r.job_status)==="ไม่พบช่างรับงาน" || text(r.job_status)==="ตีกลับ").length;
+    const timep = needs.filter(r=>text(r.job_status)==="รอพิจารณาเวลาใหม่").length;
     alertBox.style.display = "block";
     alertBox.innerHTML = `🔔 งานที่แอดมินต้องจัดการ ${needs.length} งาน` + (pending?` • รอตรวจสอบ ${pending}`:"") + (noaccept?` • ต้องยิงใหม่/ติดต่อ ${noaccept}`:"") + (timep?` • รออนุมัติเวลาใหม่ ${timep}`:"");
   } else {
@@ -348,7 +380,7 @@ function mapFilterStatus(v){
 function filterRowsForDisplay(rows, selectedFilter){
   const status = mapFilterStatus(selectedFilter || "all");
   if (status === "all") return Array.isArray(rows) ? rows : [];
-  return (Array.isArray(rows) ? rows : []).filter((row) => safe(row.job_status) === status);
+  return (Array.isArray(rows) ? rows : []).filter((row) => text(row.job_status) === status);
 }
 
 const REVIEW_QUEUE_LOAD_GUARD = {
@@ -401,42 +433,44 @@ async function loadQueue(opts = {}){
     }
 
     $("list").innerHTML = rows.map(r=>{
-      const badge = `<span class="pill">${safe(r.job_status||"")}</span>`;
+      const jobId = Number(r.job_id);
+      const safeJobId = Number.isFinite(jobId) ? jobId : 0;
+      const badge = `<span class="pill">${html(r.job_status||"")}</span>`;
       const bucket = queueBucket(r);
       const actionAllowed = isAdminActionAllowed(r);
       const items = Array.isArray(r.items) ? r.items : [];
-      const itemSummary = items.length ? items.map((it)=>`${safe(it.item_name || "-")} x${Number(it.qty || 0) || 0}`).join(" • ") : safe(r.job_type || "-");
+      const itemSummary = items.length ? items.map((it)=>`${text(it.item_name || "-")} x${Number(it.qty || 0) || 0}`).join(" • ") : text(r.job_type || "-");
       const units = Number(r.service_units || 0);
-      const reserveTech = safe(r.technician_username || "");
+      const reserveTech = text(r.technician_username || "");
       const isNew = REVIEW_QUEUE_NOTIFY.newIds.has(Number(r.job_id));
-      const mapLink = safe(r.maps_url || "");
+      const mapHref = safeExternalHttpUrl(r.maps_url);
       const urgent = (String(r.booking_mode||"").toLowerCase()==="urgent") ? '<span class="pill" style="background:#fee2e2">ด่วน</span>' : '';
-      const proposalPanel = safe(r.job_status) === "รอพิจารณาเวลาใหม่"
-        ? `<div class="proposal-panel" id="proposal-panel-${Number(r.job_id)}">
+      const proposalPanel = text(r.job_status) === "รอพิจารณาเวลาใหม่"
+        ? `<div class="proposal-panel" id="proposal-panel-${safeJobId}">
              <div class="proposal-warning">มีช่างเสนอเวลาใหม่ กรุณาสอบถามลูกค้าและกดยอมรับเวลาที่เหมาะสม</div>
              <div class="muted">กำลังโหลดเวลาที่เสนอ...</div>
            </div>`
         : "";
       return `
-        <div class="card review-card-hot ${isNew ? "review-card-new" : ""}" data-review-job-id="${Number(r.job_id)}">
+        <div class="card review-card-hot ${isNew ? "review-card-new" : ""}" data-review-job-id="${safeJobId}">
           <div class="row">
             <div>
-              <b>#${r.job_id} • ${safe(r.booking_code||"")}</b>
-              <div class="muted" style="margin-top:2px;">${safe(r.customer_name||"-")} • ${safe(r.customer_phone||"-")}</div>
+              <b>#${safeJobId} • ${html(r.booking_code||"")}</b>
+              <div class="muted" style="margin-top:2px;">${html(r.customer_name||"-")} • ${html(r.customer_phone||"-")}</div>
             </div>
             <div style="text-align:right;display:flex;flex-direction:column;gap:6px;align-items:flex-end;">
-              ${badge}${urgent}<span class="pill">${safe(REVIEW_STATUS_LABELS[bucket] || bucket)}</span>
-              <button class="btn btn-primary" type="button" onclick="openJob(${r.job_id})">เปิด</button>
-              <button class="btn" type="button" style="background:linear-gradient(135deg,#2563eb,#06b6d4);color:#fff" ${actionAllowed ? "" : "disabled"} onclick="rebroadcastOfferQuick(${Number(r.job_id)})">📣 ลองยิงใหม่</button>
+              ${badge}${urgent}<span class="pill">${html(REVIEW_STATUS_LABELS[bucket] || bucket)}</span>
+              <button class="btn btn-primary" type="button" onclick="openJob(${safeJobId})">เปิด</button>
+              <button class="btn" type="button" style="background:linear-gradient(135deg,#2563eb,#06b6d4);color:#fff" ${actionAllowed ? "" : "disabled"} onclick="rebroadcastOfferQuick(${safeJobId})">📣 ลองยิงใหม่</button>
             </div>
           </div>
-          <div class="muted" style="margin-top:8px;">📅 ${thDateTime(r.appointment_datetime)} • 🧾 ${safe(r.job_type||"-")}</div>
-          <div class="muted" style="margin-top:4px;">📍 ${safe(r.job_zone||"")} ${safe(r.address_text||"")}</div>
+          <div class="muted" style="margin-top:8px;">📅 ${html(thDateTime(r.appointment_datetime))} • 🧾 ${html(r.job_type||"-")}</div>
+          <div class="muted" style="margin-top:4px;">📍 ${html(r.job_zone||"")} ${html(r.address_text||"")}</div>
           <div class="muted" style="margin-top:4px;">⏱️ ${Number(r.duration_min||0)} นาที</div>
-          <div class="muted" style="margin-top:4px;">บริการ: ${safe(itemSummary)}</div>
+          <div class="muted" style="margin-top:4px;">บริการ: ${html(itemSummary)}</div>
           <div class="muted" style="margin-top:4px;">จำนวนเครื่อง: ${Number.isFinite(units) && units > 0 ? units : "-"} • ราคา: ${Number(r.job_price||0).toLocaleString("th-TH")} บาท</div>
-          <div class="muted" style="margin-top:4px;">ช่างที่ระบบ reserve: ${reserveTech || "-"}</div>
-          ${mapLink ? `<div class="muted" style="margin-top:4px;"><a href="${safe(mapLink)}" target="_blank" rel="noopener">เปิด Maps URL</a></div>` : ""}
+          <div class="muted" style="margin-top:4px;">ช่างที่ระบบ reserve: ${html(reserveTech || "-")}</div>
+          ${mapHref ? `<div class="muted" style="margin-top:4px;"><a href="${attr(mapHref)}" target="_blank" rel="noopener noreferrer">เปิด Maps URL</a></div>` : ""}
           ${bucket === "waiting_technician" ? `<div class="muted" style="margin-top:4px;">กำลังรอช่างรับ (${Number(r.pending_offer_count || 0)} offer ค้าง) • read-only จนกว่าจะหมดรอบหรือมีช่างรับ</div>` : ""}
           ${proposalPanel}
         </div>
@@ -449,7 +483,7 @@ async function loadQueue(opts = {}){
       stopPollingForAuth();
       return;
     }
-    $("list").innerHTML = `<div class="card"><div class="muted">โหลดไม่สำเร็จ: ${safe(e.message||e)}</div></div>`;
+    $("list").innerHTML = `<div class="card"><div class="muted">โหลดไม่สำเร็จ: ${html(e.message||e)}</div></div>`;
   }
   };
 
@@ -469,13 +503,13 @@ async function loadQueue(opts = {}){
 }
 
 async function loadProposalPanels(rows){
-  const targets = (rows || []).filter(r => safe(r.job_status) === "รอพิจารณาเวลาใหม่");
+  const targets = (rows || []).filter(r => text(r.job_status) === "รอพิจารณาเวลาใหม่");
   for (const r of targets) {
     const box = $(`proposal-panel-${Number(r.job_id)}`);
     if (!box) continue;
     try {
       const data = await apiFetch(`/admin/jobs/${Number(r.job_id)}/time-proposals`);
-      const proposals = (Array.isArray(data.rows) ? data.rows : []).filter(p => safe(p.status) === "pending");
+      const proposals = (Array.isArray(data.rows) ? data.rows : []).filter(p => text(p.status) === "pending");
       if (!proposals.length) {
         box.innerHTML = `<div class="proposal-warning">มีช่างเสนอเวลาใหม่ กรุณาสอบถามลูกค้าและกดยอมรับเวลาที่เหมาะสม</div><div class="muted">ยังไม่มีข้อเสนอที่รอพิจารณา</div>`;
         continue;
@@ -484,9 +518,9 @@ async function loadProposalPanels(rows){
         <div class="proposal-warning">มีช่างเสนอเวลาใหม่ กรุณาสอบถามลูกค้าและกดยอมรับเวลาที่เหมาะสม</div>
         ${proposals.map(p => `
           <div class="proposal-item">
-            <b>${safe(p.technician_name || p.technician_username || "-")}</b>
-            <div class="muted">เวลาใหม่: ${thDateTime(p.proposed_datetime)}</div>
-            ${safe(p.note) ? `<div class="muted">หมายเหตุช่าง: ${safe(p.note)}</div>` : ""}
+            <b>${html(p.technician_name || p.technician_username || "-")}</b>
+            <div class="muted">เวลาใหม่: ${html(thDateTime(p.proposed_datetime))}</div>
+            ${text(p.note) ? `<div class="muted">หมายเหตุช่าง: ${html(p.note)}</div>` : ""}
             <div class="proposal-actions">
               <button class="btn btn-primary" type="button" onclick="approveTimeProposal(${Number(p.proposal_id)})">ยอมรับเวลานี้</button>
               <button class="btn btn-danger" type="button" onclick="rejectTimeProposal(${Number(p.proposal_id)})">ปฏิเสธ</button>
@@ -495,7 +529,7 @@ async function loadProposalPanels(rows){
         `).join("")}
       `;
     } catch (e) {
-      box.innerHTML = `<div class="proposal-warning">มีช่างเสนอเวลาใหม่ กรุณาสอบถามลูกค้าและกดยอมรับเวลาที่เหมาะสม</div><div class="muted">โหลดข้อเสนอไม่สำเร็จ: ${safe(e.message || e)}</div>`;
+      box.innerHTML = `<div class="proposal-warning">มีช่างเสนอเวลาใหม่ กรุณาสอบถามลูกค้าและกดยอมรับเวลาที่เหมาะสม</div><div class="muted">โหลดข้อเสนอไม่สำเร็จ: ${html(e.message || e)}</div>`;
     }
   }
 }
@@ -582,7 +616,7 @@ function renderTeamPickerModal(){
   const currentPrimary = CURRENT?.technician_username || primarySel.value || "";
   primarySel.innerHTML = '<option value="">-- เลือกช่างหลัก --</option>' + group.map(t=>{
     const name = t.full_name || t.username;
-    return `<option value="${t.username}">${safe(name)} (${t.username})</option>`;
+    return `<option value="${attr(t.username)}">${html(name)} (${html(t.username)})</option>`;
   }).join("");
   primarySel.value = currentPrimary;
 
@@ -591,20 +625,20 @@ function renderTeamPickerModal(){
   TEAM_STATE.primary = primarySel.value || "";
   if(TEAM_STATE.primary) TEAM_STATE.selected.add(TEAM_STATE.primary);
 
-  const q = safe($("mTeamSearch").value).toLowerCase();
+  const q = text($("mTeamSearch").value).toLowerCase();
   const suggestBox = $("mTeamSuggest");
   const selectedBox = $("mTeamSelected");
 
   const suggestions = group
     .filter(t=>{
-      const key = (safe(t.full_name)+safe(t.username)).toLowerCase();
+      const key = (text(t.full_name)+text(t.username)).toLowerCase();
       return (!q || key.includes(q)) && !TEAM_STATE.selected.has(t.username);
     })
     .slice(0, 30);
 
   suggestBox.innerHTML = suggestions.map(t=>{
     const name = t.full_name || t.username;
-    return `<button type="button" class="team-chip team-chip-add" data-u="${t.username}">+ ${safe(name)} (${t.username})</button>`;
+    return `<button type="button" class="team-chip team-chip-add" data-u="${attr(t.username)}">+ ${html(name)} (${html(t.username)})</button>`;
   }).join("") || `<div class="team-empty">ไม่พบช่าง</div>`;
 
   const selected = Array.from(TEAM_STATE.selected).filter(Boolean);
@@ -619,11 +653,11 @@ function renderTeamPickerModal(){
     const t = group.find(x=>x.username===u);
     const name = (t?.full_name || u);
     if(isPrimary){
-      return `<div class="team-chip team-chip-primary"><span class="team-name">${safe(name)} (${u})</span><span class="team-badge">Primary</span></div>`;
+      return `<div class="team-chip team-chip-primary"><span class="team-name">${html(name)} (${html(u)})</span><span class="team-badge">Primary</span></div>`;
     }
-    return `<div class="team-chip"><span class="team-name">${safe(name)} (${u})</span>
-      <button type="button" class="team-action" data-act="primary" data-u="${u}">ตั้งเป็นหลัก</button>
-      <button type="button" class="team-x" data-act="remove" data-u="${u}">✕</button>
+    return `<div class="team-chip"><span class="team-name">${html(name)} (${html(u)})</span>
+      <button type="button" class="team-action" data-act="primary" data-u="${attr(u)}">ตั้งเป็นหลัก</button>
+      <button type="button" class="team-x" data-act="remove" data-u="${attr(u)}">✕</button>
     </div>`;
   }).join("") || `<div class="team-empty">ยังไม่ได้เลือกช่างร่วม</div>`;
 
@@ -638,10 +672,10 @@ function renderTechPickers(){
 }
 
 function technicianTypeForUsername(username){
-  const u = safe(username).trim();
+  const u = text(username).trim();
   if(!u) return "";
-  const row = (TECHS||[]).find(t => safe(t.username).trim() === u);
-  return safe(row?.employment_type || "company").trim().toLowerCase() || "company";
+  const row = (TECHS||[]).find(t => text(t.username).trim() === u);
+  return text(row?.employment_type || "company").trim().toLowerCase() || "company";
 }
 
 function setModal(show){
@@ -692,21 +726,21 @@ async function openJob(jobId){
 
     // fill
     $("mTitle").textContent = `ตรวจงาน #${CURRENT.job_id}`;
-    $("mSub").textContent = `${safe(CURRENT.booking_code||"")} • สถานะ: ${safe(CURRENT.job_status||"")}${CURRENT.job_status === "รอตรวจสอบ" && CURRENT.technician_username ? ` • ร่างจองช่าง: ${safe(CURRENT.technician_username)}` : ""}`;
+    $("mSub").textContent = `${text(CURRENT.booking_code||"")} • สถานะ: ${text(CURRENT.job_status||"")}${CURRENT.job_status === "รอตรวจสอบ" && CURRENT.technician_username ? ` • ร่างจองช่าง: ${text(CURRENT.technician_username)}` : ""}`;
 
-    $("mCustomerName").value = safe(CURRENT.customer_name||"");
-    $("mCustomerPhone").value = safe(CURRENT.customer_phone||"");
-    $("mJobType").value = safe(CURRENT.job_type||"");
-    $("mBookingCode").value = safe(CURRENT.booking_code||"");
+    $("mCustomerName").value = text(CURRENT.customer_name||"");
+    $("mCustomerPhone").value = text(CURRENT.customer_phone||"");
+    $("mJobType").value = text(CURRENT.job_type||"");
+    $("mBookingCode").value = text(CURRENT.booking_code||"");
     $("mAppt").value = toLocalInputDatetime(CURRENT.appointment_datetime);
-    $("mAddress").value = safe(CURRENT.address_text||"");
-    $("mMaps").value = safe(CURRENT.maps_url||"");
-    $("mZone").value = safe(CURRENT.job_zone||"");
+    $("mAddress").value = text(CURRENT.address_text||"");
+    $("mMaps").value = text(CURRENT.maps_url||"");
+    $("mZone").value = text(CURRENT.job_zone||"");
     // auto parse lat/lng (fail-open)
     const ll = parseLatLngClient($("mMaps").value) || parseLatLngClient($("mAddress").value);
     if (ll) { $("mLat").value = String(ll.lat); $("mLng").value = String(ll.lng); }
 
-    $("mNote").value = safe(CURRENT.customer_note||"");
+    $("mNote").value = text(CURRENT.customer_note||"");
 
     // Draft reservations must keep the reserved technician visible/preselected.
     const draftType = technicianTypeForUsername(CURRENT.technician_username);
@@ -808,20 +842,20 @@ async function loadSlots(){
 
     $("slotBox").innerHTML = slots.map(s=>{
       const dis = !s.available;
-      const iso = `${date}T${s.start}:00`;
+      const iso = `${date}T${text(s.start)}:00`;
       return `
         <div class="slot" style="${dis?'opacity:.5':''}">
           <div>
-            <b>${s.start} - ${s.end}</b><br/>
+            <b>${html(s.start)} - ${html(s.end)}</b><br/>
             <small>${dis ? "เต็ม" : `ว่าง • ช่างว่าง ${Array.isArray(s.available_tech_ids)?s.available_tech_ids.length:0} คน`}</small>
           </div>
-          <button class="btn btn-ghost" type="button" ${dis?'disabled':''} onclick="pickSlot('${iso}')">เลือก</button>
+          <button class="btn btn-ghost" type="button" ${dis?'disabled':''} onclick="pickSlot('${attr(jsString(iso))}')">เลือก</button>
         </div>
       `;
     }).join("");
   }catch(e){
     console.error(e);
-    $("slotBox").innerHTML = `<div class="muted">โหลดคิวว่างไม่สำเร็จ: ${safe(e.message||e)}</div>`;
+    $("slotBox").innerHTML = `<div class="muted">โหลดคิวว่างไม่สำเร็จ: ${html(e.message||e)}</div>`;
   }
 }
 
@@ -921,6 +955,10 @@ window.__CWF_ADMIN_REVIEW_TEST__ = {
   acknowledgeNewJob,
   renderNotificationSummary,
   applyReadOnlyMode,
+  loadQueue,
+  loadProposalPanels,
+  escapeHtml,
+  safeExternalHttpUrl,
   playNewJobSound,
   claimSharedAdminAlertSound,
   sharedAdminAlertGate,

--- a/admin-review-v2.js
+++ b/admin-review-v2.js
@@ -5,7 +5,7 @@
  * - Production-safe: fail-open, ไม่กระทบ endpoint เดิม
  */
 
-const ADMIN_REVIEW_V2_DEDUP_BUILD = "20260707_customer_booking_notify_v1";
+const ADMIN_REVIEW_V2_DEDUP_BUILD = "20260707_customer_booking_notify_v2";
 window.__CWF_ADMIN_REVIEW_V2_VERSION__ = ADMIN_REVIEW_V2_DEDUP_BUILD;
 
 let TECHS = [];
@@ -30,6 +30,7 @@ const REVIEW_QUEUE_NOTIFY = {
   newIds: new Set(),
   audioUnlocked: false,
 };
+const ADMIN_REVIEW_EXTERNAL_TOAST = typeof window.showToast === "function" ? window.showToast : null;
 
 function $(id){ return document.getElementById(id); }
 function safe(s){ return (s==null?'':String(s)); }
@@ -67,6 +68,34 @@ function isAdminActionAllowed(row){
   return queueBucket(row) !== "waiting_technician";
 }
 
+function isCurrentReadOnly(){
+  return !!(CURRENT && CURRENT.admin_action_required === false);
+}
+
+function blockReadOnlyMutation(){
+  if (!isCurrentReadOnly()) return false;
+  showToast("งานนี้กำลังรอช่างรับ ระบบเปิดให้ดูรายละเอียดเท่านั้น", "info");
+  return true;
+}
+
+function applyReadOnlyMode(readOnly){
+  const ids = [
+    "mCustomerName", "mCustomerPhone", "mJobType", "mAppt", "mAddress",
+    "mMaps", "mZone", "mNote", "mLat", "mLng", "mTechType",
+    "mPrimaryTech", "mDispatchMode", "mTeamSearch", "btnLoadSlots",
+    "btnSave", "btnDispatch", "btnRebroadcast", "btnCancel",
+  ];
+  ids.forEach((id) => {
+    const el = $(id);
+    if (el) el.disabled = !!readOnly;
+  });
+  const notice = $("mReadOnlyNotice");
+  if (notice) notice.style.display = readOnly ? "block" : "none";
+  document.querySelectorAll(".team-chip-add,.team-action,.team-x,#slotBox button").forEach((el) => {
+    el.disabled = !!readOnly;
+  });
+}
+
 function updateTitleBadge(count){
   const baseTitle = "Admin Review Queue - CWF";
   document.title = count > 0 ? `(${count}) ${baseTitle}` : baseTitle;
@@ -76,12 +105,26 @@ function markAdminInteraction(){
   REVIEW_QUEUE_NOTIFY.audioUnlocked = true;
 }
 
+function sharedAdminAlertGate(){
+  window.__CWF_ADMIN_ALERT_GATE__ = window.__CWF_ADMIN_ALERT_GATE__ || {
+    lastPlayedAt: 0,
+    minGapMs: 1500,
+  };
+  return window.__CWF_ADMIN_ALERT_GATE__;
+}
+
+function claimSharedAdminAlertSound(){
+  const gate = sharedAdminAlertGate();
+  const now = Date.now();
+  if (now - Number(gate.lastPlayedAt || 0) < Number(gate.minGapMs || 1500)) return false;
+  gate.lastPlayedAt = now;
+  return true;
+}
+
 function playNewJobSound(){
   if (!REVIEW_QUEUE_NOTIFY.audioUnlocked) return;
   try {
-    const last = Number(window.__CWF_LAST_ADMIN_ALERT_SOUND_AT || 0);
-    if (Date.now() - last < 1200) return;
-    window.__CWF_LAST_ADMIN_ALERT_SOUND_AT = Date.now();
+    if (!claimSharedAdminAlertSound()) return;
     const AudioCtx = window.AudioContext || window.webkitAudioContext;
     if (!AudioCtx) return;
     const ctx = new AudioCtx();
@@ -101,17 +144,67 @@ function playNewJobSound(){
   }
 }
 
+function notificationRows(rows){
+  return Array.isArray(rows) ? rows : [];
+}
+
+function renderNotificationSummary(rows = []){
+  const count = REVIEW_QUEUE_NOTIFY.newIds.size;
+  updateTitleBadge(count);
+  const alertBox = $("approvalAlert");
+  if (!alertBox) return;
+  if (count > 0) {
+    alertBox.style.display = "block";
+    alertBox.innerHTML = `🔔 มีงานจองใหม่ ${count} งาน`;
+    return;
+  }
+  const needs = notificationRows(rows).filter((r) => isAdminActionAllowed(r));
+  if (needs.length) {
+    const pending = needs.filter(r=>safe(r.job_status)==="รอตรวจสอบ").length;
+    const noaccept = needs.filter(r=>safe(r.job_status)==="ไม่พบช่างรับงาน" || safe(r.job_status)==="ตีกลับ").length;
+    const timep = needs.filter(r=>safe(r.job_status)==="รอพิจารณาเวลาใหม่").length;
+    alertBox.style.display = "block";
+    alertBox.innerHTML = `🔔 งานที่แอดมินต้องจัดการ ${needs.length} งาน` + (pending?` • รอตรวจสอบ ${pending}`:"") + (noaccept?` • ต้องยิงใหม่/ติดต่อ ${noaccept}`:"") + (timep?` • รออนุมัติเวลาใหม่ ${timep}`:"");
+  } else {
+    alertBox.style.display = "none";
+    alertBox.innerHTML = "";
+  }
+}
+
+function pruneNewJobIds(rows){
+  const live = new Set(notificationRows(rows).map((r) => Number(r.job_id)).filter(Number.isFinite));
+  let changed = false;
+  for (const id of Array.from(REVIEW_QUEUE_NOTIFY.newIds)) {
+    if (!live.has(Number(id))) {
+      REVIEW_QUEUE_NOTIFY.newIds.delete(id);
+      changed = true;
+    }
+  }
+  if (changed) renderNotificationSummary(rows);
+}
+
+function acknowledgeNewJob(jobId){
+  const id = Number(jobId);
+  if (!Number.isFinite(id)) return;
+  REVIEW_QUEUE_NOTIFY.newIds.delete(id);
+  renderNotificationSummary(Array.from(ROW_MAP.values()));
+  const card = document.querySelector(`[data-review-job-id="${id}"]`);
+  if (card) card.classList.remove("review-card-new");
+}
+
 function processQueueNotifications(rows, opts = {}){
   const reason = String(opts.reason || "");
   const ids = (rows || []).map((r) => Number(r.job_id)).filter(Number.isFinite);
+  pruneNewJobIds(rows);
   if (!REVIEW_QUEUE_NOTIFY.baselineReady) {
     ids.forEach((id) => REVIEW_QUEUE_NOTIFY.knownIds.add(id));
     REVIEW_QUEUE_NOTIFY.baselineReady = true;
-    updateTitleBadge(0);
+    renderNotificationSummary(rows);
     return;
   }
   if (reason === "filter_change" || reason === "manual_reload") {
     ids.forEach((id) => REVIEW_QUEUE_NOTIFY.knownIds.add(id));
+    renderNotificationSummary(rows);
     return;
   }
   const fresh = ids.filter((id) => !REVIEW_QUEUE_NOTIFY.knownIds.has(id) && !REVIEW_QUEUE_NOTIFY.notifiedIds.has(id));
@@ -122,12 +215,7 @@ function processQueueNotifications(rows, opts = {}){
     REVIEW_QUEUE_NOTIFY.notifiedIds.add(id);
   });
   saveNotifiedJobIds();
-  updateTitleBadge(REVIEW_QUEUE_NOTIFY.newIds.size);
-  const alertBox = $("approvalAlert");
-  if (alertBox) {
-    alertBox.style.display = "block";
-    alertBox.innerHTML = `🔔 มีงานจองใหม่ ${fresh.length} งาน`;
-  }
+  renderNotificationSummary(rows);
   playNewJobSound();
 }
 
@@ -230,8 +318,9 @@ function localDatetimeToBangkokISO(localValue){
 
 function showToast(msg, type="info"){
   // reuse helper if exists
-  if (typeof window.showToast === "function") return window.showToast(msg, type);
-  alert(msg);
+  if (ADMIN_REVIEW_EXTERNAL_TOAST && ADMIN_REVIEW_EXTERNAL_TOAST !== showToast) return ADMIN_REVIEW_EXTERNAL_TOAST(msg, type);
+  if (typeof alert === "function") return alert(msg);
+  console.log(`[admin-review-v2:${type}]`, msg);
 }
 
 async function loadTechs(){
@@ -256,6 +345,11 @@ function mapFilterStatus(v){
   return m[v] || "all";
 }
 
+function filterRowsForDisplay(rows, selectedFilter){
+  const status = mapFilterStatus(selectedFilter || "all");
+  if (status === "all") return Array.isArray(rows) ? rows : [];
+  return (Array.isArray(rows) ? rows : []).filter((row) => safe(row.job_status) === status);
+}
 
 const REVIEW_QUEUE_LOAD_GUARD = {
   inFlight: null,
@@ -286,37 +380,20 @@ async function loadQueue(opts = {}){
   REVIEW_QUEUE_LOAD_GUARD.lastStartAt = now;
   const runLoadQueue = async () => {
   const f = $("filterStatus")?.value || "all";
-  const status = mapFilterStatus(f);
 
   $("list").innerHTML = '<div class="card"><div class="muted">กำลังโหลด...</div></div>';
 
   try{
     const q = new URLSearchParams();
-    q.set("status", status);
+    q.set("status", "all");
     q.set("limit", "200");
     const data = await apiFetch(`/admin/review_queue_v2?${q.toString()}`);
-    const rows = Array.isArray(data.rows) ? data.rows : [];
-    ROW_MAP = new Map(rows.map(r=>[Number(r.job_id), r]));
-    processQueueNotifications(rows, opts);
+    const allRows = Array.isArray(data.rows) ? data.rows : [];
+    ROW_MAP = new Map(allRows.map(r=>[Number(r.job_id), r]));
+    processQueueNotifications(allRows, opts);
+    const rows = filterRowsForDisplay(allRows, f);
     $("pillCount").textContent = `${rows.length} งาน`;
-    const needs = rows.filter(r => ["รอตรวจสอบ","ตีกลับ","ไม่พบช่างรับงาน","รอพิจารณาเวลาใหม่"].includes(safe(r.job_status)));
-    const alertBox = $("approvalAlert");
-    if (alertBox) {
-      if (needs.length) {
-        const pending = needs.filter(r=>safe(r.job_status)==="รอตรวจสอบ").length;
-        const noaccept = needs.filter(r=>safe(r.job_status)==="ไม่พบช่างรับงาน" || safe(r.job_status)==="ตีกลับ").length;
-        const timep = needs.filter(r=>safe(r.job_status)==="รอพิจารณาเวลาใหม่").length;
-        alertBox.style.display = "block";
-        alertBox.innerHTML = `🔔 มีงานที่แอดมินต้องจัดการ ${needs.length} งาน` + (pending?` • รอตรวจสอบ ${pending}`:"") + (noaccept?` • ต้องยิงใหม่/ติดต่อ ${noaccept}`:"") + (timep?` • รออนุมัติเวลาใหม่ ${timep}`:"");
-      } else {
-        alertBox.style.display = "none";
-      }
-    }
-
-    if (REVIEW_QUEUE_NOTIFY.newIds.size && alertBox) {
-      alertBox.style.display = "block";
-      alertBox.innerHTML = `🔔 มีงานจองใหม่ ${REVIEW_QUEUE_NOTIFY.newIds.size} งาน`;
-    }
+    renderNotificationSummary(allRows);
 
     if (!rows.length){
       $("list").innerHTML = '<div class="card"><div class="muted">ไม่มีงานในคิวนี้</div></div>';
@@ -341,7 +418,7 @@ async function loadQueue(opts = {}){
            </div>`
         : "";
       return `
-        <div class="card review-card-hot ${isNew ? "review-card-new" : ""}">
+        <div class="card review-card-hot ${isNew ? "review-card-new" : ""}" data-review-job-id="${Number(r.job_id)}">
           <div class="row">
             <div>
               <b>#${r.job_id} • ${safe(r.booking_code||"")}</b>
@@ -424,6 +501,7 @@ async function loadProposalPanels(rows){
 }
 
 async function approveTimeProposal(proposalId){
+  if (blockReadOnlyMutation()) return;
   if (!confirm("ยืนยันอนุมัติเวลาใหม่นี้และมอบหมายงานให้ช่าง?")) return;
   try {
     const r = await apiFetch(`/admin/time-proposals/${Number(proposalId)}/approve`, { method:"POST", body: JSON.stringify({}) });
@@ -435,6 +513,7 @@ async function approveTimeProposal(proposalId){
 }
 
 async function rejectTimeProposal(proposalId){
+  if (blockReadOnlyMutation()) return;
   const admin_note = prompt("หมายเหตุถึงช่าง/ทีมงาน (ถ้ามี)") || "";
   try {
     const r = await apiFetch(`/admin/time-proposals/${Number(proposalId)}/reject`, { method:"POST", body: JSON.stringify({ admin_note }) });
@@ -450,6 +529,7 @@ async function rejectTimeProposal(proposalId){
 const TEAM_STATE = { selected: new Set(), primary: "" };
 
 function setPrimaryInModal(username){
+  if (blockReadOnlyMutation()) return;
   const u = String(username||"").trim();
   if(!u) return;
   TEAM_STATE.primary = u;
@@ -459,6 +539,7 @@ function setPrimaryInModal(username){
 }
 
 function addTeamMemberModal(username){
+  if (blockReadOnlyMutation()) return;
   const u = String(username||"").trim();
   if(!u) return;
   TEAM_STATE.selected.add(u);
@@ -470,6 +551,7 @@ function addTeamMemberModal(username){
 }
 
 function removeTeamMemberModal(username){
+  if (blockReadOnlyMutation()) return;
   const u = String(username||"").trim();
   if(!u) return;
   if(u === TEAM_STATE.primary) return; // must change primary first
@@ -484,6 +566,7 @@ function getSelectedTeam(){
 }
 
 function ensurePrimaryInTeam(){
+  if (isCurrentReadOnly()) return;
   const primary = $("mPrimaryTech").value;
   if(!primary) return;
   TEAM_STATE.primary = primary;
@@ -546,6 +629,7 @@ function renderTeamPickerModal(){
 
   // keep hidden team list in CURRENT for later dispatch
   CURRENT.team_members = getSelectedTeam();
+  applyReadOnlyMode(isCurrentReadOnly());
 }
 
 // public wrapper called on tech type/search changes
@@ -566,6 +650,7 @@ function setModal(show){
 
 function closeModal(){
   setModal(false);
+  applyReadOnlyMode(false);
   CURRENT = null;
   CURRENT_SLOTS = [];
   $("slotBox").style.display = "none";
@@ -578,6 +663,7 @@ async function openJob(jobId){
   try{
     const row = ROW_MAP.get(Number(jobId));
     if (!row) throw new Error("ไม่พบงาน");
+    acknowledgeNewJob(jobId);
 
     CURRENT = {
       job_id: row.job_id,
@@ -636,8 +722,7 @@ async function openJob(jobId){
     CURRENT_SLOTS = [];
 
     const actionAllowed = isAdminActionAllowed(row);
-    if ($("btnDispatch")) $("btnDispatch").disabled = !actionAllowed;
-    if ($("btnRebroadcast")) $("btnRebroadcast").disabled = !actionAllowed;
+    applyReadOnlyMode(!actionAllowed);
     setModal(true);
   }catch(e){
     console.error(e);
@@ -660,6 +745,7 @@ async function loadPricing(){
 
 async function saveJob(){
   if (!CURRENT) return;
+  if (blockReadOnlyMutation()) return;
   const payload = {
     customer_name: $("mCustomerName").value.trim() || null,
     customer_phone: $("mCustomerPhone").value.trim() || null,
@@ -683,6 +769,7 @@ async function saveJob(){
 
 function pickSlot(isoStart){
   if (!CURRENT) return;
+  if (blockReadOnlyMutation()) return;
   $("mAppt").value = toLocalInputDatetime(isoStart);
   $("slotBox").style.display = "none";
   showToast("เลือกเวลาแล้ว","success");
@@ -692,6 +779,7 @@ window.pickSlot = pickSlot;
 
 async function loadSlots(){
   if (!CURRENT) return;
+  if (blockReadOnlyMutation()) return;
   const dtStr = $("mAppt").value;
   if (!dtStr){
     showToast("ต้องเลือกวัน/เวลา ก่อนโหลดคิวว่าง","error");
@@ -739,6 +827,7 @@ async function loadSlots(){
 
 async function dispatchJob(){
   if (!CURRENT) return;
+  if (blockReadOnlyMutation()) return;
 
   const tech_type = $("mTechType").value || "company";
   const technician_username = $("mPrimaryTech").value;
@@ -771,6 +860,11 @@ async function dispatchJob(){
 async function rebroadcastOfferQuick(jobId){
   const id = Number(jobId || 0);
   if (!id) return showToast("ไม่พบรหัสงาน", "error");
+  const row = ROW_MAP.get(id);
+  if (row && !isAdminActionAllowed(row)) {
+    showToast("งานนี้กำลังรอช่างรับ ระบบเปิดให้ดูรายละเอียดเท่านั้น", "info");
+    return;
+  }
   if (!confirm("ยืนยันยิงข้อเสนอใหม่ให้ช่างที่เปิดรับงาน ว่างจริง และอยู่ในพื้นที่นี้?")) return;
   try{
     const out = await apiFetch(`/jobs/${id}/rebroadcast_offer_v2`, { method:"POST", body: JSON.stringify({ tech_type:"all" }) });
@@ -785,6 +879,7 @@ window.rebroadcastOfferQuick = rebroadcastOfferQuick;
 
 async function rebroadcastOffer(){
   if (!CURRENT) return;
+  if (blockReadOnlyMutation()) return;
   if (!confirm("ยืนยันยิงข้อเสนอใหม่ให้ช่างที่เปิดรับงาน ว่างจริง และอยู่ในพื้นที่นี้?")) return;
   try{
     await saveJob();
@@ -801,6 +896,7 @@ async function rebroadcastOffer(){
 
 async function cancelJob(){
   if (!CURRENT) return;
+  if (blockReadOnlyMutation()) return;
   if (!confirm("ยืนยันยกเลิกงานนี้?")) return;
   try{
     await apiFetch(`/jobs/${CURRENT.job_id}/cancel`, { method:"POST", body: JSON.stringify({ reason: "admin_cancel" }) });
@@ -812,7 +908,33 @@ async function cancelJob(){
   }
 }
 
-(async function init(){
+window.__CWF_ADMIN_REVIEW_TEST__ = {
+  REVIEW_QUEUE_NOTIFY,
+  ROW_MAP: () => ROW_MAP,
+  setRowMap(rows){
+    ROW_MAP = new Map((rows || []).map((r) => [Number(r.job_id), r]));
+  },
+  queueBucket,
+  isAdminActionAllowed,
+  filterRowsForDisplay,
+  processQueueNotifications,
+  acknowledgeNewJob,
+  renderNotificationSummary,
+  applyReadOnlyMode,
+  playNewJobSound,
+  claimSharedAdminAlertSound,
+  sharedAdminAlertGate,
+  setCurrent(value){ CURRENT = value; },
+  getCurrent(){ return CURRENT; },
+  openJob,
+  saveJob,
+  dispatchJob,
+  rebroadcastOffer,
+  rebroadcastOfferQuick,
+  cancelJob,
+};
+
+if (!window.__CWF_ADMIN_REVIEW_DISABLE_AUTO_INIT__) (async function init(){
   await loadTechs();
   await loadQueue({ force:true, reason:"init" });
 

--- a/admin-review-v2.js
+++ b/admin-review-v2.js
@@ -5,17 +5,164 @@
  * - Production-safe: fail-open, ไม่กระทบ endpoint เดิม
  */
 
-const ADMIN_REVIEW_V2_DEDUP_BUILD = "20260612_phase35a_review_queue_dedup";
+const ADMIN_REVIEW_V2_DEDUP_BUILD = "20260707_customer_booking_notify_v1";
 window.__CWF_ADMIN_REVIEW_V2_VERSION__ = ADMIN_REVIEW_V2_DEDUP_BUILD;
 
 let TECHS = [];
 let CURRENT = null;
 let CURRENT_SLOTS = [];
 let ROW_MAP = new Map();
+const REVIEW_POLL_MS = 12000;
+const REVIEW_WAITING_STATUS = "\u0e23\u0e2d\u0e0a\u0e48\u0e32\u0e07\u0e22\u0e37\u0e19\u0e22\u0e31\u0e19";
+const REVIEW_STATUS_LABELS = {
+  waiting_technician: "\u0e01\u0e33\u0e25\u0e31\u0e07\u0e23\u0e2d\u0e0a\u0e48\u0e32\u0e07\u0e23\u0e31\u0e1a",
+  pending_review: "\u0e23\u0e2d\u0e15\u0e23\u0e27\u0e08\u0e2a\u0e2d\u0e1a",
+  no_accept: "\u0e44\u0e21\u0e48\u0e1e\u0e1a\u0e0a\u0e48\u0e32\u0e07\u0e23\u0e31\u0e1a\u0e07\u0e32\u0e19",
+  returned: "\u0e15\u0e35\u0e01\u0e25\u0e31\u0e1a",
+  time_proposal: "\u0e23\u0e2d\u0e1e\u0e34\u0e08\u0e32\u0e23\u0e13\u0e32\u0e40\u0e27\u0e25\u0e32\u0e43\u0e2b\u0e21\u0e48",
+};
+const REVIEW_NOTIFY_STORAGE_KEY = "cwf_admin_review_notified_job_ids_v1";
+const REVIEW_QUEUE_POLL = { timer: null, stopped: false, authStopped: false };
+const REVIEW_QUEUE_NOTIFY = {
+  baselineReady: false,
+  knownIds: new Set(),
+  notifiedIds: new Set(loadNotifiedJobIds()),
+  newIds: new Set(),
+  audioUnlocked: false,
+};
 
 function $(id){ return document.getElementById(id); }
 function safe(s){ return (s==null?'':String(s)); }
 function pad2(x){ return String(x).padStart(2,'0'); }
+
+function loadNotifiedJobIds(){
+  try {
+    const raw = sessionStorage.getItem(REVIEW_NOTIFY_STORAGE_KEY);
+    const parsed = raw ? JSON.parse(raw) : [];
+    return Array.isArray(parsed) ? parsed.map(Number).filter(Number.isFinite) : [];
+  } catch (_) {
+    return [];
+  }
+}
+
+function saveNotifiedJobIds(){
+  try {
+    sessionStorage.setItem(REVIEW_NOTIFY_STORAGE_KEY, JSON.stringify(Array.from(REVIEW_QUEUE_NOTIFY.notifiedIds).slice(-500)));
+  } catch (_) {}
+}
+
+function queueBucket(row){
+  const status = safe(row?.job_status);
+  const mode = String(row?.booking_mode || "").toLowerCase();
+  if (mode === "urgent" && status === REVIEW_WAITING_STATUS) return "waiting_technician";
+  if (status === "pending_review" || status === "รอตรวจสอบ") return "pending_review";
+  if (status === "ไม่พบช่างรับงาน") return "no_accept";
+  if (status === "ตีกลับ") return "returned";
+  if (status === "รอพิจารณาเวลาใหม่") return "time_proposal";
+  return "pending_review";
+}
+
+function isAdminActionAllowed(row){
+  if (row && row.admin_action_required === false) return false;
+  return queueBucket(row) !== "waiting_technician";
+}
+
+function updateTitleBadge(count){
+  const baseTitle = "Admin Review Queue - CWF";
+  document.title = count > 0 ? `(${count}) ${baseTitle}` : baseTitle;
+}
+
+function markAdminInteraction(){
+  REVIEW_QUEUE_NOTIFY.audioUnlocked = true;
+}
+
+function playNewJobSound(){
+  if (!REVIEW_QUEUE_NOTIFY.audioUnlocked) return;
+  try {
+    const last = Number(window.__CWF_LAST_ADMIN_ALERT_SOUND_AT || 0);
+    if (Date.now() - last < 1200) return;
+    window.__CWF_LAST_ADMIN_ALERT_SOUND_AT = Date.now();
+    const AudioCtx = window.AudioContext || window.webkitAudioContext;
+    if (!AudioCtx) return;
+    const ctx = new AudioCtx();
+    const osc = ctx.createOscillator();
+    const gain = ctx.createGain();
+    osc.type = "sine";
+    osc.frequency.value = 880;
+    gain.gain.value = 0.05;
+    osc.connect(gain);
+    gain.connect(ctx.destination);
+    osc.start();
+    setTimeout(() => {
+      try { osc.stop(); ctx.close(); } catch (_) {}
+    }, 140);
+  } catch (_) {
+    // Autoplay restrictions must not break visual notification.
+  }
+}
+
+function processQueueNotifications(rows, opts = {}){
+  const reason = String(opts.reason || "");
+  const ids = (rows || []).map((r) => Number(r.job_id)).filter(Number.isFinite);
+  if (!REVIEW_QUEUE_NOTIFY.baselineReady) {
+    ids.forEach((id) => REVIEW_QUEUE_NOTIFY.knownIds.add(id));
+    REVIEW_QUEUE_NOTIFY.baselineReady = true;
+    updateTitleBadge(0);
+    return;
+  }
+  if (reason === "filter_change" || reason === "manual_reload") {
+    ids.forEach((id) => REVIEW_QUEUE_NOTIFY.knownIds.add(id));
+    return;
+  }
+  const fresh = ids.filter((id) => !REVIEW_QUEUE_NOTIFY.knownIds.has(id) && !REVIEW_QUEUE_NOTIFY.notifiedIds.has(id));
+  ids.forEach((id) => REVIEW_QUEUE_NOTIFY.knownIds.add(id));
+  if (!fresh.length) return;
+  fresh.forEach((id) => {
+    REVIEW_QUEUE_NOTIFY.newIds.add(id);
+    REVIEW_QUEUE_NOTIFY.notifiedIds.add(id);
+  });
+  saveNotifiedJobIds();
+  updateTitleBadge(REVIEW_QUEUE_NOTIFY.newIds.size);
+  const alertBox = $("approvalAlert");
+  if (alertBox) {
+    alertBox.style.display = "block";
+    alertBox.innerHTML = `🔔 มีงานจองใหม่ ${fresh.length} งาน`;
+  }
+  playNewJobSound();
+}
+
+function stopReviewQueuePolling(){
+  if (REVIEW_QUEUE_POLL.timer) {
+    clearTimeout(REVIEW_QUEUE_POLL.timer);
+    REVIEW_QUEUE_POLL.timer = null;
+  }
+}
+
+function scheduleReviewQueuePolling(){
+  if (REVIEW_QUEUE_POLL.stopped || REVIEW_QUEUE_POLL.authStopped || REVIEW_QUEUE_POLL.timer) return;
+  if (document.hidden) return;
+  REVIEW_QUEUE_POLL.timer = setTimeout(async () => {
+    REVIEW_QUEUE_POLL.timer = null;
+    if (!REVIEW_QUEUE_POLL.stopped && !REVIEW_QUEUE_POLL.authStopped && !document.hidden) {
+      await loadQueue({ reason:"poll" }).catch((e) => console.warn("[admin-review-v2] poll failed", e));
+    }
+    scheduleReviewQueuePolling();
+  }, REVIEW_POLL_MS);
+}
+
+function resumeReviewQueuePolling(reason){
+  if (REVIEW_QUEUE_POLL.authStopped) return;
+  REVIEW_QUEUE_POLL.stopped = false;
+  if (!document.hidden) loadQueue({ force:true, reason }).catch((e) => console.warn("[admin-review-v2] resume reload failed", e));
+  scheduleReviewQueuePolling();
+}
+
+function stopPollingForAuth(){
+  REVIEW_QUEUE_POLL.authStopped = true;
+  stopReviewQueuePolling();
+  try { if (typeof doLogout === "function") doLogout(); else location.replace("/login.html"); }
+  catch (_) { location.href = "/login.html"; }
+}
 
 function parseLatLngClient(input){
   const s = String(input||'').trim();
@@ -102,6 +249,7 @@ function mapFilterStatus(v){
     pending: "รอตรวจสอบ",
     return: "ตีกลับ",
     noaccept: "ไม่พบช่างรับงาน",
+    waiting: REVIEW_WAITING_STATUS,
     timeproposal: "รอพิจารณาเวลาใหม่",
     all: "all",
   };
@@ -149,6 +297,7 @@ async function loadQueue(opts = {}){
     const data = await apiFetch(`/admin/review_queue_v2?${q.toString()}`);
     const rows = Array.isArray(data.rows) ? data.rows : [];
     ROW_MAP = new Map(rows.map(r=>[Number(r.job_id), r]));
+    processQueueNotifications(rows, opts);
     $("pillCount").textContent = `${rows.length} งาน`;
     const needs = rows.filter(r => ["รอตรวจสอบ","ตีกลับ","ไม่พบช่างรับงาน","รอพิจารณาเวลาใหม่"].includes(safe(r.job_status)));
     const alertBox = $("approvalAlert");
@@ -164,6 +313,11 @@ async function loadQueue(opts = {}){
       }
     }
 
+    if (REVIEW_QUEUE_NOTIFY.newIds.size && alertBox) {
+      alertBox.style.display = "block";
+      alertBox.innerHTML = `🔔 มีงานจองใหม่ ${REVIEW_QUEUE_NOTIFY.newIds.size} งาน`;
+    }
+
     if (!rows.length){
       $("list").innerHTML = '<div class="card"><div class="muted">ไม่มีงานในคิวนี้</div></div>';
       return;
@@ -171,6 +325,14 @@ async function loadQueue(opts = {}){
 
     $("list").innerHTML = rows.map(r=>{
       const badge = `<span class="pill">${safe(r.job_status||"")}</span>`;
+      const bucket = queueBucket(r);
+      const actionAllowed = isAdminActionAllowed(r);
+      const items = Array.isArray(r.items) ? r.items : [];
+      const itemSummary = items.length ? items.map((it)=>`${safe(it.item_name || "-")} x${Number(it.qty || 0) || 0}`).join(" • ") : safe(r.job_type || "-");
+      const units = Number(r.service_units || 0);
+      const reserveTech = safe(r.technician_username || "");
+      const isNew = REVIEW_QUEUE_NOTIFY.newIds.has(Number(r.job_id));
+      const mapLink = safe(r.maps_url || "");
       const urgent = (String(r.booking_mode||"").toLowerCase()==="urgent") ? '<span class="pill" style="background:#fee2e2">ด่วน</span>' : '';
       const proposalPanel = safe(r.job_status) === "รอพิจารณาเวลาใหม่"
         ? `<div class="proposal-panel" id="proposal-panel-${Number(r.job_id)}">
@@ -179,21 +341,26 @@ async function loadQueue(opts = {}){
            </div>`
         : "";
       return `
-        <div class="card review-card-hot">
+        <div class="card review-card-hot ${isNew ? "review-card-new" : ""}">
           <div class="row">
             <div>
               <b>#${r.job_id} • ${safe(r.booking_code||"")}</b>
               <div class="muted" style="margin-top:2px;">${safe(r.customer_name||"-")} • ${safe(r.customer_phone||"-")}</div>
             </div>
             <div style="text-align:right;display:flex;flex-direction:column;gap:6px;align-items:flex-end;">
-              ${badge}${urgent}
+              ${badge}${urgent}<span class="pill">${safe(REVIEW_STATUS_LABELS[bucket] || bucket)}</span>
               <button class="btn btn-primary" type="button" onclick="openJob(${r.job_id})">เปิด</button>
-              <button class="btn" type="button" style="background:linear-gradient(135deg,#2563eb,#06b6d4);color:#fff" onclick="rebroadcastOfferQuick(${Number(r.job_id)})">📣 ลองยิงใหม่</button>
+              <button class="btn" type="button" style="background:linear-gradient(135deg,#2563eb,#06b6d4);color:#fff" ${actionAllowed ? "" : "disabled"} onclick="rebroadcastOfferQuick(${Number(r.job_id)})">📣 ลองยิงใหม่</button>
             </div>
           </div>
           <div class="muted" style="margin-top:8px;">📅 ${thDateTime(r.appointment_datetime)} • 🧾 ${safe(r.job_type||"-")}</div>
           <div class="muted" style="margin-top:4px;">📍 ${safe(r.job_zone||"")} ${safe(r.address_text||"")}</div>
           <div class="muted" style="margin-top:4px;">⏱️ ${Number(r.duration_min||0)} นาที</div>
+          <div class="muted" style="margin-top:4px;">บริการ: ${safe(itemSummary)}</div>
+          <div class="muted" style="margin-top:4px;">จำนวนเครื่อง: ${Number.isFinite(units) && units > 0 ? units : "-"} • ราคา: ${Number(r.job_price||0).toLocaleString("th-TH")} บาท</div>
+          <div class="muted" style="margin-top:4px;">ช่างที่ระบบ reserve: ${reserveTech || "-"}</div>
+          ${mapLink ? `<div class="muted" style="margin-top:4px;"><a href="${safe(mapLink)}" target="_blank" rel="noopener">เปิด Maps URL</a></div>` : ""}
+          ${bucket === "waiting_technician" ? `<div class="muted" style="margin-top:4px;">กำลังรอช่างรับ (${Number(r.pending_offer_count || 0)} offer ค้าง) • read-only จนกว่าจะหมดรอบหรือมีช่างรับ</div>` : ""}
           ${proposalPanel}
         </div>
       `;
@@ -201,6 +368,10 @@ async function loadQueue(opts = {}){
     loadProposalPanels(rows);
   }catch(e){
     console.error(e);
+    if (e && (Number(e.status) === 401 || Number(e.status) === 403)) {
+      stopPollingForAuth();
+      return;
+    }
     $("list").innerHTML = `<div class="card"><div class="muted">โหลดไม่สำเร็จ: ${safe(e.message||e)}</div></div>`;
   }
   };
@@ -424,6 +595,7 @@ async function openJob(jobId){
       job_zone: row.job_zone,
       technician_username: row.technician_username || "",
       team_members: [],
+      admin_action_required: row.admin_action_required !== false,
     };
 
     // team
@@ -463,6 +635,9 @@ async function openJob(jobId){
     $("slotBox").innerHTML = "";
     CURRENT_SLOTS = [];
 
+    const actionAllowed = isAdminActionAllowed(row);
+    if ($("btnDispatch")) $("btnDispatch").disabled = !actionAllowed;
+    if ($("btnRebroadcast")) $("btnRebroadcast").disabled = !actionAllowed;
     setModal(true);
   }catch(e){
     console.error(e);
@@ -652,8 +827,24 @@ async function cancelJob(){
     }
   }catch(e){ console.warn('auto open job', e); }
 
-  $("btnReload").addEventListener("click", () => loadQueue({ reason:"manual_reload" }));
-  $("filterStatus").addEventListener("change", () => loadQueue({ reason:"filter_change" }));
+  document.addEventListener("click", markAdminInteraction, { capture:true });
+  document.addEventListener("keydown", markAdminInteraction, { capture:true });
+  document.addEventListener("touchstart", markAdminInteraction, { capture:true, passive:true });
+  document.addEventListener("visibilitychange", () => {
+    if (document.hidden) stopReviewQueuePolling();
+    else resumeReviewQueuePolling("visibilitychange");
+  });
+  window.addEventListener("focus", () => resumeReviewQueuePolling("focus"));
+  window.addEventListener("pageshow", () => resumeReviewQueuePolling("pageshow"));
+  window.addEventListener("pagehide", () => {
+    REVIEW_QUEUE_POLL.stopped = true;
+    stopReviewQueuePolling();
+  });
+  window.addEventListener("beforeunload", stopReviewQueuePolling);
+
+  $("btnReload").addEventListener("click", () => loadQueue({ force:true, reason:"manual_reload" }));
+  $("filterStatus").addEventListener("change", () => loadQueue({ force:true, reason:"filter_change" }));
+  scheduleReviewQueuePolling();
 
   $("btnLoadSlots").addEventListener("click", loadSlots);
   $("btnSave").addEventListener("click", saveJob);

--- a/customer-app/assets/customer-app.js
+++ b/customer-app/assets/customer-app.js
@@ -3,7 +3,7 @@
 
   const App = window.CWFCustomerAppV2;
   const BOOT_TIMEOUT_MS = 3500;
-  const BUILD_ID = "20260705_payment_security_v1";
+  const BUILD_ID = "20260707_booking_admin_notify_v1";
 
   function withTimeout(promise, timeoutMs) {
     return Promise.race([

--- a/customer-app/index.html
+++ b/customer-app/index.html
@@ -17,10 +17,10 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Noto+Sans+Thai:wght@400;500;600;700;800;900&display=swap" media="print" onload="this.media='all'">
   <noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Noto+Sans+Thai:wght@400;500;600;700;800;900&display=swap"></noscript>
-  <link rel="manifest" href="./manifest.webmanifest?v=20260705_payment_security_v1">
+  <link rel="manifest" href="./manifest.webmanifest?v=20260707_booking_admin_notify_v1">
   <link rel="icon" type="image/png" sizes="192x192" href="./assets/icons/cwf-customer-192.png">
   <link rel="apple-touch-icon" sizes="180x180" href="./assets/icons/cwf-customer-180.png">
-  <link rel="stylesheet" href="./assets/customer-app.css?v=20260705_payment_security_v1">
+  <link rel="stylesheet" href="./assets/customer-app.css?v=20260707_booking_admin_notify_v1">
 </head>
 <body class="is-app-booting">
   <div class="app-shell" data-app-shell>
@@ -58,21 +58,21 @@
     </nav>
   </div>
 
-  <script src="./modules/state.js?v=20260705_payment_security_v1"></script>
-  <script src="./modules/utils.js?v=20260705_payment_security_v1"></script>
-  <script src="./modules/analytics.js?v=20260705_payment_security_v1"></script>
-  <script src="./modules/api.js?v=20260705_payment_security_v1"></script>
-  <script src="./modules/services.js?v=20260705_payment_security_v1"></script>
-  <script src="./modules/ui.js?v=20260705_payment_security_v1"></script>
-  <script src="./modules/store.js?v=20260705_payment_security_v1"></script>
-  <script src="./modules/auth.js?v=20260705_payment_security_v1"></script>
-  <script src="./modules/pricing.js?v=20260705_payment_security_v1"></script>
-  <script src="./modules/availability.js?v=20260705_payment_security_v1"></script>
-  <script src="./modules/bookingScheduled.js?v=20260705_payment_security_v1"></script>
-  <script src="./modules/bookingUrgent.js?v=20260705_payment_security_v1"></script>
-  <script src="./modules/tracking.js?v=20260705_payment_security_v1"></script>
-  <script src="./modules/profile.js?v=20260705_payment_security_v1"></script>
-  <script src="./modules/router.js?v=20260705_payment_security_v1"></script>
-  <script src="./assets/customer-app.js?v=20260705_payment_security_v1"></script>
+  <script src="./modules/state.js?v=20260707_booking_admin_notify_v1"></script>
+  <script src="./modules/utils.js?v=20260707_booking_admin_notify_v1"></script>
+  <script src="./modules/analytics.js?v=20260707_booking_admin_notify_v1"></script>
+  <script src="./modules/api.js?v=20260707_booking_admin_notify_v1"></script>
+  <script src="./modules/services.js?v=20260707_booking_admin_notify_v1"></script>
+  <script src="./modules/ui.js?v=20260707_booking_admin_notify_v1"></script>
+  <script src="./modules/store.js?v=20260707_booking_admin_notify_v1"></script>
+  <script src="./modules/auth.js?v=20260707_booking_admin_notify_v1"></script>
+  <script src="./modules/pricing.js?v=20260707_booking_admin_notify_v1"></script>
+  <script src="./modules/availability.js?v=20260707_booking_admin_notify_v1"></script>
+  <script src="./modules/bookingScheduled.js?v=20260707_booking_admin_notify_v1"></script>
+  <script src="./modules/bookingUrgent.js?v=20260707_booking_admin_notify_v1"></script>
+  <script src="./modules/tracking.js?v=20260707_booking_admin_notify_v1"></script>
+  <script src="./modules/profile.js?v=20260707_booking_admin_notify_v1"></script>
+  <script src="./modules/router.js?v=20260707_booking_admin_notify_v1"></script>
+  <script src="./assets/customer-app.js?v=20260707_booking_admin_notify_v1"></script>
 </body>
 </html>

--- a/customer-app/manifest.webmanifest
+++ b/customer-app/manifest.webmanifest
@@ -2,7 +2,7 @@
   "name": "CWF Customer Service",
   "short_name": "CWF Service",
   "description": "แอปลูกค้า Coldwindflow สำหรับเลือกบริการ จองคิว และติดตามงาน",
-  "start_url": "/customer-app/index.html?v=20260705_payment_security_v1#home",
+  "start_url": "/customer-app/index.html?v=20260707_booking_admin_notify_v1#home",
   "scope": "/customer-app/",
   "id": "/customer-app/",
   "display": "standalone",

--- a/customer-app/modules/bookingScheduled.js
+++ b/customer-app/modules/bookingScheduled.js
@@ -41,6 +41,15 @@
     return `${d.date}T${selected.start}:00`;
   }
 
+  function ensureScheduledRequestKey() {
+    const d = draft();
+    const existing = String(d.scheduled_request_key || "").trim();
+    if (existing) return existing;
+    const key = root.utils.randomKey();
+    root.state.updateDraft("scheduled", { scheduled_request_key: key });
+    return key;
+  }
+
   function dateFromYmd(value) {
     const match = String(value || "").match(/^(\d{4})-(\d{2})-(\d{2})$/);
     if (!match) return null;
@@ -721,6 +730,7 @@
       customer_note: String(d.customer_note || "").trim(),
       booking_mode: "scheduled",
       client_app: "customer_app_v2",
+      scheduled_request_key: ensureScheduledRequestKey(),
       job_zone: String(d.job_zone || "").trim(),
       service_kind: "clean",
       allow_time_proposal: d.allow_time_proposal === true,

--- a/customer-app/modules/state.js
+++ b/customer-app/modules/state.js
@@ -79,6 +79,7 @@
       // Defect 1: all admin-enabled employment types (filtered strictly server-side).
       tech_type: "all",
       selectedSlot: null,
+      scheduled_request_key: "",
       allow_time_proposal: false,
       customer_name: "",
       customer_phone: "",

--- a/customer-app/sw.js
+++ b/customer-app/sw.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const BUILD_ID = "20260705_payment_security_v1";
+const BUILD_ID = "20260707_booking_admin_notify_v1";
 const CACHE_NAME = `cwf-customer-app-v2-${BUILD_ID}`;
 const APP_SHELL = [
   `./index.html?v=${BUILD_ID}`,

--- a/index.js
+++ b/index.js
@@ -15287,7 +15287,6 @@ app.get("/admin/review_queue_v2", requireAdminSoft, async (req, res) => {
     // support: status=all (ดูทั้งหมดที่ควร review)
     const allow = ['รอตรวจสอบ', 'pending_review', 'ตีกลับ', 'ไม่พบช่างรับงาน', 'รอพิจารณาเวลาใหม่'];
     const WAITING_URGENT_STATUS = "\u0e23\u0e2d\u0e0a\u0e48\u0e32\u0e07\u0e22\u0e37\u0e19\u0e22\u0e31\u0e19";
-    allow.push(WAITING_URGENT_STATUS);
     const wantAll = status.toLowerCase() === 'all';
 
     const params = [];
@@ -15299,13 +15298,21 @@ app.get("/admin/review_queue_v2", requireAdminSoft, async (req, res) => {
     where.push(`COALESCE(booking_mode,'scheduled') IN ('scheduled','','urgent')`);
 
     if (!wantAll) {
-      if (!allow.includes(status)) return res.status(400).json({ error: 'status ไม่ถูกต้อง' });
+      if (!allow.includes(status) && status !== WAITING_URGENT_STATUS) return res.status(400).json({ error: 'status \u0e44\u0e21\u0e48\u0e16\u0e39\u0e01\u0e15\u0e49\u0e2d\u0e07' });
       params.push(status);
-      where.push(`job_status = $${p++}`);
+      const statusParam = `$${p++}`;
+      if (status === WAITING_URGENT_STATUS) {
+        where.push(`job_status = ${statusParam} AND COALESCE(booking_mode,'')='urgent' AND COALESCE(job_source,'')='customer'`);
+      } else {
+        where.push(`job_status = ${statusParam}`);
+      }
     } else {
-      // include statuses ที่ต้อง review
-      where.push(`job_status = ANY($${p++}::text[])`);
+      // Include review statuses, plus only Customer App urgent rows still waiting for technician offers.
       params.push(allow);
+      const allowParam = `$${p++}`;
+      params.push(WAITING_URGENT_STATUS);
+      const waitingReviewParam = `$${p++}`;
+      where.push(`(job_status = ANY(${allowParam}::text[]) OR (job_status = ${waitingReviewParam} AND COALESCE(booking_mode,'')='urgent' AND COALESCE(job_source,'')='customer'))`);
     }
 
     if (q) {

--- a/index.js
+++ b/index.js
@@ -15286,6 +15286,8 @@ app.get("/admin/review_queue_v2", requireAdminSoft, async (req, res) => {
 
     // support: status=all (ดูทั้งหมดที่ควร review)
     const allow = ['รอตรวจสอบ', 'pending_review', 'ตีกลับ', 'ไม่พบช่างรับงาน', 'รอพิจารณาเวลาใหม่'];
+    const WAITING_URGENT_STATUS = "\u0e23\u0e2d\u0e0a\u0e48\u0e32\u0e07\u0e22\u0e37\u0e19\u0e22\u0e31\u0e19";
+    allow.push(WAITING_URGENT_STATUS);
     const wantAll = status.toLowerCase() === 'all';
 
     const params = [];
@@ -15312,6 +15314,8 @@ app.get("/admin/review_queue_v2", requireAdminSoft, async (req, res) => {
       p++;
     }
 
+    params.push(WAITING_URGENT_STATUS);
+    const waitingStatusParam = `$${p++}`;
     const sqlWhere = where.length ? `WHERE ${where.join(' AND ')}` : '';
     const r = await pool.query(
       `
@@ -15319,7 +15323,39 @@ app.get("/admin/review_queue_v2", requireAdminSoft, async (req, res) => {
              appointment_datetime, job_status, duration_min, job_price,
              address_text, maps_url, job_zone,
              technician_username, dispatch_mode, booking_mode,
-             created_at
+             created_at,
+             COALESCE((
+               SELECT json_agg(json_build_object(
+                 'item_id', ji.item_id,
+                 'item_name', ji.item_name,
+                 'qty', ji.qty,
+                 'unit_price', ji.unit_price,
+                 'line_total', ji.line_total,
+                 'is_service', ji.is_service,
+                 'assigned_technician_username', ji.assigned_technician_username
+               ) ORDER BY ji.item_id NULLS LAST, ji.item_name)
+               FROM public.job_items ji
+               WHERE ji.job_id=public.jobs.job_id
+             ), '[]'::json) AS items,
+             COALESCE((
+               SELECT SUM(GREATEST(COALESCE(ji.qty,0),0))
+               FROM public.job_items ji
+               WHERE ji.job_id=public.jobs.job_id
+             ),0)::numeric AS service_units,
+             COALESCE((
+               SELECT COUNT(*)::int
+               FROM public.job_offers jo
+               WHERE jo.job_id=public.jobs.job_id
+                 AND jo.status='pending'
+                 AND jo.expires_at >= NOW()
+             ),0)::int AS pending_offer_count,
+             EXISTS (
+               SELECT 1
+               FROM public.job_offer_time_proposals p
+               WHERE p.job_id=public.jobs.job_id
+                 AND p.status='pending'
+             ) AS has_pending_time_proposal,
+             NOT (COALESCE(booking_mode,'')='urgent' AND job_status=${waitingStatusParam}) AS admin_action_required
       FROM public.jobs
       ${sqlWhere}
       ORDER BY created_at DESC
@@ -25149,6 +25185,12 @@ function isCustomerAppUrgentBook(body = {}) {
     String(body.client_app || "").trim().toLowerCase() === "customer_app_v2";
 }
 
+function deriveCustomerScheduledBookingToken(requestKey) {
+  const key = String(requestKey || "").trim();
+  if (!key) return null;
+  return crypto.createHash("sha256").update(`scheduled_v1:${key}`).digest("hex").slice(0, 24);
+}
+
 // Customer App V2 urgent requests are just another entry point into the
 // existing admin urgent offer engine (handleAdminBookV2): this adapter only
 // (a) strips the request down to a customer-safe allowlist and (b) computes
@@ -25223,6 +25265,7 @@ app.post("/public/book", async (req, res) => {
     wash_variant,
     repair_variant,
     services,
+    scheduled_request_key,
     catalog_item_id, // optional: links this booking to the Store catalog item it was booked for
   } = req.body || {};
 
@@ -25259,10 +25302,20 @@ app.post("/public/book", async (req, res) => {
     .map((x) => ({ item_id: Number(x.item_id), qty: Number(x.qty || 1) }))
     .filter((x) => Number.isFinite(x.item_id) && x.item_id > 0 && Number.isFinite(x.qty) && x.qty > 0);
 
-  const token = genToken(12);
+  let token = genToken(12);
   // DURATION_PRICE_V2_PUBLIC_BOOK
   let bm = (booking_mode || "scheduled").toString().trim().toLowerCase();
   const clientApp = (client_app || "").toString().trim().toLowerCase();
+  const scheduledRequestKey = bm === "scheduled" && clientApp === "customer_app_v2"
+    ? String(scheduled_request_key || "").trim()
+    : "";
+  if (scheduledRequestKey && scheduledRequestKey.length < 16) {
+    return res.status(400).json({ error: "MISSING_REQUEST_KEY", code: "MISSING_REQUEST_KEY" });
+  }
+  const scheduledDeterministicToken = scheduledRequestKey
+    ? deriveCustomerScheduledBookingToken(scheduledRequestKey)
+    : null;
+  if (scheduledDeterministicToken) token = scheduledDeterministicToken;
   const allowAdminScheduleFallback = allow_admin_schedule_fallback === true || String(allow_admin_schedule_fallback || "").trim() === "true";
   const canUseAdminScheduleFallback = bm === "scheduled" && allowAdminScheduleFallback && clientApp === "customer_app_v2";
   const urgentOfferEnabled = bm === "urgent" && ENABLE_URGENT_FLOW;
@@ -25493,6 +25546,38 @@ console.log("[latlng_parse]", { ok: !!parsedLL });
   const client = await pool.connect();
   try {
     await client.query("BEGIN");
+
+    if (scheduledRequestKey && scheduledDeterministicToken) {
+      await client.query("SELECT pg_advisory_xact_lock(hashtext($1))", [scheduledRequestKey]);
+      const existing = await client.query(
+        `SELECT job_id, booking_code, booking_token, booking_mode, dispatch_mode,
+                duration_min, job_price
+           FROM public.jobs
+          WHERE booking_token=$1
+            AND job_source='customer'
+            AND COALESCE(booking_mode,'scheduled')='scheduled'
+            AND canceled_at IS NULL
+          LIMIT 1`,
+        [scheduledDeterministicToken]
+      );
+      if (existing.rows[0]) {
+        const row = existing.rows[0];
+        await client.query("COMMIT");
+        return res.json({
+          success: true,
+          replayed: true,
+          job_id: row.job_id,
+          booking_code: row.booking_code,
+          token: row.booking_token,
+          booking_mode: "scheduled",
+          dispatch_mode: row.dispatch_mode || "normal",
+          duration_min: Number(row.duration_min || duration_min_v2 || 0),
+          effective_block_min: effectiveBlockMin(Number(row.duration_min || duration_min_v2 || 0)),
+          travel_buffer_min: TRAVEL_BUFFER_MIN,
+          base_total: Number(row.job_price || 0),
+        });
+      }
+    }
 
     let draftReservationTech = null;
     if (bm === "scheduled" && clientApp === "customer_app_v2") {

--- a/index.js
+++ b/index.js
@@ -25309,7 +25309,8 @@ app.post("/public/book", async (req, res) => {
   const scheduledRequestKey = bm === "scheduled" && clientApp === "customer_app_v2"
     ? String(scheduled_request_key || "").trim()
     : "";
-  if (scheduledRequestKey && scheduledRequestKey.length < 16) {
+  const validScheduledRequestKey = /^[A-Za-z0-9_-]{16,128}$/.test(scheduledRequestKey);
+  if (bm === "scheduled" && clientApp === "customer_app_v2" && !validScheduledRequestKey) {
     return res.status(400).json({ error: "MISSING_REQUEST_KEY", code: "MISSING_REQUEST_KEY" });
   }
   const scheduledDeterministicToken = scheduledRequestKey

--- a/test/customerAppRecovery.test.js
+++ b/test/customerAppRecovery.test.js
@@ -236,7 +236,7 @@ test("Customer App build id is consistent across shell and service worker", () =
   const sw = read("customer-app/sw.js");
   const app = read("customer-app/assets/customer-app.js");
   const manifest = read("customer-app/manifest.webmanifest");
-  const build = "20260705_payment_security_v1";
+  const build = "20260707_booking_admin_notify_v1";
 
   assert.match(index, new RegExp(`customer-app\\.css\\?v=${build}`));
   assert.match(index, new RegExp(`modules\\/api\\.js\\?v=${build}`));
@@ -254,7 +254,7 @@ test("Customer App build id is consistent across shell and service worker", () =
 test("store module is loaded in index.html and precached in the service worker app shell", () => {
   const index = read("customer-app/index.html");
   const sw = read("customer-app/sw.js");
-  const build = "20260705_payment_security_v1";
+  const build = "20260707_booking_admin_notify_v1";
 
   assert.match(index, new RegExp(`modules/store\\.js\\?v=${build}`));
   assert.match(sw, /`\.\/modules\/store\.js\?v=\$\{BUILD_ID\}`/);

--- a/test/customerAppStorePayment.test.js
+++ b/test/customerAppStorePayment.test.js
@@ -58,7 +58,7 @@ test("store falls back to the LINE hand-off when payment is unconfigured or the 
 test("payment step styles exist and the Customer App payment build id is bumped", () => {
   assert.match(cssSrc, /\.pay-method-btn/);
   assert.match(cssSrc, /\.pay-qr-img/);
-  assert.match(read("customer-app/index.html"), /modules\/store\.js\?v=20260705_payment_security_v1/);
-  assert.match(read("customer-app/sw.js"), /BUILD_ID = "20260705_payment_security_v1"/);
+  assert.match(read("customer-app/index.html"), /modules\/store\.js\?v=20260707_booking_admin_notify_v1/);
+  assert.match(read("customer-app/sw.js"), /BUILD_ID = "20260707_booking_admin_notify_v1"/);
   assert.match(storeSrc, /payment-security 20260705 loaded/);
 });

--- a/test/customerBookingAdminNotifications.test.js
+++ b/test/customerBookingAdminNotifications.test.js
@@ -19,6 +19,29 @@ const customerIndex = read("customer-app/index.html");
 const customerSw = read("customer-app/sw.js");
 const customerManifest = read("customer-app/manifest.webmanifest");
 
+const WAITING_URGENT_STATUS = "\u0e23\u0e2d\u0e0a\u0e48\u0e32\u0e07\u0e22\u0e37\u0e19\u0e22\u0e31\u0e19";
+const REVIEW_STATUSES = ["\u0e23\u0e2d\u0e15\u0e23\u0e27\u0e08\u0e2a\u0e2d\u0e1a", "pending_review", "\u0e15\u0e35\u0e01\u0e25\u0e31\u0e1a", "\u0e44\u0e21\u0e48\u0e1e\u0e1a\u0e0a\u0e48\u0e32\u0e07\u0e23\u0e31\u0e1a\u0e07\u0e32\u0e19", "\u0e23\u0e2d\u0e1e\u0e34\u0e08\u0e32\u0e23\u0e13\u0e32\u0e40\u0e27\u0e25\u0e32\u0e43\u0e2b\u0e21\u0e48"];
+
+function simulateReviewQueueRows(rows, status = "all") {
+  const wanted = String(status || "\u0e23\u0e2d\u0e15\u0e23\u0e27\u0e08\u0e2a\u0e2d\u0e1a").trim();
+  const wantAll = wanted.toLowerCase() === "all";
+  return rows
+    .filter((row) => row.canceled_at == null)
+    .filter((row) => ["scheduled", "", "urgent"].includes(String(row.booking_mode ?? "scheduled")))
+    .filter((row) => {
+      const isCustomerUrgentWaiting = row.job_status === WAITING_URGENT_STATUS
+        && String(row.booking_mode || "") === "urgent"
+        && String(row.job_source || "") === "customer";
+      if (wantAll) return REVIEW_STATUSES.includes(row.job_status) || isCustomerUrgentWaiting;
+      if (wanted === WAITING_URGENT_STATUS) return isCustomerUrgentWaiting;
+      return REVIEW_STATUSES.includes(wanted) && row.job_status === wanted;
+    })
+    .map((row) => ({
+      ...row,
+      admin_action_required: !(String(row.booking_mode || "") === "urgent" && row.job_status === WAITING_URGENT_STATUS),
+    }));
+}
+
 function deriveTestScheduledToken(requestKey) {
   return crypto.createHash("sha256").update(`scheduled_v1:${String(requestKey || "").trim()}`).digest("hex").slice(0, 24);
 }
@@ -228,7 +251,8 @@ test("scheduled customer app sends one request key and clears it on new booking 
 
 test("admin review queue includes urgent waiting rows as read-only without offer join duplication", () => {
   assert.match(index, /WAITING_URGENT_STATUS/);
-  assert.match(index, /allow\.push\(WAITING_URGENT_STATUS\)/);
+  assert.doesNotMatch(index, /allow\.push\(WAITING_URGENT_STATUS\)/);
+  assert.match(index, /COALESCE\(booking_mode,''\)='urgent' AND COALESCE\(job_source,''\)='customer'/);
   assert.match(index, /pending_offer_count/);
   assert.match(index, /json_agg\(json_build_object/);
   assert.match(index, /AS items/);
@@ -283,10 +307,34 @@ test("admin review new-job notification uses first-load baseline and one sound p
 
 test("admin/customer frontend cache versions are bumped for booking notification changes", () => {
   assert.match(adminReviewHtml, /admin-review-v2\.js\?v=20260707_customer_booking_notify_v2/);
+  assert.match(adminReviewHtml, /admin-review-ai-intake\.js\?v=ai-booking-intake-customer-cards-v11-admin-alert-gate/);
+  assert.doesNotMatch(adminReviewHtml, /admin-review-ai-intake\.js\?v=ai-booking-intake-customer-cards-v10/);
   assert.match(customerIndex, /bookingScheduled\.js\?v=20260707_booking_admin_notify_v1/);
   assert.match(customerIndex, /state\.js\?v=20260707_booking_admin_notify_v1/);
   assert.match(customerSw, /const BUILD_ID = "20260707_booking_admin_notify_v1"/);
   assert.match(customerManifest, /20260707_booking_admin_notify_v1/);
+});
+
+test("behavior: review queue only includes customer urgent waiting rows while preserving review statuses", () => {
+  const rows = [
+    { job_id: 1, job_status: WAITING_URGENT_STATUS, booking_mode: "urgent", job_source: "customer", canceled_at: null },
+    { job_id: 2, job_status: WAITING_URGENT_STATUS, booking_mode: "urgent", job_source: "admin", canceled_at: null },
+    { job_id: 3, job_status: WAITING_URGENT_STATUS, booking_mode: "scheduled", job_source: "customer", canceled_at: null },
+    { job_id: 4, job_status: "\u0e23\u0e2d\u0e15\u0e23\u0e27\u0e08\u0e2a\u0e2d\u0e1a", booking_mode: "scheduled", job_source: "customer", canceled_at: null },
+    { job_id: 5, job_status: "pending_review", booking_mode: "scheduled", job_source: "customer", canceled_at: null },
+    { job_id: 6, job_status: "\u0e15\u0e35\u0e01\u0e25\u0e31\u0e1a", booking_mode: "urgent", job_source: "customer", canceled_at: null },
+    { job_id: 7, job_status: "\u0e44\u0e21\u0e48\u0e1e\u0e1a\u0e0a\u0e48\u0e32\u0e07\u0e23\u0e31\u0e1a\u0e07\u0e32\u0e19", booking_mode: "urgent", job_source: "customer", canceled_at: null },
+    { job_id: 8, job_status: "\u0e23\u0e2d\u0e1e\u0e34\u0e08\u0e32\u0e23\u0e13\u0e32\u0e40\u0e27\u0e25\u0e32\u0e43\u0e2b\u0e21\u0e48", booking_mode: "urgent", job_source: "customer", canceled_at: null },
+  ];
+  const all = simulateReviewQueueRows(rows, "all");
+  assert.deepEqual(all.map((row) => row.job_id), [1, 4, 5, 6, 7, 8]);
+  assert.equal(all.find((row) => row.job_id === 1).admin_action_required, false);
+  assert.equal(all.some((row) => row.job_id === 2), false);
+  assert.equal(all.some((row) => row.job_id === 3), false);
+
+  const waitingOnly = simulateReviewQueueRows(rows, WAITING_URGENT_STATUS);
+  assert.deepEqual(waitingOnly.map((row) => row.job_id), [1]);
+  assert.equal(waitingOnly[0].admin_action_required, false);
 });
 
 test("behavior: concurrent scheduled requests with the same key create one job and one reservation", async () => {

--- a/test/customerBookingAdminNotifications.test.js
+++ b/test/customerBookingAdminNotifications.test.js
@@ -1,0 +1,92 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const test = require("node:test");
+
+const root = path.join(__dirname, "..");
+const read = (file) => fs.readFileSync(path.join(root, file), "utf8");
+
+const index = read("index.js");
+const adminReview = read("admin-review-v2.js");
+const adminReviewHtml = read("admin-review-v2.html");
+const scheduled = read("customer-app/modules/bookingScheduled.js");
+const state = read("customer-app/modules/state.js");
+const customerIndex = read("customer-app/index.html");
+const customerSw = read("customer-app/sw.js");
+const customerManifest = read("customer-app/manifest.webmanifest");
+
+test("scheduled customer booking has durable request-key idempotency before reservation", () => {
+  assert.match(index, /function deriveCustomerScheduledBookingToken\(requestKey\)/);
+  assert.match(index, /scheduled_request_key/);
+  assert.match(index, /pg_advisory_xact_lock\(hashtext\(\$1\)\)/);
+  assert.match(index, /WHERE booking_token=\$1[\s\S]*job_source='customer'[\s\S]*COALESCE\(booking_mode,'scheduled'\)='scheduled'/);
+  assert.match(index, /replayed:\s*true/);
+  assert.ok(index.indexOf("SELECT pg_advisory_xact_lock(hashtext($1))") < index.indexOf("reservePublicCustomerTechnician"));
+});
+
+test("scheduled customer app sends one request key and clears it on new booking reset", () => {
+  assert.match(state, /scheduled_request_key:\s*""/);
+  assert.match(scheduled, /function ensureScheduledRequestKey\(\)/);
+  assert.match(scheduled, /root\.utils\.randomKey\(\)/);
+  assert.match(scheduled, /scheduled_request_key:\s*ensureScheduledRequestKey\(\)/);
+  assert.match(scheduled, /root\.state\.resetScheduledDraft\(\)/);
+});
+
+test("admin review queue includes urgent waiting rows as read-only without offer join duplication", () => {
+  assert.match(index, /WAITING_URGENT_STATUS/);
+  assert.match(index, /allow\.push\(WAITING_URGENT_STATUS\)/);
+  assert.match(index, /pending_offer_count/);
+  assert.match(index, /json_agg\(json_build_object/);
+  assert.match(index, /AS items/);
+  assert.match(index, /AS service_units/);
+  assert.match(index, /AS admin_action_required/);
+  assert.doesNotMatch(index, /FROM public\.jobs\s+j\s+JOIN public\.job_offers/);
+});
+
+test("admin review UI separates waiting urgent jobs and disables duplicate dispatch actions", () => {
+  assert.match(adminReviewHtml, /<option value="waiting">/);
+  assert.match(adminReview, /waiting:\s*REVIEW_WAITING_STATUS/);
+  assert.match(adminReview, /function queueBucket\(row\)/);
+  assert.match(adminReview, /waiting_technician/);
+  assert.match(adminReview, /function isAdminActionAllowed\(row\)/);
+  assert.match(adminReview, /\$\("btnDispatch"\)\.disabled = !actionAllowed/);
+  assert.match(adminReview, /\$\("btnRebroadcast"\)\.disabled = !actionAllowed/);
+  assert.match(adminReview, /\$\{actionAllowed \? "" : "disabled"\} onclick="rebroadcastOfferQuick/);
+});
+
+test("admin review polling is visible-only, single-flight, and auth-aware", () => {
+  assert.match(adminReview, /const REVIEW_POLL_MS = 12000/);
+  assert.match(adminReview, /REVIEW_QUEUE_LOAD_GUARD\.inFlight/);
+  assert.match(adminReview, /function scheduleReviewQueuePolling\(\)/);
+  assert.match(adminReview, /document\.hidden/);
+  assert.match(adminReview, /visibilitychange/);
+  assert.match(adminReview, /window\.addEventListener\("focus"/);
+  assert.match(adminReview, /window\.addEventListener\("pageshow"/);
+  assert.match(adminReview, /window\.addEventListener\("pagehide"/);
+  assert.match(adminReview, /beforeunload/);
+  assert.match(adminReview, /Number\(e\.status\) === 401 \|\| Number\(e\.status\) === 403/);
+  assert.match(adminReview, /stopPollingForAuth\(\)/);
+});
+
+test("admin review new-job notification uses first-load baseline and one sound per job id", () => {
+  assert.match(adminReview, /baselineReady/);
+  assert.match(adminReview, /knownIds/);
+  assert.match(adminReview, /notifiedIds/);
+  assert.match(adminReview, /sessionStorage\.getItem\(REVIEW_NOTIFY_STORAGE_KEY\)/);
+  assert.match(adminReview, /sessionStorage\.setItem\(REVIEW_NOTIFY_STORAGE_KEY/);
+  assert.match(adminReview, /reason === "filter_change" \|\| reason === "manual_reload"/);
+  assert.match(adminReview, /AudioContext \|\| window\.webkitAudioContext/);
+  assert.match(adminReview, /__CWF_LAST_ADMIN_ALERT_SOUND_AT/);
+  assert.match(adminReview, /review-card-new/);
+  assert.match(adminReview, /document\.title = count > 0/);
+});
+
+test("admin/customer frontend cache versions are bumped for booking notification changes", () => {
+  assert.match(adminReviewHtml, /admin-review-v2\.js\?v=20260707_customer_booking_notify_v1/);
+  assert.match(customerIndex, /bookingScheduled\.js\?v=20260707_booking_admin_notify_v1/);
+  assert.match(customerIndex, /state\.js\?v=20260707_booking_admin_notify_v1/);
+  assert.match(customerSw, /const BUILD_ID = "20260707_booking_admin_notify_v1"/);
+  assert.match(customerManifest, /20260707_booking_admin_notify_v1/);
+});

--- a/test/customerBookingAdminNotifications.test.js
+++ b/test/customerBookingAdminNotifications.test.js
@@ -1,9 +1,11 @@
 "use strict";
 
 const assert = require("node:assert/strict");
+const crypto = require("node:crypto");
 const fs = require("node:fs");
 const path = require("node:path");
 const test = require("node:test");
+const vm = require("node:vm");
 
 const root = path.join(__dirname, "..");
 const read = (file) => fs.readFileSync(path.join(root, file), "utf8");
@@ -17,12 +19,202 @@ const customerIndex = read("customer-app/index.html");
 const customerSw = read("customer-app/sw.js");
 const customerManifest = read("customer-app/manifest.webmanifest");
 
+function deriveTestScheduledToken(requestKey) {
+  return crypto.createHash("sha256").update(`scheduled_v1:${String(requestKey || "").trim()}`).digest("hex").slice(0, 24);
+}
+
+function validScheduledRequestKey(value) {
+  return /^[A-Za-z0-9_-]{16,128}$/.test(String(value || "").trim());
+}
+
+async function simulateScheduledCustomerBook(store, body) {
+  const bm = String(body.booking_mode || "scheduled").trim().toLowerCase();
+  const clientApp = String(body.client_app || "").trim().toLowerCase();
+  const requestKey = bm === "scheduled" && clientApp === "customer_app_v2"
+    ? String(body.scheduled_request_key || "").trim()
+    : "";
+  if (bm === "scheduled" && clientApp === "customer_app_v2" && !validScheduledRequestKey(requestKey)) {
+    return { status: 400, body: { code: "MISSING_REQUEST_KEY" } };
+  }
+  const token = requestKey ? deriveTestScheduledToken(requestKey) : `random-${store.nextId}`;
+  store.ops.push("BEGIN");
+  await store.lock(requestKey);
+  store.ops.push("lock");
+  const existing = store.jobsByToken.get(token);
+  store.ops.push("lookup");
+  if (existing) {
+    store.unlock(requestKey);
+    store.ops.push("COMMIT");
+    return { status: 200, body: { ...existing, replayed: true } };
+  }
+  store.ops.push("reserve");
+  store.reserveCount += 1;
+  const job = {
+    job_id: store.nextId++,
+    booking_code: `CWF${store.nextId}`,
+    token,
+  };
+  store.jobsByToken.set(token, job);
+  store.unlock(requestKey);
+  store.ops.push("COMMIT");
+  return { status: 200, body: { ...job, replayed: false } };
+}
+
+function createScheduledStore() {
+  const queues = new Map();
+  const store = {
+    nextId: 1,
+    jobsByToken: new Map(),
+    reserveCount: 0,
+    ops: [],
+    async lock(key) {
+      const prior = queues.get(key) || Promise.resolve();
+      let release;
+      queues.set(key, new Promise((resolve) => { release = resolve; }));
+      await prior;
+      store.currentRelease = release;
+    },
+    unlock() {
+      const release = store.currentRelease;
+      store.currentRelease = null;
+      if (release) release();
+    },
+  };
+  return store;
+}
+
+function createElement(id = "") {
+  const classes = new Set();
+  return {
+    id,
+    value: "",
+    textContent: "",
+    innerHTML: "",
+    disabled: false,
+    style: {},
+    parentNode: null,
+    removedClass: "",
+    classList: {
+      add(name) { classes.add(name); },
+      remove(name) { classes.delete(name); this.removedClass = name; },
+      toggle(name, enabled) { if (enabled) classes.add(name); else classes.delete(name); },
+      contains(name) { return classes.has(name); },
+    },
+    addEventListener() {},
+    setAttribute() {},
+    getAttribute() { return ""; },
+    closest() { return null; },
+  };
+}
+
+function createAdminReviewSandbox() {
+  const elements = new Map();
+  const card = createElement("card-2");
+  card.classList.add("review-card-new");
+  const getElement = (id) => {
+    if (!elements.has(id)) elements.set(id, createElement(id));
+    return elements.get(id);
+  };
+  [
+    "approvalAlert", "overlay", "list", "pillCount", "filterStatus", "slotBox",
+    "mCustomerName", "mCustomerPhone", "mJobType", "mBookingCode", "mAppt",
+    "mAddress", "mMaps", "mZone", "mLat", "mLng", "mNote", "mTitle", "mSub",
+    "mTechType", "mPrimaryTech", "mDispatchMode", "mTeamSearch", "mTeamSuggest",
+    "mTeamSelected", "mPricing", "mReadOnlyNotice", "btnLoadSlots", "btnSave",
+    "btnDispatch", "btnRebroadcast", "btnCancel", "btnLoadPricing", "btnReload",
+  ].forEach(getElement);
+  getElement("filterStatus").value = "all";
+  const storage = new Map();
+  let now = 10_000;
+  let soundCount = 0;
+  class FakeDate extends Date {
+    static now() { return now; }
+  }
+  class FakeAudioContext {
+    createOscillator() {
+      return { type: "", frequency: { value: 0 }, connect() {}, start() { soundCount += 1; }, stop() {} };
+    }
+    createGain() { return { gain: { value: 0 }, connect() {} }; }
+    close() {}
+  }
+  const document = {
+    title: "Admin Review Queue - CWF",
+    hidden: false,
+    readyState: "complete",
+    head: { appendChild() {} },
+    getElementById: getElement,
+    createElement(id) {
+      const el = createElement(id);
+      el.parentNode = { insertBefore() {} };
+      return el;
+    },
+    querySelector(selector) {
+      if (selector === '[data-review-job-id="2"]') return card;
+      return null;
+    },
+    querySelectorAll() { return []; },
+    addEventListener() {},
+  };
+  getElement("list").parentNode = { insertBefore() {} };
+  const sandbox = {
+    console,
+    setTimeout,
+    clearTimeout,
+    URLSearchParams,
+    Intl,
+    Number,
+    String,
+    Array,
+    Map,
+    Set,
+    JSON,
+    Math,
+    Date: FakeDate,
+    document,
+    location: { href: "", replace(value) { this.href = value; } },
+    sessionStorage: {
+      getItem(key) { return storage.has(key) ? storage.get(key) : null; },
+      setItem(key, value) { storage.set(key, String(value)); },
+    },
+    AudioContext: FakeAudioContext,
+    webkitAudioContext: FakeAudioContext,
+    confirm() { return true; },
+    prompt() { return ""; },
+    alert() {},
+    showToast() {},
+    apiFetch: async (url, options = {}) => {
+      if (options.method) throw new Error(`unexpected mutation ${options.method} ${url}`);
+      if (/\/team/.test(url)) return { members: [] };
+      if (/\/pricing/.test(url)) return { total: 0, discount: 0 };
+      return {};
+    },
+    window: null,
+    __advance(ms) { now += ms; },
+    __soundCount() { return soundCount; },
+    __card: card,
+    __elements: elements,
+  };
+  sandbox.window = sandbox;
+  sandbox.window.__CWF_ADMIN_REVIEW_DISABLE_AUTO_INIT__ = true;
+  vm.createContext(sandbox);
+  vm.runInContext(adminReview, sandbox, { filename: "admin-review-v2.js" });
+  return sandbox;
+}
+
+function loadAiIntakeIntoSandbox(sandbox) {
+  sandbox.window.__CWF_AI_INTAKE_DISABLE_AUTO_INIT__ = true;
+  vm.runInContext(read("admin-review-ai-intake.js"), sandbox, { filename: "admin-review-ai-intake.js" });
+  return sandbox.window.__CWF_AI_INTAKE_TEST__;
+}
+
 test("scheduled customer booking has durable request-key idempotency before reservation", () => {
   assert.match(index, /function deriveCustomerScheduledBookingToken\(requestKey\)/);
   assert.match(index, /scheduled_request_key/);
   assert.match(index, /pg_advisory_xact_lock\(hashtext\(\$1\)\)/);
   assert.match(index, /WHERE booking_token=\$1[\s\S]*job_source='customer'[\s\S]*COALESCE\(booking_mode,'scheduled'\)='scheduled'/);
   assert.match(index, /replayed:\s*true/);
+  assert.match(index, /validScheduledRequestKey/);
+  assert.match(index, /\^\[A-Za-z0-9_-\]\{16,128\}\$/);
   assert.ok(index.indexOf("SELECT pg_advisory_xact_lock(hashtext($1))") < index.indexOf("reservePublicCustomerTechnician"));
 });
 
@@ -46,13 +238,16 @@ test("admin review queue includes urgent waiting rows as read-only without offer
 });
 
 test("admin review UI separates waiting urgent jobs and disables duplicate dispatch actions", () => {
-  assert.match(adminReviewHtml, /<option value="waiting">/);
+  assert.match(adminReviewHtml, /<option value="waiting">กำลังรอช่างรับ<\/option>/);
+  assert.doesNotMatch(adminReviewHtml, /\?{6,}/);
+  assert.doesNotMatch(adminReviewHtml, /\uFFFD/);
   assert.match(adminReview, /waiting:\s*REVIEW_WAITING_STATUS/);
   assert.match(adminReview, /function queueBucket\(row\)/);
   assert.match(adminReview, /waiting_technician/);
   assert.match(adminReview, /function isAdminActionAllowed\(row\)/);
-  assert.match(adminReview, /\$\("btnDispatch"\)\.disabled = !actionAllowed/);
-  assert.match(adminReview, /\$\("btnRebroadcast"\)\.disabled = !actionAllowed/);
+  assert.match(adminReview, /function applyReadOnlyMode\(readOnly\)/);
+  assert.match(adminReview, /งานนี้กำลังรอช่างรับ ระบบเปิดให้ดูรายละเอียดเท่านั้น/);
+  assert.match(adminReview, /function blockReadOnlyMutation\(\)/);
   assert.match(adminReview, /\$\{actionAllowed \? "" : "disabled"\} onclick="rebroadcastOfferQuick/);
 });
 
@@ -78,15 +273,134 @@ test("admin review new-job notification uses first-load baseline and one sound p
   assert.match(adminReview, /sessionStorage\.setItem\(REVIEW_NOTIFY_STORAGE_KEY/);
   assert.match(adminReview, /reason === "filter_change" \|\| reason === "manual_reload"/);
   assert.match(adminReview, /AudioContext \|\| window\.webkitAudioContext/);
-  assert.match(adminReview, /__CWF_LAST_ADMIN_ALERT_SOUND_AT/);
+  assert.match(adminReview, /__CWF_ADMIN_ALERT_GATE__/);
+  assert.match(adminReview, /function acknowledgeNewJob\(jobId\)/);
+  assert.match(adminReview, /function pruneNewJobIds\(rows\)/);
+  assert.match(adminReview, /function filterRowsForDisplay\(rows, selectedFilter\)/);
   assert.match(adminReview, /review-card-new/);
   assert.match(adminReview, /document\.title = count > 0/);
 });
 
 test("admin/customer frontend cache versions are bumped for booking notification changes", () => {
-  assert.match(adminReviewHtml, /admin-review-v2\.js\?v=20260707_customer_booking_notify_v1/);
+  assert.match(adminReviewHtml, /admin-review-v2\.js\?v=20260707_customer_booking_notify_v2/);
   assert.match(customerIndex, /bookingScheduled\.js\?v=20260707_booking_admin_notify_v1/);
   assert.match(customerIndex, /state\.js\?v=20260707_booking_admin_notify_v1/);
   assert.match(customerSw, /const BUILD_ID = "20260707_booking_admin_notify_v1"/);
   assert.match(customerManifest, /20260707_booking_admin_notify_v1/);
+});
+
+test("behavior: concurrent scheduled requests with the same key create one job and one reservation", async () => {
+  const store = createScheduledStore();
+  const body = {
+    booking_mode: "scheduled",
+    client_app: "customer_app_v2",
+    scheduled_request_key: "same-request-key-123",
+  };
+  const [a, b] = await Promise.all([
+    simulateScheduledCustomerBook(store, body),
+    simulateScheduledCustomerBook(store, body),
+  ]);
+  assert.equal(a.status, 200);
+  assert.equal(b.status, 200);
+  assert.equal(a.body.job_id, b.body.job_id);
+  assert.equal(a.body.booking_code, b.body.booking_code);
+  assert.equal(a.body.token, b.body.token);
+  assert.equal(store.jobsByToken.size, 1);
+  assert.equal(store.reserveCount, 1);
+  assert.ok([a.body.replayed, b.body.replayed].includes(true));
+  assert.deepEqual(store.ops.slice(0, 4), ["BEGIN", "BEGIN", "lock", "lookup"]);
+  assert.ok(store.ops.indexOf("reserve") > store.ops.indexOf("lookup"));
+});
+
+test("behavior: missing scheduled request key for Customer App V2 is rejected", async () => {
+  const store = createScheduledStore();
+  const res = await simulateScheduledCustomerBook(store, {
+    booking_mode: "scheduled",
+    client_app: "customer_app_v2",
+  });
+  assert.equal(res.status, 400);
+  assert.equal(res.body.code, "MISSING_REQUEST_KEY");
+  assert.equal(store.reserveCount, 0);
+  assert.equal(store.jobsByToken.size, 0);
+});
+
+test("behavior: urgent waiting modal is viewable but all mutation paths are read-only", async () => {
+  const sandbox = createAdminReviewSandbox();
+  const hooks = sandbox.window.__CWF_ADMIN_REVIEW_TEST__;
+  hooks.setRowMap([{
+    job_id: 7,
+    booking_code: "URG-7",
+    booking_mode: "urgent",
+    job_status: "รอช่างยืนยัน",
+    admin_action_required: false,
+    duration_min: 60,
+  }]);
+  await hooks.openJob(7);
+  assert.equal(hooks.getCurrent().job_id, 7);
+  for (const id of ["btnSave", "btnDispatch", "btnRebroadcast", "btnCancel", "btnLoadSlots", "mCustomerName", "mAppt", "mTechType", "mPrimaryTech", "mDispatchMode"]) {
+    assert.equal(sandbox.__elements.get(id).disabled, true, `${id} should be disabled`);
+  }
+  assert.equal(sandbox.__elements.get("mReadOnlyNotice").style.display, "block");
+  await hooks.saveJob();
+  await hooks.dispatchJob();
+  await hooks.rebroadcastOffer();
+  await hooks.rebroadcastOfferQuick(7);
+  await hooks.cancelJob();
+});
+
+test("behavior: notification checks all queue rows even when selected display filter hides the new job", () => {
+  const sandbox = createAdminReviewSandbox();
+  const hooks = sandbox.window.__CWF_ADMIN_REVIEW_TEST__;
+  hooks.REVIEW_QUEUE_NOTIFY.audioUnlocked = true;
+  const waiting = { job_id: 1, booking_mode: "urgent", job_status: "รอช่างยืนยัน", admin_action_required: false };
+  const scheduledPending = { job_id: 2, booking_mode: "scheduled", job_status: "รอตรวจสอบ", admin_action_required: true };
+  hooks.processQueueNotifications([waiting], { reason: "init" });
+  assert.deepEqual(hooks.filterRowsForDisplay([waiting, scheduledPending], "waiting").map((r) => r.job_id), [1]);
+  hooks.processQueueNotifications([waiting, scheduledPending], { reason: "poll" });
+  assert.equal(hooks.REVIEW_QUEUE_NOTIFY.newIds.has(2), true);
+  assert.equal(sandbox.document.title, "(1) Admin Review Queue - CWF");
+  assert.equal(sandbox.__soundCount(), 1);
+});
+
+test("behavior: unread jobs acknowledge on open, prune when gone, and do not sound twice", () => {
+  const sandbox = createAdminReviewSandbox();
+  const hooks = sandbox.window.__CWF_ADMIN_REVIEW_TEST__;
+  hooks.REVIEW_QUEUE_NOTIFY.audioUnlocked = true;
+  const one = { job_id: 1, job_status: "รอตรวจสอบ", admin_action_required: true };
+  const two = { job_id: 2, job_status: "รอตรวจสอบ", admin_action_required: true };
+  const three = { job_id: 3, job_status: "รอตรวจสอบ", admin_action_required: true };
+  hooks.processQueueNotifications([one], { reason: "init" });
+  hooks.processQueueNotifications([one, two], { reason: "poll" });
+  assert.equal(hooks.REVIEW_QUEUE_NOTIFY.newIds.has(2), true);
+  hooks.setRowMap([one, two]);
+  hooks.acknowledgeNewJob(2);
+  assert.equal(hooks.REVIEW_QUEUE_NOTIFY.newIds.size, 0);
+  assert.equal(hooks.REVIEW_QUEUE_NOTIFY.notifiedIds.has(2), true);
+  assert.equal(sandbox.document.title, "Admin Review Queue - CWF");
+  assert.equal(sandbox.__card.classList.contains("review-card-new"), false);
+  const soundAfterAck = sandbox.__soundCount();
+  hooks.processQueueNotifications([one, two], { reason: "poll" });
+  assert.equal(sandbox.__soundCount(), soundAfterAck);
+  sandbox.__advance(2000);
+  hooks.processQueueNotifications([one, two, three], { reason: "poll" });
+  assert.equal(hooks.REVIEW_QUEUE_NOTIFY.newIds.has(3), true);
+  hooks.processQueueNotifications([one, two], { reason: "poll" });
+  assert.equal(hooks.REVIEW_QUEUE_NOTIFY.newIds.has(3), false);
+  assert.equal(sandbox.document.title, "Admin Review Queue - CWF");
+});
+
+test("behavior: Customer Booking and LINE AI Intake share one sound throttle gate", () => {
+  const sandbox = createAdminReviewSandbox();
+  const admin = sandbox.window.__CWF_ADMIN_REVIEW_TEST__;
+  const ai = loadAiIntakeIntoSandbox(sandbox);
+  admin.REVIEW_QUEUE_NOTIFY.audioUnlocked = true;
+  admin.playNewJobSound();
+  assert.equal(sandbox.__soundCount(), 1);
+  ai.playSoftAlert();
+  assert.equal(sandbox.__soundCount(), 1);
+  sandbox.__advance(1600);
+  ai.playSoftAlert();
+  assert.equal(sandbox.__soundCount(), 2);
+  ai.render([{ id: 9, status: "READY_TO_CREATE_JOB", updated_at: "t2", line_display_name: "LINE Customer" }], "");
+  assert.equal(sandbox.__elements.get("aiIntakePanel").style.display, "flex");
 });

--- a/test/customerBookingAdminNotifications.test.js
+++ b/test/customerBookingAdminNotifications.test.js
@@ -130,7 +130,7 @@ function createElement(id = "") {
   };
 }
 
-function createAdminReviewSandbox() {
+function createAdminReviewSandbox(options = {}) {
   const elements = new Map();
   const card = createElement("card-2");
   card.classList.add("review-card-new");
@@ -184,6 +184,7 @@ function createAdminReviewSandbox() {
     setTimeout,
     clearTimeout,
     URLSearchParams,
+    URL,
     Intl,
     Number,
     String,
@@ -205,12 +206,12 @@ function createAdminReviewSandbox() {
     prompt() { return ""; },
     alert() {},
     showToast() {},
-    apiFetch: async (url, options = {}) => {
-      if (options.method) throw new Error(`unexpected mutation ${options.method} ${url}`);
+    apiFetch: options.apiFetch || (async (url, requestOptions = {}) => {
+      if (requestOptions.method) throw new Error(`unexpected mutation ${requestOptions.method} ${url}`);
       if (/\/team/.test(url)) return { members: [] };
       if (/\/pricing/.test(url)) return { total: 0, discount: 0 };
       return {};
-    },
+    }),
     window: null,
     __advance(ms) { now += ms; },
     __soundCount() { return soundCount; },
@@ -306,7 +307,8 @@ test("admin review new-job notification uses first-load baseline and one sound p
 });
 
 test("admin/customer frontend cache versions are bumped for booking notification changes", () => {
-  assert.match(adminReviewHtml, /admin-review-v2\.js\?v=20260707_customer_booking_notify_v2/);
+  assert.match(adminReviewHtml, /admin-review-v2\.js\?v=20260707_customer_booking_notify_v3_xss_guard/);
+  assert.doesNotMatch(adminReviewHtml, /admin-review-v2\.js\?v=20260707_customer_booking_notify_v2/);
   assert.match(adminReviewHtml, /admin-review-ai-intake\.js\?v=ai-booking-intake-customer-cards-v11-admin-alert-gate/);
   assert.doesNotMatch(adminReviewHtml, /admin-review-ai-intake\.js\?v=ai-booking-intake-customer-cards-v10/);
   assert.match(customerIndex, /bookingScheduled\.js\?v=20260707_booking_admin_notify_v1/);
@@ -335,6 +337,121 @@ test("behavior: review queue only includes customer urgent waiting rows while pr
   const waitingOnly = simulateReviewQueueRows(rows, WAITING_URGENT_STATUS);
   assert.deepEqual(waitingOnly.map((row) => row.job_id), [1]);
   assert.equal(waitingOnly[0].admin_action_required, false);
+});
+
+test("security: admin review queue escapes untrusted customer, item, proposal, technician, and error HTML", async () => {
+  const imgPayload = '<img src=x onerror="window.__xss=1">';
+  const scriptPayload = '</div><script>window.__xss=1</script>';
+  const attrPayload = '" autofocus onfocus="window.__xss=1';
+  const row = {
+    job_id: 101,
+    booking_code: `CWF-${attrPayload}`,
+    booking_mode: "scheduled",
+    job_status: REVIEW_STATUSES[4],
+    customer_name: imgPayload,
+    customer_phone: attrPayload,
+    address_text: scriptPayload,
+    job_zone: attrPayload,
+    job_type: imgPayload,
+    technician_username: attrPayload,
+    maps_url: `javascript:${attrPayload}`,
+    items: [{ item_name: imgPayload, qty: 2 }],
+    admin_action_required: true,
+  };
+  const sandbox = createAdminReviewSandbox({
+    apiFetch: async (url, requestOptions = {}) => {
+      if (requestOptions.method) throw new Error(`unexpected mutation ${requestOptions.method} ${url}`);
+      if (/review_queue_v2/.test(url)) return { rows: [row] };
+      if (/time-proposals/.test(url)) {
+        return {
+          rows: [{
+            proposal_id: 5,
+            status: "pending",
+            technician_name: imgPayload,
+            technician_username: attrPayload,
+            note: scriptPayload,
+            proposed_datetime: "2026-07-10T10:00:00+07:00",
+          }],
+        };
+      }
+      return { members: [], total: 0, discount: 0 };
+    },
+  });
+  const hooks = sandbox.window.__CWF_ADMIN_REVIEW_TEST__;
+  await hooks.loadQueue({ force: true, reason: "security" });
+  await new Promise((resolve) => setTimeout(resolve, 0));
+
+  const rendered = [
+    sandbox.__elements.get("list").innerHTML,
+    sandbox.__elements.get("proposal-panel-101").innerHTML,
+  ].join("\n");
+  assert.doesNotMatch(rendered, /<img/i);
+  assert.doesNotMatch(rendered, /<script/i);
+  assert.doesNotMatch(rendered, /onerror=/i);
+  assert.doesNotMatch(rendered, /onfocus=/i);
+  assert.match(rendered, /&lt;img src&#61;x onerror&#61;&quot;window\.__xss&#61;1&quot;&gt;/);
+  assert.match(rendered, /&lt;\/div&gt;&lt;script&gt;window\.__xss&#61;1&lt;\/script&gt;/);
+
+  const errorSandbox = createAdminReviewSandbox({
+    apiFetch: async (url) => {
+      if (/review_queue_v2/.test(url)) throw new Error(imgPayload);
+      return {};
+    },
+  });
+  await errorSandbox.window.__CWF_ADMIN_REVIEW_TEST__.loadQueue({ force: true, reason: "security_error" });
+  const errorHtml = errorSandbox.__elements.get("list").innerHTML;
+  assert.doesNotMatch(errorHtml, /<img/i);
+  assert.doesNotMatch(errorHtml, /onerror=/i);
+  assert.match(errorHtml, /&lt;img src&#61;x onerror&#61;&quot;window\.__xss&#61;1&quot;&gt;/);
+});
+
+test("security: admin review queue blocks unsafe Maps URLs and preserves valid external HTTP links", async () => {
+  const unsafeUrls = [
+    "javascript:alert(1)",
+    "data:text/html,<script>alert(1)</script>",
+    "vbscript:msgbox(1)",
+    "file:///etc/passwd",
+    "/maps",
+    "//evil.example",
+    "not a url",
+    '" autofocus onfocus="window.__xss=1',
+  ];
+  for (const maps_url of unsafeUrls) {
+    const sandbox = createAdminReviewSandbox({
+      apiFetch: async (url) => {
+        if (/review_queue_v2/.test(url)) {
+          return { rows: [{ job_id: 201, job_status: REVIEW_STATUSES[0], booking_mode: "scheduled", maps_url, admin_action_required: true }] };
+        }
+        return {};
+      },
+    });
+    await sandbox.window.__CWF_ADMIN_REVIEW_TEST__.loadQueue({ force: true, reason: "security_url" });
+    const rendered = sandbox.__elements.get("list").innerHTML;
+    assert.doesNotMatch(rendered, /<a href=/i, maps_url);
+    assert.doesNotMatch(rendered, /javascript:/i, maps_url);
+    assert.doesNotMatch(rendered, /data:/i, maps_url);
+    assert.doesNotMatch(rendered, /onfocus=/i, maps_url);
+  }
+
+  for (const maps_url of [
+    "https://maps.google.com/?q=13.7000,100.6000",
+    "https://www.google.com/maps/place/test",
+    "http://maps.example.com/location",
+  ]) {
+    const sandbox = createAdminReviewSandbox({
+      apiFetch: async (url) => {
+        if (/review_queue_v2/.test(url)) {
+          return { rows: [{ job_id: 202, job_status: REVIEW_STATUSES[0], booking_mode: "scheduled", maps_url, admin_action_required: true }] };
+        }
+        return {};
+      },
+    });
+    await sandbox.window.__CWF_ADMIN_REVIEW_TEST__.loadQueue({ force: true, reason: "security_url_valid" });
+    const rendered = sandbox.__elements.get("list").innerHTML;
+    assert.match(rendered, /<a href="https?:\/\//i);
+    assert.match(rendered, /target="_blank"/);
+    assert.match(rendered, /rel="noopener noreferrer"/);
+  }
 });
 
 test("behavior: concurrent scheduled requests with the same key create one job and one reservation", async () => {

--- a/test/customerSameDayTiming.test.js
+++ b/test/customerSameDayTiming.test.js
@@ -160,7 +160,7 @@ test("customer app disables availability HTTP cache and refreshes same-day slots
 });
 
 test("customer app build and service worker cache IDs changed", () => {
-  const id = "20260705_payment_security_v1";
+  const id = "20260707_booking_admin_notify_v1";
   for (const file of [
     "customer-app/index.html",
     "customer-app/sw.js",

--- a/test/homepageCms.test.js
+++ b/test/homepageCms.test.js
@@ -278,7 +278,7 @@ test("customer homepage has no admin control, bottom nav is fixed five-tab, and 
   const sw = read("customer-app/sw.js");
   const app = read("customer-app/assets/customer-app.js");
   const manifest = read("customer-app/manifest.webmanifest");
-  const build = "20260705_payment_security_v1";
+  const build = "20260707_booking_admin_notify_v1";
 
   assert.doesNotMatch(index + ui, /โหมดแอดมิน|openCms|localStorage\.getItem\('cwfHomeCmsDemo'/);
   assert.match(index, /data-route="store"[\s\S]*ร้านค้า/);


### PR DESCRIPTION
Base SHA: 6a18efc976f0a218b55af62ac094a85c7753896d

## Latest review-blocker fix
Previous PR head: 87ab6727783e2ef700a59823c2a647335671d948
Current head: cb40a195c009ac81dc9f2ec31208c63c11530905

### Final blockers resolved
1. Bumped `admin-review-ai-intake.js` cache query in `admin-review-v2.html` to `ai-booking-intake-customer-cards-v11-admin-alert-gate`, so production browsers load the shared admin alert gate changes.
2. Tightened `/admin/review_queue_v2` waiting rows: `รอช่างยืนยัน` is no longer part of the broad review allow-list. Waiting rows are included only when `job_status = WAITING_URGENT_STATUS`, `booking_mode = 'urgent'`, and `job_source = 'customer'`.
3. Preserved existing review statuses: `รอตรวจสอบ`, `pending_review`, `ตีกลับ`, `ไม่พบช่างรับงาน`, and `รอพิจารณาเวลาใหม่`.
4. Added mixed-row behavior coverage proving Customer App urgent waiting is read-only, admin/internal waiting is excluded, and scheduled/customer review rows remain visible.

## Previously resolved blockers
1. Fixed broken Thai waiting-filter text in `admin-review-v2.html` and added UTF-8/placeholder regression coverage.
2. Made urgent waiting rows with `admin_action_required=false` truly read-only in the modal: mutation buttons and editable fields are disabled, a read-only notice is shown, and mutation handlers guard before API calls.
3. Changed admin polling to fetch `/admin/review_queue_v2?status=all&limit=200`, use all rows for notification/baseline/unread/pruning, then filter rows client-side for display.
4. Added acknowledgement and pruning for unread jobs: opening a job clears its unread highlight/count/title, and jobs no longer in the all-queue response are pruned.
5. Required a valid `scheduled_request_key` for Customer App V2 scheduled bookings only: `^[A-Za-z0-9_-]{16,128}$`, otherwise `400 MISSING_REQUEST_KEY`.
6. Added a shared `window.__CWF_ADMIN_ALERT_GATE__` throttle used by both Customer Booking notifications and LINE AI Intake sound alerts.
7. Added behavior tests for scheduled same-key idempotency, missing key rejection, urgent read-only guards, cross-filter notification, unread acknowledge/prune, and shared sound gate.

## Root cause
- Scheduled Customer App submits did not carry/enforce a durable request key into `/public/book`, so retry/double tap could enter the booking transaction as a new request.
- `/admin/review_queue_v2` originally did not surface urgent jobs still waiting for technicians as read-only rows, and the first fix allowed waiting status too broadly.
- `admin-review-v2.js` loaded only on demand/manual refresh, and the first implementation tied new-job detection to the selected filter and left unread state uncleared.
- `admin-review-ai-intake.js` changed shared sound behavior but still used the old cache URL until this fix.

## Scheduled flow result
- Customer App scheduled submits send `scheduled_request_key`.
- Backend requires a valid key for `booking_mode=scheduled` + `client_app=customer_app_v2`, derives a deterministic booking token, takes an advisory transaction lock by request key, checks for an existing customer scheduled job before reserving technician capacity, and replays the existing booking response instead of creating a duplicate.
- Existing scheduled slot validation/reservation flow remains in place; stale slots still reject before creating a job.

## Urgent flow result
- Existing urgent offer engine remains unchanged.
- `/admin/review_queue_v2` includes only Customer App urgent jobs in the canonical waiting-for-technician status as read-only rows with pending offer count and `admin_action_required=false`.
- Admin/internal offer waiting rows are excluded from this customer booking review queue.
- Admin action remains enabled for existing fallback/review statuses such as no technician accepted and time proposal pending.

## Admin notification behavior
- Admin review page loads immediately, polls every 12 seconds only while visible, refreshes on focus/visible/pageshow, deduplicates in-flight loads, and stops polling on 401/403.
- Polling always fetches all review queue rows, while the selected dropdown filter only affects display.
- First load establishes a baseline without sound.
- New Job IDs after baseline are highlighted, counted in the in-app alert/title, remembered in sessionStorage, and play one short audio cue when browser/user interaction allows it.
- Opening a highlighted job acknowledges it; pruning clears unread state for jobs that leave the all-queue response.
- Manual reload/filter changes do not trigger retrospective new-job sounds.

## Changed files
- `index.js`
- `admin-review-v2.html`
- `admin-review-v2.js`
- `admin-review-ai-intake.js`
- `test/customerBookingAdminNotifications.test.js`

## Tests run
- `node --check index.js` — pass
- `node --check admin-review-v2.js` — pass
- `node --check admin-review-ai-intake.js` — pass
- `node --check test/customerBookingAdminNotifications.test.js` — pass
- `node --test test/customerBookingAdminNotifications.test.js` — 14 pass, 0 fail, 0 skipped
- `node --test test/customerBookingAdminNotifications.test.js test/customerBookingRecovery.test.js test/customerSlotBoundary.test.js test/customerScheduledCapacityFairness.test.js test/customerMultiServiceCalendar.test.js test/urgentPublicAdapter.test.js test/urgentProductionHotfix.test.js test/urgentFinalizer.integration.test.js` — 74 pass, 0 fail, 3 skipped due local Postgres auth unavailable
- Branch `npm test` — 915 tests, 884 pass, 20 fail, 11 skipped
- Base `npm test` at `6a18efc976f0a218b55af62ac094a85c7753896d` — 901 tests, 870 pass, 20 fail, 11 skipped
- Additional failures caused by branch: 0. The 20 failures are existing `test/adminStoreCatalogUi.test.js` failures present on base.

## Behavior test coverage added
- Concurrent scheduled request with same key: mock transaction verifies lock -> lookup -> one reserve -> replay-equivalent same job/token/code.
- Missing scheduled request key: Customer App V2 scheduled request returns `400 MISSING_REQUEST_KEY` and does not reserve/create.
- Urgent waiting read-only: modal opens but mutation controls are disabled and save/dispatch/rebroadcast/cancel do not call mutation APIs.
- Cross-filter notification: selected `waiting` display filter still alerts when all-queue poll sees a new scheduled job.
- Unread acknowledgement/pruning: open clears unread/title/highlight; leaving queue prunes; previously notified Job ID does not sound again.
- Shared sound gate: Customer Booking sound and LINE AI Intake sound use one throttle gate.
- Mixed review queue rows: Customer App urgent waiting appears read-only; admin/internal waiting does not appear; scheduled/customer review statuses still appear.
- AI Intake cache consistency: HTML references `admin-review-ai-intake.js?v=ai-booking-intake-customer-cards-v11-admin-alert-gate` and not the old v10 URL.

## Manual verification
- No production endpoints were called.
- Local/source-backed verification covered scheduled idempotency, admin queue visibility, read-only urgent waiting rows, single polling loop, auth-stop polling, new-job baseline, one-time notification, unread acknowledgement/pruning, shared sound throttling, mixed waiting-row filtering, and cache build consistency.

## Remaining risks
- Full browser manual testing with a real local database was not performed in this environment.
- Urgent finalizer integration tests that require local Postgres were skipped because local postgres authentication failed for user `postgres`; source/contract urgent tests passed, but live DB finalizer behavior was not exercised locally.

## Rollback plan
- Revert this PR branch commits to restore prior admin review polling/cache and scheduled booking submit behavior.
- No schema rollback is required.
- No migration, production data write, deployment, payment change, auth change, accounting change, or production config change was performed.