### PR TITLE
Fix payout no-pay status display

### DIFF
--- a/app.js
+++ b/app.js
@@ -2426,18 +2426,20 @@ function _paidStatusTH(status){
 }
 function _payoutPaymentDisplayStatusTH(payout){
   const p = (payout && typeof payout === 'object') ? payout : { paid_status: payout };
+  const paidStatus = String(p.paid_status || '').trim().toLowerCase();
   const net = Number(p.net_amount ?? p.total_amount ?? p.payout_month_net_amount ?? p.payout_month_amount ?? 0);
   const paid = Number(p.paid_amount || 0);
   const remainingRaw = p.remaining_amount;
   const remaining = Number(remainingRaw == null ? Math.max(0, net - paid) : remainingRaw);
   const eps = 0.0001;
   if (Number.isFinite(net) && Number.isFinite(remaining) && net <= eps && remaining <= eps) return 'ไม่มียอดจ่าย';
+  if (['hold','disputed','cancelled'].includes(paidStatus)) return _paidStatusTH(paidStatus);
   if (Number.isFinite(net) && net > eps) {
     if (Number.isFinite(paid) && paid <= eps) return 'รอจ่าย';
     if (Number.isFinite(remaining) && remaining > eps) return 'จ่ายบางส่วน';
     return 'จ่ายแล้ว';
   }
-  return _paidStatusTH(p.paid_status || 'unpaid');
+  return _paidStatusTH(paidStatus || 'unpaid');
 }
 
 

--- a/app.js
+++ b/app.js
@@ -1,7 +1,7 @@
 
 
-// CWF Technician App Stable fix12: force real 20-row history page + cache-bust marker
-window.__CWF_TECH_APP_VERSION__ = "20260622_urgent_offer_session_v1";
+// CWF Technician App: payout no-pay status display fix
+window.__CWF_TECH_APP_VERSION__ = "20260710_payout_no_pay_status_v1";
 try { console.info('[CWF_TECH_APP_VERSION]', window.__CWF_TECH_APP_VERSION__); } catch (_) {}
 
 // ✅ งานปัจจุบัน: งานล่วงหน้า (sub-tab)
@@ -1235,7 +1235,7 @@ function setPushUi(state, text) {
 
 async function ensureServiceWorkerForPush() {
   if (!('serviceWorker' in navigator)) throw new Error('เครื่องนี้ไม่รองรับ Service Worker');
-  const reg = await navigator.serviceWorker.register('/sw.js?v=20260622_urgent_offer_session_v1', { updateViaCache: 'none' });
+  const reg = await navigator.serviceWorker.register('/sw.js?v=20260710_payout_no_pay_status_v1', { updateViaCache: 'none' });
   try { await navigator.serviceWorker.ready; } catch (_) {}
   return reg;
 }
@@ -1610,6 +1610,7 @@ function _incomeMonthRangeText(data){
 }
 
 function _incomePeriodStatusTH(p){
+  if (_payoutPaymentDisplayStatusTH(p) === 'ไม่มียอดจ่าย') return 'ไม่มียอดจ่าย';
   const paid = String(p?.paid_status || '').toLowerCase();
   const st = String(p?.status || '').toLowerCase();
   if (paid === 'paid' || st === 'paid') return 'จ่ายแล้ว';
@@ -2423,6 +2424,21 @@ function _paidStatusTH(status){
   const map = { unpaid:'รอจ่าย', partial:'จ่ายบางส่วน', paid:'จ่ายแล้ว', hold:'ระงับยอด', disputed:'มีปัญหา', cancelled:'ยกเลิก' };
   return map[s] || s || '-';
 }
+function _payoutPaymentDisplayStatusTH(payout){
+  const p = (payout && typeof payout === 'object') ? payout : { paid_status: payout };
+  const net = Number(p.net_amount ?? p.total_amount ?? p.payout_month_net_amount ?? p.payout_month_amount ?? 0);
+  const paid = Number(p.paid_amount || 0);
+  const remainingRaw = p.remaining_amount;
+  const remaining = Number(remainingRaw == null ? Math.max(0, net - paid) : remainingRaw);
+  const eps = 0.0001;
+  if (Number.isFinite(net) && Number.isFinite(remaining) && net <= eps && remaining <= eps) return 'ไม่มียอดจ่าย';
+  if (Number.isFinite(net) && net > eps) {
+    if (Number.isFinite(paid) && paid <= eps) return 'รอจ่าย';
+    if (Number.isFinite(remaining) && remaining > eps) return 'จ่ายบางส่วน';
+    return 'จ่ายแล้ว';
+  }
+  return _paidStatusTH(p.paid_status || 'unpaid');
+}
 
 
 function _thaiMonthOptionLabel(ym){
@@ -2501,7 +2517,7 @@ function renderTechPayoutPeriods(list){
     const dep = formatBaht(p.deposit_deduction_amount||0);
     const total = formatBaht(p.net_amount||p.total_amount||0);
     const rem = formatBaht(p.remaining_amount||0);
-    const paySt = _safeText(_paidStatusTH(p.paid_status||'unpaid'));
+    const paySt = _safeText(_payoutPaymentDisplayStatusTH(p));
     const status = _safeText(_payoutStatusTH(p.status||'draft'));
     const active = (__cwfPayoutActiveId===p.payout_id);
     return `<button type="button" class="tr" style="width:100%;text-align:left;padding:12px;border-radius:18px;border:1px solid rgba(15,23,42,0.10);margin-bottom:10px;cursor:pointer;background:#fff;${active?'outline:2px solid rgba(11,75,179,0.35)':''}" onclick="window.openTechPayoutDetail('${id}')"><div class="row" style="justify-content:space-between;gap:10px;align-items:flex-start"><div><b>${String(p.period_type)==='25'?'ช่วง 1–15':'ช่วง 16–สิ้นเดือน'}</b><div class="muted" style="margin-top:4px">งานปิด ${st} - ${en} • ${_payoutCycleLabel(p)}</div><div class="muted" style="margin-top:4px">สถานะงวด: ${status} • จ่าย: ${paySt}</div></div><div style="text-align:right"><b style="font-size:18px;color:#0B2E6D">${total}</b><div class="muted" style="margin-top:4px">ก่อนหัก ${gross}</div><div class="muted" style="margin-top:3px">หักประกัน ${dep} • คงเหลือ ${rem}</div></div></div></button>`;
@@ -2525,7 +2541,7 @@ async function openTechPayoutDetail(payout_id){
     const gross = formatBaht(data.gross_amount||0), dep = formatBaht(data.deposit_deduction_amount||0), total = formatBaht(data.net_amount||data.total_amount||0), paid = formatBaht(data.paid_amount||0), rem = formatBaht(data.remaining_amount||0);
     const depTarget = formatBaht(data.deposit_target_amount||0), depCollected = formatBaht(data.deposit_collected_total||0), depRemaining = formatBaht(data.deposit_remaining_amount||0);
     const period = (__cwfPayoutCache.payouts||[]).find(x=>String(x.payout_id)===id) || {};
-    const type = _safeText(data.period_type || period.period_type || ''), st = _fmtDateTH(data.period_start || period.period_start), en = _fmtDateTH(data.period_end || period.period_end), paySt = _safeText(_paidStatusTH(data.paid_status||'unpaid'));
+    const type = _safeText(data.period_type || period.period_type || ''), st = _fmtDateTH(data.period_start || period.period_start), en = _fmtDateTH(data.period_end || period.period_end), paySt = _safeText(_payoutPaymentDisplayStatusTH(data));
     if (techPayoutModalTitleEl) techPayoutModalTitleEl.textContent = _payoutCycleLabel({ period_type: type, payout_id: id });
     if (techPayoutModalSubEl) techPayoutModalSubEl.textContent = `${id} • ${st} - ${en} • ${paySt}`;
     if (techPayoutModalSummaryEl) techPayoutModalSummaryEl.innerHTML = `<div class="payout-kpi"><div class="k">รายได้ก่อนหัก</div><div class="v">${gross}</div></div><div class="payout-kpi"><div class="k">หักเงินประกัน</div><div class="v">${dep}</div></div><div class="payout-kpi net"><div class="k">ยอดสุทธิในงวด</div><div class="v">${total}</div></div><div class="payout-kpi"><div class="k">จ่ายแล้ว</div><div class="v">${paid}</div></div><div class="payout-kpi"><div class="k">คงเหลือ</div><div class="v">${rem}</div></div><div class="payout-kpi"><div class="k">เงินประกันสะสม</div><div class="v">${depCollected}</div></div><div class="payout-kpi"><div class="k">เงินประกันคงเหลือ</div><div class="v">${depRemaining}</div></div><div class="payout-kpi"><div class="k">เป้าหมายประกัน</div><div class="v">${depTarget}</div></div>`;

--- a/cwf-pwa.js
+++ b/cwf-pwa.js
@@ -1,6 +1,6 @@
 (function(){
   'use strict';
-  var VERSION = '20260622_urgent_offer_session_v1';
+  var VERSION = '20260710_payout_no_pay_status_v1';
   try { window.__CWF_PWA_BUILD__ = VERSION; } catch (_) {}
   function register(){
     if (!('serviceWorker' in navigator)) return;

--- a/docs/ISSUE_149_ORPHAN_PAYOUT_AUDIT.md
+++ b/docs/ISSUE_149_ORPHAN_PAYOUT_AUDIT.md
@@ -3,8 +3,9 @@
 This audit is read-only. It only reports technician payout lines whose `job_id`
 no longer exists in `public.jobs`.
 
-Do not run this against production. Run it only against a non-production copy
-of production data after the copy has been verified.
+The generic audit below is intended for non-production copies. For the Issue
+149 final closeout, use the scoped production read-only command in the
+Production Closeout section. Neither path has a repair mode.
 
 ## Dry Run
 
@@ -25,11 +26,34 @@ NODE_ENV=staging node scripts/audit-orphan-payout-lines.js --run --json --limit=
 
 `--apply` is intentionally unsupported. There is no repair mode in this script.
 
+## Production Closeout Read-Only Audit
+
+Owner-approved production read-only audit for technician `0661479791` and work
+month `2026-06`:
+
+```bash
+NODE_ENV=production node scripts/issue-149-closeout-audit.js --run --json --allow-production-read --technician=0661479791 --month=2026-06 > issue-149-prod-audit-0661479791-2026-06.json
+```
+
+The script opens a `BEGIN READ ONLY` transaction, sets statement/lock timeouts,
+and only runs SELECT statements. It reports current totals, expected totals
+after safe cleanup candidates, exact orphan rows, cache leftovers, deposit
+impact, and classification.
+
+Generate the remediation SQL plan from that JSON without executing writes:
+
+```bash
+node scripts/issue-149-remediation-plan.js --audit=issue-149-prod-audit-0661479791-2026-06.json > issue-149-remediation-plan.sql
+```
+
+The generated plan defaults to `ROLLBACK`. Do not switch to `COMMIT` or run it
+against production until the owner approves the exact audit output and plan.
+
 ## Decision Matrix
 
 | Classification | Meaning | Required action |
 | --- | --- | --- |
-| `draft/unpaid-safe-to-review` | Orphan line is tied only to draft/unpaid payout state. | Review with operations and decide whether a targeted cleanup PR or manual non-production validation is appropriate. |
+| `draft/unpaid-safe-to-clean` | Orphan line is tied only to draft/unpaid payout state. | Review with operations and decide whether a targeted cleanup PR or manual non-production validation is appropriate. |
 | `locked/paid/payment-linked-reconciliation-required` | Orphan line is tied to locked, paid, partially paid, paid-at, or payment-row state. | Do not delete automatically. Reconcile payout/payment records with finance before any data change. |
 
 ## Notes

--- a/scripts/issue-149-closeout-audit.js
+++ b/scripts/issue-149-closeout-audit.js
@@ -1,0 +1,464 @@
+"use strict";
+
+try { require("dotenv").config(); } catch (_) {}
+
+const { Pool } = require("pg");
+const depositCollections = require("../server/services/technicianDepositCollections");
+
+const DEFAULT_TECHNICIAN = "0661479791";
+const DEFAULT_WORK_MONTH = "2026-06";
+
+function money(value) {
+  const n = Number(value || 0);
+  if (!Number.isFinite(n)) return 0;
+  return Math.round(n * 100) / 100;
+}
+
+function parseArgs(argv = process.argv.slice(2)) {
+  const opts = {
+    technician: DEFAULT_TECHNICIAN,
+    workMonth: DEFAULT_WORK_MONTH,
+    run: false,
+    json: false,
+    allowProductionRead: false,
+  };
+  for (const arg of argv) {
+    if (arg === "--run") opts.run = true;
+    else if (arg === "--json") opts.json = true;
+    else if (arg === "--allow-production-read") opts.allowProductionRead = true;
+    else if (arg.startsWith("--technician=")) opts.technician = arg.split("=").slice(1).join("=").trim();
+    else if (arg.startsWith("--month=")) opts.workMonth = arg.split("=").slice(1).join("=").trim();
+  }
+  if (!/^\d{4}-\d{2}$/.test(opts.workMonth)) throw new Error("INVALID_WORK_MONTH");
+  if (!opts.technician) throw new Error("MISSING_TECHNICIAN");
+  return opts;
+}
+
+function nextMonth(ym) {
+  const [y, m] = ym.split("-").map(Number);
+  const d = new Date(Date.UTC(y, m, 1));
+  return `${d.getUTCFullYear()}-${String(d.getUTCMonth() + 1).padStart(2, "0")}`;
+}
+
+function payoutIdsForWorkMonth(workMonth) {
+  return [`payout_${workMonth}_25`, `payout_${nextMonth(workMonth)}_10`];
+}
+
+function classify({ period, payment }) {
+  const status = String(period?.status || "draft").trim().toLowerCase();
+  const paidStatus = String(payment?.paid_status || "").trim().toLowerCase();
+  const paymentLinked = Boolean(
+    payment?.payment_id != null ||
+    Number(payment?.paid_amount || 0) > 0 ||
+    paidStatus === "partial" ||
+    paidStatus === "paid" ||
+    payment?.paid_at != null
+  );
+  if (status === "locked" || status === "paid" || paymentLinked) {
+    return "locked/paid/payment-linked-reconciliation-required";
+  }
+  return "draft/unpaid-safe-to-clean";
+}
+
+function databaseConfigFromEnv(env = process.env) {
+  const connectionString = String(env.PRODUCTION_DATABASE_URL || env.DATABASE_URL || "").trim();
+  if (connectionString) return { connectionString, ssl: { rejectUnauthorized: false } };
+  if (env.DB_HOST && env.DB_USER && env.DB_NAME) {
+    return {
+      host: env.DB_HOST,
+      port: Number(env.DB_PORT || 5432),
+      user: env.DB_USER,
+      password: env.DB_PASSWORD,
+      database: env.DB_NAME,
+      ssl: { rejectUnauthorized: false },
+    };
+  }
+  return null;
+}
+
+function redactConfig(config) {
+  if (!config) return null;
+  if (config.connectionString) return { connectionString: "[REDACTED_DATABASE_URL]" };
+  return {
+    host: config.host || "",
+    port: config.port || "",
+    user: config.user ? "[REDACTED_DB_USER]" : "",
+    database: config.database || "",
+  };
+}
+
+async function loadRows(client, technician, payoutIds) {
+  const params = [technician, payoutIds];
+  const [periods, lines, orphanLines, allAdjustments, orphanAdjustments, payments, deposits, previewCache, displayCache] = await Promise.all([
+    client.query(
+      `SELECT payout_id, status, period_start, period_end
+         FROM public.technician_payout_periods
+        WHERE payout_id = ANY($1::text[])
+        ORDER BY payout_id ASC`,
+      [payoutIds]
+    ),
+    client.query(
+      `SELECT line_id, payout_id, technician_username, job_id::text AS job_id,
+              finished_at, COALESCE(earn_amount,0)::numeric AS earn_amount
+         FROM public.technician_payout_lines
+        WHERE technician_username=$1
+          AND payout_id = ANY($2::text[])
+        ORDER BY payout_id ASC, job_id ASC, line_id ASC`,
+      params
+    ),
+    client.query(
+      `SELECT l.line_id, l.payout_id, l.technician_username, l.job_id::text AS job_id,
+              l.finished_at, COALESCE(l.earn_amount,0)::numeric AS earn_amount
+         FROM public.technician_payout_lines l
+         LEFT JOIN public.jobs j ON j.job_id::text = l.job_id::text
+        WHERE l.technician_username=$1
+          AND l.payout_id = ANY($2::text[])
+          AND j.job_id IS NULL
+        ORDER BY l.payout_id ASC, l.job_id ASC, l.line_id ASC`,
+      params
+    ),
+    client.query(
+      `SELECT adj_id, payout_id, technician_username, job_id::text AS job_id,
+              COALESCE(adj_amount,0)::numeric AS adj_amount, reason, created_at, created_by
+         FROM public.technician_payout_adjustments
+        WHERE technician_username=$1
+          AND payout_id = ANY($2::text[])
+        ORDER BY payout_id ASC, job_id ASC NULLS LAST, adj_id ASC`,
+      params
+    ),
+    client.query(
+      `SELECT a.adj_id, a.payout_id, a.technician_username, a.job_id::text AS job_id,
+              COALESCE(a.adj_amount,0)::numeric AS adj_amount, a.reason, a.created_at, a.created_by
+         FROM public.technician_payout_adjustments a
+         LEFT JOIN public.jobs j ON j.job_id::text = a.job_id::text
+        WHERE a.technician_username=$1
+          AND a.payout_id = ANY($2::text[])
+          AND a.job_id IS NOT NULL
+          AND j.job_id IS NULL
+        ORDER BY a.payout_id ASC, a.job_id ASC, a.adj_id ASC`,
+      params
+    ),
+    client.query(
+      `SELECT payment_id, payout_id, technician_username,
+              COALESCE(paid_amount,0)::numeric AS paid_amount,
+              COALESCE(paid_status,'') AS paid_status,
+              paid_at, paid_by, slip_url, note
+         FROM public.technician_payout_payments
+        WHERE technician_username=$1
+          AND payout_id = ANY($2::text[])
+        ORDER BY payout_id ASC, payment_id ASC`,
+      params
+    ),
+    client.query(
+      `SELECT ledger_id, payout_id, technician_username, transaction_type,
+              COALESCE(amount,0)::numeric AS amount, created_at, created_by
+         FROM public.technician_deposit_ledger
+        WHERE technician_username=$1
+          AND payout_id = ANY($2::text[])
+          AND transaction_type='collect'
+        ORDER BY payout_id ASC, ledger_id ASC`,
+      params
+    ),
+    client.query(
+      `SELECT p.id, p.job_id::text AS job_id, p.technician_username,
+              COALESCE(p.income_amount,0)::numeric AS income_amount,
+              p.income_source, p.is_stale, p.updated_at
+         FROM public.job_technician_income_preview p
+         LEFT JOIN public.jobs j ON j.job_id::text = p.job_id::text
+        WHERE p.technician_username=$1
+          AND j.job_id IS NULL
+        ORDER BY p.job_id ASC, p.id ASC`,
+      [technician]
+    ),
+    client.query(
+      `SELECT d.id, d.job_id::text AS job_id, d.technician_username,
+              COALESCE(d.display_amount,0)::numeric AS display_amount,
+              d.display_state, d.context, d.is_stale, d.updated_at
+         FROM public.technician_job_income_display d
+         LEFT JOIN public.jobs j ON j.job_id::text = d.job_id::text
+        WHERE d.technician_username=$1
+          AND j.job_id IS NULL
+        ORDER BY d.job_id ASC, d.id ASC`,
+      [technician]
+    ),
+  ]);
+
+  return {
+    periods: periods.rows || [],
+    lines: lines.rows || [],
+    orphanLines: orphanLines.rows || [],
+    allAdjustments: allAdjustments.rows || [],
+    orphanAdjustments: orphanAdjustments.rows || [],
+    payments: payments.rows || [],
+    deposits: deposits.rows || [],
+    previewCache: previewCache.rows || [],
+    displayCache: displayCache.rows || [],
+  };
+}
+
+function sumRows(rows, field) {
+  return money((rows || []).reduce((sum, row) => sum + Number(row[field] || 0), 0));
+}
+
+function groupKey(payoutId, technician) {
+  return `${payoutId}::${technician}`;
+}
+
+async function summarizeAudit(client, { technician, workMonth }) {
+  const payoutIds = payoutIdsForWorkMonth(workMonth);
+  const data = await loadRows(client, technician, payoutIds);
+  const periods = new Map(data.periods.map((row) => [row.payout_id, row]));
+  const payments = new Map(data.payments.map((row) => [groupKey(row.payout_id, row.technician_username), row]));
+
+  const orphanAdjustmentsByJob = new Map();
+  for (const adj of data.orphanAdjustments) {
+    const key = `${adj.payout_id}::${adj.job_id}`;
+    if (!orphanAdjustmentsByJob.has(key)) orphanAdjustmentsByJob.set(key, []);
+    orphanAdjustmentsByJob.get(key).push(adj);
+  }
+
+  const targetOrphanJobIds = new Set(orphanRows.map((row) => String(row.job_id)));
+  const targetPreviewCache = data.previewCache.filter((row) => targetOrphanJobIds.has(String(row.job_id)));
+  const targetDisplayCache = data.displayCache.filter((row) => targetOrphanJobIds.has(String(row.job_id)));
+
+  const allLinesByPayout = new Map();
+  for (const line of data.lines) {
+    if (!allLinesByPayout.has(line.payout_id)) allLinesByPayout.set(line.payout_id, []);
+    allLinesByPayout.get(line.payout_id).push(line);
+  }
+  const allAdjustmentsByPayout = new Map();
+  for (const adj of data.allAdjustments) {
+    if (!allAdjustmentsByPayout.has(adj.payout_id)) allAdjustmentsByPayout.set(adj.payout_id, []);
+    allAdjustmentsByPayout.get(adj.payout_id).push(adj);
+  }
+
+  const baseByPayout = new Map();
+  for (const payoutId of payoutIds) {
+    const period = periods.get(payoutId) || { payout_id: payoutId, status: "draft" };
+    const payment = payments.get(groupKey(payoutId, technician)) || null;
+    const gross = sumRows(allLinesByPayout.get(payoutId) || [], "earn_amount");
+    const adj = sumRows(allAdjustmentsByPayout.get(payoutId) || [], "adj_amount");
+    const currentDeposit = await depositCollections.getProjectedDepositDeductionForPayout(client, {
+      payout_id: payoutId,
+      technician_username: technician,
+      gross_amount: gross,
+      adj_total: adj,
+      period_status: period.status || "draft",
+    });
+    baseByPayout.set(payoutId, {
+      payout_id: payoutId,
+      period_status: period.status || "draft",
+      gross_amount: gross,
+      adj_total: adj,
+      deposit_deduction_amount: money(currentDeposit.deposit_deduction_amount || 0),
+      net_amount: money(gross + adj - Number(currentDeposit.deposit_deduction_amount || 0)),
+      paid_amount: money(payment?.paid_amount || 0),
+      paid_status: payment?.paid_status || "",
+      payment_id: payment?.payment_id || null,
+      payment,
+      currentDeposit,
+    });
+  }
+
+  const orphanRows = [];
+  for (const line of data.orphanLines) {
+    const period = periods.get(line.payout_id) || { payout_id: line.payout_id, status: "draft" };
+    const payment = payments.get(groupKey(line.payout_id, line.technician_username)) || null;
+    const linkedAdjustments = orphanAdjustmentsByJob.get(`${line.payout_id}::${line.job_id}`) || [];
+    const linkedAdjustmentAmount = sumRows(linkedAdjustments, "adj_amount");
+    orphanRows.push({
+      row_type: "payout_line",
+      technician_username: line.technician_username,
+      job_id: line.job_id,
+      payout_id: line.payout_id,
+      line_id: line.line_id,
+      adjustment_ids: linkedAdjustments.map((row) => row.adj_id),
+      period_status: period.status || "draft",
+      payment_id: payment?.payment_id || null,
+      paid_status: payment?.paid_status || "",
+      paid_amount: money(payment?.paid_amount || 0),
+      orphan_payout_line_amount: money(line.earn_amount),
+      linked_adjustment_amount: linkedAdjustmentAmount,
+      classification: classify({ period, payment }),
+    });
+  }
+
+  const lineJobKeys = new Set(data.orphanLines.map((line) => `${line.payout_id}::${line.job_id}`));
+  for (const adj of data.orphanAdjustments) {
+    const key = `${adj.payout_id}::${adj.job_id}`;
+    if (lineJobKeys.has(key)) continue;
+    const period = periods.get(adj.payout_id) || { payout_id: adj.payout_id, status: "draft" };
+    const payment = payments.get(groupKey(adj.payout_id, adj.technician_username)) || null;
+    orphanRows.push({
+      row_type: "adjustment_only",
+      technician_username: adj.technician_username,
+      job_id: adj.job_id,
+      payout_id: adj.payout_id,
+      line_id: null,
+      adjustment_ids: [adj.adj_id],
+      period_status: period.status || "draft",
+      payment_id: payment?.payment_id || null,
+      paid_status: payment?.paid_status || "",
+      paid_amount: money(payment?.paid_amount || 0),
+      orphan_payout_line_amount: 0,
+      linked_adjustment_amount: money(adj.adj_amount),
+      classification: classify({ period, payment }),
+    });
+  }
+
+  const safeByPayout = new Map();
+  for (const row of orphanRows.filter((r) => r.classification === "draft/unpaid-safe-to-clean")) {
+    if (!safeByPayout.has(row.payout_id)) safeByPayout.set(row.payout_id, []);
+    safeByPayout.get(row.payout_id).push(row);
+  }
+
+  const expectedByPayout = new Map();
+  for (const payoutId of payoutIds) {
+    const base = baseByPayout.get(payoutId);
+    const safeRows = safeByPayout.get(payoutId) || [];
+    const safeLineAmount = sumRows(safeRows, "orphan_payout_line_amount");
+    const safeAdjustmentAmount = sumRows(safeRows, "linked_adjustment_amount");
+    const expectedGross = money(base.gross_amount - safeLineAmount);
+    const expectedAdj = money(base.adj_total - safeAdjustmentAmount);
+    const expectedDeposit = await depositCollections.getProjectedDepositDeductionForPayout(client, {
+      payout_id: payoutId,
+      technician_username: technician,
+      gross_amount: expectedGross,
+      adj_total: expectedAdj,
+      period_status: base.period_status,
+    });
+    expectedByPayout.set(payoutId, {
+      payout_id: payoutId,
+      expected_gross_amount_after_safe_cleanup: expectedGross,
+      expected_adj_total_after_safe_cleanup: expectedAdj,
+      expected_deposit_deduction_amount_after_safe_cleanup: money(expectedDeposit.deposit_deduction_amount || 0),
+      expected_net_amount_after_safe_cleanup: money(expectedGross + expectedAdj - Number(expectedDeposit.deposit_deduction_amount || 0)),
+      safe_cleanup_line_amount: safeLineAmount,
+      safe_cleanup_adjustment_amount: safeAdjustmentAmount,
+      safe_cleanup_deposit_impact: money(base.deposit_deduction_amount - Number(expectedDeposit.deposit_deduction_amount || 0)),
+    });
+  }
+
+  for (const row of orphanRows) {
+    const base = baseByPayout.get(row.payout_id);
+    const expected = expectedByPayout.get(row.payout_id);
+    const groupRows = safeByPayout.get(row.payout_id) || [];
+    const groupPositiveImpact = groupRows.reduce((sum, r) => sum + Math.max(0, Number(r.orphan_payout_line_amount || 0) + Number(r.linked_adjustment_amount || 0)), 0);
+    const rowPositiveImpact = Math.max(0, Number(row.orphan_payout_line_amount || 0) + Number(row.linked_adjustment_amount || 0));
+    const allocatedDepositImpact = row.classification === "draft/unpaid-safe-to-clean" && groupPositiveImpact > 0
+      ? money(Number(expected.safe_cleanup_deposit_impact || 0) * rowPositiveImpact / groupPositiveImpact)
+      : 0;
+    row.current_period_deposit_deduction_amount = base.deposit_deduction_amount;
+    row.deposit_impact = allocatedDepositImpact;
+    row.net_impact = money(Number(row.orphan_payout_line_amount || 0) + Number(row.linked_adjustment_amount || 0) - allocatedDepositImpact);
+  }
+
+  const totals = {
+    orphan_rows: orphanRows.length,
+    orphan_payout_line_amount: sumRows(orphanRows, "orphan_payout_line_amount"),
+    linked_adjustment_amount: sumRows(orphanRows, "linked_adjustment_amount"),
+    deposit_impact: sumRows(orphanRows, "deposit_impact"),
+    net_impact: sumRows(orphanRows, "net_impact"),
+    by_classification: {},
+  };
+  for (const row of orphanRows) {
+    if (!totals.by_classification[row.classification]) {
+      totals.by_classification[row.classification] = {
+        rows: 0,
+        orphan_payout_line_amount: 0,
+        linked_adjustment_amount: 0,
+        deposit_impact: 0,
+        net_impact: 0,
+      };
+    }
+    const t = totals.by_classification[row.classification];
+    t.rows += 1;
+    t.orphan_payout_line_amount = money(t.orphan_payout_line_amount + Number(row.orphan_payout_line_amount || 0));
+    t.linked_adjustment_amount = money(t.linked_adjustment_amount + Number(row.linked_adjustment_amount || 0));
+    t.deposit_impact = money(t.deposit_impact + Number(row.deposit_impact || 0));
+    t.net_impact = money(t.net_impact + Number(row.net_impact || 0));
+  }
+
+  return {
+    ok: true,
+    read_only: true,
+    technician_username: technician,
+    work_month: workMonth,
+    payout_ids: payoutIds,
+    current_by_payout: Object.fromEntries([...baseByPayout.entries()]),
+    expected_after_safe_cleanup_by_payout: Object.fromEntries([...expectedByPayout.entries()]),
+    orphan_rows: orphanRows,
+    cache_orphan_rows: {
+      job_technician_income_preview: targetPreviewCache,
+      technician_job_income_display: targetDisplayCache,
+    },
+    totals,
+  };
+}
+
+function dryRunText(opts) {
+  const payoutIds = payoutIdsForWorkMonth(opts.workMonth);
+  return [
+    "Read-only audit. No writes are executed.",
+    `Technician: ${opts.technician}`,
+    `Work month: ${opts.workMonth}`,
+    `Payout IDs: ${payoutIds.join(", ")}`,
+    "",
+    "Run command:",
+    `NODE_ENV=production node scripts/issue-149-closeout-audit.js --run --json --allow-production-read --technician=${opts.technician} --month=${opts.workMonth}`,
+    "",
+    "Required env: PRODUCTION_DATABASE_URL or DATABASE_URL, or DB_HOST/DB_PORT/DB_USER/DB_PASSWORD/DB_NAME.",
+  ].join("\n");
+}
+
+async function main() {
+  const opts = parseArgs();
+  if (!opts.run) {
+    console.log(dryRunText(opts));
+    return;
+  }
+  if (String(process.env.NODE_ENV || "").toLowerCase() === "production" && !opts.allowProductionRead) {
+    throw new Error("PRODUCTION_READ_REQUIRES_--allow-production-read");
+  }
+  const config = databaseConfigFromEnv();
+  if (!config) {
+    throw new Error("PRODUCTION_DATABASE_URL or DATABASE_URL or DB_* env is required");
+  }
+  const pool = new Pool(config);
+  const client = await pool.connect();
+  try {
+    await client.query("BEGIN READ ONLY");
+    await client.query("SET LOCAL statement_timeout = '45s'");
+    await client.query("SET LOCAL lock_timeout = '5s'");
+    const result = await summarizeAudit(client, opts);
+    await client.query("COMMIT");
+    if (opts.json) {
+      console.log(JSON.stringify({ ...result, database: redactConfig(config) }, null, 2));
+    } else {
+      console.table(result.orphan_rows);
+      console.log(JSON.stringify(result.totals, null, 2));
+    }
+  } catch (err) {
+    try { await client.query("ROLLBACK"); } catch (_) {}
+    throw err;
+  } finally {
+    client.release();
+    await pool.end();
+  }
+}
+
+if (require.main === module) {
+  main().catch((err) => {
+    console.error(err && err.stack || err);
+    process.exitCode = 1;
+  });
+}
+
+module.exports = {
+  parseArgs,
+  payoutIdsForWorkMonth,
+  classify,
+  databaseConfigFromEnv,
+  summarizeAudit,
+  dryRunText,
+};

--- a/scripts/issue-149-closeout-audit.js
+++ b/scripts/issue-149-closeout-audit.js
@@ -204,6 +204,10 @@ function groupKey(payoutId, technician) {
   return `${payoutId}::${technician}`;
 }
 
+function orphanJobKey(row) {
+  return `${row.payout_id}::${row.technician_username}::${row.job_id}`;
+}
+
 async function summarizeAudit(client, { technician, workMonth }) {
   const payoutIds = payoutIdsForWorkMonth(workMonth);
   const data = await loadRows(client, technician, payoutIds);
@@ -212,14 +216,10 @@ async function summarizeAudit(client, { technician, workMonth }) {
 
   const orphanAdjustmentsByJob = new Map();
   for (const adj of data.orphanAdjustments) {
-    const key = `${adj.payout_id}::${adj.job_id}`;
+    const key = orphanJobKey(adj);
     if (!orphanAdjustmentsByJob.has(key)) orphanAdjustmentsByJob.set(key, []);
     orphanAdjustmentsByJob.get(key).push(adj);
   }
-
-  const targetOrphanJobIds = new Set(orphanRows.map((row) => String(row.job_id)));
-  const targetPreviewCache = data.previewCache.filter((row) => targetOrphanJobIds.has(String(row.job_id)));
-  const targetDisplayCache = data.displayCache.filter((row) => targetOrphanJobIds.has(String(row.job_id)));
 
   const allLinesByPayout = new Map();
   for (const line of data.lines) {
@@ -261,31 +261,47 @@ async function summarizeAudit(client, { technician, workMonth }) {
   }
 
   const orphanRows = [];
+  const orphanLineGroups = new Map();
   for (const line of data.orphanLines) {
-    const period = periods.get(line.payout_id) || { payout_id: line.payout_id, status: "draft" };
-    const payment = payments.get(groupKey(line.payout_id, line.technician_username)) || null;
-    const linkedAdjustments = orphanAdjustmentsByJob.get(`${line.payout_id}::${line.job_id}`) || [];
-    const linkedAdjustmentAmount = sumRows(linkedAdjustments, "adj_amount");
+    const key = orphanJobKey(line);
+    if (!orphanLineGroups.has(key)) {
+      orphanLineGroups.set(key, {
+        row_type: "payout_line_group",
+        technician_username: line.technician_username,
+        job_id: line.job_id,
+        payout_id: line.payout_id,
+        line_ids: [],
+        orphan_payout_line_amount: 0,
+      });
+    }
+    const group = orphanLineGroups.get(key);
+    if (line.line_id != null && !group.line_ids.includes(line.line_id)) group.line_ids.push(line.line_id);
+    group.orphan_payout_line_amount = money(group.orphan_payout_line_amount + Number(line.earn_amount || 0));
+  }
+  for (const group of orphanLineGroups.values()) {
+    const period = periods.get(group.payout_id) || { payout_id: group.payout_id, status: "draft" };
+    const payment = payments.get(groupKey(group.payout_id, group.technician_username)) || null;
+    const linkedAdjustments = orphanAdjustmentsByJob.get(orphanJobKey(group)) || [];
+    const adjustmentIds = [...new Set(linkedAdjustments.map((row) => row.adj_id).filter((id) => id != null))];
+    const linkedAdjustmentAmount = sumRows(linkedAdjustments.filter((row, index, arr) =>
+      row.adj_id == null || arr.findIndex((other) => other.adj_id === row.adj_id) === index
+    ), "adj_amount");
     orphanRows.push({
-      row_type: "payout_line",
-      technician_username: line.technician_username,
-      job_id: line.job_id,
-      payout_id: line.payout_id,
-      line_id: line.line_id,
-      adjustment_ids: linkedAdjustments.map((row) => row.adj_id),
+      ...group,
+      line_id: group.line_ids.length === 1 ? group.line_ids[0] : null,
+      adjustment_ids: adjustmentIds,
       period_status: period.status || "draft",
       payment_id: payment?.payment_id || null,
       paid_status: payment?.paid_status || "",
       paid_amount: money(payment?.paid_amount || 0),
-      orphan_payout_line_amount: money(line.earn_amount),
       linked_adjustment_amount: linkedAdjustmentAmount,
       classification: classify({ period, payment }),
     });
   }
 
-  const lineJobKeys = new Set(data.orphanLines.map((line) => `${line.payout_id}::${line.job_id}`));
+  const lineJobKeys = new Set(data.orphanLines.map(orphanJobKey));
   for (const adj of data.orphanAdjustments) {
-    const key = `${adj.payout_id}::${adj.job_id}`;
+    const key = orphanJobKey(adj);
     if (lineJobKeys.has(key)) continue;
     const period = periods.get(adj.payout_id) || { payout_id: adj.payout_id, status: "draft" };
     const payment = payments.get(groupKey(adj.payout_id, adj.technician_username)) || null;
@@ -305,6 +321,10 @@ async function summarizeAudit(client, { technician, workMonth }) {
       classification: classify({ period, payment }),
     });
   }
+
+  const targetOrphanJobIds = new Set(orphanRows.map((row) => String(row.job_id)));
+  const targetPreviewCache = data.previewCache.filter((row) => targetOrphanJobIds.has(String(row.job_id)));
+  const targetDisplayCache = data.displayCache.filter((row) => targetOrphanJobIds.has(String(row.job_id)));
 
   const safeByPayout = new Map();
   for (const row of orphanRows.filter((r) => r.classification === "draft/unpaid-safe-to-clean")) {

--- a/scripts/issue-149-remediation-plan.js
+++ b/scripts/issue-149-remediation-plan.js
@@ -42,6 +42,8 @@ function groupSafeRows(rows) {
         job_id: row.job_id,
         line_ids: [],
         adjustment_ids: [],
+        _lineIdSet: new Set(),
+        _adjustmentIdSet: new Set(),
         orphan_payout_line_amount: 0,
         linked_adjustment_amount: 0,
         deposit_impact: 0,
@@ -49,27 +51,130 @@ function groupSafeRows(rows) {
       });
     }
     const g = groups.get(key);
-    if (row.line_id != null) g.line_ids.push(row.line_id);
+    const rowLineIds = Array.isArray(row.line_ids) ? row.line_ids : [row.line_id];
+    for (const id of rowLineIds) {
+      if (id != null && !g._lineIdSet.has(id)) {
+        g._lineIdSet.add(id);
+        g.line_ids.push(id);
+      }
+    }
+    let hasNewAdjustment = false;
     for (const id of row.adjustment_ids || []) {
-      if (id != null && !g.adjustment_ids.includes(id)) g.adjustment_ids.push(id);
+      if (id != null && !g._adjustmentIdSet.has(id)) {
+        g._adjustmentIdSet.add(id);
+        g.adjustment_ids.push(id);
+        hasNewAdjustment = true;
+      }
     }
     g.orphan_payout_line_amount = money(g.orphan_payout_line_amount + Number(row.orphan_payout_line_amount || 0));
-    g.linked_adjustment_amount = money(g.linked_adjustment_amount + Number(row.linked_adjustment_amount || 0));
+    if (!Array.isArray(row.adjustment_ids) || row.adjustment_ids.length === 0 || hasNewAdjustment) {
+      g.linked_adjustment_amount = money(g.linked_adjustment_amount + Number(row.linked_adjustment_amount || 0));
+    }
     g.deposit_impact = money(g.deposit_impact + Number(row.deposit_impact || 0));
     g.net_impact = money(g.net_impact + Number(row.net_impact || 0));
   }
-  return [...groups.values()];
+  return [...groups.values()].map((group) => {
+    const { _lineIdSet, _adjustmentIdSet, ...clean } = group;
+    return clean;
+  });
 }
 
 function cleanupSqlForGroup(group) {
   const pid = sqlString(group.payout_id);
   const tech = sqlString(group.technician_username);
   const job = sqlString(group.job_id);
+  const expectedLineCount = Number(group.line_ids.length || 0);
+  const expectedAdjustmentCount = Number(group.adjustment_ids.length || 0);
+  const expectedLineTotal = money(group.orphan_payout_line_amount);
+  const expectedAdjustmentTotal = money(group.linked_adjustment_amount);
   return `
 -- A cleanup candidate: payout_id=${group.payout_id}, technician=${group.technician_username}, job_id=${group.job_id}
 -- before_count expected lines=${group.line_ids.length}, adjustments=${group.adjustment_ids.length}
--- before_total line=${money(group.orphan_payout_line_amount)}, adjustment=${money(group.linked_adjustment_amount)}, deposit_impact=${money(group.deposit_impact)}, net_impact=${money(group.net_impact)}
+-- before_total line=${expectedLineTotal}, adjustment=${expectedAdjustmentTotal}, deposit_impact=${money(group.deposit_impact)}, net_impact=${money(group.net_impact)}
 -- expected_after lines=0 total=0, adjustments=0 total=0 for this orphan job
+DO $$
+DECLARE
+  v_period_status text;
+  v_payment_count integer;
+  v_line_count integer;
+  v_line_total numeric;
+  v_adjustment_count integer;
+  v_adjustment_total numeric;
+BEGIN
+  PERFORM pg_advisory_xact_lock(hashtext('issue-149-remediation:${group.payout_id}:${group.technician_username}'));
+
+  SELECT p.status
+    INTO v_period_status
+    FROM public.technician_payout_periods p
+   WHERE p.payout_id=${pid}
+   FOR UPDATE;
+
+  IF v_period_status IS NOT NULL AND lower(COALESCE(v_period_status,'draft')) <> 'draft' THEN
+    RAISE EXCEPTION 'Issue 149 cleanup blocked: payout % status changed to %', ${pid}, v_period_status;
+  END IF;
+
+  PERFORM 1
+    FROM public.technician_payout_payments pay
+   WHERE pay.payout_id=${pid}
+     AND pay.technician_username=${tech}
+     AND (
+       pay.payment_id IS NOT NULL
+       OR COALESCE(pay.paid_amount,0) <> 0
+       OR COALESCE(pay.paid_status,'') <> ''
+       OR pay.paid_at IS NOT NULL
+     )
+   FOR UPDATE;
+
+  GET DIAGNOSTICS v_payment_count = ROW_COUNT;
+  IF v_payment_count > 0 THEN
+    RAISE EXCEPTION 'Issue 149 cleanup blocked: payment row now exists for payout %, technician %', ${pid}, ${tech};
+  END IF;
+
+  IF EXISTS (SELECT 1 FROM public.jobs j WHERE j.job_id::text=${job}) THEN
+    RAISE EXCEPTION 'Issue 149 cleanup blocked: job % exists again', ${job};
+  END IF;
+
+  PERFORM 1
+    FROM public.technician_payout_lines l
+   WHERE l.payout_id=${pid}
+     AND l.technician_username=${tech}
+     AND l.job_id::text=${job}
+   FOR UPDATE;
+
+  SELECT COUNT(*)::integer, COALESCE(SUM(earn_amount),0)::numeric
+    INTO v_line_count, v_line_total
+    FROM public.technician_payout_lines l
+   WHERE l.payout_id=${pid}
+     AND l.technician_username=${tech}
+     AND l.job_id::text=${job}
+     AND NOT EXISTS (SELECT 1 FROM public.jobs j WHERE j.job_id::text=${job});
+
+  IF v_line_count <> ${expectedLineCount} OR v_line_total <> ${expectedLineTotal}::numeric THEN
+    RAISE EXCEPTION 'Issue 149 cleanup blocked: payout line mismatch for payout %, job %; expected count %, total %, got count %, total %',
+      ${pid}, ${job}, ${expectedLineCount}, ${expectedLineTotal}::numeric, v_line_count, v_line_total;
+  END IF;
+
+  PERFORM 1
+    FROM public.technician_payout_adjustments a
+   WHERE a.payout_id=${pid}
+     AND a.technician_username=${tech}
+     AND a.job_id::text=${job}
+   FOR UPDATE;
+
+  SELECT COUNT(*)::integer, COALESCE(SUM(adj_amount),0)::numeric
+    INTO v_adjustment_count, v_adjustment_total
+    FROM public.technician_payout_adjustments a
+   WHERE a.payout_id=${pid}
+     AND a.technician_username=${tech}
+     AND a.job_id::text=${job}
+     AND NOT EXISTS (SELECT 1 FROM public.jobs j WHERE j.job_id::text=${job});
+
+  IF v_adjustment_count <> ${expectedAdjustmentCount} OR v_adjustment_total <> ${expectedAdjustmentTotal}::numeric THEN
+    RAISE EXCEPTION 'Issue 149 cleanup blocked: adjustment mismatch for payout %, job %; expected count %, total %, got count %, total %',
+      ${pid}, ${job}, ${expectedAdjustmentCount}, ${expectedAdjustmentTotal}::numeric, v_adjustment_count, v_adjustment_total;
+  END IF;
+END $$;
+
 SELECT 'before_lines' AS check_name, COUNT(*)::int AS count, COALESCE(SUM(earn_amount),0)::numeric AS total
   FROM public.technician_payout_lines
  WHERE payout_id=${pid}
@@ -88,6 +193,22 @@ DELETE FROM public.technician_payout_adjustments
  WHERE payout_id=${pid}
    AND technician_username=${tech}
    AND job_id::text=${job}
+   AND NOT EXISTS (
+     SELECT 1 FROM public.technician_payout_periods p
+      WHERE p.payout_id=${pid}
+        AND lower(COALESCE(p.status,'draft')) <> 'draft'
+   )
+   AND NOT EXISTS (
+     SELECT 1 FROM public.technician_payout_payments pay
+      WHERE pay.payout_id=${pid}
+        AND pay.technician_username=${tech}
+        AND (
+          pay.payment_id IS NOT NULL
+          OR COALESCE(pay.paid_amount,0) <> 0
+          OR COALESCE(pay.paid_status,'') <> ''
+          OR pay.paid_at IS NOT NULL
+        )
+   )
    AND NOT EXISTS (SELECT 1 FROM public.jobs j WHERE j.job_id::text=${job})
  RETURNING adj_id, payout_id, technician_username, job_id, adj_amount;
 
@@ -95,18 +216,66 @@ DELETE FROM public.technician_payout_lines
  WHERE payout_id=${pid}
    AND technician_username=${tech}
    AND job_id::text=${job}
+   AND NOT EXISTS (
+     SELECT 1 FROM public.technician_payout_periods p
+      WHERE p.payout_id=${pid}
+        AND lower(COALESCE(p.status,'draft')) <> 'draft'
+   )
+   AND NOT EXISTS (
+     SELECT 1 FROM public.technician_payout_payments pay
+      WHERE pay.payout_id=${pid}
+        AND pay.technician_username=${tech}
+        AND (
+          pay.payment_id IS NOT NULL
+          OR COALESCE(pay.paid_amount,0) <> 0
+          OR COALESCE(pay.paid_status,'') <> ''
+          OR pay.paid_at IS NOT NULL
+        )
+   )
    AND NOT EXISTS (SELECT 1 FROM public.jobs j WHERE j.job_id::text=${job})
  RETURNING line_id, payout_id, technician_username, job_id, earn_amount;
 
 DELETE FROM public.job_technician_income_preview
  WHERE technician_username=${tech}
    AND job_id::text=${job}
+   AND NOT EXISTS (
+     SELECT 1 FROM public.technician_payout_periods p
+      WHERE p.payout_id=${pid}
+        AND lower(COALESCE(p.status,'draft')) <> 'draft'
+   )
+   AND NOT EXISTS (
+     SELECT 1 FROM public.technician_payout_payments pay
+      WHERE pay.payout_id=${pid}
+        AND pay.technician_username=${tech}
+        AND (
+          pay.payment_id IS NOT NULL
+          OR COALESCE(pay.paid_amount,0) <> 0
+          OR COALESCE(pay.paid_status,'') <> ''
+          OR pay.paid_at IS NOT NULL
+        )
+   )
    AND NOT EXISTS (SELECT 1 FROM public.jobs j WHERE j.job_id::text=${job})
  RETURNING id, job_id, technician_username, income_amount;
 
 DELETE FROM public.technician_job_income_display
  WHERE technician_username=${tech}
    AND job_id::text=${job}
+   AND NOT EXISTS (
+     SELECT 1 FROM public.technician_payout_periods p
+      WHERE p.payout_id=${pid}
+        AND lower(COALESCE(p.status,'draft')) <> 'draft'
+   )
+   AND NOT EXISTS (
+     SELECT 1 FROM public.technician_payout_payments pay
+      WHERE pay.payout_id=${pid}
+        AND pay.technician_username=${tech}
+        AND (
+          pay.payment_id IS NOT NULL
+          OR COALESCE(pay.paid_amount,0) <> 0
+          OR COALESCE(pay.paid_status,'') <> ''
+          OR pay.paid_at IS NOT NULL
+        )
+   )
    AND NOT EXISTS (SELECT 1 FROM public.jobs j WHERE j.job_id::text=${job})
  RETURNING id, job_id, technician_username, display_amount;
 

--- a/scripts/issue-149-remediation-plan.js
+++ b/scripts/issue-149-remediation-plan.js
@@ -1,0 +1,199 @@
+"use strict";
+
+const fs = require("node:fs");
+
+function money(value) {
+  const n = Number(value || 0);
+  if (!Number.isFinite(n)) return 0;
+  return Math.round(n * 100) / 100;
+}
+
+function sqlString(value) {
+  return `'${String(value == null ? "" : value).replace(/'/g, "''")}'`;
+}
+
+function parseArgs(argv = process.argv.slice(2)) {
+  const opts = { audit: "", finalize: "rollback" };
+  for (const arg of argv) {
+    if (arg.startsWith("--audit=")) opts.audit = arg.split("=").slice(1).join("=");
+    else if (arg === "--finalize=commit") opts.finalize = "commit";
+    else if (arg === "--finalize=rollback") opts.finalize = "rollback";
+  }
+  if (!opts.audit) throw new Error("--audit=issue-149-audit.json is required");
+  return opts;
+}
+
+function loadAudit(file) {
+  const parsed = JSON.parse(fs.readFileSync(file, "utf8"));
+  if (!parsed || parsed.ok !== true || !Array.isArray(parsed.orphan_rows)) {
+    throw new Error("INVALID_AUDIT_JSON");
+  }
+  return parsed;
+}
+
+function groupSafeRows(rows) {
+  const groups = new Map();
+  for (const row of rows.filter((r) => r.classification === "draft/unpaid-safe-to-clean")) {
+    const key = `${row.payout_id}::${row.technician_username}::${row.job_id}`;
+    if (!groups.has(key)) {
+      groups.set(key, {
+        payout_id: row.payout_id,
+        technician_username: row.technician_username,
+        job_id: row.job_id,
+        line_ids: [],
+        adjustment_ids: [],
+        orphan_payout_line_amount: 0,
+        linked_adjustment_amount: 0,
+        deposit_impact: 0,
+        net_impact: 0,
+      });
+    }
+    const g = groups.get(key);
+    if (row.line_id != null) g.line_ids.push(row.line_id);
+    for (const id of row.adjustment_ids || []) {
+      if (id != null && !g.adjustment_ids.includes(id)) g.adjustment_ids.push(id);
+    }
+    g.orphan_payout_line_amount = money(g.orphan_payout_line_amount + Number(row.orphan_payout_line_amount || 0));
+    g.linked_adjustment_amount = money(g.linked_adjustment_amount + Number(row.linked_adjustment_amount || 0));
+    g.deposit_impact = money(g.deposit_impact + Number(row.deposit_impact || 0));
+    g.net_impact = money(g.net_impact + Number(row.net_impact || 0));
+  }
+  return [...groups.values()];
+}
+
+function cleanupSqlForGroup(group) {
+  const pid = sqlString(group.payout_id);
+  const tech = sqlString(group.technician_username);
+  const job = sqlString(group.job_id);
+  return `
+-- A cleanup candidate: payout_id=${group.payout_id}, technician=${group.technician_username}, job_id=${group.job_id}
+-- before_count expected lines=${group.line_ids.length}, adjustments=${group.adjustment_ids.length}
+-- before_total line=${money(group.orphan_payout_line_amount)}, adjustment=${money(group.linked_adjustment_amount)}, deposit_impact=${money(group.deposit_impact)}, net_impact=${money(group.net_impact)}
+-- expected_after lines=0 total=0, adjustments=0 total=0 for this orphan job
+SELECT 'before_lines' AS check_name, COUNT(*)::int AS count, COALESCE(SUM(earn_amount),0)::numeric AS total
+  FROM public.technician_payout_lines
+ WHERE payout_id=${pid}
+   AND technician_username=${tech}
+   AND job_id::text=${job}
+   AND NOT EXISTS (SELECT 1 FROM public.jobs j WHERE j.job_id::text=${job});
+
+SELECT 'before_adjustments' AS check_name, COUNT(*)::int AS count, COALESCE(SUM(adj_amount),0)::numeric AS total
+  FROM public.technician_payout_adjustments
+ WHERE payout_id=${pid}
+   AND technician_username=${tech}
+   AND job_id::text=${job}
+   AND NOT EXISTS (SELECT 1 FROM public.jobs j WHERE j.job_id::text=${job});
+
+DELETE FROM public.technician_payout_adjustments
+ WHERE payout_id=${pid}
+   AND technician_username=${tech}
+   AND job_id::text=${job}
+   AND NOT EXISTS (SELECT 1 FROM public.jobs j WHERE j.job_id::text=${job})
+ RETURNING adj_id, payout_id, technician_username, job_id, adj_amount;
+
+DELETE FROM public.technician_payout_lines
+ WHERE payout_id=${pid}
+   AND technician_username=${tech}
+   AND job_id::text=${job}
+   AND NOT EXISTS (SELECT 1 FROM public.jobs j WHERE j.job_id::text=${job})
+ RETURNING line_id, payout_id, technician_username, job_id, earn_amount;
+
+DELETE FROM public.job_technician_income_preview
+ WHERE technician_username=${tech}
+   AND job_id::text=${job}
+   AND NOT EXISTS (SELECT 1 FROM public.jobs j WHERE j.job_id::text=${job})
+ RETURNING id, job_id, technician_username, income_amount;
+
+DELETE FROM public.technician_job_income_display
+ WHERE technician_username=${tech}
+   AND job_id::text=${job}
+   AND NOT EXISTS (SELECT 1 FROM public.jobs j WHERE j.job_id::text=${job})
+ RETURNING id, job_id, technician_username, display_amount;
+
+SELECT 'after_lines' AS check_name, COUNT(*)::int AS count, COALESCE(SUM(earn_amount),0)::numeric AS total
+  FROM public.technician_payout_lines
+ WHERE payout_id=${pid}
+   AND technician_username=${tech}
+   AND job_id::text=${job};
+
+SELECT 'after_adjustments' AS check_name, COUNT(*)::int AS count, COALESCE(SUM(adj_amount),0)::numeric AS total
+  FROM public.technician_payout_adjustments
+ WHERE payout_id=${pid}
+   AND technician_username=${tech}
+   AND job_id::text=${job};
+`;
+}
+
+function payoutTotalsComments(audit) {
+  const current = audit.current_by_payout || {};
+  const expected = audit.expected_after_safe_cleanup_by_payout || {};
+  const payoutIds = audit.payout_ids || Object.keys(current);
+  const lines = [];
+  for (const payoutId of payoutIds) {
+    const before = current[payoutId] || {};
+    const after = expected[payoutId] || {};
+    lines.push(`-- before_total payout=${payoutId} gross=${money(before.gross_amount)} adj=${money(before.adj_total)} deposit=${money(before.deposit_deduction_amount)} net=${money(before.net_amount)} paid=${money(before.paid_amount)} status=${before.period_status || ""} payment_id=${before.payment_id || ""}`);
+    lines.push(`-- expected_after_safe_cleanup payout=${payoutId} gross=${money(after.expected_gross_amount_after_safe_cleanup)} adj=${money(after.expected_adj_total_after_safe_cleanup)} deposit=${money(after.expected_deposit_deduction_amount_after_safe_cleanup)} net=${money(after.expected_net_amount_after_safe_cleanup)}`);
+  }
+  return lines;
+}
+
+function reconciliationSqlForRow(row) {
+  const correction = money(-Number(row.net_impact || 0));
+  return `
+-- B reconciliation required: payout_id=${row.payout_id}, technician=${row.technician_username}, job_id=${row.job_id}
+-- Do not delete payout history. Preserve payment_id=${row.payment_id || ""}, paid_status=${row.paid_status || ""}, paid_amount=${money(row.paid_amount || 0)}.
+-- original_orphan_impact line=${money(row.orphan_payout_line_amount)}, adjustment=${money(row.linked_adjustment_amount)}, deposit=${money(row.deposit_impact)}, net=${money(row.net_impact)}
+-- Proposed accounting correction after finance approval:
+-- INSERT INTO public.technician_payout_adjustments(payout_id, technician_username, job_id, adj_amount, reason, created_by)
+-- VALUES(${sqlString(row.payout_id)}, ${sqlString(row.technician_username)}, ${sqlString(row.job_id)}, ${correction},
+--        'Issue #149 reconciliation for deleted job preserved in locked/paid payout history', 'issue-149-approved-remediation');
+-- Then re-open/reconcile paid status through the accounting payout adjustment flow so payment history remains explicit.
+`;
+}
+
+function buildPlan(audit, { finalize = "rollback" } = {}) {
+  const safeGroups = groupSafeRows(audit.orphan_rows);
+  const blockedRows = audit.orphan_rows.filter((r) => r.classification === "locked/paid/payment-linked-reconciliation-required");
+  const lines = [];
+  lines.push("-- Issue #149 remediation plan generated from read-only audit JSON.");
+  lines.push("-- Do not run on production until owner approves the exact audit result and this plan.");
+  lines.push(`-- technician=${audit.technician_username}, work_month=${audit.work_month}, payout_ids=${(audit.payout_ids || []).join(",")}`);
+  lines.push(...payoutTotalsComments(audit));
+  lines.push("BEGIN;");
+  lines.push("SET LOCAL statement_timeout = '45s';");
+  lines.push("SET LOCAL lock_timeout = '5s';");
+  lines.push("");
+  lines.push("-- Phase C/A: draft/unpaid-safe-to-clean targeted cleanup");
+  if (!safeGroups.length) lines.push("-- No A cleanup rows in audit.");
+  for (const group of safeGroups) lines.push(cleanupSqlForGroup(group));
+  lines.push("");
+  lines.push("-- Phase C/B: locked/paid/payment-linked reconciliation proposals");
+  if (!blockedRows.length) lines.push("-- No B reconciliation rows in audit.");
+  for (const row of blockedRows) lines.push(reconciliationSqlForRow(row));
+  lines.push("");
+  lines.push(finalize === "commit" ? "COMMIT;" : "ROLLBACK; -- default safety: review returned rows before changing to COMMIT after approval");
+  return lines.join("\n");
+}
+
+function main() {
+  const opts = parseArgs();
+  const audit = loadAudit(opts.audit);
+  process.stdout.write(buildPlan(audit, opts));
+}
+
+if (require.main === module) {
+  try {
+    main();
+  } catch (err) {
+    console.error(err && err.stack || err);
+    process.exitCode = 1;
+  }
+}
+
+module.exports = {
+  parseArgs,
+  loadAudit,
+  groupSafeRows,
+  buildPlan,
+};

--- a/server/services/technicianPayoutIntegrity.js
+++ b/server/services/technicianPayoutIntegrity.js
@@ -397,7 +397,7 @@ function orphanClassificationSql() {
            OR COALESCE(pay.paid_status,'') IN ('partial','paid')
            OR pay.paid_at IS NOT NULL
          THEN 'locked/paid/payment-linked-reconciliation-required'
-         ELSE 'draft/unpaid-safe-to-review'
+         ELSE 'draft/unpaid-safe-to-clean'
        END`;
 }
 

--- a/sw.js
+++ b/sw.js
@@ -1,5 +1,5 @@
 /* CWF root service worker: Tech App shell/cache refresh */
-const CWF_TECH_BUILD_ID = "20260622_urgent_offer_session_v1";
+const CWF_TECH_BUILD_ID = "20260710_payout_no_pay_status_v1";
 const CWF_ACCOUNTING_CACHE_BUMP = "20260703_accounting_payout_adjustment_v1";
 const CACHE_PREFIX = "cwf-root-tech-app-";
 const CACHE_NAME = `${CACHE_PREFIX}${CWF_TECH_BUILD_ID}-${CWF_ACCOUNTING_CACHE_BUMP}`;

--- a/tech.html
+++ b/tech.html
@@ -8,10 +8,10 @@
   <link rel="manifest" href="/manifest.json">
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-  <meta name="cwf-tech-build" content="20260622_urgent_offer_session_v1">
+  <meta name="cwf-tech-build" content="20260710_payout_no_pay_status_v1">
   <title>หน้าช่าง - CWF</title>
   <link rel="stylesheet" href="style.css">
-  <script defer src="/cwf-pwa.js?v=20260622_urgent_offer_session_v1"></script>
+  <script defer src="/cwf-pwa.js?v=20260710_payout_no_pay_status_v1"></script>
 
   <style>
     :root{
@@ -3433,7 +3433,7 @@
     }
   </style>
 
-<script src="app.js?v=20260622_urgent_offer_session_v1"></script>
+<script src="app.js?v=20260710_payout_no_pay_status_v1"></script>
   <script src="tech-onboarding.js?v=phase2a-fix-restore-onboarding-panel"></script>
   <script>
         function goEditProfile(){ location.href = '/edit-profile.html'; }

--- a/test/techCacheBuild.test.js
+++ b/test/techCacheBuild.test.js
@@ -4,7 +4,7 @@ const fs = require("node:fs");
 const path = require("node:path");
 
 const root = path.join(__dirname, "..");
-const BUILD = "20260622_urgent_offer_session_v1";
+const BUILD = "20260710_payout_no_pay_status_v1";
 
 function read(file) {
   return fs.readFileSync(path.join(root, file), "utf8");

--- a/test/technicianPayoutIntegrity.test.js
+++ b/test/technicianPayoutIntegrity.test.js
@@ -2,6 +2,7 @@ const test = require("node:test");
 const assert = require("node:assert/strict");
 
 const payoutIntegrity = require("../server/services/technicianPayoutIntegrity");
+const depositCollections = require("../server/services/technicianDepositCollections");
 const auditScript = require("../scripts/audit-orphan-payout-lines");
 const closeoutAudit = require("../scripts/issue-149-closeout-audit");
 const remediationPlan = require("../scripts/issue-149-remediation-plan");
@@ -276,6 +277,100 @@ function moneyFields(row) {
   };
 }
 
+class FakeCloseoutAuditClient {
+  constructor({ periods = [], jobs = [], lines = [], adjustments = [], payments = [], deposits = [], previews = [], displays = [] } = {}) {
+    this.periods = periods;
+    this.jobs = new Set(jobs.map((id) => String(id)));
+    this.lines = lines;
+    this.adjustments = adjustments;
+    this.payments = payments;
+    this.deposits = deposits;
+    this.previews = previews;
+    this.displays = displays;
+  }
+
+  async query(sql, params = []) {
+    const s = normSql(sql);
+    const rowsForPayouts = (rows, technician, payoutIds) => rows
+      .filter((row) => String(row.technician_username) === String(technician) && payoutIds.includes(String(row.payout_id)));
+    if (s.includes("FROM public.technician_payout_periods")) {
+      const payoutIds = params[0].map(String);
+      return { rows: this.periods.filter((row) => payoutIds.includes(String(row.payout_id))).map((row) => ({ ...row })) };
+    }
+    if (s.includes("FROM public.technician_payout_lines l")) {
+      const [technician, payoutIds] = params;
+      return {
+        rows: rowsForPayouts(this.lines, technician, payoutIds.map(String))
+          .filter((row) => !this.jobs.has(String(row.job_id)))
+          .map((row) => ({ ...row, job_id: String(row.job_id), earn_amount: Number(row.earn_amount || 0) })),
+      };
+    }
+    if (s.includes("FROM public.technician_payout_lines")) {
+      const [technician, payoutIds] = params;
+      return {
+        rows: rowsForPayouts(this.lines, technician, payoutIds.map(String))
+          .map((row) => ({ ...row, job_id: String(row.job_id), earn_amount: Number(row.earn_amount || 0) })),
+      };
+    }
+    if (s.includes("FROM public.technician_payout_adjustments a")) {
+      const [technician, payoutIds] = params;
+      return {
+        rows: rowsForPayouts(this.adjustments, technician, payoutIds.map(String))
+          .filter((row) => row.job_id != null && !this.jobs.has(String(row.job_id)))
+          .map((row) => ({ ...row, job_id: String(row.job_id), adj_amount: Number(row.adj_amount || 0) })),
+      };
+    }
+    if (s.includes("FROM public.technician_payout_adjustments")) {
+      const [technician, payoutIds] = params;
+      return {
+        rows: rowsForPayouts(this.adjustments, technician, payoutIds.map(String))
+          .map((row) => ({ ...row, job_id: row.job_id == null ? null : String(row.job_id), adj_amount: Number(row.adj_amount || 0) })),
+      };
+    }
+    if (s.includes("FROM public.technician_payout_payments")) {
+      const [technician, payoutIds] = params;
+      return { rows: rowsForPayouts(this.payments, technician, payoutIds.map(String)).map((row) => ({ ...row })) };
+    }
+    if (s.includes("FROM public.technician_deposit_ledger")) {
+      const [technician, payoutIds] = params;
+      return { rows: rowsForPayouts(this.deposits, technician, payoutIds.map(String)).map((row) => ({ ...row })) };
+    }
+    if (s.includes("FROM public.job_technician_income_preview")) {
+      const [technician] = params;
+      return {
+        rows: this.previews
+          .filter((row) => String(row.technician_username) === String(technician) && !this.jobs.has(String(row.job_id)))
+          .map((row) => ({ ...row, job_id: String(row.job_id), income_amount: Number(row.income_amount || 0) })),
+      };
+    }
+    if (s.includes("FROM public.technician_job_income_display")) {
+      const [technician] = params;
+      return {
+        rows: this.displays
+          .filter((row) => String(row.technician_username) === String(technician) && !this.jobs.has(String(row.job_id)))
+          .map((row) => ({ ...row, job_id: String(row.job_id), display_amount: Number(row.display_amount || 0) })),
+      };
+    }
+    throw new Error(`Unhandled closeout audit SQL: ${s}`);
+  }
+}
+
+async function summarizeCloseoutWithFakeClient(data) {
+  const original = depositCollections.getProjectedDepositDeductionForPayout;
+  depositCollections.getProjectedDepositDeductionForPayout = async (_client, { gross_amount, adj_total }) => ({
+    deposit_deduction_amount: 0,
+    deposit_projection_reason: Number(gross_amount || 0) + Number(adj_total || 0) > 0 ? "test_no_deduction" : "no_income",
+  });
+  try {
+    return await closeoutAudit.summarizeAudit(new FakeCloseoutAuditClient(data), {
+      technician: "0661479791",
+      workMonth: "2026-06",
+    });
+  } finally {
+    depositCollections.getProjectedDepositDeductionForPayout = original;
+  }
+}
+
 async function assertMutableForPayout(db, jobId, context, calls) {
   calls.push({ jobId, context });
   const impact = await payoutIntegrity.inspectJobPayoutDeleteImpact(db, jobId);
@@ -490,6 +585,121 @@ test("issue 149 closeout audit targets the June work-month payout ids and produc
   assert.match(closeoutAudit.dryRunText({ technician: "0661479791", workMonth: "2026-06" }), /--allow-production-read/);
 });
 
+test("issue 149 closeout summarizeAudit runs with no orphan rows", async () => {
+  const result = await summarizeCloseoutWithFakeClient({
+    periods: [
+      { payout_id: "payout_2026-06_25", status: "draft" },
+      { payout_id: "payout_2026-07_10", status: "draft" },
+    ],
+    jobs: ["501"],
+    lines: [
+      { line_id: 1, payout_id: "payout_2026-06_25", technician_username: "0661479791", job_id: "501", earn_amount: 700 },
+    ],
+    previews: [
+      { id: 1, job_id: "999", technician_username: "0661479791", income_amount: 999 },
+    ],
+    displays: [
+      { id: 2, job_id: "999", technician_username: "0661479791", display_amount: 999 },
+    ],
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.orphan_rows.length, 0);
+  assert.equal(result.totals.orphan_rows, 0);
+  assert.deepEqual(result.cache_orphan_rows.job_technician_income_preview, []);
+  assert.deepEqual(result.cache_orphan_rows.technician_job_income_display, []);
+  assert.equal(result.current_by_payout["payout_2026-06_25"].net_amount, 700);
+});
+
+test("issue 149 closeout summarizeAudit reports draft orphan rows and scoped cache impact", async () => {
+  const result = await summarizeCloseoutWithFakeClient({
+    periods: [
+      { payout_id: "payout_2026-06_25", status: "draft" },
+      { payout_id: "payout_2026-07_10", status: "draft" },
+    ],
+    jobs: [],
+    lines: [
+      { line_id: 11, payout_id: "payout_2026-06_25", technician_username: "0661479791", job_id: "501", earn_amount: 1000 },
+    ],
+    adjustments: [
+      { adj_id: 20, payout_id: "payout_2026-06_25", technician_username: "0661479791", job_id: "501", adj_amount: 100 },
+    ],
+    previews: [
+      { id: 1, job_id: "501", technician_username: "0661479791", income_amount: 1100 },
+      { id: 2, job_id: "999", technician_username: "0661479791", income_amount: 999 },
+    ],
+    displays: [
+      { id: 3, job_id: "501", technician_username: "0661479791", display_amount: 1100 },
+      { id: 4, job_id: "999", technician_username: "0661479791", display_amount: 999 },
+    ],
+  });
+
+  assert.equal(result.orphan_rows.length, 1);
+  assert.equal(result.orphan_rows[0].classification, "draft/unpaid-safe-to-clean");
+  assert.deepEqual(result.orphan_rows[0].line_ids, [11]);
+  assert.equal(result.orphan_rows[0].orphan_payout_line_amount, 1000);
+  assert.equal(result.orphan_rows[0].linked_adjustment_amount, 100);
+  assert.deepEqual(result.orphan_rows[0].adjustment_ids, [20]);
+  assert.deepEqual(result.cache_orphan_rows.job_technician_income_preview.map((row) => row.job_id), ["501"]);
+  assert.deepEqual(result.cache_orphan_rows.technician_job_income_display.map((row) => row.job_id), ["501"]);
+  assert.equal(result.expected_after_safe_cleanup_by_payout["payout_2026-06_25"].expected_gross_amount_after_safe_cleanup, 0);
+  assert.equal(result.expected_after_safe_cleanup_by_payout["payout_2026-06_25"].expected_adj_total_after_safe_cleanup, 0);
+});
+
+test("issue 149 closeout summarizeAudit classifies locked and payment-linked orphans as reconciliation-required", async () => {
+  const result = await summarizeCloseoutWithFakeClient({
+    periods: [
+      { payout_id: "payout_2026-06_25", status: "locked" },
+      { payout_id: "payout_2026-07_10", status: "draft" },
+    ],
+    jobs: [],
+    lines: [
+      { line_id: 21, payout_id: "payout_2026-06_25", technician_username: "0661479791", job_id: "601", earn_amount: 800 },
+      { line_id: 22, payout_id: "payout_2026-07_10", technician_username: "0661479791", job_id: "602", earn_amount: 900 },
+    ],
+    payments: [
+      { payment_id: 30, payout_id: "payout_2026-07_10", technician_username: "0661479791", paid_amount: 0, paid_status: "unpaid", paid_at: null },
+    ],
+  });
+
+  assert.equal(result.orphan_rows.length, 2);
+  assert.deepEqual(result.orphan_rows.map((row) => row.classification), [
+    "locked/paid/payment-linked-reconciliation-required",
+    "locked/paid/payment-linked-reconciliation-required",
+  ]);
+  assert.equal(result.totals.by_classification["locked/paid/payment-linked-reconciliation-required"].rows, 2);
+  assert.equal(result.expected_after_safe_cleanup_by_payout["payout_2026-06_25"].expected_gross_amount_after_safe_cleanup, 800);
+  assert.equal(result.expected_after_safe_cleanup_by_payout["payout_2026-07_10"].expected_gross_amount_after_safe_cleanup, 900);
+});
+
+test("issue 149 closeout summarizeAudit dedupes one linked adjustment across multiple orphan payout lines", async () => {
+  const result = await summarizeCloseoutWithFakeClient({
+    periods: [
+      { payout_id: "payout_2026-06_25", status: "draft" },
+      { payout_id: "payout_2026-07_10", status: "draft" },
+    ],
+    jobs: [],
+    lines: [
+      { line_id: 41, payout_id: "payout_2026-06_25", technician_username: "0661479791", job_id: "701", earn_amount: 600 },
+      { line_id: 42, payout_id: "payout_2026-06_25", technician_username: "0661479791", job_id: "701", earn_amount: 400 },
+    ],
+    adjustments: [
+      { adj_id: 50, payout_id: "payout_2026-06_25", technician_username: "0661479791", job_id: "701", adj_amount: 100 },
+    ],
+  });
+
+  assert.equal(result.orphan_rows.length, 1);
+  assert.equal(result.orphan_rows[0].line_id, null);
+  assert.deepEqual(result.orphan_rows[0].line_ids, [41, 42]);
+  assert.deepEqual(result.orphan_rows[0].adjustment_ids, [50]);
+  assert.equal(result.orphan_rows[0].orphan_payout_line_amount, 1000);
+  assert.equal(result.orphan_rows[0].linked_adjustment_amount, 100);
+  assert.equal(result.totals.linked_adjustment_amount, 100);
+  assert.equal(result.totals.net_impact, 1100);
+  assert.equal(result.expected_after_safe_cleanup_by_payout["payout_2026-06_25"].expected_gross_amount_after_safe_cleanup, 0);
+  assert.equal(result.expected_after_safe_cleanup_by_payout["payout_2026-06_25"].expected_adj_total_after_safe_cleanup, 0);
+});
+
 test("issue 149 remediation plan emits only targeted cleanup SQL and keeps B rows as reconciliation comments", () => {
   const plan = remediationPlan.buildPlan({
     ok: true,
@@ -521,7 +731,8 @@ test("issue 149 remediation plan emits only targeted cleanup SQL and keeps B row
         payout_id: "payout_2026-06_25",
         technician_username: "0661479791",
         job_id: "501",
-        line_id: 10,
+        line_id: null,
+        line_ids: [10, 11],
         adjustment_ids: [20],
         orphan_payout_line_amount: 1000,
         linked_adjustment_amount: 100,
@@ -546,6 +757,17 @@ test("issue 149 remediation plan emits only targeted cleanup SQL and keeps B row
 
   assert.match(plan, /WHERE payout_id='payout_2026-06_25'\s+AND technician_username='0661479791'\s+AND job_id::text='501'/);
   assert.match(plan, /NOT EXISTS \(SELECT 1 FROM public\.jobs/);
+  assert.match(plan, /pg_advisory_xact_lock\(hashtext\('issue-149-remediation:payout_2026-06_25:0661479791'\)\)/);
+  assert.match(plan, /FOR UPDATE/);
+  assert.match(plan, /lower\(COALESCE\(v_period_status,'draft'\)\) <> 'draft'/);
+  assert.match(plan, /pay\.payment_id IS NOT NULL/);
+  assert.match(plan, /COALESCE\(pay\.paid_amount,0\) <> 0/);
+  assert.match(plan, /COALESCE\(pay\.paid_status,''\) <> ''/);
+  assert.match(plan, /pay\.paid_at IS NOT NULL/);
+  assert.match(plan, /IF v_line_count <> 2 OR v_line_total <> 1000::numeric THEN/);
+  assert.match(plan, /IF v_adjustment_count <> 1 OR v_adjustment_total <> 100::numeric THEN/);
+  assert.match(plan, /RAISE EXCEPTION 'Issue 149 cleanup blocked: payout line mismatch/);
+  assert.match(plan, /RAISE EXCEPTION 'Issue 149 cleanup blocked: adjustment mismatch/);
   assert.match(plan, /before_total payout=payout_2026-06_25 gross=1000 adj=100 deposit=500 net=600/);
   assert.match(plan, /expected_after_safe_cleanup payout=payout_2026-06_25 gross=0 adj=0 deposit=0 net=0/);
   assert.match(plan, /expected_after lines=0 total=0, adjustments=0 total=0/);

--- a/test/technicianPayoutIntegrity.test.js
+++ b/test/technicianPayoutIntegrity.test.js
@@ -3,6 +3,8 @@ const assert = require("node:assert/strict");
 
 const payoutIntegrity = require("../server/services/technicianPayoutIntegrity");
 const auditScript = require("../scripts/audit-orphan-payout-lines");
+const closeoutAudit = require("../scripts/issue-149-closeout-audit");
+const remediationPlan = require("../scripts/issue-149-remediation-plan");
 
 function normSql(sql) {
   return String(sql || "").replace(/\s+/g, " ").trim();
@@ -455,7 +457,7 @@ test("orphan payout audit is read-only, classifies rows, and normalizes limit", 
   const sql = payoutIntegrity.orphanPayoutLinesAuditSql({ limit: "50.5" });
   assert.match(sql, /SELECT l\.payout_id/);
   assert.match(sql, /classification/);
-  assert.match(sql, /draft\/unpaid-safe-to-review/);
+  assert.match(sql, /draft\/unpaid-safe-to-clean/);
   assert.match(sql, /locked\/paid\/payment-linked-reconciliation-required/);
   assert.match(sql, /LIMIT 50\b/);
   assert.doesNotMatch(sql, /\bUPDATE\b|\bDELETE\b|\bINSERT\b|\bALTER\b|\bDROP\b/i);
@@ -469,4 +471,86 @@ test("orphan payout audit is read-only, classifies rows, and normalizes limit", 
   });
   assert.equal(auditScript.shouldRefuseProductionExecution({ NODE_ENV: "production" }), true);
   assert.equal(auditScript.shouldRefuseProductionExecution({ NODE_ENV: "test" }), false);
+});
+
+test("issue 149 closeout audit targets the June work-month payout ids and production read flag", () => {
+  assert.deepEqual(closeoutAudit.payoutIdsForWorkMonth("2026-06"), ["payout_2026-06_25", "payout_2026-07_10"]);
+  assert.equal(closeoutAudit.classify({
+    period: { status: "draft" },
+    payment: null,
+  }), "draft/unpaid-safe-to-clean");
+  assert.equal(closeoutAudit.classify({
+    period: { status: "locked" },
+    payment: null,
+  }), "locked/paid/payment-linked-reconciliation-required");
+  assert.equal(closeoutAudit.classify({
+    period: { status: "draft" },
+    payment: { payment_id: 12, paid_amount: 0, paid_status: "unpaid" },
+  }), "locked/paid/payment-linked-reconciliation-required");
+  assert.match(closeoutAudit.dryRunText({ technician: "0661479791", workMonth: "2026-06" }), /--allow-production-read/);
+});
+
+test("issue 149 remediation plan emits only targeted cleanup SQL and keeps B rows as reconciliation comments", () => {
+  const plan = remediationPlan.buildPlan({
+    ok: true,
+    technician_username: "0661479791",
+    work_month: "2026-06",
+    payout_ids: ["payout_2026-06_25", "payout_2026-07_10"],
+    current_by_payout: {
+      "payout_2026-06_25": {
+        gross_amount: 1000,
+        adj_total: 100,
+        deposit_deduction_amount: 500,
+        net_amount: 600,
+        paid_amount: 0,
+        period_status: "draft",
+        payment_id: null,
+      },
+    },
+    expected_after_safe_cleanup_by_payout: {
+      "payout_2026-06_25": {
+        expected_gross_amount_after_safe_cleanup: 0,
+        expected_adj_total_after_safe_cleanup: 0,
+        expected_deposit_deduction_amount_after_safe_cleanup: 0,
+        expected_net_amount_after_safe_cleanup: 0,
+      },
+    },
+    orphan_rows: [
+      {
+        classification: "draft/unpaid-safe-to-clean",
+        payout_id: "payout_2026-06_25",
+        technician_username: "0661479791",
+        job_id: "501",
+        line_id: 10,
+        adjustment_ids: [20],
+        orphan_payout_line_amount: 1000,
+        linked_adjustment_amount: 100,
+        deposit_impact: 500,
+        net_impact: 600,
+      },
+      {
+        classification: "locked/paid/payment-linked-reconciliation-required",
+        payout_id: "payout_2026-07_10",
+        technician_username: "0661479791",
+        job_id: "502",
+        payment_id: 30,
+        paid_status: "paid",
+        paid_amount: 900,
+        orphan_payout_line_amount: 900,
+        linked_adjustment_amount: 0,
+        deposit_impact: 0,
+        net_impact: 900,
+      },
+    ],
+  });
+
+  assert.match(plan, /WHERE payout_id='payout_2026-06_25'\s+AND technician_username='0661479791'\s+AND job_id::text='501'/);
+  assert.match(plan, /NOT EXISTS \(SELECT 1 FROM public\.jobs/);
+  assert.match(plan, /before_total payout=payout_2026-06_25 gross=1000 adj=100 deposit=500 net=600/);
+  assert.match(plan, /expected_after_safe_cleanup payout=payout_2026-06_25 gross=0 adj=0 deposit=0 net=0/);
+  assert.match(plan, /expected_after lines=0 total=0, adjustments=0 total=0/);
+  assert.match(plan, /ROLLBACK; -- default safety/);
+  assert.match(plan, /B reconciliation required/);
+  assert.doesNotMatch(plan, /DELETE FROM public\.technician_payout_lines\s*;/);
+  assert.doesNotMatch(plan, /DELETE FROM public\.technician_payout_adjustments\s*;/);
 });

--- a/test/technicianPayoutUiStatus.test.js
+++ b/test/technicianPayoutUiStatus.test.js
@@ -128,6 +128,26 @@ test("technician payout display status maps payable states without mutating paid
   assert.deepEqual(Array.from(statuses), ["ไม่มียอดจ่าย", "รอจ่าย", "จ่ายบางส่วน", "จ่ายแล้ว"]);
 });
 
+test("technician payout display status preserves exceptional paid_status values unless the period has no payable amount", () => {
+  const { run } = createAppSandbox();
+  const result = run(`({
+    hold: _payoutPaymentDisplayStatusTH({ net_amount: 1000, paid_amount: 0, remaining_amount: 1000, paid_status: "hold" }),
+    holdExpected: _paidStatusTH("hold"),
+    disputed: _payoutPaymentDisplayStatusTH({ net_amount: 1000, paid_amount: 400, remaining_amount: 600, paid_status: "disputed" }),
+    disputedExpected: _paidStatusTH("disputed"),
+    cancelled: _payoutPaymentDisplayStatusTH({ net_amount: 1000, paid_amount: 1000, remaining_amount: 0, paid_status: "cancelled" }),
+    cancelledExpected: _paidStatusTH("cancelled"),
+    noPay: _payoutPaymentDisplayStatusTH({ net_amount: 0, paid_amount: 0, remaining_amount: 0, paid_status: "hold" }),
+    noPayExpected: _payoutPaymentDisplayStatusTH({ net_amount: 0, paid_amount: 0, remaining_amount: 0, paid_status: "unpaid" })
+  })`);
+
+  assert.equal(result.hold, result.holdExpected);
+  assert.equal(result.disputed, result.disputedExpected);
+  assert.equal(result.cancelled, result.cancelledExpected);
+  assert.equal(result.noPay, result.noPayExpected);
+  assert.notEqual(result.noPay, result.holdExpected);
+});
+
 test("technician payout list renders no-pay and payable statuses from the same display rule", () => {
   const { run, elements } = createAppSandbox();
   run(`renderTechPayoutPeriods([

--- a/test/technicianPayoutUiStatus.test.js
+++ b/test/technicianPayoutUiStatus.test.js
@@ -1,0 +1,193 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const vm = require("node:vm");
+
+function createElement(id = "") {
+  const style = {
+    setProperty(name, value) { this[name] = value; },
+    removeProperty(name) { delete this[name]; },
+  };
+  return {
+    id,
+    innerHTML: "",
+    textContent: "",
+    value: "",
+    dataset: {},
+    style,
+    hidden: false,
+    classList: {
+      add() {},
+      remove() {},
+      toggle() {},
+      contains() { return false; },
+    },
+    addEventListener() {},
+    removeEventListener() {},
+    appendChild() {},
+    setAttribute() {},
+    getAttribute() { return null; },
+    querySelector() { return null; },
+    querySelectorAll() { return []; },
+    closest() { return null; },
+  };
+}
+
+function createAppSandbox({ fetchResponse } = {}) {
+  const elements = new Map();
+  const document = {
+    body: { dataset: {}, style: createElement("body").style, classList: { add() {}, remove() {}, toggle() {} } },
+    cookie: "",
+    documentElement: { style: createElement("documentElement").style },
+    getElementById(id) {
+      if (!elements.has(id)) elements.set(id, createElement(id));
+      return elements.get(id);
+    },
+    querySelector() { return createElement(); },
+    querySelectorAll() { return []; },
+    createElement,
+    addEventListener() {},
+    removeEventListener() {},
+  };
+  const storage = new Map([
+    ["username", "0661479791"],
+    ["role", "technician"],
+  ]);
+  const localStorage = {
+    getItem(key) { return storage.has(key) ? storage.get(key) : null; },
+    setItem(key, value) { storage.set(key, String(value)); },
+    removeItem(key) { storage.delete(key); },
+  };
+  const location = {
+    origin: "https://example.test",
+    href: "https://example.test/tech.html",
+    hash: "",
+  };
+  const sandbox = {
+    console: { log() {}, info() {}, warn() {}, error() {} },
+    window: {},
+    document,
+    localStorage,
+    location,
+    navigator: { serviceWorker: { register: async () => ({}), ready: Promise.resolve({}) } },
+    Notification: function Notification() {},
+    PushManager: function PushManager() {},
+    FormData: class FormData {},
+    FileReader: class FileReader {},
+    Blob,
+    URL,
+    URLSearchParams,
+    Date,
+    Math,
+    Number,
+    String,
+    Array,
+    Object,
+    JSON,
+    RegExp,
+    Promise,
+    parseInt,
+    parseFloat,
+    isNaN,
+    setTimeout() { return 1; },
+    clearTimeout() {},
+    setInterval() { return 1; },
+    clearInterval() {},
+    addEventListener() {},
+    removeEventListener() {},
+    alert() {},
+    confirm() { return true; },
+    fetch: async () => ({
+      json: async () => fetchResponse || { ok: true },
+    }),
+  };
+  sandbox.window = sandbox;
+  sandbox.globalThis = sandbox;
+  vm.createContext(sandbox);
+  const appSource = fs.readFileSync(path.join(__dirname, "..", "app.js"), "utf8");
+  vm.runInContext(appSource, sandbox, { filename: "app.js" });
+  return {
+    sandbox,
+    elements,
+    run(code) {
+      return vm.runInContext(code, sandbox);
+    },
+  };
+}
+
+test("technician payout display status maps payable states without mutating paid_status", () => {
+  const { run } = createAppSandbox();
+  const statuses = run(`[
+    _payoutPaymentDisplayStatusTH({ net_amount: 0, paid_amount: 0, remaining_amount: 0, paid_status: "unpaid" }),
+    _payoutPaymentDisplayStatusTH({ net_amount: 1000, paid_amount: 0, remaining_amount: 1000, paid_status: "unpaid" }),
+    _payoutPaymentDisplayStatusTH({ net_amount: 1000, paid_amount: 400, remaining_amount: 600, paid_status: "partial" }),
+    _payoutPaymentDisplayStatusTH({ net_amount: 1000, paid_amount: 1000, remaining_amount: 0, paid_status: "paid" })
+  ]`);
+
+  assert.deepEqual(Array.from(statuses), ["ไม่มียอดจ่าย", "รอจ่าย", "จ่ายบางส่วน", "จ่ายแล้ว"]);
+});
+
+test("technician payout list renders no-pay and payable statuses from the same display rule", () => {
+  const { run, elements } = createAppSandbox();
+  run(`renderTechPayoutPeriods([
+    {
+      payout_id: "payout_2026-06_25",
+      period_type: "25",
+      period_start: "2026-06-01T00:00:00.000Z",
+      period_end: "2026-06-16T00:00:00.000Z",
+      status: "locked",
+      gross_amount: 0,
+      deposit_deduction_amount: 0,
+      net_amount: 0,
+      paid_amount: 0,
+      remaining_amount: 0,
+      paid_status: "unpaid"
+    },
+    {
+      payout_id: "payout_2026-07_10",
+      period_type: "10",
+      period_start: "2026-06-16T00:00:00.000Z",
+      period_end: "2026-07-01T00:00:00.000Z",
+      status: "locked",
+      gross_amount: 1000,
+      deposit_deduction_amount: 0,
+      net_amount: 1000,
+      paid_amount: 400,
+      remaining_amount: 600,
+      paid_status: "partial"
+    }
+  ])`);
+
+  const html = elements.get("techPayoutPeriods").innerHTML;
+  assert.match(html, /จ่าย: ไม่มียอดจ่าย/);
+  assert.match(html, /จ่าย: จ่ายบางส่วน/);
+});
+
+test("technician payout detail modal uses the same no-pay display rule as the list", async () => {
+  const { run, elements } = createAppSandbox({
+    fetchResponse: {
+      ok: true,
+      payout_id: "payout_2026-06_25",
+      period_type: "25",
+      period_start: "2026-06-01T00:00:00.000Z",
+      period_end: "2026-06-16T00:00:00.000Z",
+      status: "locked",
+      gross_amount: 0,
+      adj_total: 0,
+      deposit_deduction_amount: 0,
+      net_amount: 0,
+      total_amount: 0,
+      paid_amount: 0,
+      remaining_amount: 0,
+      paid_status: "unpaid",
+      lines: [],
+      adjustments: [],
+      payment: null,
+    },
+  });
+
+  await run(`openTechPayoutDetail("payout_2026-06_25")`);
+
+  assert.match(elements.get("techPayoutModalSub").textContent, /ไม่มียอดจ่าย/);
+});


### PR DESCRIPTION
## Summary
- Fixes Tech App payout payment-status display so `net_amount=0` and `remaining_amount=0` renders `ไม่มียอดจ่าย` without creating/changing payment rows.
- Applies the same display rule to the payout list and payout detail modal, with cache-bust updates for Tech App assets.
- Adds scoped Issue #149 production read-only audit tooling and a generated remediation-plan script that defaults to `ROLLBACK`.
- Addresses FINAL REVIEW blockers: `summarizeAudit()` runtime ordering, behavior-level summarize tests, remediation execution-time guards, exceptional UI statuses, and duplicate adjustment impact.

## Root Cause
The UI mapped payment text directly from `paid_status`, so a zero-net/zero-remaining payout with `paid_status='unpaid'` rendered `รอจ่าย` even though there was no payable amount. This was a display-layer truth bug, not a payment-row mutation requirement.

For deleted jobs still counted in historical payouts, the code path must be determined from production rows: orphan payout lines, linked adjustments, income preview/display cache, or locked/paid snapshots. This PR adds targeted read-only audit and plan-generation tooling for that verification; it does not write production data.

## Production Read-Only Audit Status
Attempted the owner-approved read-only audit locally, but this environment has no production DB credentials/env:

```powershell
$env:NODE_ENV='production'; node scripts\issue-149-closeout-audit.js --run --json --allow-production-read --technician=0661479791 --month=2026-06; Remove-Item Env:NODE_ENV
```

Result:

```text
Error: PRODUCTION_DATABASE_URL or DATABASE_URL or DB_* env is required
```

Ops/owner command to run with production read-only credentials:

```bash
NODE_ENV=production node scripts/issue-149-closeout-audit.js --run --json --allow-production-read --technician=0661479791 --month=2026-06 > issue-149-prod-audit-0661479791-2026-06.json
node scripts/issue-149-remediation-plan.js --audit=issue-149-prod-audit-0661479791-2026-06.json > issue-149-remediation-plan.sql
```

The audit targets only `0661479791`, work month `2026-06`, payout IDs `payout_2026-06_25` and `payout_2026-07_10`, and reports exact rows/classifications/impacts. No production write, delete, update, migration, deploy, auth, config, or payment gateway change is included.

## Tests
- PASS: `node --check app.js scripts/issue-149-closeout-audit.js scripts/issue-149-remediation-plan.js test/technicianPayoutIntegrity.test.js test/technicianPayoutUiStatus.test.js`
- PASS: `node --test test\technicianPayoutIntegrity.test.js test\technicianPayoutUiStatus.test.js test\techCacheBuild.test.js test\technicianDepositCollections.test.js test\accountingPayoutAdjustments.test.js` (58/58)
- FAIL with pre-existing baseline failures: branch `npm test` -> 925 pass, 20 fail, 11 skipped. Failures are the same `test\adminStoreCatalogUi.test.js` missing-function/template assertions seen on base `027d8cb70f11782ff60d2f7a4e726cb8c657dfcc`.
- Base comparison rerun from `origin/main` -> 915 pass, 20 fail, 11 skipped, same `adminStoreCatalogUi.test.js` failure set.

## Remediation Guardrails
- A (`draft/unpaid-safe-to-clean`): generated SQL uses exact `payout_id + technician_username + job_id`, `NOT EXISTS(public.jobs...)`, before/after counts/totals, transaction, execution-time period/payment/count/amount guards with `RAISE EXCEPTION`, and default `ROLLBACK`.
- B (`locked/paid/payment-linked-reconciliation-required`): generated plan emits comments only; it preserves paid/locked history and requires explicit finance-approved compensating adjustment/accounting correction.

Issue #149 is not fully closeable until the production audit JSON is produced and owner approves any production remediation write.