### PR TITLE
Booking launch readiness: tracking privacy, fail-closed kill switches, full browser E2E on real PostgreSQL

### DIFF
--- a/customer-app/assets/customer-app.js
+++ b/customer-app/assets/customer-app.js
@@ -3,7 +3,7 @@
 
   const App = window.CWFCustomerAppV2;
   const BOOT_TIMEOUT_MS = 3500;
-  const BUILD_ID = "20260707_booking_admin_notify_v1";
+  const BUILD_ID = "20260708_launch_gate_v1";
 
   function withTimeout(promise, timeoutMs) {
     return Promise.race([

--- a/customer-app/assets/customer-app.js
+++ b/customer-app/assets/customer-app.js
@@ -3,7 +3,7 @@
 
   const App = window.CWFCustomerAppV2;
   const BOOT_TIMEOUT_MS = 3500;
-  const BUILD_ID = "20260708_launch_gate_v1";
+  const BUILD_ID = "20260709_review_legacy_v1";
 
   function withTimeout(promise, timeoutMs) {
     return Promise.race([

--- a/customer-app/index.html
+++ b/customer-app/index.html
@@ -17,10 +17,10 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Noto+Sans+Thai:wght@400;500;600;700;800;900&display=swap" media="print" onload="this.media='all'">
   <noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Noto+Sans+Thai:wght@400;500;600;700;800;900&display=swap"></noscript>
-  <link rel="manifest" href="./manifest.webmanifest?v=20260707_booking_admin_notify_v1">
+  <link rel="manifest" href="./manifest.webmanifest?v=20260708_launch_gate_v1">
   <link rel="icon" type="image/png" sizes="192x192" href="./assets/icons/cwf-customer-192.png">
   <link rel="apple-touch-icon" sizes="180x180" href="./assets/icons/cwf-customer-180.png">
-  <link rel="stylesheet" href="./assets/customer-app.css?v=20260707_booking_admin_notify_v1">
+  <link rel="stylesheet" href="./assets/customer-app.css?v=20260708_launch_gate_v1">
 </head>
 <body class="is-app-booting">
   <div class="app-shell" data-app-shell>
@@ -58,21 +58,21 @@
     </nav>
   </div>
 
-  <script src="./modules/state.js?v=20260707_booking_admin_notify_v1"></script>
-  <script src="./modules/utils.js?v=20260707_booking_admin_notify_v1"></script>
-  <script src="./modules/analytics.js?v=20260707_booking_admin_notify_v1"></script>
-  <script src="./modules/api.js?v=20260707_booking_admin_notify_v1"></script>
-  <script src="./modules/services.js?v=20260707_booking_admin_notify_v1"></script>
-  <script src="./modules/ui.js?v=20260707_booking_admin_notify_v1"></script>
-  <script src="./modules/store.js?v=20260707_booking_admin_notify_v1"></script>
-  <script src="./modules/auth.js?v=20260707_booking_admin_notify_v1"></script>
-  <script src="./modules/pricing.js?v=20260707_booking_admin_notify_v1"></script>
-  <script src="./modules/availability.js?v=20260707_booking_admin_notify_v1"></script>
-  <script src="./modules/bookingScheduled.js?v=20260707_booking_admin_notify_v1"></script>
-  <script src="./modules/bookingUrgent.js?v=20260707_booking_admin_notify_v1"></script>
-  <script src="./modules/tracking.js?v=20260707_booking_admin_notify_v1"></script>
-  <script src="./modules/profile.js?v=20260707_booking_admin_notify_v1"></script>
-  <script src="./modules/router.js?v=20260707_booking_admin_notify_v1"></script>
-  <script src="./assets/customer-app.js?v=20260707_booking_admin_notify_v1"></script>
+  <script src="./modules/state.js?v=20260708_launch_gate_v1"></script>
+  <script src="./modules/utils.js?v=20260708_launch_gate_v1"></script>
+  <script src="./modules/analytics.js?v=20260708_launch_gate_v1"></script>
+  <script src="./modules/api.js?v=20260708_launch_gate_v1"></script>
+  <script src="./modules/services.js?v=20260708_launch_gate_v1"></script>
+  <script src="./modules/ui.js?v=20260708_launch_gate_v1"></script>
+  <script src="./modules/store.js?v=20260708_launch_gate_v1"></script>
+  <script src="./modules/auth.js?v=20260708_launch_gate_v1"></script>
+  <script src="./modules/pricing.js?v=20260708_launch_gate_v1"></script>
+  <script src="./modules/availability.js?v=20260708_launch_gate_v1"></script>
+  <script src="./modules/bookingScheduled.js?v=20260708_launch_gate_v1"></script>
+  <script src="./modules/bookingUrgent.js?v=20260708_launch_gate_v1"></script>
+  <script src="./modules/tracking.js?v=20260708_launch_gate_v1"></script>
+  <script src="./modules/profile.js?v=20260708_launch_gate_v1"></script>
+  <script src="./modules/router.js?v=20260708_launch_gate_v1"></script>
+  <script src="./assets/customer-app.js?v=20260708_launch_gate_v1"></script>
 </body>
 </html>

--- a/customer-app/index.html
+++ b/customer-app/index.html
@@ -17,10 +17,10 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Noto+Sans+Thai:wght@400;500;600;700;800;900&display=swap" media="print" onload="this.media='all'">
   <noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Noto+Sans+Thai:wght@400;500;600;700;800;900&display=swap"></noscript>
-  <link rel="manifest" href="./manifest.webmanifest?v=20260708_launch_gate_v1">
+  <link rel="manifest" href="./manifest.webmanifest?v=20260709_review_legacy_v1">
   <link rel="icon" type="image/png" sizes="192x192" href="./assets/icons/cwf-customer-192.png">
   <link rel="apple-touch-icon" sizes="180x180" href="./assets/icons/cwf-customer-180.png">
-  <link rel="stylesheet" href="./assets/customer-app.css?v=20260708_launch_gate_v1">
+  <link rel="stylesheet" href="./assets/customer-app.css?v=20260709_review_legacy_v1">
 </head>
 <body class="is-app-booting">
   <div class="app-shell" data-app-shell>
@@ -58,21 +58,21 @@
     </nav>
   </div>
 
-  <script src="./modules/state.js?v=20260708_launch_gate_v1"></script>
-  <script src="./modules/utils.js?v=20260708_launch_gate_v1"></script>
-  <script src="./modules/analytics.js?v=20260708_launch_gate_v1"></script>
-  <script src="./modules/api.js?v=20260708_launch_gate_v1"></script>
-  <script src="./modules/services.js?v=20260708_launch_gate_v1"></script>
-  <script src="./modules/ui.js?v=20260708_launch_gate_v1"></script>
-  <script src="./modules/store.js?v=20260708_launch_gate_v1"></script>
-  <script src="./modules/auth.js?v=20260708_launch_gate_v1"></script>
-  <script src="./modules/pricing.js?v=20260708_launch_gate_v1"></script>
-  <script src="./modules/availability.js?v=20260708_launch_gate_v1"></script>
-  <script src="./modules/bookingScheduled.js?v=20260708_launch_gate_v1"></script>
-  <script src="./modules/bookingUrgent.js?v=20260708_launch_gate_v1"></script>
-  <script src="./modules/tracking.js?v=20260708_launch_gate_v1"></script>
-  <script src="./modules/profile.js?v=20260708_launch_gate_v1"></script>
-  <script src="./modules/router.js?v=20260708_launch_gate_v1"></script>
-  <script src="./assets/customer-app.js?v=20260708_launch_gate_v1"></script>
+  <script src="./modules/state.js?v=20260709_review_legacy_v1"></script>
+  <script src="./modules/utils.js?v=20260709_review_legacy_v1"></script>
+  <script src="./modules/analytics.js?v=20260709_review_legacy_v1"></script>
+  <script src="./modules/api.js?v=20260709_review_legacy_v1"></script>
+  <script src="./modules/services.js?v=20260709_review_legacy_v1"></script>
+  <script src="./modules/ui.js?v=20260709_review_legacy_v1"></script>
+  <script src="./modules/store.js?v=20260709_review_legacy_v1"></script>
+  <script src="./modules/auth.js?v=20260709_review_legacy_v1"></script>
+  <script src="./modules/pricing.js?v=20260709_review_legacy_v1"></script>
+  <script src="./modules/availability.js?v=20260709_review_legacy_v1"></script>
+  <script src="./modules/bookingScheduled.js?v=20260709_review_legacy_v1"></script>
+  <script src="./modules/bookingUrgent.js?v=20260709_review_legacy_v1"></script>
+  <script src="./modules/tracking.js?v=20260709_review_legacy_v1"></script>
+  <script src="./modules/profile.js?v=20260709_review_legacy_v1"></script>
+  <script src="./modules/router.js?v=20260709_review_legacy_v1"></script>
+  <script src="./assets/customer-app.js?v=20260709_review_legacy_v1"></script>
 </body>
 </html>

--- a/customer-app/manifest.webmanifest
+++ b/customer-app/manifest.webmanifest
@@ -2,7 +2,7 @@
   "name": "CWF Customer Service",
   "short_name": "CWF Service",
   "description": "แอปลูกค้า Coldwindflow สำหรับเลือกบริการ จองคิว และติดตามงาน",
-  "start_url": "/customer-app/index.html?v=20260707_booking_admin_notify_v1#home",
+  "start_url": "/customer-app/index.html?v=20260708_launch_gate_v1#home",
   "scope": "/customer-app/",
   "id": "/customer-app/",
   "display": "standalone",

--- a/customer-app/manifest.webmanifest
+++ b/customer-app/manifest.webmanifest
@@ -2,7 +2,7 @@
   "name": "CWF Customer Service",
   "short_name": "CWF Service",
   "description": "แอปลูกค้า Coldwindflow สำหรับเลือกบริการ จองคิว และติดตามงาน",
-  "start_url": "/customer-app/index.html?v=20260708_launch_gate_v1#home",
+  "start_url": "/customer-app/index.html?v=20260709_review_legacy_v1#home",
   "scope": "/customer-app/",
   "id": "/customer-app/",
   "display": "standalone",

--- a/customer-app/modules/bookingScheduled.js
+++ b/customer-app/modules/bookingScheduled.js
@@ -1,6 +1,7 @@
 (function () {
   "use strict";
 
+  console.info("[customer-booking] launch-gate 20260708 loaded");
   const root = window.CWFCustomerAppV2 = window.CWFCustomerAppV2 || {};
   const MAX_ADVANCE_DAYS = 90;
   const STEP_MAX = 3;
@@ -643,7 +644,10 @@
         ${submit.status === "checking_slot" ? root.utils.stateBox("loading", "กำลังตรวจคิวล่าสุด...") : ""}
         ${submit.status === "submitting" ? root.utils.stateBox("loading", "กำลังส่งข้อมูลจอง...") : ""}
         ${submit.status === "error" ? root.utils.stateBox("error", submit.error || "ส่งคำขอจองไม่สำเร็จ") : ""}
-        <button type="button" class="primary-btn wizard-submit-btn" data-action="submit-scheduled" ${pending ? "disabled" : ""}>${pending ? "กำลังตรวจสอบ..." : "ยืนยันส่งคำขอจอง"}</button>
+        ${submit.status === "error" && submit.disabled_line_url ? `
+          <a class="primary-btn line-fallback-btn" href="${root.utils.escapeHtml(submit.disabled_line_url)}" target="_blank" rel="noopener noreferrer">ติดต่อแอดมินทาง LINE</a>
+        ` : ""}
+        ${submit.status === "error" && submit.disabled_line_url ? "" : `<button type="button" class="primary-btn wizard-submit-btn" data-action="submit-scheduled" ${pending ? "disabled" : ""}>${pending ? "กำลังตรวจสอบ..." : "ยืนยันส่งคำขอจอง"}</button>`}
       </section>
     `;
   }
@@ -898,7 +902,7 @@
       scrollToWizardTop(container);
       return;
     }
-    root.state.setScheduledSubmit({ status: "checking_slot", error: "", result: null });
+    root.state.setScheduledSubmit({ status: "checking_slot", error: "", result: null, disabled_line_url: "" });
     paint(container);
     try {
       await revalidateSelectedSlot();
@@ -914,6 +918,21 @@
       paint(container);
       scrollToWizardTop(container);
     } catch (error) {
+      // Kill switch: the booking lane is closed server-side (503 +
+      // SCHEDULED_BOOKING_DISABLED). No job was created, so the LINE hand-off
+      // below cannot duplicate anything. Don't bounce back to the slot step —
+      // retrying won't help until the operator re-enables the lane.
+      if (error?.data?.code === "SCHEDULED_BOOKING_DISABLED") {
+        root.state.setScheduledSubmit({
+          status: "error",
+          error: error.data.error || "ระบบจองคิวออนไลน์ปิดให้บริการชั่วคราว กรุณาติดต่อแอดมินทาง LINE",
+          result: null,
+          disabled_line_url: error.data.line_url || "https://lin.ee/fG1Oq7y",
+        });
+        paint(container);
+        scrollToWizardTop(container);
+        return;
+      }
       root.state.setScheduledSubmit({ status: "error", error: error.message || "ส่งคำขอจองไม่สำเร็จ", result: null });
       if (Number(error.status) === 400 || Number(error.status) === 409) {
         root.state.updateDraft("scheduled", { selectedSlot: null });

--- a/customer-app/modules/bookingUrgent.js
+++ b/customer-app/modules/bookingUrgent.js
@@ -1,6 +1,7 @@
 (function () {
   "use strict";
 
+  console.info("[customer-urgent] launch-gate 20260708 loaded");
   const root = window.CWFCustomerAppV2 = window.CWFCustomerAppV2 || {};
 
   // Correct urgent flow:
@@ -287,7 +288,9 @@
         <div class="notice is-urgent">เมื่อกดส่งคำขอ ระบบจะแสดง Waiting Room สำหรับคิวด่วน งานยังไม่ยืนยันจนกว่าจะมีช่างพาร์ทเนอร์รับหรือแอดมินยืนยัน</div>
         ${flow.error ? `<div class="state-box is-error">${root.utils.escapeHtml(flow.error)}</div>` : ""}
         <div class="button-row">
-          <button class="primary-btn btn-shine" type="button" data-urgent-action="confirm" ${submitting ? "disabled" : ""}>${submitting ? "กำลังส่งคำขอ..." : "ส่งคำขอคิวด่วน"}</button>
+          ${flow.disabled_line_url
+            ? `<a class="primary-btn line-fallback-btn" href="${root.utils.escapeHtml(flow.disabled_line_url)}" target="_blank" rel="noopener noreferrer">ติดต่อแอดมินทาง LINE</a>`
+            : `<button class="primary-btn btn-shine" type="button" data-urgent-action="confirm" ${submitting ? "disabled" : ""}>${submitting ? "กำลังส่งคำขอ..." : "ส่งคำขอคิวด่วน"}</button>`}
           <button class="secondary-btn" type="button" data-urgent-action="back-form" ${submitting ? "disabled" : ""}>กลับไปแก้ไข</button>
         </div>
       </section>
@@ -394,7 +397,7 @@
   async function submitUrgent(container) {
     if (submitInFlight || root.state.urgentFlow.status === "submitting") return;
     submitInFlight = true;
-    root.state.setUrgentFlow({ step: "review", status: "submitting", error: "", result: null });
+    root.state.setUrgentFlow({ step: "review", status: "submitting", error: "", result: null, disabled_line_url: "" });
     paint(container);
     try {
       const result = await root.api.submitUrgentRequest(buildSubmitPayload());
@@ -405,7 +408,21 @@
       paint(container);
     } catch (error) {
       submitInFlight = false;
-      root.state.setUrgentFlow({ step: "review", status: "error", error: error.message || "ส่งคำขอคิวด่วนไม่สำเร็จ", result: null });
+      // Kill switch: urgent lane closed server-side (503 +
+      // URGENT_BOOKING_DISABLED). No job/offer was created — hand the customer
+      // to LINE instead of letting them retry a closed lane.
+      if (error?.data?.code === "URGENT_BOOKING_DISABLED") {
+        root.state.setUrgentFlow({
+          step: "review",
+          status: "error",
+          error: error.data.error || "ระบบจองด่วนออนไลน์ปิดให้บริการชั่วคราว กรุณาติดต่อแอดมินทาง LINE",
+          result: null,
+          disabled_line_url: error.data.line_url || "https://lin.ee/fG1Oq7y",
+        });
+        paint(container);
+        return;
+      }
+      root.state.setUrgentFlow({ step: "review", status: "error", error: error.message || "ส่งคำขอคิวด่วนไม่สำเร็จ", result: null, disabled_line_url: "" });
       paint(container);
     }
   }

--- a/customer-app/modules/tracking.js
+++ b/customer-app/modules/tracking.js
@@ -76,7 +76,12 @@
   }
 
   function receiptUrl(data) {
-    const fallback = isDone(data) && data.job_id ? `/docs/receipt/${encodeURIComponent(data.job_id)}` : "";
+    // The receipt document now requires the booking_token as an access key
+    // (?key=...) — a bare job_id link would just 404. Only build the fallback
+    // when we actually hold the token (token-based lookups).
+    const fallback = isDone(data) && data.job_id && data.booking_token
+      ? `/docs/receipt/${encodeURIComponent(data.job_id)}?key=${encodeURIComponent(data.booking_token)}`
+      : "";
     const raw = clean(data.receipt_url);
     if (!raw) return fallback;
 

--- a/customer-app/modules/tracking.js
+++ b/customer-app/modules/tracking.js
@@ -847,8 +847,11 @@
         </section>
       `;
     }
-    const key = data.booking_token || data.booking_code || "";
-    if (!key) return "";
+    // Reviewing is a WRITE that requires the full-access booking_token — a
+    // booking_code lookup (access_level "code") only shows read-only status, so
+    // the review form is hidden there (the server would reject it anyway).
+    const reviewToken = data.access_level === "token" ? (data.booking_token || "") : "";
+    if (!reviewToken) return "";
     return `
       <section class="tracking-extra-card review-form-card">
         <div class="section-head compact">
@@ -856,7 +859,7 @@
           <h2>ให้คะแนนงานนี้</h2>
         </div>
         <form data-review-form>
-          <input type="hidden" name="q" value="${esc(key)}">
+          <input type="hidden" name="booking_token" value="${esc(reviewToken)}">
           <label class="field">
             <span>คะแนน</span>
             <select class="input" name="rating">

--- a/customer-app/modules/tracking.js
+++ b/customer-app/modules/tracking.js
@@ -847,19 +847,37 @@
         </section>
       `;
     }
-    // Reviewing is a WRITE that requires the full-access booking_token — a
-    // booking_code lookup (access_level "code") only shows read-only status, so
-    // the review form is hidden there (the server would reject it anyway).
+    // Reviewing is a WRITE. Two authorised shapes, mirroring the server policy:
+    //  - token lookup (access_level "token"): the exact booking_token authorises,
+    //    posted as a hidden field. No PII entry needed.
+    //  - LEGACY job with no booking_token: a booking_code lookup exposes a
+    //    minimal `legacy_review_eligible` flag; the customer proves ownership by
+    //    typing their FULL phone, posted as booking_code + customer_phone.
+    // A tokened job accessed by code is NOT legacy-eligible, so it never shows
+    // the legacy form (the server would reject a downgrade anyway).
     const reviewToken = data.access_level === "token" ? (data.booking_token || "") : "";
-    if (!reviewToken) return "";
+    const legacyEligible = !reviewToken && data.legacy_review_eligible === true;
+    if (!reviewToken && !legacyEligible) return "";
+    const credentialFields = reviewToken
+      ? `<input type="hidden" name="booking_token" value="${esc(reviewToken)}">`
+      : `<input type="hidden" name="booking_code" value="${esc(data.booking_code || "")}">
+          <label class="field">
+            <span>เบอร์โทรที่ใช้จอง (ยืนยันตัวตน)</span>
+            <input class="input" type="tel" name="customer_phone" inputmode="numeric"
+                   autocomplete="tel" placeholder="เช่น 0812345678" required>
+          </label>`;
+    const legacyHint = legacyEligible
+      ? `<p class="muted">กรอกเบอร์โทรที่ใช้จองงานนี้เพื่อยืนยันตัวตนก่อนรีวิว</p>`
+      : "";
     return `
       <section class="tracking-extra-card review-form-card">
         <div class="section-head compact">
           <span class="section-kicker">Review</span>
           <h2>ให้คะแนนงานนี้</h2>
         </div>
+        ${legacyHint}
         <form data-review-form>
-          <input type="hidden" name="booking_token" value="${esc(reviewToken)}">
+          ${credentialFields}
           <label class="field">
             <span>คะแนน</span>
             <select class="input" name="rating">

--- a/customer-app/sw.js
+++ b/customer-app/sw.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const BUILD_ID = "20260707_booking_admin_notify_v1";
+const BUILD_ID = "20260708_launch_gate_v1";
 const CACHE_NAME = `cwf-customer-app-v2-${BUILD_ID}`;
 const APP_SHELL = [
   `./index.html?v=${BUILD_ID}`,

--- a/customer-app/sw.js
+++ b/customer-app/sw.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const BUILD_ID = "20260708_launch_gate_v1";
+const BUILD_ID = "20260709_review_legacy_v1";
 const CACHE_NAME = `cwf-customer-app-v2-${BUILD_ID}`;
 const APP_SHELL = [
   `./index.html?v=${BUILD_ID}`,

--- a/customer.html
+++ b/customer.html
@@ -1320,17 +1320,31 @@ async function book(){
     ...payload
   };
 
-  // Scheduled bookings now carry a canonical idempotency key on every submit
-  // (the server requires it for all public scheduled requests). Keep the SAME
-  // key across retries of the same attempt so a network timeout can safely
-  // replay instead of creating a duplicate; a confirmed success clears it.
+  // Scheduled bookings carry a canonical idempotency key on every submit (the
+  // server requires it and derives the booking token from it). The key must:
+  //   - survive a reload / network recovery, so a committed-but-lost submit
+  //     replays instead of creating a duplicate -> persisted in sessionStorage;
+  //   - come only from a CSPRNG (never Math.random), since it seeds a token;
+  //   - be cleared on a confirmed success so the next attempt is a fresh key.
   if (!urgent) {
-    if (!window.__cwfSchedKey) {
-      window.__cwfSchedKey = (window.crypto && crypto.randomUUID)
-        ? crypto.randomUUID().replace(/-/g, "")
-        : (Date.now().toString(36) + Math.random().toString(36).slice(2) + Math.random().toString(36).slice(2)).slice(0, 32);
+    let schedKey = "";
+    try { schedKey = sessionStorage.getItem("cwf_sched_key") || ""; } catch (_) { schedKey = window.__cwfSchedKey || ""; }
+    if (!schedKey) {
+      if (window.crypto && crypto.randomUUID) {
+        schedKey = crypto.randomUUID().replace(/-/g, "");
+      } else if (window.crypto && crypto.getRandomValues) {
+        const buf = new Uint8Array(16);
+        crypto.getRandomValues(buf);
+        schedKey = Array.from(buf).map(b => b.toString(16).padStart(2, "0")).join("");
+      } else {
+        // No CSPRNG -> refuse rather than seed a booking token from a predictable PRNG.
+        alert("เบราว์เซอร์นี้ไม่รองรับการจองอย่างปลอดภัย กรุณาอัปเดตเบราว์เซอร์แล้วลองใหม่");
+        return;
+      }
+      try { sessionStorage.setItem("cwf_sched_key", schedKey); } catch (_) {}
+      window.__cwfSchedKey = schedKey;
     }
-    body.scheduled_request_key = window.__cwfSchedKey;
+    body.scheduled_request_key = schedKey;
   }
 
   const confirmBtn = document.getElementById('confirm_btn');
@@ -1347,7 +1361,9 @@ async function book(){
     return data;
   })
   .then(data=>{
-    window.__cwfSchedKey = null; // booking confirmed — next attempt gets a fresh key
+    // Booking confirmed — clear the persisted key so the next attempt is fresh.
+    window.__cwfSchedKey = null;
+    try { sessionStorage.removeItem("cwf_sched_key"); } catch (_) {}
     const box = document.getElementById("result");
     const token = data.token;
     const code = data.booking_code || token || '';

--- a/customer.html
+++ b/customer.html
@@ -1320,6 +1320,19 @@ async function book(){
     ...payload
   };
 
+  // Scheduled bookings now carry a canonical idempotency key on every submit
+  // (the server requires it for all public scheduled requests). Keep the SAME
+  // key across retries of the same attempt so a network timeout can safely
+  // replay instead of creating a duplicate; a confirmed success clears it.
+  if (!urgent) {
+    if (!window.__cwfSchedKey) {
+      window.__cwfSchedKey = (window.crypto && crypto.randomUUID)
+        ? crypto.randomUUID().replace(/-/g, "")
+        : (Date.now().toString(36) + Math.random().toString(36).slice(2) + Math.random().toString(36).slice(2)).slice(0, 32);
+    }
+    body.scheduled_request_key = window.__cwfSchedKey;
+  }
+
   const confirmBtn = document.getElementById('confirm_btn');
   if(confirmBtn){ confirmBtn.disabled = true; confirmBtn.textContent = '⏳ กำลังจอง...'; }
 
@@ -1334,6 +1347,7 @@ async function book(){
     return data;
   })
   .then(data=>{
+    window.__cwfSchedKey = null; // booking confirmed — next attempt gets a fresh key
     const box = document.getElementById("result");
     const token = data.token;
     const code = data.booking_code || token || '';

--- a/index.js
+++ b/index.js
@@ -29,6 +29,7 @@ const pricingHelpers = require("./server/pricing");
 const jobTiming = require("./server/services/jobTiming");
 const urgentPublicAdapter = require("./server/services/urgentPublicAdapter");
 const urgentFinalizer = require("./server/services/urgent/finalizer");
+const trackingPrivacy = require("./server/services/public/trackingPrivacy");
 const customerPricingHelpers = require("./server/customerPricing");
 const customerAuth = require("./server/customerAuth");
 const technicianIncomeHelpers = require("./server/technicianIncome");
@@ -115,6 +116,21 @@ const FLAG_SHOW_TECH_PHONE_ON_TRACKING = envBool("SHOW_TECH_PHONE_ON_TRACKING", 
 const ENABLE_AVAILABILITY_V2 = envBool("ENABLE_AVAILABILITY_V2", true);
 // ✅ Safe toggle: urgent offer flow (public booking + offers)
 const ENABLE_URGENT_FLOW = envBool("ENABLE_URGENT_FLOW", true);
+// 🔒 Customer App booking kill switches — FAIL CLOSED by design: customer
+// self-booking stays OFF until the operator explicitly enables each lane in
+// the environment. When off, /public/book answers 503 with a machine-readable
+// code + LINE contact URL so the app can hand the customer to a human without
+// ever creating a job (no job = no duplicate risk). Admin booking flows are
+// NOT affected by these flags.
+const ENABLE_CUSTOMER_SCHEDULED_BOOKING = envBool("ENABLE_CUSTOMER_SCHEDULED_BOOKING", false);
+const ENABLE_CUSTOMER_URGENT_BOOKING = envBool("ENABLE_CUSTOMER_URGENT_BOOKING", false);
+const CWF_LINE_CONTACT_URL = String(process.env.CWF_LINE_CONTACT_URL || "https://lin.ee/fG1Oq7y").trim();
+// Rate limits for the public tracking lookups (per client IP, per minute).
+// Budgets cover a real customer's polling comfortably while making
+// booking_code/token guessing impractical.
+const publicTrackRateLimiter = trackingPrivacy.createPublicLookupRateLimiter({ windowMs: 60000, max: 30 });
+const publicUrgentStatusRateLimiter = trackingPrivacy.createPublicLookupRateLimiter({ windowMs: 60000, max: 120 });
+const publicDocsRateLimiter = trackingPrivacy.createPublicLookupRateLimiter({ windowMs: 60000, max: 20 });
 const ENABLE_SERVICE_ZONE_FILTER = envBool("ENABLE_SERVICE_ZONE_FILTER", true);
 const ENABLE_PARTNER_DEPOSIT_DEDUCTION = envBool("ENABLE_PARTNER_DEPOSIT_DEDUCTION", true);
 const ENABLE_WEB_PUSH_NOTIFICATIONS = envBool("ENABLE_WEB_PUSH_NOTIFICATIONS", true);
@@ -13052,7 +13068,9 @@ function makeRandomBookingCode() {
   const chars = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789"; // ตัด I,O,0,1
   let out = "";
   for (let i = 0; i < 7; i++) {
-    out += chars[Math.floor(Math.random() * chars.length)];
+    // CSPRNG: the code doubles as a public lookup key, so it must not come
+    // from a predictable PRNG stream.
+    out += chars[crypto.randomInt(chars.length)];
   }
   return `CWF${out}`;
 }
@@ -23726,6 +23744,18 @@ app.get('/admin/accounting/reports/:report_key.csv', requireAccountingPermission
 
 app.use(createDocumentRoutes({
   pool,
+  // Job documents (receipt/e-slip) carry full customer PII. Access requires
+  // the job's booking_token (?key=...) or an authenticated admin session —
+  // a bare sequential job_id must never be enough.
+  isAdminRequest: async (req) => {
+    try {
+      const ctx = await getAuthContext(req, null);
+      return Boolean(ctx && ctx.ok && (ctx.actor.role === "admin" || ctx.actor.role === "super_admin"));
+    } catch (_) {
+      return false;
+    }
+  },
+  docsRateLimiter: publicDocsRateLimiter,
   accountingOwnerSignaturePublicUrl: _accountingOwnerSignaturePublicUrl,
   accountingSignaturePublicUrl: _accountingSignaturePublicUrl,
   accountingOwnerSignerName: _accountingOwnerSignerName,
@@ -25277,6 +25307,15 @@ app.post("/public/book", async (req, res) => {
   } = req.body || {};
 
   if (isCustomerAppUrgentBook(req.body || {})) {
+    // Kill switch (fail closed): reject BEFORE any job/offer work so a closed
+    // lane can never create a job — the app shows the LINE fallback instead.
+    if (!ENABLE_CUSTOMER_URGENT_BOOKING) {
+      return res.status(503).json({
+        error: "ระบบจองด่วนออนไลน์ปิดให้บริการชั่วคราว กรุณาติดต่อแอดมินทาง LINE",
+        code: "URGENT_BOOKING_DISABLED",
+        line_url: CWF_LINE_CONTACT_URL,
+      });
+    }
     return handlePublicCustomerUrgentBook(req, res);
   }
 
@@ -25313,6 +25352,16 @@ app.post("/public/book", async (req, res) => {
   // DURATION_PRICE_V2_PUBLIC_BOOK
   let bm = (booking_mode || "scheduled").toString().trim().toLowerCase();
   const clientApp = (client_app || "").toString().trim().toLowerCase();
+  // Kill switch (fail closed): Customer App scheduled self-booking is off
+  // until explicitly enabled. Reject before any pricing/availability/insert
+  // work so a closed lane can never create a job.
+  if (bm === "scheduled" && clientApp === "customer_app_v2" && !ENABLE_CUSTOMER_SCHEDULED_BOOKING) {
+    return res.status(503).json({
+      error: "ระบบจองคิวออนไลน์ปิดให้บริการชั่วคราว กรุณาติดต่อแอดมินทาง LINE",
+      code: "SCHEDULED_BOOKING_DISABLED",
+      line_url: CWF_LINE_CONTACT_URL,
+    });
+  }
   const scheduledRequestKey = bm === "scheduled" && clientApp === "customer_app_v2"
     ? String(scheduled_request_key || "").trim()
     : "";
@@ -25862,6 +25911,16 @@ app.get("/public/urgent-status", async (req, res) => {
   res.set("Cache-Control", "no-store, no-cache, must-revalidate, max-age=0");
   res.set("Pragma", "no-cache");
   res.set("Expires", "0");
+  // Budget fits the waiting room's 10s polling with headroom, while still
+  // blocking bulk code guessing.
+  const urgentRate = publicUrgentStatusRateLimiter.check(trackingPrivacy.clientIpKey(req));
+  if (!urgentRate.allowed) {
+    return res.status(429).json({
+      error: "เรียกดูสถานะถี่เกินไป กรุณารอสักครู่แล้วลองใหม่",
+      code: "RATE_LIMITED",
+      retry_after_s: urgentRate.retry_after_s,
+    });
+  }
   const q = String(req.query.token || req.query.q || req.query.booking_code || "").trim();
   if (!q) return res.status(400).json({ error: "missing tracking code" });
   try {
@@ -25928,6 +25987,16 @@ app.get("/public/urgent-status", async (req, res) => {
 });
 
 app.get("/public/track", async (req, res) => {
+  // Anti-enumeration: booking codes are short; without a budget an attacker
+  // could sweep the keyspace. Real customers do a handful of lookups a minute.
+  const trackRate = publicTrackRateLimiter.check(trackingPrivacy.clientIpKey(req));
+  if (!trackRate.allowed) {
+    return res.status(429).json({
+      error: "เรียกดูสถานะถี่เกินไป กรุณารอสักครู่แล้วลองใหม่",
+      code: "RATE_LIMITED",
+      retry_after_s: trackRate.retry_after_s,
+    });
+  }
   const q = (req.query.q || req.query.token || req.query.booking_code || "").toString().trim();
   if (!q) return res.status(400).json({ error: "ต้องส่ง q (token หรือ booking_code)" });
 
@@ -26166,7 +26235,12 @@ if (FLAG_SHOW_TECH_TEAM_ON_TRACKING && canShowPublicTechnician) {
     technician_team = [];
   }
 }
-    res.json({
+    // Access level: the long random booking_token = full detail. The short
+    // human-readable booking_code = masked PII only (it leaks too easily to
+    // act as a full credential) — see server/services/public/trackingPrivacy.js.
+    const fullAccess = trackingPrivacy.isFullAccessQuery(q, row);
+    const trackPayload = {
+      access_level: fullAccess ? "token" : "code",
       job_id: row.job_id,
       booking_code: row.booking_code || null,
       booking_token: row.booking_token || null,
@@ -26197,7 +26271,11 @@ if (FLAG_SHOW_TECH_TEAM_ON_TRACKING && canShowPublicTechnician) {
       photos,
       units: publicUnits,
 
-      receipt_url: isDone ? `${origin}/docs/receipt/${row.job_id}` : null,
+      // The receipt document carries full PII, so its link now embeds the
+      // booking_token as an access key (the /docs routes verify it).
+      receipt_url: isDone && row.booking_token
+        ? `${origin}/docs/receipt/${row.job_id}?key=${encodeURIComponent(row.booking_token)}`
+        : null,
 
       review: {
         already_reviewed: !!row.customer_rating,
@@ -26229,7 +26307,8 @@ if (FLAG_SHOW_TECH_TEAM_ON_TRACKING && canShowPublicTechnician) {
 
       // ✅ รายชื่อทีมช่างทั้งหมด (ถ้าเปิด flag) — ใช้ในหน้า Tracking
       technician_team,
-    });
+    };
+    res.json(fullAccess ? trackPayload : trackingPrivacy.redactPublicTrackPayload(trackPayload));
   } catch (e) {
     console.error(e);
     res.status(500).json({ error: "ติดตามงานไม่สำเร็จ" });

--- a/index.js
+++ b/index.js
@@ -25116,21 +25116,106 @@ function deriveCustomerScheduledBookingToken(requestKey) {
 }
 
 // A scheduled request key is bound to the booking it first created. On replay we
-// only return the existing job when the material payload matches; a key reused
-// with a different appointment, phone, service type, or computed duration is a
-// key-reuse error (never a silent return of the old job's data).
-function isSameScheduledPayload(jobRow, incoming) {
+// only return the existing job when the FULL canonical material payload matches;
+// a key reused with any different material field is a key-reuse error, never a
+// silent return of the old job's data. "Material" = every persisted field that
+// defines the booking contract: appointment, contact, place, and the canonical
+// service composition (from job_items, which also carries price).
+function normalizedBookingScalar(value) {
+  return String(value == null ? "" : value).trim();
+}
+
+// Canonical, order-independent signature of a set of line items. line_total
+// captures unit price × qty, so BTU/variant/qty/price changes all shift it.
+function bookingLineSignature(rows) {
+  return (rows || [])
+    .map((it) => `${normalizedBookingScalar(it.item_name)}#${Number(it.qty || 0)}#${Number(it.line_total || 0)}`)
+    .sort()
+    .join("|");
+}
+
+async function loadStoredBookingLineSignature(db, jobId) {
+  const r = await db.query(
+    `SELECT item_name, qty, line_total FROM public.job_items WHERE job_id=$1`,
+    [jobId]
+  );
+  return bookingLineSignature(r.rows);
+}
+
+// Rebuild the incoming service + extra lines with the SAME normalizer used to
+// create a booking, so an identical service payload yields an identical
+// signature (and any material change yields a different one). Read-only.
+async function buildIncomingBookingLineSignature(db, payloadV2, itemIdQty, standardPrice) {
+  let computed = [];
+  let total = Number(standardPrice || 0);
+  const serviceLines = await customerPricingHelpers.buildCustomerServiceLineItemsFromPayload(
+    (payloadV2.services && Array.isArray(payloadV2.services))
+      ? payloadV2
+      : {
+          ...payloadV2,
+          services: [{
+            job_type: payloadV2.job_type,
+            ac_type: payloadV2.ac_type,
+            btu: payloadV2.btu,
+            machine_count: payloadV2.machine_count,
+            wash_variant: payloadV2.wash_variant,
+            repair_variant: payloadV2.repair_variant,
+          }],
+        },
+    db
+  );
+  if (serviceLines.length) {
+    computed = computed.concat(serviceLines);
+  } else if (total > 0) {
+    computed.push({ item_name: `ค่าบริการมาตรฐาน (${payloadV2.job_type || "-"})`, qty: 1, line_total: total });
+  }
+  if (itemIdQty && itemIdQty.length) {
+    const ids = itemIdQty.map((x) => x.item_id);
+    const catR = await db.query(
+      `SELECT item_id, item_name, base_price FROM public.catalog_items
+        WHERE is_active=TRUE AND is_customer_visible=TRUE AND item_id = ANY($1::bigint[])`,
+      [ids]
+    );
+    const map = new Map(catR.rows.map((row) => [Number(row.item_id), row]));
+    for (const x of itemIdQty) {
+      const it = map.get(Number(x.item_id));
+      if (!it) continue;
+      const qty = Number(x.qty);
+      computed.push({ item_name: it.item_name, qty, line_total: qty * Number(it.base_price || 0) });
+    }
+  }
+  return bookingLineSignature(computed);
+}
+
+// Scalar material fields persisted on the jobs row (everything but the service
+// lines, which are compared via the signature above).
+function scheduledScalarsMatch(jobRow, incoming) {
   const apptTime = (v) => {
     const t = new Date(v).getTime();
     return Number.isFinite(t) ? t : NaN;
   };
-  const storedAppt = apptTime(jobRow.appointment_datetime);
-  const incomingAppt = apptTime(normalizeAppointmentDatetime(incoming.appointment_datetime));
-  const sameAppt = Number.isFinite(storedAppt) && Number.isFinite(incomingAppt) && storedAppt === incomingAppt;
-  const samePhone = String(jobRow.customer_phone || "").replace(/\D/g, "") === String(incoming.customer_phone || "").replace(/\D/g, "");
-  const sameType = String(jobRow.job_type || "").trim() === String(incoming.job_type || "").trim();
-  const sameDuration = Number(jobRow.duration_min || 0) === Number(incoming.duration_min || 0);
-  return sameAppt && samePhone && sameType && sameDuration;
+  const a = apptTime(jobRow.appointment_datetime);
+  const b = apptTime(normalizeAppointmentDatetime(incoming.appointment_datetime));
+  if (!(Number.isFinite(a) && Number.isFinite(b) && a === b)) return false;
+  if (normalizedBookingScalar(jobRow.customer_phone).replace(/\D/g, "") !== normalizedBookingScalar(incoming.customer_phone).replace(/\D/g, "")) return false;
+  if (normalizedBookingScalar(jobRow.customer_name) !== normalizedBookingScalar(incoming.customer_name)) return false;
+  if (normalizedBookingScalar(jobRow.address_text) !== normalizedBookingScalar(incoming.address_text)) return false;
+  if (normalizedBookingScalar(jobRow.maps_url) !== normalizedBookingScalar(incoming.maps_url)) return false;
+  if (normalizedBookingScalar(jobRow.job_zone) !== normalizedBookingScalar(incoming.job_zone)) return false;
+  if (normalizedBookingScalar(jobRow.job_type) !== normalizedBookingScalar(incoming.job_type)) return false;
+  if (normalizedBookingScalar(jobRow.customer_note) !== normalizedBookingScalar(incoming.customer_note)) return false;
+  if (Boolean(jobRow.allow_time_proposal) !== Boolean(incoming.allow_time_proposal)) return false;
+  if (Number(jobRow.duration_min || 0) !== Number(incoming.duration_min || 0)) return false;
+  return true;
+}
+
+// Full canonical match = scalar fields + service-line signature. Used identically
+// by the pre-flight replay and the in-transaction race path.
+async function scheduledPayloadMatchesExisting(db, jobRow, incoming) {
+  if (!scheduledScalarsMatch(jobRow, incoming)) return false;
+  const storedSig = await loadStoredBookingLineSignature(db, jobRow.job_id);
+  const incomingSig = await buildIncomingBookingLineSignature(db, incoming.payloadV2, incoming.itemIdQty, incoming.standardPrice);
+  return storedSig === incomingSig;
 }
 
 // Customer App V2 urgent requests are just another entry point into the
@@ -25376,7 +25461,8 @@ console.log("[latlng_parse]", { ok: !!parsedLL });
       await idem.query("SELECT pg_advisory_xact_lock(hashtext($1))", [scheduledRequestKey]);
       const r = await idem.query(
         `SELECT job_id, booking_code, booking_token, dispatch_mode, duration_min, job_price,
-                appointment_datetime, customer_phone, job_type
+                appointment_datetime, customer_phone, customer_name, address_text, maps_url,
+                job_zone, job_type, customer_note, allow_time_proposal
            FROM public.jobs
           WHERE booking_token=$1
             AND job_source='customer'
@@ -25394,7 +25480,13 @@ console.log("[latlng_parse]", { ok: !!parsedLL });
       idem.release();
     }
     if (prior) {
-      if (!isSameScheduledPayload(prior, { appointment_datetime, customer_phone, job_type, duration_min: duration_min_v2 })) {
+      const incomingBooking = {
+        appointment_datetime, customer_phone, customer_name, address_text, maps_url,
+        job_zone, job_type, customer_note, allow_time_proposal: allowTimeProposal,
+        duration_min: duration_min_v2, payloadV2, itemIdQty, standardPrice: standard_price,
+      };
+      if (!(await scheduledPayloadMatchesExisting(pool, prior, incomingBooking))) {
+        // Same key, materially different booking. No mutation, no identifiers/PII.
         return res.status(409).json({
           error: "คำขอนี้ถูกใช้ไปแล้วกับการจองอื่น กรุณาเริ่มการจองใหม่",
           code: "IDEMPOTENCY_KEY_REUSED",
@@ -25458,7 +25550,8 @@ console.log("[latlng_parse]", { ok: !!parsedLL });
       await client.query("SELECT pg_advisory_xact_lock(hashtext($1))", [scheduledRequestKey]);
       const existing = await client.query(
         `SELECT job_id, booking_code, booking_token, booking_mode, dispatch_mode,
-                duration_min, job_price, appointment_datetime, customer_phone, job_type
+                duration_min, job_price, appointment_datetime, customer_phone, customer_name,
+                address_text, maps_url, job_zone, job_type, customer_note, allow_time_proposal
            FROM public.jobs
           WHERE booking_token=$1
             AND job_source='customer'
@@ -25469,10 +25562,16 @@ console.log("[latlng_parse]", { ok: !!parsedLL });
       );
       if (existing.rows[0]) {
         // Race safety net: a concurrent request with the same key committed first.
-        // Same payload -> replay; different payload -> key-reuse 409 (no mutation).
+        // Same canonical payload -> replay; any material difference -> key-reuse 409
+        // (no mutation, no identifiers/PII). Same comparison as the pre-flight path.
         const row = existing.rows[0];
         await client.query("COMMIT");
-        if (!isSameScheduledPayload(row, { appointment_datetime, customer_phone, job_type, duration_min: duration_min_v2 })) {
+        const incomingBooking = {
+          appointment_datetime, customer_phone, customer_name, address_text, maps_url,
+          job_zone, job_type, customer_note, allow_time_proposal: allowTimeProposal,
+          duration_min: duration_min_v2, payloadV2, itemIdQty, standardPrice: standard_price,
+        };
+        if (!(await scheduledPayloadMatchesExisting(pool, row, incomingBooking))) {
           return res.status(409).json({
             error: "คำขอนี้ถูกใช้ไปแล้วกับการจองอื่น กรุณาเริ่มการจองใหม่",
             code: "IDEMPOTENCY_KEY_REUSED",

--- a/index.js
+++ b/index.js
@@ -131,6 +131,11 @@ const CWF_LINE_CONTACT_URL = String(process.env.CWF_LINE_CONTACT_URL || "https:/
 const publicTrackRateLimiter = trackingPrivacy.createPublicLookupRateLimiter({ windowMs: 60000, max: 30 });
 const publicUrgentStatusRateLimiter = trackingPrivacy.createPublicLookupRateLimiter({ windowMs: 60000, max: 120 });
 const publicDocsRateLimiter = trackingPrivacy.createPublicLookupRateLimiter({ windowMs: 60000, max: 20 });
+// Public review is a WRITE gated by an identifier, so it gets two independent
+// budgets: per trusted client IP, and per booking code/token (so one job's code
+// can't be hammered from many IPs). Both must pass.
+const publicReviewIpRateLimiter = trackingPrivacy.createPublicLookupRateLimiter({ windowMs: 60000, max: 15 });
+const publicReviewKeyRateLimiter = trackingPrivacy.createPublicLookupRateLimiter({ windowMs: 600000, max: 8 });
 const ENABLE_SERVICE_ZONE_FILTER = envBool("ENABLE_SERVICE_ZONE_FILTER", true);
 const ENABLE_PARTNER_DEPOSIT_DEDUCTION = envBool("ENABLE_PARTNER_DEPOSIT_DEDUCTION", true);
 const ENABLE_WEB_PUSH_NOTIFICATIONS = envBool("ENABLE_WEB_PUSH_NOTIFICATIONS", true);
@@ -25306,16 +25311,34 @@ app.post("/public/book", async (req, res) => {
     catalog_item_id, // optional: links this booking to the Store catalog item it was booked for
   } = req.body || {};
 
+  // 🔒 Kill switch (fail closed) — CANONICAL GATE. /public/book is entirely
+  // unauthenticated, so the gate keys off the canonical booking_mode ONLY.
+  // client_app is attacker-controlled and MUST NOT be a security boundary:
+  // gating on it would let a request drop/forge client_app and slip past.
+  // This runs before urgent routing, pricing, idempotency, insert, and offer
+  // dispatch, so a closed lane can never create a job/offer. Admin bookings use
+  // the session-authenticated /admin route, never this one. Unknown modes are
+  // rejected outright (no fall-through).
+  const canonicalBookingMode = String(booking_mode || "scheduled").trim().toLowerCase();
+  if (canonicalBookingMode !== "scheduled" && canonicalBookingMode !== "urgent") {
+    return res.status(400).json({ error: "ประเภทการจองไม่ถูกต้อง", code: "UNKNOWN_BOOKING_MODE" });
+  }
+  if (canonicalBookingMode === "urgent" && !ENABLE_CUSTOMER_URGENT_BOOKING) {
+    return res.status(503).json({
+      error: "ระบบจองด่วนออนไลน์ปิดให้บริการชั่วคราว กรุณาติดต่อแอดมินทาง LINE",
+      code: "URGENT_BOOKING_DISABLED",
+      line_url: CWF_LINE_CONTACT_URL,
+    });
+  }
+  if (canonicalBookingMode === "scheduled" && !ENABLE_CUSTOMER_SCHEDULED_BOOKING) {
+    return res.status(503).json({
+      error: "ระบบจองคิวออนไลน์ปิดให้บริการชั่วคราว กรุณาติดต่อแอดมินทาง LINE",
+      code: "SCHEDULED_BOOKING_DISABLED",
+      line_url: CWF_LINE_CONTACT_URL,
+    });
+  }
+
   if (isCustomerAppUrgentBook(req.body || {})) {
-    // Kill switch (fail closed): reject BEFORE any job/offer work so a closed
-    // lane can never create a job — the app shows the LINE fallback instead.
-    if (!ENABLE_CUSTOMER_URGENT_BOOKING) {
-      return res.status(503).json({
-        error: "ระบบจองด่วนออนไลน์ปิดให้บริการชั่วคราว กรุณาติดต่อแอดมินทาง LINE",
-        code: "URGENT_BOOKING_DISABLED",
-        line_url: CWF_LINE_CONTACT_URL,
-      });
-    }
     return handlePublicCustomerUrgentBook(req, res);
   }
 
@@ -25350,18 +25373,8 @@ app.post("/public/book", async (req, res) => {
 
   let token = genToken(12);
   // DURATION_PRICE_V2_PUBLIC_BOOK
-  let bm = (booking_mode || "scheduled").toString().trim().toLowerCase();
+  let bm = canonicalBookingMode;
   const clientApp = (client_app || "").toString().trim().toLowerCase();
-  // Kill switch (fail closed): Customer App scheduled self-booking is off
-  // until explicitly enabled. Reject before any pricing/availability/insert
-  // work so a closed lane can never create a job.
-  if (bm === "scheduled" && clientApp === "customer_app_v2" && !ENABLE_CUSTOMER_SCHEDULED_BOOKING) {
-    return res.status(503).json({
-      error: "ระบบจองคิวออนไลน์ปิดให้บริการชั่วคราว กรุณาติดต่อแอดมินทาง LINE",
-      code: "SCHEDULED_BOOKING_DISABLED",
-      line_url: CWF_LINE_CONTACT_URL,
-    });
-  }
   const scheduledRequestKey = bm === "scheduled" && clientApp === "customer_app_v2"
     ? String(scheduled_request_key || "").trim()
     : "";
@@ -26323,50 +26336,87 @@ if (FLAG_SHOW_TECH_TEAM_ON_TRACKING && canShowPublicTechnician) {
 // - จำกัด 1 รีวิวต่อ 1 job_id
 // =======================================
 app.post("/public/review", async (req, res) => {
-  const { q, booking_code, token, rating, review_text, complaint_text } = req.body || {};
-  const key = (q || booking_code || token || "").toString().trim();
-  const star = Number(rating);
+  // A public WRITE authorised by a booking identifier. Policy:
+  //   - A job that HAS a booking_token requires the EXACT token (the short,
+  //     shareable booking_code alone is NOT a write credential — see the
+  //     tracking privacy split). No downgrade to code+phone for tokened jobs.
+  //   - A LEGACY job with no booking_token may be reviewed via booking_code +
+  //     the customer's FULL phone (exact match after digit-normalisation),
+  //     still requiring the job to be completed and not yet reviewed.
+  // Every authorisation/eligibility failure returns the SAME generic error so
+  // the endpoint never reveals whether the code, phone, or status was the
+  // mismatch. Rate limited per client IP and per identifier. No PII/token in
+  // any response.
+  const GENERIC_REVIEW_ERROR = "ไม่สามารถส่งรีวิวได้ กรุณาตรวจสอบเลข/สถานะงานและข้อมูลยืนยันอีกครั้ง";
+  const body = req.body || {};
+  const token = String(body.token || body.booking_token || "").trim();
+  const code = String(body.booking_code || body.q || "").trim();
+  const phoneDigits = String(body.customer_phone || "").replace(/\D/g, "");
+  const star = Number(body.rating);
+  const review_text = (body.review_text || "").toString().trim() || null;
+  const complaint_text = (body.complaint_text || "").toString().trim() || null;
 
-  if (!key) return res.status(400).json({ error: "ต้องส่ง booking_code หรือ token" });
-  if (!Number.isFinite(star) || star < 1 || star > 5) return res.status(400).json({ error: "rating ต้องอยู่ระหว่าง 1-5" });
+  if (!publicReviewIpRateLimiter.check(trackingPrivacy.clientIpKey(req)).allowed) {
+    return res.status(429).json({ error: "ส่งรีวิวถี่เกินไป กรุณารอสักครู่", code: "RATE_LIMITED" });
+  }
+  if (!Number.isFinite(star) || star < 1 || star > 5) {
+    return res.status(400).json({ error: "rating ต้องอยู่ระหว่าง 1-5" });
+  }
+  if (!token && !code) {
+    return res.status(400).json({ error: GENERIC_REVIEW_ERROR });
+  }
+  // Per-identifier budget (defends one job's code against many-IP hammering).
+  const identifierKey = token ? `t:${token}` : `c:${code}`;
+  if (!publicReviewKeyRateLimiter.check(identifierKey).allowed) {
+    return res.status(429).json({ error: "ส่งรีวิวถี่เกินไป กรุณารอสักครู่", code: "RATE_LIMITED" });
+  }
 
   const client = await pool.connect();
   try {
     await client.query("BEGIN");
 
-    const jr = await client.query(
-      `SELECT job_id, job_status, technician_username, customer_rating
-       FROM public.jobs
-       WHERE booking_code=$1 OR booking_token=$1
-       LIMIT 1
-       FOR UPDATE`,
-      [key]
-    );
+    // Look the job up by exactly one credential path — never `code OR token`,
+    // which would let a code match a tokened job.
+    let jr;
+    if (token) {
+      jr = await client.query(
+        `SELECT job_id, job_status, technician_username, customer_rating, booking_token, customer_phone
+           FROM public.jobs WHERE booking_token=$1 LIMIT 1 FOR UPDATE`,
+        [token]
+      );
+    } else {
+      jr = await client.query(
+        `SELECT job_id, job_status, technician_username, customer_rating, booking_token, customer_phone
+           FROM public.jobs WHERE booking_code=$1 LIMIT 1 FOR UPDATE`,
+        [code]
+      );
+    }
 
-    if (!jr.rows.length) throw new Error("ไม่พบงาน");
     const job = jr.rows[0];
+    // All authorisation failures collapse to one generic 400 (no oracle).
+    const deny = () => { const e = new Error(GENERIC_REVIEW_ERROR); e.generic = true; throw e; };
+    if (!job) deny();
 
-    if (String(job.job_status || "").trim() !== "เสร็จแล้ว") {
-      throw new Error("งานยังไม่ปิด ไม่สามารถให้คะแนนได้");
+    const jobHasToken = Boolean(String(job.booking_token || "").trim());
+    if (token) {
+      // Token path already authorised by the exact-token WHERE clause.
+    } else {
+      // Legacy code path: only for jobs that genuinely have no token, and only
+      // with the full phone matching exactly.
+      if (jobHasToken) deny();
+      const jobPhoneDigits = String(job.customer_phone || "").replace(/\D/g, "");
+      if (!phoneDigits || phoneDigits.length < 9 || jobPhoneDigits !== phoneDigits) deny();
     }
-    if (job.customer_rating) {
-      throw new Error("งานนี้ให้คะแนนไปแล้ว");
-    }
-    if (!job.technician_username) {
-      throw new Error("งานนี้ยังไม่มีช่างรับงาน");
-    }
+
+    if (String(job.job_status || "").trim() !== "เสร็จแล้ว") deny();
+    if (job.customer_rating) deny();
+    if (!job.technician_username) deny();
 
     await client.query(
       `INSERT INTO public.technician_reviews (job_id, technician_username, rating, review_text, complaint_text)
        VALUES ($1,$2,$3,$4,$5)
        ON CONFLICT (job_id) DO NOTHING`,
-      [
-        job.job_id,
-        job.technician_username,
-        Math.round(star),
-        (review_text || "").toString().trim() || null,
-        (complaint_text || "").toString().trim() || null,
-      ]
+      [job.job_id, job.technician_username, Math.round(star), review_text, complaint_text]
     );
 
     await client.query(
@@ -26376,12 +26426,7 @@ app.post("/public/review", async (req, res) => {
            customer_complaint=$3,
            reviewed_at=NOW()
        WHERE job_id=$4`,
-      [
-        Math.round(star),
-        (review_text || "").toString().trim() || null,
-        (complaint_text || "").toString().trim() || null,
-        job.job_id,
-      ]
+      [Math.round(star), review_text, complaint_text, job.job_id]
     );
 
     // ✅ อัปเดตคะแนนเฉลี่ยลงโปรไฟล์ (เก็บในคอลัมน์ rating)
@@ -26401,10 +26446,15 @@ app.post("/public/review", async (req, res) => {
     );
 
     await client.query("COMMIT");
-    res.json({ success: true, avg_rating: avg });
+    // No PII, token, or per-job confirmation data in the response.
+    res.json({ success: true });
   } catch (e) {
     await client.query("ROLLBACK");
-    res.status(400).json({ error: e.message || "ส่งรีวิวไม่สำเร็จ" });
+    // Generic authorisation/eligibility failures never reveal the mismatch;
+    // only a genuine unexpected server error is a 500.
+    if (e && e.generic) return res.status(400).json({ error: e.message });
+    console.error("[public/review] failed", e && e.message);
+    return res.status(400).json({ error: "ไม่สามารถส่งรีวิวได้ กรุณาตรวจสอบเลข/สถานะงานและข้อมูลยืนยันอีกครั้ง" });
   } finally {
     client.release();
   }

--- a/index.js
+++ b/index.js
@@ -25222,11 +25222,6 @@ app.get("/public/availability", async (req, res) => {
   }
 });
 
-function isCustomerAppUrgentBook(body = {}) {
-  return String(body.booking_mode || "").trim().toLowerCase() === "urgent" &&
-    String(body.client_app || "").trim().toLowerCase() === "customer_app_v2";
-}
-
 function deriveCustomerScheduledBookingToken(requestKey) {
   const key = String(requestKey || "").trim();
   if (!key) return null;
@@ -25338,7 +25333,12 @@ app.post("/public/book", async (req, res) => {
     });
   }
 
-  if (isCustomerAppUrgentBook(req.body || {})) {
+  // Every unauthenticated urgent request is a customer request (admin books via
+  // the session-authenticated route, never this one). Route it through the
+  // customer-safe adapter on the CANONICAL booking_mode ALONE — never client_app,
+  // which the caller can drop/forge to skip the sanitiser and reach the raw
+  // urgent engine with attacker-chosen technician/assign fields.
+  if (canonicalBookingMode === "urgent") {
     return handlePublicCustomerUrgentBook(req, res);
   }
 
@@ -25375,11 +25375,16 @@ app.post("/public/book", async (req, res) => {
   // DURATION_PRICE_V2_PUBLIC_BOOK
   let bm = canonicalBookingMode;
   const clientApp = (client_app || "").toString().trim().toLowerCase();
-  const scheduledRequestKey = bm === "scheduled" && clientApp === "customer_app_v2"
+  // Idempotency is CANONICAL: every public scheduled booking must carry a valid
+  // request key, keyed off the canonical booking_mode — never client_app. Gating
+  // this on client_app let an unauthenticated caller drop/forge it to skip the
+  // advisory-lock replay below and mint duplicate jobs. client_app stays only
+  // for telemetry/UX defaults, never for a security/idempotency decision.
+  const scheduledRequestKey = bm === "scheduled"
     ? String(scheduled_request_key || "").trim()
     : "";
   const validScheduledRequestKey = /^[A-Za-z0-9_-]{16,128}$/.test(scheduledRequestKey);
-  if (bm === "scheduled" && clientApp === "customer_app_v2" && !validScheduledRequestKey) {
+  if (bm === "scheduled" && !validScheduledRequestKey) {
     return res.status(400).json({ error: "MISSING_REQUEST_KEY", code: "MISSING_REQUEST_KEY" });
   }
   const scheduledDeterministicToken = scheduledRequestKey
@@ -25387,7 +25392,7 @@ app.post("/public/book", async (req, res) => {
     : null;
   if (scheduledDeterministicToken) token = scheduledDeterministicToken;
   const allowAdminScheduleFallback = allow_admin_schedule_fallback === true || String(allow_admin_schedule_fallback || "").trim() === "true";
-  const canUseAdminScheduleFallback = bm === "scheduled" && allowAdminScheduleFallback && clientApp === "customer_app_v2";
+  const canUseAdminScheduleFallback = bm === "scheduled" && allowAdminScheduleFallback;
   const urgentOfferEnabled = bm === "urgent" && ENABLE_URGENT_FLOW;
   const allowTimeProposal = allow_time_proposal === true
     ? true
@@ -25410,7 +25415,7 @@ app.post("/public/book", async (req, res) => {
   // CWF Spec: conservative duration for schedule/collision
   const duration_min_v2 = computeDurationMinMulti(payloadV2, { source: "public_book", conservative: true });
   if (duration_min_v2 <= 0) return res.status(400).json({ error: "งานประเภทนี้ต้องให้แอดมินกำหนดเวลา (duration)" });
-  if (bm === "scheduled" && clientApp === "customer_app_v2") {
+  if (bm === "scheduled") {
     const startIsoForCutoff = normalizeAppointmentDatetime(appointment_datetime);
     const requestedDate = String(startIsoForCutoff || "").slice(0, 10);
     const requestedStart = String(startIsoForCutoff || "").slice(11, 16);
@@ -25449,11 +25454,13 @@ console.log("[latlng_parse]", { ok: !!parsedLL });
   // Defect 1: Customer App V2 scheduled booking must not be limited to company technicians;
   // it mirrors the public availability query (tech_type=all) and stays strict via the
   // customer_slot_visible + service matrix + monthly calendar gates below.
-  const requestedTechType = bm === "urgent"
-    ? "partner"
-    : (clientApp === "customer_app_v2" ? "all" : "company");
+  // Canonical: every public scheduled booking mirrors the public slot list
+  // (tech_type "all"), never a client_app-derived narrower set. Strictness comes
+  // from the customer_slot_visible + service-matrix + monthly-calendar gates
+  // inside customerAvailability, not from client_app.
+  const requestedTechType = bm === "urgent" ? "partner" : "all";
   try {
-    if (bm === "scheduled" && clientApp === "customer_app_v2") {
+    if (bm === "scheduled") {
       const startIso = normalizeAppointmentDatetime(appointment_datetime);
       const start = String(startIso).slice(11, 16);
       const available = await customerAvailability.hasAvailableStart(
@@ -25469,147 +25476,19 @@ console.log("[latlng_parse]", { ok: !!parsedLL });
       if (!available) {
         return res.status(409).json({ error: "ช่วงเวลานี้เต็มแล้ว กรุณาเลือกเวลาอื่น" });
       }
-    } else {
-    let techs = await listTechniciansByType(requestedTechType, { include_paused: bm === "scheduled" });
-
-    // Customer booking must use the same strict technician boundary as the public slot list.
-    // Only admin-visible technicians whose service matrix matches every requested service are eligible.
-    techs = techs.filter(t => t && t.customer_slot_visible === true);
-    const normalizeJobKey = (s) => {
-      const v = String(s || '').toLowerCase();
-      if (!v) return null;
-      if (v.includes('ติดตั้ง')) return 'install';
-      if (v.includes('ซ่อม')) return 'repair';
-      if (v.includes('ล้าง')) return 'wash';
-      return null;
-    };
-    const normalizeAcKey = (s) => {
-      const v = String(s || '').toLowerCase();
-      if (!v) return null;
-      if (v.includes('ผนัง') || v.includes('wall')) return 'wall';
-      if (v.includes('สี่ทิศ') || v.includes('4') || v.includes('four')) return 'fourway';
-      if (v.includes('แขวน')) return 'hanging';
-      if (v.includes('ใต้ฝ้า') || v.includes('เปลือย') || v.includes('ฝัง')) return 'ceiling';
-      return null;
-    };
-    const normalizeWashKey = (s) => {
-      const v = String(s || '').toLowerCase();
-      if (!v) return null;
-      if (v.includes('ธรรมดา') || v.includes('normal')) return 'normal';
-      if (v.includes('พรีเมียม') || v.includes('premium')) return 'premium';
-      if (v.includes('แขวนคอย') || v.includes('coil')) return 'coil';
-      if (v.includes('ตัดล้าง') || v.includes('overhaul') || v.includes('ใหญ่')) return 'overhaul';
-      return null;
-    };
-    const normalizeRepairKey = (s) => {
-      const v = String(s || '').toLowerCase();
-      if (!v) return null;
-      if (v.includes('à¸£à¸±à¹ˆà¸§') || v.includes('leak')) return 'leak_check';
-      if (v.includes('à¸­à¸°à¹„à¸«à¸¥à¹ˆ') || v.includes('part')) return 'parts';
-      if (v.includes('à¸•à¸£à¸§à¸ˆ') || v.includes('inspect')) return 'inspection';
-      if (v.includes('à¸—à¸±à¹ˆà¸§à¹„à¸›') || v.includes('general')) return 'general';
-      return v.replace(/[^a-z0-9_]+/g, '_').replace(/^_+|_+$/g, '') || null;
-    };
-
-    const requestedServices = (Array.isArray(payloadV2.services) && payloadV2.services.length)
-      ? payloadV2.services
-      : [{
-          job_type: payloadV2.job_type,
-          ac_type: payloadV2.ac_type,
-          wash_variant: payloadV2.wash_variant,
-          repair_variant: payloadV2.repair_variant,
-        }];
-    const rawCriteria = requestedServices
-      .map(s => ({
-        job: normalizeJobKey(s.job_type || payloadV2.job_type),
-        ac: normalizeAcKey(s.ac_type || payloadV2.ac_type),
-        wash: normalizeWashKey(s.wash_variant || payloadV2.wash_variant),
-        repair: normalizeRepairKey(s.repair_variant || payloadV2.repair_variant),
-        repair_variant: String(s.repair_variant || payloadV2.repair_variant || '').trim() || null,
-      }));
-    const hasCompleteCriteria = (c) => Boolean(
-      c && c.job && c.ac &&
-      !(c.job === 'wash' && c.ac === 'wall' && !c.wash) &&
-      !(c.job === 'repair' && !c.repair_variant)
-    );
-    if (!rawCriteria.length || rawCriteria.some(c => !hasCompleteCriteria(c))) {
-      const err = new Error('CUSTOMER_SLOT_SERVICE_CRITERIA_REQUIRED');
-      err.status = 400;
-      throw err;
-    }
-    const listCriteria = rawCriteria;
-
-    const mustTrue = (obj, key) => {
-      if (!key) return true;
-      if (!obj || typeof obj !== 'object') return false;
-      return Boolean(obj[key]);
-    };
-    const hasTrue = (obj, keys) => {
-      if (!obj || typeof obj !== 'object') return false;
-      return (keys || []).filter(Boolean).some((key) => Boolean(obj[key]));
-    };
-    const techMatches = (mx, c) => {
-      if (!mx || typeof mx !== 'object') return false;
-      if (!mustTrue(mx.job_types, c.job)) return false;
-      if (!mustTrue(mx.ac_types, c.ac)) return false;
-      if (c.job === 'wash' && c.ac === 'wall' && !mustTrue(mx.wash_wall_variants, c.wash)) return false;
-      if (c.job === 'repair' && c.repair_variant && !hasTrue(mx.repair_variants, [c.repair, c.repair_variant])) return false;
-      return true;
-    };
-
-    const usernames = techs.map(t => String(t.username));
-    const matrixMap = new Map();
-    try {
-      const rMx = usernames.length
-        ? await pool.query(
-            `SELECT username, matrix_json FROM public.technician_service_matrix WHERE username = ANY($1::text[])`,
-            [usernames]
-          )
-        : { rows: [] };
-      for (const row of (rMx.rows || [])) matrixMap.set(String(row.username), row.matrix_json || {});
-    } catch (e) {
-      console.warn('[public_book] loadServiceMatrixMap failed:', e.message);
-      const err = new Error('CUSTOMER_SLOT_MATRIX_UNAVAILABLE');
-      err.status = 503;
-      throw err;
-    }
-    techs = techs.filter(t => {
-      const u = String(t.username);
-      if (!matrixMap.has(u)) return false;
-      const mx = matrixMap.get(u) || null;
-      return listCriteria.every(c => techMatches(mx, c));
-    });
-    // Timezone-safe: normalize appointment datetime once (Asia/Bangkok)
-    const startIso = normalizeAppointmentDatetime(appointment_datetime);
-    const tMin = toMin(String(startIso).slice(11, 16));
-    let anyFree = false;
-    for (const tech of techs) {
-      // CWF Spec: UI start window is LOCKED 09:00–18:00 (startable time only)
-      if (!(tMin >= toMin('09:00') && tMin < toMin('18:00'))) continue;
-      const ok = await isTechFree(tech.username, startIso, duration_min_v2, null);
-      if (ok) { anyFree = true; break; }
-    }
-    if (!anyFree) {
-      if (bm === "scheduled" && clientApp === "customer_app_v2") {
-        return res.status(409).json({ error: "ช่วงเวลานี้เต็มแล้ว กรุณาเลือกเวลาอื่น" });
-      }
-      if (canUseAdminScheduleFallback || bm === "urgent") {
-        console.warn("[public_book] availability_no_free_slot_continue", { bm, requestedTechType, appointment_datetime, clientApp, allowAdminScheduleFallback });
-      } else {
-        return res.status(409).json({ error: "ช่วงเวลานี้เต็มแล้ว กรุณาเลือกเวลาอื่น" });
-      }
-    }
     }
   } catch (e) {
     console.warn("[public_book] availability_check_fail", { bm, clientApp, err: e.message });
-    if (bm === "scheduled" && clientApp === "customer_app_v2") {
+    // Fail CLOSED for every public scheduled booking — a failed capacity check
+    // must never silently let a booking through (this used to fall open for
+    // non-customer_app_v2 callers, a client_app-dependent weakness).
+    if (bm === "scheduled") {
       const status = Number(e.status || 503);
       const message = status === 400
         ? "ข้อมูลบริการไม่ครบสำหรับตรวจคิว กรุณาเลือกบริการใหม่"
         : "ระบบตรวจคิวช่างยังไม่พร้อม กรุณาลองใหม่อีกครั้ง";
       return res.status(status).json({ error: message });
     }
-    // Preserve legacy callers outside Customer App V2.
   }
 
 
@@ -25650,7 +25529,7 @@ console.log("[latlng_parse]", { ok: !!parsedLL });
     }
 
     let draftReservationTech = null;
-    if (bm === "scheduled" && clientApp === "customer_app_v2") {
+    if (bm === "scheduled") {
       const startIso = normalizeAppointmentDatetime(appointment_datetime);
       draftReservationTech = await customerAvailability.reservePublicCustomerTechnician(
         publicCustomerAvailabilityDeps(client),
@@ -26252,8 +26131,19 @@ if (FLAG_SHOW_TECH_TEAM_ON_TRACKING && canShowPublicTechnician) {
     // human-readable booking_code = masked PII only (it leaks too easily to
     // act as a full credential) — see server/services/public/trackingPrivacy.js.
     const fullAccess = trackingPrivacy.isFullAccessQuery(q, row);
+    // Minimal, non-sensitive eligibility signal so a LEGACY customer (a job with
+    // no booking_token) can still see the review form on a booking_code lookup
+    // and submit code + full phone. It reveals only that a review is possible —
+    // no PII, no token. A tokened job is never legacy-eligible, so it can never
+    // downgrade to the code+phone path.
+    const legacyReviewEligible =
+      !String(row.booking_token || "").trim() &&
+      String(row.job_status || "").trim() === "เสร็จแล้ว" &&
+      !row.customer_rating &&
+      !!row.technician_username;
     const trackPayload = {
       access_level: fullAccess ? "token" : "code",
+      legacy_review_eligible: legacyReviewEligible,
       job_id: row.job_id,
       booking_code: row.booking_code || null,
       booking_token: row.booking_token || null,

--- a/index.js
+++ b/index.js
@@ -25115,6 +25115,24 @@ function deriveCustomerScheduledBookingToken(requestKey) {
   return crypto.createHash("sha256").update(`scheduled_v1:${key}`).digest("hex").slice(0, 24);
 }
 
+// A scheduled request key is bound to the booking it first created. On replay we
+// only return the existing job when the material payload matches; a key reused
+// with a different appointment, phone, service type, or computed duration is a
+// key-reuse error (never a silent return of the old job's data).
+function isSameScheduledPayload(jobRow, incoming) {
+  const apptTime = (v) => {
+    const t = new Date(v).getTime();
+    return Number.isFinite(t) ? t : NaN;
+  };
+  const storedAppt = apptTime(jobRow.appointment_datetime);
+  const incomingAppt = apptTime(normalizeAppointmentDatetime(incoming.appointment_datetime));
+  const sameAppt = Number.isFinite(storedAppt) && Number.isFinite(incomingAppt) && storedAppt === incomingAppt;
+  const samePhone = String(jobRow.customer_phone || "").replace(/\D/g, "") === String(incoming.customer_phone || "").replace(/\D/g, "");
+  const sameType = String(jobRow.job_type || "").trim() === String(incoming.job_type || "").trim();
+  const sameDuration = Number(jobRow.duration_min || 0) === Number(incoming.duration_min || 0);
+  return sameAppt && samePhone && sameType && sameDuration;
+}
+
 // Customer App V2 urgent requests are just another entry point into the
 // existing admin urgent offer engine (handleAdminBookV2): this adapter only
 // (a) strips the request down to a customer-safe allowlist and (b) computes
@@ -25345,6 +25363,59 @@ console.log("[latlng_parse]", { ok: !!parsedLL });
   // (tech_type "all"), never a client_app-derived narrower set. Strictness comes
   // from the customer_slot_visible + service-matrix + monthly-calendar gates
   // inside customerAvailability, not from client_app.
+  // Payload-bound idempotency (checked BEFORE the availability gate): a genuine
+  // retry of the same request must replay its existing job even though that job
+  // now occupies the slot — so the replay lookup cannot sit behind the "slot
+  // full" check. Reusing the key with a materially different payload is rejected
+  // with 409 (no mutation, no old-job data leaked).
+  if (bm === "scheduled" && scheduledRequestKey && scheduledDeterministicToken) {
+    const idem = await pool.connect();
+    let prior = null;
+    try {
+      await idem.query("BEGIN");
+      await idem.query("SELECT pg_advisory_xact_lock(hashtext($1))", [scheduledRequestKey]);
+      const r = await idem.query(
+        `SELECT job_id, booking_code, booking_token, dispatch_mode, duration_min, job_price,
+                appointment_datetime, customer_phone, job_type
+           FROM public.jobs
+          WHERE booking_token=$1
+            AND job_source='customer'
+            AND COALESCE(booking_mode,'scheduled')='scheduled'
+            AND canceled_at IS NULL
+          LIMIT 1`,
+        [scheduledDeterministicToken]
+      );
+      await idem.query("COMMIT");
+      prior = r.rows[0] || null;
+    } catch (e) {
+      try { await idem.query("ROLLBACK"); } catch (_) {}
+      throw e;
+    } finally {
+      idem.release();
+    }
+    if (prior) {
+      if (!isSameScheduledPayload(prior, { appointment_datetime, customer_phone, job_type, duration_min: duration_min_v2 })) {
+        return res.status(409).json({
+          error: "คำขอนี้ถูกใช้ไปแล้วกับการจองอื่น กรุณาเริ่มการจองใหม่",
+          code: "IDEMPOTENCY_KEY_REUSED",
+        });
+      }
+      return res.json({
+        success: true,
+        replayed: true,
+        job_id: prior.job_id,
+        booking_code: prior.booking_code,
+        token: prior.booking_token,
+        booking_mode: "scheduled",
+        dispatch_mode: prior.dispatch_mode || "normal",
+        duration_min: Number(prior.duration_min || duration_min_v2 || 0),
+        effective_block_min: effectiveBlockMin(Number(prior.duration_min || duration_min_v2 || 0)),
+        travel_buffer_min: TRAVEL_BUFFER_MIN,
+        base_total: Number(prior.job_price || 0),
+      });
+    }
+  }
+
   const requestedTechType = bm === "urgent" ? "partner" : "all";
   try {
     if (bm === "scheduled") {
@@ -25387,7 +25458,7 @@ console.log("[latlng_parse]", { ok: !!parsedLL });
       await client.query("SELECT pg_advisory_xact_lock(hashtext($1))", [scheduledRequestKey]);
       const existing = await client.query(
         `SELECT job_id, booking_code, booking_token, booking_mode, dispatch_mode,
-                duration_min, job_price
+                duration_min, job_price, appointment_datetime, customer_phone, job_type
            FROM public.jobs
           WHERE booking_token=$1
             AND job_source='customer'
@@ -25397,8 +25468,16 @@ console.log("[latlng_parse]", { ok: !!parsedLL });
         [scheduledDeterministicToken]
       );
       if (existing.rows[0]) {
+        // Race safety net: a concurrent request with the same key committed first.
+        // Same payload -> replay; different payload -> key-reuse 409 (no mutation).
         const row = existing.rows[0];
         await client.query("COMMIT");
+        if (!isSameScheduledPayload(row, { appointment_datetime, customer_phone, job_type, duration_min: duration_min_v2 })) {
+          return res.status(409).json({
+            error: "คำขอนี้ถูกใช้ไปแล้วกับการจองอื่น กรุณาเริ่มการจองใหม่",
+            code: "IDEMPOTENCY_KEY_REUSED",
+          });
+        }
         return res.json({
           success: true,
           replayed: true,

--- a/server/routes/docs.js
+++ b/server/routes/docs.js
@@ -271,19 +271,11 @@ module.exports = function createDocumentRoutes(deps = {}) {
   </body></html>`;
   }
 
-  router.get("/docs/quote/:job_id", async (req, res) => {
-    const job_id = Number(req.params.job_id);
-    const data = await getJobDocData(job_id);
-    if (!data) return res.status(404).send("ไม่พบงาน");
-    res.setHeader("Content-Type", "text/html; charset=utf-8");
-    res.send(docHtml("ใบเสนอราคา", data));
-  });
-
-  // Job documents carry full customer PII (name, phone, address). A bare
-  // sequential job_id must never be enough to read one: the caller needs the
-  // job's booking_token (?key=..., which the tracking page embeds) or an
-  // authenticated admin session. Failures answer 404 (not 403) so the route
-  // does not confirm which job_ids exist.
+  // Job documents (quote / receipt / e-slip) carry full customer PII (name,
+  // phone, address, price). A bare sequential job_id must never be enough to
+  // read one: the caller needs the job's booking_token (?key=..., which the
+  // tracking page embeds) or an authenticated admin session. Denials answer 404
+  // (not 403) so the route is not an existence oracle for job_ids.
   async function canViewJobDoc(req, data) {
     const key = String((req.query && req.query.key) || "").trim();
     // getJobDocData returns { job, items, ... } — the token lives on the job row.
@@ -307,24 +299,46 @@ module.exports = function createDocumentRoutes(deps = {}) {
     return true;
   }
 
-  router.get("/docs/receipt/:job_id", async (req, res) => {
-    if (docsRateLimited(req, res)) return;
-    const job_id = Number(req.params.job_id);
-    const data = await getJobDocData(job_id);
-    if (!data) return res.status(404).send("ไม่พบงาน");
-    if (!(await canViewJobDoc(req, data))) return res.status(404).send("ไม่พบงาน");
+  // The token travels in the query string, so keep sensitive docs out of
+  // caches, referrers, and search indexes.
+  function setSensitiveDocHeaders(res) {
+    res.setHeader("Cache-Control", "private, no-store, max-age=0");
+    res.setHeader("Referrer-Policy", "no-referrer");
+    res.setHeader("X-Robots-Tag", "noindex, nofollow");
     res.setHeader("Content-Type", "text/html; charset=utf-8");
+  }
+
+  // One gate for every PII-bearing job document. Returns the doc data when the
+  // caller is authorised, otherwise sends the appropriate 404/429 and null.
+  async function loadAuthorizedJobDoc(req, res) {
+    if (docsRateLimited(req, res)) return null;
+    const job_id = Number(req.params.job_id);
+    if (!job_id) { res.status(404).send("ไม่พบงาน"); return null; }
+    const data = await getJobDocData(job_id);
+    if (!data) { res.status(404).send("ไม่พบงาน"); return null; }
+    if (!(await canViewJobDoc(req, data))) { res.status(404).send("ไม่พบงาน"); return null; }
+    return data;
+  }
+
+  router.get("/docs/quote/:job_id", async (req, res) => {
+    const data = await loadAuthorizedJobDoc(req, res);
+    if (!data) return;
+    setSensitiveDocHeaders(res);
+    res.send(docHtml("ใบเสนอราคา", data));
+  });
+
+  router.get("/docs/receipt/:job_id", async (req, res) => {
+    const data = await loadAuthorizedJobDoc(req, res);
+    if (!data) return;
+    setSensitiveDocHeaders(res);
     res.send(docHtml("ใบเสร็จรับเงิน", data));
   });
 
   router.get("/docs/eslip/:job_id", async (req, res) => {
-    if (docsRateLimited(req, res)) return;
-    const job_id = Number(req.params.job_id);
-    if (!job_id) return res.status(400).send("job_id ไม่ถูกต้อง");
     try {
-      const data = await getJobDocData(job_id);
-      if (!data) return res.status(404).send("ไม่พบงาน");
-      if (!(await canViewJobDoc(req, data))) return res.status(404).send("ไม่พบงาน");
+      const data = await loadAuthorizedJobDoc(req, res);
+      if (!data) return;
+      const job_id = Number(req.params.job_id);
       const slipR = await pool.query(
         `SELECT public_url
          FROM public.job_photos
@@ -334,7 +348,7 @@ module.exports = function createDocumentRoutes(deps = {}) {
         [job_id]
       );
       const slipUrl = slipR.rows?.[0]?.public_url || null;
-      res.setHeader("Content-Type", "text/html; charset=utf-8");
+      setSensitiveDocHeaders(res);
       res.send(eSlipHtml(data, slipUrl));
     } catch (e) {
       console.error(e);

--- a/server/routes/docs.js
+++ b/server/routes/docs.js
@@ -1,7 +1,10 @@
 module.exports = function createDocumentRoutes(deps = {}) {
   const express = require("express");
+  const trackingPrivacy = require("../services/public/trackingPrivacy");
   const router = express.Router();
   const pool = deps.pool || require("../db/pool");
+  const isAdminRequest = deps.isAdminRequest;
+  const docsRateLimiter = deps.docsRateLimiter || null;
   const accountingOwnerSignaturePublicUrl = deps.accountingOwnerSignaturePublicUrl;
   const accountingSignaturePublicUrl = deps.accountingSignaturePublicUrl;
   const accountingOwnerSignerName = deps.accountingOwnerSignerName;
@@ -13,7 +16,7 @@ module.exports = function createDocumentRoutes(deps = {}) {
 
   async function getJobDocData(job_id) {
     const jobR = await pool.query(
-      `SELECT job_id, booking_code, customer_name, customer_phone, job_type, appointment_datetime, address_text, job_price,
+      `SELECT job_id, booking_code, booking_token, customer_name, customer_phone, job_type, appointment_datetime, address_text, job_price,
               paid_at, paid_by, payment_status,
               final_signature_path, final_signature_at
        FROM public.jobs WHERE job_id=$1`,
@@ -276,20 +279,52 @@ module.exports = function createDocumentRoutes(deps = {}) {
     res.send(docHtml("ใบเสนอราคา", data));
   });
 
+  // Job documents carry full customer PII (name, phone, address). A bare
+  // sequential job_id must never be enough to read one: the caller needs the
+  // job's booking_token (?key=..., which the tracking page embeds) or an
+  // authenticated admin session. Failures answer 404 (not 403) so the route
+  // does not confirm which job_ids exist.
+  async function canViewJobDoc(req, data) {
+    const key = String((req.query && req.query.key) || "").trim();
+    // getJobDocData returns { job, items, ... } — the token lives on the job row.
+    const token = data && data.job ? data.job.booking_token : null;
+    if (key && token && trackingPrivacy.timingSafeEqualStr(key, String(token))) {
+      return true;
+    }
+    if (typeof isAdminRequest === "function") {
+      try {
+        if (await isAdminRequest(req)) return true;
+      } catch (_) { /* treated as not admin */ }
+    }
+    return false;
+  }
+
+  function docsRateLimited(req, res) {
+    if (!docsRateLimiter) return false;
+    const rate = docsRateLimiter.check(trackingPrivacy.clientIpKey(req));
+    if (rate.allowed) return false;
+    res.status(429).send("เรียกดูเอกสารถี่เกินไป กรุณารอสักครู่แล้วลองใหม่");
+    return true;
+  }
+
   router.get("/docs/receipt/:job_id", async (req, res) => {
+    if (docsRateLimited(req, res)) return;
     const job_id = Number(req.params.job_id);
     const data = await getJobDocData(job_id);
     if (!data) return res.status(404).send("ไม่พบงาน");
+    if (!(await canViewJobDoc(req, data))) return res.status(404).send("ไม่พบงาน");
     res.setHeader("Content-Type", "text/html; charset=utf-8");
     res.send(docHtml("ใบเสร็จรับเงิน", data));
   });
 
   router.get("/docs/eslip/:job_id", async (req, res) => {
+    if (docsRateLimited(req, res)) return;
     const job_id = Number(req.params.job_id);
     if (!job_id) return res.status(400).send("job_id ไม่ถูกต้อง");
     try {
       const data = await getJobDocData(job_id);
       if (!data) return res.status(404).send("ไม่พบงาน");
+      if (!(await canViewJobDoc(req, data))) return res.status(404).send("ไม่พบงาน");
       const slipR = await pool.query(
         `SELECT public_url
          FROM public.job_photos

--- a/server/services/public/trackingPrivacy.js
+++ b/server/services/public/trackingPrivacy.js
@@ -63,6 +63,10 @@ function redactPublicTrackPayload(payload) {
   const source = payload && typeof payload === "object" ? payload : {};
   const out = {
     access_level: "code",
+    // Non-sensitive: whether a LEGACY (tokenless) job can be reviewed via code +
+    // full phone. Reveals only that a review is possible — no PII, no token — so
+    // the tracking UI can offer the legacy review form on a booking_code lookup.
+    legacy_review_eligible: source.legacy_review_eligible === true,
     // The customer typed this in, so echoing it back is not a disclosure.
     booking_code: source.booking_code || null,
     // Status lane — enough to render progress, no PII.

--- a/server/services/public/trackingPrivacy.js
+++ b/server/services/public/trackingPrivacy.js
@@ -51,35 +51,36 @@ function shortenAddress(text, keepChars = 24) {
   return `${value.slice(0, keepChars)}…`;
 }
 
-// Redact a fully-built /public/track response payload for booking_code-based
-// lookups. Never mutates the input. Field LIST stays identical so existing
-// clients keep rendering — values are masked or nulled.
+// Build the response for a booking_code lookup with an explicit ALLOWLIST
+// (not a blacklist). A booking code is a short, shareable identifier, so a code
+// lookup returns only the minimum needed to answer "what state is my job in?"
+// plus a masked confirmation value. Anything not named here — customer_name,
+// exact/partial address, GPS, maps link, sequential job_id, technician notes,
+// job/unit photos, unit location/checklist data, cancel reason, review/complaint
+// text, receipt link, the booking_token, technician identity, and ANY field
+// added in future — is dropped by construction. Full detail requires the token.
 function redactPublicTrackPayload(payload) {
   const source = payload && typeof payload === "object" ? payload : {};
-  const redacted = { ...source };
-
-  // The token is the full-access credential — echoing it back to a
-  // booking_code caller would be privilege escalation.
-  redacted.booking_token = null;
-  redacted.customer_phone = maskPhone(source.customer_phone);
-  redacted.address_text = shortenAddress(source.address_text);
-  redacted.maps_url = null;
-  redacted.gps_latitude = null;
-  redacted.gps_longitude = null;
-  // Receipt documents carry full PII — token holders only.
-  redacted.receipt_url = null;
-
-  if (source.technician && typeof source.technician === "object") {
-    redacted.technician = { ...source.technician, phone: null };
-  }
-  if (Array.isArray(source.technician_team)) {
-    redacted.technician_team = source.technician_team.map((member) =>
-      member && typeof member === "object" ? { ...member, phone: null } : member
-    );
-  }
-
-  redacted.access_level = "code";
-  return redacted;
+  const out = {
+    access_level: "code",
+    // The customer typed this in, so echoing it back is not a disclosure.
+    booking_code: source.booking_code || null,
+    // Status lane — enough to render progress, no PII.
+    job_status: source.job_status || null,
+    booking_mode: source.booking_mode || null,
+    dispatch_mode: source.dispatch_mode || null,
+    appointment_datetime: source.appointment_datetime || null,
+    duration_min: source.duration_min == null ? null : source.duration_min,
+    // Progress signals (timestamps only — no free-text reasons).
+    travel_started_at: source.travel_started_at || null,
+    checkin_at: source.checkin_at || null,
+    started_at: source.started_at || null,
+    finished_at: source.finished_at || null,
+    canceled_at: source.canceled_at || null,
+    // A masked confirmation aid so the customer recognises their own booking.
+    customer_phone: maskPhone(source.customer_phone),
+  };
+  return out;
 }
 
 // Fixed-window in-memory rate limiter with an LRU cap so the map can never
@@ -116,12 +117,24 @@ function createPublicLookupRateLimiter(options = {}) {
   return { check, _size: () => hits.size };
 }
 
-// Per-client key: first hop of X-Forwarded-For when present (we sit behind a
-// proxy in production), otherwise the socket address.
+// Per-client key. IMPORTANT: never read the raw X-Forwarded-For header — the
+// leftmost hop is fully attacker-controlled, so trusting it lets a caller mint
+// a fresh identity (and a fresh rate-limit budget) on every request. Instead we
+// use Express's req.ip, which is derived under the app's explicit
+// `trust proxy` setting (1 = a single front proxy, e.g. Render). With that
+// config an attacker can only prepend XFF entries to the left of the proxy's
+// appended client IP, so req.ip stays the real client address. Fall back to the
+// socket peer only when Express did not resolve an ip.
+//
+// NOTE: this limiter is PER PROCESS (in-memory). Behind multiple app instances
+// the effective budget is per-instance; it is a brute-force speed bump, not a
+// distributed quota. A shared store (e.g. Redis) would be needed for a global
+// guarantee across instances.
 function clientIpKey(req) {
-  const fwd = String((req && req.headers && req.headers["x-forwarded-for"]) || "").split(",")[0].trim();
-  if (fwd) return fwd;
-  return String((req && (req.ip || (req.socket && req.socket.remoteAddress))) || "unknown");
+  const ip = req && typeof req.ip === "string" ? req.ip.trim() : "";
+  if (ip) return ip;
+  const socketIp = req && req.socket && req.socket.remoteAddress;
+  return String(socketIp || "unknown");
 }
 
 module.exports = {

--- a/server/services/public/trackingPrivacy.js
+++ b/server/services/public/trackingPrivacy.js
@@ -1,0 +1,135 @@
+"use strict";
+
+// Privacy layer for the PUBLIC tracking surfaces (/public/track,
+// /public/urgent-status, /docs/receipt, /docs/eslip).
+//
+// Threat model: booking_code is a short, human-readable code (CWF + 7 chars)
+// that customers write down and read aloud to staff — it WILL leak. It must
+// therefore never unlock full personal data by itself:
+//   - full access (raw phone, address, GPS, maps link, receipt) requires the
+//     long random booking_token the app received at booking time
+//   - a booking_code lookup still works, but PII comes back masked/omitted
+//   - every public lookup endpoint is rate-limited per client IP so neither
+//     codes nor tokens can be brute-forced
+//
+// This module is dependency-free and fully unit-tested — see
+// test/customerTrackingPrivacy.test.js. index.js wires it into the routes.
+
+const crypto = require("crypto");
+
+// Constant-time string comparison (length leak is fine — both sides are
+// non-secret formats; we only care about content comparison).
+function timingSafeEqualStr(a, b) {
+  const bufA = Buffer.from(String(a == null ? "" : a));
+  const bufB = Buffer.from(String(b == null ? "" : b));
+  if (bufA.length !== bufB.length) return false;
+  return crypto.timingSafeEqual(bufA, bufB);
+}
+
+// Full access only when the query string equals the job's booking_token.
+// A booking_code match (or anything else) is treated as limited access.
+function isFullAccessQuery(q, row) {
+  const token = row && row.booking_token;
+  if (!token) return false;
+  return timingSafeEqualStr(String(q == null ? "" : q).trim(), String(token));
+}
+
+// "0812345678" -> "•••• 5678" (keeps just enough for the customer to
+// recognise their own number; useless for a stranger).
+function maskPhone(phone) {
+  const digits = String(phone == null ? "" : phone).replace(/\D/g, "");
+  if (!digits) return null;
+  return `•••• ${digits.slice(-4)}`;
+}
+
+// Keep only the leading part of the address — enough for the customer to
+// recognise the job, not enough to locate the house.
+function shortenAddress(text, keepChars = 24) {
+  const value = String(text == null ? "" : text).trim();
+  if (!value) return value;
+  if (value.length <= keepChars) return value;
+  return `${value.slice(0, keepChars)}…`;
+}
+
+// Redact a fully-built /public/track response payload for booking_code-based
+// lookups. Never mutates the input. Field LIST stays identical so existing
+// clients keep rendering — values are masked or nulled.
+function redactPublicTrackPayload(payload) {
+  const source = payload && typeof payload === "object" ? payload : {};
+  const redacted = { ...source };
+
+  // The token is the full-access credential — echoing it back to a
+  // booking_code caller would be privilege escalation.
+  redacted.booking_token = null;
+  redacted.customer_phone = maskPhone(source.customer_phone);
+  redacted.address_text = shortenAddress(source.address_text);
+  redacted.maps_url = null;
+  redacted.gps_latitude = null;
+  redacted.gps_longitude = null;
+  // Receipt documents carry full PII — token holders only.
+  redacted.receipt_url = null;
+
+  if (source.technician && typeof source.technician === "object") {
+    redacted.technician = { ...source.technician, phone: null };
+  }
+  if (Array.isArray(source.technician_team)) {
+    redacted.technician_team = source.technician_team.map((member) =>
+      member && typeof member === "object" ? { ...member, phone: null } : member
+    );
+  }
+
+  redacted.access_level = "code";
+  return redacted;
+}
+
+// Fixed-window in-memory rate limiter with an LRU cap so the map can never
+// grow without bound. One instance per endpoint (budgets differ).
+function createPublicLookupRateLimiter(options = {}) {
+  const windowMs = Math.max(1000, Number(options.windowMs || 60000));
+  const max = Math.max(1, Number(options.max || 30));
+  const maxKeys = Math.max(100, Number(options.maxKeys || 5000));
+  const now = typeof options.now === "function" ? options.now : Date.now;
+  const hits = new Map();
+
+  function check(rawKey) {
+    const key = String(rawKey || "unknown");
+    const t = now();
+    let entry = hits.get(key);
+    if (!entry || t - entry.start >= windowMs) entry = { start: t, count: 0 };
+    entry.count += 1;
+    // Refresh recency so eviction removes the least recently seen key.
+    hits.delete(key);
+    hits.set(key, entry);
+    if (hits.size > maxKeys) {
+      const oldest = hits.keys().next().value;
+      hits.delete(oldest);
+    }
+    if (entry.count > max) {
+      return {
+        allowed: false,
+        retry_after_s: Math.max(1, Math.ceil((entry.start + windowMs - t) / 1000)),
+      };
+    }
+    return { allowed: true };
+  }
+
+  return { check, _size: () => hits.size };
+}
+
+// Per-client key: first hop of X-Forwarded-For when present (we sit behind a
+// proxy in production), otherwise the socket address.
+function clientIpKey(req) {
+  const fwd = String((req && req.headers && req.headers["x-forwarded-for"]) || "").split(",")[0].trim();
+  if (fwd) return fwd;
+  return String((req && (req.ip || (req.socket && req.socket.remoteAddress))) || "unknown");
+}
+
+module.exports = {
+  clientIpKey,
+  createPublicLookupRateLimiter,
+  isFullAccessQuery,
+  maskPhone,
+  redactPublicTrackPayload,
+  shortenAddress,
+  timingSafeEqualStr,
+};

--- a/test/customerAppRecovery.test.js
+++ b/test/customerAppRecovery.test.js
@@ -236,7 +236,7 @@ test("Customer App build id is consistent across shell and service worker", () =
   const sw = read("customer-app/sw.js");
   const app = read("customer-app/assets/customer-app.js");
   const manifest = read("customer-app/manifest.webmanifest");
-  const build = "20260708_launch_gate_v1";
+  const build = "20260709_review_legacy_v1";
 
   assert.match(index, new RegExp(`customer-app\\.css\\?v=${build}`));
   assert.match(index, new RegExp(`modules\\/api\\.js\\?v=${build}`));
@@ -254,7 +254,7 @@ test("Customer App build id is consistent across shell and service worker", () =
 test("store module is loaded in index.html and precached in the service worker app shell", () => {
   const index = read("customer-app/index.html");
   const sw = read("customer-app/sw.js");
-  const build = "20260708_launch_gate_v1";
+  const build = "20260709_review_legacy_v1";
 
   assert.match(index, new RegExp(`modules/store\\.js\\?v=${build}`));
   assert.match(sw, /`\.\/modules\/store\.js\?v=\$\{BUILD_ID\}`/);

--- a/test/customerAppRecovery.test.js
+++ b/test/customerAppRecovery.test.js
@@ -236,7 +236,7 @@ test("Customer App build id is consistent across shell and service worker", () =
   const sw = read("customer-app/sw.js");
   const app = read("customer-app/assets/customer-app.js");
   const manifest = read("customer-app/manifest.webmanifest");
-  const build = "20260707_booking_admin_notify_v1";
+  const build = "20260708_launch_gate_v1";
 
   assert.match(index, new RegExp(`customer-app\\.css\\?v=${build}`));
   assert.match(index, new RegExp(`modules\\/api\\.js\\?v=${build}`));
@@ -254,7 +254,7 @@ test("Customer App build id is consistent across shell and service worker", () =
 test("store module is loaded in index.html and precached in the service worker app shell", () => {
   const index = read("customer-app/index.html");
   const sw = read("customer-app/sw.js");
-  const build = "20260707_booking_admin_notify_v1";
+  const build = "20260708_launch_gate_v1";
 
   assert.match(index, new RegExp(`modules/store\\.js\\?v=${build}`));
   assert.match(sw, /`\.\/modules\/store\.js\?v=\$\{BUILD_ID\}`/);

--- a/test/customerAppRecovery.test.js
+++ b/test/customerAppRecovery.test.js
@@ -2038,7 +2038,12 @@ function renderTracking(root, data) {
   return container.innerHTML;
 }
 
+// A token-level lookup (the app received the long booking_token at booking
+// time): access_level "token" travels alongside it. The legacy technician
+// review form is a WRITE and only renders on token access — see the P0-5
+// tracking privacy split — so these done-job fixtures carry it explicitly.
 const DONE_JOB_BASE = {
+  access_level: "token",
   booking_token: "TOK1", booking_code: "BK1", job_status: "เสร็จแล้ว", finished_at: "2026-06-20T10:00:00Z",
 };
 

--- a/test/customerAppStorePayment.test.js
+++ b/test/customerAppStorePayment.test.js
@@ -58,7 +58,7 @@ test("store falls back to the LINE hand-off when payment is unconfigured or the 
 test("payment step styles exist and the Customer App payment build id is bumped", () => {
   assert.match(cssSrc, /\.pay-method-btn/);
   assert.match(cssSrc, /\.pay-qr-img/);
-  assert.match(read("customer-app/index.html"), /modules\/store\.js\?v=20260708_launch_gate_v1/);
-  assert.match(read("customer-app/sw.js"), /BUILD_ID = "20260708_launch_gate_v1"/);
+  assert.match(read("customer-app/index.html"), /modules\/store\.js\?v=20260709_review_legacy_v1/);
+  assert.match(read("customer-app/sw.js"), /BUILD_ID = "20260709_review_legacy_v1"/);
   assert.match(storeSrc, /payment-security 20260705 loaded/);
 });

--- a/test/customerAppStorePayment.test.js
+++ b/test/customerAppStorePayment.test.js
@@ -58,7 +58,7 @@ test("store falls back to the LINE hand-off when payment is unconfigured or the 
 test("payment step styles exist and the Customer App payment build id is bumped", () => {
   assert.match(cssSrc, /\.pay-method-btn/);
   assert.match(cssSrc, /\.pay-qr-img/);
-  assert.match(read("customer-app/index.html"), /modules\/store\.js\?v=20260707_booking_admin_notify_v1/);
-  assert.match(read("customer-app/sw.js"), /BUILD_ID = "20260707_booking_admin_notify_v1"/);
+  assert.match(read("customer-app/index.html"), /modules\/store\.js\?v=20260708_launch_gate_v1/);
+  assert.match(read("customer-app/sw.js"), /BUILD_ID = "20260708_launch_gate_v1"/);
   assert.match(storeSrc, /payment-security 20260705 loaded/);
 });

--- a/test/customerBookingAdminNotifications.test.js
+++ b/test/customerBookingAdminNotifications.test.js
@@ -311,10 +311,10 @@ test("admin/customer frontend cache versions are bumped for booking notification
   assert.doesNotMatch(adminReviewHtml, /admin-review-v2\.js\?v=20260707_customer_booking_notify_v2/);
   assert.match(adminReviewHtml, /admin-review-ai-intake\.js\?v=ai-booking-intake-customer-cards-v11-admin-alert-gate/);
   assert.doesNotMatch(adminReviewHtml, /admin-review-ai-intake\.js\?v=ai-booking-intake-customer-cards-v10/);
-  assert.match(customerIndex, /bookingScheduled\.js\?v=20260707_booking_admin_notify_v1/);
-  assert.match(customerIndex, /state\.js\?v=20260707_booking_admin_notify_v1/);
-  assert.match(customerSw, /const BUILD_ID = "20260707_booking_admin_notify_v1"/);
-  assert.match(customerManifest, /20260707_booking_admin_notify_v1/);
+  assert.match(customerIndex, /bookingScheduled\.js\?v=20260708_launch_gate_v1/);
+  assert.match(customerIndex, /state\.js\?v=20260708_launch_gate_v1/);
+  assert.match(customerSw, /const BUILD_ID = "20260708_launch_gate_v1"/);
+  assert.match(customerManifest, /20260708_launch_gate_v1/);
 });
 
 test("behavior: review queue only includes customer urgent waiting rows while preserving review statuses", () => {

--- a/test/customerBookingAdminNotifications.test.js
+++ b/test/customerBookingAdminNotifications.test.js
@@ -311,10 +311,10 @@ test("admin/customer frontend cache versions are bumped for booking notification
   assert.doesNotMatch(adminReviewHtml, /admin-review-v2\.js\?v=20260707_customer_booking_notify_v2/);
   assert.match(adminReviewHtml, /admin-review-ai-intake\.js\?v=ai-booking-intake-customer-cards-v11-admin-alert-gate/);
   assert.doesNotMatch(adminReviewHtml, /admin-review-ai-intake\.js\?v=ai-booking-intake-customer-cards-v10/);
-  assert.match(customerIndex, /bookingScheduled\.js\?v=20260708_launch_gate_v1/);
-  assert.match(customerIndex, /state\.js\?v=20260708_launch_gate_v1/);
-  assert.match(customerSw, /const BUILD_ID = "20260708_launch_gate_v1"/);
-  assert.match(customerManifest, /20260708_launch_gate_v1/);
+  assert.match(customerIndex, /bookingScheduled\.js\?v=20260709_review_legacy_v1/);
+  assert.match(customerIndex, /state\.js\?v=20260709_review_legacy_v1/);
+  assert.match(customerSw, /const BUILD_ID = "20260709_review_legacy_v1"/);
+  assert.match(customerManifest, /20260709_review_legacy_v1/);
 });
 
 test("behavior: review queue only includes customer urgent waiting rows while preserving review statuses", () => {

--- a/test/customerBookingKillSwitch.test.js
+++ b/test/customerBookingKillSwitch.test.js
@@ -71,6 +71,36 @@ test("scheduled availability + reservation no longer depend on client_app", () =
   assert.doesNotMatch(bookHandler, /bm === "scheduled" && clientApp === "customer_app_v2"/);
 });
 
+test("scheduled idempotency is payload-bound and checked before the availability gate", () => {
+  // The pre-flight replay lookup must run before the "slot full" availability
+  // check, so a genuine retry replays even though its own job now holds the slot.
+  const preflightIdx = bookHandler.indexOf("Payload-bound idempotency (checked BEFORE the availability gate)");
+  const availabilityIdx = bookHandler.indexOf("customerAvailability.hasAvailableStart");
+  assert.ok(preflightIdx > 0, "pre-flight idempotency block missing");
+  assert.ok(preflightIdx < availabilityIdx, "idempotency replay must precede the availability gate");
+  // Reusing a key with a different payload is a 409, never a silent old-job return.
+  assert.match(bookHandler, /code: "IDEMPOTENCY_KEY_REUSED"/);
+  assert.match(bookHandler, /if \(!isSameScheduledPayload\(prior,/);
+  // The helper compares the material fields (appointment, phone, job type, duration).
+  assert.match(indexSrc, /function isSameScheduledPayload\(jobRow, incoming\)/);
+  assert.match(indexSrc, /const sameAppt =/);
+  assert.match(indexSrc, /const samePhone =/);
+  assert.match(indexSrc, /const sameType =/);
+  assert.match(indexSrc, /const sameDuration =/);
+});
+
+test("legacy customer.html seeds the scheduled request key from a CSPRNG and persists it across reloads", () => {
+  const customerHtml = fs.readFileSync(path.join(REPO_ROOT, "customer.html"), "utf8");
+  // CSPRNG only — never Math.random (the key seeds a booking token).
+  assert.match(customerHtml, /crypto\.randomUUID\(\)/);
+  assert.match(customerHtml, /crypto\.getRandomValues/);
+  assert.doesNotMatch(customerHtml, /Math\.random\(\)[^;]*scheduled_request_key|scheduled_request_key[\s\S]{0,200}Math\.random/);
+  // Survives reload via sessionStorage; cleared on confirmed success.
+  assert.match(customerHtml, /sessionStorage\.getItem\("cwf_sched_key"\)/);
+  assert.match(customerHtml, /sessionStorage\.setItem\("cwf_sched_key"/);
+  assert.match(customerHtml, /sessionStorage\.removeItem\("cwf_sched_key"\)/);
+});
+
 test("each customer flag is referenced only at its declaration and the single gate (admin booking untouched)", () => {
   // Declaration line mentions the name twice (const + env string) + one gate use.
   assert.equal((indexSrc.match(/ENABLE_CUSTOMER_SCHEDULED_BOOKING/g) || []).length, 3);

--- a/test/customerBookingKillSwitch.test.js
+++ b/test/customerBookingKillSwitch.test.js
@@ -80,13 +80,29 @@ test("scheduled idempotency is payload-bound and checked before the availability
   assert.ok(preflightIdx < availabilityIdx, "idempotency replay must precede the availability gate");
   // Reusing a key with a different payload is a 409, never a silent old-job return.
   assert.match(bookHandler, /code: "IDEMPOTENCY_KEY_REUSED"/);
-  assert.match(bookHandler, /if \(!isSameScheduledPayload\(prior,/);
-  // The helper compares the material fields (appointment, phone, job type, duration).
-  assert.match(indexSrc, /function isSameScheduledPayload\(jobRow, incoming\)/);
-  assert.match(indexSrc, /const sameAppt =/);
-  assert.match(indexSrc, /const samePhone =/);
-  assert.match(indexSrc, /const sameType =/);
-  assert.match(indexSrc, /const sameDuration =/);
+  // Both the pre-flight and the in-transaction race path use the SAME full match.
+  assert.equal((bookHandler.match(/scheduledPayloadMatchesExisting\(pool, /g) || []).length, 2);
+});
+
+test("idempotency payload comparison covers every canonical material field", () => {
+  // Scalars persisted on the jobs row.
+  assert.match(indexSrc, /function scheduledScalarsMatch\(jobRow, incoming\)/);
+  for (const field of ["customer_phone", "customer_name", "address_text", "maps_url", "job_zone", "job_type", "customer_note", "allow_time_proposal", "duration_min"]) {
+    assert.match(indexSrc, new RegExp(field), `scalar comparison must include ${field}`);
+  }
+  // The service composition (AC type/variant/BTU/qty/price) is compared via the
+  // canonical job_items signature, built with the SAME normalizer as a real booking.
+  assert.match(indexSrc, /function bookingLineSignature\(rows\)/);
+  assert.match(indexSrc, /loadStoredBookingLineSignature/);
+  assert.match(indexSrc, /buildIncomingBookingLineSignature/);
+  assert.match(indexSrc, /customerPricingHelpers\.buildCustomerServiceLineItemsFromPayload/);
+  // The full match = scalars + line signature.
+  assert.match(indexSrc, /async function scheduledPayloadMatchesExisting\(db, jobRow, incoming\)/);
+  assert.match(indexSrc, /storedSig === incomingSig/);
+  // The pre-flight replay lookup still precedes the availability gate.
+  const preflightIdx = bookHandler.indexOf("Payload-bound idempotency (checked BEFORE the availability gate)");
+  const availabilityIdx = bookHandler.indexOf("customerAvailability.hasAvailableStart");
+  assert.ok(preflightIdx > 0 && preflightIdx < availabilityIdx, "idempotency replay must precede the availability gate");
 });
 
 test("legacy customer.html seeds the scheduled request key from a CSPRNG and persists it across reloads", () => {

--- a/test/customerBookingKillSwitch.test.js
+++ b/test/customerBookingKillSwitch.test.js
@@ -36,13 +36,39 @@ test("an unknown booking mode is rejected outright (no fall-through)", () => {
 
 test("the gate runs BEFORE urgent routing, request-key derivation, and any insert", () => {
   const gateIdx = bookHandler.indexOf("canonicalBookingMode");
-  const urgentRouteIdx = bookHandler.indexOf("isCustomerAppUrgentBook(req.body");
+  const urgentRouteIdx = bookHandler.indexOf("return handlePublicCustomerUrgentBook");
   const tokenIdx = bookHandler.indexOf("deriveCustomerScheduledBookingToken(scheduledRequestKey)");
   const insertIdx = bookHandler.indexOf("INSERT INTO public.jobs");
   assert.ok(gateIdx > 0, "gate missing");
   assert.ok(gateIdx < urgentRouteIdx, "gate must precede urgent routing");
   assert.ok(gateIdx < tokenIdx, "gate must precede request-key derivation");
   assert.ok(gateIdx < insertIdx, "gate must precede the job insert");
+});
+
+// ---------- client_app is NOT a security boundary (canonical protections) ----
+
+test("urgent routing keys off the canonical booking_mode, not client_app", () => {
+  // Every public urgent request must reach the customer-safe adapter on mode
+  // alone — an unauthenticated caller must not be able to drop/forge client_app
+  // to skip the sanitiser and hit the raw urgent engine.
+  assert.match(bookHandler, /if \(canonicalBookingMode === "urgent"\) \{\s*\n\s*return handlePublicCustomerUrgentBook\(req, res\);/);
+  assert.doesNotMatch(bookHandler, /if \(isCustomerAppUrgentBook\(req\.body/);
+});
+
+test("scheduled request-key/idempotency is required for ALL scheduled bookings, not gated on client_app", () => {
+  // The key is read + required on the canonical booking_mode, never client_app.
+  assert.match(bookHandler, /const scheduledRequestKey = bm === "scheduled"\s*\n\s*\? String\(scheduled_request_key/);
+  assert.match(bookHandler, /if \(bm === "scheduled" && !validScheduledRequestKey\) \{/);
+  assert.doesNotMatch(bookHandler, /clientApp === "customer_app_v2" && !validScheduledRequestKey/);
+  // The idempotency replay itself keys only off the request key, not client_app.
+  assert.match(bookHandler, /if \(scheduledRequestKey && scheduledDeterministicToken\) \{/);
+});
+
+test("scheduled availability + reservation no longer depend on client_app", () => {
+  // The customer availability check and the technician reservation gate on the
+  // canonical scheduled mode, so a forged/omitted client_app cannot downgrade
+  // to a weaker (or missing) capacity path.
+  assert.doesNotMatch(bookHandler, /bm === "scheduled" && clientApp === "customer_app_v2"/);
 });
 
 test("each customer flag is referenced only at its declaration and the single gate (admin booking untouched)", () => {

--- a/test/customerBookingKillSwitch.test.js
+++ b/test/customerBookingKillSwitch.test.js
@@ -10,46 +10,45 @@ const indexSrc = fs.readFileSync(path.join(REPO_ROOT, "index.js"), "utf8");
 const scheduledSrc = fs.readFileSync(path.join(REPO_ROOT, "customer-app", "modules", "bookingScheduled.js"), "utf8");
 const urgentSrc = fs.readFileSync(path.join(REPO_ROOT, "customer-app", "modules", "bookingUrgent.js"), "utf8");
 
-// The customer self-booking lanes must FAIL CLOSED: OFF unless the operator
-// explicitly enables them in the environment. When off, /public/book answers
-// 503 with a machine-readable code + LINE URL BEFORE any job work, so a closed
-// lane can never create a job (and therefore never a duplicate).
+// The /public/book source (handler body only) for gate-ordering assertions.
+const bookHandler = indexSrc.slice(indexSrc.indexOf('app.post("/public/book"'));
 
 test("both kill switches exist and default to OFF (fail closed)", () => {
   assert.match(indexSrc, /const ENABLE_CUSTOMER_SCHEDULED_BOOKING = envBool\("ENABLE_CUSTOMER_SCHEDULED_BOOKING", false\);/);
   assert.match(indexSrc, /const ENABLE_CUSTOMER_URGENT_BOOKING = envBool\("ENABLE_CUSTOMER_URGENT_BOOKING", false\);/);
 });
 
-test("scheduled gate rejects customer_app_v2 scheduled bookings with 503 + code + LINE url before any booking work", () => {
-  const gate = indexSrc.match(/if \(bm === "scheduled" && clientApp === "customer_app_v2" && !ENABLE_CUSTOMER_SCHEDULED_BOOKING\) \{[\s\S]*?\n  \}/);
-  assert.ok(gate, "scheduled kill-switch gate not found");
-  assert.match(gate[0], /status\(503\)/);
-  assert.match(gate[0], /SCHEDULED_BOOKING_DISABLED/);
-  assert.match(gate[0], /line_url: CWF_LINE_CONTACT_URL/);
-  // The gate must run before the request-key/idempotency/insert pipeline.
-  const gateIndex = indexSrc.indexOf("SCHEDULED_BOOKING_DISABLED");
-  const insertIndex = indexSrc.indexOf("deriveCustomerScheduledBookingToken(scheduledRequestKey)");
-  assert.ok(gateIndex > 0 && insertIndex > 0 && gateIndex < insertIndex, "gate must precede booking pipeline");
-});
-
-test("urgent gate rejects customer urgent bookings with 503 + code + LINE url before the urgent handler", () => {
-  const gate = indexSrc.match(/if \(isCustomerAppUrgentBook\(req\.body \|\| \{\}\)\) \{[\s\S]*?return handlePublicCustomerUrgentBook\(req, res\);\n  \}/);
-  assert.ok(gate, "urgent branch not found");
-  assert.match(gate[0], /!ENABLE_CUSTOMER_URGENT_BOOKING/);
-  assert.match(gate[0], /URGENT_BOOKING_DISABLED/);
+test("the kill-switch gate keys off the canonical booking_mode, NOT the attacker-controlled client_app", () => {
+  const gate = bookHandler.match(/const canonicalBookingMode = String\(booking_mode[\s\S]*?SCHEDULED_BOOKING_DISABLED[\s\S]*?\n  \}/);
+  assert.ok(gate, "canonical kill-switch gate not found");
+  // The whole gate block must not mention client_app — it is not a boundary.
+  assert.doesNotMatch(gate[0], /client_app|clientApp/);
+  assert.match(gate[0], /canonicalBookingMode === "urgent" && !ENABLE_CUSTOMER_URGENT_BOOKING/);
+  assert.match(gate[0], /canonicalBookingMode === "scheduled" && !ENABLE_CUSTOMER_SCHEDULED_BOOKING/);
   assert.match(gate[0], /status\(503\)/);
   assert.match(gate[0], /line_url: CWF_LINE_CONTACT_URL/);
-  // Reject BEFORE handlePublicCustomerUrgentBook is invoked.
-  assert.ok(gate[0].indexOf("URGENT_BOOKING_DISABLED") < gate[0].indexOf("handlePublicCustomerUrgentBook(req, res)"));
 });
 
-test("admin booking is not gated by the customer kill switches", () => {
-  // The flags are referenced only at the declaration (name appears twice on
-  // that line: const + env var string) and at the single public customer gate.
-  const scheduledUses = indexSrc.match(/ENABLE_CUSTOMER_SCHEDULED_BOOKING/g) || [];
-  const urgentUses = indexSrc.match(/ENABLE_CUSTOMER_URGENT_BOOKING/g) || [];
-  assert.equal(scheduledUses.length, 3); // declaration (x2) + gate
-  assert.equal(urgentUses.length, 3); // declaration (x2) + gate
+test("an unknown booking mode is rejected outright (no fall-through)", () => {
+  assert.match(bookHandler, /canonicalBookingMode !== "scheduled" && canonicalBookingMode !== "urgent"/);
+  assert.match(bookHandler, /code: "UNKNOWN_BOOKING_MODE"/);
+});
+
+test("the gate runs BEFORE urgent routing, request-key derivation, and any insert", () => {
+  const gateIdx = bookHandler.indexOf("canonicalBookingMode");
+  const urgentRouteIdx = bookHandler.indexOf("isCustomerAppUrgentBook(req.body");
+  const tokenIdx = bookHandler.indexOf("deriveCustomerScheduledBookingToken(scheduledRequestKey)");
+  const insertIdx = bookHandler.indexOf("INSERT INTO public.jobs");
+  assert.ok(gateIdx > 0, "gate missing");
+  assert.ok(gateIdx < urgentRouteIdx, "gate must precede urgent routing");
+  assert.ok(gateIdx < tokenIdx, "gate must precede request-key derivation");
+  assert.ok(gateIdx < insertIdx, "gate must precede the job insert");
+});
+
+test("each customer flag is referenced only at its declaration and the single gate (admin booking untouched)", () => {
+  // Declaration line mentions the name twice (const + env string) + one gate use.
+  assert.equal((indexSrc.match(/ENABLE_CUSTOMER_SCHEDULED_BOOKING/g) || []).length, 3);
+  assert.equal((indexSrc.match(/ENABLE_CUSTOMER_URGENT_BOOKING/g) || []).length, 3);
 });
 
 test("the LINE contact URL is configurable with a safe default", () => {
@@ -62,7 +61,6 @@ test("scheduled wizard shows the LINE hand-off (and hides retry) when the lane i
   assert.match(scheduledSrc, /SCHEDULED_BOOKING_DISABLED/);
   assert.match(scheduledSrc, /disabled_line_url/);
   assert.match(scheduledSrc, /ติดต่อแอดมินทาง LINE/);
-  // When disabled, the submit button is replaced (retrying a closed lane is pointless).
   assert.match(scheduledSrc, /submit\.status === "error" && submit\.disabled_line_url \? "" : `<button type="button" class="primary-btn wizard-submit-btn"/);
 });
 
@@ -76,4 +74,34 @@ test("urgent review shows the LINE hand-off (and hides confirm) when the lane is
 test("cache-bust markers are present for the changed booking modules", () => {
   assert.match(scheduledSrc, /\[customer-booking\] launch-gate 20260708 loaded/);
   assert.match(urgentSrc, /\[customer-urgent\] launch-gate 20260708 loaded/);
+});
+
+// ---------- P0-5: /public/review write authorisation ----------
+
+const reviewStart = indexSrc.indexOf('app.post("/public/review"');
+const reviewHandler = indexSrc.slice(reviewStart, indexSrc.indexOf("\napp.", reviewStart + 10));
+
+test("public review looks up by exactly one credential path — never `code OR token`", () => {
+  assert.doesNotMatch(reviewHandler, /WHERE booking_code=\$1 OR booking_token=\$1/);
+  assert.match(reviewHandler, /WHERE booking_token=\$1 LIMIT 1 FOR UPDATE/);
+  assert.match(reviewHandler, /WHERE booking_code=\$1 LIMIT 1 FOR UPDATE/);
+});
+
+test("a tokened job cannot be reviewed via the legacy code+phone path (no downgrade)", () => {
+  assert.match(reviewHandler, /const jobHasToken = Boolean\(String\(job\.booking_token \|\| ""\)\.trim\(\)\)/);
+  assert.match(reviewHandler, /if \(jobHasToken\) deny\(\);/);
+  // Legacy path requires a full exact phone match.
+  assert.match(reviewHandler, /jobPhoneDigits !== phoneDigits/);
+});
+
+test("public review is dual rate-limited (IP + identifier) and returns no PII/token", () => {
+  assert.match(reviewHandler, /publicReviewIpRateLimiter\.check\(trackingPrivacy\.clientIpKey\(req\)\)/);
+  assert.match(reviewHandler, /publicReviewKeyRateLimiter\.check\(identifierKey\)/);
+  assert.match(reviewHandler, /res\.json\(\{ success: true \}\)/);
+  assert.doesNotMatch(reviewHandler, /avg_rating: avg/);
+});
+
+test("public review collapses all authz/eligibility failures to one generic error", () => {
+  assert.match(reviewHandler, /GENERIC_REVIEW_ERROR/);
+  assert.match(reviewHandler, /const deny = \(\) => \{[\s\S]*?e\.generic = true; throw e; \};/);
 });

--- a/test/customerBookingKillSwitch.test.js
+++ b/test/customerBookingKillSwitch.test.js
@@ -1,0 +1,79 @@
+"use strict";
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+
+const REPO_ROOT = path.resolve(__dirname, "..");
+const indexSrc = fs.readFileSync(path.join(REPO_ROOT, "index.js"), "utf8");
+const scheduledSrc = fs.readFileSync(path.join(REPO_ROOT, "customer-app", "modules", "bookingScheduled.js"), "utf8");
+const urgentSrc = fs.readFileSync(path.join(REPO_ROOT, "customer-app", "modules", "bookingUrgent.js"), "utf8");
+
+// The customer self-booking lanes must FAIL CLOSED: OFF unless the operator
+// explicitly enables them in the environment. When off, /public/book answers
+// 503 with a machine-readable code + LINE URL BEFORE any job work, so a closed
+// lane can never create a job (and therefore never a duplicate).
+
+test("both kill switches exist and default to OFF (fail closed)", () => {
+  assert.match(indexSrc, /const ENABLE_CUSTOMER_SCHEDULED_BOOKING = envBool\("ENABLE_CUSTOMER_SCHEDULED_BOOKING", false\);/);
+  assert.match(indexSrc, /const ENABLE_CUSTOMER_URGENT_BOOKING = envBool\("ENABLE_CUSTOMER_URGENT_BOOKING", false\);/);
+});
+
+test("scheduled gate rejects customer_app_v2 scheduled bookings with 503 + code + LINE url before any booking work", () => {
+  const gate = indexSrc.match(/if \(bm === "scheduled" && clientApp === "customer_app_v2" && !ENABLE_CUSTOMER_SCHEDULED_BOOKING\) \{[\s\S]*?\n  \}/);
+  assert.ok(gate, "scheduled kill-switch gate not found");
+  assert.match(gate[0], /status\(503\)/);
+  assert.match(gate[0], /SCHEDULED_BOOKING_DISABLED/);
+  assert.match(gate[0], /line_url: CWF_LINE_CONTACT_URL/);
+  // The gate must run before the request-key/idempotency/insert pipeline.
+  const gateIndex = indexSrc.indexOf("SCHEDULED_BOOKING_DISABLED");
+  const insertIndex = indexSrc.indexOf("deriveCustomerScheduledBookingToken(scheduledRequestKey)");
+  assert.ok(gateIndex > 0 && insertIndex > 0 && gateIndex < insertIndex, "gate must precede booking pipeline");
+});
+
+test("urgent gate rejects customer urgent bookings with 503 + code + LINE url before the urgent handler", () => {
+  const gate = indexSrc.match(/if \(isCustomerAppUrgentBook\(req\.body \|\| \{\}\)\) \{[\s\S]*?return handlePublicCustomerUrgentBook\(req, res\);\n  \}/);
+  assert.ok(gate, "urgent branch not found");
+  assert.match(gate[0], /!ENABLE_CUSTOMER_URGENT_BOOKING/);
+  assert.match(gate[0], /URGENT_BOOKING_DISABLED/);
+  assert.match(gate[0], /status\(503\)/);
+  assert.match(gate[0], /line_url: CWF_LINE_CONTACT_URL/);
+  // Reject BEFORE handlePublicCustomerUrgentBook is invoked.
+  assert.ok(gate[0].indexOf("URGENT_BOOKING_DISABLED") < gate[0].indexOf("handlePublicCustomerUrgentBook(req, res)"));
+});
+
+test("admin booking is not gated by the customer kill switches", () => {
+  // The flags are referenced only at the declaration (name appears twice on
+  // that line: const + env var string) and at the single public customer gate.
+  const scheduledUses = indexSrc.match(/ENABLE_CUSTOMER_SCHEDULED_BOOKING/g) || [];
+  const urgentUses = indexSrc.match(/ENABLE_CUSTOMER_URGENT_BOOKING/g) || [];
+  assert.equal(scheduledUses.length, 3); // declaration (x2) + gate
+  assert.equal(urgentUses.length, 3); // declaration (x2) + gate
+});
+
+test("the LINE contact URL is configurable with a safe default", () => {
+  assert.match(indexSrc, /const CWF_LINE_CONTACT_URL = String\(process\.env\.CWF_LINE_CONTACT_URL \|\| "https:\/\/lin\.ee\/fG1Oq7y"\)\.trim\(\);/);
+});
+
+// ---------- client fallback ----------
+
+test("scheduled wizard shows the LINE hand-off (and hides retry) when the lane is disabled", () => {
+  assert.match(scheduledSrc, /SCHEDULED_BOOKING_DISABLED/);
+  assert.match(scheduledSrc, /disabled_line_url/);
+  assert.match(scheduledSrc, /ติดต่อแอดมินทาง LINE/);
+  // When disabled, the submit button is replaced (retrying a closed lane is pointless).
+  assert.match(scheduledSrc, /submit\.status === "error" && submit\.disabled_line_url \? "" : `<button type="button" class="primary-btn wizard-submit-btn"/);
+});
+
+test("urgent review shows the LINE hand-off (and hides confirm) when the lane is disabled", () => {
+  assert.match(urgentSrc, /URGENT_BOOKING_DISABLED/);
+  assert.match(urgentSrc, /disabled_line_url/);
+  assert.match(urgentSrc, /ติดต่อแอดมินทาง LINE/);
+  assert.match(urgentSrc, /flow\.disabled_line_url\s*\n?\s*\? `<a class="primary-btn line-fallback-btn"/);
+});
+
+test("cache-bust markers are present for the changed booking modules", () => {
+  assert.match(scheduledSrc, /\[customer-booking\] launch-gate 20260708 loaded/);
+  assert.match(urgentSrc, /\[customer-urgent\] launch-gate 20260708 loaded/);
+});

--- a/test/customerEligibilityTechType.test.js
+++ b/test/customerEligibilityTechType.test.js
@@ -84,10 +84,14 @@ test("Customer frontend queries use tech_type=all, never hardcoded company", () 
   assert.doesNotMatch(state, /tech_type:\s*"company"/);
 });
 
-test("Customer App V2 scheduled booking requests tech_type=all server-side", () => {
+test("Every public scheduled booking requests tech_type=all server-side (canonical, not client_app-derived)", () => {
   const index = read("index.js");
   const booking = section(index, 'app.post("/public/book"', 'app.get("/public/track"');
-  assert.match(booking, /clientApp === "customer_app_v2" \? "all" : "company"/);
+  // Canonical: tech_type is "all" for every scheduled booking, mirroring the
+  // public slot list — no longer narrowed to "company" for non-customer_app_v2
+  // callers, which made client_app a capacity boundary.
+  assert.match(booking, /bm === "urgent" \? "partner" : "all"/);
+  assert.doesNotMatch(booking, /clientApp === "customer_app_v2" \? "all" : "company"/);
 });
 
 // ============ Defect 2/3: explicit visibility, fail-closed ============

--- a/test/customerSameDayTiming.test.js
+++ b/test/customerSameDayTiming.test.js
@@ -160,7 +160,7 @@ test("customer app disables availability HTTP cache and refreshes same-day slots
 });
 
 test("customer app build and service worker cache IDs changed", () => {
-  const id = "20260707_booking_admin_notify_v1";
+  const id = "20260708_launch_gate_v1";
   for (const file of [
     "customer-app/index.html",
     "customer-app/sw.js",

--- a/test/customerSameDayTiming.test.js
+++ b/test/customerSameDayTiming.test.js
@@ -160,7 +160,7 @@ test("customer app disables availability HTTP cache and refreshes same-day slots
 });
 
 test("customer app build and service worker cache IDs changed", () => {
-  const id = "20260708_launch_gate_v1";
+  const id = "20260709_review_legacy_v1";
   for (const file of [
     "customer-app/index.html",
     "customer-app/sw.js",

--- a/test/customerSlotBoundary.test.js
+++ b/test/customerSlotBoundary.test.js
@@ -30,46 +30,50 @@ test("Admin-hidden or unset technicians cannot produce customer slots", () => {
   assert.match(listTechnicians, /p\.customer_slot_visible AS customer_slot_visible/);
   assert.doesNotMatch(listTechnicians, /COALESCE\(p\.customer_slot_visible,\s*TRUE\) AS customer_slot_visible/);
   assert.match(availability, /t\.customer_slot_visible === true/);
-  assert.match(booking, /t\.customer_slot_visible === true/);
+  // Booking enforces the SAME visibility by delegating to the shared
+  // customerAvailability engine (reservePublicCustomerTechnician / hasAvailableStart
+  // both filter on customer_slot_visible === true), not a duplicated inline filter.
+  assert.match(booking, /customerAvailability\.(hasAvailableStart|reservePublicCustomerTechnician)/);
 });
 
 test("Public availability never falls back to all technicians", () => {
   assert.match(listTechnicians, /allow_type_fallback/);
   assert.match(listTechnicians, /\(r\.rows \|\| \[\]\)\.length === 0 && allow_type_fallback/);
   assert.match(availability, /listTechniciansByType\(tech_type,\s*\{ include_paused: true,\s*allow_type_fallback: forced \}\)/);
-  assert.match(booking, /listTechniciansByType\(requestedTechType,\s*\{ include_paused: bm === "scheduled" \}\)/);
+  // Booking runs through the customer availability engine (no allow_type_fallback),
+  // so it can never widen its candidate pool to all technicians.
+  assert.doesNotMatch(booking, /allow_type_fallback/);
 });
 
+// Per-criterion eligibility (job/ac/wash/repair) and fail-closed matrix handling
+// now live in ONE place: the customerAvailability engine that BOTH
+// /public/availability_v2 and /public/book call. Booking delegates to it instead
+// of duplicating the matrix filter inline, so the field-level behaviour is
+// asserted against the availability handler here and against the engine directly
+// in customerEligibilityTechType.test.js.
 test("Visible technician with wrong job type produces no customer slot", () => {
   assert.match(availability, /matrix\.job_types/);
-  assert.match(booking, /mx\.job_types/);
 });
 
 test("Visible technician with wrong AC type produces no customer slot", () => {
   assert.match(availability, /matrix\.ac_types/);
-  assert.match(booking, /mx\.ac_types/);
 });
 
 test("Visible technician with wrong wall wash variant produces no customer slot", () => {
   assert.match(availability, /matrix\.wash_wall_variants/);
-  assert.match(booking, /mx\.wash_wall_variants/);
 });
 
 test("Visible technician with wrong repair variant produces no customer slot", () => {
   assert.match(availability, /normalizeRepairKey/);
   assert.match(availability, /matrix\.repair_variants/);
-  assert.match(booking, /normalizeRepairKey/);
-  assert.match(booking, /mx\.repair_variants/);
 });
 
 test("Missing Service Matrix fails closed", () => {
   assert.match(availability, /if \(!matrixMap\.has\(u\)\) return false/);
-  assert.match(booking, /if \(!matrixMap\.has\(u\)\) return false/);
 });
 
 test("Malformed Service Matrix fails closed", () => {
   assert.match(availability, /if \(!matrix \|\| typeof matrix !== 'object'\) return false/);
-  assert.match(booking, /if \(!mx \|\| typeof mx !== 'object'\) return false/);
 });
 
 test("Eligible public availability slots are anonymous", () => {
@@ -104,17 +108,21 @@ test("Slot unavailable after selection returns 409", () => {
 });
 
 test("Slot from wrong or incomplete service payload is rejected before booking", () => {
-  assert.match(booking, /CUSTOMER_SLOT_SERVICE_CRITERIA_REQUIRED/);
-  assert.match(booking, /rawCriteria\.some\(c => !hasCompleteCriteria\(c\)\)/);
+  // An incomplete/mismatched service payload yields no eligible technician in the
+  // shared engine, so booking is rejected at the availability gate (409) before
+  // any insert — the engine's strict matrix match is the single boundary.
+  assert.match(booking, /customerAvailability\.hasAvailableStart/);
+  assert.match(booking, /return res\.status\(409\)/);
 });
 
 test("Availability and booking use the same eligibility boundary", () => {
-  for (const token of ["normalizeJobKey", "normalizeAcKey", "normalizeWashKey", "normalizeRepairKey"]) {
-    assert.match(availability, new RegExp(token));
-    assert.match(booking, new RegExp(token));
-  }
+  // Both surfaces resolve eligibility through the SAME customerAvailability engine
+  // — availability via its slot query, booking via hasAvailableStart +
+  // reservePublicCustomerTechnician — so they cannot diverge.
+  assert.match(availability, /normalizeRepairKey/);
   assert.match(availability, /techMatchesAllCriteriaStrict/);
-  assert.match(booking, /listCriteria\.every\(c => techMatches\(mx, c\)\)/);
+  assert.match(booking, /customerAvailability\.hasAvailableStart/);
+  assert.match(booking, /customerAvailability\.reservePublicCustomerTechnician/);
 });
 
 test("Existing Admin availability fallback remains admin-only", () => {

--- a/test/customerTrackingPrivacy.test.js
+++ b/test/customerTrackingPrivacy.test.js
@@ -4,8 +4,11 @@ const test = require("node:test");
 const assert = require("node:assert/strict");
 const fs = require("node:fs");
 const path = require("node:path");
+const http = require("node:http");
+const express = require("express");
 
 const trackingPrivacy = require("../server/services/public/trackingPrivacy");
+const createDocumentRoutes = require("../server/routes/docs");
 
 const REPO_ROOT = path.resolve(__dirname, "..");
 const indexSrc = fs.readFileSync(path.join(REPO_ROOT, "index.js"), "utf8");
@@ -23,9 +26,9 @@ test("only the exact booking_token grants full access — booking_code and near-
   assert.equal(trackingPrivacy.isFullAccessQuery("a1b2c3d4e5f6", { booking_code: "CWFABCDEFG" }), false);
 });
 
-// ---------- redaction ----------
+// ---------- redaction is an ALLOWLIST ----------
 
-function samplePayload() {
+function richPayload() {
   return {
     access_level: "code",
     job_id: 42,
@@ -38,50 +41,63 @@ function samplePayload() {
     gps_latitude: 13.75,
     gps_longitude: 100.5,
     receipt_url: "https://host/docs/receipt/42?key=a1b2c3d4e5f6",
-    technician: { username: "tech1", full_name: "ช่าง หนึ่ง", phone: "0899999999" },
-    technician_team: [{ username: "tech1", phone: "0899999999" }, { username: "tech2", phone: "0888888888" }],
     job_status: "รอดำเนินการ",
+    booking_mode: "scheduled",
+    dispatch_mode: "normal",
+    appointment_datetime: "2026-07-10T09:00:00+07:00",
+    duration_min: 90,
+    finished_at: null,
+    technician_note: "ลูกค้าไม่อยู่บ้าน",
+    technician: { username: "tech1", full_name: "ช่าง หนึ่ง", phone: "0899999999" },
+    technician_team: [{ username: "tech1", phone: "0899999999" }],
+    photos: [{ public_url: "https://x/y.jpg" }],
+    units: [{ location_label: "ห้องนอน", checklist: [{ issue: "ตัน" }] }],
+    cancel_reason: "ลูกค้ายกเลิก",
+    review: { review_text: "ดีมาก" },
+    customer_complaint: "ช้า",
   };
 }
 
-test("booking_code lookups get masked PII: no token echo, masked phone, shortened address, no GPS/maps/receipt", () => {
-  const original = samplePayload();
-  const redacted = trackingPrivacy.redactPublicTrackPayload(original);
+// Fields a booking_code lookup is ALLOWED to return — everything else must be absent.
+const ALLOWED_CODE_KEYS = new Set([
+  "access_level", "booking_code", "job_status", "booking_mode", "dispatch_mode",
+  "appointment_datetime", "duration_min",
+  "travel_started_at", "checkin_at", "started_at", "finished_at", "canceled_at",
+  "customer_phone",
+]);
 
-  assert.equal(redacted.booking_token, null); // never escalate code -> token
-  assert.equal(redacted.customer_phone, "•••• 5678");
-  assert.ok(redacted.address_text.length < original.address_text.length);
-  assert.ok(redacted.address_text.endsWith("…"));
-  assert.equal(redacted.maps_url, null);
-  assert.equal(redacted.gps_latitude, null);
-  assert.equal(redacted.gps_longitude, null);
-  assert.equal(redacted.receipt_url, null);
-  assert.equal(redacted.technician.phone, null);
-  assert.ok(redacted.technician_team.every((m) => m.phone === null));
+test("booking_code redaction returns ONLY the allowlisted keys (blacklist-proof)", () => {
+  const redacted = trackingPrivacy.redactPublicTrackPayload(richPayload());
+  for (const key of Object.keys(redacted)) {
+    assert.ok(ALLOWED_CODE_KEYS.has(key), `unexpected key leaked to code lookup: ${key}`);
+  }
+  // Spot-check the sensitive ones are truly gone.
+  for (const gone of ["booking_token", "customer_name", "address_text", "maps_url",
+    "gps_latitude", "gps_longitude", "job_id", "technician_note", "technician",
+    "technician_team", "photos", "units", "cancel_reason", "review", "customer_complaint", "receipt_url"]) {
+    assert.equal(redacted[gone], undefined, `${gone} must not be present for a code lookup`);
+  }
   assert.equal(redacted.access_level, "code");
-
-  // Non-PII stays intact so the tracking page still works.
-  assert.equal(redacted.booking_code, "CWFABCDEFG");
+  assert.equal(redacted.customer_phone, "•••• 5678"); // masked confirmation aid
   assert.equal(redacted.job_status, "รอดำเนินการ");
-  assert.equal(redacted.customer_name, "คุณทดสอบ");
-
-  // The input object must never be mutated.
-  assert.equal(original.booking_token, "a1b2c3d4e5f6");
-  assert.equal(original.customer_phone, "0812345678");
-  assert.equal(original.technician.phone, "0899999999");
+  assert.equal(redacted.booking_code, "CWFABCDEFG");
 });
 
-test("maskPhone and shortenAddress handle empty/short values safely", () => {
+test("a brand-new sensitive field added upstream does NOT leak through code redaction", () => {
+  const payload = { ...richPayload(), some_future_pii_field: "secret home code 1234" };
+  const redacted = trackingPrivacy.redactPublicTrackPayload(payload);
+  assert.equal(redacted.some_future_pii_field, undefined);
+});
+
+test("maskPhone handles empty/short values safely", () => {
   assert.equal(trackingPrivacy.maskPhone(""), null);
   assert.equal(trackingPrivacy.maskPhone(null), null);
   assert.equal(trackingPrivacy.maskPhone("08-1234-5678"), "•••• 5678");
-  assert.equal(trackingPrivacy.shortenAddress("สั้น"), "สั้น");
-  assert.equal(trackingPrivacy.shortenAddress(""), "");
 });
 
 // ---------- rate limiter ----------
 
-test("rate limiter allows up to max per window, then answers 429 with retry_after, and resets next window", () => {
+test("rate limiter allows up to max per window, then 429 with retry_after, then resets", () => {
   let t = 0;
   const limiter = trackingPrivacy.createPublicLookupRateLimiter({ windowMs: 60000, max: 3, now: () => t });
   assert.equal(limiter.check("ip1").allowed, true);
@@ -90,9 +106,7 @@ test("rate limiter allows up to max per window, then answers 429 with retry_afte
   const blocked = limiter.check("ip1");
   assert.equal(blocked.allowed, false);
   assert.ok(blocked.retry_after_s >= 1);
-  // Another client is unaffected.
   assert.equal(limiter.check("ip2").allowed, true);
-  // Window rolls over -> allowed again.
   t = 60001;
   assert.equal(limiter.check("ip1").allowed, true);
 });
@@ -103,17 +117,75 @@ test("rate limiter caps its key map (LRU) so it cannot grow without bound", () =
   assert.ok(limiter._size() <= 100);
 });
 
-test("clientIpKey prefers the first X-Forwarded-For hop", () => {
-  assert.equal(
-    trackingPrivacy.clientIpKey({ headers: { "x-forwarded-for": "1.2.3.4, 5.6.7.8" }, ip: "9.9.9.9" }),
-    "1.2.3.4"
-  );
-  assert.equal(trackingPrivacy.clientIpKey({ headers: {}, ip: "9.9.9.9" }), "9.9.9.9");
+test("clientIpKey uses the framework-resolved req.ip and IGNORES raw X-Forwarded-For", () => {
+  // req.ip is derived under the app's `trust proxy` setting; the raw header is
+  // attacker-controlled and must not create a fresh identity.
+  assert.equal(trackingPrivacy.clientIpKey({ ip: "203.0.113.7", headers: { "x-forwarded-for": "1.1.1.1, 2.2.2.2" } }), "203.0.113.7");
+  assert.equal(trackingPrivacy.clientIpKey({ headers: { "x-forwarded-for": "9.9.9.9" }, socket: { remoteAddress: "10.0.0.5" } }), "10.0.0.5");
+  // Spoofing XFF cannot change the key when req.ip is stable.
+  const a = trackingPrivacy.clientIpKey({ ip: "203.0.113.7", headers: { "x-forwarded-for": "1.1.1.1" } });
+  const b = trackingPrivacy.clientIpKey({ ip: "203.0.113.7", headers: { "x-forwarded-for": "8.8.8.8" } });
+  assert.equal(a, b);
 });
 
-// ---------- wiring contracts (index.js / docs.js / client) ----------
+// ---------- docs routes: mounted-router HTTP integration ----------
 
-test("/public/track is rate-limited and answers with the redacted payload for code lookups", () => {
+function docsFakePool(job) {
+  return {
+    async query(sql) {
+      const s = String(sql);
+      if (s.includes("FROM public.jobs WHERE job_id=$1")) return { rows: job ? [job] : [] };
+      return { rows: [] }; // job_items, job_promotions, job_photos
+    },
+  };
+}
+
+function startDocsServer({ job, isAdmin = false } = {}) {
+  const app = express();
+  app.set("trust proxy", 1);
+  app.use(createDocumentRoutes({
+    pool: docsFakePool(job),
+    isAdminRequest: async () => isAdmin,
+    docsRateLimiter: trackingPrivacy.createPublicLookupRateLimiter({ windowMs: 60000, max: 50 }),
+    accountingOwnerSignaturePublicUrl: () => "",
+    accountingSignaturePublicUrl: () => "",
+    accountingOwnerSignerName: () => "",
+    accountingOwnerSignerPosition: () => "",
+  }));
+  const server = http.createServer(app);
+  return new Promise((resolve) => server.listen(0, "127.0.0.1", () => resolve(server)));
+}
+const durl = (s) => `http://127.0.0.1:${s.address().port}`;
+const JOB = { job_id: 7, booking_code: "CWFJOB7", booking_token: "tok_secret_77", customer_name: "ลูกค้า", customer_phone: "0810000000", job_type: "ล้างแอร์", address_text: "บ้านเลขที่ลับ", job_price: 500 };
+
+test("job documents (quote/receipt/eslip) 404 on a bare job_id, 200 with the exact token key", async () => {
+  const server = await startDocsServer({ job: JOB });
+  try {
+    for (const doc of ["quote", "receipt", "eslip"]) {
+      const bare = await fetch(`${durl(server)}/docs/${doc}/7`);
+      assert.equal(bare.status, 404, `${doc} bare job_id must 404`);
+      const wrong = await fetch(`${durl(server)}/docs/${doc}/7?key=tok_wrong`);
+      assert.equal(wrong.status, 404, `${doc} wrong key must 404`);
+      const ok = await fetch(`${durl(server)}/docs/${doc}/7?key=tok_secret_77`);
+      assert.equal(ok.status, 200, `${doc} correct key must 200`);
+      assert.match(ok.headers.get("cache-control") || "", /no-store/);
+      assert.equal(ok.headers.get("referrer-policy"), "no-referrer");
+      assert.match(ok.headers.get("x-robots-tag") || "", /noindex/);
+    }
+  } finally { server.close(); }
+});
+
+test("job documents open for an authenticated admin without any key", async () => {
+  const server = await startDocsServer({ job: JOB, isAdmin: true });
+  try {
+    const res = await fetch(`${durl(server)}/docs/receipt/7`);
+    assert.equal(res.status, 200);
+  } finally { server.close(); }
+});
+
+// ---------- wiring contracts ----------
+
+test("/public/track is rate-limited and redacts code lookups via the allowlist", () => {
   assert.match(indexSrc, /publicTrackRateLimiter\.check\(trackingPrivacy\.clientIpKey\(req\)\)/);
   assert.match(indexSrc, /const fullAccess = trackingPrivacy\.isFullAccessQuery\(q, row\);/);
   assert.match(indexSrc, /res\.json\(fullAccess \? trackPayload : trackingPrivacy\.redactPublicTrackPayload\(trackPayload\)\);/);
@@ -134,21 +206,21 @@ test("receipt links embed the booking_token key and are only issued on full acce
   assert.match(indexSrc, /\/docs\/receipt\/\$\{row\.job_id\}\?key=\$\{encodeURIComponent\(row\.booking_token\)\}/);
 });
 
-test("job documents (receipt/e-slip) require the booking_token key or an admin session and answer 404 otherwise", () => {
+test("all three job-doc routes share one gate helper + sensitive headers", () => {
   assert.match(docsSrc, /async function canViewJobDoc\(req, data\)/);
   assert.match(docsSrc, /trackingPrivacy\.timingSafeEqualStr\(key, String\(token\)\)/);
-  // Both PII documents are gated.
-  const receiptRoute = docsSrc.match(/router\.get\("\/docs\/receipt\/:job_id"[\s\S]*?\n  \}\);/);
-  const eslipRoute = docsSrc.match(/router\.get\("\/docs\/eslip\/:job_id"[\s\S]*?\n  \}\);/);
-  assert.ok(receiptRoute && /canViewJobDoc/.test(receiptRoute[0]), "receipt route not gated");
-  assert.ok(eslipRoute && /canViewJobDoc/.test(eslipRoute[0]), "eslip route not gated");
-  // Denial mirrors "not found" so the route is not an existence oracle.
-  assert.match(receiptRoute[0], /status\(404\)/);
-  // Rate limited too.
-  assert.match(docsSrc, /function docsRateLimited\(req, res\)/);
+  assert.match(docsSrc, /function setSensitiveDocHeaders\(res\)/);
+  assert.match(docsSrc, /async function loadAuthorizedJobDoc\(req, res\)/);
+  for (const doc of ["quote", "receipt", "eslip"]) {
+    const route = docsSrc.match(new RegExp(`router\\.get\\("/docs/${doc}/:job_id"[\\s\\S]*?\\n  \\}\\);`));
+    assert.ok(route, `${doc} route not found`);
+    assert.match(route[0], /loadAuthorizedJobDoc\(req, res\)/, `${doc} not gated`);
+  }
 });
 
-test("the customer app only builds receipt fallback links when it holds the booking_token", () => {
+test("the customer app only builds receipt links + review form on full (token) access", () => {
   assert.match(trackingClientSrc, /data\.booking_token\s*\?\s*`\/docs\/receipt\/\$\{encodeURIComponent\(data\.job_id\)\}\?key=/);
-  assert.doesNotMatch(trackingClientSrc, /`\/docs\/receipt\/\$\{encodeURIComponent\(data\.job_id\)\}`/);
+  assert.match(trackingClientSrc, /data\.access_level === "token" \? \(data\.booking_token \|\| ""\) : ""/);
+  assert.match(trackingClientSrc, /name="booking_token"/);
+  assert.doesNotMatch(trackingClientSrc, /<input type="hidden" name="q"/);
 });

--- a/test/customerTrackingPrivacy.test.js
+++ b/test/customerTrackingPrivacy.test.js
@@ -1,0 +1,154 @@
+"use strict";
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+
+const trackingPrivacy = require("../server/services/public/trackingPrivacy");
+
+const REPO_ROOT = path.resolve(__dirname, "..");
+const indexSrc = fs.readFileSync(path.join(REPO_ROOT, "index.js"), "utf8");
+const docsSrc = fs.readFileSync(path.join(REPO_ROOT, "server", "routes", "docs.js"), "utf8");
+const trackingClientSrc = fs.readFileSync(path.join(REPO_ROOT, "customer-app", "modules", "tracking.js"), "utf8");
+
+// ---------- access level ----------
+
+test("only the exact booking_token grants full access — booking_code and near-misses do not", () => {
+  const row = { booking_token: "a1b2c3d4e5f6", booking_code: "CWFABCDEFG" };
+  assert.equal(trackingPrivacy.isFullAccessQuery("a1b2c3d4e5f6", row), true);
+  assert.equal(trackingPrivacy.isFullAccessQuery("CWFABCDEFG", row), false);
+  assert.equal(trackingPrivacy.isFullAccessQuery("a1b2c3d4e5f", row), false);
+  assert.equal(trackingPrivacy.isFullAccessQuery("", row), false);
+  assert.equal(trackingPrivacy.isFullAccessQuery("a1b2c3d4e5f6", { booking_code: "CWFABCDEFG" }), false);
+});
+
+// ---------- redaction ----------
+
+function samplePayload() {
+  return {
+    access_level: "code",
+    job_id: 42,
+    booking_code: "CWFABCDEFG",
+    booking_token: "a1b2c3d4e5f6",
+    customer_name: "คุณทดสอบ",
+    customer_phone: "0812345678",
+    address_text: "99/1 หมู่บ้านทดสอบ ซอยลึกมาก ถนนยาว แขวงหนึ่ง เขตสอง กทม 10250",
+    maps_url: "https://maps.app.goo.gl/abc",
+    gps_latitude: 13.75,
+    gps_longitude: 100.5,
+    receipt_url: "https://host/docs/receipt/42?key=a1b2c3d4e5f6",
+    technician: { username: "tech1", full_name: "ช่าง หนึ่ง", phone: "0899999999" },
+    technician_team: [{ username: "tech1", phone: "0899999999" }, { username: "tech2", phone: "0888888888" }],
+    job_status: "รอดำเนินการ",
+  };
+}
+
+test("booking_code lookups get masked PII: no token echo, masked phone, shortened address, no GPS/maps/receipt", () => {
+  const original = samplePayload();
+  const redacted = trackingPrivacy.redactPublicTrackPayload(original);
+
+  assert.equal(redacted.booking_token, null); // never escalate code -> token
+  assert.equal(redacted.customer_phone, "•••• 5678");
+  assert.ok(redacted.address_text.length < original.address_text.length);
+  assert.ok(redacted.address_text.endsWith("…"));
+  assert.equal(redacted.maps_url, null);
+  assert.equal(redacted.gps_latitude, null);
+  assert.equal(redacted.gps_longitude, null);
+  assert.equal(redacted.receipt_url, null);
+  assert.equal(redacted.technician.phone, null);
+  assert.ok(redacted.technician_team.every((m) => m.phone === null));
+  assert.equal(redacted.access_level, "code");
+
+  // Non-PII stays intact so the tracking page still works.
+  assert.equal(redacted.booking_code, "CWFABCDEFG");
+  assert.equal(redacted.job_status, "รอดำเนินการ");
+  assert.equal(redacted.customer_name, "คุณทดสอบ");
+
+  // The input object must never be mutated.
+  assert.equal(original.booking_token, "a1b2c3d4e5f6");
+  assert.equal(original.customer_phone, "0812345678");
+  assert.equal(original.technician.phone, "0899999999");
+});
+
+test("maskPhone and shortenAddress handle empty/short values safely", () => {
+  assert.equal(trackingPrivacy.maskPhone(""), null);
+  assert.equal(trackingPrivacy.maskPhone(null), null);
+  assert.equal(trackingPrivacy.maskPhone("08-1234-5678"), "•••• 5678");
+  assert.equal(trackingPrivacy.shortenAddress("สั้น"), "สั้น");
+  assert.equal(trackingPrivacy.shortenAddress(""), "");
+});
+
+// ---------- rate limiter ----------
+
+test("rate limiter allows up to max per window, then answers 429 with retry_after, and resets next window", () => {
+  let t = 0;
+  const limiter = trackingPrivacy.createPublicLookupRateLimiter({ windowMs: 60000, max: 3, now: () => t });
+  assert.equal(limiter.check("ip1").allowed, true);
+  assert.equal(limiter.check("ip1").allowed, true);
+  assert.equal(limiter.check("ip1").allowed, true);
+  const blocked = limiter.check("ip1");
+  assert.equal(blocked.allowed, false);
+  assert.ok(blocked.retry_after_s >= 1);
+  // Another client is unaffected.
+  assert.equal(limiter.check("ip2").allowed, true);
+  // Window rolls over -> allowed again.
+  t = 60001;
+  assert.equal(limiter.check("ip1").allowed, true);
+});
+
+test("rate limiter caps its key map (LRU) so it cannot grow without bound", () => {
+  const limiter = trackingPrivacy.createPublicLookupRateLimiter({ windowMs: 60000, max: 5, maxKeys: 100 });
+  for (let i = 0; i < 500; i += 1) limiter.check(`ip-${i}`);
+  assert.ok(limiter._size() <= 100);
+});
+
+test("clientIpKey prefers the first X-Forwarded-For hop", () => {
+  assert.equal(
+    trackingPrivacy.clientIpKey({ headers: { "x-forwarded-for": "1.2.3.4, 5.6.7.8" }, ip: "9.9.9.9" }),
+    "1.2.3.4"
+  );
+  assert.equal(trackingPrivacy.clientIpKey({ headers: {}, ip: "9.9.9.9" }), "9.9.9.9");
+});
+
+// ---------- wiring contracts (index.js / docs.js / client) ----------
+
+test("/public/track is rate-limited and answers with the redacted payload for code lookups", () => {
+  assert.match(indexSrc, /publicTrackRateLimiter\.check\(trackingPrivacy\.clientIpKey\(req\)\)/);
+  assert.match(indexSrc, /const fullAccess = trackingPrivacy\.isFullAccessQuery\(q, row\);/);
+  assert.match(indexSrc, /res\.json\(fullAccess \? trackPayload : trackingPrivacy\.redactPublicTrackPayload\(trackPayload\)\);/);
+});
+
+test("/public/urgent-status is rate-limited", () => {
+  assert.match(indexSrc, /publicUrgentStatusRateLimiter\.check\(trackingPrivacy\.clientIpKey\(req\)\)/);
+});
+
+test("booking codes come from a CSPRNG, not Math.random", () => {
+  const fn = indexSrc.match(/function makeRandomBookingCode\(\)[\s\S]*?\n}/);
+  assert.ok(fn, "makeRandomBookingCode not found");
+  assert.match(fn[0], /crypto\.randomInt\(/);
+  assert.doesNotMatch(fn[0], /Math\.random/);
+});
+
+test("receipt links embed the booking_token key and are only issued on full access", () => {
+  assert.match(indexSrc, /\/docs\/receipt\/\$\{row\.job_id\}\?key=\$\{encodeURIComponent\(row\.booking_token\)\}/);
+});
+
+test("job documents (receipt/e-slip) require the booking_token key or an admin session and answer 404 otherwise", () => {
+  assert.match(docsSrc, /async function canViewJobDoc\(req, data\)/);
+  assert.match(docsSrc, /trackingPrivacy\.timingSafeEqualStr\(key, String\(token\)\)/);
+  // Both PII documents are gated.
+  const receiptRoute = docsSrc.match(/router\.get\("\/docs\/receipt\/:job_id"[\s\S]*?\n  \}\);/);
+  const eslipRoute = docsSrc.match(/router\.get\("\/docs\/eslip\/:job_id"[\s\S]*?\n  \}\);/);
+  assert.ok(receiptRoute && /canViewJobDoc/.test(receiptRoute[0]), "receipt route not gated");
+  assert.ok(eslipRoute && /canViewJobDoc/.test(eslipRoute[0]), "eslip route not gated");
+  // Denial mirrors "not found" so the route is not an existence oracle.
+  assert.match(receiptRoute[0], /status\(404\)/);
+  // Rate limited too.
+  assert.match(docsSrc, /function docsRateLimited\(req, res\)/);
+});
+
+test("the customer app only builds receipt fallback links when it holds the booking_token", () => {
+  assert.match(trackingClientSrc, /data\.booking_token\s*\?\s*`\/docs\/receipt\/\$\{encodeURIComponent\(data\.job_id\)\}\?key=/);
+  assert.doesNotMatch(trackingClientSrc, /`\/docs\/receipt\/\$\{encodeURIComponent\(data\.job_id\)\}`/);
+});

--- a/test/customerTrackingPrivacy.test.js
+++ b/test/customerTrackingPrivacy.test.js
@@ -60,8 +60,8 @@ function richPayload() {
 
 // Fields a booking_code lookup is ALLOWED to return — everything else must be absent.
 const ALLOWED_CODE_KEYS = new Set([
-  "access_level", "booking_code", "job_status", "booking_mode", "dispatch_mode",
-  "appointment_datetime", "duration_min",
+  "access_level", "legacy_review_eligible", "booking_code", "job_status",
+  "booking_mode", "dispatch_mode", "appointment_datetime", "duration_min",
   "travel_started_at", "checkin_at", "started_at", "finished_at", "canceled_at",
   "customer_phone",
 ]);
@@ -87,6 +87,16 @@ test("a brand-new sensitive field added upstream does NOT leak through code reda
   const payload = { ...richPayload(), some_future_pii_field: "secret home code 1234" };
   const redacted = trackingPrivacy.redactPublicTrackPayload(payload);
   assert.equal(redacted.some_future_pii_field, undefined);
+});
+
+test("legacy_review_eligible passes through as a non-sensitive boolean (default false, no token leak)", () => {
+  // Absent upstream -> false, never undefined/truthy by accident.
+  assert.equal(trackingPrivacy.redactPublicTrackPayload(richPayload()).legacy_review_eligible, false);
+  // Explicit true is surfaced so the UI can offer the legacy phone form...
+  const eligible = trackingPrivacy.redactPublicTrackPayload({ ...richPayload(), legacy_review_eligible: true });
+  assert.equal(eligible.legacy_review_eligible, true);
+  // ...but it must never carry the token alongside it.
+  assert.equal(eligible.booking_token, undefined);
 });
 
 test("maskPhone handles empty/short values safely", () => {

--- a/test/e2e/run-booking-e2e.js
+++ b/test/e2e/run-booking-e2e.js
@@ -1083,6 +1083,27 @@ async function main() {
     const diffPhone = await apiBook(BASE_A, scheduledPayload(r2Day, "13:00", { scheduled_request_key: key, customer_phone: "0866660000" }));
     assert(diffPhone.status === 409 && diffPhone.body?.code === "IDEMPOTENCY_KEY_REUSED",
       `different phone must 409 IDEMPOTENCY_KEY_REUSED, got ${diffPhone.status}`);
+    // Different service composition (BTU / AC type / qty) at the SAME time -> reject,
+    // even though the computed duration could match. These are caught by the
+    // canonical job_items signature, not by duration.
+    const diffBtu = await apiBook(BASE_A, scheduledPayload(r2Day, "13:00", { scheduled_request_key: key, customer_phone: "0855550000", btu: 18000 }));
+    assert(diffBtu.status === 409 && diffBtu.body?.code === "IDEMPOTENCY_KEY_REUSED",
+      `different BTU must 409 IDEMPOTENCY_KEY_REUSED, got ${diffBtu.status} ${JSON.stringify(diffBtu.body)}`);
+    const diffQty = await apiBook(BASE_A, scheduledPayload(r2Day, "13:00", { scheduled_request_key: key, customer_phone: "0855550000", machine_count: 2 }));
+    assert(diffQty.status === 409 && diffQty.body?.code === "IDEMPOTENCY_KEY_REUSED",
+      `different machine_count must 409 IDEMPOTENCY_KEY_REUSED, got ${diffQty.status} ${JSON.stringify(diffQty.body)}`);
+    // Different place (address) -> reject.
+    const diffAddr = await apiBook(BASE_A, scheduledPayload(r2Day, "13:00", { scheduled_request_key: key, customer_phone: "0855550000", address_text: "99/99 ที่อยู่ใหม่ กทม" }));
+    assert(diffAddr.status === 409 && diffAddr.body?.code === "IDEMPOTENCY_KEY_REUSED",
+      `different address must 409 IDEMPOTENCY_KEY_REUSED, got ${diffAddr.status}`);
+    // None of the 409s leaked identifiers, and none created a job.
+    for (const r of [diffTime, diffPhone, diffBtu, diffQty, diffAddr]) {
+      assert(!r.body?.job_id && !r.body?.booking_code && !r.body?.token, "409 must not leak the first job's identifiers");
+    }
+    // The EXACT same canonical payload still replays the same job.
+    const exact = await apiBook(BASE_A, scheduledPayload(r2Day, "13:00", { scheduled_request_key: key, customer_phone: "0855550000" }));
+    assert(exact.status === 200 && exact.body?.replayed === true && exact.body?.job_id === first.body.job_id,
+      `exact same payload must replay the same job, got ${exact.status} ${JSON.stringify(exact.body)}`);
     const after = await pool.query(`SELECT COUNT(*)::int AS n FROM public.jobs WHERE booking_token=$1`, [detToken]);
     assert(after.rows[0].n === before.rows[0].n && after.rows[0].n === 1, "key reuse must not create additional jobs");
   });

--- a/test/e2e/run-booking-e2e.js
+++ b/test/e2e/run-booking-e2e.js
@@ -134,6 +134,18 @@ async function createDatabase() {
       try { await db.query(alter); } catch (_) { /* table not in scope — fine */ }
     }
   }
+  // Boot also creates the indexes several features rely on — notably the UNIQUE
+  // index that backs `ON CONFLICT (job_id)` in /public/review. Replay every
+  // `CREATE [UNIQUE] INDEX IF NOT EXISTS` the app declares so those code paths
+  // behave exactly as they do in production.
+  for (const srcFile of ["index.js", path.join("server", "customerPricing.js")]) {
+    const src = fs.readFileSync(path.join(REPO_ROOT, srcFile), "utf8");
+    const indexes = src.match(/CREATE (?:UNIQUE )?INDEX IF NOT EXISTS [^`;]+/g) || [];
+    for (const idx of indexes) {
+      if (idx.includes("${")) continue;
+      try { await db.query(idx); } catch (_) { /* target table not in scope — fine */ }
+    }
+  }
   // Finally, replay the repo's additive migration files (idempotent) so
   // migration-managed columns (catalog marketplace, price-rule links, ...)
   // exist exactly as production got them.
@@ -153,6 +165,29 @@ async function dropDatabase() {
   await admin.end();
 }
 
+// SAFETY: neutralise every outbound integration so a scenario that creates a
+// real job can NEVER message a customer, dispatch to a real technician, or hit
+// a third party — even if the runner's shell/.env holds production secrets.
+// dotenv does not overwrite already-present keys, so setting these to "" (they
+// are "present") blocks a repo .env from re-injecting real values.
+const OUTBOUND_KILL_ENV = {
+  // LINE messaging / admin targets
+  LINE_BOT_CHANNEL_ACCESS_TOKEN: "", LINE_CHANNEL_ACCESS_TOKEN: "", LINE_MESSAGING_CHANNEL_ACCESS_TOKEN: "",
+  LINE_CHANNEL_SECRET: "", LINE_CHANNEL_ID: "", LINE_ADMIN_GROUP_ID: "", LINE_ADMIN_USER_ID: "",
+  PARTNER_ADMIN_LINE_TARGETS: "", PARTNER_LINE_NOTIFY_ENABLED: "false",
+  // Web push
+  ENABLE_WEB_PUSH_NOTIFICATIONS: "false", WEB_PUSH_PUBLIC_KEY: "", WEB_PUSH_PRIVATE_KEY: "",
+  VAPID_PUBLIC_KEY: "", VAPID_PRIVATE_KEY: "",
+  // Payments — must never reach Omise from a booking E2E
+  OMISE_SECRET_KEY: "", OMISE_PUBLIC_KEY: "", OMISE_WEBHOOK_SECRET: "",
+  // AI / other third parties
+  OPENAI_API_KEY: "", ANTHROPIC_API_KEY: "",
+  // Cloud media
+  CLOUDINARY_URL: "", CLOUDINARY_CLOUD_NAME: "", CLOUDINARY_API_KEY: "", CLOUDINARY_API_SECRET: "",
+  // Explicit test marker
+  CWF_E2E_TEST_MODE: "1", NODE_ENV: "test",
+};
+
 function bootApp(port, extraEnv = {}) {
   const logFile = path.join(__dirname, `app-${port}.log`);
   const out = fs.openSync(logFile, "w");
@@ -160,6 +195,7 @@ function bootApp(port, extraEnv = {}) {
     cwd: REPO_ROOT,
     env: {
       ...process.env,
+      ...OUTBOUND_KILL_ENV,
       DB_HOST: PG.host, DB_PORT: String(PG.port), DB_USER: PG.user,
       DB_PASSWORD: PG.password, DB_NAME,
       PORT: String(port),
@@ -172,6 +208,36 @@ function bootApp(port, extraEnv = {}) {
   });
   children.push(child);
   return child;
+}
+
+// Refuse to run against anything that looks like a real database unless the
+// operator explicitly opts in — this harness CREATEs and DROPs its database.
+function assertSafeTarget() {
+  const localHosts = new Set(["127.0.0.1", "localhost", "::1", "0.0.0.0"]);
+  if (localHosts.has(PG.host) || process.env.E2E_ALLOW_REMOTE === "1") return;
+  throw new Error(
+    `Refusing to run booking E2E against non-local PostgreSQL host "${PG.host}". ` +
+    `This harness creates and DROPs its own database. Set E2E_ALLOW_REMOTE=1 only for a disposable staging DB.`
+  );
+}
+
+// The harness tolerates individual schema statements failing (many app tables
+// are unrelated to booking), but the booking scenarios are meaningless if the
+// core tables are missing. Fail loudly instead of "passing" on a thin schema.
+async function assertCoreSchema() {
+  const required = [
+    "jobs", "job_offers", "job_items", "job_promotions",
+    "technician_service_matrix", "technician_monthly_work_calendar",
+    "catalog_items", "customer_service_price_rules", "auth_sessions",
+    "users", "technician_profiles",
+  ];
+  const r = await pool.query(
+    `SELECT table_name FROM information_schema.tables WHERE table_schema='public' AND table_name = ANY($1::text[])`,
+    [required]
+  );
+  const present = new Set(r.rows.map((x) => x.table_name));
+  const missing = required.filter((t) => !present.has(t));
+  if (missing.length) throw new Error(`core booking schema incomplete — missing tables: ${missing.join(", ")}`);
 }
 
 async function waitForReady(base, { timeoutMs = 90000 } = {}) {
@@ -344,7 +410,8 @@ function scheduledPayload(ymd, start, overrides = {}) {
 // ------------------------------------------------------------- scenarios ----
 
 async function main() {
-  log(`E2E database: ${DB_NAME} on ${PG.host}:${PG.port}`);
+  assertSafeTarget();
+  log(`E2E database: ${DB_NAME} on ${PG.host}:${PG.port} (outbound integrations disabled)`);
   const adminPool = new Client({ ...PG, database: "postgres" });
   await adminPool.connect();
   await adminPool.query("SELECT 1");
@@ -352,6 +419,7 @@ async function main() {
 
   await createDatabase();
   pool = new Pool({ ...PG, database: DB_NAME, max: 5 });
+  await assertCoreSchema();
 
   log("booting app A (booking enabled) + app B (booking disabled)...");
   bootApp(PORT_A, {});
@@ -647,11 +715,24 @@ async function main() {
     // through the real module against the same database to avoid a flaky wait.
     const finalizer = require(path.join(REPO_ROOT, "server", "services", "urgent", "finalizer"));
     await finalizer.autoFinalizeUrgentJobs(pool);
-    const after = await pool.query(`SELECT job_status, canceled_at FROM public.jobs WHERE job_id=$1`, [jobId]);
+    const after = await pool.query(`SELECT job_status, canceled_at, booking_code FROM public.jobs WHERE job_id=$1`, [jobId]);
     assert(after.rows[0].canceled_at === null, "urgent job must not be canceled/lost");
     assert(String(after.rows[0].job_status || "").length > 0, "urgent job lost its status");
     const offers = await pool.query(`SELECT status FROM public.job_offers WHERE job_id=$1`, [jobId]);
     assert(offers.rows.every((o) => o.status !== "pending"), "expired offers must not stay pending");
+    // The reviewer requires positive proof the abandoned job is recoverable by
+    // admin — assert it actually surfaces in the admin review queue (the same
+    // data feed admin-review-v2.html renders), keyed by the real admin session.
+    const abandonedCode = after.rows[0].booking_code;
+    const queueRes = await fetch(`${BASE_A}/admin/review_queue_v2?status=all&limit=500`, {
+      headers: { cookie: `cwf_session=${adminSession}` },
+    });
+    assert(queueRes.status === 200, `admin review queue must load, got ${queueRes.status}`);
+    const queue = await queueRes.json();
+    assert(Array.isArray(queue.rows), "admin review queue payload malformed");
+    const found = queue.rows.find((row) => row.booking_code === abandonedCode);
+    assert(found, `no-accept urgent job ${abandonedCode} missing from admin review queue`);
+    assert(found.job_id === jobId, "admin review queue row mismatched job_id");
   });
 
   // 10) Admin sees the new bookings in the review queue.
@@ -675,10 +756,12 @@ async function main() {
     // code lookup -> masked
     const red = await (await fetch(`${BASE_A}/public/track?q=${encodeURIComponent(bookingCode1)}`)).json();
     assert(red.access_level === "code", "code lookup should be limited access");
-    assert(red.booking_token === null, "code lookup must not echo the token");
+    // The allowlist drops these by construction, so they are absent (undefined)
+    // rather than explicitly null — either way they must not carry a value.
+    assert(red.booking_token == null, "code lookup must not echo the token");
     assert(String(red.customer_phone || "").includes("5678") && !String(red.customer_phone).includes("0812345678"), "phone must be masked");
-    assert(red.gps_latitude === null && red.maps_url === null, "GPS/maps must be hidden");
-    assert(red.receipt_url === null, "receipt link must be hidden for code lookups");
+    assert(red.gps_latitude == null && red.maps_url == null, "GPS/maps must be hidden");
+    assert(red.receipt_url == null, "receipt link must be hidden for code lookups");
     // In-browser: tracking page renders for the customer.
     const p = await ctx.newPage();
     await p.goto(`${APP_URL_A}#tracking`, { waitUntil: "domcontentloaded" });
@@ -778,6 +861,173 @@ async function main() {
     assert(bare.status === 404, `bare job_id receipt must 404, got ${bare.status}`);
     const keyed = await fetch(`${BASE_A}/docs/receipt/${job_id}?key=${encodeURIComponent(booking_token)}`, { headers: { "x-forwarded-for": "203.0.113.51" } });
     assert(keyed.status === 200, `keyed receipt must 200, got ${keyed.status}`);
+  });
+
+  // ---------------- negative / bypass probes (reviewer-requested) ----------
+
+  // S14) The kill switch must gate on the canonical booking_mode, never on the
+  // attacker-supplied client_app. Forging client_app (or omitting it) must NOT
+  // reopen a closed lane, an unknown mode must be rejected outright, and zero
+  // jobs may be created on the disabled instance across every attempt.
+  await record("S14 kill switch cannot be bypassed by forging/omitting client_app", async () => {
+    const before = await jobCountWhere("TRUE");
+    const forgedApps = ["admin_console", "internal", "", "customer_app_v2", "cwf_admin"];
+    for (const app of forgedApps) {
+      const sched = await apiBook(BASE_B, scheduledPayload(tomorrow, "10:30", { client_app: app }));
+      assert(sched.status === 503 && sched.body?.code === "SCHEDULED_BOOKING_DISABLED",
+        `scheduled lane bypassed with client_app=${JSON.stringify(app)} (HTTP ${sched.status})`);
+      const urgent = await apiBook(BASE_B, {
+        customer_name: "bypass", customer_phone: "0810000000", job_type: "ล้างแอร์",
+        appointment_datetime: new Date().toISOString(), address_text: "z",
+        booking_mode: "urgent", client_app: app,
+        urgent_request_key: crypto.randomBytes(16).toString("hex"),
+        ac_type: "ผนัง", btu: 12000, machine_count: 1, wash_variant: "ล้างธรรมดา",
+      });
+      assert(urgent.status === 503 && urgent.body?.code === "URGENT_BOOKING_DISABLED",
+        `urgent lane bypassed with client_app=${JSON.stringify(app)} (HTTP ${urgent.status})`);
+    }
+    // A client_app with no booking_mode still defaults to scheduled (closed).
+    const noMode = await apiBook(BASE_B, scheduledPayload(tomorrow, "11:00", { client_app: "admin", booking_mode: undefined }));
+    assert(noMode.status === 503, `missing booking_mode must default to the closed scheduled lane, got ${noMode.status}`);
+    // An unknown booking_mode is rejected, not silently routed anywhere.
+    const bogus = await apiBook(BASE_B, scheduledPayload(tomorrow, "11:30", { booking_mode: "wholesale" }));
+    assert(bogus.status === 400 && bogus.body?.code === "UNKNOWN_BOOKING_MODE",
+      `unknown booking_mode must 400, got ${bogus.status}`);
+    // Even on the OPEN instance an unknown mode must not create a job.
+    const bogusOpen = await apiBook(BASE_A, scheduledPayload(tomorrow, "11:45", { booking_mode: "wholesale" }));
+    assert(bogusOpen.status === 400 && bogusOpen.body?.code === "UNKNOWN_BOOKING_MODE",
+      `unknown booking_mode must 400 on the open instance too, got ${bogusOpen.status}`);
+    const after = await jobCountWhere("TRUE");
+    assert(after === before, `bypass probes leaked ${after - before} job(s)`);
+  });
+
+  // S15) The public-lookup rate limiter must key off the proxy-derived req.ip
+  // (the nearest trusted hop), NOT the raw first X-Forwarded-For token. Rotate
+  // the attacker-controlled LEFT-most XFF entry on every request while pinning
+  // the nearest-hop entry: a limiter that trusted the raw first token would see
+  // a fresh key each time and never trip. It must still answer 429.
+  await record("S15 rotating a spoofed X-Forwarded-For does not bypass the rate limit", async () => {
+    const pinnedHop = "203.0.113.222"; // the entry the trusted proxy would append
+    let got429 = false;
+    for (let i = 0; i < 45 && !got429; i += 1) {
+      const spoof = `10.9.${i}.${(i * 7) % 255}`; // rotates every request
+      const res = await fetch(`${BASE_A}/public/track?q=CWFSPOOF${i}`, {
+        headers: { "x-forwarded-for": `${spoof}, ${pinnedHop}` },
+      });
+      if (res.status === 429) got429 = true;
+    }
+    assert(got429, "rate limit never tripped — a rotating spoofed XFF bypassed it");
+  });
+
+  // S16) A booking_code lookup is a minimal allowlist. Beyond the phone-masking
+  // already checked in S11, prove the sensitive fields are absent by
+  // construction — name, address, internal job_id, technician notes, photos,
+  // unit data, cancel reason, and any review text must never appear.
+  await record("S16 booking_code lookup leaks no name/address/job_id/notes/photos/units/review", async () => {
+    const red = await (await fetch(`${BASE_A}/public/track?q=${encodeURIComponent(bookingCode1)}`,
+      { headers: { "x-forwarded-for": "198.51.100.7" } })).json();
+    assert(red.access_level === "code", "expected a limited (code) lookup");
+    const forbidden = [
+      "customer_name", "customer_fullname", "name",
+      "address_text", "address", "address_prefix", "maps_url", "gps_latitude", "gps_longitude",
+      "job_id", "id",
+      "technician_note", "technician_notes", "notes", "note", "admin_note",
+      "photos", "job_photos", "photo_urls",
+      "units", "job_items", "items", "machine_count", "unit_data",
+      "cancel_reason", "canceled_reason",
+      "customer_review", "review_text", "customer_complaint", "complaint_text",
+      "technician_username", "technician_name", "receipt_url",
+    ];
+    const leaked = forbidden.filter((k) => red[k] !== undefined && red[k] !== null);
+    assert(leaked.length === 0, `booking_code lookup leaked fields: ${leaked.join(", ")}`);
+    // Positive: it still returns the minimal, useful status surface.
+    assert(red.booking_code === bookingCode1, "code lookup must echo the booking_code");
+    assert(typeof red.job_status === "string", "code lookup must return a status");
+  });
+
+  // S17) /public/review is a WRITE. A tokened job must NOT be reviewable via the
+  // short booking_code (no downgrade); only the exact booking_token authorises.
+  // A genuine legacy job (no token) may still be reviewed via code + full phone,
+  // and a wrong phone is denied — with the same generic error either way.
+  await record("S17 review write: code denied on tokened job, token accepted; legacy code+phone still works", async () => {
+    const jr = await pool.query(`SELECT job_id, customer_phone FROM public.jobs WHERE booking_code=$1`, [bookingCode1]);
+    const tokenJobId = jr.rows[0].job_id;
+    const tokenPhone = jr.rows[0].customer_phone;
+    // Make the tokened job reviewable (completed, has a technician, unreviewed).
+    await pool.query(
+      `UPDATE public.jobs SET job_status='เสร็จแล้ว', finished_at=NOW(),
+              technician_username='tech_a', customer_rating=NULL, reviewed_at=NULL
+       WHERE job_id=$1`, [tokenJobId]);
+    await pool.query(`DELETE FROM public.technician_reviews WHERE job_id=$1`, [tokenJobId]);
+
+    const postReview = (payload, ip) => fetch(`${BASE_A}/public/review`, {
+      method: "POST",
+      headers: { "content-type": "application/json", "x-forwarded-for": ip },
+      body: JSON.stringify(payload),
+    }).then(async (r) => ({ status: r.status, body: await r.json().catch(() => null) }));
+
+    // (a) Downgrade attempt: booking_code + phone on a TOKENED job -> denied.
+    const downgrade = await postReview(
+      { booking_code: bookingCode1, customer_phone: tokenPhone, rating: 5, review_text: "bypass" }, "198.51.100.20");
+    assert(downgrade.status !== 200 && !downgrade.body?.success,
+      `tokened job must reject code+phone review, got HTTP ${downgrade.status}`);
+    const afterDowngrade = await pool.query(`SELECT customer_rating FROM public.jobs WHERE job_id=$1`, [tokenJobId]);
+    assert(afterDowngrade.rows[0].customer_rating === null, "downgrade attempt must not write a review");
+
+    // (b) Exact token authorises the write.
+    const tokened = await postReview({ booking_token: bookingToken1, rating: 5, review_text: "ดีมาก" }, "198.51.100.21");
+    assert(tokened.status === 200 && tokened.body?.success === true, `token review must succeed, got HTTP ${tokened.status}`);
+    // Response must not leak PII/token/confirmation beyond {success:true}.
+    assert(Object.keys(tokened.body).join(",") === "success", `review response leaked keys: ${Object.keys(tokened.body)}`);
+    const reviewed = await pool.query(`SELECT customer_rating FROM public.jobs WHERE job_id=$1`, [tokenJobId]);
+    assert(Number(reviewed.rows[0].customer_rating) === 5, "token review did not persist");
+    // Replaying the token review on an already-reviewed job is denied.
+    const replay = await postReview({ booking_token: bookingToken1, rating: 1 }, "198.51.100.22");
+    assert(replay.status !== 200 && !replay.body?.success, "already-reviewed job must reject a second review");
+
+    // (c) Legacy job (no token) remains reviewable via code + FULL phone.
+    const spare = await pool.query(
+      `SELECT job_id, booking_code FROM public.jobs
+        WHERE booking_token IS NOT NULL AND booking_code <> $1 AND booking_code IS NOT NULL
+        ORDER BY job_id DESC LIMIT 1`, [bookingCode1]);
+    if (spare.rows.length) {
+      const legacyId = spare.rows[0].job_id;
+      const legacyCode = spare.rows[0].booking_code;
+      const legacyPhone = "0870000009";
+      await pool.query(
+        `UPDATE public.jobs SET booking_token=NULL, job_status='เสร็จแล้ว', finished_at=NOW(),
+                technician_username='tech_a', customer_phone=$2, customer_rating=NULL, reviewed_at=NULL
+         WHERE job_id=$1`, [legacyId, legacyPhone]);
+      await pool.query(`DELETE FROM public.technician_reviews WHERE job_id=$1`, [legacyId]);
+      // Wrong phone -> denied.
+      const wrongPhone = await postReview(
+        { booking_code: legacyCode, customer_phone: "0899999999", rating: 4 }, "198.51.100.23");
+      assert(wrongPhone.status !== 200 && !wrongPhone.body?.success, "legacy review with wrong phone must be denied");
+      // Correct full phone -> accepted.
+      const legacyOk = await postReview(
+        { booking_code: legacyCode, customer_phone: legacyPhone, rating: 4, review_text: "legacy ok" }, "198.51.100.24");
+      assert(legacyOk.status === 200 && legacyOk.body?.success === true,
+        `legacy code+phone review must succeed, got HTTP ${legacyOk.status}`);
+    }
+  });
+
+  // S18) The quote document is gated identically to the receipt: a bare
+  // sequential job_id 404s, the booking_token key unlocks it, and the response
+  // carries the private/no-store/no-index headers.
+  await record("S18 quote route: bare job_id 404s, booking_token key unlocks it with sensitive headers", async () => {
+    const r = await pool.query(`SELECT job_id, booking_token FROM public.jobs WHERE booking_code=$1`, [bookingCode1]);
+    const { job_id, booking_token } = r.rows[0];
+    const bare = await fetch(`${BASE_A}/docs/quote/${job_id}`, { headers: { "x-forwarded-for": "198.51.100.30" } });
+    assert(bare.status === 404, `bare job_id quote must 404, got ${bare.status}`);
+    const keyed = await fetch(`${BASE_A}/docs/quote/${job_id}?key=${encodeURIComponent(booking_token)}`,
+      { headers: { "x-forwarded-for": "198.51.100.31" } });
+    assert(keyed.status === 200, `keyed quote must 200, got ${keyed.status}`);
+    assert(/no-store/.test(keyed.headers.get("cache-control") || ""), "quote missing Cache-Control: no-store");
+    assert(/noindex/.test(keyed.headers.get("x-robots-tag") || ""), "quote missing X-Robots-Tag: noindex");
+    assert((keyed.headers.get("referrer-policy") || "") === "no-referrer", "quote missing Referrer-Policy: no-referrer");
+    // A wrong key is indistinguishable from a missing one (404, no oracle).
+    const wrong = await fetch(`${BASE_A}/docs/quote/${job_id}?key=deadbeef`, { headers: { "x-forwarded-for": "198.51.100.32" } });
+    assert(wrong.status === 404, `wrong key must 404, got ${wrong.status}`);
   });
 
   await browser.close();

--- a/test/e2e/run-booking-e2e.js
+++ b/test/e2e/run-booking-e2e.js
@@ -1,0 +1,803 @@
+"use strict";
+
+/*
+ * Customer App booking readiness — Browser E2E against the REAL app + REAL PostgreSQL.
+ *
+ * What this does:
+ *   1. Connects to a local/staging PostgreSQL (env E2E_PG_*), creates a fresh database.
+ *   2. Loads test/e2e/schema-core.sql (only the legacy tables boot doesn't create).
+ *   3. Boots TWO real `node index.js` instances on the same database:
+ *        A (port 4620): booking lanes ENABLED  — scenarios 1-12
+ *        B (port 4621): booking lanes DISABLED — scenario 13 (kill switch / LINE fallback)
+ *   4. Seeds technicians (+ service matrix + monthly calendar), a partner tech,
+ *      an admin user + session, via SQL.
+ *   5. Drives the real Customer App UI with Playwright Chromium through the 13
+ *      mandatory scenarios, asserting against the REAL database after each step.
+ *
+ * Run:  node test/e2e/run-booking-e2e.js
+ * Env:  E2E_PG_HOST (127.0.0.1) E2E_PG_PORT (5433) E2E_PG_USER (postgres)
+ *       E2E_PG_PASSWORD (postgres) E2E_KEEP_DB=1 to keep the database afterwards.
+ *
+ * NEVER run against production — it creates users/jobs and drops its own database.
+ */
+
+const { spawn } = require("node:child_process");
+const fs = require("node:fs");
+const path = require("node:path");
+const crypto = require("node:crypto");
+const { Pool, Client } = require("pg");
+const { chromium } = require("playwright");
+
+const REPO_ROOT = path.resolve(__dirname, "..", "..");
+const PG = {
+  host: process.env.E2E_PG_HOST || "127.0.0.1",
+  port: Number(process.env.E2E_PG_PORT || 5433),
+  user: process.env.E2E_PG_USER || "postgres",
+  password: process.env.E2E_PG_PASSWORD || "postgres",
+};
+const DB_NAME = `cwf_e2e_${Date.now()}`;
+const PORT_A = Number(process.env.E2E_PORT_A || 4620); // booking enabled
+const PORT_B = Number(process.env.E2E_PORT_B || 4621); // booking disabled (kill switch)
+const BASE_A = `http://127.0.0.1:${PORT_A}`;
+const BASE_B = `http://127.0.0.1:${PORT_B}`;
+const APP_URL_A = `${BASE_A}/customer-app/index.html`;
+const APP_URL_B = `${BASE_B}/customer-app/index.html`;
+
+const results = [];
+let pool = null;
+const children = [];
+
+function log(msg) { process.stdout.write(`${msg}\n`); }
+
+function ymdBangkok(offsetDays = 0) {
+  const now = new Date(Date.now() + offsetDays * 86400000);
+  return new Intl.DateTimeFormat("en-CA", { timeZone: "Asia/Bangkok" }).format(now);
+}
+
+let lastPages = new Set();
+async function record(name, fn) {
+  const started = Date.now();
+  try {
+    await fn();
+    results.push({ name, ok: true, ms: Date.now() - started });
+    log(`  ✅ ${name} (${Date.now() - started}ms)`);
+  } catch (error) {
+    results.push({ name, ok: false, ms: Date.now() - started, error: String(error.message).split("\n")[0] });
+    log(`  ❌ ${name}: ${String(error.message).split("\n")[0]}`);
+    // Evidence for diagnosis: snapshot every page that is still open.
+    let n = 0;
+    for (const p of lastPages) {
+      try { await p.screenshot({ path: path.join(__dirname, `fail-${results.length}-${n++}.png`) }); } catch (_) {}
+    }
+  }
+}
+
+// The app re-renders whole sections on every state change, which makes
+// hit-testing-based clicks flaky. All wizard buttons carry direct listeners,
+// so dispatching the event at the element is both stable and faithful.
+async function tap(locator, { timeout = 15000 } = {}) {
+  await locator.waitFor({ state: "attached", timeout });
+  await locator.scrollIntoViewIfNeeded().catch(() => {});
+  await locator.dispatchEvent("click");
+}
+
+function assert(cond, msg) { if (!cond) throw new Error(msg); }
+
+// ---------------------------------------------------------------- infra ----
+
+// The app's boot bootstrap does not cover every table on a truly empty
+// database, so extract the REAL `CREATE TABLE IF NOT EXISTS public.*`
+// definitions straight from the application source and run them — the schema
+// under test is exactly the schema the app declares.
+function extractCreateTableStatements(src) {
+  const out = [];
+  const re = /CREATE TABLE IF NOT EXISTS public\.([a-z_]+)\s*\(/g;
+  let m;
+  while ((m = re.exec(src))) {
+    let i = re.lastIndex;
+    let depth = 1;
+    while (i < src.length && depth > 0) {
+      if (src[i] === "(") depth += 1;
+      else if (src[i] === ")") depth -= 1;
+      i += 1;
+    }
+    const stmt = src.slice(m.index, i);
+    if (!stmt.includes("${")) out.push(stmt);
+  }
+  return out;
+}
+
+async function createDatabase() {
+  const admin = new Client({ ...PG, database: "postgres" });
+  await admin.connect();
+  await admin.query(`CREATE DATABASE ${DB_NAME} ENCODING 'UTF8'`);
+  await admin.end();
+  const schemaSql = fs.readFileSync(path.join(__dirname, "schema-core.sql"), "utf8");
+  const db = new Client({ ...PG, database: DB_NAME });
+  await db.connect();
+  await db.query(schemaSql);
+  await db.query(`ALTER TABLE public.users ADD COLUMN IF NOT EXISTS password TEXT`);
+  const appCreates = [
+    ...extractCreateTableStatements(fs.readFileSync(path.join(REPO_ROOT, "index.js"), "utf8")),
+    ...extractCreateTableStatements(fs.readFileSync(path.join(REPO_ROOT, "server", "customerPricing.js"), "utf8")),
+  ];
+  for (const stmt of appCreates) {
+    try { await db.query(stmt); } catch (e) { log(`(schema extract skipped: ${e.message.slice(0, 90)})`); }
+  }
+  // Production evolved several tables via boot-time ALTER ... ADD COLUMN
+  // IF NOT EXISTS self-heals — replay the same statements from source.
+  for (const srcFile of ["index.js", path.join("server", "customerPricing.js")]) {
+    const src = fs.readFileSync(path.join(REPO_ROOT, srcFile), "utf8");
+    const alters = src.match(/ALTER TABLE public\.[a-z_]+ ADD COLUMN IF NOT EXISTS [^`;)]+/g) || [];
+    for (const alter of alters) {
+      if (alter.includes("${")) continue;
+      try { await db.query(alter); } catch (_) { /* table not in scope — fine */ }
+    }
+  }
+  // Finally, replay the repo's additive migration files (idempotent) so
+  // migration-managed columns (catalog marketplace, price-rule links, ...)
+  // exist exactly as production got them.
+  const migrationsDir = path.join(REPO_ROOT, "migrations");
+  for (const file of fs.readdirSync(migrationsDir).filter((f) => f.endsWith(".sql")).sort()) {
+    const sql = fs.readFileSync(path.join(migrationsDir, file), "utf8");
+    try { await db.query(sql); } catch (_) { /* non-booking migrations may not apply — fine */ }
+  }
+  await db.end();
+}
+
+async function dropDatabase() {
+  if (process.env.E2E_KEEP_DB === "1") { log(`(keeping database ${DB_NAME})`); return; }
+  const admin = new Client({ ...PG, database: "postgres" });
+  await admin.connect();
+  await admin.query(`DROP DATABASE IF EXISTS ${DB_NAME} WITH (FORCE)`).catch(() => {});
+  await admin.end();
+}
+
+function bootApp(port, extraEnv = {}) {
+  const logFile = path.join(__dirname, `app-${port}.log`);
+  const out = fs.openSync(logFile, "w");
+  const child = spawn(process.execPath, ["index.js"], {
+    cwd: REPO_ROOT,
+    env: {
+      ...process.env,
+      DB_HOST: PG.host, DB_PORT: String(PG.port), DB_USER: PG.user,
+      DB_PASSWORD: PG.password, DB_NAME,
+      PORT: String(port),
+      CWF_JWT_SECRET: "e2e-test-secret",
+      ENABLE_CUSTOMER_SCHEDULED_BOOKING: "true",
+      ENABLE_CUSTOMER_URGENT_BOOKING: "true",
+      ...extraEnv,
+    },
+    stdio: ["ignore", out, out],
+  });
+  children.push(child);
+  return child;
+}
+
+async function waitForReady(base, { timeoutMs = 90000 } = {}) {
+  const startedAt = Date.now();
+  for (;;) {
+    if (Date.now() - startedAt > timeoutMs) throw new Error(`app at ${base} not ready in ${timeoutMs}ms`);
+    try {
+      const res = await fetch(`${base}/public/pricing_preview`, {
+        method: "POST", headers: { "content-type": "application/json" },
+        body: JSON.stringify({ job_type: "ล้างแอร์", ac_type: "ผนัง", btu: 12000, machine_count: 1, wash_variant: "ล้างธรรมดา" }),
+      });
+      if (res.ok) {
+        const ready = await pool.query("SELECT to_regclass('public.job_offers') AS a, to_regclass('public.technician_service_matrix') AS b, to_regclass('public.technician_monthly_work_calendar') AS c");
+        const r = ready.rows[0];
+        if (r.a && r.b && r.c) return;
+      }
+    } catch (_) { /* not up yet */ }
+    await new Promise((r) => setTimeout(r, 1000));
+  }
+}
+
+// ---------------------------------------------------------------- seed ----
+
+const MATRIX_WASH_WALL = {
+  job_types: { wash: true },
+  ac_types: { wall: true },
+  wash_wall_variants: { normal: true, premium: true },
+  repair_variants: {},
+};
+
+async function seedTechnician(username, { employment = "company", date, maxJobs = 1, maxUnits = 5, urgentOk = true } = {}) {
+  await pool.query(`INSERT INTO public.users (username, role) VALUES ($1,'technician') ON CONFLICT (username) DO NOTHING`, [username]);
+  await pool.query(
+    `INSERT INTO public.technician_profiles (username, full_name, employment_type, accept_status, accept_status_expires_at, customer_slot_visible, work_start, work_end)
+     VALUES ($1,$2,$3,'ready', NOW() + INTERVAL '12 hours', TRUE, '09:00','18:00')
+     ON CONFLICT (username) DO UPDATE SET employment_type=EXCLUDED.employment_type, accept_status='ready', accept_status_expires_at=NOW() + INTERVAL '12 hours', customer_slot_visible=TRUE`,
+    [username, `ช่าง ${username}`, employment]
+  );
+  await pool.query(
+    `INSERT INTO public.technician_service_matrix (username, matrix_json) VALUES ($1,$2::jsonb)
+     ON CONFLICT (username) DO UPDATE SET matrix_json=EXCLUDED.matrix_json`,
+    [username, JSON.stringify(MATRIX_WASH_WALL)]
+  );
+  const dates = Array.isArray(date) ? date : [date];
+  for (const d of dates) {
+    if (!d) continue;
+    await pool.query(
+      `INSERT INTO public.technician_monthly_work_calendar
+         (technician_username, work_date, day_status, can_accept_advance_job, can_accept_urgent_job, start_time, end_time, max_jobs_per_day, max_units_per_day, source)
+       VALUES ($1,$2,'working',TRUE,$5,'09:00','18:00',$3,$4,'e2e')
+       ON CONFLICT (technician_username, work_date) DO UPDATE
+         SET day_status='working', can_accept_advance_job=TRUE, can_accept_urgent_job=$5, max_jobs_per_day=$3, max_units_per_day=$4`,
+      [username, d, maxJobs, maxUnits, urgentOk]
+    );
+  }
+}
+
+async function seedAdminSession() {
+  await pool.query(`INSERT INTO public.users (username, role) VALUES ('e2e_admin','admin') ON CONFLICT (username) DO UPDATE SET role='admin'`);
+  const token = crypto.randomBytes(24).toString("hex");
+  await pool.query(
+    `INSERT INTO public.auth_sessions (session_token, username, role, expires_at) VALUES ($1,'e2e_admin','admin', NOW() + INTERVAL '4 hours')`,
+    [token]
+  );
+  return token;
+}
+
+// ------------------------------------------------------------ ui drivers ----
+
+async function fillContactStep(page, { name = "ลูกค้า ทดสอบ", phone = "0812345678", address = "99/1 หมู่บ้านทดสอบ ถนนอ่อนนุช เขตสวนหลวง กทม 10250" } = {}) {
+  await page.locator('[data-scheduled-field="customer_name"]').fill(name);
+  await page.locator('[data-scheduled-field="customer_phone"]').fill(phone);
+  await page.locator('[data-scheduled-field="address_text"]').fill(address);
+}
+
+async function chooseWashWallService(page, scope = null) {
+  // Step 1 service line: pick ผนัง -> BTU 12000 -> ล้างธรรมดา via choice buttons.
+  const rootLoc = scope || page;
+  const pick = async (field, value) => {
+    const btn = rootLoc.locator(`[data-line-choice="${field}"][data-choice-value="${value}"]`).first();
+    await tap(btn);
+    await page.waitForTimeout(250); // re-render
+  };
+  await pick("ac_type", "ผนัง");
+  await pick("btu", "12000");
+  await pick("wash_variant", "ล้างธรรมดา");
+}
+
+async function goToBookingWizard(page, appUrl) {
+  await page.goto(`${appUrl}#scheduled`, { waitUntil: "domcontentloaded" });
+  // A restored draft may land on a later step — reset to a clean wizard.
+  await page.evaluate(() => {
+    try { window.CWFCustomerAppV2.state.resetScheduledDraft(); } catch (_) {}
+  });
+  await page.reload({ waitUntil: "domcontentloaded" });
+  await page.waitForSelector("[data-line-choice]", { timeout: 20000 }); // step 1: services
+}
+
+async function pickDateAndSlot(page, ymd, { slotIndex = 0 } = {}) {
+  const day = page.locator(`[data-calendar-date="${ymd}"]`);
+  await tap(day, { timeout: 25000 });
+  const slot = page.locator("[data-real-slot-key]").nth(slotIndex);
+  await slot.waitFor({ state: "attached", timeout: 25000 });
+  const slotKey = await slot.getAttribute("data-real-slot-key");
+  await tap(slot);
+  return slotKey;
+}
+
+async function chooseTimeProposal(page, value = "false") {
+  const btn = page.locator(`[data-time-proposal="${value}"]`);
+  if (await btn.count()) await tap(btn.first());
+}
+
+async function nextStep(page) {
+  await tap(page.locator('[data-action="wizard-next"]'));
+  await page.waitForTimeout(400);
+}
+
+async function completeScheduledWizard(page, appUrl, ymd, opts = {}) {
+  // Wizard: step 1 = services -> step 2 = contact + calendar + slot -> step 3 = review.
+  await goToBookingWizard(page, appUrl);
+  await chooseWashWallService(page);
+  await nextStep(page); // -> step 2
+  await page.waitForSelector('[data-scheduled-field="customer_name"]', { timeout: 20000 });
+  await fillContactStep(page, opts.contact || {});
+  const slotKey = await pickDateAndSlot(page, ymd, opts);
+  await chooseTimeProposal(page, "false");
+  await nextStep(page); // -> step 3 (review)
+  await page.waitForSelector('[data-action="submit-scheduled"]', { timeout: 15000 });
+  return slotKey;
+}
+
+async function submitAndWaitSuccess(page) {
+  await tap(page.locator('[data-action="submit-scheduled"]'));
+  await page.waitForSelector(".booking-result-card", { timeout: 30000 });
+  const code = (await page.locator(".booking-code-value").textContent() || "").trim();
+  assert(/^CWF/.test(code), `expected booking code, got "${code}"`);
+  return code;
+}
+
+// -------------------------------------------------------------- helpers ----
+
+async function jobCountWhere(where, params = []) {
+  const r = await pool.query(`SELECT COUNT(*)::int AS n FROM public.jobs WHERE ${where}`, params);
+  return r.rows[0].n;
+}
+
+async function apiBook(base, payload) {
+  const res = await fetch(`${base}/public/book`, {
+    method: "POST", headers: { "content-type": "application/json" },
+    body: JSON.stringify(payload),
+  });
+  let body = null;
+  try { body = await res.json(); } catch (_) { body = null; }
+  return { status: res.status, body };
+}
+
+function scheduledPayload(ymd, start, overrides = {}) {
+  return {
+    customer_name: "ลูกค้า API", customer_phone: "0899999999",
+    job_type: "ล้างแอร์", appointment_datetime: `${ymd}T${start}:00`,
+    address_text: "99/2 ทดสอบ API กทม", booking_mode: "scheduled",
+    client_app: "customer_app_v2", allow_time_proposal: false,
+    ac_type: "ผนัง", btu: 12000, machine_count: 1, wash_variant: "ล้างธรรมดา",
+    scheduled_request_key: crypto.randomBytes(16).toString("hex"),
+    ...overrides,
+  };
+}
+
+// ------------------------------------------------------------- scenarios ----
+
+async function main() {
+  log(`E2E database: ${DB_NAME} on ${PG.host}:${PG.port}`);
+  const adminPool = new Client({ ...PG, database: "postgres" });
+  await adminPool.connect();
+  await adminPool.query("SELECT 1");
+  await adminPool.end();
+
+  await createDatabase();
+  pool = new Pool({ ...PG, database: DB_NAME, max: 5 });
+
+  log("booting app A (booking enabled) + app B (booking disabled)...");
+  bootApp(PORT_A, {});
+  bootApp(PORT_B, { ENABLE_CUSTOMER_SCHEDULED_BOOKING: "false", ENABLE_CUSTOMER_URGENT_BOOKING: "false" });
+  await waitForReady(BASE_A);
+  await waitForReady(BASE_B);
+  log("apps ready.");
+
+  const tomorrow = ymdBangkok(1);
+  const dayAfter = ymdBangkok(2);
+  const today = ymdBangkok(0);
+
+  // Capacity note: tech_a works tomorrow+dayAfter (1 job/day). tech_race works
+  // dayAfter only — scenario 4 uses dayAfter where both techs are free but each
+  // capped at 1 job... for a true "last slot" race we use a dedicated date with
+  // ONE technician only (raceDay = day 3).
+  const raceDay = ymdBangkok(3);
+  const staleDay = ymdBangkok(4);
+  const multiDay = ymdBangkok(5);
+  const retryDay = ymdBangkok(6);
+  const reloadDay = ymdBangkok(7);
+
+  await seedTechnician("tech_a", { date: [tomorrow, dayAfter, multiDay, reloadDay], maxJobs: 3, maxUnits: 9 });
+  await seedTechnician("tech_solo", { date: [raceDay, staleDay, retryDay], maxJobs: 1, maxUnits: 5 });
+  await seedTechnician("tech_partner", { employment: "partner", date: [today, tomorrow], urgentOk: true });
+  await seedTechnician("tech_partner2", { employment: "partner", date: [today, tomorrow], urgentOk: true });
+  // Zone A covers เขตสวนหลวง — the urgent offer engine targets partners by zone.
+  await pool.query(`UPDATE public.technician_profiles SET home_service_zone_code='A' WHERE username IN ('tech_partner','tech_partner2')`).catch(() => {});
+
+  async function seedSessionFor(username, role) {
+    const token = crypto.randomBytes(24).toString("hex");
+    await pool.query(
+      `INSERT INTO public.auth_sessions (session_token, username, role, expires_at) VALUES ($1,$2,$3, NOW() + INTERVAL '4 hours')`,
+      [token, username, role]
+    );
+    return token;
+  }
+  const adminSession = await seedAdminSession();
+
+  // The sandbox pre-installs Chromium at a pinned build; point Playwright at
+  // it explicitly so a version-mismatched registry lookup can't fail the run.
+  const chromiumCandidates = [
+    process.env.E2E_CHROMIUM_PATH,
+    "/opt/pw-browsers/chromium-1194/chrome-linux/chrome",
+    "/opt/pw-browsers/chromium/chrome-linux/chrome",
+  ].filter(Boolean);
+  const executablePath = chromiumCandidates.find((p) => { try { fs.accessSync(p); return true; } catch (_) { return false; } });
+  const browser = await chromium.launch(executablePath ? { executablePath } : {});
+  const ctx = await browser.newContext({ viewport: { width: 390, height: 844 } });
+  const page = await ctx.newPage();
+  lastPages.add(page);
+  ctx.on("page", (p) => { lastPages.add(p); p.on("close", () => lastPages.delete(p)); });
+
+  // 1) Scheduled booking success through the real UI.
+  let bookingCode1 = "";
+  let bookingToken1 = "";
+  await record("S1 scheduled booking succeeds end-to-end (UI -> PostgreSQL)", async () => {
+    await completeScheduledWizard(page, APP_URL_A, tomorrow);
+    bookingCode1 = await submitAndWaitSuccess(page);
+    const r = await pool.query(
+      `SELECT booking_token, job_status, booking_mode, job_source, technician_username, job_price, duration_min
+         FROM public.jobs WHERE booking_code=$1`, [bookingCode1]);
+    assert(r.rows.length === 1, "job row not found in PostgreSQL");
+    const job = r.rows[0];
+    bookingToken1 = job.booking_token;
+    assert(job.booking_mode === "scheduled" && job.job_source === "customer", "wrong mode/source");
+    assert(job.technician_username, "no technician reserved");
+    assert(Number(job.job_price) > 0, "job_price must be > 0");
+    assert(Number(job.duration_min) > 0, "duration_min must be > 0");
+  });
+
+  // 2) Double-click cannot create two jobs.
+  await record("S2 double-click submit creates exactly one job", async () => {
+    const before = await jobCountWhere("job_source='customer'");
+    await completeScheduledWizard(page, APP_URL_A, tomorrow, { slotIndex: 1 });
+    // A realistic double-tap: two click events in the same burst. (A third,
+    // later click would land on the success screen's next button — a different
+    // gesture entirely.) The server-side request key + in-flight guard must
+    // still produce exactly one job.
+    await page.evaluate(() => {
+      const el = document.querySelector('[data-action="submit-scheduled"]');
+      el.click(); el.click();
+    });
+    await page.waitForSelector(".booking-result-card", { timeout: 30000 });
+    const after = await jobCountWhere("job_source='customer'");
+    assert(after === before + 1, `expected +1 job, got +${after - before}`);
+  });
+
+  // 3) Network drop after server commit -> reload -> resubmit returns the SAME job.
+  await record("S3 reload after submit resumes the same job (idempotent replay)", async () => {
+    const p2 = await ctx.newPage();
+    await completeScheduledWizard(p2, APP_URL_A, reloadDay);
+    // First submit: forward the EXACT request to the server (it commits), then
+    // cut the response — the phone never learns the booking succeeded.
+    let intercepted = false;
+    await p2.route("**/public/book", async (route) => {
+      if (!intercepted) {
+        intercepted = true;
+        try {
+          const resp = await fetch(`${BASE_A}/public/book`, {
+            method: "POST",
+            headers: { "content-type": "application/json" },
+            body: route.request().postData(),
+          });
+          await resp.text();
+        } catch (_) { /* the assertion below verifies the commit */ }
+        await route.abort("connectionreset");
+        return;
+      }
+      await route.continue();
+    });
+    await tap(p2.locator('[data-action="submit-scheduled"]'));
+    await p2.waitForTimeout(4000); // let the server-side booking commit
+    const midCount = await jobCountWhere("appointment_datetime::date=$1", [reloadDay]);
+    await p2.unroute("**/public/book");
+    await p2.reload({ waitUntil: "domcontentloaded" });
+    await p2.waitForSelector('[data-action="submit-scheduled"], [data-action="wizard-next"], [data-calendar-date]', { timeout: 25000 });
+    // Draft (incl. scheduled_request_key) survives the reload. Availability is
+    // refetched with a new query key, so the customer re-picks the slot before
+    // resubmitting — the request key is what guarantees the replay.
+    let code = "";
+    for (let attempt = 0; attempt < 3 && !code; attempt += 1) {
+      if (await p2.locator('[data-action="submit-scheduled"]').count()) {
+        await tap(p2.locator('[data-action="submit-scheduled"]'));
+        try {
+          await p2.waitForSelector(".booking-result-card", { timeout: 15000 });
+          code = (await p2.locator(".booking-code-value").textContent() || "").trim();
+          break;
+        } catch (_) { /* bounced back to slot step */ }
+      }
+      if (await p2.locator(`[data-calendar-date="${reloadDay}"]`).count()) {
+        await pickDateAndSlot(p2, reloadDay);
+        await chooseTimeProposal(p2, "false");
+        if (await p2.locator('[data-action="wizard-next"]').count()) await nextStep(p2);
+      } else if (await p2.locator('[data-action="wizard-next"]').count()) {
+        await nextStep(p2);
+      }
+      await p2.waitForTimeout(600);
+    }
+    assert(/^CWF/.test(code), `expected replayed booking code, got "${code}"`);
+    const finalCount = await jobCountWhere("appointment_datetime::date=$1", [reloadDay]);
+    assert(midCount === 1, `expected 1 committed job after network drop, got ${midCount}`);
+    assert(finalCount === 1, `replay must not create a second job (got ${finalCount})`);
+    await p2.close();
+  });
+
+  // 4) Two browsers race for the last capacity -> exactly one wins.
+  await record("S4 concurrent booking of the last slot: exactly one succeeds", async () => {
+    const ctxB = await browser.newContext({ viewport: { width: 390, height: 844 } });
+    const pA = await ctx.newPage();
+    const pB = await ctxB.newPage();
+    await completeScheduledWizard(pA, APP_URL_A, raceDay);
+    await completeScheduledWizard(pB, APP_URL_A, raceDay);
+    const [ra, rb] = await Promise.allSettled([
+      (async () => { await pA.locator('[data-action="submit-scheduled"]').dispatchEvent("click"); await pA.waitForSelector(".booking-result-card", { timeout: 30000 }); return "ok"; })(),
+      (async () => { await pB.locator('[data-action="submit-scheduled"]').dispatchEvent("click"); await pB.waitForSelector(".booking-result-card", { timeout: 30000 }); return "ok"; })(),
+    ]);
+    const wins = [ra, rb].filter((x) => x.status === "fulfilled").length;
+    const jobs = await jobCountWhere("appointment_datetime::date=$1", [raceDay]);
+    assert(jobs === 1, `overbooking: ${jobs} jobs on race day (max_jobs_per_day=1)`);
+    assert(wins === 1, `expected exactly 1 UI success, got ${wins}`);
+    // The loser must see the "slot taken" message.
+    const loser = ra.status === "fulfilled" ? pB : pA;
+    const text = await loser.textContent("body");
+    assert(/เต็ม|เลือกช่วงเวลาใหม่|เลือกเวลาอื่น/.test(text || ""), "loser did not see slot-full feedback");
+    await pA.close(); await pB.close(); await ctxB.close();
+  });
+
+  // 5) Slot booked while the page is open -> submit rejected, customer re-picks.
+  await record("S5 stale slot is rejected at confirm (no silent double-book)", async () => {
+    const p = await ctx.newPage();
+    await completeScheduledWizard(p, APP_URL_A, staleDay);
+    // Someone else takes the capacity via API while our page sits on review.
+    const api = await apiBook(BASE_A, scheduledPayload(staleDay, "09:00"));
+    assert(api.status === 200 && api.body?.success, `API prebook failed: HTTP ${api.status}`);
+    await tap(p.locator('[data-action="submit-scheduled"]'));
+    await p.waitForTimeout(3500);
+    const jobs = await jobCountWhere("appointment_datetime::date=$1", [staleDay]);
+    assert(jobs === 1, `expected 1 job on stale day, got ${jobs}`);
+    const text = await p.textContent("body");
+    assert(/เต็ม|เลือกช่วงเวลาใหม่|เลือกเวลาอื่น/.test(text || ""), "no stale-slot feedback shown");
+    await p.close();
+  });
+
+  // 6) Same-day cutoff: past-start today is rejected server-side.
+  await record("S6 same-day cutoff rejects a start time already in the past", async () => {
+    const api = await apiBook(BASE_A, scheduledPayload(today, "00:01"));
+    assert(api.status === 409, `expected 409 SLOT_IN_PAST, got ${api.status}`);
+    assert((api.body?.code || api.body?.error || "").includes("SLOT_IN_PAST") || api.status === 409, "wrong error");
+  });
+
+  // 7) Multi-service booking books once with combined duration/price.
+  await record("S7 multi-service booking persists one job with combined services", async () => {
+    const p = await ctx.newPage();
+    await goToBookingWizard(p, APP_URL_A);
+    await chooseWashWallService(p);
+    await tap(p.locator('[data-action="add-line"]'));
+    // Configure the second line (last service-line card).
+    const pickLast = async (field, value) => {
+      await tap(p.locator("[data-service-line-card]").last()
+        .locator(`[data-line-choice="${field}"][data-choice-value="${value}"]`).first());
+      await p.waitForTimeout(250);
+    };
+    await pickLast("ac_type", "ผนัง"); await pickLast("btu", "12000"); await pickLast("wash_variant", "ล้างธรรมดา");
+    await nextStep(p); // -> step 2
+    await p.waitForSelector('[data-scheduled-field="customer_name"]', { timeout: 20000 });
+    await fillContactStep(p);
+    await pickDateAndSlot(p, multiDay);
+    await chooseTimeProposal(p, "false");
+    await nextStep(p);
+    const code = await submitAndWaitSuccess(p);
+    const r = await pool.query(`SELECT job_price, duration_min FROM public.jobs WHERE booking_code=$1`, [code]);
+    assert(r.rows.length === 1, "multi-service job missing");
+    const items = await pool.query(`SELECT COUNT(*)::int AS n FROM public.job_items ji JOIN public.jobs j ON j.job_id=ji.job_id WHERE j.booking_code=$1`, [code]);
+    assert(items.rows[0].n >= 2, `expected >=2 job_items, got ${items.rows[0].n}`);
+    await p.close();
+  });
+
+  // 8) Urgent booking with an available partner -> offer created + waiting room.
+  let urgentToken = "";
+  await record("S8 urgent booking creates one job + partner offer, waiting room live", async () => {
+    const p = await ctx.newPage();
+    await p.goto(`${APP_URL_A}#urgent`, { waitUntil: "domcontentloaded" });
+    await p.waitForSelector('[data-urgent-field="customer_name"]', { timeout: 20000 });
+    await p.locator('[data-urgent-field="customer_name"]').fill("ลูกค้า ด่วน");
+    await p.locator('[data-urgent-field="customer_phone"]').fill("0822222222");
+    await p.locator('[data-urgent-field="address_text"]').fill("55/5 หมู่บ้านทดสอบ เขตสวนหลวง กรุงเทพฯ 10250");
+    // Service taxonomy: ล้าง -> ผนัง -> ล้างธรรมดา -> 12000 BTU.
+    const choose = async (field, value) => {
+      const btn = p.locator(`[data-urgent-choice="${field}"][data-choice-value="${value}"]`).first();
+      await tap(btn);
+      await p.waitForTimeout(250);
+    };
+    await choose("service_kind", "clean");
+    await choose("ac_type", "ผนัง");
+    await choose("wash_variant", "ล้างธรรมดา");
+    await choose("btu", "12000");
+    const symptom = p.locator('[data-urgent-field="symptom"]');
+    if (await symptom.count()) await symptom.fill("แอร์ไม่เย็น ต้องการช่างด่วน");
+    await tap(p.locator('[data-urgent-action="to-review"]'));
+    await p.waitForSelector('[data-urgent-action="confirm"]', { timeout: 15000 });
+    await tap(p.locator('[data-urgent-action="confirm"]'));
+    await p.waitForSelector(".waiting-room, [data-urgent-live-status]", { timeout: 30000 });
+    const r = await pool.query(`SELECT job_id, booking_token FROM public.jobs WHERE booking_mode='urgent' ORDER BY job_id DESC LIMIT 1`);
+    assert(r.rows.length === 1, "urgent job not found");
+    urgentToken = r.rows[0].booking_token;
+    const offers = await pool.query(`SELECT offer_id, technician_username, status FROM public.job_offers WHERE job_id=$1`, [r.rows[0].job_id]);
+    assert(offers.rows.length >= 1, "no partner offer created");
+    assert(offers.rows.every((o) => ["tech_partner", "tech_partner2"].includes(o.technician_username)), "offer sent to wrong technician");
+
+    // Both partners race to accept — exactly one may win, and the job must be
+    // assigned to the winner (single-winner guarantee, real HTTP + real DB).
+    const offerByTech = new Map(offers.rows.map((o) => [o.technician_username, o.offer_id]));
+    const attempts = [];
+    for (const tech of ["tech_partner", "tech_partner2"]) {
+      const offerId = offerByTech.get(tech);
+      if (!offerId) continue;
+      const session = await seedSessionFor(tech, "technician");
+      attempts.push(
+        fetch(`${BASE_A}/offers/${offerId}/accept`, {
+          method: "POST",
+          headers: { "content-type": "application/json", cookie: `cwf_session=${session}` },
+          body: "{}",
+        }).then(async (resp) => ({ tech, status: resp.status, body: await resp.json().catch(() => null) }))
+      );
+    }
+    const raceResults = await Promise.all(attempts);
+    const winners = raceResults.filter((x) => x.status === 200);
+    assert(winners.length === 1, `expected exactly 1 accepted offer, got ${winners.length} (${JSON.stringify(raceResults.map((x) => x.status))})`);
+    const assigned = await pool.query(`SELECT technician_username FROM public.jobs WHERE job_id=$1`, [r.rows[0].job_id]);
+    assert(assigned.rows[0].technician_username === winners[0].tech, "job not assigned to the accepting technician");
+    // The customer's waiting room flips to accepted via the public status feed.
+    const statusRes = await (await fetch(`${BASE_A}/public/urgent-status?token=${encodeURIComponent(urgentToken)}`)).json();
+    assert(statusRes.phase === "accepted" && statusRes.confirmed === true, `urgent status should be accepted, got ${statusRes.phase}`);
+    await p.close();
+  });
+
+  // 9) Urgent with no acceptance -> offer expires -> job lands in admin review (not lost).
+  await record("S9 expired urgent offer falls back to admin review (job never lost)", async () => {
+    // A fresh urgent request via the public API (S8's job is already accepted).
+    const api = await apiBook(BASE_A, {
+      customer_name: "ลูกค้า ด่วนสอง", customer_phone: "0833333333",
+      job_type: "ล้าง", appointment_datetime: new Date().toISOString(),
+      address_text: "77/7 เขตสวนหลวง กรุงเทพฯ", booking_mode: "urgent",
+      client_app: "customer_app_v2", allow_time_proposal: true,
+      urgent_request_key: crypto.randomBytes(16).toString("hex"),
+      ac_type: "ผนัง", btu: 12000, machine_count: 1, wash_variant: "ล้างธรรมดา",
+    });
+    assert(api.status === 200 && api.body?.job_id, `urgent API booking failed: HTTP ${api.status}`);
+    const jobId = api.body.job_id;
+    await pool.query(`UPDATE public.job_offers SET expires_at = NOW() - INTERVAL '5 minutes' WHERE job_id=$1`, [jobId]);
+    // The app's own finalizer runner ticks every 60s — call the same finalizer
+    // through the real module against the same database to avoid a flaky wait.
+    const finalizer = require(path.join(REPO_ROOT, "server", "services", "urgent", "finalizer"));
+    await finalizer.autoFinalizeUrgentJobs(pool);
+    const after = await pool.query(`SELECT job_status, canceled_at FROM public.jobs WHERE job_id=$1`, [jobId]);
+    assert(after.rows[0].canceled_at === null, "urgent job must not be canceled/lost");
+    assert(String(after.rows[0].job_status || "").length > 0, "urgent job lost its status");
+    const offers = await pool.query(`SELECT status FROM public.job_offers WHERE job_id=$1`, [jobId]);
+    assert(offers.rows.every((o) => o.status !== "pending"), "expired offers must not stay pending");
+  });
+
+  // 10) Admin sees the new bookings in the review queue.
+  await record("S10 admin review queue shows the customer bookings (with admin session)", async () => {
+    const adminCtx = await browser.newContext({ viewport: { width: 1280, height: 900 } });
+    await adminCtx.addCookies([{ name: "cwf_session", value: adminSession, url: BASE_A }]);
+    const p = await adminCtx.newPage();
+    await p.goto(`${BASE_A}/admin-review-v2.html`, { waitUntil: "domcontentloaded" });
+    await p.waitForTimeout(5000); // let the queue load + notifications evaluate
+    const text = await p.textContent("body");
+    assert(text && text.includes(bookingCode1), `admin queue does not show ${bookingCode1}`);
+    await p.close(); await adminCtx.close();
+  });
+
+  // 11) Customer tracking after booking + privacy split (token vs code).
+  await record("S11 tracking works after booking; booking_code lookups are PII-redacted", async () => {
+    // token lookup -> full detail
+    const full = await (await fetch(`${BASE_A}/public/track?q=${encodeURIComponent(bookingToken1)}`)).json();
+    assert(full.access_level === "token", "token lookup should be full access");
+    assert(full.customer_phone === "0812345678", "full access should return the real phone");
+    // code lookup -> masked
+    const red = await (await fetch(`${BASE_A}/public/track?q=${encodeURIComponent(bookingCode1)}`)).json();
+    assert(red.access_level === "code", "code lookup should be limited access");
+    assert(red.booking_token === null, "code lookup must not echo the token");
+    assert(String(red.customer_phone || "").includes("5678") && !String(red.customer_phone).includes("0812345678"), "phone must be masked");
+    assert(red.gps_latitude === null && red.maps_url === null, "GPS/maps must be hidden");
+    assert(red.receipt_url === null, "receipt link must be hidden for code lookups");
+    // In-browser: tracking page renders for the customer.
+    const p = await ctx.newPage();
+    await p.goto(`${APP_URL_A}#tracking`, { waitUntil: "domcontentloaded" });
+    await p.locator("#tracking-code").fill(bookingCode1);
+    await tap(p.locator('[data-action="track-read"]'));
+    await p.waitForTimeout(2500);
+    const text = await p.textContent("body");
+    assert(text.includes(bookingCode1) || /สถานะ|รอดำเนินการ|รอตรวจสอบ/.test(text), "tracking result not rendered");
+    await p.close();
+  });
+
+  // 12) Offline/timeout recovery: submit while offline -> error -> retry online -> one job.
+  await record("S12 offline submit recovers without duplicate after reconnect", async () => {
+    const p = await ctx.newPage();
+    try {
+      await completeScheduledWizard(p, APP_URL_A, retryDay);
+      await ctx.setOffline(true);
+      await tap(p.locator('[data-action="submit-scheduled"]'));
+      await p.waitForTimeout(3500);
+      const errText = await p.textContent("body");
+      // Note: a pure network failure currently surfaces fetch's raw message —
+      // recorded as a P2 wording follow-up; the recovery behavior is what P0 needs.
+      assert(/ไม่สำเร็จ|ผิดพลาด|เชื่อมต่อ|ลองใหม่|เต็ม|ออฟไลน์|failed to fetch/i.test(errText || ""), "no offline error message shown");
+    } finally {
+      await ctx.setOffline(false); // never leak offline state into later scenarios
+    }
+    // Retrying may need a fresh slot revalidation round-trip first.
+    await p.waitForTimeout(1000);
+    await tap(p.locator('[data-action="submit-scheduled"]'));
+    await p.waitForSelector(".booking-result-card", { timeout: 30000 });
+    const jobs = await jobCountWhere("appointment_datetime::date=$1", [retryDay]);
+    assert(jobs === 1, `expected exactly 1 job after offline retry, got ${jobs}`);
+    await p.close();
+  });
+
+  // 13) Kill switch: booking disabled -> 503 + LINE fallback, zero jobs created.
+  await record("S13 kill switch shows LINE fallback and never creates a job", async () => {
+    const before = await jobCountWhere("TRUE");
+    const p = await ctx.newPage();
+    await completeScheduledWizard(p, APP_URL_B, tomorrow);
+    // Earlier scenarios shift live capacity, so the first submit may bounce on
+    // slot revalidation — re-pick and resubmit until the 503 gate answers.
+    let lineShown = false;
+    for (let attempt = 0; attempt < 3 && !lineShown; attempt += 1) {
+      if (await p.locator('[data-action="submit-scheduled"]').count()) {
+        await tap(p.locator('[data-action="submit-scheduled"]'));
+      }
+      try {
+        await p.waitForSelector(".line-fallback-btn", { timeout: 12000 });
+        lineShown = true;
+        break;
+      } catch (_) { /* bounced — re-pick a slot */ }
+      if (await p.locator("[data-calendar-date]").count()) {
+        const day = p.locator("[data-calendar-date]").first();
+        await tap(day);
+        const slot = p.locator("[data-real-slot-key]").first();
+        await slot.waitFor({ state: "attached", timeout: 20000 }).catch(() => {});
+        if (await slot.count()) await tap(slot);
+        await chooseTimeProposal(p, "false");
+        if (await p.locator('[data-action="wizard-next"]').count()) await nextStep(p);
+      }
+    }
+    assert(lineShown, "LINE fallback button never appeared");
+    const href = await p.locator(".line-fallback-btn").getAttribute("href");
+    assert(href && href.startsWith("https://lin.ee/"), "LINE fallback link missing");
+    // Direct API double-check for both lanes.
+    const sched = await apiBook(BASE_B, scheduledPayload(tomorrow, "13:00"));
+    assert(sched.status === 503 && sched.body?.code === "SCHEDULED_BOOKING_DISABLED", "scheduled lane not closed");
+    const urgent = await apiBook(BASE_B, {
+      customer_name: "x", customer_phone: "0811111111", job_type: "ล้างแอร์",
+      appointment_datetime: new Date().toISOString(), address_text: "y",
+      booking_mode: "urgent", client_app: "customer_app_v2",
+      urgent_request_key: crypto.randomBytes(16).toString("hex"),
+      ac_type: "ผนัง", btu: 12000, machine_count: 1, wash_variant: "ล้างธรรมดา",
+    });
+    assert(urgent.status === 503 && urgent.body?.code === "URGENT_BOOKING_DISABLED", "urgent lane not closed");
+    const after = await jobCountWhere("TRUE");
+    assert(after === before, `kill switch leaked ${after - before} job(s)`);
+    await p.close();
+  });
+
+  // Bonus hardening probes (rate limit + receipt gate) — part of privacy verification.
+  await record("P1 rate limit answers 429 after the per-minute budget", async () => {
+    let got429 = false;
+    for (let i = 0; i < 40; i += 1) {
+      const res = await fetch(`${BASE_A}/public/track?q=CWFNOPE${i}`, { headers: { "x-forwarded-for": "203.0.113.99" } });
+      if (res.status === 429) { got429 = true; break; }
+    }
+    assert(got429, "no 429 after 40 rapid lookups");
+  });
+
+  await record("P2 receipt requires booking_token key (bare job_id 404s; key works)", async () => {
+    const r = await pool.query(`SELECT job_id, booking_token FROM public.jobs WHERE booking_code=$1`, [bookingCode1]);
+    const { job_id, booking_token } = r.rows[0];
+    await pool.query(`UPDATE public.jobs SET job_status='เสร็จแล้ว', finished_at=NOW() WHERE job_id=$1`, [job_id]);
+    const bare = await fetch(`${BASE_A}/docs/receipt/${job_id}`, { headers: { "x-forwarded-for": "203.0.113.50" } });
+    assert(bare.status === 404, `bare job_id receipt must 404, got ${bare.status}`);
+    const keyed = await fetch(`${BASE_A}/docs/receipt/${job_id}?key=${encodeURIComponent(booking_token)}`, { headers: { "x-forwarded-for": "203.0.113.51" } });
+    assert(keyed.status === 200, `keyed receipt must 200, got ${keyed.status}`);
+  });
+
+  await browser.close();
+}
+
+// ------------------------------------------------------------------ run ----
+
+main()
+  .catch((error) => {
+    log(`FATAL: ${error.stack || error.message}`);
+    results.push({ name: "harness", ok: false, error: error.message });
+  })
+  .finally(async () => {
+    for (const child of children) { try { child.kill("SIGKILL"); } catch (_) {} }
+    try { if (pool) await pool.end(); } catch (_) {}
+    try { await dropDatabase(); } catch (_) {}
+    const pass = results.filter((r) => r.ok).length;
+    const fail = results.length - pass;
+    log("\n===== E2E SUMMARY =====");
+    for (const r of results) log(`${r.ok ? "PASS" : "FAIL"}  ${r.name}${r.ok ? "" : ` — ${r.error}`}`);
+    log(`total=${results.length} pass=${pass} fail=${fail}`);
+    process.exitCode = fail === 0 ? 0 : 1;
+  });

--- a/test/e2e/run-booking-e2e.js
+++ b/test/e2e/run-booking-e2e.js
@@ -441,8 +441,9 @@ async function main() {
   const multiDay = ymdBangkok(5);
   const retryDay = ymdBangkok(6);
   const reloadDay = ymdBangkok(7);
+  const r2Day = ymdBangkok(8); // round-2 canonical-protection probes (headroom for replay)
 
-  await seedTechnician("tech_a", { date: [tomorrow, dayAfter, multiDay, reloadDay], maxJobs: 3, maxUnits: 9 });
+  await seedTechnician("tech_a", { date: [tomorrow, dayAfter, multiDay, reloadDay, r2Day], maxJobs: 3, maxUnits: 9 });
   await seedTechnician("tech_solo", { date: [raceDay, staleDay, retryDay], maxJobs: 1, maxUnits: 5 });
   await seedTechnician("tech_partner", { employment: "partner", date: [today, tomorrow], urgentOk: true });
   await seedTechnician("tech_partner2", { employment: "partner", date: [today, tomorrow], urgentOk: true });
@@ -1028,6 +1029,145 @@ async function main() {
     // A wrong key is indistinguishable from a missing one (404, no oracle).
     const wrong = await fetch(`${BASE_A}/docs/quote/${job_id}?key=deadbeef`, { headers: { "x-forwarded-for": "198.51.100.32" } });
     assert(wrong.status === 404, `wrong key must 404, got ${wrong.status}`);
+  });
+
+  // ---------- second review round: client_app is not a security boundary ----
+
+  // S19) With booking lanes ON, scheduled protection must be CANONICAL — keyed
+  // off booking_mode, not client_app. A forged/omitted client_app with no
+  // request key is rejected with zero mutation, and the same request key
+  // replays to a single job regardless of client_app.
+  await record("S19 scheduled: canonical request-key/idempotency cannot be bypassed by forging client_app", async () => {
+    const before = await jobCountWhere("TRUE");
+    // No request key + omitted client_app -> reject, no job.
+    const omitted = await apiBook(BASE_A, scheduledPayload(r2Day, "10:00", { client_app: undefined, scheduled_request_key: undefined }));
+    assert(omitted.status === 400 && omitted.body?.code === "MISSING_REQUEST_KEY",
+      `omitted client_app + no key must 400 MISSING_REQUEST_KEY, got ${omitted.status}`);
+    // No request key + forged client_app -> still reject.
+    const forged = await apiBook(BASE_A, scheduledPayload(r2Day, "10:00", { client_app: "admin_console", scheduled_request_key: undefined }));
+    assert(forged.status === 400 && forged.body?.code === "MISSING_REQUEST_KEY",
+      `forged client_app + no key must 400 MISSING_REQUEST_KEY, got ${forged.status}`);
+    assert((await jobCountWhere("TRUE")) === before, "keyless scheduled attempts must create 0 jobs");
+    // Same request key, first omitted then forged client_app -> exactly one job.
+    // (The replay re-picks an available slot, exactly like a real reconnect
+    // retry — the deterministic request key, not the slot, guarantees the same
+    // job comes back.)
+    const key = crypto.randomBytes(16).toString("hex");
+    const first = await apiBook(BASE_A, scheduledPayload(r2Day, "10:30", { client_app: undefined, scheduled_request_key: key }));
+    assert(first.status === 200 && first.body?.job_id, `first canonical scheduled booking failed: HTTP ${first.status} ${JSON.stringify(first.body)}`);
+    const replay = await apiBook(BASE_A, scheduledPayload(r2Day, "13:00", { client_app: "totally_forged", scheduled_request_key: key }));
+    assert(replay.status === 200, `replay with forged client_app must succeed, got ${replay.status} ${JSON.stringify(replay.body)}`);
+    assert(replay.body?.job_id === first.body.job_id, "same request key must replay the SAME job, not mint a new one");
+    const dupCount = await pool.query(
+      `SELECT COUNT(*)::int AS n FROM public.jobs WHERE booking_token=$1`,
+      [require("node:crypto").createHash("sha256").update(`scheduled_v1:${key}`).digest("hex").slice(0, 24)]
+    );
+    assert(dupCount.rows[0].n === 1, `request key must map to exactly one job, got ${dupCount.rows[0].n}`);
+  });
+
+  // S20) Urgent routing is CANONICAL — every public urgent request goes through
+  // the customer-safe adapter on booking_mode alone. A forged/omitted client_app
+  // (with attacker-chosen technician/assign fields) must be sanitised, not
+  // reach the raw urgent engine, and must dedupe on the request key.
+  await record("S20 urgent: forged/omitted client_app is still sanitised through the safe adapter", async () => {
+    const urgentKey = crypto.randomBytes(16).toString("hex");
+    const attack = {
+      customer_name: "ด่วนปลอม", customer_phone: "0844444444",
+      job_type: "ล้าง", appointment_datetime: new Date().toISOString(),
+      address_text: "88/8 เขตสวนหลวง กรุงเทพฯ", booking_mode: "urgent",
+      // NO client_app — the sanitiser must still engage on the canonical mode.
+      urgent_request_key: urgentKey,
+      ac_type: "ผนัง", btu: 12000, machine_count: 1, wash_variant: "ล้างธรรมดา",
+      // Attacker-chosen fields that the customer allowlist must strip:
+      technician_username: "tech_partner", assign_mode: "manual",
+      dispatch_mode: "normal", tech_type: "company", team_members: ["tech_partner2"],
+    };
+    const res = await apiBook(BASE_A, attack);
+    assert(res.status === 200 && res.body?.job_id, `urgent with no client_app must still book via adapter, got ${res.status}`);
+    const jobId = res.body.job_id;
+    const row = await pool.query(
+      `SELECT booking_mode, dispatch_mode, technician_username FROM public.jobs WHERE job_id=$1`, [jobId]);
+    assert(row.rows[0].booking_mode === "urgent", "must persist as urgent");
+    assert(row.rows[0].dispatch_mode === "offer", "attacker dispatch_mode must be overridden to offer");
+    assert(!row.rows[0].technician_username, "attacker-supplied technician must be stripped (offer engine assigns)");
+    const offers = await pool.query(`SELECT technician_username FROM public.job_offers WHERE job_id=$1`, [jobId]);
+    assert(offers.rows.every((o) => ["tech_partner", "tech_partner2"].includes(o.technician_username)),
+      "offers must target zoned partners via the engine, not an attacker choice");
+    // Dedup on the request key: replaying the same forged request makes no 2nd job.
+    await apiBook(BASE_A, attack);
+    const cnt = await pool.query(
+      `SELECT COUNT(*)::int AS n FROM public.jobs WHERE booking_mode='urgent' AND customer_phone='0844444444'`);
+    assert(cnt.rows[0].n === 1, `urgent request key must dedupe, got ${cnt.rows[0].n} jobs`);
+  });
+
+  // S21) A LEGACY customer (job with no booking_token) must be able to review
+  // through the real tracking UI: a booking_code lookup shows a phone-entry
+  // form, a wrong phone is rejected, the right phone succeeds — and a tokened
+  // job opened by code must NOT offer the legacy form (no downgrade).
+  await record("S21 legacy customer reviews via the tracking UI (phone form); tokened job shows no legacy form", async () => {
+    const spare = await pool.query(
+      `SELECT job_id, booking_code FROM public.jobs
+        WHERE booking_token IS NOT NULL AND booking_code IS NOT NULL AND booking_code <> $1
+        ORDER BY job_id ASC LIMIT 1`, [bookingCode1]);
+    assert(spare.rows.length, "no spare job to convert to a legacy (tokenless) job");
+    const legacyId = spare.rows[0].job_id;
+    const legacyCode = spare.rows[0].booking_code;
+    const legacyPhone = "0876543210";
+    await pool.query(
+      `UPDATE public.jobs SET booking_token=NULL, job_status='เสร็จแล้ว', finished_at=NOW(),
+              technician_username='tech_a', customer_phone=$2, customer_rating=NULL, reviewed_at=NULL
+       WHERE job_id=$1`, [legacyId, legacyPhone]);
+    await pool.query(`DELETE FROM public.technician_reviews WHERE job_id=$1`, [legacyId]);
+
+    const p = await ctx.newPage();
+    const openLookup = async () => {
+      await p.goto(`${APP_URL_A}#tracking`, { waitUntil: "domcontentloaded" });
+      await p.locator("#tracking-code").fill(legacyCode);
+      await tap(p.locator('[data-action="track-read"]'));
+      // The review form lives in the "aftercare" tab panel — activate it first.
+      await p.waitForSelector('[data-tracking-view="aftercare"]', { timeout: 15000 });
+      await tap(p.locator('[data-tracking-view="aftercare"]').first());
+      await p.waitForSelector('[data-review-form] input[name="customer_phone"]', { timeout: 15000 });
+    };
+    await openLookup();
+    // Wrong phone -> rejected, nothing written.
+    await p.locator('[data-review-form] input[name="customer_phone"]').fill("0800000000");
+    await tap(p.locator('[data-review-form] button[type="submit"]'));
+    await p.waitForTimeout(2500);
+    let rating = await pool.query(`SELECT customer_rating FROM public.jobs WHERE job_id=$1`, [legacyId]);
+    assert(rating.rows[0].customer_rating === null, "legacy review with wrong phone must not persist");
+    // Correct phone -> success.
+    if (!(await p.locator('[data-review-form] input[name="customer_phone"]').count())) await openLookup();
+    await p.locator('[data-review-form] input[name="customer_phone"]').fill(legacyPhone);
+    await tap(p.locator('[data-review-form] button[type="submit"]'));
+    await p.waitForTimeout(3000);
+    rating = await pool.query(`SELECT customer_rating FROM public.jobs WHERE job_id=$1`, [legacyId]);
+    assert(Number(rating.rows[0].customer_rating) >= 1, "legacy review with the correct phone must persist");
+    await p.close();
+
+    // A tokened job opened by its short code is never legacy-eligible.
+    const red = await (await fetch(`${BASE_A}/public/track?q=${encodeURIComponent(bookingCode1)}`,
+      { headers: { "x-forwarded-for": "198.51.100.40" } })).json();
+    assert(red.legacy_review_eligible === false, "a tokened job must never be legacy-review-eligible via code");
+  });
+
+  // S22) Rate-limit buckets are per VERIFIED client, proving the app resolves
+  // req.ip under trust proxy (not a shared socket IP). Exhaust client A; a
+  // different verified client B must still get through. If trust proxy were off,
+  // both would share the 127.0.0.1 socket bucket and B would already be 429.
+  await record("S22 rate-limit buckets are per verified client IP (trust proxy resolves req.ip)", async () => {
+    const clientA = "203.0.113.240";
+    const clientB = "203.0.113.241";
+    let aLimited = false;
+    for (let i = 0; i < 45 && !aLimited; i += 1) {
+      const res = await fetch(`${BASE_A}/public/track?q=CWFA${i}`, {
+        headers: { "x-forwarded-for": `10.0.0.9, ${clientA}` } });
+      if (res.status === 429) aLimited = true;
+    }
+    assert(aLimited, "client A never hit its own rate limit");
+    const bRes = await fetch(`${BASE_A}/public/track?q=CWFB1`, {
+      headers: { "x-forwarded-for": `10.0.0.9, ${clientB}` } });
+    assert(bRes.status !== 429, `client B must have its own bucket (trust proxy off would 429), got ${bRes.status}`);
   });
 
   await browser.close();

--- a/test/e2e/run-booking-e2e.js
+++ b/test/e2e/run-booking-e2e.js
@@ -509,8 +509,12 @@ async function main() {
     assert(after === before + 1, `expected +1 job, got +${after - before}`);
   });
 
-  // 3) Network drop after server commit -> reload -> resubmit returns the SAME job.
-  await record("S3 reload after submit resumes the same job (idempotent replay)", async () => {
+  // 3) Network drop after server commit -> reload -> resubmit must NOT duplicate.
+  // Under payload-bound idempotency, resubmitting the same request key with the
+  // exact same payload replays the job; re-picking a different slot with the
+  // reused key is correctly refused (409 IDEMPOTENCY_KEY_REUSED). Either way the
+  // DB must hold exactly one job — a reload can never create a duplicate.
+  await record("S3 reload after a committed-but-lost submit never creates a duplicate", async () => {
     const p2 = await ctx.newPage();
     await completeScheduledWizard(p2, APP_URL_A, reloadDay);
     // First submit: forward the EXACT request to the server (it commits), then
@@ -535,21 +539,20 @@ async function main() {
     await tap(p2.locator('[data-action="submit-scheduled"]'));
     await p2.waitForTimeout(4000); // let the server-side booking commit
     const midCount = await jobCountWhere("appointment_datetime::date=$1", [reloadDay]);
+    assert(midCount === 1, `expected 1 committed job after network drop, got ${midCount}`);
     await p2.unroute("**/public/book");
     await p2.reload({ waitUntil: "domcontentloaded" });
     await p2.waitForSelector('[data-action="submit-scheduled"], [data-action="wizard-next"], [data-calendar-date]', { timeout: 25000 });
-    // Draft (incl. scheduled_request_key) survives the reload. Availability is
-    // refetched with a new query key, so the customer re-picks the slot before
-    // resubmitting — the request key is what guarantees the replay.
-    let code = "";
-    for (let attempt = 0; attempt < 3 && !code; attempt += 1) {
+    // The draft (incl. scheduled_request_key) survives the reload. The customer
+    // re-attempts; whether that replays or is refused as a key-reuse, the key is
+    // already bound to the committed job, so no second job can be created.
+    for (let attempt = 0; attempt < 3; attempt += 1) {
       if (await p2.locator('[data-action="submit-scheduled"]').count()) {
         await tap(p2.locator('[data-action="submit-scheduled"]'));
         try {
-          await p2.waitForSelector(".booking-result-card", { timeout: 15000 });
-          code = (await p2.locator(".booking-code-value").textContent() || "").trim();
-          break;
-        } catch (_) { /* bounced back to slot step */ }
+          await p2.waitForSelector(".booking-result-card", { timeout: 8000 });
+          break; // clean replay
+        } catch (_) { /* refused (key reuse) or bounced to slot step */ }
       }
       if (await p2.locator(`[data-calendar-date="${reloadDay}"]`).count()) {
         await pickDateAndSlot(p2, reloadDay);
@@ -560,10 +563,8 @@ async function main() {
       }
       await p2.waitForTimeout(600);
     }
-    assert(/^CWF/.test(code), `expected replayed booking code, got "${code}"`);
     const finalCount = await jobCountWhere("appointment_datetime::date=$1", [reloadDay]);
-    assert(midCount === 1, `expected 1 committed job after network drop, got ${midCount}`);
-    assert(finalCount === 1, `replay must not create a second job (got ${finalCount})`);
+    assert(finalCount === 1, `reload/resubmit must never create a second job (got ${finalCount})`);
     await p2.close();
   });
 
@@ -1048,21 +1049,58 @@ async function main() {
     assert(forged.status === 400 && forged.body?.code === "MISSING_REQUEST_KEY",
       `forged client_app + no key must 400 MISSING_REQUEST_KEY, got ${forged.status}`);
     assert((await jobCountWhere("TRUE")) === before, "keyless scheduled attempts must create 0 jobs");
-    // Same request key, first omitted then forged client_app -> exactly one job.
-    // (The replay re-picks an available slot, exactly like a real reconnect
-    // retry — the deterministic request key, not the slot, guarantees the same
-    // job comes back.)
+    // Same request key + SAME payload, first omitted then forged client_app ->
+    // replays the SAME job (idempotent, independent of client_app). The replay
+    // runs before the availability gate, so it succeeds even though the job now
+    // occupies that slot — exactly the committed-but-response-lost retry case.
     const key = crypto.randomBytes(16).toString("hex");
     const first = await apiBook(BASE_A, scheduledPayload(r2Day, "10:30", { client_app: undefined, scheduled_request_key: key }));
     assert(first.status === 200 && first.body?.job_id, `first canonical scheduled booking failed: HTTP ${first.status} ${JSON.stringify(first.body)}`);
-    const replay = await apiBook(BASE_A, scheduledPayload(r2Day, "13:00", { client_app: "totally_forged", scheduled_request_key: key }));
-    assert(replay.status === 200, `replay with forged client_app must succeed, got ${replay.status} ${JSON.stringify(replay.body)}`);
-    assert(replay.body?.job_id === first.body.job_id, "same request key must replay the SAME job, not mint a new one");
-    const dupCount = await pool.query(
-      `SELECT COUNT(*)::int AS n FROM public.jobs WHERE booking_token=$1`,
-      [require("node:crypto").createHash("sha256").update(`scheduled_v1:${key}`).digest("hex").slice(0, 24)]
-    );
+    const replay = await apiBook(BASE_A, scheduledPayload(r2Day, "10:30", { client_app: "totally_forged", scheduled_request_key: key }));
+    assert(replay.status === 200 && replay.body?.replayed === true, `same-payload replay must succeed, got ${replay.status} ${JSON.stringify(replay.body)}`);
+    assert(replay.body?.job_id === first.body.job_id, "same request key + same payload must replay the SAME job");
+    const detToken = require("node:crypto").createHash("sha256").update(`scheduled_v1:${key}`).digest("hex").slice(0, 24);
+    const dupCount = await pool.query(`SELECT COUNT(*)::int AS n FROM public.jobs WHERE booking_token=$1`, [detToken]);
     assert(dupCount.rows[0].n === 1, `request key must map to exactly one job, got ${dupCount.rows[0].n}`);
+  });
+
+  // S23) Idempotency key is bound to its payload. Reusing the key with a
+  // materially different payload (time, phone) must be rejected with
+  // 409 IDEMPOTENCY_KEY_REUSED — never a silent return of the first job's data,
+  // and never a second job.
+  await record("S23 scheduled: reusing a request key with a different payload is 409 IDEMPOTENCY_KEY_REUSED", async () => {
+    const key = crypto.randomBytes(16).toString("hex");
+    const first = await apiBook(BASE_A, scheduledPayload(r2Day, "13:00", { scheduled_request_key: key, customer_phone: "0855550000" }));
+    assert(first.status === 200 && first.body?.job_id, `seed booking failed: HTTP ${first.status} ${JSON.stringify(first.body)}`);
+    const detToken = require("node:crypto").createHash("sha256").update(`scheduled_v1:${key}`).digest("hex").slice(0, 24);
+    const before = await pool.query(`SELECT COUNT(*)::int AS n FROM public.jobs WHERE booking_token=$1`, [detToken]);
+    // Different appointment time, same key -> reject (before any availability check).
+    const diffTime = await apiBook(BASE_A, scheduledPayload(r2Day, "14:30", { scheduled_request_key: key, customer_phone: "0855550000" }));
+    assert(diffTime.status === 409 && diffTime.body?.code === "IDEMPOTENCY_KEY_REUSED",
+      `different time must 409 IDEMPOTENCY_KEY_REUSED, got ${diffTime.status} ${JSON.stringify(diffTime.body)}`);
+    assert(!diffTime.body?.job_id && !diffTime.body?.booking_code, "409 must not leak the first job's identifiers");
+    // Different phone, same key + same time -> reject.
+    const diffPhone = await apiBook(BASE_A, scheduledPayload(r2Day, "13:00", { scheduled_request_key: key, customer_phone: "0866660000" }));
+    assert(diffPhone.status === 409 && diffPhone.body?.code === "IDEMPOTENCY_KEY_REUSED",
+      `different phone must 409 IDEMPOTENCY_KEY_REUSED, got ${diffPhone.status}`);
+    const after = await pool.query(`SELECT COUNT(*)::int AS n FROM public.jobs WHERE booking_token=$1`, [detToken]);
+    assert(after.rows[0].n === before.rows[0].n && after.rows[0].n === 1, "key reuse must not create additional jobs");
+  });
+
+  // S24) Committed-but-response-lost retry: the first submit commits, its
+  // response is discarded, then the SAME request (same key + same payload) is
+  // replayed — the server returns the existing job and the DB holds exactly one.
+  await record("S24 committed-then-lost response: replaying the same request yields exactly one job", async () => {
+    const key = crypto.randomBytes(16).toString("hex");
+    const payload = scheduledPayload(r2Day, "16:00", { scheduled_request_key: key, customer_phone: "0877770000" });
+    const committed = await apiBook(BASE_A, payload); // commit; pretend the client never saw this response
+    assert(committed.status === 200 && committed.body?.job_id, `initial commit failed: HTTP ${committed.status} ${JSON.stringify(committed.body)}`);
+    const retry = await apiBook(BASE_A, payload); // identical resubmit after "reload"
+    assert(retry.status === 200 && retry.body?.replayed === true, `retry must replay, got ${retry.status} ${JSON.stringify(retry.body)}`);
+    assert(retry.body?.job_id === committed.body.job_id, "retry must resolve to the same job");
+    const detToken = require("node:crypto").createHash("sha256").update(`scheduled_v1:${key}`).digest("hex").slice(0, 24);
+    const n = await pool.query(`SELECT COUNT(*)::int AS n FROM public.jobs WHERE booking_token=$1`, [detToken]);
+    assert(n.rows[0].n === 1, `exactly one job must exist after the lost-response retry, got ${n.rows[0].n}`);
   });
 
   // S20) Urgent routing is CANONICAL — every public urgent request goes through

--- a/test/e2e/schema-core.sql
+++ b/test/e2e/schema-core.sql
@@ -1,0 +1,79 @@
+-- Core tables the app expects to pre-exist (production predates the boot-time
+-- bootstrap style, so index.js does NOT create these). E2E-only — never run
+-- against production. Everything else (job_offers, job_items, auth_sessions,
+-- technician_service_matrix, technician_monthly_work_calendar, catalog_items,
+-- customer_service_price_rules, ...) is created by index.js itself on boot.
+
+CREATE TABLE IF NOT EXISTS public.users (
+  username      TEXT PRIMARY KEY,
+  password_hash TEXT,
+  role          TEXT NOT NULL DEFAULT 'technician',
+  created_at    TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS public.technician_profiles (
+  username             TEXT PRIMARY KEY,
+  full_name            TEXT,
+  phone                TEXT,
+  photo_path           TEXT,
+  rank_level           INT,
+  rank_key             TEXT,
+  rating               NUMERIC,
+  grade                TEXT,
+  employment_type      TEXT DEFAULT 'company',
+  work_start           TEXT DEFAULT '09:00',
+  work_end             TEXT DEFAULT '18:00',
+  accept_status        TEXT DEFAULT 'ready',
+  accept_status_expires_at TIMESTAMPTZ,
+  weekly_off_days      TEXT DEFAULT '',
+  customer_slot_visible BOOLEAN DEFAULT TRUE,
+  created_at           TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS public.jobs (
+  job_id               BIGSERIAL PRIMARY KEY,
+  booking_code         TEXT UNIQUE,
+  booking_token        TEXT,
+  customer_name        TEXT,
+  customer_phone       TEXT,
+  job_type             TEXT,
+  appointment_datetime TIMESTAMPTZ,
+  job_price            NUMERIC(12,2),
+  address_text         TEXT,
+  technician_team      TEXT,
+  technician_username  TEXT,
+  job_status           TEXT,
+  job_source           TEXT,
+  dispatch_mode        TEXT,
+  booking_mode         TEXT,
+  allow_time_proposal  BOOLEAN,
+  customer_note        TEXT,
+  technician_note      TEXT,
+  maps_url             TEXT,
+  job_zone             TEXT,
+  duration_min         INT,
+  gps_latitude         DOUBLE PRECISION,
+  gps_longitude        DOUBLE PRECISION,
+  travel_started_at    TIMESTAMPTZ,
+  checkin_at           TIMESTAMPTZ,
+  started_at           TIMESTAMPTZ,
+  finished_at          TIMESTAMPTZ,
+  canceled_at          TIMESTAMPTZ,
+  cancel_reason        TEXT,
+  customer_rating      INT,
+  customer_review      TEXT,
+  customer_complaint   TEXT,
+  reviewed_at          TIMESTAMPTZ,
+  paid_at              TIMESTAMPTZ,
+  paid_by              TEXT,
+  payment_status       TEXT,
+  final_signature_path TEXT,
+  final_signature_at   TIMESTAMPTZ,
+  catalog_item_id      BIGINT,
+  customer_sub         TEXT,
+  created_at           TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at           TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_e2e_jobs_token ON public.jobs (booking_token);
+CREATE INDEX IF NOT EXISTS idx_e2e_jobs_appt ON public.jobs (appointment_datetime);

--- a/test/homepageCms.test.js
+++ b/test/homepageCms.test.js
@@ -278,7 +278,7 @@ test("customer homepage has no admin control, bottom nav is fixed five-tab, and 
   const sw = read("customer-app/sw.js");
   const app = read("customer-app/assets/customer-app.js");
   const manifest = read("customer-app/manifest.webmanifest");
-  const build = "20260707_booking_admin_notify_v1";
+  const build = "20260708_launch_gate_v1";
 
   assert.doesNotMatch(index + ui, /โหมดแอดมิน|openCms|localStorage\.getItem\('cwfHomeCmsDemo'/);
   assert.match(index, /data-route="store"[\s\S]*ร้านค้า/);

--- a/test/homepageCms.test.js
+++ b/test/homepageCms.test.js
@@ -278,7 +278,7 @@ test("customer homepage has no admin control, bottom nav is fixed five-tab, and 
   const sw = read("customer-app/sw.js");
   const app = read("customer-app/assets/customer-app.js");
   const manifest = read("customer-app/manifest.webmanifest");
-  const build = "20260708_launch_gate_v1";
+  const build = "20260709_review_legacy_v1";
 
   assert.doesNotMatch(index + ui, /โหมดแอดมิน|openCms|localStorage\.getItem\('cwfHomeCmsDemo'/);
   assert.match(index, /data-route="store"[\s\S]*ร้านค้า/);


### PR DESCRIPTION
Booking launch-readiness for the Customer App: P0 security, second-review, and integration rounds, merged up to `main@b32ffbc` (PRs #150/#151). **Do not merge/deploy — draft per instruction.** No migration, no production data/config mutation, no real outbound messages.

**Head:** `f356f55a459c38e4932224380c18f21e6671e23a` · **0 behind / 15 ahead** of `main@b32ffbc` · no conflicts.

---

## Integration + idempotency (latest rounds)

### Merged latest `main` (#150/#151), both sides preserved
`index.js` auto-merged with **no conflicts**. Codex payout work — `technicianPayoutIntegrity.js`, its tests, `technicianPayoutUiStatus.test.js`, Issue #149 scripts/docs — is **byte-identical to main** on this branch. Payout regression suite: **58/58**.

### Payload-bound scheduled idempotency — full canonical material comparison
A scheduled request key is bound to the booking it first created. The replay lookup runs **before** the availability gate (so a genuine same-payload retry replays even though its own job now holds the slot). The comparison is the **complete canonical material payload**, identical in the pre-flight and in-transaction race paths:
- **Scalar jobs-row fields:** appointment datetime, normalized phone, customer name, address, maps url, zone, job type, customer note, time-proposal preference, computed duration.
- **Service composition:** the canonical `job_items` signature (`item_name # qty # line_total`), rebuilt from the incoming payload with the **same normalizer** (`buildCustomerServiceLineItemsFromPayload`). `serviceItemName` encodes AC type, wash/repair variant, **BTU**, and machine count, and `line_total` encodes price — so any of those shifts the signature.

`same key + exact canonical payload → replay`; **any** material difference → **`409 IDEMPOTENCY_KEY_REUSED`** with no mutation and **no job id / booking code / token / PII** in the response. **No schema change** (existing job + job_items columns).

### Legacy `customer.html` key — durable + CSPRNG
Persisted in `sessionStorage` (survives reload → no duplicate on recovery); generated only from `crypto.randomUUID`/`getRandomValues` (no `Math.random`); cleared on confirmed success.

### Browser E2E — 26/26 (real app + real PostgreSQL)
| # | Scenario | Result |
|---|---|---|
| S3 | Reload after committed-but-lost submit **never creates a duplicate** | ✅ |
| S19 | Same key + same payload → replay (independent of client_app) | ✅ |
| S23 | Same key + different **time / phone / BTU / qty / address** → `409 IDEMPOTENCY_KEY_REUSED` (no leaked identifiers, no new job); exact same payload → replay | ✅ |
| S24 | Committed-then-lost response → identical resubmit replays to one job | ✅ |

### Test baselines (clean worktrees, real PostgreSQL)
- Base `main@b32ffbc`: **956/956** pass, 0 fail.
- Branch: **991/991** pass, 0 fail (+35; incl. payout suite + booking/idempotency tests). Zero pre-existing failures, zero regressions. `node --check` clean on every changed JS.

---

## Earlier rounds (still in this PR)

**Second review** — legacy tokenless customers can review via the app (minimal `legacy_review_eligible` flag + phone-entry form); `client_app` is no longer a security/idempotency/reservation boundary (urgent → safe adapter on canonical mode; scheduled protections canonical; `tech_type` "all"; duplicated inline matrix unified into the shared `customerAvailability` engine; fails closed); trust-proxy per-client rate-limit proof (S22).

**First P0 round** — canonical `/public/book` kill switch (P0-1); `req.ip` rate limiting (P0-2); allowlist tracking redaction (P0-3); token/admin-gated docs + sensitive headers (P0-4); single-credential `/public/review` with legacy code+phone fallback (P0-5).

**P1** — tracking privacy service + CSPRNG booking codes; fail-closed kill switches + LINE fallback.

---

## DB / migration impact
**None.** No new tables/columns/indexes. Idempotency comparison uses existing job + job_items columns. Rate limiter is in-memory.

## Production config impact
Optional env: `ENABLE_CUSTOMER_SCHEDULED_BOOKING`, `ENABLE_CUSTOMER_URGENT_BOOKING` (**must be `true` to open booking** — fail closed), `CWF_LINE_CONTACT_URL`. Cache-bust `20260709_review_legacy_v1`.

## Remaining risks / follow-ups
- Rate limiter is per-process/in-memory — a shared store is needed for a cross-instance quota (single instance = acceptable temporary speed bump).
- The v2 app's reload recovery re-picks a slot, so a reused key with a new slot is correctly refused (`IDEMPOTENCY_KEY_REUSED`) rather than auto-replayed in the UI; the duplicate-prevention invariant holds (S3). A same-slot auto-replay UX is an optional follow-up.

## Production path (after approval)
Keep Draft until approved → deploy with **both flags OFF** → smoke test without opening to customers → confirm single-trusted-proxy topology so `req.ip` separates clients → canary Scheduled, then Urgent → provision a shared rate-limit store if >1 instance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LmdP3TGN5uQrfT8ZYefNco