### PR TITLE
Fix service price rule safety

### DIFF
--- a/admin-promotions-v2.html
+++ b/admin-promotions-v2.html
@@ -242,6 +242,6 @@
   </div>
 
   <script src="/admin-v2-common.js?v=20260428_allpages_ui1"></script>
-  <script src="/admin-promotions-v2.js?v=20260707_price_rule_safety_v1"></script>
+  <script src="/admin-promotions-v2.js?v=20260708_price_rule_safety_v2"></script>
 </body>
 </html>

--- a/admin-promotions-v2.html
+++ b/admin-promotions-v2.html
@@ -242,6 +242,6 @@
   </div>
 
   <script src="/admin-v2-common.js?v=20260428_allpages_ui1"></script>
-  <script src="/admin-promotions-v2.js?v=20260520_generic_price_campaign_v1"></script>
+  <script src="/admin-promotions-v2.js?v=20260707_price_rule_safety_v1"></script>
 </body>
 </html>

--- a/admin-promotions-v2.js
+++ b/admin-promotions-v2.js
@@ -20,6 +20,43 @@ function fmtMoney(v){
   return n.toLocaleString('th-TH', { maximumFractionDigits: 0 });
 }
 
+const PRICE_RULE_RISK_LABELS = {
+  MISSING_JOB_TYPE: 'missing job type',
+  MISSING_AC_TYPE: 'missing AC type',
+  UNSUPPORTED_JOB_TYPE: 'unsupported job type',
+  UNSUPPORTED_AC_TYPE: 'unsupported AC type',
+  INVALID_PRICE: 'invalid price',
+  ACTIVE_PRICE_ABOVE_NORMAL: 'active price above normal',
+  PRICE_OUTLIER: 'price outlier',
+  INVALID_BTU_RANGE: 'invalid BTU range',
+  INVALID_MACHINE_RANGE: 'invalid machine range',
+  INVALID_DATE_RANGE: 'invalid date range',
+  PRODUCT_RULE_LEAK: 'product-linked rule',
+  CATALOG_SCOPE_MISMATCH: 'catalog scope mismatch',
+  OVERLAPPING_ACTIVE_RULE: 'overlapping active rule',
+  INVALID_PRIORITY: 'invalid priority',
+  UNSUPPORTED_WASH_VARIANT: 'unsupported wash variant',
+};
+
+function riskText(codes){
+  return (codes || []).map((c) => PRICE_RULE_RISK_LABELS[c] || c).join(', ');
+}
+
+function clientPriceRuleRisks(body){
+  const risks = [];
+  if(!body.job_type) risks.push('MISSING_JOB_TYPE');
+  if(!body.ac_type) risks.push('MISSING_AC_TYPE');
+  if(!Number.isFinite(Number(body.normal_price)) || Number(body.normal_price) <= 0 || !Number.isFinite(Number(body.active_price)) || Number(body.active_price) <= 0) risks.push('INVALID_PRICE');
+  if(Number(body.active_price) > Number(body.normal_price)) risks.push('ACTIVE_PRICE_ABOVE_NORMAL');
+  if(body.btu_min && (!Number.isFinite(Number(body.btu_min)) || Number(body.btu_min) <= 0)) risks.push('INVALID_BTU_RANGE');
+  if(body.btu_max && (!Number.isFinite(Number(body.btu_max)) || Number(body.btu_max) <= 0)) risks.push('INVALID_BTU_RANGE');
+  if(body.btu_min && body.btu_max && Number(body.btu_min) > Number(body.btu_max)) risks.push('INVALID_BTU_RANGE');
+  if(body.effective_from && body.effective_to && Date.parse(body.effective_from) > Date.parse(body.effective_to)) risks.push('INVALID_DATE_RANGE');
+  if(!Number.isInteger(Number(body.priority)) || Number(body.priority) < -1000 || Number(body.priority) > 1000) risks.push('INVALID_PRIORITY');
+  if(Number(body.normal_price) >= 10000 || Number(body.active_price) >= 10000) risks.push('PRICE_OUTLIER');
+  return [...new Set(risks)];
+}
+
 function pricePayload(){
   const from = (el('price_effective_from')?.value || '').trim();
   const to = (el('price_effective_to')?.value || '').trim();
@@ -66,6 +103,8 @@ function dateInputValue(value){
 
 function priceRuleCard(r){
   const active = !!r.is_active;
+  const risks = r.risk_codes || [];
+  const unsafe = risks.length || r.is_safe_for_service_pricing === false;
   const range = `${r.btu_min || 0}${r.btu_max ? `-${r.btu_max}` : '+'} BTU`;
   const promo = r.campaign_name || r.label || '';
   const dates = [dateInputValue(r.effective_from), dateInputValue(r.effective_to)].filter(Boolean).join(' ถึง ');
@@ -75,6 +114,7 @@ function priceRuleCard(r){
       <div class="svc-title"><b>${r.job_type || '-'} / ${r.ac_type || '-'} ${r.wash_variant || ''}</b></div>
       <div class="muted2 mini">${range} • ปกติ ${fmtMoney(r.normal_price)} บาท • ใช้จริง ${fmtMoney(r.active_price)} บาท</div>
       <div class="muted2 mini">${promo ? `แคมเปญ: ${promo} • ` : ''}${dates ? `ช่วงเวลา: ${dates} • ` : ''}priority ${Number(r.priority || 0)} • สถานะ: <b>${active ? 'เปิดใช้' : 'ปิด'}</b></div>
+      ${unsafe ? `<div class="muted2 mini" style="color:#991b1b">Risk: ${riskText(risks)}</div>` : ''}
     </div>
     <div style="display:flex;gap:8px;flex-wrap:wrap;justify-content:flex-end">
       <button class="secondary btn-small" data-price-act="edit" data-id="${r.rule_id}">แก้ไข</button>
@@ -92,6 +132,10 @@ async function loadPriceRules(){
     const rules = r.rules || [];
     window.__priceRules = rules;
     box.innerHTML = rules.map(priceRuleCard).join('') || `<div class="muted2">ยังไม่มีราคาบริการ</div>`;
+    const riskyCount = rules.filter((rule) => (rule.risk_codes || []).length || rule.is_safe_for_service_pricing === false).length;
+    if (riskyCount) {
+      box.innerHTML = `<div class="svc-row" style="border-color:#fecaca;background:#fff1f2;color:#991b1b">Risky service price rules: ${riskyCount}</div>` + box.innerHTML;
+    }
   }catch(e){
     box.innerHTML = `<div class="muted2">โหลดราคาบริการไม่สำเร็จ: ${e.message}</div>`;
   }
@@ -101,6 +145,11 @@ async function savePriceRule(){
   const body = pricePayload();
   if(!body.job_type || !body.ac_type || !body.normal_price || !body.active_price){
     showToast('กรอกประเภทงาน ประเภทแอร์ ราคาปกติ และราคาที่ใช้จริง', 'error');
+    return;
+  }
+  const risks = clientPriceRuleRisks(body);
+  if(risks.length){
+    showToast(`Rule เสี่ยง: ${riskText(risks)}`, 'error');
     return;
   }
   try{
@@ -136,6 +185,14 @@ function editPriceRule(id){
 }
 
 async function togglePriceRule(id, currentActive){
+  if(currentActive === false){
+    const rule = (window.__priceRules || []).find((r) => Number(r.rule_id) === Number(id));
+    const risks = rule ? (rule.risk_codes || []) : [];
+    if(risks.length || rule?.is_safe_for_service_pricing === false){
+      showToast(`เปิดใช้ไม่ได้: ${riskText(risks)}`, 'error');
+      return;
+    }
+  }
   try{
     await apiFetch(`/admin/customer-pricing/rules/${id}/toggle`, { method:'PATCH', body: JSON.stringify({ is_active: !currentActive }) });
     await loadPriceRules();

--- a/admin-promotions-v2.js
+++ b/admin-promotions-v2.js
@@ -33,7 +33,9 @@ const PRICE_RULE_RISK_LABELS = {
   INVALID_DATE_RANGE: 'invalid date range',
   PRODUCT_RULE_LEAK: 'product-linked rule',
   CATALOG_SCOPE_MISMATCH: 'catalog scope mismatch',
+  CATALOG_LINKAGE_UNVERIFIED: 'catalog linkage unverified',
   OVERLAPPING_ACTIVE_RULE: 'overlapping active rule',
+  AUTO_PRICING_UNSUPPORTED: 'auto pricing unsupported',
   INVALID_PRIORITY: 'invalid priority',
   UNSUPPORTED_WASH_VARIANT: 'unsupported wash variant',
 };
@@ -53,7 +55,6 @@ function clientPriceRuleRisks(body){
   if(body.btu_min && body.btu_max && Number(body.btu_min) > Number(body.btu_max)) risks.push('INVALID_BTU_RANGE');
   if(body.effective_from && body.effective_to && Date.parse(body.effective_from) > Date.parse(body.effective_to)) risks.push('INVALID_DATE_RANGE');
   if(!Number.isInteger(Number(body.priority)) || Number(body.priority) < -1000 || Number(body.priority) > 1000) risks.push('INVALID_PRIORITY');
-  if(Number(body.normal_price) >= 10000 || Number(body.active_price) >= 10000) risks.push('PRICE_OUTLIER');
   return [...new Set(risks)];
 }
 
@@ -108,12 +109,17 @@ function priceRuleCard(r){
   const range = `${r.btu_min || 0}${r.btu_max ? `-${r.btu_max}` : '+'} BTU`;
   const promo = r.campaign_name || r.label || '';
   const dates = [dateInputValue(r.effective_from), dateInputValue(r.effective_to)].filter(Boolean).join(' ถึง ');
+  const linkedCount = Number(r.linked_catalog_item_count || 0);
+  const linkMeta = linkedCount
+    ? `Linked catalog: ${linkedCount}${r.linked_catalog_has_product ? ' • product-linked' : ''}${r.catalog_linkage_status && r.catalog_linkage_status !== 'verified' ? ` • ${r.catalog_linkage_status}` : ''}`
+    : (r.catalog_linkage_status && r.catalog_linkage_status !== 'verified' ? `Catalog linkage: ${r.catalog_linkage_status}` : '');
   return `
   <div class="svc-row" style="align-items:flex-start">
     <div class="svc-main" style="flex:1">
       <div class="svc-title"><b>${r.job_type || '-'} / ${r.ac_type || '-'} ${r.wash_variant || ''}</b></div>
       <div class="muted2 mini">${range} • ปกติ ${fmtMoney(r.normal_price)} บาท • ใช้จริง ${fmtMoney(r.active_price)} บาท</div>
       <div class="muted2 mini">${promo ? `แคมเปญ: ${promo} • ` : ''}${dates ? `ช่วงเวลา: ${dates} • ` : ''}priority ${Number(r.priority || 0)} • สถานะ: <b>${active ? 'เปิดใช้' : 'ปิด'}</b></div>
+      ${linkMeta ? `<div class="muted2 mini">${linkMeta}</div>` : ''}
       ${unsafe ? `<div class="muted2 mini" style="color:#991b1b">Risk: ${riskText(risks)}</div>` : ''}
     </div>
     <div style="display:flex;gap:8px;flex-wrap:wrap;justify-content:flex-end">

--- a/admin-store-catalog.html
+++ b/admin-store-catalog.html
@@ -76,6 +76,6 @@
   </div>
 
   <script src="/admin-v2-common.js?v=20260622_admin_menu_catalog_entry"></script>
-  <script src="/admin-store-catalog.js?v=20260702_cat_v2"></script>
+  <script src="/admin-store-catalog.js?v=20260707_price_rule_safety_v1"></script>
 </body>
 </html>

--- a/admin-store-catalog.html
+++ b/admin-store-catalog.html
@@ -76,6 +76,6 @@
   </div>
 
   <script src="/admin-v2-common.js?v=20260622_admin_menu_catalog_entry"></script>
-  <script src="/admin-store-catalog.js?v=20260707_price_rule_safety_v1"></script>
+  <script src="/admin-store-catalog.js?v=20260708_price_rule_safety_v2"></script>
 </body>
 </html>

--- a/admin-store-catalog.html
+++ b/admin-store-catalog.html
@@ -76,6 +76,6 @@
   </div>
 
   <script src="/admin-v2-common.js?v=20260622_admin_menu_catalog_entry"></script>
-  <script src="/admin-store-catalog.js?v=20260708_price_rule_safety_v2"></script>
+  <script src="/admin-store-catalog.js?v=20260708_price_rule_safety_v3"></script>
 </body>
 </html>

--- a/admin-store-catalog.js
+++ b/admin-store-catalog.js
@@ -48,7 +48,6 @@ function modalPricingRisk(payload) {
   if (payload.item_category === "service") {
     if (!payload.job_category) risks.push("MISSING_JOB_TYPE");
     if (!payload.ac_type) risks.push("MISSING_AC_TYPE");
-    if (normal >= 10000 || active >= 10000) risks.push("PRICE_OUTLIER");
   }
   return [...new Set(risks)];
 }

--- a/admin-store-catalog.js
+++ b/admin-store-catalog.js
@@ -31,6 +31,28 @@ function escapeHtml(value) {
     .replace(/"/g, "&quot;");
 }
 
+const CATALOG_PRICE_ONLY_TEXT = "ราคาสินค้าเท่านั้น ไม่ใช้คำนวณค่าบริการ";
+
+function catalogPricingRiskCodes(item) {
+  return Array.isArray(item.pricing_risk_codes) ? item.pricing_risk_codes : [];
+}
+
+function modalPricingRisk(payload) {
+  const risks = [];
+  if (!payload.pricing) return risks;
+  const normal = Number(payload.pricing.normal_price);
+  const active = Number(payload.pricing.active_price);
+  if (!Number.isFinite(normal) || normal <= 0 || !Number.isFinite(active) || active <= 0) risks.push("INVALID_PRICE");
+  if (active > normal) risks.push("ACTIVE_PRICE_ABOVE_NORMAL");
+  if (payload.btu_min !== "" && payload.btu_max !== "" && Number(payload.btu_min) > Number(payload.btu_max)) risks.push("INVALID_BTU_RANGE");
+  if (payload.item_category === "service") {
+    if (!payload.job_category) risks.push("MISSING_JOB_TYPE");
+    if (!payload.ac_type) risks.push("MISSING_AC_TYPE");
+    if (normal >= 10000 || active >= 10000) risks.push("PRICE_OUTLIER");
+  }
+  return [...new Set(risks)];
+}
+
 function fmtMoney(n) {
   const v = Number(n);
   return Number.isFinite(v) ? v.toLocaleString("th-TH") : "0";
@@ -104,6 +126,7 @@ function ensureCatalogModal() {
         <div class="asc-section">
           <div class="asc-section-title">3) ราคาและโปรโมชั่น</div>
           <div class="asc-warning">${escapeHtml(PRICING_WARNING_TEXT)}</div>
+          <div id="cm_pricing_scope_note" class="muted2 mini">${escapeHtml(CATALOG_PRICE_ONLY_TEXT)}</div>
           <div class="asc-field"><label>ราคาฐาน (Base Price) *</label><input id="cm_base_price" type="number" step="1" min="0" placeholder="ใช้เมื่อยังไม่มีราคาโปรโมชัน"></div>
           <div class="asc-grid2">
             <div class="asc-field"><label>ราคาปกติ (บาท) *</label><input id="cm_normal_price" type="number" step="1" min="0"></div>
@@ -495,6 +518,8 @@ function validateCatalogModalPayload(payload) {
       return "ราคาขายจริงต้องเป็นตัวเลขตั้งแต่ 0 ขึ้นไป";
     }
   }
+  const risks = modalPricingRisk(payload);
+  if (risks.length) return `Rule เสี่ยง: ${risks.join(", ")}`;
   return "";
 }
 
@@ -961,6 +986,8 @@ function catalogItemCard(item) {
   const hasPromo = !!item.has_promo;
   const salePrice = item.display_price != null ? item.display_price : item.base_price;
   const showAsk = !(Number(salePrice) > 0);
+  const riskCodes = catalogPricingRiskCodes(item);
+  const pricingUnsafe = riskCodes.length || item.pricing_is_safe_for_service_pricing === false;
 
   const thumbUrl = catalogItemThumbUrl(item);
   const thumb = thumbUrl
@@ -988,6 +1015,8 @@ function catalogItemCard(item) {
         ${item.booking_mode === "bookable" ? `<span class="asc-badge asc-badge-bookable">จองออนไลน์ได้</span>` : item.booking_mode === "purchase" ? `<span class="asc-badge asc-badge-purchase">สินค้า (ขาย)</span>` : `<span class="asc-badge asc-badge-contact">ติดต่อแอดมิน</span>`}
         ${item.is_featured ? `<span class="asc-badge asc-badge-featured">แนะนำ</span>` : ""}
         ${item.is_hot ? `<span class="asc-badge asc-badge-hot">HOT</span>` : ""}
+        ${item.pricing_catalog_only ? `<span class="asc-badge asc-badge-contact">${escapeHtml(CATALOG_PRICE_ONLY_TEXT)}</span>` : ""}
+        ${pricingUnsafe ? `<span class="asc-badge asc-badge-inactive">Risk: ${escapeHtml(riskCodes.join(", "))}</span>` : ""}
       </div>
     </div>
     <div class="asc-item-actions">

--- a/admin-store-catalog.js
+++ b/admin-store-catalog.js
@@ -242,7 +242,7 @@ function ensureCatalogModal() {
             <div></div>
           </div>
           <div class="asc-grid2">
-            <div class="asc-field"><label>BTU ต่ำสุด *</label><input id="cm_btu_min" type="number" step="1" min="1" placeholder="ว่าง = ไม่จำกัด"></div>
+            <div class="asc-field"><label>BTU ต่ำสุด *</label><input id="cm_btu_min" type="number" step="1" min="0" placeholder="ว่าง = ไม่จำกัด"></div>
             <div class="asc-field"><label>BTU สูงสุด *</label><input id="cm_btu_max" type="number" step="1" min="1" placeholder="ว่าง = ไม่จำกัด"></div>
           </div>
         </details>
@@ -486,11 +486,11 @@ function validateCatalogModalPayload(payload) {
   if (payload.base_price !== "" && (!Number.isFinite(Number(payload.base_price)) || Number(payload.base_price) < 0)) {
     return "ราคาฐานต้องเป็นตัวเลขตั้งแต่ 0 ขึ้นไป";
   }
-  if (payload.btu_min !== "" && (!Number.isFinite(Number(payload.btu_min)) || Number(payload.btu_min) <= 0)) {
-    return "btu_min ต้องเป็นค่าว่างหรือจำนวนบวก";
+  if (payload.btu_min !== "" && (!Number.isInteger(Number(payload.btu_min)) || Number(payload.btu_min) < 0)) {
+    return "btu_min ต้องเป็นค่าว่างหรือจำนวนเต็มตั้งแต่ 0 ขึ้นไป";
   }
-  if (payload.btu_max !== "" && (!Number.isFinite(Number(payload.btu_max)) || Number(payload.btu_max) <= 0)) {
-    return "btu_max ต้องเป็นค่าว่างหรือจำนวนบวก";
+  if (payload.btu_max !== "" && (!Number.isInteger(Number(payload.btu_max)) || Number(payload.btu_max) <= 0)) {
+    return "btu_max ต้องเป็นค่าว่างหรือจำนวนเต็มบวก";
   }
   if (payload.btu_min !== "" && payload.btu_max !== "" && Number(payload.btu_min) > Number(payload.btu_max)) {
     return "btu_min ต้องไม่มากกว่า btu_max";

--- a/server/customerPricing.js
+++ b/server/customerPricing.js
@@ -32,6 +32,21 @@ function boolish(value, fallback = false) {
   return fallback;
 }
 
+const SUPPORTED_JOB_TYPES = new Set([
+  normalizeServiceType("clean"),
+  normalizeServiceType("repair"),
+  normalizeServiceType("install"),
+]);
+const SUPPORTED_AC_TYPES = new Set([
+  normalizeAcType("wall"),
+  normalizeAcType("cassette"),
+  normalizeAcType("hanging"),
+  normalizeAcType("concealed"),
+]);
+const SUPPORTED_WASH_KEYS = new Set(["normal", "premium", "coil", "overhaul"]);
+const MAX_RULE_PRIORITY = 1000;
+const MIN_RULE_PRIORITY = -1000;
+
 function normalizeLine(raw = {}, fallback = {}) {
   const job_type = normalizeServiceType(raw.job_type || raw.jobType || fallback.job_type || "");
   const ac_type = normalizeAcType(raw.ac_type || raw.acType || fallback.ac_type || "");
@@ -50,6 +65,132 @@ function normalizeLine(raw = {}, fallback = {}) {
     assigned_technician_username: raw.assigned_technician_username || raw.assigned_to || fallback.assigned_technician_username || fallback.assigned_to || null,
     allocations: raw.allocations || raw.allocation || null,
   };
+}
+
+function rulePrice(value) {
+  const n = Number(value);
+  return Number.isFinite(n) ? money(n) : NaN;
+}
+
+function positiveIntOrNullValue(value) {
+  if (value === null || value === undefined || String(value).trim() === "") return null;
+  const n = Number(value);
+  if (!Number.isFinite(n) || n <= 0) return NaN;
+  return Math.round(n);
+}
+
+function dateTimeOrNull(value) {
+  if (value === null || value === undefined || String(value).trim() === "") return null;
+  const ts = Date.parse(String(value));
+  return Number.isFinite(ts) ? ts : NaN;
+}
+
+function catalogLinkFromRule(row = {}) {
+  const itemId = row.linked_catalog_item_id ?? row.catalog_item_id ?? row.item_id ?? null;
+  if (itemId == null) return null;
+  return {
+    item_id: itemId,
+    item_category: row.linked_catalog_item_category ?? row.catalog_item_category ?? row.item_category ?? null,
+    job_category: row.linked_catalog_job_category ?? row.catalog_job_category ?? row.job_category ?? null,
+    ac_type: row.linked_catalog_ac_type ?? row.catalog_ac_type ?? row.catalog_item_ac_type ?? null,
+  };
+}
+
+function serviceRuleSafety(row = {}, options = {}) {
+  const risk = new Set();
+  const rawJob = String(row.job_type || "").trim();
+  const rawAc = String(row.ac_type || "").trim();
+  const job_type = normalizeServiceType(rawJob);
+  const ac_type = normalizeAcType(rawAc);
+  const wash_variant = normalizeWashVariantLabel(row.wash_variant || "");
+  const wash_key = normalizeWashKey(wash_variant);
+  const normal_price = rulePrice(row.normal_price);
+  const active_price = rulePrice(row.active_price);
+  const btu_min = positiveIntOrNullValue(row.btu_min);
+  const btu_max = positiveIntOrNullValue(row.btu_max);
+  const machine_min = positiveIntOrNullValue(row.machine_min);
+  const machine_max = positiveIntOrNullValue(row.machine_max);
+  const fromTs = dateTimeOrNull(row.effective_from);
+  const toTs = dateTimeOrNull(row.effective_to);
+  const priority = Number(row.priority ?? 0);
+  const linked = options.linkedCatalogItem || catalogLinkFromRule(row);
+
+  if (!rawJob) risk.add("MISSING_JOB_TYPE");
+  else if (!SUPPORTED_JOB_TYPES.has(job_type)) risk.add("UNSUPPORTED_JOB_TYPE");
+  if (!rawAc) risk.add("MISSING_AC_TYPE");
+  else if (!SUPPORTED_AC_TYPES.has(ac_type)) risk.add("UNSUPPORTED_AC_TYPE");
+  if (!Number.isFinite(normal_price) || normal_price <= 0 || !Number.isFinite(active_price) || active_price <= 0) {
+    risk.add("INVALID_PRICE");
+  } else if (active_price > normal_price) {
+    risk.add("ACTIVE_PRICE_ABOVE_NORMAL");
+  }
+  if (!Number.isNaN(btu_min) && !Number.isNaN(btu_max) && btu_min !== null && btu_max !== null && btu_min > btu_max) risk.add("INVALID_BTU_RANGE");
+  if (Number.isNaN(btu_min) || Number.isNaN(btu_max)) risk.add("INVALID_BTU_RANGE");
+  if (!Number.isNaN(machine_min) && !Number.isNaN(machine_max) && machine_min !== null && machine_max !== null && machine_min > machine_max) risk.add("INVALID_MACHINE_RANGE");
+  if (Number.isNaN(machine_min) || Number.isNaN(machine_max)) risk.add("INVALID_MACHINE_RANGE");
+  if (Number.isNaN(fromTs) || Number.isNaN(toTs) || (fromTs !== null && toTs !== null && fromTs > toTs)) risk.add("INVALID_DATE_RANGE");
+  if (!Number.isInteger(priority) || priority < MIN_RULE_PRIORITY || priority > MAX_RULE_PRIORITY) risk.add("INVALID_PRIORITY");
+  if (wash_variant && !SUPPORTED_WASH_KEYS.has(wash_key)) risk.add("UNSUPPORTED_WASH_VARIANT");
+
+  if (linked) {
+    const category = String(linked.item_category || "").trim().toLowerCase();
+    const linkedJob = normalizeServiceType(linked.job_category || "");
+    const linkedAc = normalizeAcType(linked.ac_type || "");
+    if (category === "product") risk.add("PRODUCT_RULE_LEAK");
+    if ((linkedJob && job_type && linkedJob !== job_type) || (linkedAc && ac_type && linkedAc !== ac_type)) {
+      risk.add("CATALOG_SCOPE_MISMATCH");
+    }
+    if (category === "service" && (!linkedJob || !linkedAc)) risk.add("CATALOG_SCOPE_MISMATCH");
+  }
+
+  const fallbackUnit = Number(options.fallbackUnit || 0);
+  if (fallbackUnit > 0 && Number.isFinite(normal_price) && Number.isFinite(active_price)) {
+    const maxSafeUnit = Math.max(fallbackUnit * 10, 10000);
+    if (normal_price > maxSafeUnit || active_price > maxSafeUnit) risk.add("PRICE_OUTLIER");
+  }
+
+  const risk_codes = Array.from(risk);
+  return {
+    ok: risk_codes.length === 0,
+    is_safe_for_service_pricing: risk_codes.length === 0,
+    risk_codes,
+    normalized: {
+      job_type,
+      ac_type,
+      wash_variant: wash_variant || null,
+      wash_key,
+      normal_price,
+      active_price,
+      btu_min,
+      btu_max,
+      machine_min,
+      machine_max,
+      priority,
+    },
+    effective_scope: {
+      job_type: job_type || null,
+      ac_type: ac_type || null,
+      wash_variant: wash_variant || null,
+      btu_min: Number.isNaN(btu_min) ? null : btu_min,
+      btu_max: Number.isNaN(btu_max) ? null : btu_max,
+      machine_min: Number.isNaN(machine_min) ? null : machine_min,
+      machine_max: Number.isNaN(machine_max) ? null : machine_max,
+    },
+    linked_catalog_item_id: linked?.item_id || null,
+    linked_catalog_item_category: linked?.item_category || null,
+  };
+}
+
+function rejectRuleLog(row, safety, line) {
+  try {
+    console.warn("[customer_pricing] rejected unsafe service price rule", {
+      rule_id: row?.rule_id || null,
+      risk_codes: safety?.risk_codes || [],
+      job_type: line?.job_type || null,
+      ac_type: line?.ac_type || null,
+      wash_key: line?.wash_key || null,
+    });
+  } catch (_) {}
 }
 
 function servicesFromPayload(payload = {}) {
@@ -142,29 +283,91 @@ async function ensureCustomerPriceBookSchema(db) {
 }
 
 async function loadCandidateRules(db) {
-  const r = await db.query(`
-    SELECT rule_id, job_type, ac_type, wash_variant, btu_min, btu_max, machine_min, machine_max,
-           normal_price, active_price, label, campaign_name, campaign_copy, seed_key, effective_from, effective_to,
-           is_active, priority, created_at, updated_at, updated_by
-      FROM public.customer_service_price_rules
-     WHERE COALESCE(is_active, TRUE)=TRUE
-       AND (effective_from IS NULL OR effective_from <= NOW())
-       AND (effective_to IS NULL OR effective_to >= NOW())
-  `);
+  let r;
+  try {
+    r = await db.query(`
+      SELECT r.rule_id, r.job_type, r.ac_type, r.wash_variant, r.btu_min, r.btu_max, r.machine_min, r.machine_max,
+             r.normal_price, r.active_price, r.label, r.campaign_name, r.campaign_copy, r.seed_key, r.effective_from, r.effective_to,
+             r.is_active, r.priority, r.created_at, r.updated_at, r.updated_by,
+             ci.item_id AS linked_catalog_item_id,
+             ci.item_category AS linked_catalog_item_category,
+             ci.job_category AS linked_catalog_job_category,
+             ci.ac_type AS linked_catalog_ac_type
+        FROM public.customer_service_price_rules r
+        LEFT JOIN public.catalog_items ci ON ci.price_rule_id = r.rule_id
+       WHERE COALESCE(r.is_active, TRUE)=TRUE
+         AND (r.effective_from IS NULL OR r.effective_from <= NOW())
+         AND (r.effective_to IS NULL OR r.effective_to >= NOW())
+    `);
+  } catch (e) {
+    if (!["42P01", "42703"].includes(String(e && e.code || ""))) throw e;
+    r = await db.query(`
+      SELECT rule_id, job_type, ac_type, wash_variant, btu_min, btu_max, machine_min, machine_max,
+             normal_price, active_price, label, campaign_name, campaign_copy, seed_key, effective_from, effective_to,
+             is_active, priority, created_at, updated_at, updated_by
+        FROM public.customer_service_price_rules
+       WHERE COALESCE(is_active, TRUE)=TRUE
+         AND (effective_from IS NULL OR effective_from <= NOW())
+         AND (effective_to IS NULL OR effective_to >= NOW())
+    `);
+  }
   return r.rows || [];
+}
+
+async function loadAdminRuleRows(db) {
+  try {
+    const r = await db.query(
+      `SELECT r.rule_id, r.job_type, r.ac_type, r.wash_variant, r.btu_min, r.btu_max, r.machine_min, r.machine_max,
+              r.normal_price, r.active_price, r.label, r.campaign_name, r.campaign_copy, r.effective_from, r.effective_to,
+              r.is_active, r.priority, r.created_at, r.updated_at, r.updated_by,
+              ci.item_id AS linked_catalog_item_id,
+              ci.item_category AS linked_catalog_item_category,
+              ci.job_category AS linked_catalog_job_category,
+              ci.ac_type AS linked_catalog_ac_type
+         FROM public.customer_service_price_rules r
+         LEFT JOIN public.catalog_items ci ON ci.price_rule_id = r.rule_id
+        ORDER BY r.is_active DESC, r.priority DESC, r.job_type, r.ac_type, r.wash_variant, r.btu_min NULLS FIRST, r.rule_id DESC`
+    );
+    return r.rows || [];
+  } catch (e) {
+    if (!["42P01", "42703"].includes(String((e && e.code) || ""))) throw e;
+    const r = await db.query(
+      `SELECT rule_id, job_type, ac_type, wash_variant, btu_min, btu_max, machine_min, machine_max,
+              normal_price, active_price, label, campaign_name, campaign_copy, effective_from, effective_to,
+              is_active, priority, created_at, updated_at, updated_by
+         FROM public.customer_service_price_rules
+        ORDER BY is_active DESC, priority DESC, job_type, ac_type, wash_variant, btu_min NULLS FIRST, rule_id DESC`
+    );
+    return r.rows || [];
+  }
 }
 
 async function resolveLinePrice(line, db) {
   const fallbackTotal = money(pricingHelpers.computeStandardPrice(line));
   const qty = Math.max(1, Number(line.machine_count || 1));
+  const fallbackUnit = qty > 0 ? money(fallbackTotal / qty) : fallbackTotal;
+  const rejected = [];
   try {
     const rows = await loadCandidateRules(db);
-    const match = rows
+    const matches = rows
       .filter((row) => rowMatches(row, line))
-      .sort((a, b) => (Number(b.priority || 0) - Number(a.priority || 0)) || (specificity(b) - specificity(a)) || (Number(b.rule_id || 0) - Number(a.rule_id || 0)))[0];
+      .map((row) => {
+        const safety = serviceRuleSafety(row, { fallbackUnit });
+        if (!safety.ok) {
+          rejected.push({ row, safety });
+          rejectRuleLog(row, safety, line);
+        }
+        return { row, safety };
+      })
+      .filter((x) => x.safety.ok)
+      .sort((a, b) => (Number(b.row.priority || 0) - Number(a.row.priority || 0)) || (specificity(b.row) - specificity(a.row)) || (Number(b.row.rule_id || 0) - Number(a.row.rule_id || 0)));
+    const match = matches[0]?.row || null;
     if (match) {
       const normalUnit = money(match.normal_price || match.active_price || 0);
       const activeUnit = money(match.active_price || match.normal_price || 0);
+      const overlap = matches.length > 1
+        && Number(matches[1].row.priority || 0) === Number(match.priority || 0)
+        && specificity(matches[1].row) === specificity(match);
       return {
         normal_unit_price: normalUnit,
         active_unit_price: activeUnit,
@@ -175,12 +378,14 @@ async function resolveLinePrice(line, db) {
         campaign_copy: match.campaign_copy || null,
         rule_id: match.rule_id,
         source: "customer_service_price_rules",
+        pricing_warning: overlap ? "OVERLAPPING_ACTIVE_RULE" : null,
+        rejected_rule_id: rejected[0]?.row?.rule_id || null,
+        rejected_rule_codes: rejected[0]?.safety?.risk_codes || [],
       };
     }
   } catch (e) {
     try { console.warn("[customer_pricing] DB lookup failed, using fallback:", e.message); } catch (_) {}
   }
-  const fallbackUnit = qty > 0 ? money(fallbackTotal / qty) : fallbackTotal;
   return {
     normal_unit_price: fallbackUnit,
     active_unit_price: fallbackUnit,
@@ -190,7 +395,10 @@ async function resolveLinePrice(line, db) {
     campaign_name: null,
     campaign_copy: null,
     rule_id: null,
-    source: "fallback_pricing_js",
+    source: rejected.length ? "fallback_pricing_js_invalid_rule" : "fallback_pricing_js",
+    pricing_warning: rejected.length ? "INVALID_SERVICE_PRICE_RULE" : null,
+    rejected_rule_id: rejected[0]?.row?.rule_id || null,
+    rejected_rule_codes: rejected[0]?.safety?.risk_codes || [],
   };
 }
 
@@ -214,7 +422,12 @@ async function resolveCustomerPricingMulti(payload = {}, db) {
     label: applied?.label || null,
     campaign_name: applied?.campaign_name || null,
     campaign_copy: applied?.campaign_copy || null,
-    source: resolved.some((x) => x.pricing.source === "customer_service_price_rules") ? "customer_service_price_rules" : "fallback_pricing_js",
+    source: resolved.some((x) => x.pricing.source === "customer_service_price_rules")
+      ? "customer_service_price_rules"
+      : (resolved.some((x) => x.pricing.source === "fallback_pricing_js_invalid_rule") ? "fallback_pricing_js_invalid_rule" : "fallback_pricing_js"),
+    pricing_warning: resolved.find((x) => x.pricing.pricing_warning)?.pricing.pricing_warning || null,
+    rejected_rule_id: resolved.find((x) => x.pricing.rejected_rule_id)?.pricing.rejected_rule_id || null,
+    rejected_rule_codes: resolved.find((x) => x.pricing.rejected_rule_codes?.length)?.pricing.rejected_rule_codes || [],
     lines: resolved.map((x) => ({ ...x.line, ...x.pricing })),
   };
 }
@@ -393,6 +606,70 @@ function cleanRuleBody(b = {}) {
   };
 }
 
+function rangesOverlap(aMin, aMax, bMin, bMax) {
+  const amin = aMin == null ? -Infinity : Number(aMin);
+  const amax = aMax == null ? Infinity : Number(aMax);
+  const bmin = bMin == null ? -Infinity : Number(bMin);
+  const bmax = bMax == null ? Infinity : Number(bMax);
+  return amin <= bmax && bmin <= amax;
+}
+
+function annotateRuleRisks(rows = []) {
+  const annotated = rows.map((row) => {
+    const safety = serviceRuleSafety(row);
+    return {
+      ...row,
+      risk_codes: [...safety.risk_codes],
+      is_safe_for_service_pricing: safety.is_safe_for_service_pricing,
+      effective_scope: safety.effective_scope,
+      linked_catalog_item_category: safety.linked_catalog_item_category,
+      linked_catalog_item_id: safety.linked_catalog_item_id,
+      overlaps_with_rule_ids: [],
+    };
+  });
+  for (let i = 0; i < annotated.length; i += 1) {
+    for (let j = i + 1; j < annotated.length; j += 1) {
+      const a = annotated[i];
+      const b = annotated[j];
+      if (!a.is_active || !b.is_active) continue;
+      if (Number(a.priority || 0) !== Number(b.priority || 0)) continue;
+      if (!a.is_safe_for_service_pricing || !b.is_safe_for_service_pricing) continue;
+      if (normalizeServiceType(a.job_type || "") !== normalizeServiceType(b.job_type || "")) continue;
+      if (normalizeAcType(a.ac_type || "") !== normalizeAcType(b.ac_type || "")) continue;
+      if (normalizeWashKey(a.wash_variant || "") !== normalizeWashKey(b.wash_variant || "")) continue;
+      if (!rangesOverlap(a.btu_min, a.btu_max, b.btu_min, b.btu_max)) continue;
+      if (!rangesOverlap(a.machine_min, a.machine_max, b.machine_min, b.machine_max)) continue;
+      a.overlaps_with_rule_ids.push(b.rule_id);
+      b.overlaps_with_rule_ids.push(a.rule_id);
+    }
+  }
+  for (const row of annotated) {
+    if (row.overlaps_with_rule_ids.length && !row.risk_codes.includes("OVERLAPPING_ACTIVE_RULE")) {
+      row.risk_codes.push("OVERLAPPING_ACTIVE_RULE");
+      row.is_safe_for_service_pricing = false;
+    }
+  }
+  return annotated;
+}
+
+function validateServicePriceRuleForWrite(body) {
+  const baseLine = {
+    job_type: normalizeServiceType(body.job_type || ""),
+    ac_type: normalizeAcType(body.ac_type || ""),
+    wash_variant: normalizeWashVariantLabel(body.wash_variant || ""),
+    btu: Number(body.btu_min || body.btu_max || 24000),
+    machine_count: 1,
+  };
+  const fallbackUnit = money(pricingHelpers.computeStandardPrice(baseLine));
+  const safety = serviceRuleSafety(body, { fallbackUnit });
+  return {
+    ok: safety.is_safe_for_service_pricing,
+    error: safety.risk_codes.join(", "),
+    risk_codes: safety.risk_codes,
+    normalized: safety.normalized,
+  };
+}
+
 function createCustomerPricingRoutes({ pool, requireAdminSoft }) {
   const router = express.Router();
   const guard = requireAdminSoft || ((req, res, next) => next());
@@ -400,14 +677,8 @@ function createCustomerPricingRoutes({ pool, requireAdminSoft }) {
   router.get("/admin/customer-pricing/rules", guard, async (req, res) => {
     try {
       await ensureCustomerPriceBookSchema(pool);
-      const r = await pool.query(
-        `SELECT rule_id, job_type, ac_type, wash_variant, btu_min, btu_max, machine_min, machine_max,
-                normal_price, active_price, label, campaign_name, campaign_copy, effective_from, effective_to,
-                is_active, priority, created_at, updated_at, updated_by
-           FROM public.customer_service_price_rules
-          ORDER BY is_active DESC, priority DESC, job_type, ac_type, wash_variant, btu_min NULLS FIRST, rule_id DESC`
-      );
-      res.json({ success: true, rules: r.rows || [] });
+      const rows = await loadAdminRuleRows(pool);
+      res.json({ success: true, rules: annotateRuleRisks(rows) });
     } catch (e) {
       console.error("GET /admin/customer-pricing/rules", e);
       res.status(500).json({ error: "โหลดราคาบริการไม่สำเร็จ" });
@@ -418,6 +689,11 @@ function createCustomerPricingRoutes({ pool, requireAdminSoft }) {
     try {
       await ensureCustomerPriceBookSchema(pool);
       const b = cleanRuleBody(req.body || {});
+      const validation = validateServicePriceRuleForWrite(b);
+      if (!validation.ok) return res.status(400).json({ error: "UNSAFE_SERVICE_PRICE_RULE", code: "UNSAFE_SERVICE_PRICE_RULE", risk_codes: validation.risk_codes });
+      b.job_type = validation.normalized.job_type;
+      b.ac_type = validation.normalized.ac_type;
+      b.wash_variant = validation.normalized.wash_variant;
       if (!b.job_type || !b.ac_type || !b.normal_price || !b.active_price) return res.status(400).json({ error: "กรอกประเภทงาน ประเภทแอร์ ราคาปกติ และราคาที่ใช้จริง" });
       const r = await pool.query(
         `INSERT INTO public.customer_service_price_rules
@@ -441,6 +717,11 @@ function createCustomerPricingRoutes({ pool, requireAdminSoft }) {
       const id = Number(req.params.id);
       if (!id) return res.status(400).json({ error: "rule_id ไม่ถูกต้อง" });
       const b = cleanRuleBody(req.body || {});
+      const validation = validateServicePriceRuleForWrite(b);
+      if (!validation.ok) return res.status(400).json({ error: "UNSAFE_SERVICE_PRICE_RULE", code: "UNSAFE_SERVICE_PRICE_RULE", risk_codes: validation.risk_codes });
+      b.job_type = validation.normalized.job_type;
+      b.ac_type = validation.normalized.ac_type;
+      b.wash_variant = validation.normalized.wash_variant;
       await pool.query(
         `UPDATE public.customer_service_price_rules
             SET job_type=$2, ac_type=$3, wash_variant=$4, btu_min=$5, btu_max=$6, machine_min=$7, machine_max=$8,
@@ -462,6 +743,11 @@ function createCustomerPricingRoutes({ pool, requireAdminSoft }) {
       const id = Number(req.params.id);
       if (!id) return res.status(400).json({ error: "rule_id ไม่ถูกต้อง" });
       const active = boolish(req.body?.is_active, true);
+      if (active) {
+        const existing = await pool.query(`SELECT * FROM public.customer_service_price_rules WHERE rule_id=$1`, [id]);
+        const validation = validateServicePriceRuleForWrite(existing.rows?.[0] || {});
+        if (!validation.ok) return res.status(400).json({ error: "UNSAFE_SERVICE_PRICE_RULE", code: "UNSAFE_SERVICE_PRICE_RULE", risk_codes: validation.risk_codes });
+      }
       await pool.query(`UPDATE public.customer_service_price_rules SET is_active=$2, updated_at=NOW() WHERE rule_id=$1`, [id, active]);
       res.json({ success: true });
     } catch (e) {
@@ -493,4 +779,7 @@ module.exports = {
   intOrNull,
   boolish,
   cleanRuleBody,
+  serviceRuleSafety,
+  validateServicePriceRuleForWrite,
+  annotateRuleRisks,
 };

--- a/server/customerPricing.js
+++ b/server/customerPricing.js
@@ -72,6 +72,13 @@ function rulePrice(value) {
   return Number.isFinite(n) ? money(n) : NaN;
 }
 
+function nonNegativeIntOrNullValue(value) {
+  if (value === null || value === undefined || String(value).trim() === "") return null;
+  const n = Number(value);
+  if (!Number.isFinite(n) || n < 0) return NaN;
+  return Math.round(n);
+}
+
 function positiveIntOrNullValue(value) {
   if (value === null || value === undefined || String(value).trim() === "") return null;
   const n = Number(value);
@@ -85,14 +92,65 @@ function dateTimeOrNull(value) {
   return Number.isFinite(ts) ? ts : NaN;
 }
 
-function catalogLinkFromRule(row = {}) {
-  const itemId = row.linked_catalog_item_id ?? row.catalog_item_id ?? row.item_id ?? null;
-  if (itemId == null) return null;
+function representativeBtuFromRange(btuMin, btuMax) {
+  const hasMin = btuMin !== null && !Number.isNaN(btuMin);
+  const hasMax = btuMax !== null && !Number.isNaN(btuMax);
+  if (hasMin && hasMax) return btuMin > 0 ? btuMin : btuMax;
+  if (hasMin) return btuMin > 0 ? btuMin : 12000;
+  if (hasMax) return btuMax;
+  return 24000;
+}
+
+function canonicalFallbackUnitForRule(row = {}) {
+  const btu_min = nonNegativeIntOrNullValue(row.btu_min);
+  const btu_max = positiveIntOrNullValue(row.btu_max);
+  const line = {
+    job_type: normalizeServiceType(row.job_type || ""),
+    ac_type: normalizeAcType(row.ac_type || ""),
+    wash_variant: normalizeWashVariantLabel(row.wash_variant || ""),
+    btu: representativeBtuFromRange(btu_min, btu_max),
+    machine_count: 1,
+    repair_variant: row.repair_variant || row.repairVariant || "",
+  };
+  return money(pricingHelpers.computeStandardPrice(line));
+}
+
+function emptyCatalogLinkage(status = "verified") {
   return {
-    item_id: itemId,
-    item_category: row.linked_catalog_item_category ?? row.catalog_item_category ?? row.item_category ?? null,
-    job_category: row.linked_catalog_job_category ?? row.catalog_job_category ?? row.job_category ?? null,
-    ac_type: row.linked_catalog_ac_type ?? row.catalog_ac_type ?? row.catalog_item_ac_type ?? null,
+    linked_catalog_item_count: 0,
+    linked_catalog_item_ids: [],
+    linked_catalog_has_product: false,
+    linked_catalog_has_service: false,
+    linked_catalog_service_scopes: [],
+    catalog_linkage_status: status,
+  };
+}
+
+function catalogLinkFromRule(row = {}) {
+  if (row.linked_catalog_item_count != null || row.catalog_linkage_status) {
+    return {
+      linked_catalog_item_count: Number(row.linked_catalog_item_count || 0),
+      linked_catalog_item_ids: Array.isArray(row.linked_catalog_item_ids) ? row.linked_catalog_item_ids : [],
+      linked_catalog_has_product: Boolean(row.linked_catalog_has_product),
+      linked_catalog_has_service: Boolean(row.linked_catalog_has_service),
+      linked_catalog_service_scopes: Array.isArray(row.linked_catalog_service_scopes) ? row.linked_catalog_service_scopes : [],
+      catalog_linkage_status: row.catalog_linkage_status || "verified",
+    };
+  }
+  const itemId = row.linked_catalog_item_id ?? row.catalog_item_id ?? row.item_id ?? null;
+  if (itemId == null) return emptyCatalogLinkage();
+  return {
+    linked_catalog_item_count: 1,
+    linked_catalog_item_ids: [itemId],
+    linked_catalog_has_product: String(row.linked_catalog_item_category ?? row.catalog_item_category ?? row.item_category ?? "").trim().toLowerCase() === "product",
+    linked_catalog_has_service: String(row.linked_catalog_item_category ?? row.catalog_item_category ?? row.item_category ?? "").trim().toLowerCase() === "service",
+    linked_catalog_service_scopes: [{
+      item_id: itemId,
+      item_category: row.linked_catalog_item_category ?? row.catalog_item_category ?? row.item_category ?? null,
+      job_category: row.linked_catalog_job_category ?? row.catalog_job_category ?? row.job_category ?? null,
+      ac_type: row.linked_catalog_ac_type ?? row.catalog_ac_type ?? row.catalog_item_ac_type ?? null,
+    }],
+    catalog_linkage_status: "verified",
   };
 }
 
@@ -106,7 +164,7 @@ function serviceRuleSafety(row = {}, options = {}) {
   const wash_key = normalizeWashKey(wash_variant);
   const normal_price = rulePrice(row.normal_price);
   const active_price = rulePrice(row.active_price);
-  const btu_min = positiveIntOrNullValue(row.btu_min);
+  const btu_min = nonNegativeIntOrNullValue(row.btu_min);
   const btu_max = positiveIntOrNullValue(row.btu_max);
   const machine_min = positiveIntOrNullValue(row.machine_min);
   const machine_max = positiveIntOrNullValue(row.machine_max);
@@ -114,6 +172,7 @@ function serviceRuleSafety(row = {}, options = {}) {
   const toTs = dateTimeOrNull(row.effective_to);
   const priority = Number(row.priority ?? 0);
   const linked = options.linkedCatalogItem || catalogLinkFromRule(row);
+  const fallbackUnit = options.fallbackUnit != null ? Number(options.fallbackUnit) : canonicalFallbackUnitForRule(row);
 
   if (!rawJob) risk.add("MISSING_JOB_TYPE");
   else if (!SUPPORTED_JOB_TYPES.has(job_type)) risk.add("UNSUPPORTED_JOB_TYPE");
@@ -132,21 +191,25 @@ function serviceRuleSafety(row = {}, options = {}) {
   if (!Number.isInteger(priority) || priority < MIN_RULE_PRIORITY || priority > MAX_RULE_PRIORITY) risk.add("INVALID_PRIORITY");
   if (wash_variant && !SUPPORTED_WASH_KEYS.has(wash_key)) risk.add("UNSUPPORTED_WASH_VARIANT");
 
+  if (job_type && ac_type && fallbackUnit <= 0) risk.add("AUTO_PRICING_UNSUPPORTED");
+
   if (linked) {
-    const category = String(linked.item_category || "").trim().toLowerCase();
-    const linkedJob = normalizeServiceType(linked.job_category || "");
-    const linkedAc = normalizeAcType(linked.ac_type || "");
-    if (category === "product") risk.add("PRODUCT_RULE_LEAK");
-    if ((linkedJob && job_type && linkedJob !== job_type) || (linkedAc && ac_type && linkedAc !== ac_type)) {
-      risk.add("CATALOG_SCOPE_MISMATCH");
+    if (linked.catalog_linkage_status === "unverified") risk.add("CATALOG_LINKAGE_UNVERIFIED");
+    if (linked.linked_catalog_has_product) risk.add("PRODUCT_RULE_LEAK");
+    for (const scope of linked.linked_catalog_service_scopes || []) {
+      const category = String(scope.item_category || "").trim().toLowerCase();
+      if (category !== "service") continue;
+      const linkedJob = normalizeServiceType(scope.job_category || "");
+      const linkedAc = normalizeAcType(scope.ac_type || "");
+      if (!linkedJob || !linkedAc || (job_type && linkedJob !== job_type) || (ac_type && linkedAc !== ac_type)) {
+        risk.add("CATALOG_SCOPE_MISMATCH");
+      }
     }
-    if (category === "service" && (!linkedJob || !linkedAc)) risk.add("CATALOG_SCOPE_MISMATCH");
   }
 
-  const fallbackUnit = Number(options.fallbackUnit || 0);
   if (fallbackUnit > 0 && Number.isFinite(normal_price) && Number.isFinite(active_price)) {
     const maxSafeUnit = Math.max(fallbackUnit * 10, 10000);
-    if (normal_price > maxSafeUnit || active_price > maxSafeUnit) risk.add("PRICE_OUTLIER");
+    if (normal_price >= maxSafeUnit || active_price >= maxSafeUnit) risk.add("PRICE_OUTLIER");
   }
 
   const risk_codes = Array.from(risk);
@@ -176,8 +239,14 @@ function serviceRuleSafety(row = {}, options = {}) {
       machine_min: Number.isNaN(machine_min) ? null : machine_min,
       machine_max: Number.isNaN(machine_max) ? null : machine_max,
     },
-    linked_catalog_item_id: linked?.item_id || null,
-    linked_catalog_item_category: linked?.item_category || null,
+    canonical_fallback_unit: fallbackUnit,
+    linked_catalog_item_id: linked?.linked_catalog_item_ids?.[0] || null,
+    linked_catalog_item_category: linked?.linked_catalog_has_product ? "product" : (linked?.linked_catalog_has_service ? "service" : null),
+    linked_catalog_item_count: linked?.linked_catalog_item_count || 0,
+    linked_catalog_item_ids: linked?.linked_catalog_item_ids || [],
+    linked_catalog_has_product: Boolean(linked?.linked_catalog_has_product),
+    linked_catalog_has_service: Boolean(linked?.linked_catalog_has_service),
+    catalog_linkage_status: linked?.catalog_linkage_status || "verified",
   };
 }
 
@@ -282,64 +351,116 @@ async function ensureCustomerPriceBookSchema(db) {
   await db.query(`ALTER TABLE public.job_items ADD COLUMN IF NOT EXISTS customer_price_source TEXT`);
 }
 
-async function loadCandidateRules(db) {
-  let r;
-  try {
-    r = await db.query(`
-      SELECT r.rule_id, r.job_type, r.ac_type, r.wash_variant, r.btu_min, r.btu_max, r.machine_min, r.machine_max,
-             r.normal_price, r.active_price, r.label, r.campaign_name, r.campaign_copy, r.seed_key, r.effective_from, r.effective_to,
-             r.is_active, r.priority, r.created_at, r.updated_at, r.updated_by,
-             ci.item_id AS linked_catalog_item_id,
-             ci.item_category AS linked_catalog_item_category,
-             ci.job_category AS linked_catalog_job_category,
-             ci.ac_type AS linked_catalog_ac_type
-        FROM public.customer_service_price_rules r
-        LEFT JOIN public.catalog_items ci ON ci.price_rule_id = r.rule_id
-       WHERE COALESCE(r.is_active, TRUE)=TRUE
-         AND (r.effective_from IS NULL OR r.effective_from <= NOW())
-         AND (r.effective_to IS NULL OR r.effective_to >= NOW())
-    `);
-  } catch (e) {
-    if (!["42P01", "42703"].includes(String(e && e.code || ""))) throw e;
-    r = await db.query(`
-      SELECT rule_id, job_type, ac_type, wash_variant, btu_min, btu_max, machine_min, machine_max,
-             normal_price, active_price, label, campaign_name, campaign_copy, seed_key, effective_from, effective_to,
-             is_active, priority, created_at, updated_at, updated_by
-        FROM public.customer_service_price_rules
-       WHERE COALESCE(is_active, TRUE)=TRUE
+async function loadRuleRows(db, options = {}) {
+  const where = options.activeOnly
+    ? `WHERE COALESCE(is_active, TRUE)=TRUE
          AND (effective_from IS NULL OR effective_from <= NOW())
-         AND (effective_to IS NULL OR effective_to >= NOW())
-    `);
-  }
+         AND (effective_to IS NULL OR effective_to >= NOW())`
+    : "";
+  const r = await db.query(`
+    SELECT rule_id, job_type, ac_type, wash_variant, btu_min, btu_max, machine_min, machine_max,
+           normal_price, active_price, label, campaign_name, campaign_copy, seed_key, effective_from, effective_to,
+           is_active, priority, created_at, updated_at, updated_by
+      FROM public.customer_service_price_rules
+      ${where}
+     ORDER BY is_active DESC, priority DESC, job_type, ac_type, wash_variant, btu_min NULLS FIRST, rule_id DESC
+  `);
   return r.rows || [];
 }
 
-async function loadAdminRuleRows(db) {
-  try {
-    const r = await db.query(
-      `SELECT r.rule_id, r.job_type, r.ac_type, r.wash_variant, r.btu_min, r.btu_max, r.machine_min, r.machine_max,
-              r.normal_price, r.active_price, r.label, r.campaign_name, r.campaign_copy, r.effective_from, r.effective_to,
-              r.is_active, r.priority, r.created_at, r.updated_at, r.updated_by,
-              ci.item_id AS linked_catalog_item_id,
-              ci.item_category AS linked_catalog_item_category,
-              ci.job_category AS linked_catalog_job_category,
-              ci.ac_type AS linked_catalog_ac_type
-         FROM public.customer_service_price_rules r
-         LEFT JOIN public.catalog_items ci ON ci.price_rule_id = r.rule_id
-        ORDER BY r.is_active DESC, r.priority DESC, r.job_type, r.ac_type, r.wash_variant, r.btu_min NULLS FIRST, r.rule_id DESC`
-    );
-    return r.rows || [];
-  } catch (e) {
-    if (!["42P01", "42703"].includes(String((e && e.code) || ""))) throw e;
-    const r = await db.query(
-      `SELECT rule_id, job_type, ac_type, wash_variant, btu_min, btu_max, machine_min, machine_max,
-              normal_price, active_price, label, campaign_name, campaign_copy, effective_from, effective_to,
-              is_active, priority, created_at, updated_at, updated_by
-         FROM public.customer_service_price_rules
-        ORDER BY is_active DESC, priority DESC, job_type, ac_type, wash_variant, btu_min NULLS FIRST, rule_id DESC`
-    );
-    return r.rows || [];
+function aggregateCatalogLinks(rows = [], fallbackStatus = "verified") {
+  const map = new Map();
+  for (const row of rows || []) {
+    const id = Number(row.price_rule_id);
+    if (!Number.isFinite(id)) continue;
+    const current = map.get(id) || emptyCatalogLinkage("verified");
+    current.linked_catalog_item_count += 1;
+    current.linked_catalog_item_ids.push(row.item_id);
+    const category = String(row.item_category || "").trim().toLowerCase();
+    if (category === "product") current.linked_catalog_has_product = true;
+    if (category === "service") current.linked_catalog_has_service = true;
+    if (category === "service") {
+      current.linked_catalog_service_scopes.push({
+        item_id: row.item_id,
+        item_category: row.item_category,
+        job_category: row.job_category,
+        ac_type: row.ac_type,
+      });
+    }
+    map.set(id, current);
   }
+  map.fallbackStatus = fallbackStatus;
+  return map;
+}
+
+async function loadCatalogLinkageMap(db, ruleIds = []) {
+  const ids = [...new Set((ruleIds || []).map((id) => Number(id)).filter(Number.isFinite))];
+  if (!ids.length) return aggregateCatalogLinks([]);
+  try {
+    const minimal = await db.query(
+      `SELECT item_id, price_rule_id
+         FROM public.catalog_items
+        WHERE price_rule_id = ANY($1::bigint[])`,
+      [ids]
+    );
+    const minimalRows = minimal.rows || [];
+    if (!minimalRows.length) return aggregateCatalogLinks([]);
+    try {
+      const full = await db.query(
+        `SELECT item_id, price_rule_id, item_category, job_category, ac_type
+           FROM public.catalog_items
+          WHERE price_rule_id = ANY($1::bigint[])`,
+        [ids]
+      );
+      return aggregateCatalogLinks(full.rows || []);
+    } catch (e) {
+      if (!["42703"].includes(String((e && e.code) || ""))) throw e;
+      const map = new Map();
+      for (const row of minimalRows) {
+        const id = Number(row.price_rule_id);
+        const current = map.get(id) || emptyCatalogLinkage("unverified");
+        current.catalog_linkage_status = "unverified";
+        current.linked_catalog_item_count += 1;
+        current.linked_catalog_item_ids.push(row.item_id);
+        map.set(id, current);
+      }
+      map.fallbackStatus = "verified";
+      return map;
+    }
+  } catch (e) {
+    const code = String((e && e.code) || "");
+    if (["42P01", "42703"].includes(code)) {
+      return aggregateCatalogLinks([], "absent");
+    }
+    try {
+      console.warn("[customer_pricing] catalog linkage lookup failed, marking rules unverified", { code });
+    } catch (_) {}
+    const map = new Map();
+    for (const id of ids) map.set(id, { ...emptyCatalogLinkage("unverified") });
+    map.fallbackStatus = "unverified";
+    return map;
+  }
+}
+
+function mergeCatalogLinkage(rows = [], linkMap) {
+  const status = linkMap?.fallbackStatus || "verified";
+  return (rows || []).map((row) => {
+    const id = Number(row.rule_id);
+    const linkage = linkMap?.get?.(id) || emptyCatalogLinkage(status);
+    return { ...row, ...linkage };
+  });
+}
+
+async function loadCandidateRules(db) {
+  const rows = await loadRuleRows(db, { activeOnly: true });
+  const linkMap = await loadCatalogLinkageMap(db, rows.map((row) => row.rule_id));
+  return mergeCatalogLinkage(rows, linkMap);
+}
+
+async function loadAdminRuleRows(db) {
+  const rows = await loadRuleRows(db, { activeOnly: false });
+  const linkMap = await loadCatalogLinkageMap(db, rows.map((row) => row.rule_id));
+  return mergeCatalogLinkage(rows, linkMap);
 }
 
 async function resolveLinePrice(line, db) {
@@ -624,6 +745,12 @@ function annotateRuleRisks(rows = []) {
       effective_scope: safety.effective_scope,
       linked_catalog_item_category: safety.linked_catalog_item_category,
       linked_catalog_item_id: safety.linked_catalog_item_id,
+      linked_catalog_item_count: safety.linked_catalog_item_count,
+      linked_catalog_item_ids: safety.linked_catalog_item_ids,
+      linked_catalog_has_product: safety.linked_catalog_has_product,
+      linked_catalog_has_service: safety.linked_catalog_has_service,
+      catalog_linkage_status: safety.catalog_linkage_status,
+      canonical_fallback_unit: safety.canonical_fallback_unit,
       overlaps_with_rule_ids: [],
     };
   });
@@ -631,6 +758,7 @@ function annotateRuleRisks(rows = []) {
     for (let j = i + 1; j < annotated.length; j += 1) {
       const a = annotated[i];
       const b = annotated[j];
+      if (Number(a.rule_id) === Number(b.rule_id)) continue;
       if (!a.is_active || !b.is_active) continue;
       if (Number(a.priority || 0) !== Number(b.priority || 0)) continue;
       if (!a.is_safe_for_service_pricing || !b.is_safe_for_service_pricing) continue;
@@ -653,14 +781,7 @@ function annotateRuleRisks(rows = []) {
 }
 
 function validateServicePriceRuleForWrite(body) {
-  const baseLine = {
-    job_type: normalizeServiceType(body.job_type || ""),
-    ac_type: normalizeAcType(body.ac_type || ""),
-    wash_variant: normalizeWashVariantLabel(body.wash_variant || ""),
-    btu: Number(body.btu_min || body.btu_max || 24000),
-    machine_count: 1,
-  };
-  const fallbackUnit = money(pricingHelpers.computeStandardPrice(baseLine));
+  const fallbackUnit = canonicalFallbackUnitForRule(body);
   const safety = serviceRuleSafety(body, { fallbackUnit });
   return {
     ok: safety.is_safe_for_service_pricing,
@@ -780,6 +901,7 @@ module.exports = {
   boolish,
   cleanRuleBody,
   serviceRuleSafety,
+  canonicalFallbackUnitForRule,
   validateServicePriceRuleForWrite,
   annotateRuleRisks,
 };

--- a/server/customerPricing.js
+++ b/server/customerPricing.js
@@ -463,6 +463,26 @@ async function loadAdminRuleRows(db) {
   return mergeCatalogLinkage(rows, linkMap);
 }
 
+async function loadRuleWithCatalogLinkage(db, ruleId) {
+  const r = await db.query(`SELECT * FROM public.customer_service_price_rules WHERE rule_id=$1`, [ruleId]);
+  const row = r.rows?.[0] || null;
+  if (!row) return null;
+  const linkMap = await loadCatalogLinkageMap(db, [row.rule_id]);
+  return mergeCatalogLinkage([row], linkMap)[0] || null;
+}
+
+function mergeRuleLinkageMetadata(candidate, source) {
+  return {
+    ...candidate,
+    linked_catalog_item_count: source?.linked_catalog_item_count || 0,
+    linked_catalog_item_ids: source?.linked_catalog_item_ids || [],
+    linked_catalog_has_product: Boolean(source?.linked_catalog_has_product),
+    linked_catalog_has_service: Boolean(source?.linked_catalog_has_service),
+    linked_catalog_service_scopes: source?.linked_catalog_service_scopes || [],
+    catalog_linkage_status: source?.catalog_linkage_status || "verified",
+  };
+}
+
 async function resolveLinePrice(line, db) {
   const fallbackTotal = money(pricingHelpers.computeStandardPrice(line));
   const qty = Math.max(1, Number(line.machine_count || 1));
@@ -837,8 +857,10 @@ function createCustomerPricingRoutes({ pool, requireAdminSoft }) {
       await ensureCustomerPriceBookSchema(pool);
       const id = Number(req.params.id);
       if (!id) return res.status(400).json({ error: "rule_id ไม่ถูกต้อง" });
+      const existing = await loadRuleWithCatalogLinkage(pool, id);
+      if (!existing) return res.status(404).json({ error: "PRICE_RULE_NOT_FOUND", code: "PRICE_RULE_NOT_FOUND" });
       const b = cleanRuleBody(req.body || {});
-      const validation = validateServicePriceRuleForWrite(b);
+      const validation = validateServicePriceRuleForWrite(mergeRuleLinkageMetadata(b, existing));
       if (!validation.ok) return res.status(400).json({ error: "UNSAFE_SERVICE_PRICE_RULE", code: "UNSAFE_SERVICE_PRICE_RULE", risk_codes: validation.risk_codes });
       b.job_type = validation.normalized.job_type;
       b.ac_type = validation.normalized.ac_type;
@@ -865,8 +887,9 @@ function createCustomerPricingRoutes({ pool, requireAdminSoft }) {
       if (!id) return res.status(400).json({ error: "rule_id ไม่ถูกต้อง" });
       const active = boolish(req.body?.is_active, true);
       if (active) {
-        const existing = await pool.query(`SELECT * FROM public.customer_service_price_rules WHERE rule_id=$1`, [id]);
-        const validation = validateServicePriceRuleForWrite(existing.rows?.[0] || {});
+        const existing = await loadRuleWithCatalogLinkage(pool, id);
+        if (!existing) return res.status(404).json({ error: "PRICE_RULE_NOT_FOUND", code: "PRICE_RULE_NOT_FOUND" });
+        const validation = validateServicePriceRuleForWrite(existing);
         if (!validation.ok) return res.status(400).json({ error: "UNSAFE_SERVICE_PRICE_RULE", code: "UNSAFE_SERVICE_PRICE_RULE", risk_codes: validation.risk_codes });
       }
       await pool.query(`UPDATE public.customer_service_price_rules SET is_active=$2, updated_at=NOW() WHERE rule_id=$1`, [id, active]);

--- a/server/routes/catalog/items.js
+++ b/server/routes/catalog/items.js
@@ -1,4 +1,4 @@
-const { money, intOrNull, boolish } = require("../../customerPricing");
+const { money, intOrNull, boolish, validateServicePriceRuleForWrite, serviceRuleSafety } = require("../../customerPricing");
 const cloudinaryImageUpload = require("../../lib/cloudinaryImageUpload");
 const customerAvailability = require("../../services/public/customerAvailability");
 const { getBangkokNow, computeJobTiming } = require("../../services/jobTiming");
@@ -350,10 +350,40 @@ function validatePricingInput(pricing) {
   };
 }
 
+function validateCatalogPricingScope(pricing, catalogFields) {
+  if (!pricing) return { ok: true };
+  const category = normalizeItemCategory(catalogFields.item_category, catalogFields.booking_mode);
+  if (category === "product" || String(catalogFields.booking_mode || "").trim() === "purchase") {
+    return { ok: true, catalog_only: true };
+  }
+  const candidate = {
+    job_type: catalogFields.job_category,
+    ac_type: catalogFields.ac_type,
+    wash_variant: pricing.wash_variant,
+    btu_min: catalogFields.btu_min,
+    btu_max: catalogFields.btu_max,
+    normal_price: pricing.normal_price,
+    active_price: pricing.active_price,
+    effective_from: pricing.effective_from,
+    effective_to: pricing.effective_to,
+    priority: pricing.priority,
+  };
+  const validation = validateServicePriceRuleForWrite(candidate);
+  if (!validation.ok) {
+    return {
+      ok: false,
+      error: "UNSAFE_SERVICE_PRICE_RULE",
+      risk_codes: validation.risk_codes,
+    };
+  }
+  return { ok: true, catalog_only: false };
+}
+
 const CATALOG_SELECT_WITH_PRICING = `
   SELECT ci.item_id, ci.item_name, ci.item_category, ci.base_price, ci.unit_label, ci.is_active,
          ci.job_category, ci.ac_type, ci.btu_min, ci.btu_max, ci.is_customer_visible,
          ci.image_url, ci.image_public_id, ci.price_rule_id,
+         pr.job_type AS rule_job_type, pr.ac_type AS rule_ac_type,
          pr.normal_price AS rule_normal_price, pr.active_price AS rule_active_price,
          pr.campaign_name AS rule_campaign_name, pr.is_active AS rule_is_active,
          pr.effective_from AS rule_effective_from, pr.effective_to AS rule_effective_to,
@@ -833,6 +863,23 @@ function serializeCatalogDetailRow(row) {
 function serializeAdminCatalogRow(row) {
   const base = serializeCatalogRow(row);
   const hasRule = Boolean(row.price_rule_id);
+  const ruleSafety = hasRule ? serviceRuleSafety({
+    rule_id: row.price_rule_id,
+    job_type: row.rule_job_type || row.job_category,
+    ac_type: row.rule_ac_type || row.ac_type,
+    wash_variant: row.rule_wash_variant,
+    btu_min: row.btu_min,
+    btu_max: row.btu_max,
+    normal_price: row.rule_normal_price,
+    active_price: row.rule_active_price,
+    effective_from: row.rule_effective_from,
+    effective_to: row.rule_effective_to,
+    priority: row.rule_priority,
+    linked_catalog_item_id: row.item_id,
+    linked_catalog_item_category: row.item_category,
+    linked_catalog_job_category: row.job_category,
+    linked_catalog_ac_type: row.ac_type,
+  }) : { risk_codes: [], is_safe_for_service_pricing: true };
   return {
     ...base,
     pricing_normal_price: hasRule ? Number(row.rule_normal_price ?? 0) : null,
@@ -844,6 +891,9 @@ function serializeAdminCatalogRow(row) {
     pricing_is_active: hasRule ? Boolean(row.rule_is_active) : null,
     pricing_wash_variant: hasRule ? (row.rule_wash_variant || null) : null,
     pricing_priority: hasRule ? (row.rule_priority != null ? Number(row.rule_priority) : null) : null,
+    pricing_risk_codes: ruleSafety.risk_codes || [],
+    pricing_is_safe_for_service_pricing: Boolean(ruleSafety.is_safe_for_service_pricing),
+    pricing_catalog_only: hasRule && String(row.item_category || "").toLowerCase() === "product",
     // Raw marketplace fields for the admin Edit form (booking_mode is already on
     // `base` since it's needed for public CTA routing too; this adds the rest).
     long_description: row.long_description || null,
@@ -1171,6 +1221,8 @@ module.exports = function createCatalogItemRoutes(deps = {}) {
     const v = result.value;
     const mv = marketplaceResult.value;
     const hv = hotResult.value;
+    const pricingScopeResult = validateCatalogPricingScope(pricingResult.value, { ...v, booking_mode: mv.booking_mode });
+    if (!pricingScopeResult.ok) return res.status(400).json({ error: pricingScopeResult.error, code: pricingScopeResult.error, risk_codes: pricingScopeResult.risk_codes || [] });
     const client = await pool.connect();
     try {
       await client.query("BEGIN");
@@ -1298,6 +1350,8 @@ module.exports = function createCatalogItemRoutes(deps = {}) {
     const v = result.value;
     const mv = marketplaceResult.value;
     const hv = hotResult.value;
+    const pricingScopeResult = validateCatalogPricingScope(pricingResult.value, { ...v, booking_mode: mv.booking_mode });
+    if (!pricingScopeResult.ok) return res.status(400).json({ error: pricingScopeResult.error, code: pricingScopeResult.error, risk_codes: pricingScopeResult.risk_codes || [] });
     const client = await pool.connect();
     try {
       await client.query("BEGIN");

--- a/server/routes/catalog/items.js
+++ b/server/routes/catalog/items.js
@@ -28,6 +28,20 @@ function parseOptionalPositiveNumber(value, fieldLabel) {
   return { ok: true, value: n };
 }
 
+function parseOptionalNonNegativeInteger(value, fieldLabel) {
+  if (value === undefined || value === null || value === "") return { ok: true, value: null };
+  const n = Number(value);
+  if (!Number.isInteger(n) || n < 0) return { ok: false, error: `${fieldLabel} ต้องเป็นค่าว่างหรือจำนวนเต็มตั้งแต่ 0 ขึ้นไป` };
+  return { ok: true, value: n };
+}
+
+function parseOptionalPositiveInteger(value, fieldLabel) {
+  if (value === undefined || value === null || value === "") return { ok: true, value: null };
+  const n = Number(value);
+  if (!Number.isInteger(n) || n <= 0) return { ok: false, error: `${fieldLabel} ต้องเป็นค่าว่างหรือจำนวนเต็มบวก` };
+  return { ok: true, value: n };
+}
+
 function parseRequiredPositivePrice(value, fieldLabel) {
   if (value === undefined || value === null) {
     return { ok: false, error: `${fieldLabel} ต้องระบุและมากกว่า 0` };
@@ -265,9 +279,9 @@ function validateMergedCatalogItem(merged) {
     else base_price = n;
   }
 
-  const btuMinResult = parseOptionalPositiveNumber(merged.btu_min, "btu_min");
+  const btuMinResult = parseOptionalNonNegativeInteger(merged.btu_min, "btu_min");
   if (!btuMinResult.ok) errors.push(btuMinResult.error);
-  const btuMaxResult = parseOptionalPositiveNumber(merged.btu_max, "btu_max");
+  const btuMaxResult = parseOptionalPositiveInteger(merged.btu_max, "btu_max");
   if (!btuMaxResult.ok) errors.push(btuMaxResult.error);
 
   const btu_min = btuMinResult.ok ? btuMinResult.value : null;

--- a/test/adminStoreCatalogUi.test.js
+++ b/test/adminStoreCatalogUi.test.js
@@ -370,7 +370,7 @@ test("gallery delete and set-primary actions ask for confirmation only on delete
 
 test("admin-store-catalog.html keeps CSS cache and bumps JS cache for pricing safety", () => {
   assert.match(catalogHtmlSource, /admin-store-catalog\.css\?v=20260702_cat_v2/);
-  assert.match(catalogHtmlSource, /admin-store-catalog\.js\?v=20260708_price_rule_safety_v2/);
+  assert.match(catalogHtmlSource, /admin-store-catalog\.js\?v=20260708_price_rule_safety_v3/);
 });
 
 test("the item_category field is a service/product dropdown, not free text", () => {

--- a/test/adminStoreCatalogUi.test.js
+++ b/test/adminStoreCatalogUi.test.js
@@ -368,9 +368,9 @@ test("gallery delete and set-primary actions ask for confirmation only on delete
   assert.match(catalogJsSource, /async function onGalleryDelete\(imageId\) \{[\s\S]*?confirm\(.*ลบรูปภาพ/);
 });
 
-test("admin-store-catalog.html script and stylesheet references share a consistent cache-bust build id", () => {
+test("admin-store-catalog.html keeps CSS cache and bumps JS cache for pricing safety", () => {
   assert.match(catalogHtmlSource, /admin-store-catalog\.css\?v=20260702_cat_v2/);
-  assert.match(catalogHtmlSource, /admin-store-catalog\.js\?v=20260702_cat_v2/);
+  assert.match(catalogHtmlSource, /admin-store-catalog\.js\?v=20260707_price_rule_safety_v1/);
 });
 
 test("the item_category field is a service/product dropdown, not free text", () => {

--- a/test/adminStoreCatalogUi.test.js
+++ b/test/adminStoreCatalogUi.test.js
@@ -370,7 +370,7 @@ test("gallery delete and set-primary actions ask for confirmation only on delete
 
 test("admin-store-catalog.html keeps CSS cache and bumps JS cache for pricing safety", () => {
   assert.match(catalogHtmlSource, /admin-store-catalog\.css\?v=20260702_cat_v2/);
-  assert.match(catalogHtmlSource, /admin-store-catalog\.js\?v=20260707_price_rule_safety_v1/);
+  assert.match(catalogHtmlSource, /admin-store-catalog\.js\?v=20260708_price_rule_safety_v2/);
 });
 
 test("the item_category field is a service/product dropdown, not free text", () => {

--- a/test/catalogItemsRoutes.test.js
+++ b/test/catalogItemsRoutes.test.js
@@ -1161,7 +1161,7 @@ test("admin POST with a pricing object creates the catalog item and the linked p
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
-        item_name: "ล้างแอร์โปร", base_price: 700,
+        item_name: "ล้างแอร์โปร", base_price: 700, job_category: "ล้าง", ac_type: "ผนัง",
         pricing: { normal_price: 700, active_price: 500, campaign_name: "โปรทดสอบ", pricing_is_active: true },
       }),
     });
@@ -1698,6 +1698,8 @@ test("admin POST with a pricing rule still responds successfully against a singl
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
         item_name: "ทดสอบราคา",
+        job_category: "ล้าง",
+        ac_type: "ผนัง",
         pricing: { normal_price: 700, active_price: 550, pricing_is_active: true },
       }),
     });

--- a/test/catalogItemsRoutes.test.js
+++ b/test/catalogItemsRoutes.test.js
@@ -710,6 +710,35 @@ test("admin POST create rejects btu_min > btu_max", async () => {
   });
 });
 
+test("admin POST create accepts service catalog btu_min zero and rejects unsafe BTU bounds", async () => {
+  const pool = makePool(sampleItems());
+  const router = createCatalogItemRoutes({ pool, requireAdminSession: allowAdmin });
+  await withServer(router, async (base) => {
+    const ok = await fetch(`${base}/admin/catalog/items`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ item_name: "zero btu min", item_category: "service", job_category: "ล้าง", ac_type: "ผนัง", btu_min: 0, btu_max: 12000, base_price: 600 }),
+    });
+    assert.equal(ok.status, 201);
+    const body = await ok.json();
+    assert.equal(body.btu_min, 0);
+    assert.equal(body.btu_max, 12000);
+
+    for (const payload of [
+      { item_name: "bad min", btu_min: -1, btu_max: 12000 },
+      { item_name: "bad max", btu_min: 0, btu_max: 0 },
+      { item_name: "bad range", btu_min: 18000, btu_max: 12000 },
+    ]) {
+      const res = await fetch(`${base}/admin/catalog/items`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      });
+      assert.equal(res.status, 400);
+    }
+  });
+});
+
 test("admin POST create succeeds with valid payload and defaults is_customer_visible to false", async () => {
   const pool = makePool(sampleItems());
   const router = createCatalogItemRoutes({ pool, requireAdminSession: allowAdmin });
@@ -750,6 +779,36 @@ test("admin PATCH update rejects btu_min > btu_max against the merged record", a
       body: JSON.stringify({ btu_min: 99999 }),
     });
     assert.equal(res.status, 400);
+  });
+});
+
+test("admin PATCH preserves existing service catalog btu_min zero when editing name or pricing", async () => {
+  const items = sampleItems();
+  items[0].btu_min = 0;
+  items[0].btu_max = 12000;
+  const pool = makePool(items);
+  const router = createCatalogItemRoutes({ pool, requireAdminSession: allowAdmin });
+  await withServer(router, async (base) => {
+    const rename = await fetch(`${base}/admin/catalog/items/1`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ item_name: "zero min renamed" }),
+    });
+    assert.equal(rename.status, 200);
+    const renamed = await rename.json();
+    assert.equal(renamed.item_name, "zero min renamed");
+    assert.equal(renamed.btu_min, 0);
+
+    const pricing = await fetch(`${base}/admin/catalog/items/1`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ pricing: { normal_price: 600, active_price: 550 } }),
+    });
+    assert.equal(pricing.status, 200);
+    const priced = await pricing.json();
+    assert.equal(priced.btu_min, 0);
+    assert.equal(Number(priced.pricing_normal_price), 600);
+    assert.equal(Number(priced.pricing_active_price), 550);
   });
 });
 

--- a/test/customerPricingSafety.test.js
+++ b/test/customerPricingSafety.test.js
@@ -8,11 +8,20 @@ const express = require("express");
 const customerPricing = require("../server/customerPricing");
 const createCatalogItemRoutes = require("../server/routes/catalog/items");
 
-function dbWithRules(rows = []) {
+function dbWithRules(rows = [], options = {}) {
+  const links = options.links || [];
+  const failCatalogLinks = options.failCatalogLinks || null;
+  const fullLinkError = options.fullLinkError || null;
   return {
     queries: [],
     async query(sql, params = []) {
-      this.queries.push({ sql: String(sql), params });
+      const s = String(sql);
+      this.queries.push({ sql: s, params });
+      if (s.includes("FROM public.catalog_items")) {
+        if (fullLinkError && s.includes("item_category")) throw fullLinkError;
+        if (failCatalogLinks) throw failCatalogLinks;
+        return { rows: links.map((r) => ({ ...r })) };
+      }
       return { rows: rows.map((r) => ({ ...r })) };
     },
   };
@@ -63,11 +72,16 @@ test("resolver rejects specific concealed 99999/88888 outlier and returns safe f
 test("resolver rejects wildcard, product-linked, blank service, and catalog-mismatch rules", async () => {
   const badRules = [
     rule({ rule_id: 11, job_type: null, ac_type: null, normal_price: 99999, active_price: 88888 }),
-    rule({ rule_id: 12, linked_catalog_item_id: 5, linked_catalog_item_category: "product" }),
+    rule({ rule_id: 12 }),
     rule({ rule_id: 13, job_type: "", ac_type: "" }),
-    rule({ rule_id: 14, linked_catalog_item_id: 6, linked_catalog_item_category: "service", linked_catalog_job_category: "repair", linked_catalog_ac_type: "wall" }),
+    rule({ rule_id: 14 }),
   ];
-  const result = await customerPricing.resolveCustomerPricingMulti(concealedPayload(), dbWithRules(badRules));
+  const result = await customerPricing.resolveCustomerPricingMulti(concealedPayload(), dbWithRules(badRules, {
+    links: [
+      { price_rule_id: 12, item_id: 5, item_category: "product", job_category: null, ac_type: null },
+      { price_rule_id: 14, item_id: 6, item_category: "service", job_category: "repair", ac_type: "wall" },
+    ],
+  }));
   assert.equal(result.active_price, 1200);
   assert.equal(result.source, "fallback_pricing_js_invalid_rule");
   assert.ok(result.lines[0].rejected_rule_codes.length);
@@ -96,6 +110,48 @@ test("validator rejects active above normal and invalid ranges", () => {
   assert.deepEqual(customerPricing.validateServicePriceRuleForWrite(rule({ normal_price: 1200, active_price: 1300 })).risk_codes, ["ACTIVE_PRICE_ABOVE_NORMAL"]);
   assert.ok(customerPricing.validateServicePriceRuleForWrite(rule({ btu_min: 30000, btu_max: 9000 })).risk_codes.includes("INVALID_BTU_RANGE"));
   assert.ok(customerPricing.validateServicePriceRuleForWrite(rule({ machine_min: 5, machine_max: 1 })).risk_codes.includes("INVALID_MACHINE_RANGE"));
+});
+
+test("BTU range validation preserves rainy-season btu_min zero rules", async () => {
+  assert.equal(customerPricing.validateServicePriceRuleForWrite(rule({ job_type: "clean", ac_type: "wall", wash_variant: "normal", btu_min: 0, btu_max: 12000, normal_price: 600, active_price: 550 })).ok, true);
+  assert.ok(customerPricing.validateServicePriceRuleForWrite(rule({ btu_min: -1, btu_max: 12000 })).risk_codes.includes("INVALID_BTU_RANGE"));
+  assert.ok(customerPricing.validateServicePriceRuleForWrite(rule({ btu_min: 0, btu_max: 0 })).risk_codes.includes("INVALID_BTU_RANGE"));
+  assert.ok(customerPricing.validateServicePriceRuleForWrite(rule({ btu_min: 18000, btu_max: 12000 })).risk_codes.includes("INVALID_BTU_RANGE"));
+
+  const rainyRules = [
+    rule({ rule_id: 41, job_type: "clean", ac_type: "wall", wash_variant: "normal", btu_min: 0, btu_max: 12000, normal_price: 600, active_price: 550 }),
+    rule({ rule_id: 42, job_type: "clean", ac_type: "wall", wash_variant: "premium", btu_min: 0, btu_max: 12000, normal_price: 900, active_price: 790 }),
+    rule({ rule_id: 43, job_type: "clean", ac_type: "wall", wash_variant: "coil", btu_min: 0, btu_max: 12000, normal_price: 1400, active_price: 1290 }),
+    rule({ rule_id: 44, job_type: "clean", ac_type: "wall", wash_variant: "overhaul", btu_min: 0, btu_max: 12000, normal_price: 2000, active_price: 1850 }),
+    rule({ rule_id: 45, job_type: "clean", ac_type: "wall", wash_variant: "normal", btu_min: 18000, btu_max: null, normal_price: 750, active_price: 690 }),
+  ];
+  for (const [wash_variant, btu, expected] of [["normal", 9000, 550], ["premium", 9000, 790], ["coil", 9000, 1290], ["overhaul", 9000, 1850], ["normal", 18000, 690]]) {
+    const result = await customerPricing.resolveCustomerPricingMulti(wallPayload({ wash_variant, btu }), dbWithRules(rainyRules));
+    assert.equal(result.active_price, expected);
+    assert.equal(result.source, "customer_service_price_rules");
+  }
+});
+
+test("install service price rules are unsupported and never auto-price manual quote work", async () => {
+  const high = rule({ rule_id: 51, job_type: "install", ac_type: "wall", normal_price: 99999, active_price: 88888 });
+  const normalLooking = rule({ rule_id: 52, job_type: "install", ac_type: "wall", normal_price: 3000, active_price: 3000 });
+  assert.ok(customerPricing.validateServicePriceRuleForWrite(high).risk_codes.includes("AUTO_PRICING_UNSUPPORTED"));
+  assert.ok(customerPricing.validateServicePriceRuleForWrite(normalLooking).risk_codes.includes("AUTO_PRICING_UNSUPPORTED"));
+  const result = await customerPricing.resolveCustomerPricingMulti({ job_type: "install", ac_type: "wall", btu: 12000, machine_count: 1 }, dbWithRules([normalLooking]));
+  assert.equal(result.active_price, 0);
+  assert.equal(result.source, "fallback_pricing_js_invalid_rule");
+  assert.ok(result.rejected_rule_codes.includes("AUTO_PRICING_UNSUPPORTED"));
+});
+
+test("admin audit flags outliers and exact threshold boundary with the same backend safety decision", () => {
+  const unsafe = rule({ rule_id: 61, normal_price: 99999, active_price: 88888, btu_min: 24000, btu_max: 24000 });
+  const boundary = rule({ rule_id: 62, normal_price: 12000, active_price: 12000, btu_min: 24000, btu_max: 24000 });
+  const safe = rule({ rule_id: 63, normal_price: 1200, active_price: 1200, btu_min: 24000, btu_max: 24000 });
+  assert.equal(customerPricing.canonicalFallbackUnitForRule(unsafe), 1200);
+  const rows = customerPricing.annotateRuleRisks([unsafe, boundary, safe]);
+  assert.ok(rows.find((r) => r.rule_id === 61).risk_codes.includes("PRICE_OUTLIER"));
+  assert.ok(rows.find((r) => r.rule_id === 62).risk_codes.includes("PRICE_OUTLIER"));
+  assert.equal(rows.find((r) => r.rule_id === 63).is_safe_for_service_pricing, true);
 });
 
 test("overlapping safe rules choose deterministic winner and return warning", async () => {
@@ -149,6 +205,34 @@ function routePool({ existingRule } = {}) {
   return pool;
 }
 
+function adminRulesPool(rows = [], links = [], options = {}) {
+  const state = { updated: [] };
+  let catalogReads = 0;
+  return {
+    state,
+    async query(sql, params = []) {
+      const s = String(sql);
+      if (/CREATE TABLE|ALTER TABLE|CREATE INDEX/i.test(s)) return { rows: [] };
+      if (s.includes("UPDATE public.customer_service_price_rules")) {
+        state.updated.push(params);
+        return { rows: [] };
+      }
+      if (s.includes("SELECT * FROM public.customer_service_price_rules")) {
+        return { rows: rows.filter((row) => Number(row.rule_id) === Number(params[0])).map((row) => ({ ...row })) };
+      }
+      if (s.includes("FROM public.customer_service_price_rules")) return { rows: rows.map((row) => ({ ...row })) };
+      if (s.includes("FROM public.catalog_items")) {
+        catalogReads += 1;
+        if (options.catalogError) throw options.catalogError;
+        if (options.fullLinkError && s.includes("item_category")) throw options.fullLinkError;
+        return { rows: links.map((link) => ({ ...link })) };
+      }
+      return { rows: [] };
+    },
+    get catalogReads() { return catalogReads; },
+  };
+}
+
 test("POST and PUT customer price rules use the same safety validation", async () => {
   const pool = routePool();
   const router = customerPricing.createCustomerPricingRoutes({ pool, requireAdminSoft: (_req, _res, next) => next() });
@@ -163,6 +247,23 @@ test("POST and PUT customer price rules use the same safety validation", async (
   });
 });
 
+test("POST, PUT, and toggle reject install auto-pricing rules", async () => {
+  const installRule = rule({ rule_id: 71, job_type: "install", ac_type: "wall", normal_price: 3000, active_price: 3000 });
+  const pool = adminRulesPool([installRule]);
+  const router = customerPricing.createCustomerPricingRoutes({ pool, requireAdminSoft: (_req, _res, next) => next() });
+  await withServer(router, async (base) => {
+    const post = await fetch(`${base}/admin/customer-pricing/rules`, { method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify(installRule) });
+    const put = await fetch(`${base}/admin/customer-pricing/rules/71`, { method: "PUT", headers: { "content-type": "application/json" }, body: JSON.stringify(installRule) });
+    const toggle = await fetch(`${base}/admin/customer-pricing/rules/71/toggle`, { method: "PATCH", headers: { "content-type": "application/json" }, body: JSON.stringify({ is_active: true }) });
+    assert.equal(post.status, 400);
+    assert.equal(put.status, 400);
+    assert.equal(toggle.status, 400);
+    assert.ok((await post.json()).risk_codes.includes("AUTO_PRICING_UNSUPPORTED"));
+    assert.ok((await put.json()).risk_codes.includes("AUTO_PRICING_UNSUPPORTED"));
+    assert.ok((await toggle.json()).risk_codes.includes("AUTO_PRICING_UNSUPPORTED"));
+  });
+});
+
 test("direct price book rejects blank scope and active price above normal", async () => {
   const pool = routePool();
   const router = customerPricing.createCustomerPricingRoutes({ pool, requireAdminSoft: (_req, _res, next) => next() });
@@ -173,6 +274,93 @@ test("direct price book rejects blank scope and active price above normal", asyn
     assert.ok((await blank.json()).risk_codes.includes("MISSING_JOB_TYPE"));
     assert.equal(inverted.status, 400);
     assert.ok((await inverted.json()).risk_codes.includes("ACTIVE_PRICE_ABOVE_NORMAL"));
+  });
+});
+
+test("GET admin rules returns one row per rule with outlier and install audit risks", async () => {
+  const pool = adminRulesPool([
+    rule({ rule_id: 81, normal_price: 99999, active_price: 88888, btu_min: 24000, btu_max: 24000 }),
+    rule({ rule_id: 82, job_type: "install", ac_type: "wall", normal_price: 3000, active_price: 3000 }),
+  ]);
+  const router = customerPricing.createCustomerPricingRoutes({ pool, requireAdminSoft: (_req, _res, next) => next() });
+  await withServer(router, async (base) => {
+    const res = await fetch(`${base}/admin/customer-pricing/rules`);
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.equal(body.rules.length, 2);
+    assert.ok(body.rules.find((r) => r.rule_id === 81).risk_codes.includes("PRICE_OUTLIER"));
+    assert.ok(body.rules.find((r) => r.rule_id === 82).risk_codes.includes("AUTO_PRICING_UNSUPPORTED"));
+  });
+});
+
+test("catalog linkage aggregation evaluates each rule once and avoids self-overlap", async () => {
+  const sharedRule = rule({ rule_id: 91, job_type: "clean", ac_type: "wall", wash_variant: "normal", normal_price: 600, active_price: 550 });
+  const links = [
+    { price_rule_id: 91, item_id: 1, item_category: "service", job_category: "clean", ac_type: "wall" },
+    { price_rule_id: 91, item_id: 2, item_category: "service", job_category: "clean", ac_type: "wall" },
+  ];
+  const result = await customerPricing.resolveCustomerPricingMulti(wallPayload(), dbWithRules([sharedRule], { links }));
+  assert.equal(result.active_price, 550);
+  assert.equal(result.lines[0].pricing_warning, null);
+
+  const pool = adminRulesPool([sharedRule], links);
+  const router = customerPricing.createCustomerPricingRoutes({ pool, requireAdminSoft: (_req, _res, next) => next() });
+  await withServer(router, async (base) => {
+    const res = await fetch(`${base}/admin/customer-pricing/rules`);
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.equal(body.rules.length, 1);
+    assert.equal(body.rules[0].linked_catalog_item_count, 2);
+    assert.deepEqual(body.rules[0].overlaps_with_rule_ids, []);
+  });
+});
+
+test("catalog linkage risks reject product, mismatched, incomplete, and unverified links", async () => {
+  const rules = [
+    rule({ rule_id: 101 }),
+    rule({ rule_id: 102 }),
+    rule({ rule_id: 103 }),
+  ];
+  const links = [
+    { price_rule_id: 101, item_id: 1, item_category: "product", job_category: null, ac_type: null },
+    { price_rule_id: 102, item_id: 2, item_category: "service", job_category: "repair", ac_type: "wall" },
+    { price_rule_id: 103, item_id: 3, item_category: "service", job_category: "clean", ac_type: null },
+  ];
+  const result = await customerPricing.resolveCustomerPricingMulti(concealedPayload(), dbWithRules(rules, { links }));
+  assert.equal(result.active_price, 1200);
+  assert.equal(result.source, "fallback_pricing_js_invalid_rule");
+
+  const unverified = await customerPricing.resolveCustomerPricingMulti(concealedPayload(), dbWithRules([rule({ rule_id: 104 })], {
+    links: [{ price_rule_id: 104, item_id: 4 }],
+    fullLinkError: Object.assign(new Error("metadata unavailable"), { code: "42703" }),
+  }));
+  assert.equal(unverified.active_price, 1200);
+  assert.equal(unverified.source, "fallback_pricing_js_invalid_rule");
+  assert.ok(unverified.rejected_rule_codes.includes("CATALOG_LINKAGE_UNVERIFIED"));
+});
+
+test("catalog linkage failure modes fail closed only when needed", async () => {
+  const safeDirect = rule({ rule_id: 111, normal_price: 1200, active_price: 1200 });
+  const absentCatalog = await customerPricing.resolveCustomerPricingMulti(concealedPayload(), dbWithRules([safeDirect], {
+    failCatalogLinks: Object.assign(new Error("catalog absent"), { code: "42P01" }),
+  }));
+  assert.equal(absentCatalog.active_price, 1200);
+  assert.equal(absentCatalog.source, "customer_service_price_rules");
+
+  const unexpected = await customerPricing.resolveCustomerPricingMulti(concealedPayload(), dbWithRules([safeDirect], {
+    failCatalogLinks: Object.assign(new Error("connection dropped"), { code: "57P01" }),
+  }));
+  assert.equal(unexpected.active_price, 1200);
+  assert.equal(unexpected.source, "fallback_pricing_js_invalid_rule");
+  assert.ok(unexpected.rejected_rule_codes.includes("CATALOG_LINKAGE_UNVERIFIED"));
+
+  const pool = adminRulesPool([safeDirect], [{ price_rule_id: 111, item_id: 1 }], { fullLinkError: Object.assign(new Error("missing metadata"), { code: "42703" }) });
+  const router = customerPricing.createCustomerPricingRoutes({ pool, requireAdminSoft: (_req, _res, next) => next() });
+  await withServer(router, async (base) => {
+    const res = await fetch(`${base}/admin/customer-pricing/rules`);
+    const body = await res.json();
+    assert.equal(body.rules.length, 1);
+    assert.ok(body.rules[0].risk_codes.includes("CATALOG_LINKAGE_UNVERIFIED"));
   });
 });
 
@@ -259,8 +447,12 @@ test("admin UI source exposes safety warnings and cache-busted assets", () => {
   const catalogHtml = fs.readFileSync(path.join(__dirname, "..", "admin-store-catalog.html"), "utf8");
   assert.match(promoJs, /Risky service price rules/);
   assert.match(promoJs, /ACTIVE_PRICE_ABOVE_NORMAL/);
+  assert.match(promoJs, /AUTO_PRICING_UNSUPPORTED/);
+  assert.match(promoJs, /Linked catalog/);
+  assert.doesNotMatch(promoJs, /normal_price\) >= 10000/);
+  assert.doesNotMatch(catalogJs, /normal >= 10000/);
   assert.match(catalogJs, /ราคาสินค้าเท่านั้น ไม่ใช้คำนวณค่าบริการ/);
   assert.match(catalogJs, /modalPricingRisk/);
-  assert.match(promoHtml, /admin-promotions-v2\.js\?v=20260707_price_rule_safety_v1/);
-  assert.match(catalogHtml, /admin-store-catalog\.js\?v=20260707_price_rule_safety_v1/);
+  assert.match(promoHtml, /admin-promotions-v2\.js\?v=20260708_price_rule_safety_v2/);
+  assert.match(catalogHtml, /admin-store-catalog\.js\?v=20260708_price_rule_safety_v2/);
 });

--- a/test/customerPricingSafety.test.js
+++ b/test/customerPricingSafety.test.js
@@ -20,7 +20,9 @@ function dbWithRules(rows = [], options = {}) {
       if (s.includes("FROM public.catalog_items")) {
         if (fullLinkError && s.includes("item_category")) throw fullLinkError;
         if (failCatalogLinks) throw failCatalogLinks;
-        return { rows: links.map((r) => ({ ...r })) };
+        const ids = Array.isArray(params?.[0]) ? params[0].map((id) => Number(id)) : null;
+        const selected = ids ? links.filter((link) => ids.includes(Number(link.price_rule_id))) : links;
+        return { rows: selected.map((r) => ({ ...r })) };
       }
       return { rows: rows.map((r) => ({ ...r })) };
     },
@@ -225,7 +227,9 @@ function adminRulesPool(rows = [], links = [], options = {}) {
         catalogReads += 1;
         if (options.catalogError) throw options.catalogError;
         if (options.fullLinkError && s.includes("item_category")) throw options.fullLinkError;
-        return { rows: links.map((link) => ({ ...link })) };
+        const ids = Array.isArray(params?.[0]) ? params[0].map((id) => Number(id)) : null;
+        const selected = ids ? links.filter((link) => ids.includes(Number(link.price_rule_id))) : links;
+        return { rows: selected.map((link) => ({ ...link })) };
       }
       return { rows: [] };
     },
@@ -261,6 +265,67 @@ test("POST, PUT, and toggle reject install auto-pricing rules", async () => {
     assert.ok((await post.json()).risk_codes.includes("AUTO_PRICING_UNSUPPORTED"));
     assert.ok((await put.json()).risk_codes.includes("AUTO_PRICING_UNSUPPORTED"));
     assert.ok((await toggle.json()).risk_codes.includes("AUTO_PRICING_UNSUPPORTED"));
+  });
+});
+
+test("PUT and toggle validate catalog reverse linkage before mutating price book rules", async () => {
+  const linkedRule = rule({ rule_id: 72, job_type: "clean", ac_type: "wall", normal_price: 600, active_price: 550 });
+  const mismatchRule = rule({ rule_id: 73, job_type: "clean", ac_type: "wall", normal_price: 600, active_price: 550 });
+  const incompleteRule = rule({ rule_id: 74, job_type: "clean", ac_type: "wall", normal_price: 600, active_price: 550 });
+  const rules = [linkedRule, mismatchRule, incompleteRule];
+  const links = [
+    { price_rule_id: 72, item_id: 1, item_category: "product", job_category: null, ac_type: null },
+    { price_rule_id: 73, item_id: 2, item_category: "service", job_category: "repair", ac_type: "wall" },
+    { price_rule_id: 74, item_id: 3, item_category: "service", job_category: "clean", ac_type: null },
+  ];
+  const pool = adminRulesPool(rules, links);
+  const router = customerPricing.createCustomerPricingRoutes({ pool, requireAdminSoft: (_req, _res, next) => next() });
+  await withServer(router, async (base) => {
+    const productPut = await fetch(`${base}/admin/customer-pricing/rules/72`, { method: "PUT", headers: { "content-type": "application/json" }, body: JSON.stringify(linkedRule) });
+    assert.equal(productPut.status, 400);
+    assert.ok((await productPut.json()).risk_codes.includes("PRODUCT_RULE_LEAK"));
+    assert.equal(pool.state.updated.length, 0);
+
+    const productOn = await fetch(`${base}/admin/customer-pricing/rules/72/toggle`, { method: "PATCH", headers: { "content-type": "application/json" }, body: JSON.stringify({ is_active: true }) });
+    assert.equal(productOn.status, 400);
+    assert.equal(pool.state.updated.length, 0);
+
+    const productOff = await fetch(`${base}/admin/customer-pricing/rules/72/toggle`, { method: "PATCH", headers: { "content-type": "application/json" }, body: JSON.stringify({ is_active: false }) });
+    assert.equal(productOff.status, 200);
+    assert.equal(pool.state.updated.length, 1);
+
+    const mismatchPut = await fetch(`${base}/admin/customer-pricing/rules/73`, { method: "PUT", headers: { "content-type": "application/json" }, body: JSON.stringify(mismatchRule) });
+    assert.equal(mismatchPut.status, 400);
+    assert.ok((await mismatchPut.json()).risk_codes.includes("CATALOG_SCOPE_MISMATCH"));
+
+    const mismatchOn = await fetch(`${base}/admin/customer-pricing/rules/73/toggle`, { method: "PATCH", headers: { "content-type": "application/json" }, body: JSON.stringify({ is_active: true }) });
+    assert.equal(mismatchOn.status, 400);
+
+    const incompletePut = await fetch(`${base}/admin/customer-pricing/rules/74`, { method: "PUT", headers: { "content-type": "application/json" }, body: JSON.stringify(incompleteRule) });
+    assert.equal(incompletePut.status, 400);
+    assert.ok((await incompletePut.json()).risk_codes.includes("CATALOG_SCOPE_MISMATCH"));
+    assert.equal(pool.state.updated.length, 1);
+  });
+});
+
+test("PUT and toggle reject unverified linkage but allow safe direct price book rules", async () => {
+  const unsafeLinked = rule({ rule_id: 75, job_type: "clean", ac_type: "wall", normal_price: 600, active_price: 550 });
+  const safeDirect = rule({ rule_id: 76, job_type: "clean", ac_type: "wall", normal_price: 600, active_price: 550 });
+  const pool = adminRulesPool([unsafeLinked, safeDirect], [{ price_rule_id: 75, item_id: 5 }], { fullLinkError: Object.assign(new Error("missing metadata"), { code: "42703" }) });
+  const router = customerPricing.createCustomerPricingRoutes({ pool, requireAdminSoft: (_req, _res, next) => next() });
+  await withServer(router, async (base) => {
+    const unverifiedPut = await fetch(`${base}/admin/customer-pricing/rules/75`, { method: "PUT", headers: { "content-type": "application/json" }, body: JSON.stringify(unsafeLinked) });
+    assert.equal(unverifiedPut.status, 400);
+    assert.ok((await unverifiedPut.json()).risk_codes.includes("CATALOG_LINKAGE_UNVERIFIED"));
+
+    const unverifiedToggle = await fetch(`${base}/admin/customer-pricing/rules/75/toggle`, { method: "PATCH", headers: { "content-type": "application/json" }, body: JSON.stringify({ is_active: true }) });
+    assert.equal(unverifiedToggle.status, 400);
+
+    const safePut = await fetch(`${base}/admin/customer-pricing/rules/76`, { method: "PUT", headers: { "content-type": "application/json" }, body: JSON.stringify(safeDirect) });
+    assert.equal(safePut.status, 200);
+
+    const safeToggle = await fetch(`${base}/admin/customer-pricing/rules/76/toggle`, { method: "PATCH", headers: { "content-type": "application/json" }, body: JSON.stringify({ is_active: true }) });
+    assert.equal(safeToggle.status, 200);
   });
 });
 
@@ -430,6 +495,16 @@ test("catalog product pricing can save but remains catalog-only, while service p
     assert.equal(productBody.pricing_catalog_only, true);
     assert.ok(productBody.pricing_risk_codes.includes("PRODUCT_RULE_LEAK"));
 
+    const productPatch = await fetch(`${base}/admin/catalog/items/${productBody.item_id}`, {
+      method: "PATCH",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ pricing: { normal_price: 99999, active_price: 88888 } }),
+    });
+    assert.equal(productPatch.status, 200);
+    const patchedProduct = await productPatch.json();
+    assert.equal(Number(patchedProduct.display_price), 88888);
+    assert.equal(patchedProduct.pricing_catalog_only, true);
+
     const service = await fetch(`${base}/admin/catalog/items`, {
       method: "POST",
       headers: { "content-type": "application/json" },
@@ -451,8 +526,11 @@ test("admin UI source exposes safety warnings and cache-busted assets", () => {
   assert.match(promoJs, /Linked catalog/);
   assert.doesNotMatch(promoJs, /normal_price\) >= 10000/);
   assert.doesNotMatch(catalogJs, /normal >= 10000/);
+  assert.match(catalogJs, /Number\(payload\.btu_min\) < 0/);
+  assert.doesNotMatch(catalogJs, /Number\(payload\.btu_min\)\) \|\| Number\(payload\.btu_min\) <= 0/);
+  assert.match(catalogJs, /id="cm_btu_min"[^>]*min="0"/);
   assert.match(catalogJs, /ราคาสินค้าเท่านั้น ไม่ใช้คำนวณค่าบริการ/);
   assert.match(catalogJs, /modalPricingRisk/);
   assert.match(promoHtml, /admin-promotions-v2\.js\?v=20260708_price_rule_safety_v2/);
-  assert.match(catalogHtml, /admin-store-catalog\.js\?v=20260708_price_rule_safety_v2/);
+  assert.match(catalogHtml, /admin-store-catalog\.js\?v=20260708_price_rule_safety_v3/);
 });

--- a/test/customerPricingSafety.test.js
+++ b/test/customerPricingSafety.test.js
@@ -1,0 +1,266 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const http = require("node:http");
+const express = require("express");
+
+const customerPricing = require("../server/customerPricing");
+const createCatalogItemRoutes = require("../server/routes/catalog/items");
+
+function dbWithRules(rows = []) {
+  return {
+    queries: [],
+    async query(sql, params = []) {
+      this.queries.push({ sql: String(sql), params });
+      return { rows: rows.map((r) => ({ ...r })) };
+    },
+  };
+}
+
+function concealedPayload(overrides = {}) {
+  return { job_type: "clean", ac_type: "concealed", btu: 24000, machine_count: 1, ...overrides };
+}
+
+function wallPayload(overrides = {}) {
+  return { job_type: "clean", ac_type: "wall", btu: 9000, machine_count: 1, wash_variant: "normal", ...overrides };
+}
+
+function rule(overrides = {}) {
+  return {
+    rule_id: 1,
+    job_type: "clean",
+    ac_type: "concealed",
+    wash_variant: null,
+    btu_min: null,
+    btu_max: null,
+    machine_min: null,
+    machine_max: null,
+    normal_price: 1200,
+    active_price: 1200,
+    is_active: true,
+    priority: 10,
+    ...overrides,
+  };
+}
+
+test("resolver uses concealed fallback 1200 when no service rule is safe", async () => {
+  const result = await customerPricing.resolveCustomerPricingMulti(concealedPayload(), dbWithRules([]));
+  assert.equal(result.active_price, 1200);
+  assert.equal(result.source, "fallback_pricing_js");
+});
+
+test("resolver rejects specific concealed 99999/88888 outlier and returns safe fallback", async () => {
+  const result = await customerPricing.resolveCustomerPricingMulti(concealedPayload(), dbWithRules([
+    rule({ rule_id: 9, normal_price: 99999, active_price: 88888, btu_min: 24000, btu_max: 24000 }),
+  ]));
+  assert.equal(result.active_price, 1200);
+  assert.equal(result.source, "fallback_pricing_js_invalid_rule");
+  assert.equal(result.rejected_rule_id, 9);
+  assert.ok(result.rejected_rule_codes.includes("PRICE_OUTLIER"));
+});
+
+test("resolver rejects wildcard, product-linked, blank service, and catalog-mismatch rules", async () => {
+  const badRules = [
+    rule({ rule_id: 11, job_type: null, ac_type: null, normal_price: 99999, active_price: 88888 }),
+    rule({ rule_id: 12, linked_catalog_item_id: 5, linked_catalog_item_category: "product" }),
+    rule({ rule_id: 13, job_type: "", ac_type: "" }),
+    rule({ rule_id: 14, linked_catalog_item_id: 6, linked_catalog_item_category: "service", linked_catalog_job_category: "repair", linked_catalog_ac_type: "wall" }),
+  ];
+  const result = await customerPricing.resolveCustomerPricingMulti(concealedPayload(), dbWithRules(badRules));
+  assert.equal(result.active_price, 1200);
+  assert.equal(result.source, "fallback_pricing_js_invalid_rule");
+  assert.ok(result.lines[0].rejected_rule_codes.length);
+});
+
+test("resolver applies legitimate concealed, rainy wall, and repair rules", async () => {
+  const concealed = await customerPricing.resolveCustomerPricingMulti(concealedPayload(), dbWithRules([
+    rule({ rule_id: 21, normal_price: 1200, active_price: 1200 }),
+  ]));
+  assert.equal(concealed.active_price, 1200);
+  assert.equal(concealed.source, "customer_service_price_rules");
+
+  const wall = await customerPricing.resolveCustomerPricingMulti(wallPayload(), dbWithRules([
+    rule({ rule_id: 22, job_type: "clean", ac_type: "wall", wash_variant: "normal", normal_price: 600, active_price: 550 }),
+  ]));
+  assert.equal(wall.active_price, 550);
+  assert.equal(wall.normal_price, 600);
+
+  const repair = await customerPricing.resolveCustomerPricingMulti({ job_type: "repair", ac_type: "wall", btu: 12000, machine_count: 1 }, dbWithRules([
+    rule({ rule_id: 23, job_type: "repair", ac_type: "wall", normal_price: 3500, active_price: 3500 }),
+  ]));
+  assert.equal(repair.active_price, 3500);
+});
+
+test("validator rejects active above normal and invalid ranges", () => {
+  assert.deepEqual(customerPricing.validateServicePriceRuleForWrite(rule({ normal_price: 1200, active_price: 1300 })).risk_codes, ["ACTIVE_PRICE_ABOVE_NORMAL"]);
+  assert.ok(customerPricing.validateServicePriceRuleForWrite(rule({ btu_min: 30000, btu_max: 9000 })).risk_codes.includes("INVALID_BTU_RANGE"));
+  assert.ok(customerPricing.validateServicePriceRuleForWrite(rule({ machine_min: 5, machine_max: 1 })).risk_codes.includes("INVALID_MACHINE_RANGE"));
+});
+
+test("overlapping safe rules choose deterministic winner and return warning", async () => {
+  const result = await customerPricing.resolveCustomerPricingMulti(concealedPayload(), dbWithRules([
+    rule({ rule_id: 31, normal_price: 1300, active_price: 1300, priority: 5 }),
+    rule({ rule_id: 32, normal_price: 1250, active_price: 1250, priority: 5 }),
+  ]));
+  assert.equal(result.active_price, 1250);
+  assert.equal(result.lines[0].rule_id, 32);
+  assert.equal(result.lines[0].pricing_warning, "OVERLAPPING_ACTIVE_RULE");
+});
+
+function withServer(router, fn) {
+  const app = express();
+  app.use(express.json());
+  app.use(router);
+  const server = http.createServer(app);
+  return new Promise((resolve, reject) => {
+    server.listen(0, "127.0.0.1", async () => {
+      const { port } = server.address();
+      try {
+        await fn(`http://127.0.0.1:${port}`);
+        server.close(resolve);
+      } catch (e) {
+        server.close(() => reject(e));
+      }
+    });
+  });
+}
+
+function routePool({ existingRule } = {}) {
+  const state = { inserted: [], updated: [], existingRule: existingRule || rule({ rule_id: 1 }) };
+  const pool = {
+    state,
+    async query(sql, params = []) {
+      const s = String(sql);
+      if (/CREATE TABLE|ALTER TABLE|CREATE INDEX/i.test(s)) return { rows: [] };
+      if (s.includes("SELECT * FROM public.customer_service_price_rules")) return { rows: [state.existingRule] };
+      if (s.includes("INSERT INTO public.customer_service_price_rules")) {
+        state.inserted.push(params);
+        return { rows: [{ rule_id: 99 }] };
+      }
+      if (s.includes("UPDATE public.customer_service_price_rules")) {
+        state.updated.push(params);
+        return { rows: [] };
+      }
+      if (s.includes("FROM public.customer_service_price_rules")) return { rows: [state.existingRule] };
+      return { rows: [] };
+    },
+  };
+  return pool;
+}
+
+test("POST and PUT customer price rules use the same safety validation", async () => {
+  const pool = routePool();
+  const router = customerPricing.createCustomerPricingRoutes({ pool, requireAdminSoft: (_req, _res, next) => next() });
+  await withServer(router, async (base) => {
+    const unsafe = { job_type: "clean", ac_type: "concealed", btu_min: 24000, btu_max: 24000, normal_price: 99999, active_price: 88888 };
+    const post = await fetch(`${base}/admin/customer-pricing/rules`, { method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify(unsafe) });
+    const put = await fetch(`${base}/admin/customer-pricing/rules/1`, { method: "PUT", headers: { "content-type": "application/json" }, body: JSON.stringify(unsafe) });
+    assert.equal(post.status, 400);
+    assert.equal(put.status, 400);
+    assert.equal((await post.json()).code, "UNSAFE_SERVICE_PRICE_RULE");
+    assert.equal((await put.json()).code, "UNSAFE_SERVICE_PRICE_RULE");
+  });
+});
+
+test("direct price book rejects blank scope and active price above normal", async () => {
+  const pool = routePool();
+  const router = customerPricing.createCustomerPricingRoutes({ pool, requireAdminSoft: (_req, _res, next) => next() });
+  await withServer(router, async (base) => {
+    const blank = await fetch(`${base}/admin/customer-pricing/rules`, { method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify({ normal_price: 1200, active_price: 1200 }) });
+    const inverted = await fetch(`${base}/admin/customer-pricing/rules`, { method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify({ job_type: "clean", ac_type: "wall", normal_price: 600, active_price: 700 }) });
+    assert.equal(blank.status, 400);
+    assert.ok((await blank.json()).risk_codes.includes("MISSING_JOB_TYPE"));
+    assert.equal(inverted.status, 400);
+    assert.ok((await inverted.json()).risk_codes.includes("ACTIVE_PRICE_ABOVE_NORMAL"));
+  });
+});
+
+function catalogPool() {
+  const state = { items: [], rules: [], queries: [] };
+  let nextItemId = 1;
+  let nextRuleId = 10;
+  const pool = {
+    state,
+    connect: async () => ({ query: pool.query, release() {} }),
+    async query(sql, params = []) {
+      const s = String(sql);
+      state.queries.push({ sql: s, params });
+      if (/^\s*(BEGIN|COMMIT|ROLLBACK)/i.test(s)) return { rows: [] };
+      if (s.includes("information_schema.columns") && s.includes("price_rule_id")) return { rows: [{ cnt: 3 }] };
+      if (s.includes("information_schema.columns") && s.includes("short_description")) return { rows: [{ cnt: 0 }] };
+      if (s.includes("information_schema.columns") && s.includes("is_autoplay_enabled")) return { rows: [{ cnt: 0 }] };
+      if (s.includes("information_schema.columns")) return { rows: [{ cnt: 0 }] };
+      if (s.includes("to_regclass")) return { rows: [{ reg: null }] };
+      if (s.includes("INSERT INTO public.catalog_items")) {
+        const [item_name, item_category, base_price, unit_label, job_category, ac_type, btu_min, btu_max, is_active, is_customer_visible] = params;
+        const row = { item_id: nextItemId++, item_name, item_category, base_price, unit_label, job_category, ac_type, btu_min, btu_max, is_active, is_customer_visible, price_rule_id: null, image_url: null };
+        state.items.push(row);
+        return { rows: [{ item_id: row.item_id }] };
+      }
+      if (s.includes("INSERT INTO public.customer_service_price_rules")) {
+        const [job_type, ac_type, btu_min, btu_max, normal_price, active_price] = params;
+        const row = { rule_id: nextRuleId++, job_type, ac_type, btu_min, btu_max, normal_price, active_price, is_active: true };
+        state.rules.push(row);
+        return { rows: [{ rule_id: row.rule_id }] };
+      }
+      if (s.includes("SET price_rule_id=$1 WHERE item_id=$2")) {
+        const item = state.items.find((x) => Number(x.item_id) === Number(params[1]));
+        if (item) item.price_rule_id = params[0];
+        return { rows: [] };
+      }
+      if (s.includes("FROM public.catalog_items")) {
+        return { rows: state.items.map((item) => {
+          const linked = state.rules.find((r) => Number(r.rule_id) === Number(item.price_rule_id));
+          return {
+            ...item,
+            rule_job_type: linked?.job_type || null,
+            rule_ac_type: linked?.ac_type || null,
+            rule_normal_price: linked?.normal_price || null,
+            rule_active_price: linked?.active_price || null,
+            rule_is_active: linked?.is_active ?? null,
+          };
+        }) };
+      }
+      return { rows: [] };
+    },
+  };
+  return pool;
+}
+
+test("catalog product pricing can save but remains catalog-only, while service pricing requires job/ac scope", async () => {
+  const pool = catalogPool();
+  const router = createCatalogItemRoutes({ pool, requireAdminSession: (_req, _res, next) => next() });
+  await withServer(router, async (base) => {
+    const product = await fetch(`${base}/admin/catalog/items`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ item_name: "AC Product", item_category: "product", unit_label: "unit", base_price: 99999, is_active: true, is_customer_visible: true, pricing: { normal_price: 99999, active_price: 88888 } }),
+    });
+    assert.equal(product.status, 201);
+    const productBody = await product.json();
+    assert.equal(productBody.pricing_catalog_only, true);
+    assert.ok(productBody.pricing_risk_codes.includes("PRODUCT_RULE_LEAK"));
+
+    const service = await fetch(`${base}/admin/catalog/items`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ item_name: "Unsafe service", item_category: "service", unit_label: "unit", base_price: 0, is_active: true, is_customer_visible: true, pricing: { normal_price: 1200, active_price: 1200 } }),
+    });
+    assert.equal(service.status, 400);
+    assert.ok((await service.json()).risk_codes.includes("MISSING_JOB_TYPE"));
+  });
+});
+
+test("admin UI source exposes safety warnings and cache-busted assets", () => {
+  const promoJs = fs.readFileSync(path.join(__dirname, "..", "admin-promotions-v2.js"), "utf8");
+  const promoHtml = fs.readFileSync(path.join(__dirname, "..", "admin-promotions-v2.html"), "utf8");
+  const catalogJs = fs.readFileSync(path.join(__dirname, "..", "admin-store-catalog.js"), "utf8");
+  const catalogHtml = fs.readFileSync(path.join(__dirname, "..", "admin-store-catalog.html"), "utf8");
+  assert.match(promoJs, /Risky service price rules/);
+  assert.match(promoJs, /ACTIVE_PRICE_ABOVE_NORMAL/);
+  assert.match(catalogJs, /ราคาสินค้าเท่านั้น ไม่ใช้คำนวณค่าบริการ/);
+  assert.match(catalogJs, /modalPricingRisk/);
+  assert.match(promoHtml, /admin-promotions-v2\.js\?v=20260707_price_rule_safety_v1/);
+  assert.match(catalogHtml, /admin-store-catalog\.js\?v=20260707_price_rule_safety_v1/);
+});


### PR DESCRIPTION
## Base

- Base SHA at start: `e865ed50fa7ac65bdcba8fbe0927ffa5de5f22de`
- Base SHA before latest push: `e865ed50fa7ac65bdcba8fbe0927ffa5de5f22de`
- Head SHA: `52e3f2283f6d87e7ed3c3e5a4a03db10d82d77b5`
- Rebase: not needed; `origin/main` remained an ancestor of the branch.

## Root Cause

Service price rules were applied by match/sort only. Empty service scope acted as a wildcard, catalog/product-linked rules could be selected by the service resolver, POST/PUT validation was not equivalent, audit did not evaluate canonical fallback/outlier risk, install rules bypassed outlier protection because canonical fallback is 0, and reverse catalog linkage used a direct join that could duplicate rules or fail open. Catalog item validation also still rejected `btu_min=0`, breaking legitimate rainy-season service/catalog ranges.

## What Changed

- `btu_min=0` is valid in catalog backend and admin catalog UI; `btu_max=0`, negative values, decimals, and inverted ranges are rejected.
- Existing catalog rows with `btu_min=0` can be patched for name-only or pricing-only edits without being rejected.
- Added `loadRuleWithCatalogLinkage()` so Price Book PUT/toggle validate the current rule with reverse catalog metadata.
- PUT now rejects product-linked, mismatched service-linked, incomplete service-linked, unverified linkage, outlier, install/manual-quote, and existing range/price risks before UPDATE.
- Toggle `is_active=true` now validates linkage before UPDATE; toggle `is_active=false` remains allowed so unsafe rules can be disabled.
- Direct Price Book POST remains unchanged and does not query catalog linkage.
- Product catalog POST/PATCH pricing remains allowed and catalog-only.
- Admin Store Catalog cache version bumped to `20260708_price_rule_safety_v3`.

## Changed Files

- `server/customerPricing.js`
- `server/routes/catalog/items.js`
- `admin-store-catalog.js`
- `admin-store-catalog.html`
- `test/customerPricingSafety.test.js`
- `test/catalogItemsRoutes.test.js`
- `test/adminStoreCatalogUi.test.js`

## Tests

- `node --check server/customerPricing.js server/routes/catalog/items.js admin-store-catalog.js test/customerPricingSafety.test.js test/catalogItemsRoutes.test.js test/adminStoreCatalogUi.test.js`: pass
- `node --test test/customerPricingSafety.test.js`: 20 pass, 0 fail
- `node --test test/catalogItemsRoutes.test.js`: 169 pass, 0 fail
- `node --test test/adminStoreCatalogUi.test.js`: 65 tests, 49 pass, 16 fail, 0 skipped; failures are existing adminStoreCatalogUi failures present on base
- `node --test test/customerPricingSafety.test.js test/catalogItemsRoutes.test.js test/customerAppRecovery.test.js test/adminJobEditPriceStability.test.js`: 311 pass, 0 fail
- Branch `npm test`: 939 tests, 912 pass, 16 fail, 11 skipped
- Base `npm test` on latest `origin/main`: 917 tests, 886 pass, 20 fail, 11 skipped
- Additional branch failures: 0

The remaining failures are existing `adminStoreCatalogUi.test.js` source/assertion failures present on `origin/main`.

## DB / Production Safety

- No migration or schema change added.
- No production data mutation.
- Existing saved job item prices are not changed.
- Unsafe existing rules are only annotated/ignored/rejected on mutation paths; no automatic disable/delete/backfill.

## Remaining Risks

- Existing unsafe production rows still need owner-led read-only audit and manual correction outside this PR.
- The resolver logs rejected rule id/risk codes for operators; customer-facing flows continue with safe fallback without exposing internal rule ids.

## Rollback

Revert this PR. No migration/schema rollback is required. Existing production data remains untouched.