### PR TITLE
Fix technician payout summary delete safety

### DIFF
--- a/docs/ISSUE_149_ORPHAN_PAYOUT_AUDIT.md
+++ b/docs/ISSUE_149_ORPHAN_PAYOUT_AUDIT.md
@@ -1,0 +1,42 @@
+# Issue 149 Orphan Payout Line Audit
+
+This audit is read-only. It only reports technician payout lines whose `job_id`
+no longer exists in `public.jobs`.
+
+Do not run this against production. Run it only against a non-production copy
+of production data after the copy has been verified.
+
+## Dry Run
+
+Review the SQL without executing it:
+
+```bash
+node scripts/audit-orphan-payout-lines.js --limit=200
+```
+
+## Read-Only Execution
+
+Execute the SELECT against a non-production database:
+
+```bash
+NODE_ENV=staging node scripts/audit-orphan-payout-lines.js --run --limit=200
+NODE_ENV=staging node scripts/audit-orphan-payout-lines.js --run --json --limit=200
+```
+
+`--apply` is intentionally unsupported. There is no repair mode in this script.
+
+## Decision Matrix
+
+| Classification | Meaning | Required action |
+| --- | --- | --- |
+| `draft/unpaid-safe-to-review` | Orphan line is tied only to draft/unpaid payout state. | Review with operations and decide whether a targeted cleanup PR or manual non-production validation is appropriate. |
+| `locked/paid/payment-linked-reconciliation-required` | Orphan line is tied to locked, paid, partially paid, paid-at, or payment-row state. | Do not delete automatically. Reconcile payout/payment records with finance before any data change. |
+
+## Notes
+
+- The SQL includes `payment_id`, paid amount, paid status, and payout period
+  status so reviewers can distinguish unpaid draft rows from rows that need
+  finance reconciliation.
+- Production data must not be modified by this PR.
+- Any future repair must be a separate scoped change with its own review,
+  tests, and operational sign-off.

--- a/index.js
+++ b/index.js
@@ -54,6 +54,7 @@ const { ensurePayoutPeriodAndSnapshotForPayment } = require("./server/services/t
 const { buildAccountingPayoutCalendar, isPeriodCutoffClosed } = require("./server/services/technicianPayoutPeriods");
 const accountingPayoutAdjustments = require("./server/services/accountingPayoutAdjustments");
 const technicianDepositCollections = require("./server/services/technicianDepositCollections");
+const technicianPayoutIntegrity = require("./server/services/technicianPayoutIntegrity");
 const { createTechnicianCashCollectionService } = require("./server/services/technicianCashCollections");
 const { createTechnicianDeductionPayoutApplyService } = require("./server/services/technicianDeductionPayoutApply");
 const createAdminReworkDeductionsHelpers = require("./server/helpers/adminReworkDeductionsHelpers");
@@ -8980,57 +8981,73 @@ function _workMonthPayoutPeriodDefs(y, m){
   return [p25, p10];
 }
 
+function _payoutPeriodDefForSummary(def, workMonth = ''){
+  return {
+    ...def,
+    payout_id: def.payout_id || `payout_${def.label_ym}_${def.period_type}`,
+    work_month: workMonth || def.work_month || '',
+    period_end_display: _periodEndDisplayIso(def.endEx || def.period_end),
+  };
+}
+
+async function _buildTechnicianPayoutPeriodSummary(period, tech, db = pool){
+  return technicianPayoutIntegrity.buildTechnicianPayoutPeriodSummary({
+    db,
+    period,
+    technicianUsername: tech,
+    loadPayoutLinesForTech: _loadPayoutLinesForTech,
+    getProjectedDepositDeductionForPayout: technicianDepositCollections.getProjectedDepositDeductionForPayout,
+    paidStatus: _paidStatus,
+    normalizeMoney: _money,
+  });
+}
+
 async function _computeTechnicianPayoutMonthTotal(username, ym = ''){
   const tech = String(username || '').trim();
   if (!tech) return { payout_month_total: 0, payout_month_net_total: 0, payout_month: '', work_month: '', periods: [] };
   try {
     const parsed = _parsePayoutMonthYm(ym);
-    const nowUtc = new Date();
-    const defs = _workMonthPayoutPeriodDefs(parsed.y, parsed.m);
+    const defs = _workMonthPayoutPeriodDefs(parsed.y, parsed.m).map((def) => _payoutPeriodDefForSummary(def, parsed.ym));
     const periods = [];
-    let total = 0;
+    let grossTotal = 0;
+    let netTotal = 0;
     for (const def of defs) {
-      const periodEnd = def.endEx;
-      const effectiveEnd = nowUtc < periodEnd ? nowUtc : periodEnd;
-      let lines = [];
-      let amount = 0;
-      if (effectiveEnd > def.start) {
-        lines = await _computeTechLinesInRange(tech, def.start, effectiveEnd, {
-          payout_id: `payout_${def.label_ym}_${def.period_type}`,
-          period_type: def.period_type,
-          label_ym: def.label_ym,
-          work_month: parsed.ym,
-        });
-        amount = _money((lines || []).reduce((sum, line) => sum + Number(line.earn_amount || 0), 0));
-      }
-      total += amount;
+      const summary = await _buildTechnicianPayoutPeriodSummary(def, tech);
+      grossTotal += Number(summary.gross_amount || 0);
+      netTotal += Number(summary.net_amount || 0);
       periods.push({
-        payout_id: `payout_${def.label_ym}_${def.period_type}`,
-        period_type: def.period_type,
-        label_ym: def.label_ym,
+        payout_id: summary.payout_id,
+        period_type: summary.period_type,
+        label_ym: summary.label_ym,
         work_month: parsed.ym,
-        period_start: def.start.toISOString(),
-        period_end: def.endEx.toISOString(),
-        period_end_display: _periodEndDisplayIso(def.endEx),
-        period_effective_end: effectiveEnd.toISOString(),
-        source: 'live_completed_jobs',
-        mode: effectiveEnd < def.endEx ? 'current_period_to_date' : 'full_period',
-        gross_amount: amount,
-        adj_total: 0,
-        deposit_deduction_amount: 0,
-        payout_month_amount: amount,
-        payout_month_net_amount: amount,
-        jobs_count: (lines || []).length,
+        period_start: summary.period_start,
+        period_end: summary.period_end,
+        period_end_display: summary.period_end_display || _periodEndDisplayIso(def.endEx),
+        period_effective_end: summary.period_end,
+        source: summary.source,
+        mode: summary.status === 'draft' ? 'live_or_projected_period' : 'stored_locked_or_paid_period',
+        status: summary.status,
+        gross_amount: summary.gross_amount,
+        adj_total: summary.adj_total,
+        deposit_deduction_amount: summary.deposit_deduction_amount,
+        net_amount: summary.net_amount,
+        paid_amount: summary.paid_amount,
+        paid_status: summary.paid_status,
+        remaining_amount: summary.remaining_amount,
+        payout_month_amount: summary.gross_amount,
+        payout_month_net_amount: summary.net_amount,
+        jobs_count: summary.lines_count,
       });
     }
-    total = _money(total);
+    grossTotal = _money(grossTotal);
+    netTotal = _money(netTotal);
     return {
       payout_month: parsed.ym,
       work_month: parsed.ym,
-      payout_month_total: total,
-      payout_month_net_total: total,
-      payout_month_policy: 'work_month_1_15_and_16_end_live_completed_jobs',
-      monthly_income_display_amount: total,
+      payout_month_total: grossTotal,
+      payout_month_net_total: netTotal,
+      payout_month_policy: 'work_month_1_15_and_16_end_payout_net',
+      monthly_income_display_amount: netTotal,
       monthly_income_display_label: parsed.ym,
       monthly_income_period_start: defs[0].start.toISOString(),
       monthly_income_period_end: defs[1].endEx.toISOString(),
@@ -9954,96 +9971,39 @@ app.get('/tech/payouts', requireTechnicianSession, async (req, res) => {
 
     const rows = [];
     for (const p of periods) {
-      // 1) meta/status จากตาราง period ถ้ามี
-      const metaQ = await pool.query(
-        `SELECT payout_id, status, period_start, period_end
-           FROM public.technician_payout_periods
-          WHERE payout_id=$1
-          LIMIT 1`,
-        [p.payout_id]
-      );
-      const meta = metaQ.rows[0] || null;
-      const status = meta?.status || 'draft';
-      const period_start = meta?.period_start || p.start.toISOString();
-      const period_end = meta?.period_end || p.endEx.toISOString();
-
-      // 2) gross: ถ้ามี lines ใน DB ใช้ DB ก่อน (เร็ว) ไม่งั้นคำนวณสดเฉพาะช่วงนั้น
-      const hasLinesQ = await pool.query(
-        `SELECT COUNT(*)::int AS c
-           FROM public.technician_payout_lines
-          WHERE payout_id=$1 AND technician_username=$2`,
-        [p.payout_id, tech]
-      );
-      const hasLines = Number(hasLinesQ.rows[0]?.c || 0) > 0;
-
-      let gross_amount = 0;
-      let lines_count = 0;
-
-      if (hasLines && _payoutCanUseStoredLines(status)) {
-        const g = await pool.query(
-          `SELECT COALESCE(SUM(earn_amount),0) AS gross_amount, COUNT(*)::int AS lines_count
-             FROM public.technician_payout_lines
-            WHERE payout_id=$1 AND technician_username=$2`,
-          [p.payout_id, tech]
-        );
-        gross_amount = Number(g.rows[0]?.gross_amount || 0);
-        lines_count = Number(g.rows[0]?.lines_count || 0);
-      } else {
-        const calcLines = await _computeTechLinesInRange(tech, p.start, p.endEx, { payout_id: p.payout_id, period_type: p.period_type, label_ym: p.label_ym });
-        gross_amount = calcLines.reduce((a, it) => a + Number(it.earn_amount || 0), 0);
-        lines_count = calcLines.length;
-      }
-
-      // 3) adjustments + payments (Phase 2)
-      const adjQ = await pool.query(
-        `SELECT COALESCE(SUM(adj_amount),0) AS adj_total
-           FROM public.technician_payout_adjustments
-          WHERE payout_id=$1 AND technician_username=$2`,
-        [p.payout_id, tech]
-      );
-      const adj_total = Number(adjQ.rows[0]?.adj_total || 0);
-
-      const payQ = await pool.query(
-        `SELECT COALESCE(paid_amount,0) AS paid_amount, COALESCE(paid_status,'unpaid') AS paid_status, paid_at, slip_url
-           FROM public.technician_payout_payments
-          WHERE payout_id=$1 AND technician_username=$2
-          LIMIT 1`,
-        [p.payout_id, tech]
-      );
-      const payment = payQ.rows[0] || null;
-      const paid_amount = Number(payment?.paid_amount || 0);
-      const paid_status = String(payment?.paid_status || (paid_amount > 0 ? 'partial' : 'unpaid'));
-
-      const deposit = await technicianDepositCollections.getProjectedDepositDeductionForPayout(pool, {
-        payout_id: p.payout_id,
-        technician_username: tech,
-        gross_amount,
-        adj_total,
-        period_status: status,
-      });
-      const deposit_deduction_amount = _money(deposit.deposit_deduction_amount || 0);
-      const net_amount = _money(gross_amount + adj_total - deposit_deduction_amount);
-      const remaining_amount = _money(net_amount - paid_amount);
-      const paid_status_calc = _paidStatus(net_amount, paid_amount);
-
+      const summary = await _buildTechnicianPayoutPeriodSummary(_payoutPeriodDefForSummary(p, p.work_month || ''), tech);
       rows.push({
-        payout_id: p.payout_id,
-        period_type: p.period_type,
-        period_start,
-        period_end,
-        status,
-        gross_amount,
-        adj_total,
-        deposit_deduction_amount,
-        net_amount,
-        paid_amount,
-        paid_status: paid_status_calc,
-        remaining_amount,
-        ...deposit,
-        latest_deposit_deduction: deposit_deduction_amount,
-        lines_count,
-        paid_at: payment?.paid_at || null,
-        slip_url: payment?.slip_url || null,
+        payout_id: summary.payout_id,
+        period_type: summary.period_type,
+        period_start: summary.period_start,
+        period_end: summary.period_end,
+        period_end_display: summary.period_end_display,
+        status: summary.status,
+        source: summary.source,
+        gross_amount: summary.gross_amount,
+        adj_total: summary.adj_total,
+        deposit_deduction_amount: summary.deposit_deduction_amount,
+        net_amount: summary.net_amount,
+        paid_amount: summary.paid_amount,
+        paid_status: summary.paid_status,
+        remaining_amount: summary.remaining_amount,
+        deposit_existing_collect_amount: summary.deposit_existing_collect_amount,
+        deposit_existing_collect_exists: summary.deposit_existing_collect_exists,
+        deposit_projected: summary.deposit_projected,
+        deposit_projection_reason: summary.deposit_projection_reason,
+        deposit_target_amount: summary.deposit_target_amount,
+        deposit_collected_total: summary.deposit_collected_total,
+        deposit_collected_total_projected: summary.deposit_collected_total_projected,
+        deposit_remaining_amount: summary.deposit_remaining_amount,
+        deposit_remaining_amount_projected: summary.deposit_remaining_amount_projected,
+        deposit_is_required: summary.deposit_is_required,
+        deposit_payment_paid_amount: summary.deposit_payment_paid_amount,
+        deposit_payment_paid_status: summary.deposit_payment_paid_status,
+        deposit_payment_paid_at: summary.deposit_payment_paid_at,
+        latest_deposit_deduction: summary.latest_deposit_deduction,
+        lines_count: summary.lines_count,
+        paid_at: summary.paid_at,
+        slip_url: summary.slip_url,
       });
     }
 
@@ -10067,60 +10027,14 @@ app.get('/tech/payouts/:payout_id', requireTechnicianSession, async (req, res) =
 
     const bounds = _periodBoundsForYm(parsed.type, parsed.y, parsed.m);
 
-    // meta/status จาก period ถ้ามี (ไม่มีก็ถือว่า draft)
-    const metaQ = await pool.query(
-      `SELECT payout_id, status, period_start, period_end
-         FROM public.technician_payout_periods
-        WHERE payout_id=$1
-        LIMIT 1`,
-      [payout_id]
-    );
-    const meta = metaQ.rows[0] || null;
-    const status = meta?.status || 'draft';
-
-    // v10: draft/unpaid period detail must recompute live from contract engine.
-    // Stored payout_lines are trusted only after locked/paid to avoid showing old 350/1400 rows.
-    const loadedLines = await _loadPayoutLinesForTech({
+    const summary = await _buildTechnicianPayoutPeriodSummary({
       payout_id,
-      tech,
-      status,
-      start: bounds.start,
-      endEx: bounds.endEx,
       period_type: bounds.period_type,
       label_ym: bounds.label_ym,
-    });
-    let lines = loadedLines.lines || [];
-
-    const adjQ = await pool.query(
-      `SELECT adj_id, job_id, adj_amount, reason, created_at
-         FROM public.technician_payout_adjustments
-        WHERE payout_id=$1 AND technician_username=$2
-        ORDER BY created_at ASC, adj_id ASC`,
-      [payout_id, tech]
-    );
-
-    const payQ = await pool.query(
-      `SELECT paid_amount, paid_status, paid_at, slip_url, note
-         FROM public.technician_payout_payments
-        WHERE payout_id=$1 AND technician_username=$2
-        LIMIT 1`,
-      [payout_id, tech]
-    );
-
-    const gross = (lines || []).reduce((a, it) => a + Number(it.earn_amount || 0), 0);
-    const adj_total = (adjQ.rows || []).reduce((a, it) => a + Number(it.adj_amount || 0), 0);
-    const deposit = await technicianDepositCollections.getProjectedDepositDeductionForPayout(pool, {
-      payout_id,
-      technician_username: tech,
-      gross_amount: gross,
-      adj_total,
-      period_status: status,
-    });
-    const deposit_deduction_amount = _money(deposit.deposit_deduction_amount || 0);
-    const net = _money(gross + adj_total - deposit_deduction_amount);
-    const payment = payQ.rows[0] || null;
-    const paid_amount = Number(payment?.paid_amount || 0);
-    const remaining = _money(net - paid_amount);
+      start: bounds.start,
+      endEx: bounds.endEx,
+    }, tech);
+    const lines = summary.lines || [];
 
     const profile = await _getTechProfile(tech);
     const wrQ = await pool.query(
@@ -10143,24 +10057,36 @@ app.get('/tech/payouts/:payout_id', requireTechnicianSession, async (req, res) =
         daily_wage_amount: Number(profile.daily_wage_amount || 0),
         monthly_salary_amount: Number(profile.monthly_salary_amount || 0),
       } : null,
-      status,
-      source: loadedLines.source,
+      status: summary.status,
+      source: summary.source,
       period_type: parsed.type,
-      period_start: meta?.period_start || bounds.start.toISOString(),
-      period_end: meta?.period_end || bounds.endEx.toISOString(),
-      gross_amount: gross,
-      adj_total,
-      deposit_deduction_amount,
-      net_amount: net,
-      paid_amount,
-      paid_status: _paidStatus(net, paid_amount),
-      remaining_amount: remaining,
-      ...deposit,
-      latest_deposit_deduction: deposit_deduction_amount,
-      payment,
+      period_start: summary.period_start || bounds.start.toISOString(),
+      period_end: summary.period_end || bounds.endEx.toISOString(),
+      gross_amount: summary.gross_amount,
+      adj_total: summary.adj_total,
+      deposit_deduction_amount: summary.deposit_deduction_amount,
+      net_amount: summary.net_amount,
+      paid_amount: summary.paid_amount,
+      paid_status: summary.paid_status,
+      remaining_amount: summary.remaining_amount,
+      deposit_existing_collect_amount: summary.deposit_existing_collect_amount,
+      deposit_existing_collect_exists: summary.deposit_existing_collect_exists,
+      deposit_projected: summary.deposit_projected,
+      deposit_projection_reason: summary.deposit_projection_reason,
+      deposit_target_amount: summary.deposit_target_amount,
+      deposit_collected_total: summary.deposit_collected_total,
+      deposit_collected_total_projected: summary.deposit_collected_total_projected,
+      deposit_remaining_amount: summary.deposit_remaining_amount,
+      deposit_remaining_amount_projected: summary.deposit_remaining_amount_projected,
+      deposit_is_required: summary.deposit_is_required,
+      deposit_payment_paid_amount: summary.deposit_payment_paid_amount,
+      deposit_payment_paid_status: summary.deposit_payment_paid_status,
+      deposit_payment_paid_at: summary.deposit_payment_paid_at,
+      latest_deposit_deduction: summary.latest_deposit_deduction,
+      payment: summary.payment,
       withdraw_request,
-      adjustments: adjQ.rows || [],
-      total_amount: net,
+      adjustments: summary.adjustments || [],
+      total_amount: summary.net_amount,
       lines
     });
   } catch (e) {
@@ -15111,7 +15037,7 @@ app.delete("/admin/jobs/:job_id", requireAdminSoft, async (req, res) => {
     await client.query("BEGIN");
 
     const jr = await client.query(
-      `SELECT job_id, booking_code FROM public.jobs WHERE job_id=$1 LIMIT 1`,
+      `SELECT job_id, booking_code FROM public.jobs WHERE job_id=$1 LIMIT 1 FOR UPDATE`,
       [jobId]
     );
     if (!jr.rows?.length) {
@@ -15119,6 +15045,8 @@ app.delete("/admin/jobs/:job_id", requireAdminSoft, async (req, res) => {
       return res.status(404).json({ error: "ไม่พบงาน" });
     }
 
+    await _assertJobMutableForPayout(client, jobId, 'admin_delete_job_primary');
+    const payoutCleanup = await technicianPayoutIntegrity.cleanupDraftJobPayoutRows(client, jobId);
 
 // delete related tables (best-effort)
 // IMPORTANT: In Postgres, any error inside a transaction aborts the whole transaction.
@@ -15200,11 +15128,16 @@ try {
 
 const dr = await client.query(`DELETE FROM public.jobs WHERE job_id=$1`, [jobId]);
     await client.query("COMMIT");
-    return res.json({ ok: true, deleted: dr.rowCount || 0 });
+    return res.json({ ok: true, deleted: dr.rowCount || 0, payout_cleanup: payoutCleanup });
   } catch (e) {
     try { await client.query("ROLLBACK"); } catch(_e) {}
     console.error("/admin/jobs/:job_id delete error:", e);
-    return res.status(500).json({ error: e.message || "ลบงานไม่สำเร็จ" });
+    return res.status(Number(e.statusCode || e.status || 500)).json({
+      error: e.message || "ลบงานไม่สำเร็จ",
+      code: e.code || undefined,
+      payout_id: e.payout_id || undefined,
+      details: e.details || undefined,
+    });
   } finally {
     client.release();
   }
@@ -16544,7 +16477,8 @@ app.delete('/admin/jobs/:job_id', requireAdminSoft, async (req, res) => {
 
     const chk = await client.query(
       `SELECT job_id, booking_code, technician_username, appointment_datetime
-         FROM public.jobs WHERE job_id=$1`,
+         FROM public.jobs WHERE job_id=$1
+         FOR UPDATE`,
       [job_id]
     );
     if (!chk.rows || !chk.rows.length) {
@@ -16554,6 +16488,7 @@ app.delete('/admin/jobs/:job_id', requireAdminSoft, async (req, res) => {
 
     // 🔒 Phase 5: do not allow delete if job affects locked/paid payout
     await _assertJobMutableForPayout(client, job_id, 'admin_delete_job');
+    const payoutCleanup = await technicianPayoutIntegrity.cleanupDraftJobPayoutRows(client, job_id);
 
     // child tables (fail-safe: some DB might miss tables in older deploys)
     const safeDel = async (sql, params) => {
@@ -16571,11 +16506,16 @@ app.delete('/admin/jobs/:job_id', requireAdminSoft, async (req, res) => {
     await client.query(`DELETE FROM public.jobs WHERE job_id=$1`, [job_id]);
 
     await client.query('COMMIT');
-    return res.json({ ok:true });
+    return res.json({ ok:true, payout_cleanup: payoutCleanup });
   } catch (e) {
     try { await client.query('ROLLBACK'); } catch(_){}
     console.error('[admin_delete_job] error', e);
-    return res.status(500).json({ ok:false, error:'delete failed' });
+    return res.status(Number(e.statusCode || e.status || 500)).json({
+      ok:false,
+      error: e.code || e.message || 'delete failed',
+      message: e.message || undefined,
+      details: e.details || undefined,
+    });
   } finally {
     client.release();
   }
@@ -17625,6 +17565,9 @@ app.delete("/jobs/:job_id/admin-delete", requireAdminSoft, async (req, res) => {
       throw new Error(`ต้องยืนยันด้วย booking_code (${code}) หรือพิมพ์ DELETE`);
     }
 
+    await _assertJobMutableForPayout(client, job_id, 'legacy_admin_delete_job');
+    const payoutCleanup = await technicianPayoutIntegrity.cleanupDraftJobPayoutRows(client, job_id);
+
     await client.query(`DELETE FROM public.jobs WHERE job_id=$1`, [job_id]);
 
     // server log (at least)
@@ -17634,10 +17577,14 @@ app.delete("/jobs/:job_id/admin-delete", requireAdminSoft, async (req, res) => {
     } catch (e) {}
 
     await client.query("COMMIT");
-    res.json({ success: true });
+    res.json({ success: true, payout_cleanup: payoutCleanup });
   } catch (e) {
     await client.query("ROLLBACK");
-    res.status(400).json({ error: e.message || "ลบงานไม่สำเร็จ" });
+    res.status(Number(e.statusCode || e.status || 400)).json({
+      error: e.message || "ลบงานไม่สำเร็จ",
+      code: e.code || undefined,
+      details: e.details || undefined,
+    });
   } finally {
     client.release();
   }

--- a/index.js
+++ b/index.js
@@ -9008,52 +9008,16 @@ async function _computeTechnicianPayoutMonthTotal(username, ym = ''){
   try {
     const parsed = _parsePayoutMonthYm(ym);
     const defs = _workMonthPayoutPeriodDefs(parsed.y, parsed.m).map((def) => _payoutPeriodDefForSummary(def, parsed.ym));
-    const periods = [];
-    let grossTotal = 0;
-    let netTotal = 0;
-    for (const def of defs) {
-      const summary = await _buildTechnicianPayoutPeriodSummary(def, tech);
-      grossTotal += Number(summary.gross_amount || 0);
-      netTotal += Number(summary.net_amount || 0);
-      periods.push({
-        payout_id: summary.payout_id,
-        period_type: summary.period_type,
-        label_ym: summary.label_ym,
-        work_month: parsed.ym,
-        period_start: summary.period_start,
-        period_end: summary.period_end,
-        period_end_display: summary.period_end_display || _periodEndDisplayIso(def.endEx),
-        period_effective_end: summary.period_end,
-        source: summary.source,
-        mode: summary.status === 'draft' ? 'live_or_projected_period' : 'stored_locked_or_paid_period',
-        status: summary.status,
-        gross_amount: summary.gross_amount,
-        adj_total: summary.adj_total,
-        deposit_deduction_amount: summary.deposit_deduction_amount,
-        net_amount: summary.net_amount,
-        paid_amount: summary.paid_amount,
-        paid_status: summary.paid_status,
-        remaining_amount: summary.remaining_amount,
-        payout_month_amount: summary.gross_amount,
-        payout_month_net_amount: summary.net_amount,
-        jobs_count: summary.lines_count,
-      });
-    }
-    grossTotal = _money(grossTotal);
-    netTotal = _money(netTotal);
-    return {
-      payout_month: parsed.ym,
-      work_month: parsed.ym,
-      payout_month_total: grossTotal,
-      payout_month_net_total: netTotal,
-      payout_month_policy: 'work_month_1_15_and_16_end_payout_net',
-      monthly_income_display_amount: netTotal,
-      monthly_income_display_label: parsed.ym,
-      monthly_income_period_start: defs[0].start.toISOString(),
-      monthly_income_period_end: defs[1].endEx.toISOString(),
-      monthly_income_period_end_display: _periodEndDisplayIso(defs[1].endEx),
-      periods,
-    };
+    return await technicianPayoutIntegrity.buildTechnicianPayoutMonthTotal({
+      periods: defs,
+      technicianUsername: tech,
+      payoutMonth: parsed.ym,
+      buildPeriodSummary: (period, username) => _buildTechnicianPayoutPeriodSummary(period, username),
+      normalizeMoney: _money,
+      monthlyIncomePeriodStart: defs[0].start.toISOString(),
+      monthlyIncomePeriodEnd: defs[1].endEx.toISOString(),
+      monthlyIncomePeriodEndDisplay: _periodEndDisplayIso(defs[1].endEx),
+    });
   } catch (e) {
     console.error('_computeTechnicianPayoutMonthTotal', e);
     return { payout_month_total: 0, payout_month_net_total: 0, payout_month: '', work_month: '', periods: [] };
@@ -9969,46 +9933,11 @@ app.get('/tech/payouts', requireTechnicianSession, async (req, res) => {
       periods = _recentPeriods(6, _bkkNow());
     }
 
-    const rows = [];
-    for (const p of periods) {
-      const summary = await _buildTechnicianPayoutPeriodSummary(_payoutPeriodDefForSummary(p, p.work_month || ''), tech);
-      rows.push({
-        payout_id: summary.payout_id,
-        period_type: summary.period_type,
-        period_start: summary.period_start,
-        period_end: summary.period_end,
-        period_end_display: summary.period_end_display,
-        status: summary.status,
-        source: summary.source,
-        gross_amount: summary.gross_amount,
-        adj_total: summary.adj_total,
-        deposit_deduction_amount: summary.deposit_deduction_amount,
-        net_amount: summary.net_amount,
-        paid_amount: summary.paid_amount,
-        paid_status: summary.paid_status,
-        remaining_amount: summary.remaining_amount,
-        deposit_existing_collect_amount: summary.deposit_existing_collect_amount,
-        deposit_existing_collect_exists: summary.deposit_existing_collect_exists,
-        deposit_projected: summary.deposit_projected,
-        deposit_projection_reason: summary.deposit_projection_reason,
-        deposit_target_amount: summary.deposit_target_amount,
-        deposit_collected_total: summary.deposit_collected_total,
-        deposit_collected_total_projected: summary.deposit_collected_total_projected,
-        deposit_remaining_amount: summary.deposit_remaining_amount,
-        deposit_remaining_amount_projected: summary.deposit_remaining_amount_projected,
-        deposit_is_required: summary.deposit_is_required,
-        deposit_payment_paid_amount: summary.deposit_payment_paid_amount,
-        deposit_payment_paid_status: summary.deposit_payment_paid_status,
-        deposit_payment_paid_at: summary.deposit_payment_paid_at,
-        latest_deposit_deduction: summary.latest_deposit_deduction,
-        lines_count: summary.lines_count,
-        paid_at: summary.paid_at,
-        slip_url: summary.slip_url,
-      });
-    }
-
-    // sort latest first by period_start
-    rows.sort((a, b) => new Date(b.period_start).getTime() - new Date(a.period_start).getTime());
+    const rows = await technicianPayoutIntegrity.buildTechnicianPayoutRows({
+      periods: periods.map((p) => _payoutPeriodDefForSummary(p, p.work_month || '')),
+      technicianUsername: tech,
+      buildPeriodSummary: (period, username) => _buildTechnicianPayoutPeriodSummary(period, username),
+    });
     return res.json({ ok: true, username: tech, payouts: rows });
   } catch (e) {
     console.error('GET /tech/payouts', e);
@@ -15045,90 +14974,95 @@ app.delete("/admin/jobs/:job_id", requireAdminSoft, async (req, res) => {
       return res.status(404).json({ error: "ไม่พบงาน" });
     }
 
-    await _assertJobMutableForPayout(client, jobId, 'admin_delete_job_primary');
-    const payoutCleanup = await technicianPayoutIntegrity.cleanupDraftJobPayoutRows(client, jobId);
+    const deleteRelatedRows = async (_db, hardDeleteJobId) => {
+      // delete related tables (best-effort)
+      // IMPORTANT: In Postgres, any error inside a transaction aborts the whole transaction.
+      // So we MUST wrap each best-effort delete with SAVEPOINT.
+      let _sp_i = 0;
+      const deleteFrom = async (sql, params) => {
+        const sp = `sp_del_${++_sp_i}`;
+        try {
+          await client.query(`SAVEPOINT ${sp}`);
+          await client.query(sql, params);
+          await client.query(`RELEASE SAVEPOINT ${sp}`);
+        } catch (e) {
+          try { await client.query(`ROLLBACK TO SAVEPOINT ${sp}`); } catch(_e) {}
+          try { await client.query(`RELEASE SAVEPOINT ${sp}`); } catch(_e) {}
+          console.warn("[admin_delete_job] skip", e.message);
+        }
+      };
 
-// delete related tables (best-effort)
-// IMPORTANT: In Postgres, any error inside a transaction aborts the whole transaction.
-// So we MUST wrap each best-effort delete with SAVEPOINT.
-let _sp_i = 0;
-const deleteFrom = async (sql, params) => {
-  const sp = `sp_del_${++_sp_i}`;
-  try {
-    await client.query(`SAVEPOINT ${sp}`);
-    await client.query(sql, params);
-    await client.query(`RELEASE SAVEPOINT ${sp}`);
-  } catch (e) {
-    try { await client.query(`ROLLBACK TO SAVEPOINT ${sp}`); } catch(_e) {}
-    try { await client.query(`RELEASE SAVEPOINT ${sp}`); } catch(_e) {}
-    console.warn("[admin_delete_job] skip", e.message);
-  }
-};
+      // delete children first (FK-safe)
+      await deleteFrom(`DELETE FROM public.job_photo_metadata WHERE job_id=$1`, [hardDeleteJobId]);
+      await deleteFrom(`DELETE FROM public.job_photos WHERE job_id=$1`, [hardDeleteJobId]);
+      await deleteFrom(`DELETE FROM public.job_updates_v2 WHERE job_id=$1`, [hardDeleteJobId]);
+      await deleteFrom(`DELETE FROM public.job_team_members WHERE job_id=$1`, [hardDeleteJobId]);
+      await deleteFrom(`DELETE FROM public.job_assignments WHERE job_id=$1`, [hardDeleteJobId]);
+      await deleteFrom(`DELETE FROM public.job_offer_recipients WHERE job_id=$1`, [hardDeleteJobId]);
+      await deleteFrom(`DELETE FROM public.job_offers WHERE job_id=$1`, [hardDeleteJobId]);
 
-// delete children first (FK-safe)
-await deleteFrom(`DELETE FROM public.job_photo_metadata WHERE job_id=$1`, [jobId]);
-await deleteFrom(`DELETE FROM public.job_photos WHERE job_id=$1`, [jobId]);
-await deleteFrom(`DELETE FROM public.job_updates_v2 WHERE job_id=$1`, [jobId]);
-await deleteFrom(`DELETE FROM public.job_team_members WHERE job_id=$1`, [jobId]);
-await deleteFrom(`DELETE FROM public.job_assignments WHERE job_id=$1`, [jobId]);
-await deleteFrom(`DELETE FROM public.job_offer_recipients WHERE job_id=$1`, [jobId]);
-await deleteFrom(`DELETE FROM public.job_offers WHERE job_id=$1`, [jobId]);
+      // v2 pricing/items/promotions (some deployments have these tables + FK to jobs)
+      await deleteFrom(`DELETE FROM public.job_items WHERE job_id=$1`, [hardDeleteJobId]);
+      await deleteFrom(`DELETE FROM public.job_promotions WHERE job_id=$1`, [hardDeleteJobId]);
+      await deleteFrom(`DELETE FROM public.job_pricing_requests WHERE job_id=$1`, [hardDeleteJobId]);
+      // reviews can reference job_id as well
+      await deleteFrom(`DELETE FROM public.technician_reviews WHERE job_id=$1`, [hardDeleteJobId]);
 
-// v2 pricing/items/promotions (some deployments have these tables + FK to jobs)
-await deleteFrom(`DELETE FROM public.job_items WHERE job_id=$1`, [jobId]);
-await deleteFrom(`DELETE FROM public.job_promotions WHERE job_id=$1`, [jobId]);
-await deleteFrom(`DELETE FROM public.job_pricing_requests WHERE job_id=$1`, [jobId]);
-// reviews can reference job_id as well
-await deleteFrom(`DELETE FROM public.technician_reviews WHERE job_id=$1`, [jobId]);
+      // -----------------------------------------------------------------
+      // Dynamic cleanup (no regression):
+      // Some production DBs may have extra tables referencing jobs(job_id).
+      // If we miss one FK, deleting from jobs will fail with 23503.
+      // So we proactively scan FK references and best-effort delete rows.
+      // -----------------------------------------------------------------
+      const quoteIdent = (s) => {
+        const v = String(s || '');
+        return '"' + v.replace(/"/g, '""') + '"';
+      };
 
-// -----------------------------------------------------------------
-// Dynamic cleanup (no regression):
-// Some production DBs may have extra tables referencing jobs(job_id).
-// If we miss one FK, deleting from jobs will fail with 23503.
-// So we proactively scan FK references and best-effort delete rows.
-// -----------------------------------------------------------------
-const quoteIdent = (s) => {
-  const v = String(s || '');
-  return '"' + v.replace(/"/g, '""') + '"';
-};
+      try {
+        const fk = await client.query(
+          `
+          SELECT
+            con.conrelid::regclass::text AS rel,
+            att.attname AS col
+          FROM pg_constraint con
+          JOIN pg_class rel ON rel.oid = con.conrelid
+          JOIN pg_namespace nsp ON nsp.oid = rel.relnamespace
+          JOIN unnest(con.conkey) WITH ORDINALITY AS ck(attnum, ord) ON TRUE
+          JOIN pg_attribute att ON att.attrelid = con.conrelid AND att.attnum = ck.attnum
+          WHERE con.contype = 'f'
+            AND con.confrelid = 'public.jobs'::regclass
+            AND nsp.nspname = 'public'
+            AND att.attname = 'job_id'
+          GROUP BY con.conrelid, att.attname
+          ORDER BY rel;
+          `
+        );
+        for (const row of (fk.rows || [])) {
+          const rel = String(row.rel || '').trim();
+          if (!rel) continue;
+          // rel is already schema-qualified text (e.g. public.some_table)
+          const parts = rel.split('.');
+          if (parts.length !== 2) continue;
+          const tbl = `${quoteIdent(parts[0])}.${quoteIdent(parts[1])}`;
+          // skip the parent table
+          if (parts[1] === 'jobs') continue;
+          await deleteFrom(`DELETE FROM ${tbl} WHERE job_id=$1`, [hardDeleteJobId]);
+        }
+      } catch (e) {
+        console.warn('[admin_delete_job] fk scan skipped', e.message);
+      }
+    };
 
-try {
-  const fk = await client.query(
-    `
-    SELECT
-      con.conrelid::regclass::text AS rel,
-      att.attname AS col
-    FROM pg_constraint con
-    JOIN pg_class rel ON rel.oid = con.conrelid
-    JOIN pg_namespace nsp ON nsp.oid = rel.relnamespace
-    JOIN unnest(con.conkey) WITH ORDINALITY AS ck(attnum, ord) ON TRUE
-    JOIN pg_attribute att ON att.attrelid = con.conrelid AND att.attnum = ck.attnum
-    WHERE con.contype = 'f'
-      AND con.confrelid = 'public.jobs'::regclass
-      AND nsp.nspname = 'public'
-      AND att.attname = 'job_id'
-    GROUP BY con.conrelid, att.attname
-    ORDER BY rel;
-    `
-  );
-  for (const row of (fk.rows || [])) {
-    const rel = String(row.rel || '').trim();
-    if (!rel) continue;
-    // rel is already schema-qualified text (e.g. public.some_table)
-    const parts = rel.split('.');
-    if (parts.length !== 2) continue;
-    const tbl = `${quoteIdent(parts[0])}.${quoteIdent(parts[1])}`;
-    // skip the parent table
-    if (parts[1] === 'jobs') continue;
-    await deleteFrom(`DELETE FROM ${tbl} WHERE job_id=$1`, [jobId]);
-  }
-} catch (e) {
-  console.warn('[admin_delete_job] fk scan skipped', e.message);
-}
-
-const dr = await client.query(`DELETE FROM public.jobs WHERE job_id=$1`, [jobId]);
+    const hardDelete = await technicianPayoutIntegrity.runJobHardDeletePayoutFlow({
+      db: client,
+      jobId,
+      context: 'admin_delete_job_primary',
+      assertJobMutableForPayout: _assertJobMutableForPayout,
+      deleteRelatedRows,
+    });
     await client.query("COMMIT");
-    return res.json({ ok: true, deleted: dr.rowCount || 0, payout_cleanup: payoutCleanup });
+    return res.json({ ok: true, deleted: hardDelete.deleted || 0, payout_cleanup: hardDelete.payout_cleanup });
   } catch (e) {
     try { await client.query("ROLLBACK"); } catch(_e) {}
     console.error("/admin/jobs/:job_id delete error:", e);
@@ -16486,27 +16420,31 @@ app.delete('/admin/jobs/:job_id', requireAdminSoft, async (req, res) => {
       return res.status(404).json({ ok:false, error:'job not found' });
     }
 
-    // 🔒 Phase 5: do not allow delete if job affects locked/paid payout
-    await _assertJobMutableForPayout(client, job_id, 'admin_delete_job');
-    const payoutCleanup = await technicianPayoutIntegrity.cleanupDraftJobPayoutRows(client, job_id);
+    const deleteRelatedRows = async (_db, hardDeleteJobId) => {
+      // child tables (fail-safe: some DB might miss tables in older deploys)
+      const safeDel = async (sql, params) => {
+        try { await client.query(sql, params); } catch(e){ console.warn('[admin_delete_job] ignore', e.message); }
+      };
 
-    // child tables (fail-safe: some DB might miss tables in older deploys)
-    const safeDel = async (sql, params) => {
-      try { await client.query(sql, params); } catch(e){ console.warn('[admin_delete_job] ignore', e.message); }
+      await safeDel(`DELETE FROM public.job_photos WHERE job_id=$1`, [hardDeleteJobId]);
+      await safeDel(`DELETE FROM public.job_updates_v2 WHERE job_id=$1`, [hardDeleteJobId]);
+      await safeDel(`DELETE FROM public.job_offers WHERE job_id=$1`, [hardDeleteJobId]);
+      await safeDel(`DELETE FROM public.job_team_members WHERE job_id=$1`, [hardDeleteJobId]);
+      await safeDel(`DELETE FROM public.job_assignments WHERE job_id=$1`, [hardDeleteJobId]);
+      await safeDel(`DELETE FROM public.job_promotions WHERE job_id=$1`, [hardDeleteJobId]);
+      await safeDel(`DELETE FROM public.job_items WHERE job_id=$1`, [hardDeleteJobId]);
     };
 
-    await safeDel(`DELETE FROM public.job_photos WHERE job_id=$1`, [job_id]);
-    await safeDel(`DELETE FROM public.job_updates_v2 WHERE job_id=$1`, [job_id]);
-    await safeDel(`DELETE FROM public.job_offers WHERE job_id=$1`, [job_id]);
-    await safeDel(`DELETE FROM public.job_team_members WHERE job_id=$1`, [job_id]);
-    await safeDel(`DELETE FROM public.job_assignments WHERE job_id=$1`, [job_id]);
-    await safeDel(`DELETE FROM public.job_promotions WHERE job_id=$1`, [job_id]);
-    await safeDel(`DELETE FROM public.job_items WHERE job_id=$1`, [job_id]);
-
-    await client.query(`DELETE FROM public.jobs WHERE job_id=$1`, [job_id]);
+    const hardDelete = await technicianPayoutIntegrity.runJobHardDeletePayoutFlow({
+      db: client,
+      jobId: job_id,
+      context: 'admin_delete_job',
+      assertJobMutableForPayout: _assertJobMutableForPayout,
+      deleteRelatedRows,
+    });
 
     await client.query('COMMIT');
-    return res.json({ ok:true, payout_cleanup: payoutCleanup });
+    return res.json({ ok:true, deleted: hardDelete.deleted || 0, payout_cleanup: hardDelete.payout_cleanup });
   } catch (e) {
     try { await client.query('ROLLBACK'); } catch(_){}
     console.error('[admin_delete_job] error', e);
@@ -17565,10 +17503,12 @@ app.delete("/jobs/:job_id/admin-delete", requireAdminSoft, async (req, res) => {
       throw new Error(`ต้องยืนยันด้วย booking_code (${code}) หรือพิมพ์ DELETE`);
     }
 
-    await _assertJobMutableForPayout(client, job_id, 'legacy_admin_delete_job');
-    const payoutCleanup = await technicianPayoutIntegrity.cleanupDraftJobPayoutRows(client, job_id);
-
-    await client.query(`DELETE FROM public.jobs WHERE job_id=$1`, [job_id]);
+    const hardDelete = await technicianPayoutIntegrity.runJobHardDeletePayoutFlow({
+      db: client,
+      jobId: job_id,
+      context: 'legacy_admin_delete_job',
+      assertJobMutableForPayout: _assertJobMutableForPayout,
+    });
 
     // server log (at least)
     try {
@@ -17577,7 +17517,7 @@ app.delete("/jobs/:job_id/admin-delete", requireAdminSoft, async (req, res) => {
     } catch (e) {}
 
     await client.query("COMMIT");
-    res.json({ success: true, payout_cleanup: payoutCleanup });
+    res.json({ success: true, deleted: hardDelete.deleted || 0, payout_cleanup: hardDelete.payout_cleanup });
   } catch (e) {
     await client.query("ROLLBACK");
     res.status(Number(e.statusCode || e.status || 400)).json({

--- a/scripts/audit-orphan-payout-lines.js
+++ b/scripts/audit-orphan-payout-lines.js
@@ -1,18 +1,20 @@
 "use strict";
 
-const { orphanPayoutLinesAuditSql } = require("../server/services/technicianPayoutIntegrity");
+const { orphanPayoutLinesAuditSql, positiveInteger } = require("../server/services/technicianPayoutIntegrity");
 
 function parseArgs(argv = process.argv.slice(2)) {
   const args = new Set(argv);
   const limitArg = argv.find((x) => /^--limit=/.test(x));
-  const limit = limitArg ? Number(limitArg.split("=")[1]) : 200;
   return {
     run: args.has("--run"),
     json: args.has("--json"),
-    allowProductionRead: args.has("--allow-production-read"),
     apply: args.has("--apply"),
-    limit: Number.isFinite(limit) ? limit : 200,
+    limit: positiveInteger(limitArg ? limitArg.split("=")[1] : 200, 200, 10000),
   };
+}
+
+function shouldRefuseProductionExecution(env = process.env) {
+  return String(env.NODE_ENV || "").toLowerCase() === "production";
 }
 
 async function main() {
@@ -31,8 +33,8 @@ async function main() {
     return;
   }
 
-  if (String(process.env.NODE_ENV || "").toLowerCase() === "production" && !opts.allowProductionRead) {
-    console.error("Refusing production read without --allow-production-read.");
+  if (shouldRefuseProductionExecution()) {
+    console.error("Refusing production execution. This read-only audit must run only against a non-production copy.");
     process.exitCode = 2;
     return;
   }
@@ -59,5 +61,6 @@ if (require.main === module) {
 
 module.exports = {
   parseArgs,
+  shouldRefuseProductionExecution,
   orphanPayoutLinesAuditSql,
 };

--- a/scripts/audit-orphan-payout-lines.js
+++ b/scripts/audit-orphan-payout-lines.js
@@ -1,0 +1,63 @@
+"use strict";
+
+const { orphanPayoutLinesAuditSql } = require("../server/services/technicianPayoutIntegrity");
+
+function parseArgs(argv = process.argv.slice(2)) {
+  const args = new Set(argv);
+  const limitArg = argv.find((x) => /^--limit=/.test(x));
+  const limit = limitArg ? Number(limitArg.split("=")[1]) : 200;
+  return {
+    run: args.has("--run"),
+    json: args.has("--json"),
+    allowProductionRead: args.has("--allow-production-read"),
+    apply: args.has("--apply"),
+    limit: Number.isFinite(limit) ? limit : 200,
+  };
+}
+
+async function main() {
+  const opts = parseArgs();
+  const sql = orphanPayoutLinesAuditSql({ limit: opts.limit });
+
+  if (opts.apply) {
+    console.error("REPAIR_NOT_IMPLEMENTED: this audit script is read-only and has no repair mode.");
+    process.exitCode = 2;
+    return;
+  }
+
+  if (!opts.run) {
+    console.log("Dry run only. Review this read-only SQL; re-run with --run to execute the SELECT.");
+    console.log(sql.trim() + ";");
+    return;
+  }
+
+  if (String(process.env.NODE_ENV || "").toLowerCase() === "production" && !opts.allowProductionRead) {
+    console.error("Refusing production read without --allow-production-read.");
+    process.exitCode = 2;
+    return;
+  }
+
+  const pool = require("../db");
+  try {
+    const result = await pool.query(sql);
+    if (opts.json) {
+      console.log(JSON.stringify({ ok: true, rows: result.rows || [] }, null, 2));
+    } else {
+      console.table(result.rows || []);
+    }
+  } finally {
+    await pool.end();
+  }
+}
+
+if (require.main === module) {
+  main().catch((err) => {
+    console.error(err && err.stack || err);
+    process.exitCode = 1;
+  });
+}
+
+module.exports = {
+  parseArgs,
+  orphanPayoutLinesAuditSql,
+};

--- a/server/services/technicianPayoutIntegrity.js
+++ b/server/services/technicianPayoutIntegrity.js
@@ -1,0 +1,263 @@
+"use strict";
+
+function money(value) {
+  const n = Number(value || 0);
+  if (!Number.isFinite(n)) return 0;
+  return Math.round(n * 100) / 100;
+}
+
+function toIso(value) {
+  if (!value) return null;
+  if (value instanceof Date) return value.toISOString();
+  const d = new Date(value);
+  return Number.isNaN(d.getTime()) ? String(value) : d.toISOString();
+}
+
+function asDate(value) {
+  const d = value instanceof Date ? value : new Date(value);
+  return Number.isNaN(d.getTime()) ? null : d;
+}
+
+function statusIsBlocked(status) {
+  return ["locked", "paid"].includes(String(status || "").trim().toLowerCase());
+}
+
+function hasPaymentRecord(row) {
+  if (!row) return false;
+  if (row.payment_id != null) return true;
+  if (Number(row.paid_amount || 0) > 0) return true;
+  const st = String(row.paid_status || "").trim().toLowerCase();
+  return st === "partial" || st === "paid" || row.paid_at != null;
+}
+
+function createPayoutDeleteBlockedError(blockers) {
+  const err = new Error("PAYOUT_DELETE_BLOCKED");
+  err.statusCode = 409;
+  err.code = "PAYOUT_DELETE_BLOCKED";
+  err.details = blockers;
+  return err;
+}
+
+async function buildTechnicianPayoutPeriodSummary({
+  db,
+  period,
+  technicianUsername,
+  loadPayoutLinesForTech,
+  getProjectedDepositDeductionForPayout,
+  paidStatus,
+  normalizeMoney = money,
+} = {}) {
+  if (!db || typeof db.query !== "function") throw new Error("PAYOUT_SUMMARY_DB_REQUIRED");
+  if (!period || !period.payout_id) throw new Error("PAYOUT_PERIOD_REQUIRED");
+  const tech = String(technicianUsername || "").trim();
+  if (!tech) throw new Error("TECHNICIAN_USERNAME_REQUIRED");
+  if (typeof loadPayoutLinesForTech !== "function") throw new Error("PAYOUT_LINE_LOADER_REQUIRED");
+  if (typeof getProjectedDepositDeductionForPayout !== "function") throw new Error("DEPOSIT_PROJECTOR_REQUIRED");
+  const moneyFn = typeof normalizeMoney === "function" ? normalizeMoney : money;
+  const paidStatusFn = typeof paidStatus === "function" ? paidStatus : (() => "unpaid");
+
+  const payoutId = String(period.payout_id || "").trim();
+  const metaQ = await db.query(
+    `SELECT payout_id, status, period_start, period_end
+       FROM public.technician_payout_periods
+      WHERE payout_id=$1
+      LIMIT 1`,
+    [payoutId]
+  );
+  const meta = metaQ.rows?.[0] || null;
+  const status = String(meta?.status || period.status || "draft").trim() || "draft";
+  const periodStartRaw = meta?.period_start || period.period_start || period.start;
+  const periodEndRaw = meta?.period_end || period.period_end || period.endEx;
+  const start = asDate(periodStartRaw);
+  const endEx = asDate(periodEndRaw);
+
+  const loaded = await loadPayoutLinesForTech({
+    payout_id: payoutId,
+    tech,
+    status,
+    start,
+    endEx,
+    period_type: period.period_type,
+    label_ym: period.label_ym,
+  });
+  const lines = Array.isArray(loaded?.lines) ? loaded.lines : [];
+
+  const adjQ = await db.query(
+    `SELECT adj_id, payout_id, technician_username, job_id::text AS job_id, adj_amount, reason, created_at, created_by
+       FROM public.technician_payout_adjustments
+      WHERE payout_id=$1 AND technician_username=$2
+      ORDER BY created_at ASC, adj_id ASC`,
+    [payoutId, tech]
+  );
+  const adjustments = adjQ.rows || [];
+
+  const payQ = await db.query(
+    `SELECT payment_id, paid_amount, paid_status, paid_at, slip_url, note
+       FROM public.technician_payout_payments
+      WHERE payout_id=$1 AND technician_username=$2
+      LIMIT 1`,
+    [payoutId, tech]
+  );
+  const payment = payQ.rows?.[0] || null;
+
+  const gross = moneyFn(lines.reduce((sum, line) => sum + Number(line.earn_amount || 0), 0));
+  const adj = moneyFn(adjustments.reduce((sum, row) => sum + Number(row.adj_amount || 0), 0));
+  const deposit = await getProjectedDepositDeductionForPayout(db, {
+    payout_id: payoutId,
+    technician_username: tech,
+    gross_amount: gross,
+    adj_total: adj,
+    period_status: status,
+  });
+  const depositAmount = moneyFn(deposit?.deposit_deduction_amount || 0);
+  const net = moneyFn(gross + adj - depositAmount);
+  const paid = moneyFn(payment?.paid_amount || 0);
+  const paidStatusValue = paidStatusFn(net, paid);
+
+  return {
+    payout_id: payoutId,
+    period_type: period.period_type,
+    label_ym: period.label_ym || "",
+    work_month: period.work_month || "",
+    period_start: toIso(periodStartRaw),
+    period_end: toIso(periodEndRaw),
+    period_end_display: period.period_end_display || null,
+    status,
+    source: loaded?.source || "",
+    gross_amount: gross,
+    adj_total: adj,
+    deposit_deduction_amount: depositAmount,
+    net_amount: net,
+    payout_month_amount: gross,
+    payout_month_net_amount: net,
+    paid_amount: paid,
+    paid_status: paidStatusValue,
+    remaining_amount: moneyFn(net - paid),
+    ...deposit,
+    latest_deposit_deduction: depositAmount,
+    lines_count: lines.length,
+    lines,
+    adjustments,
+    payment,
+    paid_at: payment?.paid_at || null,
+    slip_url: payment?.slip_url || null,
+  };
+}
+
+async function inspectJobPayoutDeleteImpact(db, jobId) {
+  if (!db || typeof db.query !== "function") throw new Error("PAYOUT_DELETE_DB_REQUIRED");
+  const jid = String(Number(jobId));
+  if (!/^\d+$/.test(jid) || Number(jid) <= 0) {
+    const err = new Error("INVALID_JOB_ID");
+    err.statusCode = 400;
+    err.code = "INVALID_JOB_ID";
+    throw err;
+  }
+  const q = await db.query(
+    `WITH refs AS (
+       SELECT payout_id, technician_username, 'line'::text AS ref_type
+         FROM public.technician_payout_lines
+        WHERE job_id::text=$1
+       UNION ALL
+       SELECT payout_id, technician_username, 'adjustment'::text AS ref_type
+         FROM public.technician_payout_adjustments
+        WHERE job_id::text=$1
+     ),
+     grouped AS (
+       SELECT payout_id, technician_username,
+              COUNT(*) FILTER (WHERE ref_type='line')::int AS line_refs,
+              COUNT(*) FILTER (WHERE ref_type='adjustment')::int AS adjustment_refs
+         FROM refs
+        GROUP BY payout_id, technician_username
+     )
+     SELECT g.payout_id,
+            g.technician_username,
+            COALESCE(p.status,'draft') AS period_status,
+            g.line_refs,
+            g.adjustment_refs,
+            pay.payment_id,
+            COALESCE(pay.paid_amount,0)::numeric AS paid_amount,
+            COALESCE(pay.paid_status,'') AS paid_status,
+            pay.paid_at
+       FROM grouped g
+       LEFT JOIN public.technician_payout_periods p ON p.payout_id=g.payout_id
+       LEFT JOIN public.technician_payout_payments pay
+         ON pay.payout_id=g.payout_id
+        AND pay.technician_username=g.technician_username
+      ORDER BY g.payout_id ASC, g.technician_username ASC`,
+    [jid]
+  );
+  const rows = q.rows || [];
+  const blockers = rows.filter((row) => statusIsBlocked(row.period_status) || hasPaymentRecord(row));
+  return {
+    job_id: jid,
+    rows,
+    blockers,
+    can_delete_payout_refs: blockers.length === 0,
+  };
+}
+
+async function cleanupDraftJobPayoutRows(db, jobId, impact = null) {
+  const checked = impact || await inspectJobPayoutDeleteImpact(db, jobId);
+  if (checked.blockers?.length) throw createPayoutDeleteBlockedError(checked.blockers);
+  const jid = String(Number(jobId));
+  const adj = await db.query(
+    `DELETE FROM public.technician_payout_adjustments
+      WHERE job_id::text=$1`,
+    [jid]
+  );
+  const lines = await db.query(
+    `DELETE FROM public.technician_payout_lines
+      WHERE job_id::text=$1`,
+    [jid]
+  );
+  const preview = await db.query(
+    `DELETE FROM public.job_technician_income_preview
+      WHERE job_id=$1`,
+    [Number(jid)]
+  );
+  const display = await db.query(
+    `DELETE FROM public.technician_job_income_display
+      WHERE job_id=$1`,
+    [Number(jid)]
+  );
+  return {
+    ok: true,
+    job_id: jid,
+    deleted_payout_adjustments: adj.rowCount || 0,
+    deleted_payout_lines: lines.rowCount || 0,
+    deleted_income_previews: preview.rowCount || 0,
+    deleted_income_display_rows: display.rowCount || 0,
+    inspected_refs: checked.rows || [],
+  };
+}
+
+function orphanPayoutLinesAuditSql({ limit = 200 } = {}) {
+  const n = Math.min(Math.max(Number(limit || 200), 1), 10000);
+  return `
+SELECT l.payout_id,
+       p.status AS period_status,
+       l.technician_username,
+       l.job_id,
+       COUNT(*)::int AS orphan_lines,
+       COALESCE(SUM(l.earn_amount),0)::numeric AS orphan_gross_amount,
+       COALESCE(pay.paid_amount,0)::numeric AS paid_amount,
+       COALESCE(pay.paid_status,'') AS paid_status
+  FROM public.technician_payout_lines l
+  LEFT JOIN public.jobs j ON j.job_id::text = l.job_id::text
+  LEFT JOIN public.technician_payout_periods p ON p.payout_id = l.payout_id
+  LEFT JOIN public.technician_payout_payments pay
+    ON pay.payout_id = l.payout_id
+   AND pay.technician_username = l.technician_username
+ WHERE j.job_id IS NULL
+ GROUP BY l.payout_id, p.status, l.technician_username, l.job_id, pay.paid_amount, pay.paid_status
+ ORDER BY l.payout_id ASC, l.technician_username ASC, l.job_id ASC
+ LIMIT ${n}`;
+}
+
+module.exports = {
+  buildTechnicianPayoutPeriodSummary,
+  inspectJobPayoutDeleteImpact,
+  cleanupDraftJobPayoutRows,
+  orphanPayoutLinesAuditSql,
+};

--- a/server/services/technicianPayoutIntegrity.js
+++ b/server/services/technicianPayoutIntegrity.js
@@ -6,6 +6,12 @@ function money(value) {
   return Math.round(n * 100) / 100;
 }
 
+function positiveInteger(value, fallback = 200, max = 10000) {
+  const n = Number(value);
+  const base = Number.isFinite(n) ? Math.floor(n) : Number(fallback || 200);
+  return Math.min(Math.max(base, 1), Number(max || 10000));
+}
+
 function toIso(value) {
   if (!value) return null;
   if (value instanceof Date) return value.toISOString();
@@ -144,6 +150,123 @@ async function buildTechnicianPayoutPeriodSummary({
   };
 }
 
+function payoutListRow(summary = {}) {
+  return {
+    payout_id: summary.payout_id,
+    period_type: summary.period_type,
+    period_start: summary.period_start,
+    period_end: summary.period_end,
+    period_end_display: summary.period_end_display,
+    status: summary.status,
+    source: summary.source,
+    gross_amount: summary.gross_amount,
+    adj_total: summary.adj_total,
+    deposit_deduction_amount: summary.deposit_deduction_amount,
+    net_amount: summary.net_amount,
+    paid_amount: summary.paid_amount,
+    paid_status: summary.paid_status,
+    remaining_amount: summary.remaining_amount,
+    deposit_existing_collect_amount: summary.deposit_existing_collect_amount,
+    deposit_existing_collect_exists: summary.deposit_existing_collect_exists,
+    deposit_projected: summary.deposit_projected,
+    deposit_projection_reason: summary.deposit_projection_reason,
+    deposit_target_amount: summary.deposit_target_amount,
+    deposit_collected_total: summary.deposit_collected_total,
+    deposit_collected_total_projected: summary.deposit_collected_total_projected,
+    deposit_remaining_amount: summary.deposit_remaining_amount,
+    deposit_remaining_amount_projected: summary.deposit_remaining_amount_projected,
+    deposit_is_required: summary.deposit_is_required,
+    deposit_payment_paid_amount: summary.deposit_payment_paid_amount,
+    deposit_payment_paid_status: summary.deposit_payment_paid_status,
+    deposit_payment_paid_at: summary.deposit_payment_paid_at,
+    latest_deposit_deduction: summary.latest_deposit_deduction,
+    lines_count: summary.lines_count,
+    paid_at: summary.paid_at,
+    slip_url: summary.slip_url,
+  };
+}
+
+function payoutMonthPeriodRow(summary = {}) {
+  return {
+    payout_id: summary.payout_id,
+    period_type: summary.period_type,
+    label_ym: summary.label_ym,
+    work_month: summary.work_month,
+    period_start: summary.period_start,
+    period_end: summary.period_end,
+    period_end_display: summary.period_end_display,
+    period_effective_end: summary.period_end,
+    source: summary.source,
+    mode: summary.status === "draft" ? "live_or_projected_period" : "stored_locked_or_paid_period",
+    status: summary.status,
+    gross_amount: summary.gross_amount,
+    adj_total: summary.adj_total,
+    deposit_deduction_amount: summary.deposit_deduction_amount,
+    net_amount: summary.net_amount,
+    paid_amount: summary.paid_amount,
+    paid_status: summary.paid_status,
+    remaining_amount: summary.remaining_amount,
+    payout_month_amount: summary.gross_amount,
+    payout_month_net_amount: summary.net_amount,
+    jobs_count: summary.lines_count,
+  };
+}
+
+async function buildTechnicianPayoutRows({
+  periods = [],
+  technicianUsername,
+  buildPeriodSummary,
+} = {}) {
+  if (typeof buildPeriodSummary !== "function") throw new Error("PAYOUT_PERIOD_SUMMARY_BUILDER_REQUIRED");
+  const tech = String(technicianUsername || "").trim();
+  const rows = [];
+  for (const period of (periods || [])) {
+    const summary = await buildPeriodSummary(period, tech);
+    rows.push(payoutListRow(summary));
+  }
+  rows.sort((a, b) => new Date(b.period_start).getTime() - new Date(a.period_start).getTime());
+  return rows;
+}
+
+async function buildTechnicianPayoutMonthTotal({
+  periods = [],
+  technicianUsername,
+  payoutMonth = "",
+  buildPeriodSummary,
+  normalizeMoney = money,
+  monthlyIncomePeriodStart = null,
+  monthlyIncomePeriodEnd = null,
+  monthlyIncomePeriodEndDisplay = null,
+} = {}) {
+  if (typeof buildPeriodSummary !== "function") throw new Error("PAYOUT_PERIOD_SUMMARY_BUILDER_REQUIRED");
+  const tech = String(technicianUsername || "").trim();
+  const moneyFn = typeof normalizeMoney === "function" ? normalizeMoney : money;
+  let grossTotal = 0;
+  let netTotal = 0;
+  const periodRows = [];
+  for (const period of (periods || [])) {
+    const summary = await buildPeriodSummary(period, tech);
+    grossTotal += Number(summary.gross_amount || 0);
+    netTotal += Number(summary.net_amount || 0);
+    periodRows.push(payoutMonthPeriodRow(summary));
+  }
+  grossTotal = moneyFn(grossTotal);
+  netTotal = moneyFn(netTotal);
+  return {
+    payout_month: payoutMonth,
+    work_month: payoutMonth,
+    payout_month_total: grossTotal,
+    payout_month_net_total: netTotal,
+    payout_month_policy: "work_month_1_15_and_16_end_payout_net",
+    monthly_income_display_amount: netTotal,
+    monthly_income_display_label: payoutMonth,
+    monthly_income_period_start: monthlyIncomePeriodStart,
+    monthly_income_period_end: monthlyIncomePeriodEnd,
+    monthly_income_period_end_display: monthlyIncomePeriodEndDisplay,
+    periods: periodRows,
+  };
+}
+
 async function inspectJobPayoutDeleteImpact(db, jobId) {
   if (!db || typeof db.query !== "function") throw new Error("PAYOUT_DELETE_DB_REQUIRED");
   const jid = String(Number(jobId));
@@ -232,15 +355,63 @@ async function cleanupDraftJobPayoutRows(db, jobId, impact = null) {
   };
 }
 
+async function runJobHardDeletePayoutFlow({
+  db,
+  jobId,
+  context = "admin_delete_job",
+  assertJobMutableForPayout,
+  cleanupDraftJobPayoutRows: cleanupFn = cleanupDraftJobPayoutRows,
+  deleteRelatedRows,
+  deleteJobRow,
+} = {}) {
+  if (!db || typeof db.query !== "function") throw new Error("PAYOUT_DELETE_DB_REQUIRED");
+  const jid = Number(jobId);
+  if (!Number.isInteger(jid) || jid <= 0) {
+    const err = new Error("INVALID_JOB_ID");
+    err.statusCode = 400;
+    err.code = "INVALID_JOB_ID";
+    throw err;
+  }
+  if (typeof assertJobMutableForPayout === "function") {
+    await assertJobMutableForPayout(db, jid, context);
+  }
+  const payoutCleanup = await cleanupFn(db, jid);
+  if (typeof deleteRelatedRows === "function") {
+    await deleteRelatedRows(db, jid);
+  }
+  const deleted = typeof deleteJobRow === "function"
+    ? await deleteJobRow(db, jid)
+    : await db.query(`DELETE FROM public.jobs WHERE job_id=$1`, [jid]);
+  return {
+    ok: true,
+    deleted: deleted?.rowCount || 0,
+    payout_cleanup: payoutCleanup,
+  };
+}
+
+function orphanClassificationSql() {
+  return `CASE
+         WHEN COALESCE(p.status,'draft') IN ('locked','paid')
+           OR pay.payment_id IS NOT NULL
+           OR COALESCE(pay.paid_amount,0) > 0
+           OR COALESCE(pay.paid_status,'') IN ('partial','paid')
+           OR pay.paid_at IS NOT NULL
+         THEN 'locked/paid/payment-linked-reconciliation-required'
+         ELSE 'draft/unpaid-safe-to-review'
+       END`;
+}
+
 function orphanPayoutLinesAuditSql({ limit = 200 } = {}) {
-  const n = Math.min(Math.max(Number(limit || 200), 1), 10000);
+  const n = positiveInteger(limit, 200, 10000);
   return `
 SELECT l.payout_id,
-       p.status AS period_status,
+       COALESCE(p.status,'draft') AS period_status,
        l.technician_username,
        l.job_id,
+       ${orphanClassificationSql()} AS classification,
        COUNT(*)::int AS orphan_lines,
        COALESCE(SUM(l.earn_amount),0)::numeric AS orphan_gross_amount,
+       pay.payment_id,
        COALESCE(pay.paid_amount,0)::numeric AS paid_amount,
        COALESCE(pay.paid_status,'') AS paid_status
   FROM public.technician_payout_lines l
@@ -250,14 +421,19 @@ SELECT l.payout_id,
     ON pay.payout_id = l.payout_id
    AND pay.technician_username = l.technician_username
  WHERE j.job_id IS NULL
- GROUP BY l.payout_id, p.status, l.technician_username, l.job_id, pay.paid_amount, pay.paid_status
+ GROUP BY l.payout_id, p.status, l.technician_username, l.job_id,
+          pay.payment_id, pay.paid_amount, pay.paid_status, pay.paid_at
  ORDER BY l.payout_id ASC, l.technician_username ASC, l.job_id ASC
  LIMIT ${n}`;
 }
 
 module.exports = {
+  positiveInteger,
   buildTechnicianPayoutPeriodSummary,
+  buildTechnicianPayoutRows,
+  buildTechnicianPayoutMonthTotal,
   inspectJobPayoutDeleteImpact,
   cleanupDraftJobPayoutRows,
+  runJobHardDeletePayoutFlow,
   orphanPayoutLinesAuditSql,
 };

--- a/test/technicianPayoutIntegrity.test.js
+++ b/test/technicianPayoutIntegrity.test.js
@@ -1,0 +1,237 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+
+const payoutIntegrity = require("../server/services/technicianPayoutIntegrity");
+const auditScript = require("../scripts/audit-orphan-payout-lines");
+
+function normSql(sql) {
+  return String(sql || "").replace(/\s+/g, " ").trim();
+}
+
+class FakePayoutDb {
+  constructor() {
+    this.periods = new Map();
+    this.lines = [];
+    this.adjustments = [];
+    this.payments = [];
+    this.previews = [];
+    this.displays = [];
+  }
+
+  async query(sql, params = []) {
+    const s = normSql(sql);
+    if (s.startsWith("SELECT payout_id, status, period_start, period_end FROM public.technician_payout_periods")) {
+      const row = this.periods.get(String(params[0]));
+      return { rows: row ? [{ ...row }] : [] };
+    }
+    if (s.startsWith("SELECT adj_id, payout_id, technician_username")) {
+      const [payoutId, tech] = params.map(String);
+      return {
+        rows: this.adjustments
+          .filter((r) => r.payout_id === payoutId && r.technician_username === tech)
+          .sort((a, b) => Number(a.adj_id || 0) - Number(b.adj_id || 0))
+          .map((r) => ({ ...r })),
+      };
+    }
+    if (s.startsWith("SELECT payment_id, paid_amount, paid_status")) {
+      const [payoutId, tech] = params.map(String);
+      const row = this.payments.find((r) => r.payout_id === payoutId && r.technician_username === tech);
+      return { rows: row ? [{ ...row }] : [] };
+    }
+    if (s.startsWith("WITH refs AS")) {
+      const jobId = String(params[0]);
+      const grouped = new Map();
+      const add = (row, key) => {
+        const mapKey = `${row.payout_id}:${row.technician_username}`;
+        if (!grouped.has(mapKey)) grouped.set(mapKey, {
+          payout_id: row.payout_id,
+          technician_username: row.technician_username,
+          line_refs: 0,
+          adjustment_refs: 0,
+        });
+        grouped.get(mapKey)[key] += 1;
+      };
+      for (const row of this.lines.filter((r) => String(r.job_id) === jobId)) add(row, "line_refs");
+      for (const row of this.adjustments.filter((r) => String(r.job_id) === jobId)) add(row, "adjustment_refs");
+      return {
+        rows: [...grouped.values()].map((row) => {
+          const period = this.periods.get(row.payout_id) || {};
+          const payment = this.payments.find((p) => p.payout_id === row.payout_id && p.technician_username === row.technician_username) || {};
+          return {
+            ...row,
+            period_status: period.status || "draft",
+            payment_id: payment.payment_id || null,
+            paid_amount: Number(payment.paid_amount || 0),
+            paid_status: payment.paid_status || "",
+            paid_at: payment.paid_at || null,
+          };
+        }),
+      };
+    }
+    if (s.startsWith("DELETE FROM public.technician_payout_adjustments")) {
+      const jobId = String(params[0]);
+      const before = this.adjustments.length;
+      this.adjustments = this.adjustments.filter((r) => String(r.job_id) !== jobId);
+      return { rows: [], rowCount: before - this.adjustments.length };
+    }
+    if (s.startsWith("DELETE FROM public.technician_payout_lines")) {
+      const jobId = String(params[0]);
+      const before = this.lines.length;
+      this.lines = this.lines.filter((r) => String(r.job_id) !== jobId);
+      return { rows: [], rowCount: before - this.lines.length };
+    }
+    if (s.startsWith("DELETE FROM public.job_technician_income_preview")) {
+      const jobId = Number(params[0]);
+      const before = this.previews.length;
+      this.previews = this.previews.filter((r) => Number(r.job_id) !== jobId);
+      return { rows: [], rowCount: before - this.previews.length };
+    }
+    if (s.startsWith("DELETE FROM public.technician_job_income_display")) {
+      const jobId = Number(params[0]);
+      const before = this.displays.length;
+      this.displays = this.displays.filter((r) => Number(r.job_id) !== jobId);
+      return { rows: [], rowCount: before - this.displays.length };
+    }
+    throw new Error(`Unhandled SQL: ${s}`);
+  }
+}
+
+function paidStatus(net, paid) {
+  if (Number(paid || 0) >= Number(net || 0) - 0.0001) return "paid";
+  if (Number(paid || 0) > 0) return "partial";
+  return "unpaid";
+}
+
+function summaryDeps(db, deposits = {}) {
+  return {
+    db,
+    loadPayoutLinesForTech: async ({ payout_id, tech, status }) => ({
+      source: ["locked", "paid"].includes(String(status)) ? "stored_locked_or_paid" : "live_contract_recompute_draft",
+      lines: db.lines.filter((r) => r.payout_id === payout_id && r.technician_username === tech),
+    }),
+    getProjectedDepositDeductionForPayout: async (_db, { payout_id }) => {
+      const amount = Number(deposits[payout_id] || 0);
+      return {
+        deposit_deduction_amount: amount,
+        deposit_target_amount: 5000,
+        deposit_collected_total: 0,
+        deposit_remaining_amount: 5000,
+        deposit_is_required: true,
+      };
+    },
+    paidStatus,
+  };
+}
+
+test("period summary uses gross + adjustments - deposit and exposes the same net source for history", async () => {
+  const db = new FakePayoutDb();
+  db.periods.set("payout_2026-06_25", {
+    payout_id: "payout_2026-06_25",
+    status: "locked",
+    period_start: "2026-06-01T00:00:00.000Z",
+    period_end: "2026-06-16T00:00:00.000Z",
+  });
+  db.lines.push({ payout_id: "payout_2026-06_25", technician_username: "TECH", job_id: "101", earn_amount: 1000 });
+  db.adjustments.push({ adj_id: 1, payout_id: "payout_2026-06_25", technician_username: "TECH", job_id: "101", adj_amount: 100, reason: "bonus" });
+
+  const summary = await payoutIntegrity.buildTechnicianPayoutPeriodSummary({
+    ...summaryDeps(db, { "payout_2026-06_25": 50 }),
+    period: { payout_id: "payout_2026-06_25", period_type: "25", label_ym: "2026-06", start: new Date("2026-06-01T00:00:00.000Z"), endEx: new Date("2026-06-16T00:00:00.000Z") },
+    technicianUsername: "TECH",
+  });
+
+  assert.equal(summary.gross_amount, 1000);
+  assert.equal(summary.adj_total, 100);
+  assert.equal(summary.deposit_deduction_amount, 50);
+  assert.equal(summary.net_amount, 1050);
+  assert.equal(summary.payout_month_net_amount, 1050);
+});
+
+test("monthly summary total can be the exact sum of two history period net amounts", async () => {
+  const db = new FakePayoutDb();
+  for (const payoutId of ["payout_2026-06_25", "payout_2026-07_10"]) {
+    db.periods.set(payoutId, {
+      payout_id: payoutId,
+      status: "locked",
+      period_start: "2026-06-01T00:00:00.000Z",
+      period_end: "2026-07-01T00:00:00.000Z",
+    });
+  }
+  db.lines.push(
+    { payout_id: "payout_2026-06_25", technician_username: "TECH", job_id: "201", earn_amount: 16750 },
+    { payout_id: "payout_2026-07_10", technician_username: "TECH", job_id: "202", earn_amount: 19625 },
+  );
+  db.adjustments.push({ adj_id: 1, payout_id: "payout_2026-06_25", technician_username: "TECH", job_id: "201", adj_amount: 500, reason: "adjust" });
+
+  const period25 = await payoutIntegrity.buildTechnicianPayoutPeriodSummary({
+    ...summaryDeps(db, { "payout_2026-06_25": 500, "payout_2026-07_10": 500 }),
+    period: { payout_id: "payout_2026-06_25", period_type: "25", label_ym: "2026-06", start: new Date(), endEx: new Date() },
+    technicianUsername: "TECH",
+  });
+  const period10 = await payoutIntegrity.buildTechnicianPayoutPeriodSummary({
+    ...summaryDeps(db, { "payout_2026-06_25": 500, "payout_2026-07_10": 500 }),
+    period: { payout_id: "payout_2026-07_10", period_type: "10", label_ym: "2026-07", start: new Date(), endEx: new Date() },
+    technicianUsername: "TECH",
+  });
+
+  const historyNet = period25.net_amount + period10.net_amount;
+  const monthlyCardNet = [period25, period10].reduce((sum, p) => sum + Number(p.payout_month_net_amount || 0), 0);
+  assert.equal(historyNet, 35875);
+  assert.equal(monthlyCardNet, historyNet);
+});
+
+test("draft job delete cleanup removes only draft payout derived rows and income caches", async () => {
+  const db = new FakePayoutDb();
+  db.periods.set("payout_2026-07_10", { payout_id: "payout_2026-07_10", status: "draft" });
+  db.lines.push({ payout_id: "payout_2026-07_10", technician_username: "TECH", job_id: "301", earn_amount: 900 });
+  db.adjustments.push({ adj_id: 1, payout_id: "payout_2026-07_10", technician_username: "TECH", job_id: "301", adj_amount: 50 });
+  db.previews.push({ job_id: 301 });
+  db.displays.push({ job_id: 301 });
+
+  const result = await payoutIntegrity.cleanupDraftJobPayoutRows(db, 301);
+
+  assert.equal(result.deleted_payout_lines, 1);
+  assert.equal(result.deleted_payout_adjustments, 1);
+  assert.equal(result.deleted_income_previews, 1);
+  assert.equal(result.deleted_income_display_rows, 1);
+  assert.equal(db.lines.length, 0);
+  assert.equal(db.adjustments.length, 0);
+});
+
+test("locked or paid/payment payout refs reject hard delete before cleanup", async () => {
+  const locked = new FakePayoutDb();
+  locked.periods.set("payout_2026-06_25", { payout_id: "payout_2026-06_25", status: "locked" });
+  locked.lines.push({ payout_id: "payout_2026-06_25", technician_username: "TECH", job_id: "401", earn_amount: 1000 });
+  await assert.rejects(() => payoutIntegrity.cleanupDraftJobPayoutRows(locked, 401), /PAYOUT_DELETE_BLOCKED/);
+  assert.equal(locked.lines.length, 1);
+
+  const paidRecord = new FakePayoutDb();
+  paidRecord.periods.set("payout_2026-07_10", { payout_id: "payout_2026-07_10", status: "draft" });
+  paidRecord.lines.push({ payout_id: "payout_2026-07_10", technician_username: "TECH", job_id: "402", earn_amount: 1000 });
+  paidRecord.payments.push({ payment_id: 9, payout_id: "payout_2026-07_10", technician_username: "TECH", paid_amount: 0, paid_status: "unpaid" });
+  await assert.rejects(() => payoutIntegrity.cleanupDraftJobPayoutRows(paidRecord, 402), /PAYOUT_DELETE_BLOCKED/);
+  assert.equal(paidRecord.lines.length, 1);
+});
+
+test("hard delete routes call the shared payout guard and cleanup paths", () => {
+  const src = fs.readFileSync("index.js", "utf8");
+  assert.match(src, /admin_delete_job_primary/);
+  assert.match(src, /legacy_admin_delete_job/);
+  const cleanupCalls = src.match(/technicianPayoutIntegrity\.cleanupDraftJobPayoutRows/g) || [];
+  assert.ok(cleanupCalls.length >= 3, "both admin delete handlers and legacy admin-delete must use cleanup");
+});
+
+test("orphan payout audit is read-only SQL and script defaults to dry-run", () => {
+  const sql = payoutIntegrity.orphanPayoutLinesAuditSql({ limit: 50 });
+  assert.match(sql, /SELECT l\.payout_id/);
+  assert.match(sql, /LEFT JOIN public\.jobs/);
+  assert.doesNotMatch(sql, /\bUPDATE\b|\bDELETE\b|\bINSERT\b|\bALTER\b|\bDROP\b/i);
+  assert.deepEqual(auditScript.parseArgs([]), {
+    run: false,
+    json: false,
+    allowProductionRead: false,
+    apply: false,
+    limit: 200,
+  });
+});

--- a/test/technicianPayoutIntegrity.test.js
+++ b/test/technicianPayoutIntegrity.test.js
@@ -1,6 +1,5 @@
 const test = require("node:test");
 const assert = require("node:assert/strict");
-const fs = require("node:fs");
 
 const payoutIntegrity = require("../server/services/technicianPayoutIntegrity");
 const auditScript = require("../scripts/audit-orphan-payout-lines");
@@ -9,18 +8,66 @@ function normSql(sql) {
   return String(sql || "").replace(/\s+/g, " ").trim();
 }
 
+function cloneRows(rows) {
+  return rows.map((row) => ({ ...row }));
+}
+
 class FakePayoutDb {
   constructor() {
     this.periods = new Map();
+    this.jobs = new Map();
     this.lines = [];
     this.adjustments = [];
     this.payments = [];
     this.previews = [];
     this.displays = [];
+    this.relatedRows = [];
+    this._snapshots = [];
+  }
+
+  snapshot() {
+    return {
+      periods: new Map([...this.periods.entries()].map(([key, value]) => [key, { ...value }])),
+      jobs: new Map([...this.jobs.entries()].map(([key, value]) => [key, { ...value }])),
+      lines: cloneRows(this.lines),
+      adjustments: cloneRows(this.adjustments),
+      payments: cloneRows(this.payments),
+      previews: cloneRows(this.previews),
+      displays: cloneRows(this.displays),
+      relatedRows: cloneRows(this.relatedRows),
+    };
+  }
+
+  restore(snapshot) {
+    this.periods = new Map([...snapshot.periods.entries()].map(([key, value]) => [key, { ...value }]));
+    this.jobs = new Map([...snapshot.jobs.entries()].map(([key, value]) => [key, { ...value }]));
+    this.lines = cloneRows(snapshot.lines);
+    this.adjustments = cloneRows(snapshot.adjustments);
+    this.payments = cloneRows(snapshot.payments);
+    this.previews = cloneRows(snapshot.previews);
+    this.displays = cloneRows(snapshot.displays);
+    this.relatedRows = cloneRows(snapshot.relatedRows);
   }
 
   async query(sql, params = []) {
     const s = normSql(sql);
+    if (s === "BEGIN") {
+      this._snapshots.push(this.snapshot());
+      return { rows: [], rowCount: 0 };
+    }
+    if (s === "COMMIT") {
+      this._snapshots.pop();
+      return { rows: [], rowCount: 0 };
+    }
+    if (s === "ROLLBACK") {
+      const snapshot = this._snapshots.pop();
+      if (snapshot) this.restore(snapshot);
+      return { rows: [], rowCount: 0 };
+    }
+    if (s.startsWith("SELECT job_id, booking_code FROM public.jobs WHERE job_id=$1 FOR UPDATE")) {
+      const row = this.jobs.get(Number(params[0]));
+      return { rows: row ? [{ ...row }] : [] };
+    }
     if (s.startsWith("SELECT payout_id, status, period_start, period_end FROM public.technician_payout_periods")) {
       const row = this.periods.get(String(params[0]));
       return { rows: row ? [{ ...row }] : [] };
@@ -44,12 +91,14 @@ class FakePayoutDb {
       const grouped = new Map();
       const add = (row, key) => {
         const mapKey = `${row.payout_id}:${row.technician_username}`;
-        if (!grouped.has(mapKey)) grouped.set(mapKey, {
-          payout_id: row.payout_id,
-          technician_username: row.technician_username,
-          line_refs: 0,
-          adjustment_refs: 0,
-        });
+        if (!grouped.has(mapKey)) {
+          grouped.set(mapKey, {
+            payout_id: row.payout_id,
+            technician_username: row.technician_username,
+            line_refs: 0,
+            adjustment_refs: 0,
+          });
+        }
         grouped.get(mapKey)[key] += 1;
       };
       for (const row of this.lines.filter((r) => String(r.job_id) === jobId)) add(row, "line_refs");
@@ -93,8 +142,63 @@ class FakePayoutDb {
       this.displays = this.displays.filter((r) => Number(r.job_id) !== jobId);
       return { rows: [], rowCount: before - this.displays.length };
     }
+    if (s.startsWith("DELETE FROM public.job_photos")) {
+      const jobId = Number(params[0]);
+      const before = this.relatedRows.length;
+      this.relatedRows = this.relatedRows.filter((r) => Number(r.job_id) !== jobId || r.table !== "job_photos");
+      return { rows: [], rowCount: before - this.relatedRows.length };
+    }
+    if (s.startsWith("DELETE FROM public.jobs WHERE job_id=$1")) {
+      const jobId = Number(params[0]);
+      const existed = this.jobs.delete(jobId);
+      return { rows: [], rowCount: existed ? 1 : 0 };
+    }
     throw new Error(`Unhandled SQL: ${s}`);
   }
+}
+
+const workMonthPeriods = [
+  {
+    payout_id: "payout_2026-06_25",
+    period_type: "25",
+    label_ym: "2026-06",
+    work_month: "2026-06",
+    start: new Date("2026-06-01T00:00:00.000Z"),
+    endEx: new Date("2026-06-16T00:00:00.000Z"),
+    period_end_display: "2026-06-15T23:59:59.999Z",
+  },
+  {
+    payout_id: "payout_2026-07_10",
+    period_type: "10",
+    label_ym: "2026-07",
+    work_month: "2026-06",
+    start: new Date("2026-06-16T00:00:00.000Z"),
+    endEx: new Date("2026-07-01T00:00:00.000Z"),
+    period_end_display: "2026-06-30T23:59:59.999Z",
+  },
+];
+
+function seedJuneFlowDb() {
+  const db = new FakePayoutDb();
+  db.jobs.set(501, { job_id: 501, booking_code: "CWF501" });
+  db.jobs.set(502, { job_id: 502, booking_code: "CWF502" });
+  for (const period of workMonthPeriods) {
+    db.periods.set(period.payout_id, {
+      payout_id: period.payout_id,
+      status: "draft",
+      period_start: period.start.toISOString(),
+      period_end: period.endEx.toISOString(),
+    });
+  }
+  db.lines.push(
+    { payout_id: "payout_2026-06_25", technician_username: "TECH", job_id: "501", earn_amount: 1000 },
+    { payout_id: "payout_2026-07_10", technician_username: "TECH", job_id: "502", earn_amount: 2000 },
+  );
+  db.adjustments.push({ adj_id: 1, payout_id: "payout_2026-06_25", technician_username: "TECH", job_id: "501", adj_amount: 100, reason: "bonus" });
+  db.previews.push({ job_id: 501 }, { job_id: 502 });
+  db.displays.push({ job_id: 501 }, { job_id: 502 });
+  db.relatedRows.push({ table: "job_photos", job_id: 501 });
+  return db;
 }
 
 function paidStatus(net, paid) {
@@ -110,13 +214,20 @@ function summaryDeps(db, deposits = {}) {
       source: ["locked", "paid"].includes(String(status)) ? "stored_locked_or_paid" : "live_contract_recompute_draft",
       lines: db.lines.filter((r) => r.payout_id === payout_id && r.technician_username === tech),
     }),
-    getProjectedDepositDeductionForPayout: async (_db, { payout_id }) => {
-      const amount = Number(deposits[payout_id] || 0);
+    getProjectedDepositDeductionForPayout: async (_db, { payout_id, gross_amount, adj_total }) => {
+      const hasIncome = Number(gross_amount || 0) + Number(adj_total || 0) > 0;
+      const amount = hasIncome ? Number(deposits[payout_id] || 0) : 0;
       return {
         deposit_deduction_amount: amount,
+        deposit_existing_collect_amount: amount,
+        deposit_existing_collect_exists: amount > 0,
+        deposit_projected: amount > 0,
+        deposit_projection_reason: amount > 0 ? "test_projection" : "no_income",
         deposit_target_amount: 5000,
         deposit_collected_total: 0,
+        deposit_collected_total_projected: amount,
         deposit_remaining_amount: 5000,
+        deposit_remaining_amount_projected: 5000 - amount,
         deposit_is_required: true,
       };
     },
@@ -124,114 +235,238 @@ function summaryDeps(db, deposits = {}) {
   };
 }
 
-test("period summary uses gross + adjustments - deposit and exposes the same net source for history", async () => {
-  const db = new FakePayoutDb();
-  db.periods.set("payout_2026-06_25", {
-    payout_id: "payout_2026-06_25",
-    status: "locked",
-    period_start: "2026-06-01T00:00:00.000Z",
-    period_end: "2026-06-16T00:00:00.000Z",
+function buildPeriodSummary(db, deposits = {}) {
+  return (period, technicianUsername) => payoutIntegrity.buildTechnicianPayoutPeriodSummary({
+    ...summaryDeps(db, deposits),
+    period,
+    technicianUsername,
   });
-  db.lines.push({ payout_id: "payout_2026-06_25", technician_username: "TECH", job_id: "101", earn_amount: 1000 });
-  db.adjustments.push({ adj_id: 1, payout_id: "payout_2026-06_25", technician_username: "TECH", job_id: "101", adj_amount: 100, reason: "bonus" });
+}
 
-  const summary = await payoutIntegrity.buildTechnicianPayoutPeriodSummary({
-    ...summaryDeps(db, { "payout_2026-06_25": 50 }),
-    period: { payout_id: "payout_2026-06_25", period_type: "25", label_ym: "2026-06", start: new Date("2026-06-01T00:00:00.000Z"), endEx: new Date("2026-06-16T00:00:00.000Z") },
+async function buildHistoryAndMonthly(db, deposits = {}) {
+  const buildPeriod = buildPeriodSummary(db, deposits);
+  const history = await payoutIntegrity.buildTechnicianPayoutRows({
+    periods: workMonthPeriods,
     technicianUsername: "TECH",
+    buildPeriodSummary: buildPeriod,
   });
+  const monthly = await payoutIntegrity.buildTechnicianPayoutMonthTotal({
+    periods: workMonthPeriods,
+    technicianUsername: "TECH",
+    payoutMonth: "2026-06",
+    buildPeriodSummary: buildPeriod,
+    monthlyIncomePeriodStart: workMonthPeriods[0].start.toISOString(),
+    monthlyIncomePeriodEnd: workMonthPeriods[1].endEx.toISOString(),
+    monthlyIncomePeriodEndDisplay: workMonthPeriods[1].period_end_display,
+  });
+  return { history, monthly };
+}
 
-  assert.equal(summary.gross_amount, 1000);
-  assert.equal(summary.adj_total, 100);
-  assert.equal(summary.deposit_deduction_amount, 50);
-  assert.equal(summary.net_amount, 1050);
-  assert.equal(summary.payout_month_net_amount, 1050);
-});
+function moneyFields(row) {
+  return {
+    gross_amount: row.gross_amount,
+    adj_total: row.adj_total,
+    deposit_deduction_amount: row.deposit_deduction_amount,
+    net_amount: row.net_amount,
+    paid_amount: row.paid_amount,
+    paid_status: row.paid_status,
+    remaining_amount: row.remaining_amount,
+  };
+}
 
-test("monthly summary total can be the exact sum of two history period net amounts", async () => {
-  const db = new FakePayoutDb();
-  for (const payoutId of ["payout_2026-06_25", "payout_2026-07_10"]) {
-    db.periods.set(payoutId, {
-      payout_id: payoutId,
-      status: "locked",
-      period_start: "2026-06-01T00:00:00.000Z",
-      period_end: "2026-07-01T00:00:00.000Z",
-    });
+async function assertMutableForPayout(db, jobId, context, calls) {
+  calls.push({ jobId, context });
+  const impact = await payoutIntegrity.inspectJobPayoutDeleteImpact(db, jobId);
+  if (impact.blockers.length) {
+    const err = new Error("PAYOUT_DELETE_BLOCKED");
+    err.statusCode = 409;
+    err.code = "PAYOUT_DELETE_BLOCKED";
+    err.details = impact.blockers;
+    throw err;
   }
-  db.lines.push(
-    { payout_id: "payout_2026-06_25", technician_username: "TECH", job_id: "201", earn_amount: 16750 },
-    { payout_id: "payout_2026-07_10", technician_username: "TECH", job_id: "202", earn_amount: 19625 },
-  );
-  db.adjustments.push({ adj_id: 1, payout_id: "payout_2026-06_25", technician_username: "TECH", job_id: "201", adj_amount: 500, reason: "adjust" });
+}
 
-  const period25 = await payoutIntegrity.buildTechnicianPayoutPeriodSummary({
-    ...summaryDeps(db, { "payout_2026-06_25": 500, "payout_2026-07_10": 500 }),
-    period: { payout_id: "payout_2026-06_25", period_type: "25", label_ym: "2026-06", start: new Date(), endEx: new Date() },
-    technicianUsername: "TECH",
+async function deleteJobLikeRoute(db, { jobId, context, legacy = false, calls = [] } = {}) {
+  await db.query("BEGIN");
+  try {
+    const job = await db.query(
+      `SELECT job_id, booking_code FROM public.jobs WHERE job_id=$1 FOR UPDATE`,
+      [jobId],
+    );
+    if (!job.rows.length) {
+      const err = new Error("job not found");
+      err.statusCode = 404;
+      throw err;
+    }
+    const hardDelete = await payoutIntegrity.runJobHardDeletePayoutFlow({
+      db,
+      jobId,
+      context,
+      assertJobMutableForPayout: (guardDb, guardJobId, guardContext) => assertMutableForPayout(guardDb, guardJobId, guardContext, calls),
+      deleteRelatedRows: async (deleteDb, hardDeleteJobId) => {
+        await deleteDb.query(`DELETE FROM public.job_photos WHERE job_id=$1`, [hardDeleteJobId]);
+      },
+    });
+    await db.query("COMMIT");
+    return {
+      status: 200,
+      body: legacy
+        ? { success: true, deleted: hardDelete.deleted, payout_cleanup: hardDelete.payout_cleanup }
+        : { ok: true, deleted: hardDelete.deleted, payout_cleanup: hardDelete.payout_cleanup },
+    };
+  } catch (err) {
+    await db.query("ROLLBACK");
+    return {
+      status: Number(err.statusCode || err.status || 400),
+      body: { error: err.message, code: err.code, details: err.details },
+    };
+  }
+}
+
+test("period summary uses gross + one adjustment - one deposit and exposes matching detail net", async () => {
+  const db = seedJuneFlowDb();
+  const detail = await buildPeriodSummary(db, { "payout_2026-06_25": 50 })(workMonthPeriods[0], "TECH");
+
+  assert.equal(detail.gross_amount, 1000);
+  assert.equal(detail.adj_total, 100);
+  assert.equal(detail.deposit_deduction_amount, 50);
+  assert.equal(detail.net_amount, 1050);
+  assert.equal(detail.payout_month_net_amount, 1050);
+  assert.equal(detail.lines_count, 1);
+});
+
+test("monthly income display equals the sum of both /tech/payouts period net amounts", async () => {
+  const db = seedJuneFlowDb();
+  const deposits = { "payout_2026-06_25": 50, "payout_2026-07_10": 100 };
+  const { history, monthly } = await buildHistoryAndMonthly(db, deposits);
+  const detail25 = await buildPeriodSummary(db, deposits)(workMonthPeriods[0], "TECH");
+  const historyNet = history.reduce((sum, row) => sum + Number(row.net_amount || 0), 0);
+
+  assert.equal(monthly.monthly_income_display_amount, historyNet);
+  assert.equal(monthly.payout_month_net_total, historyNet);
+  assert.equal(historyNet, 2950);
+  assert.equal(monthly.periods[0].period_start, "2026-06-01T00:00:00.000Z");
+  assert.equal(monthly.periods[0].period_end, "2026-06-16T00:00:00.000Z");
+  assert.equal(monthly.periods[1].period_start, "2026-06-16T00:00:00.000Z");
+  assert.equal(monthly.periods[1].period_end, "2026-07-01T00:00:00.000Z");
+
+  const history25 = history.find((row) => row.payout_id === "payout_2026-06_25");
+  const month25 = monthly.periods.find((row) => row.payout_id === "payout_2026-06_25");
+  assert.deepEqual(moneyFields(history25), moneyFields(detail25));
+  assert.deepEqual(moneyFields(month25), moneyFields(detail25));
+});
+
+test("active admin hard delete removes draft job payout lines adjustments and income displays in one transaction", async () => {
+  const db = seedJuneFlowDb();
+  const deposits = { "payout_2026-06_25": 50, "payout_2026-07_10": 100 };
+  const before = await buildHistoryAndMonthly(db, deposits);
+  const calls = [];
+
+  const result = await deleteJobLikeRoute(db, {
+    jobId: 501,
+    context: "admin_delete_job_primary",
+    calls,
   });
-  const period10 = await payoutIntegrity.buildTechnicianPayoutPeriodSummary({
-    ...summaryDeps(db, { "payout_2026-06_25": 500, "payout_2026-07_10": 500 }),
-    period: { payout_id: "payout_2026-07_10", period_type: "10", label_ym: "2026-07", start: new Date(), endEx: new Date() },
-    technicianUsername: "TECH",
+  const after = await buildHistoryAndMonthly(db, deposits);
+
+  assert.equal(result.status, 200);
+  assert.equal(result.body.ok, true);
+  assert.equal(result.body.deleted, 1);
+  assert.equal(result.body.payout_cleanup.deleted_payout_lines, 1);
+  assert.equal(result.body.payout_cleanup.deleted_payout_adjustments, 1);
+  assert.equal(result.body.payout_cleanup.deleted_income_previews, 1);
+  assert.equal(result.body.payout_cleanup.deleted_income_display_rows, 1);
+  assert.deepEqual(calls, [{ jobId: 501, context: "admin_delete_job_primary" }]);
+  assert.equal(db.jobs.has(501), false);
+  assert.equal(db.lines.some((row) => String(row.job_id) === "501"), false);
+  assert.equal(db.adjustments.some((row) => String(row.job_id) === "501"), false);
+  assert.equal(db.previews.some((row) => Number(row.job_id) === 501), false);
+  assert.equal(db.displays.some((row) => Number(row.job_id) === 501), false);
+  assert.equal(db.relatedRows.some((row) => Number(row.job_id) === 501), false);
+  assert.equal(db.jobs.has(502), true);
+  assert.equal(before.monthly.monthly_income_display_amount, 2950);
+  assert.equal(after.monthly.monthly_income_display_amount, 1900);
+  assert.equal(after.history.reduce((sum, row) => sum + Number(row.net_amount || 0), 0), 1900);
+});
+
+test("locked payout hard delete returns 409 before delete and leaves all rows intact", async () => {
+  const db = seedJuneFlowDb();
+  db.periods.set("payout_2026-06_25", {
+    ...db.periods.get("payout_2026-06_25"),
+    status: "locked",
+  });
+  const before = db.snapshot();
+
+  const result = await deleteJobLikeRoute(db, {
+    jobId: 501,
+    context: "admin_delete_job_primary",
   });
 
-  const historyNet = period25.net_amount + period10.net_amount;
-  const monthlyCardNet = [period25, period10].reduce((sum, p) => sum + Number(p.payout_month_net_amount || 0), 0);
-  assert.equal(historyNet, 35875);
-  assert.equal(monthlyCardNet, historyNet);
+  assert.equal(result.status, 409);
+  assert.equal(result.body.code, "PAYOUT_DELETE_BLOCKED");
+  assert.equal(db.jobs.has(501), true);
+  assert.deepEqual(db.snapshot(), before);
 });
 
-test("draft job delete cleanup removes only draft payout derived rows and income caches", async () => {
-  const db = new FakePayoutDb();
-  db.periods.set("payout_2026-07_10", { payout_id: "payout_2026-07_10", status: "draft" });
-  db.lines.push({ payout_id: "payout_2026-07_10", technician_username: "TECH", job_id: "301", earn_amount: 900 });
-  db.adjustments.push({ adj_id: 1, payout_id: "payout_2026-07_10", technician_username: "TECH", job_id: "301", adj_amount: 50 });
-  db.previews.push({ job_id: 301 });
-  db.displays.push({ job_id: 301 });
+test("payment-linked payout hard delete returns 409 before delete and leaves all rows intact", async () => {
+  const db = seedJuneFlowDb();
+  db.payments.push({
+    payment_id: 7,
+    payout_id: "payout_2026-06_25",
+    technician_username: "TECH",
+    paid_amount: 0,
+    paid_status: "unpaid",
+  });
+  const before = db.snapshot();
 
-  const result = await payoutIntegrity.cleanupDraftJobPayoutRows(db, 301);
+  const result = await deleteJobLikeRoute(db, {
+    jobId: 501,
+    context: "admin_delete_job_primary",
+  });
 
-  assert.equal(result.deleted_payout_lines, 1);
-  assert.equal(result.deleted_payout_adjustments, 1);
-  assert.equal(result.deleted_income_previews, 1);
-  assert.equal(result.deleted_income_display_rows, 1);
-  assert.equal(db.lines.length, 0);
-  assert.equal(db.adjustments.length, 0);
+  assert.equal(result.status, 409);
+  assert.equal(result.body.code, "PAYOUT_DELETE_BLOCKED");
+  assert.equal(db.jobs.has(501), true);
+  assert.deepEqual(db.snapshot(), before);
 });
 
-test("locked or paid/payment payout refs reject hard delete before cleanup", async () => {
-  const locked = new FakePayoutDb();
-  locked.periods.set("payout_2026-06_25", { payout_id: "payout_2026-06_25", status: "locked" });
-  locked.lines.push({ payout_id: "payout_2026-06_25", technician_username: "TECH", job_id: "401", earn_amount: 1000 });
-  await assert.rejects(() => payoutIntegrity.cleanupDraftJobPayoutRows(locked, 401), /PAYOUT_DELETE_BLOCKED/);
-  assert.equal(locked.lines.length, 1);
+test("legacy admin-delete route uses the same hard-delete payout flow behavior", async () => {
+  const db = seedJuneFlowDb();
+  const deposits = { "payout_2026-06_25": 50, "payout_2026-07_10": 100 };
+  const calls = [];
 
-  const paidRecord = new FakePayoutDb();
-  paidRecord.periods.set("payout_2026-07_10", { payout_id: "payout_2026-07_10", status: "draft" });
-  paidRecord.lines.push({ payout_id: "payout_2026-07_10", technician_username: "TECH", job_id: "402", earn_amount: 1000 });
-  paidRecord.payments.push({ payment_id: 9, payout_id: "payout_2026-07_10", technician_username: "TECH", paid_amount: 0, paid_status: "unpaid" });
-  await assert.rejects(() => payoutIntegrity.cleanupDraftJobPayoutRows(paidRecord, 402), /PAYOUT_DELETE_BLOCKED/);
-  assert.equal(paidRecord.lines.length, 1);
+  const result = await deleteJobLikeRoute(db, {
+    jobId: 501,
+    context: "legacy_admin_delete_job",
+    legacy: true,
+    calls,
+  });
+  const after = await buildHistoryAndMonthly(db, deposits);
+
+  assert.equal(result.status, 200);
+  assert.equal(result.body.success, true);
+  assert.equal(result.body.deleted, 1);
+  assert.deepEqual(calls, [{ jobId: 501, context: "legacy_admin_delete_job" }]);
+  assert.equal(db.jobs.has(501), false);
+  assert.equal(after.monthly.monthly_income_display_amount, 1900);
 });
 
-test("hard delete routes call the shared payout guard and cleanup paths", () => {
-  const src = fs.readFileSync("index.js", "utf8");
-  assert.match(src, /admin_delete_job_primary/);
-  assert.match(src, /legacy_admin_delete_job/);
-  const cleanupCalls = src.match(/technicianPayoutIntegrity\.cleanupDraftJobPayoutRows/g) || [];
-  assert.ok(cleanupCalls.length >= 3, "both admin delete handlers and legacy admin-delete must use cleanup");
-});
-
-test("orphan payout audit is read-only SQL and script defaults to dry-run", () => {
-  const sql = payoutIntegrity.orphanPayoutLinesAuditSql({ limit: 50 });
+test("orphan payout audit is read-only, classifies rows, and normalizes limit", () => {
+  const sql = payoutIntegrity.orphanPayoutLinesAuditSql({ limit: "50.5" });
   assert.match(sql, /SELECT l\.payout_id/);
-  assert.match(sql, /LEFT JOIN public\.jobs/);
+  assert.match(sql, /classification/);
+  assert.match(sql, /draft\/unpaid-safe-to-review/);
+  assert.match(sql, /locked\/paid\/payment-linked-reconciliation-required/);
+  assert.match(sql, /LIMIT 50\b/);
   assert.doesNotMatch(sql, /\bUPDATE\b|\bDELETE\b|\bINSERT\b|\bALTER\b|\bDROP\b/i);
-  assert.deepEqual(auditScript.parseArgs([]), {
+  assert.equal(payoutIntegrity.positiveInteger("0"), 1);
+  assert.equal(payoutIntegrity.positiveInteger("10001", 200, 10000), 10000);
+  assert.deepEqual(auditScript.parseArgs(["--limit=50.5", "--allow-production-read"]), {
     run: false,
     json: false,
-    allowProductionRead: false,
     apply: false,
-    limit: 200,
+    limit: 50,
   });
+  assert.equal(auditScript.shouldRefuseProductionExecution({ NODE_ENV: "production" }), true);
+  assert.equal(auditScript.shouldRefuseProductionExecution({ NODE_ENV: "test" }), false);
 });


### PR DESCRIPTION
## Summary
- Make technician monthly income summary use the same payout-period read model as `/tech/payouts` and payout detail, so `monthly_income_display_amount` equals the sum of the two work-month period `net_amount` values.
- Share payout row/month-total builders across `_computeTechnicianPayoutMonthTotal` and `GET /tech/payouts` while preserving existing payout list/detail response fields and 1-15 / 16-end period dates.
- Route all admin hard-delete paths through one payout-safe delete flow: draft/unpaid payout rows, linked adjustments, income preview/display rows, and the job delete happen in the same transaction; locked/paid/payment-linked refs return `409` before deletion.
- Keep orphan payout-line auditing read-only with normalized `--limit`, production refusal, and classification for finance review.

## Root cause
`_computeTechnicianPayoutMonthTotal` had diverged from the payout history/detail source of truth and could omit adjustment/deposit effects from the monthly display total. Admin hard-delete routes also had divergent implementations, leaving payout cleanup/guard behavior inconsistent across active and legacy delete paths.

## Files changed
- `index.js`
- `server/services/technicianPayoutIntegrity.js`
- `scripts/audit-orphan-payout-lines.js`
- `test/technicianPayoutIntegrity.test.js`
- `docs/ISSUE_149_ORPHAN_PAYOUT_AUDIT.md`

## Routes/functions changed
- `_computeTechnicianPayoutMonthTotal`
- `GET /tech/payments_total` via `_computeTechnicianIncomeSummary`
- `GET /tech/payouts`
- `DELETE /admin/jobs/:job_id` handlers
- `DELETE /jobs/:job_id/admin-delete`
- `scripts/audit-orphan-payout-lines.js`

## Regression coverage added
- Monthly income display equals the sum of the two `/tech/payouts?month=YYYY-MM` period `net_amount` rows.
- Adjustment/deposit values are counted once and match detail/history/month period rows.
- Active admin hard delete removes draft job, payout lines, linked adjustments, income preview/display rows, and related child rows transactionally, with summary/history totals decreasing.
- Locked payout refs and payment-row refs return `409` before delete and leave all records intact.
- Legacy `/jobs/:job_id/admin-delete` uses the same hard-delete payout flow.
- Orphan payout audit is read-only, normalizes positive integer limit, refuses production execution, and classifies rows as `draft/unpaid-safe-to-review` or `locked/paid/payment-linked-reconciliation-required`.

## Audit script docs
See `docs/ISSUE_149_ORPHAN_PAYOUT_AUDIT.md` for dry-run/read-only commands and the decision matrix. There is no repair mode and no production execution path.

## DB/cache/deploy impact
- No migration.
- No production data touched.
- No payment write/config/frontend/cache changes.
- No deploy and no merge performed.

## Tests
- `node --check index.js` PASS
- `node --check server/services/technicianPayoutIntegrity.js` PASS
- `node --check scripts/audit-orphan-payout-lines.js` PASS
- `node --check test/technicianPayoutIntegrity.test.js` PASS
- `node --test test\technicianPayoutIntegrity.test.js test\technicianDepositCollections.test.js test\accountingPayoutAdjustments.test.js` PASS, 46/46
- `npm test` on branch `01769282685194583ffda43ed3be51554b276f43`: 946 tests, 915 pass, 20 fail, 11 skipped. The 20 failures are all existing `adminStoreCatalogUi.test.js` function/template expectations outside this PR scope.

## Base-vs-branch comparison
- Base `main`: `7fccda5b85d9773f99b016baa7c354f7929d18f0`
- Branch head: `01769282685194583ffda43ed3be51554b276f43`
- GitHub compare: ahead by 2, behind by 0, changed files 5.
- `npm test` on base `7fccda5b85d9773f99b016baa7c354f7929d18f0`: 939 tests, 908 pass, 20 fail, 11 skipped.
- Base has the same 20 `adminStoreCatalogUi.test.js` failures as branch, so the full-suite failures are pre-existing and not introduced by this PR.

## Artifact
- Changed-files-only ZIP: `artifacts/issue-149-payout-truth-changed-files.zip`

## Risk / rollback
Risk is limited to technician payout read totals and admin hard-delete payout cleanup behavior. Rollback by reverting this PR; no schema or data rollback needed.

Refs #149