### PR TITLE
Add legacy customer claim and history prefill

### DIFF
--- a/customer-app/assets/customer-app.js
+++ b/customer-app/assets/customer-app.js
@@ -3,7 +3,7 @@
 
   const App = window.CWFCustomerAppV2;
   const BOOT_TIMEOUT_MS = 3500;
-  const BUILD_ID = "20260709_review_legacy_v1";
+  const BUILD_ID = "20260710_legacy_claim_v1";
 
   function withTimeout(promise, timeoutMs) {
     return Promise.race([

--- a/customer-app/assets/customer-app.js
+++ b/customer-app/assets/customer-app.js
@@ -3,7 +3,7 @@
 
   const App = window.CWFCustomerAppV2;
   const BOOT_TIMEOUT_MS = 3500;
-  const BUILD_ID = "20260710_legacy_claim_v1";
+  const BUILD_ID = "20260710_legacy_claim_v2";
 
   function withTimeout(promise, timeoutMs) {
     return Promise.race([

--- a/customer-app/index.html
+++ b/customer-app/index.html
@@ -17,10 +17,10 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Noto+Sans+Thai:wght@400;500;600;700;800;900&display=swap" media="print" onload="this.media='all'">
   <noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Noto+Sans+Thai:wght@400;500;600;700;800;900&display=swap"></noscript>
-  <link rel="manifest" href="./manifest.webmanifest?v=20260710_legacy_claim_v1">
+  <link rel="manifest" href="./manifest.webmanifest?v=20260710_legacy_claim_v2">
   <link rel="icon" type="image/png" sizes="192x192" href="./assets/icons/cwf-customer-192.png">
   <link rel="apple-touch-icon" sizes="180x180" href="./assets/icons/cwf-customer-180.png">
-  <link rel="stylesheet" href="./assets/customer-app.css?v=20260710_legacy_claim_v1">
+  <link rel="stylesheet" href="./assets/customer-app.css?v=20260710_legacy_claim_v2">
 </head>
 <body class="is-app-booting">
   <div class="app-shell" data-app-shell>
@@ -58,21 +58,21 @@
     </nav>
   </div>
 
-  <script src="./modules/state.js?v=20260710_legacy_claim_v1"></script>
-  <script src="./modules/utils.js?v=20260710_legacy_claim_v1"></script>
-  <script src="./modules/analytics.js?v=20260710_legacy_claim_v1"></script>
-  <script src="./modules/api.js?v=20260710_legacy_claim_v1"></script>
-  <script src="./modules/services.js?v=20260710_legacy_claim_v1"></script>
-  <script src="./modules/ui.js?v=20260710_legacy_claim_v1"></script>
-  <script src="./modules/store.js?v=20260710_legacy_claim_v1"></script>
-  <script src="./modules/auth.js?v=20260710_legacy_claim_v1"></script>
-  <script src="./modules/pricing.js?v=20260710_legacy_claim_v1"></script>
-  <script src="./modules/availability.js?v=20260710_legacy_claim_v1"></script>
-  <script src="./modules/bookingScheduled.js?v=20260710_legacy_claim_v1"></script>
-  <script src="./modules/bookingUrgent.js?v=20260710_legacy_claim_v1"></script>
-  <script src="./modules/tracking.js?v=20260710_legacy_claim_v1"></script>
-  <script src="./modules/profile.js?v=20260710_legacy_claim_v1"></script>
-  <script src="./modules/router.js?v=20260710_legacy_claim_v1"></script>
-  <script src="./assets/customer-app.js?v=20260710_legacy_claim_v1"></script>
+  <script src="./modules/state.js?v=20260710_legacy_claim_v2"></script>
+  <script src="./modules/utils.js?v=20260710_legacy_claim_v2"></script>
+  <script src="./modules/analytics.js?v=20260710_legacy_claim_v2"></script>
+  <script src="./modules/api.js?v=20260710_legacy_claim_v2"></script>
+  <script src="./modules/services.js?v=20260710_legacy_claim_v2"></script>
+  <script src="./modules/ui.js?v=20260710_legacy_claim_v2"></script>
+  <script src="./modules/store.js?v=20260710_legacy_claim_v2"></script>
+  <script src="./modules/auth.js?v=20260710_legacy_claim_v2"></script>
+  <script src="./modules/pricing.js?v=20260710_legacy_claim_v2"></script>
+  <script src="./modules/availability.js?v=20260710_legacy_claim_v2"></script>
+  <script src="./modules/bookingScheduled.js?v=20260710_legacy_claim_v2"></script>
+  <script src="./modules/bookingUrgent.js?v=20260710_legacy_claim_v2"></script>
+  <script src="./modules/tracking.js?v=20260710_legacy_claim_v2"></script>
+  <script src="./modules/profile.js?v=20260710_legacy_claim_v2"></script>
+  <script src="./modules/router.js?v=20260710_legacy_claim_v2"></script>
+  <script src="./assets/customer-app.js?v=20260710_legacy_claim_v2"></script>
 </body>
 </html>

--- a/customer-app/index.html
+++ b/customer-app/index.html
@@ -17,10 +17,10 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Noto+Sans+Thai:wght@400;500;600;700;800;900&display=swap" media="print" onload="this.media='all'">
   <noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Noto+Sans+Thai:wght@400;500;600;700;800;900&display=swap"></noscript>
-  <link rel="manifest" href="./manifest.webmanifest?v=20260709_review_legacy_v1">
+  <link rel="manifest" href="./manifest.webmanifest?v=20260710_legacy_claim_v1">
   <link rel="icon" type="image/png" sizes="192x192" href="./assets/icons/cwf-customer-192.png">
   <link rel="apple-touch-icon" sizes="180x180" href="./assets/icons/cwf-customer-180.png">
-  <link rel="stylesheet" href="./assets/customer-app.css?v=20260709_review_legacy_v1">
+  <link rel="stylesheet" href="./assets/customer-app.css?v=20260710_legacy_claim_v1">
 </head>
 <body class="is-app-booting">
   <div class="app-shell" data-app-shell>
@@ -58,21 +58,21 @@
     </nav>
   </div>
 
-  <script src="./modules/state.js?v=20260709_review_legacy_v1"></script>
-  <script src="./modules/utils.js?v=20260709_review_legacy_v1"></script>
-  <script src="./modules/analytics.js?v=20260709_review_legacy_v1"></script>
-  <script src="./modules/api.js?v=20260709_review_legacy_v1"></script>
-  <script src="./modules/services.js?v=20260709_review_legacy_v1"></script>
-  <script src="./modules/ui.js?v=20260709_review_legacy_v1"></script>
-  <script src="./modules/store.js?v=20260709_review_legacy_v1"></script>
-  <script src="./modules/auth.js?v=20260709_review_legacy_v1"></script>
-  <script src="./modules/pricing.js?v=20260709_review_legacy_v1"></script>
-  <script src="./modules/availability.js?v=20260709_review_legacy_v1"></script>
-  <script src="./modules/bookingScheduled.js?v=20260709_review_legacy_v1"></script>
-  <script src="./modules/bookingUrgent.js?v=20260709_review_legacy_v1"></script>
-  <script src="./modules/tracking.js?v=20260709_review_legacy_v1"></script>
-  <script src="./modules/profile.js?v=20260709_review_legacy_v1"></script>
-  <script src="./modules/router.js?v=20260709_review_legacy_v1"></script>
-  <script src="./assets/customer-app.js?v=20260709_review_legacy_v1"></script>
+  <script src="./modules/state.js?v=20260710_legacy_claim_v1"></script>
+  <script src="./modules/utils.js?v=20260710_legacy_claim_v1"></script>
+  <script src="./modules/analytics.js?v=20260710_legacy_claim_v1"></script>
+  <script src="./modules/api.js?v=20260710_legacy_claim_v1"></script>
+  <script src="./modules/services.js?v=20260710_legacy_claim_v1"></script>
+  <script src="./modules/ui.js?v=20260710_legacy_claim_v1"></script>
+  <script src="./modules/store.js?v=20260710_legacy_claim_v1"></script>
+  <script src="./modules/auth.js?v=20260710_legacy_claim_v1"></script>
+  <script src="./modules/pricing.js?v=20260710_legacy_claim_v1"></script>
+  <script src="./modules/availability.js?v=20260710_legacy_claim_v1"></script>
+  <script src="./modules/bookingScheduled.js?v=20260710_legacy_claim_v1"></script>
+  <script src="./modules/bookingUrgent.js?v=20260710_legacy_claim_v1"></script>
+  <script src="./modules/tracking.js?v=20260710_legacy_claim_v1"></script>
+  <script src="./modules/profile.js?v=20260710_legacy_claim_v1"></script>
+  <script src="./modules/router.js?v=20260710_legacy_claim_v1"></script>
+  <script src="./assets/customer-app.js?v=20260710_legacy_claim_v1"></script>
 </body>
 </html>

--- a/customer-app/manifest.webmanifest
+++ b/customer-app/manifest.webmanifest
@@ -2,7 +2,7 @@
   "name": "CWF Customer Service",
   "short_name": "CWF Service",
   "description": "แอปลูกค้า Coldwindflow สำหรับเลือกบริการ จองคิว และติดตามงาน",
-  "start_url": "/customer-app/index.html?v=20260709_review_legacy_v1#home",
+  "start_url": "/customer-app/index.html?v=20260710_legacy_claim_v1#home",
   "scope": "/customer-app/",
   "id": "/customer-app/",
   "display": "standalone",

--- a/customer-app/manifest.webmanifest
+++ b/customer-app/manifest.webmanifest
@@ -2,7 +2,7 @@
   "name": "CWF Customer Service",
   "short_name": "CWF Service",
   "description": "แอปลูกค้า Coldwindflow สำหรับเลือกบริการ จองคิว และติดตามงาน",
-  "start_url": "/customer-app/index.html?v=20260710_legacy_claim_v1#home",
+  "start_url": "/customer-app/index.html?v=20260710_legacy_claim_v2#home",
   "scope": "/customer-app/",
   "id": "/customer-app/",
   "display": "standalone",

--- a/customer-app/modules/api.js
+++ b/customer-app/modules/api.js
@@ -75,6 +75,28 @@
       });
     },
 
+    async claimCustomerHistory(payload) {
+      return requestJson("/public/customer-history/claim", {
+        method: "POST",
+        body: {
+          phone: String((payload && payload.phone) || "").trim(),
+          booking_code: String((payload && payload.booking_code) || "").trim(),
+        },
+      });
+    },
+
+    async loadCustomerHistory() {
+      return requestJson("/public/customer-history", { cache: "no-store" });
+    },
+
+    async loadCustomerHistoryDetail(jobRef) {
+      return requestJson(`/public/customer-history/${encodeURIComponent(String(jobRef || ""))}`, { cache: "no-store" });
+    },
+
+    async loadCustomerHistoryLocations() {
+      return requestJson("/public/customer-history/locations", { cache: "no-store" });
+    },
+
     async previewPricing(payload) {
       return requestJson("/public/pricing_preview", {
         method: "POST",

--- a/customer-app/modules/profile.js
+++ b/customer-app/modules/profile.js
@@ -77,11 +77,189 @@
     `;
   }
 
+  function historyState() {
+    return root.state.customerHistory || {};
+  }
+
+  function renderHistoryClaimPanel() {
+    const h = historyState();
+    const items = Array.isArray(h.items) ? h.items : [];
+    const locations = Array.isArray(h.locations) ? h.locations : [];
+    const claimed = h.claimed === true;
+    const loading = h.status === "loading" || h.locationsStatus === "loading";
+    return `
+      <section class="card profile-history-card">
+        <div class="section-head">
+          <h2>เชื่อมประวัติลูกค้าเก่า</h2>
+          <p class="muted">ไม่มี OTP ระบบใช้เบอร์โทรเต็มและ Booking Code จากงานเดิมเพื่อยืนยันประวัติ</p>
+        </div>
+        <form class="profile-history-claim-form" data-history-claim-form>
+          <div class="form-grid">
+            <div class="field">
+              <label for="history-phone">เบอร์โทรเดิม</label>
+              <input id="history-phone" class="input" name="phone" inputmode="tel" autocomplete="tel"
+                value="${root.utils.escapeHtml(h.claimPhone || "")}" placeholder="081-234-5678">
+            </div>
+            <div class="field">
+              <label for="history-booking-code">Booking Code</label>
+              <input id="history-booking-code" class="input" name="booking_code" autocapitalize="characters"
+                value="${root.utils.escapeHtml(h.claimBookingCode || "")}" placeholder="CWF...">
+            </div>
+          </div>
+          ${h.claimError ? `<div class="state-box is-error">${root.utils.escapeHtml(h.claimError)}</div>` : ""}
+          ${h.claimSuccess ? `<div class="state-box is-success">${root.utils.escapeHtml(h.claimSuccess)}</div>` : ""}
+          <div class="button-row">
+            <button class="primary-btn" type="submit" ${h.claimStatus === "saving" ? "disabled" : ""}>
+              ${h.claimStatus === "saving" ? "กำลังตรวจสอบ..." : "เชื่อมประวัติ"}
+            </button>
+            <button class="secondary-btn" type="button" data-history-refresh ${loading ? "disabled" : ""}>โหลดประวัติ</button>
+          </div>
+        </form>
+        ${renderHistorySummary({ claimed, items, locations, loading, error: h.error || h.locationsError })}
+      </section>
+    `;
+  }
+
+  function renderHistorySummary({ claimed, items, locations, loading, error }) {
+    if (loading) return `<div class="state-box">กำลังโหลดประวัติ...</div>`;
+    if (error) return `<div class="state-box is-error">${root.utils.escapeHtml(error)}</div>`;
+    if (!claimed) return `<p class="muted">เชื่อมประวัติก่อนเพื่อดูงานเดิมและเลือกสถานที่ที่เคยใช้บริการ</p>`;
+    const locationHtml = locations.length
+      ? locations.map((loc, index) => `
+          <div class="address-status-card has-address">
+            <span class="address-status-icon">${root.utils.icon("pin", 20)}</span>
+            <div>
+              <strong>${root.utils.escapeHtml(loc.job_zone || "สถานที่เดิม")}</strong>
+              <p>${root.utils.escapeHtml(loc.address_text || "-")}</p>
+              <p class="muted">${root.utils.escapeHtml(`${loc.job_count || 1} งาน • ล่าสุด ${loc.last_seen_at || "-"}`)}</p>
+              <div class="button-row">
+                <button class="secondary-btn" type="button" data-history-location-index="${index}" data-history-location-target="scheduled">ใช้จองล่วงหน้า</button>
+                <button class="secondary-btn" type="button" data-history-location-index="${index}" data-history-location-target="urgent">ใช้จองด่วน</button>
+              </div>
+            </div>
+          </div>
+        `).join("")
+      : `<p class="muted">ยังไม่พบสถานที่จากประวัติงานที่เชื่อมแล้ว</p>`;
+    const historyHtml = items.length
+      ? items.slice(0, 8).map((item) => `
+          <div class="data-row">
+            <strong>${root.utils.escapeHtml(item.booking_code || "งานเดิม")}</strong>
+            <span>${root.utils.escapeHtml(`${item.appointment_datetime || "-"} • ${item.job_status || "-"}`)}</span>
+          </div>
+        `).join("")
+      : `<p class="muted">ยังไม่พบประวัติงานที่แสดงได้</p>`;
+    return `
+      <div class="profile-history-summary">
+        <div class="section-head section-head-compact"><h2>สถานที่ที่เคยใช้บริการ</h2></div>
+        <div class="profile-location-list">${locationHtml}</div>
+        <div class="section-head section-head-compact"><h2>ประวัติบริการ</h2></div>
+        <div>${historyHtml}</div>
+      </div>
+    `;
+  }
+
+  async function loadHistoryData(container) {
+    if (!root.state.customer?.logged_in || !root.api?.loadCustomerHistory) return;
+    root.state.setCustomerHistory({ status: "loading", locationsStatus: "loading", error: "", locationsError: "" });
+    paintHistory(container);
+    try {
+      const [historyData, locationsData] = await Promise.all([
+        root.api.loadCustomerHistory(),
+        root.api.loadCustomerHistoryLocations(),
+      ]);
+      root.state.setCustomerHistory({
+        status: "success",
+        locationsStatus: "success",
+        claimed: !!(historyData?.claimed || locationsData?.claimed),
+        items: Array.isArray(historyData?.items) ? historyData.items : [],
+        locations: Array.isArray(locationsData?.locations) ? locationsData.locations : [],
+        error: "",
+        locationsError: "",
+      });
+    } catch (error) {
+      const message = error?.status === 503
+        ? "ระบบประวัติลูกค้ายังไม่พร้อมใช้งาน"
+        : (error?.message || "โหลดประวัติไม่สำเร็จ");
+      root.state.setCustomerHistory({ status: "error", locationsStatus: "error", error: message, locationsError: message });
+    }
+    paintHistory(container);
+  }
+
+  function paintHistory(container) {
+    const mount = container?.querySelector("[data-profile-history]");
+    if (!mount) return;
+    mount.innerHTML = renderHistoryClaimPanel();
+    bindHistory(container);
+  }
+
   function paintAddress(container) {
     const mount = container?.querySelector("[data-profile-address]");
     if (!mount) return;
     mount.innerHTML = renderServiceAddress();
     bindAddress(container);
+  }
+
+  function bindHistory(container) {
+    const form = container?.querySelector("[data-history-claim-form]");
+    if (form && form.dataset.bound !== "1") {
+      form.dataset.bound = "1";
+      form.addEventListener("submit", async (event) => {
+        event.preventDefault();
+        const phone = String(form.elements.phone.value || "").trim();
+        const bookingCode = String(form.elements.booking_code.value || "").trim();
+        root.state.setCustomerHistory({
+          claimStatus: "saving",
+          claimError: "",
+          claimSuccess: "",
+          claimPhone: phone,
+          claimBookingCode: bookingCode,
+        });
+        paintHistory(container);
+        try {
+          await root.api.claimCustomerHistory({ phone, booking_code: bookingCode });
+          root.state.setCustomerHistory({
+            claimStatus: "success",
+            claimError: "",
+            claimSuccess: "เชื่อมประวัติสำเร็จ",
+            claimed: true,
+          });
+          await loadHistoryData(container);
+        } catch (_) {
+          root.state.setCustomerHistory({
+            claimStatus: "error",
+            claimError: "ไม่สามารถยืนยันประวัติงานได้ กรุณาตรวจสอบข้อมูลอีกครั้ง",
+            claimSuccess: "",
+          });
+          paintHistory(container);
+        }
+      });
+    }
+
+    const refresh = container?.querySelector("[data-history-refresh]");
+    if (refresh && refresh.dataset.bound !== "1") {
+      refresh.dataset.bound = "1";
+      refresh.addEventListener("click", () => loadHistoryData(container));
+    }
+
+    const locationButtons = typeof container?.querySelectorAll === "function"
+      ? container.querySelectorAll("[data-history-location-index]")
+      : [];
+    locationButtons.forEach((button) => {
+      if (button.dataset.bound === "1") return;
+      button.dataset.bound = "1";
+      button.addEventListener("click", () => {
+        const index = Number(button.getAttribute("data-history-location-index"));
+        const target = button.getAttribute("data-history-location-target") === "urgent" ? "urgent" : "scheduled";
+        const loc = (root.state.customerHistory?.locations || [])[index];
+        if (!root.state.applyHistoryLocation(target, loc)) return;
+        root.utils.routeTo(target === "urgent" ? "urgent" : "scheduled");
+      });
+    });
+  }
+
+  function bindProfile(container) {
+    bindAddress(container);
+    bindHistory(container);
   }
 
   function bindAddress(container) {
@@ -183,6 +361,8 @@
           <div data-profile-address>${renderServiceAddress()}</div>
         </section>
 
+        <div data-profile-history>${renderHistoryClaimPanel()}</div>
+
         <section class="card profile-action-card">
           <div class="section-head"><h2>เมนูใช้งาน</h2></div>
           <div class="profile-action-grid">
@@ -195,7 +375,8 @@
       </section>
     `;
     root.auth.loadCustomer(container);
-    bindAddress(container);
+    bindProfile(container);
+    loadHistoryData(container);
     root.auth.bindAvatarFallbacks?.(container);
   }
 

--- a/customer-app/modules/profile.js
+++ b/customer-app/modules/profile.js
@@ -115,12 +115,12 @@
             <button class="secondary-btn" type="button" data-history-refresh ${loading ? "disabled" : ""}>โหลดประวัติ</button>
           </div>
         </form>
-        ${renderHistorySummary({ claimed, items, locations, loading, error: h.error || h.locationsError })}
+        ${renderHistorySummary({ claimed, items, locations, loading, error: h.error || h.locationsError, detail: h.detail, detailStatus: h.detailStatus, detailError: h.detailError })}
       </section>
     `;
   }
 
-  function renderHistorySummary({ claimed, items, locations, loading, error }) {
+  function renderHistorySummary({ claimed, items, locations, loading, error, detail, detailStatus, detailError }) {
     if (loading) return `<div class="state-box">กำลังโหลดประวัติ...</div>`;
     if (error) return `<div class="state-box is-error">${root.utils.escapeHtml(error)}</div>`;
     if (!claimed) return `<p class="muted">เชื่อมประวัติก่อนเพื่อดูงานเดิมและเลือกสถานที่ที่เคยใช้บริการ</p>`;
@@ -141,19 +141,41 @@
         `).join("")
       : `<p class="muted">ยังไม่พบสถานที่จากประวัติงานที่เชื่อมแล้ว</p>`;
     const historyHtml = items.length
-      ? items.slice(0, 8).map((item) => `
+      ? items.slice(0, 8).map((item, index) => `
           <div class="data-row">
-            <strong>${root.utils.escapeHtml(item.booking_code || "งานเดิม")}</strong>
-            <span>${root.utils.escapeHtml(`${item.appointment_datetime || "-"} • ${item.job_status || "-"}`)}</span>
+            <div>
+              <strong>${root.utils.escapeHtml(item.booking_code || "งานเดิม")}</strong>
+              <span>${root.utils.escapeHtml(`${item.appointment_datetime || "-"} • ${item.job_status || "-"}`)}</span>
+            </div>
+            <button class="secondary-btn" type="button" data-history-detail-index="${index}">ดูรายละเอียด</button>
           </div>
         `).join("")
       : `<p class="muted">ยังไม่พบประวัติงานที่แสดงได้</p>`;
+    const detailHtml = detailStatus === "loading"
+      ? `<div class="state-box">กำลังโหลดรายละเอียด...</div>`
+      : detailError
+        ? `<div class="state-box is-error">${root.utils.escapeHtml(detailError)}</div>`
+        : detail
+          ? `
+            <div class="address-status-card has-address">
+              <span class="address-status-icon">${root.utils.icon("pin", 20)}</span>
+              <div>
+                <strong>${root.utils.escapeHtml(detail.booking_code || "รายละเอียดงาน")}</strong>
+                <p>${root.utils.escapeHtml(`${detail.appointment_datetime || "-"} • ${detail.job_status || "-"}`)}</p>
+                <p>${root.utils.escapeHtml(detail.service_summary || "-")}</p>
+                <p>${root.utils.escapeHtml(detail.address_text || "-")}</p>
+                <p class="muted">${root.utils.escapeHtml(`ราคา ${detail.job_price == null ? "-" : detail.job_price} • ${detail.customer_phone_masked || ""}`)}</p>
+              </div>
+            </div>
+          `
+          : "";
     return `
       <div class="profile-history-summary">
         <div class="section-head section-head-compact"><h2>สถานที่ที่เคยใช้บริการ</h2></div>
         <div class="profile-location-list">${locationHtml}</div>
         <div class="section-head section-head-compact"><h2>ประวัติบริการ</h2></div>
         <div>${historyHtml}</div>
+        ${detailHtml ? `<div class="section-head section-head-compact"><h2>รายละเอียดงาน</h2></div><div>${detailHtml}</div>` : ""}
       </div>
     `;
   }
@@ -221,6 +243,7 @@
             claimStatus: "success",
             claimError: "",
             claimSuccess: "เชื่อมประวัติสำเร็จ",
+            claimBookingCode: "",
             claimed: true,
           });
           await loadHistoryData(container);
@@ -253,6 +276,29 @@
         const loc = (root.state.customerHistory?.locations || [])[index];
         if (!root.state.applyHistoryLocation(target, loc)) return;
         root.utils.routeTo(target === "urgent" ? "urgent" : "scheduled");
+      });
+    });
+
+    const detailButtons = typeof container?.querySelectorAll === "function"
+      ? container.querySelectorAll("[data-history-detail-index]")
+      : [];
+    detailButtons.forEach((button) => {
+      if (button.dataset.bound === "1") return;
+      button.dataset.bound = "1";
+      button.addEventListener("click", async () => {
+        const index = Number(button.getAttribute("data-history-detail-index"));
+        const item = (root.state.customerHistory?.items || [])[index];
+        const jobRef = item && item.job_ref;
+        if (!jobRef || !root.api?.loadCustomerHistoryDetail) return;
+        root.state.setCustomerHistory({ detailStatus: "loading", detailError: "", detail: null });
+        paintHistory(container);
+        try {
+          const detailData = await root.api.loadCustomerHistoryDetail(jobRef);
+          root.state.setCustomerHistory({ detailStatus: "success", detailError: "", detail: detailData?.item || null });
+        } catch (_) {
+          root.state.setCustomerHistory({ detailStatus: "error", detailError: "โหลดรายละเอียดงานไม่สำเร็จ", detail: null });
+        }
+        paintHistory(container);
       });
     });
   }

--- a/customer-app/modules/state.js
+++ b/customer-app/modules/state.js
@@ -132,6 +132,20 @@
     homeActiveJob: { status: "idle", data: null, error: "" },
     addressPrefill: { status: "idle", scopes: {}, error: "" },
     profileAddressForm: { editing: false, status: "idle", error: "", success: "" },
+    customerHistory: {
+      claimStatus: "idle",
+      claimError: "",
+      claimSuccess: "",
+      claimPhone: "",
+      claimBookingCode: "",
+      status: "idle",
+      error: "",
+      claimed: false,
+      items: [],
+      locationsStatus: "idle",
+      locationsError: "",
+      locations: [],
+    },
     scheduledWizard: {
       step: 1,
       maxStep: MAX_SCHEDULED_STEP,
@@ -300,6 +314,12 @@
         ...(patch || {}),
       };
     },
+    setCustomerHistory(patch) {
+      this.customerHistory = {
+        ...(this.customerHistory || {}),
+        ...(patch || {}),
+      };
+    },
     savedAddress() {
       const profile = this.customer && this.customer.logged_in ? (this.customer.profile || {}) : {};
       return {
@@ -348,6 +368,21 @@
           ...(patch || {}),
         },
       };
+    },
+    applyHistoryLocation(scope, location) {
+      const loc = location || {};
+      const patch = {
+        address_text: String(loc.address_text || "").trim(),
+        maps_url: String(loc.maps_url || "").trim(),
+        job_zone: String(loc.job_zone || "").trim(),
+      };
+      if (!patch.address_text) return false;
+      this.updateDraft(scope, patch);
+      this.addressPrefill.scopes = {
+        ...(this.addressPrefill.scopes || {}),
+        [scope]: true,
+      };
+      return true;
     },
     setScheduledWizard(patch) {
       this.scheduledWizard = {

--- a/customer-app/sw.js
+++ b/customer-app/sw.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const BUILD_ID = "20260710_legacy_claim_v1";
+const BUILD_ID = "20260710_legacy_claim_v2";
 const CACHE_NAME = `cwf-customer-app-v2-${BUILD_ID}`;
 const APP_SHELL = [
   `./index.html?v=${BUILD_ID}`,

--- a/customer-app/sw.js
+++ b/customer-app/sw.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const BUILD_ID = "20260709_review_legacy_v1";
+const BUILD_ID = "20260710_legacy_claim_v1";
 const CACHE_NAME = `cwf-customer-app-v2-${BUILD_ID}`;
 const APP_SHELL = [
   `./index.html?v=${BUILD_ID}`,

--- a/index.js
+++ b/index.js
@@ -46,6 +46,7 @@ const createCatalogItemRoutes = require("./server/routes/catalog/items");
 const createCatalogReviewRoutes = require("./server/routes/catalog/reviews");
 const { createHomepageRoutes, CONFIG_KEY: HOMEPAGE_CONFIG_KEY } = require("./server/routes/homepage");
 const { createCustomerOrdersRoutes } = require("./server/routes/customerOrders");
+const createCustomerHistoryRoutes = require("./server/routes/public/customerHistory");
 const articleSync = require("./server/services/articleSync");
 const createServiceZoneRoutes = require("./server/routes/serviceZones");
 const createPageRoutes = require("./server/routes/pages");
@@ -815,6 +816,8 @@ function requireCustomerJwt(req, res, next) {
     return res.status(401).json({ error: 'NOT_LOGGED_IN' });
   }
 }
+
+app.use(createCustomerHistoryRoutes({ pool, requireCustomerJwt, getSecret: getJwtSecret, logger: console }));
 
 app.get('/auth/line', (req, res) => {
   const clientId = String(process.env.LINE_CHANNEL_ID || '').trim();

--- a/migrations/20260710_customer_history_claims.sql
+++ b/migrations/20260710_customer_history_claims.sql
@@ -1,0 +1,46 @@
+-- Legacy Customer Claim + Phone-Verified History.
+-- Additive only. Do not run against production until reviewed and approved.
+-- This migration stores durable ownership of a normalized phone after a logged-in
+-- customer proves one legacy job with full phone + booking code. Raw booking
+-- codes and raw claim input are intentionally not persisted.
+
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS public.customer_history_claims (
+  claim_id BIGSERIAL PRIMARY KEY,
+  customer_sub TEXT NOT NULL REFERENCES public.customer_profiles(sub) ON DELETE CASCADE,
+  phone_norm TEXT NOT NULL,
+  phone_last4 TEXT NOT NULL,
+  proof_job_id BIGINT NOT NULL REFERENCES public.jobs(job_id) ON DELETE RESTRICT,
+  claim_method TEXT NOT NULL DEFAULT 'booking_code_phone',
+  claimed_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  last_verified_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  revoked_at TIMESTAMPTZ NULL,
+  revoke_reason TEXT NULL,
+  CONSTRAINT customer_history_claims_method_check
+    CHECK (claim_method IN ('booking_code_phone')),
+  CONSTRAINT customer_history_claims_phone_norm_not_blank
+    CHECK (length(btrim(phone_norm)) > 0),
+  CONSTRAINT customer_history_claims_phone_last4_check
+    CHECK (phone_last4 ~ '^[0-9]{4}$')
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS ux_customer_history_claims_active_phone
+  ON public.customer_history_claims(phone_norm)
+  WHERE revoked_at IS NULL;
+
+CREATE UNIQUE INDEX IF NOT EXISTS ux_customer_history_claims_active_proof_job
+  ON public.customer_history_claims(proof_job_id)
+  WHERE revoked_at IS NULL;
+
+CREATE INDEX IF NOT EXISTS idx_customer_history_claims_customer_sub
+  ON public.customer_history_claims(customer_sub)
+  WHERE revoked_at IS NULL;
+
+COMMIT;
+
+-- Rollback outline, review before use:
+-- DROP INDEX IF EXISTS idx_customer_history_claims_customer_sub;
+-- DROP INDEX IF EXISTS ux_customer_history_claims_active_proof_job;
+-- DROP INDEX IF EXISTS ux_customer_history_claims_active_phone;
+-- DROP TABLE IF EXISTS public.customer_history_claims;

--- a/migrations/20260710_customer_history_claims.sql
+++ b/migrations/20260710_customer_history_claims.sql
@@ -21,8 +21,10 @@ CREATE TABLE IF NOT EXISTS public.customer_history_claims (
     CHECK (claim_method IN ('booking_code_phone')),
   CONSTRAINT customer_history_claims_phone_norm_not_blank
     CHECK (length(btrim(phone_norm)) > 0),
+  CONSTRAINT customer_history_claims_phone_norm_canonical_check
+    CHECK (phone_norm ~ '^0[0-9]{8,9}$'),
   CONSTRAINT customer_history_claims_phone_last4_check
-    CHECK (phone_last4 ~ '^[0-9]{4}$')
+    CHECK (phone_last4 ~ '^[0-9]{4}$' AND phone_last4 = right(phone_norm, 4))
 );
 
 CREATE UNIQUE INDEX IF NOT EXISTS ux_customer_history_claims_active_phone

--- a/package.json
+++ b/package.json
@@ -5,6 +5,8 @@
   "scripts": {
     "start": "node index.js",
     "migrate:customer-auth": "node scripts/run-customer-auth-migration.js",
+    "migrate:customer-history-claims:check": "node scripts/run-customer-history-claims-migration.js",
+    "migrate:customer-history-claims": "node scripts/run-customer-history-claims-migration.js",
     "migrate:catalog-store-media-pricing": "node scripts/run-catalog-store-media-pricing-migration.js",
     "migrate:catalog-marketplace-v2": "node scripts/run-catalog-marketplace-v2-migration.js",
     "migrate:catalog-autoplay": "node scripts/run-catalog-autoplay-migration.js",

--- a/scripts/run-customer-history-claims-migration.js
+++ b/scripts/run-customer-history-claims-migration.js
@@ -1,0 +1,326 @@
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+const crypto = require("crypto");
+const { Client } = require("pg");
+
+const MIGRATION_RELATIVE_PATH = "migrations/20260710_customer_history_claims.sql";
+const EXPECTED_SHA256 = "745446126557ec50d726bdd73a6d4ba8a6c67ba5f9239895186d0759f1f351bd";
+const CONFIRM_ENV = "CONFIRM_CUSTOMER_HISTORY_CLAIMS_MIGRATION";
+const CONFIRM_VALUE = "APPLY_20260710_CUSTOMER_HISTORY_CLAIMS";
+const ADVISORY_LOCK_KEY = "202607100152";
+
+function clean(value) {
+  return String(value == null ? "" : value).trim();
+}
+
+function safeErrorMessage(error) {
+  const msg = clean(error && error.message ? error.message : error) || "unknown error";
+  return msg
+    .replace(/postgres(?:ql)?:\/\/[^\s"'<>]+/gi, "[REDACTED_DATABASE_URL]")
+    .replace(/(password|passwd|pwd|secret|token)=([^&\s]+)/gi, "$1=[REDACTED]")
+    .replace(/password authentication failed for user\s+"[^"]+"/gi, 'password authentication failed for user "[REDACTED]"')
+    .replace(/user\s+"[^"]+"/gi, 'user "[REDACTED]"')
+    .replace(/host\s+"[^"]+"/gi, 'host "[REDACTED]"')
+    .replace(/\b(?:[a-z0-9-]+\.)+[a-z]{2,}\b/gi, "[REDACTED_HOST]")
+    .replace(/\b(?:\d{1,3}\.){3}\d{1,3}(?::\d+)?\b/g, "[REDACTED_HOST]")
+    .replace(/\blocalhost(?::\d+)?\b/gi, "[REDACTED_HOST]");
+}
+
+function resolveMigrationPath(repoRoot = path.resolve(__dirname, "..")) {
+  const root = path.resolve(repoRoot);
+  const migrationPath = path.resolve(root, MIGRATION_RELATIVE_PATH);
+  const expected = path.resolve(root, "migrations", "20260710_customer_history_claims.sql");
+  if (migrationPath !== expected || !migrationPath.startsWith(root + path.sep)) {
+    throw new Error("migration path rejected");
+  }
+  return migrationPath;
+}
+
+function readMigrationSql(repoRoot) {
+  return fs.readFileSync(resolveMigrationPath(repoRoot), "utf8");
+}
+
+function migrationChecksum(repoRoot) {
+  return crypto.createHash("sha256").update(readMigrationSql(repoRoot), "utf8").digest("hex");
+}
+
+function verifyChecksum(repoRoot) {
+  const actual = migrationChecksum(repoRoot);
+  if (actual !== EXPECTED_SHA256) {
+    throw new Error("migration checksum mismatch");
+  }
+  return actual;
+}
+
+function createClientConfig(env = process.env) {
+  const databaseUrl = clean(env.DATABASE_URL);
+  if (!databaseUrl) throw new Error("DATABASE_URL is required");
+  return {
+    connectionString: databaseUrl,
+    options: "-c timezone=Asia/Bangkok",
+    ssl: { rejectUnauthorized: false },
+  };
+}
+
+function mapRows(rows, key) {
+  return new Map((rows || []).map((row) => [String(row[key]), row]));
+}
+
+async function inspectPreflight(client) {
+  const tables = await client.query(`
+    SELECT
+      to_regclass('public.customer_profiles') IS NOT NULL AS has_customer_profiles,
+      to_regclass('public.jobs') IS NOT NULL AS has_jobs,
+      to_regclass('public.customer_history_claims') IS NOT NULL AS has_claims
+  `);
+  const t = tables.rows?.[0] || {};
+  if (!t.has_customer_profiles) throw new Error("customer_profiles prerequisite missing");
+  if (!t.has_jobs) throw new Error("jobs prerequisite missing");
+
+  const columns = await client.query(`
+    SELECT table_name, column_name, data_type, is_nullable
+      FROM information_schema.columns
+     WHERE table_schema='public'
+       AND ((table_name='jobs' AND column_name='job_id')
+         OR (table_name='customer_profiles' AND column_name='sub'))
+  `);
+  const byTableColumn = new Map((columns.rows || []).map((row) => [`${row.table_name}.${row.column_name}`, row]));
+  if (byTableColumn.get("jobs.job_id")?.data_type !== "bigint") throw new Error("jobs.job_id must be bigint");
+  if (!byTableColumn.has("customer_profiles.sub")) throw new Error("customer_profiles.sub missing");
+
+  const subKey = await client.query(`
+    SELECT con.conname,
+           array_agg(att.attname ORDER BY cols.ordinality) AS column_names
+      FROM pg_constraint con
+      JOIN pg_class rel ON rel.oid = con.conrelid
+      JOIN pg_namespace nsp ON nsp.oid = rel.relnamespace
+      JOIN unnest(con.conkey) WITH ORDINALITY AS cols(attnum, ordinality) ON TRUE
+      JOIN pg_attribute att ON att.attrelid = rel.oid AND att.attnum = cols.attnum
+     WHERE nsp.nspname='public'
+       AND rel.relname='customer_profiles'
+       AND con.contype IN ('p','u')
+     GROUP BY con.conname
+  `);
+  const supportsSubFk = (subKey.rows || []).some((row) => {
+    const names = Array.isArray(row.column_names) ? row.column_names : [];
+    return names.length === 1 && names[0] === "sub";
+  });
+  if (!supportsSubFk) throw new Error("customer_profiles.sub does not support FK");
+
+  return { claimsExists: !!t.has_claims };
+}
+
+async function verifyAppliedSchema(client, options = {}) {
+  const table = await client.query("SELECT to_regclass('public.customer_history_claims') AS table_name");
+  if (!table.rows?.[0]?.table_name) throw new Error("customer_history_claims table missing");
+
+  const columns = await client.query(`
+    SELECT column_name, data_type, is_nullable
+      FROM information_schema.columns
+     WHERE table_schema='public'
+       AND table_name='customer_history_claims'
+     ORDER BY column_name
+  `);
+  const cols = mapRows(columns.rows, "column_name");
+  const expectedColumns = {
+    claim_id: ["bigint", "NO"],
+    customer_sub: ["text", "NO"],
+    phone_norm: ["text", "NO"],
+    phone_last4: ["text", "NO"],
+    proof_job_id: ["bigint", "NO"],
+    claim_method: ["text", "NO"],
+    claimed_at: ["timestamp with time zone", "NO"],
+    last_verified_at: ["timestamp with time zone", "NO"],
+    revoked_at: ["timestamp with time zone", "YES"],
+    revoke_reason: ["text", "YES"],
+  };
+  for (const [name, [type, nullable]] of Object.entries(expectedColumns)) {
+    const row = cols.get(name);
+    if (!row || row.data_type !== type || row.is_nullable !== nullable) {
+      throw new Error(`customer_history_claims column drift: ${name}`);
+    }
+  }
+
+  const fks = await client.query(`
+    SELECT con.conname,
+           confrel.relname AS foreign_table,
+           array_agg(att.attname ORDER BY cols.ordinality) AS column_names,
+           array_agg(fatt.attname ORDER BY cols.ordinality) AS foreign_column_names
+      FROM pg_constraint con
+      JOIN pg_class rel ON rel.oid = con.conrelid
+      JOIN pg_namespace nsp ON nsp.oid = rel.relnamespace
+      JOIN pg_class confrel ON confrel.oid = con.confrelid
+      JOIN unnest(con.conkey) WITH ORDINALITY AS cols(attnum, ordinality) ON TRUE
+      JOIN unnest(con.confkey) WITH ORDINALITY AS fcols(attnum, ordinality) ON fcols.ordinality = cols.ordinality
+      JOIN pg_attribute att ON att.attrelid = rel.oid AND att.attnum = cols.attnum
+      JOIN pg_attribute fatt ON fatt.attrelid = confrel.oid AND fatt.attnum = fcols.attnum
+     WHERE nsp.nspname='public'
+       AND rel.relname='customer_history_claims'
+       AND con.contype='f'
+     GROUP BY con.conname, confrel.relname
+  `);
+  const hasCustomerFk = (fks.rows || []).some((row) => row.foreign_table === "customer_profiles"
+    && (row.column_names || []).join(",") === "customer_sub"
+    && (row.foreign_column_names || []).join(",") === "sub");
+  const hasJobFk = (fks.rows || []).some((row) => row.foreign_table === "jobs"
+    && (row.column_names || []).join(",") === "proof_job_id"
+    && (row.foreign_column_names || []).join(",") === "job_id");
+  if (!hasCustomerFk) throw new Error("customer_sub FK missing");
+  if (!hasJobFk) throw new Error("proof_job_id FK missing");
+
+  const checks = await client.query(`
+    SELECT conname, pg_get_constraintdef(oid) AS definition
+      FROM pg_constraint
+     WHERE conrelid='public.customer_history_claims'::regclass
+       AND contype='c'
+  `);
+  const checkText = (checks.rows || []).map((row) => `${row.conname} ${row.definition}`).join("\n");
+  if (!/booking_code_phone/.test(checkText)) throw new Error("claim_method CHECK missing");
+  if (!/phone_norm/.test(checkText) || !/\^0\[0-9\]\{8,9\}\$/.test(checkText)) throw new Error("canonical phone_norm CHECK missing");
+  if (!/phone_last4/.test(checkText) || !/right\(phone_norm,\s*4\)/i.test(checkText)) throw new Error("phone_last4 CHECK missing");
+
+  const indexes = await client.query(`
+    SELECT indexname, indexdef
+      FROM pg_indexes
+     WHERE schemaname='public'
+       AND tablename='customer_history_claims'
+  `);
+  const indexDefs = new Map((indexes.rows || []).map((row) => [row.indexname, row.indexdef]));
+  const activePhone = indexDefs.get("ux_customer_history_claims_active_phone") || "";
+  const activeProof = indexDefs.get("ux_customer_history_claims_active_proof_job") || "";
+  const activeSub = indexDefs.get("idx_customer_history_claims_customer_sub") || "";
+  if (!/UNIQUE/i.test(activePhone) || !/phone_norm/.test(activePhone) || !/revoked_at IS NULL/i.test(activePhone)) {
+    throw new Error("active phone partial unique index missing");
+  }
+  if (!/UNIQUE/i.test(activeProof) || !/proof_job_id/.test(activeProof) || !/revoked_at IS NULL/i.test(activeProof)) {
+    throw new Error("active proof job partial unique index missing");
+  }
+  if (!/customer_sub/.test(activeSub) || !/revoked_at IS NULL/i.test(activeSub)) {
+    throw new Error("active customer_sub index missing");
+  }
+
+  const count = await client.query("SELECT COUNT(*)::bigint AS count FROM public.customer_history_claims");
+  const rowCount = Number(count.rows?.[0]?.count || 0);
+  if (options.expectEmpty && rowCount !== 0) throw new Error("customer_history_claims row count must be zero after first apply");
+  return { rowCount };
+}
+
+async function preflight(client) {
+  const info = await inspectPreflight(client);
+  if (info.claimsExists) {
+    await verifyAppliedSchema(client);
+    return { status: "ALREADY_APPLIED" };
+  }
+  return { status: "READY_TO_APPLY" };
+}
+
+function applyIntent(argv = [], env = process.env) {
+  const hasApply = argv.includes("--apply");
+  const hasConfirm = clean(env[CONFIRM_ENV]) === CONFIRM_VALUE;
+  if (hasApply && !hasConfirm) throw new Error("confirmation env missing");
+  if (!hasApply && hasConfirm) throw new Error("--apply argument missing");
+  return hasApply && hasConfirm;
+}
+
+async function runMigration(options = {}) {
+  const env = options.env || process.env;
+  const argv = options.argv || process.argv.slice(2);
+  const logger = options.logger || console;
+  const repoRoot = options.repoRoot || path.resolve(__dirname, "..");
+  const clientFactory = options.clientFactory || ((config) => new Client(config));
+  verifyChecksum(repoRoot);
+  const shouldApply = applyIntent(argv, env);
+  const config = createClientConfig(env);
+  const client = clientFactory(config);
+  let locked = false;
+  let applied = false;
+  let originalError = null;
+
+  try {
+    await client.connect();
+    const preflightResult = await preflight(client);
+    if (preflightResult.status === "ALREADY_APPLIED") {
+      logger.log("CUSTOMER_HISTORY_CLAIMS_MIGRATION_ALREADY_APPLIED");
+      return { status: "ALREADY_APPLIED" };
+    }
+    if (!shouldApply) {
+      logger.log("CUSTOMER_HISTORY_CLAIMS_MIGRATION_PREFLIGHT_OK");
+      return { status: "READY_TO_APPLY" };
+    }
+
+    const lock = await client.query("SELECT pg_try_advisory_lock($1::bigint) AS locked", [ADVISORY_LOCK_KEY]);
+    locked = lock.rows?.[0]?.locked === true;
+    if (!locked) throw new Error("migration lock unavailable");
+    await client.query("SET lock_timeout = '5s'");
+    await client.query("SET statement_timeout = '60s'");
+    await client.query("SET idle_in_transaction_session_timeout = '60s'");
+    logger.log("CUSTOMER_HISTORY_CLAIMS_MIGRATION_APPLY_START");
+    try {
+      await client.query(readMigrationSql(repoRoot));
+      applied = true;
+    } catch (error) {
+      try { await client.query("ROLLBACK"); } catch (_) {}
+      throw error;
+    }
+    await verifyAppliedSchema(client, { expectEmpty: true });
+    logger.log("CUSTOMER_HISTORY_CLAIMS_MIGRATION_OK");
+    return { status: "APPLIED" };
+  } catch (error) {
+    originalError = error;
+    throw error;
+  } finally {
+    let cleanupError = null;
+    if (locked) {
+      try {
+        await client.query("SELECT pg_advisory_unlock($1::bigint)", [ADVISORY_LOCK_KEY]);
+      } catch (error) {
+        cleanupError = cleanupError || error;
+      }
+    }
+    try {
+      await client.end();
+    } catch (error) {
+      cleanupError = cleanupError || error;
+    }
+    if (!originalError && cleanupError) throw cleanupError;
+  }
+}
+
+async function runCli(options = {}) {
+  const logger = options.logger || console;
+  try {
+    await runMigration(options);
+    return 0;
+  } catch (error) {
+    logger.error(`CUSTOMER_HISTORY_CLAIMS_MIGRATION_FAILED: ${safeErrorMessage(error)}`);
+    return 1;
+  }
+}
+
+if (require.main === module) {
+  runCli().then((code) => {
+    process.exitCode = code;
+  });
+}
+
+module.exports = {
+  ADVISORY_LOCK_KEY,
+  CONFIRM_ENV,
+  CONFIRM_VALUE,
+  EXPECTED_SHA256,
+  MIGRATION_RELATIVE_PATH,
+  applyIntent,
+  createClientConfig,
+  inspectPreflight,
+  migrationChecksum,
+  preflight,
+  readMigrationSql,
+  resolveMigrationPath,
+  runCli,
+  runMigration,
+  safeErrorMessage,
+  verifyAppliedSchema,
+  verifyChecksum,
+};

--- a/server/routes/public/customerHistory.js
+++ b/server/routes/public/customerHistory.js
@@ -18,6 +18,11 @@ function createCustomerHistoryRoutes(deps = {}) {
   const subLimiter = trackingPrivacy.createPublicLookupRateLimiter({ windowMs: 10 * 60 * 1000, max: 12, maxKeys: 5000 });
   const proofLimiter = trackingPrivacy.createPublicLookupRateLimiter({ windowMs: 10 * 60 * 1000, max: 6, maxKeys: 5000 });
 
+  router.use("/public/customer-history", (_req, res, next) => {
+    res.set("Cache-Control", "private, no-store");
+    next();
+  });
+
   function secret() {
     return String(getSecret() || "").trim();
   }
@@ -38,6 +43,22 @@ function createCustomerHistoryRoutes(deps = {}) {
       error: history.GENERIC_CLAIM_ERROR,
       message: "ไม่สามารถยืนยันประวัติงานได้ กรุณาตรวจสอบข้อมูลอีกครั้ง",
     });
+  }
+
+  async function resolveClaimUniqueRace(customerSub, phone, proofJobId) {
+    const r = await pool.query(
+      `SELECT claim_id, customer_sub, phone_norm, phone_last4, proof_job_id
+         FROM public.customer_history_claims
+        WHERE revoked_at IS NULL
+          AND (phone_norm=$1 OR proof_job_id=$2)
+        ORDER BY claimed_at ASC
+        LIMIT 1`,
+      [phone.phone_norm, proofJobId]
+    );
+    const row = r.rows?.[0] || null;
+    if (!row) return { replayed: false, failed: true };
+    if (String(row.customer_sub) !== customerSub) return { replayed: false, failed: true };
+    return { replayed: true, failed: false, phone_last4: row.phone_last4 || phone.phone_last4 };
   }
 
   async function authorizedContext(db, customerSub) {
@@ -64,6 +85,7 @@ function createCustomerHistoryRoutes(deps = {}) {
     }
 
     const client = await pool.connect();
+    let proofJobId = null;
     try {
       await client.query("BEGIN");
       const ready = await history.schemaReady(client);
@@ -88,6 +110,7 @@ function createCustomerHistoryRoutes(deps = {}) {
         await client.query("ROLLBACK");
         return genericClaimFailure(res);
       }
+      proofJobId = job.job_id;
 
       const existingPhone = await client.query(
         `SELECT claim_id, customer_sub
@@ -137,6 +160,15 @@ function createCustomerHistoryRoutes(deps = {}) {
       return res.json({ ok: true, claimed: true, phone_last4: phone.phone_last4 });
     } catch (error) {
       try { await client.query("ROLLBACK"); } catch (_) {}
+      if (error && error.code === "23505") {
+        try {
+          const resolved = await resolveClaimUniqueRace(customerSub, phone, proofJobId);
+          if (resolved.replayed) {
+            return res.json({ ok: true, claimed: true, replayed: true, phone_last4: resolved.phone_last4 });
+          }
+        } catch (_) {}
+        return genericClaimFailure(res);
+      }
       logger.warn?.("[customer_history_claim] failed", { code: error.code || error.message || "error" });
       return res.status(error.status || 500).json({ error: error.status === 503 ? "CUSTOMER_HISTORY_SCHEMA_NOT_READY" : "CLAIM_FAILED" });
     } finally {

--- a/server/routes/public/customerHistory.js
+++ b/server/routes/public/customerHistory.js
@@ -1,0 +1,250 @@
+"use strict";
+
+const express = require("express");
+const trackingPrivacy = require("../../services/public/trackingPrivacy");
+const history = require("../../services/public/customerHistory");
+
+function createCustomerHistoryRoutes(deps = {}) {
+  const pool = deps.pool;
+  const requireCustomerJwt = deps.requireCustomerJwt;
+  const getSecret = deps.getSecret;
+  const logger = deps.logger || console;
+  if (!pool || typeof pool.query !== "function") throw new Error("createCustomerHistoryRoutes requires pool");
+  if (typeof requireCustomerJwt !== "function") throw new Error("createCustomerHistoryRoutes requires requireCustomerJwt");
+  if (typeof getSecret !== "function") throw new Error("createCustomerHistoryRoutes requires getSecret");
+
+  const router = express.Router();
+  const ipLimiter = trackingPrivacy.createPublicLookupRateLimiter({ windowMs: 10 * 60 * 1000, max: 20, maxKeys: 5000 });
+  const subLimiter = trackingPrivacy.createPublicLookupRateLimiter({ windowMs: 10 * 60 * 1000, max: 12, maxKeys: 5000 });
+  const proofLimiter = trackingPrivacy.createPublicLookupRateLimiter({ windowMs: 10 * 60 * 1000, max: 6, maxKeys: 5000 });
+
+  function secret() {
+    return String(getSecret() || "").trim();
+  }
+
+  function rateLimitClaim(req, phoneNorm, bookingCode) {
+    const jwtSecret = secret();
+    const sub = history.clean(req.customer?.sub);
+    const ipOk = ipLimiter.check(trackingPrivacy.clientIpKey(req));
+    const subOk = subLimiter.check(sub ? history.hmacHex(jwtSecret, "customer-history-sub-limit", sub) : "missing-sub");
+    const proofKey = history.hmacHex(jwtSecret, "customer-history-proof-limit", `${phoneNorm}\0${bookingCode}`);
+    const proofOk = proofLimiter.check(proofKey);
+    return ipOk.allowed && subOk.allowed && proofOk.allowed;
+  }
+
+  function genericClaimFailure(res) {
+    return res.status(400).json({
+      ok: false,
+      error: history.GENERIC_CLAIM_ERROR,
+      message: "ไม่สามารถยืนยันประวัติงานได้ กรุณาตรวจสอบข้อมูลอีกครั้ง",
+    });
+  }
+
+  async function authorizedContext(db, customerSub) {
+    const ready = await history.schemaReady(db);
+    if (!ready.has_claims) {
+      const err = new Error("CUSTOMER_HISTORY_SCHEMA_NOT_READY");
+      err.status = 503;
+      throw err;
+    }
+    const claims = await history.activeClaims(db, customerSub);
+    const phoneDigits = history.phoneMatchDigitsForClaims(claims);
+    return { ready, claims, phoneDigits };
+  }
+
+  router.post("/public/customer-history/claim", requireCustomerJwt, async (req, res) => {
+    const customerSub = history.clean(req.customer?.sub);
+    if (!customerSub) return res.status(401).json({ error: "NOT_LOGGED_IN" });
+
+    const phone = history.normalizeClaimPhone(req.body?.phone);
+    const bookingCode = history.normalizeBookingCode(req.body?.booking_code);
+    if (!phone || !bookingCode) return genericClaimFailure(res);
+    if (!rateLimitClaim(req, phone.phone_norm, bookingCode)) {
+      return res.status(429).json({ error: "RATE_LIMITED", message: "ลองใหม่อีกครั้งภายหลัง" });
+    }
+
+    const client = await pool.connect();
+    try {
+      await client.query("BEGIN");
+      const ready = await history.schemaReady(client);
+      if (!ready.has_claims) {
+        await client.query("ROLLBACK");
+        return res.status(503).json({ error: "CUSTOMER_HISTORY_SCHEMA_NOT_READY" });
+      }
+
+      const jobR = await client.query(
+        `SELECT job_id, booking_code, customer_phone
+           FROM public.jobs
+          WHERE upper(btrim(COALESCE(booking_code,''))) = $1
+            AND COALESCE(NULLIF(btrim(booking_code), ''), '') <> ''
+            AND COALESCE(NULLIF(btrim(customer_phone), ''), '') <> ''
+          LIMIT 2
+          FOR UPDATE`,
+        [bookingCode]
+      );
+      const job = jobR.rows && jobR.rows.length === 1 ? jobR.rows[0] : null;
+      const jobPhoneNorm = history.normalizeJobPhoneDigits(job?.customer_phone);
+      if (!job || jobPhoneNorm !== phone.phone_norm) {
+        await client.query("ROLLBACK");
+        return genericClaimFailure(res);
+      }
+
+      const existingPhone = await client.query(
+        `SELECT claim_id, customer_sub
+           FROM public.customer_history_claims
+          WHERE phone_norm=$1 AND revoked_at IS NULL
+          LIMIT 1
+          FOR UPDATE`,
+        [phone.phone_norm]
+      );
+      const activePhone = existingPhone.rows?.[0] || null;
+      if (activePhone && String(activePhone.customer_sub) !== customerSub) {
+        await client.query("ROLLBACK");
+        return genericClaimFailure(res);
+      }
+      if (activePhone && String(activePhone.customer_sub) === customerSub) {
+        await client.query(
+          `UPDATE public.customer_history_claims
+              SET last_verified_at=NOW()
+            WHERE claim_id=$1`,
+          [activePhone.claim_id]
+        );
+        await client.query("COMMIT");
+        return res.json({ ok: true, claimed: true, replayed: true, phone_last4: phone.phone_last4 });
+      }
+
+      const existingJob = await client.query(
+        `SELECT claim_id, customer_sub
+           FROM public.customer_history_claims
+          WHERE proof_job_id=$1 AND revoked_at IS NULL
+          LIMIT 1
+          FOR UPDATE`,
+        [job.job_id]
+      );
+      const activeJob = existingJob.rows?.[0] || null;
+      if (activeJob && String(activeJob.customer_sub) !== customerSub) {
+        await client.query("ROLLBACK");
+        return genericClaimFailure(res);
+      }
+
+      await client.query(
+        `INSERT INTO public.customer_history_claims
+           (customer_sub, phone_norm, phone_last4, proof_job_id, claim_method, claimed_at, last_verified_at)
+         VALUES ($1,$2,$3,$4,$5,NOW(),NOW())`,
+        [customerSub, phone.phone_norm, phone.phone_last4, job.job_id, history.CLAIM_METHOD]
+      );
+      await client.query("COMMIT");
+      return res.json({ ok: true, claimed: true, phone_last4: phone.phone_last4 });
+    } catch (error) {
+      try { await client.query("ROLLBACK"); } catch (_) {}
+      logger.warn?.("[customer_history_claim] failed", { code: error.code || error.message || "error" });
+      return res.status(error.status || 500).json({ error: error.status === 503 ? "CUSTOMER_HISTORY_SCHEMA_NOT_READY" : "CLAIM_FAILED" });
+    } finally {
+      client.release();
+    }
+  });
+
+  router.get("/public/customer-history", requireCustomerJwt, async (req, res) => {
+    const customerSub = history.clean(req.customer?.sub);
+    if (!customerSub) return res.status(401).json({ error: "NOT_LOGGED_IN" });
+    if (req.query && Object.prototype.hasOwnProperty.call(req.query, "phone")) {
+      return res.status(400).json({ error: "PHONE_QUERY_NOT_ALLOWED" });
+    }
+    try {
+      const ctx = await authorizedContext(pool, customerSub);
+      const auth = history.buildAuthorizedWhere({
+        customerSub,
+        hasCustomerSub: ctx.ready.has_customer_sub,
+        phoneDigits: ctx.phoneDigits,
+      });
+      const r = await pool.query(
+        `SELECT j.job_id, j.booking_code, j.appointment_datetime, j.job_status, j.booking_mode,
+                j.job_type, j.job_price, j.address_text, j.maps_url, j.job_zone
+           FROM public.jobs j
+          WHERE ${auth.where}
+            AND COALESCE(NULLIF(btrim(j.booking_code), ''), '') <> ''
+          ORDER BY COALESCE(j.finished_at, j.appointment_datetime, j.created_at) DESC NULLS LAST, j.job_id DESC
+          LIMIT 100`,
+        auth.params
+      );
+      return res.json({
+        ok: true,
+        claimed: ctx.claims.length > 0,
+        items: (r.rows || []).map((row) => history.historyRow(row, { secret: secret(), customerSub })),
+      });
+    } catch (error) {
+      return res.status(error.status || 500).json({ error: error.status === 503 ? "CUSTOMER_HISTORY_SCHEMA_NOT_READY" : "CUSTOMER_HISTORY_FAILED" });
+    }
+  });
+
+  router.get("/public/customer-history/locations", requireCustomerJwt, async (req, res) => {
+    const customerSub = history.clean(req.customer?.sub);
+    if (!customerSub) return res.status(401).json({ error: "NOT_LOGGED_IN" });
+    if (req.query && Object.prototype.hasOwnProperty.call(req.query, "phone")) {
+      return res.status(400).json({ error: "PHONE_QUERY_NOT_ALLOWED" });
+    }
+    try {
+      const ctx = await authorizedContext(pool, customerSub);
+      const auth = history.buildAuthorizedWhere({
+        customerSub,
+        hasCustomerSub: ctx.ready.has_customer_sub,
+        phoneDigits: ctx.phoneDigits,
+      });
+      const r = await pool.query(
+        `SELECT j.booking_code, j.appointment_datetime, j.finished_at,
+                j.address_text, j.maps_url, j.job_zone, j.gps_latitude, j.gps_longitude
+           FROM public.jobs j
+          WHERE ${auth.where}
+            AND COALESCE(NULLIF(btrim(j.address_text), ''), '') <> ''
+          ORDER BY COALESCE(j.finished_at, j.appointment_datetime, j.created_at) DESC NULLS LAST, j.job_id DESC
+          LIMIT 200`,
+        auth.params
+      );
+      const locations = history.groupLocations(r.rows || []);
+      return res.json({
+        ok: true,
+        claimed: ctx.claims.length > 0,
+        auto_select: false,
+        has_multiple_locations: locations.length > 1,
+        locations,
+      });
+    } catch (error) {
+      return res.status(error.status || 500).json({ error: error.status === 503 ? "CUSTOMER_HISTORY_SCHEMA_NOT_READY" : "CUSTOMER_HISTORY_LOCATIONS_FAILED" });
+    }
+  });
+
+  router.get("/public/customer-history/:job_ref", requireCustomerJwt, async (req, res) => {
+    const customerSub = history.clean(req.customer?.sub);
+    if (!customerSub) return res.status(401).json({ error: "NOT_LOGGED_IN" });
+    const parsed = history.parseJobRef({ secret: secret(), customerSub, jobRef: req.params.job_ref });
+    if (!parsed) return res.status(404).json({ error: "NOT_FOUND" });
+    try {
+      const ctx = await authorizedContext(pool, customerSub);
+      const auth = history.buildAuthorizedWhere({
+        customerSub,
+        hasCustomerSub: ctx.ready.has_customer_sub,
+        phoneDigits: ctx.phoneDigits,
+        startParam: 2,
+      });
+      const r = await pool.query(
+        `SELECT j.job_id, j.booking_code, j.appointment_datetime, j.job_status, j.booking_mode,
+                j.job_type, j.job_price, j.address_text, j.maps_url, j.job_zone,
+                j.duration_min, j.finished_at, j.canceled_at, j.customer_phone
+           FROM public.jobs j
+          WHERE j.job_id::text=$1
+            AND ${auth.where}
+          LIMIT 1`,
+        [parsed.job_id, ...auth.params]
+      );
+      const row = r.rows?.[0] || null;
+      if (!row) return res.status(404).json({ error: "NOT_FOUND" });
+      return res.json({ ok: true, item: history.detailRow(row, { secret: secret(), customerSub }) });
+    } catch (error) {
+      return res.status(error.status || 500).json({ error: error.status === 503 ? "CUSTOMER_HISTORY_SCHEMA_NOT_READY" : "CUSTOMER_HISTORY_DETAIL_FAILED" });
+    }
+  });
+
+  return router;
+}
+
+module.exports = createCustomerHistoryRoutes;

--- a/server/services/public/customerHistory.js
+++ b/server/services/public/customerHistory.js
@@ -1,0 +1,241 @@
+"use strict";
+
+const crypto = require("crypto");
+
+const REF_VERSION = "v1";
+const CLAIM_METHOD = "booking_code_phone";
+const GENERIC_CLAIM_ERROR = "CLAIM_FAILED";
+
+function clean(value) {
+  return String(value == null ? "" : value).trim();
+}
+
+function b64url(input) {
+  const buffer = Buffer.isBuffer(input) ? input : Buffer.from(String(input));
+  return buffer.toString("base64").replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/g, "");
+}
+
+function b64urlDecode(value) {
+  const raw = clean(value).replace(/-/g, "+").replace(/_/g, "/");
+  const pad = raw.length % 4 ? "=".repeat(4 - (raw.length % 4)) : "";
+  return Buffer.from(raw + pad, "base64");
+}
+
+function hmacHex(secret, context, value) {
+  return crypto.createHmac("sha256", String(secret || "")).update(`${context}\0${String(value || "")}`).digest("hex");
+}
+
+function keyFromSecret(secret) {
+  return crypto.createHash("sha256").update(`customer-history-ref\0${String(secret || "")}`).digest();
+}
+
+function makeJobRef({ secret, customerSub, jobId }) {
+  const sub = clean(customerSub);
+  const id = clean(jobId);
+  if (!secret || !sub || !id) return "";
+  const iv = crypto.randomBytes(12);
+  const cipher = crypto.createCipheriv("aes-256-gcm", keyFromSecret(secret), iv);
+  cipher.setAAD(Buffer.from("cwf-customer-history-ref-v1"));
+  const plaintext = Buffer.from(JSON.stringify({ sub, job_id: id }), "utf8");
+  const ciphertext = Buffer.concat([cipher.update(plaintext), cipher.final()]);
+  const tag = cipher.getAuthTag();
+  return `${REF_VERSION}.${b64url(Buffer.concat([iv, tag, ciphertext]))}`;
+}
+
+function parseJobRef({ secret, customerSub, jobRef }) {
+  const sub = clean(customerSub);
+  const ref = clean(jobRef);
+  if (!secret || !sub || !ref.startsWith(`${REF_VERSION}.`)) return null;
+  try {
+    const payload = b64urlDecode(ref.slice(REF_VERSION.length + 1));
+    if (payload.length <= 28) return null;
+    const iv = payload.subarray(0, 12);
+    const tag = payload.subarray(12, 28);
+    const ciphertext = payload.subarray(28);
+    const decipher = crypto.createDecipheriv("aes-256-gcm", keyFromSecret(secret), iv);
+    decipher.setAAD(Buffer.from("cwf-customer-history-ref-v1"));
+    decipher.setAuthTag(tag);
+    const plaintext = Buffer.concat([decipher.update(ciphertext), decipher.final()]).toString("utf8");
+    const data = JSON.parse(plaintext);
+    if (clean(data.sub) !== sub) return null;
+    const jobId = clean(data.job_id);
+    return jobId ? { job_id: jobId } : null;
+  } catch (_) {
+    return null;
+  }
+}
+
+function normalizeClaimPhone(value) {
+  const raw = clean(value);
+  const digits = raw.replace(/\D/g, "");
+  if (!digits) return null;
+  let local = "";
+  if (/^0[0-9]{8,9}$/.test(digits)) {
+    local = digits;
+  } else if (/^66[1-9][0-9]{7,8}$/.test(digits)) {
+    local = `0${digits.slice(2)}`;
+  } else if (/^0066[1-9][0-9]{7,8}$/.test(digits)) {
+    local = `0${digits.slice(4)}`;
+  }
+  if (!/^0[0-9]{8,9}$/.test(local)) return null;
+  const e164Digits = `66${local.slice(1)}`;
+  return {
+    phone_norm: local,
+    phone_last4: local.slice(-4),
+    match_digits: [local, e164Digits, `00${e164Digits}`],
+  };
+}
+
+function normalizeBookingCode(value) {
+  const code = clean(value).toUpperCase();
+  return /^[A-Z0-9_-]{3,40}$/.test(code) ? code : "";
+}
+
+function normalizeJobPhoneDigits(value) {
+  const digits = clean(value).replace(/\D/g, "");
+  const parsed = normalizeClaimPhone(digits);
+  return parsed ? parsed.phone_norm : "";
+}
+
+function publicStatus(value) {
+  const raw = clean(value);
+  if (raw === "ตีกลับ" || raw === "งานแก้ไข") return "รอดำเนินการ";
+  return raw;
+}
+
+function historyRow(row, { secret, customerSub }) {
+  return {
+    job_ref: makeJobRef({ secret, customerSub, jobId: row.job_id }),
+    booking_code: row.booking_code || null,
+    appointment_datetime: row.appointment_datetime || null,
+    job_status: publicStatus(row.job_status),
+    booking_mode: row.booking_mode || null,
+    service_summary: row.job_type || null,
+    job_price: row.job_price == null ? null : Number(row.job_price),
+    address_text: row.address_text || null,
+    maps_url: row.maps_url || null,
+    job_zone: row.job_zone || null,
+  };
+}
+
+function detailRow(row, { secret, customerSub }) {
+  return {
+    ...historyRow(row, { secret, customerSub }),
+    duration_min: row.duration_min == null ? null : Number(row.duration_min),
+    finished_at: row.finished_at || null,
+    canceled_at: row.canceled_at || null,
+    customer_phone_masked: row.customer_phone ? `•••• ${clean(row.customer_phone).replace(/\D/g, "").slice(-4)}` : null,
+  };
+}
+
+function compactText(value) {
+  return clean(value).replace(/\s+/g, " ");
+}
+
+function locationKey(row) {
+  return [
+    compactText(row.address_text).toLowerCase(),
+    compactText(row.maps_url).toLowerCase(),
+    compactText(row.job_zone).toLowerCase(),
+    row.gps_latitude == null ? "" : String(row.gps_latitude),
+    row.gps_longitude == null ? "" : String(row.gps_longitude),
+  ].join("|");
+}
+
+function groupLocations(rows) {
+  const byKey = new Map();
+  for (const row of rows || []) {
+    const address = compactText(row.address_text);
+    if (!address) continue;
+    const key = locationKey(row);
+    if (!byKey.has(key)) {
+      byKey.set(key, {
+        location_ref: b64url(crypto.createHash("sha256").update(`location\0${key}`).digest()).slice(0, 24),
+        address_text: address,
+        maps_url: compactText(row.maps_url) || null,
+        job_zone: compactText(row.job_zone) || null,
+        job_count: 0,
+        last_seen_at: null,
+        sample_booking_code: row.booking_code || null,
+        auto_select: false,
+      });
+    }
+    const item = byKey.get(key);
+    item.job_count += 1;
+    const seen = row.last_seen_at || row.appointment_datetime || row.finished_at || null;
+    if (seen && (!item.last_seen_at || String(seen) > String(item.last_seen_at))) {
+      item.last_seen_at = seen;
+      item.sample_booking_code = row.booking_code || item.sample_booking_code || null;
+    }
+  }
+  return [...byKey.values()].sort((a, b) => String(b.last_seen_at || "").localeCompare(String(a.last_seen_at || "")));
+}
+
+async function schemaReady(db) {
+  const r = await db.query(`
+    SELECT
+      to_regclass('public.customer_history_claims') IS NOT NULL AS has_claims,
+      EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_schema='public' AND table_name='jobs' AND column_name='customer_sub'
+      ) AS has_customer_sub
+  `);
+  return {
+    has_claims: !!r.rows?.[0]?.has_claims,
+    has_customer_sub: !!r.rows?.[0]?.has_customer_sub,
+  };
+}
+
+async function activeClaims(db, customerSub) {
+  const r = await db.query(
+    `SELECT phone_norm, phone_last4
+       FROM public.customer_history_claims
+      WHERE customer_sub=$1 AND revoked_at IS NULL
+      ORDER BY claimed_at ASC`,
+    [customerSub]
+  );
+  return r.rows || [];
+}
+
+function phoneMatchDigitsForClaims(claims) {
+  const set = new Set();
+  for (const claim of claims || []) {
+    const parsed = normalizeClaimPhone(claim.phone_norm);
+    if (!parsed) continue;
+    for (const value of parsed.match_digits) set.add(value);
+  }
+  return [...set];
+}
+
+function buildAuthorizedWhere({ customerSub, hasCustomerSub, phoneDigits, startParam = 1 }) {
+  const parts = [];
+  const params = [];
+  if (hasCustomerSub) {
+    parts.push(`j.customer_sub=$${startParam + params.length}`);
+    params.push(customerSub);
+  }
+  if (phoneDigits.length) {
+    parts.push(`regexp_replace(COALESCE(j.customer_phone,''), '[^0-9]', '', 'g') = ANY($${startParam + params.length}::text[])`);
+    params.push(phoneDigits);
+  }
+  return { where: parts.length ? `(${parts.join(" OR ")})` : "(FALSE)", params };
+}
+
+module.exports = {
+  CLAIM_METHOD,
+  GENERIC_CLAIM_ERROR,
+  buildAuthorizedWhere,
+  clean,
+  detailRow,
+  groupLocations,
+  hmacHex,
+  historyRow,
+  makeJobRef,
+  normalizeBookingCode,
+  normalizeClaimPhone,
+  normalizeJobPhoneDigits,
+  parseJobRef,
+  phoneMatchDigitsForClaims,
+  schemaReady,
+  activeClaims,
+};

--- a/server/services/public/customerHistory.js
+++ b/server/services/public/customerHistory.js
@@ -150,13 +150,11 @@ function groupLocations(rows) {
     const key = locationKey(row);
     if (!byKey.has(key)) {
       byKey.set(key, {
-        location_ref: b64url(crypto.createHash("sha256").update(`location\0${key}`).digest()).slice(0, 24),
         address_text: address,
         maps_url: compactText(row.maps_url) || null,
         job_zone: compactText(row.job_zone) || null,
         job_count: 0,
         last_seen_at: null,
-        sample_booking_code: row.booking_code || null,
         auto_select: false,
       });
     }
@@ -165,7 +163,6 @@ function groupLocations(rows) {
     const seen = row.last_seen_at || row.appointment_datetime || row.finished_at || null;
     if (seen && (!item.last_seen_at || String(seen) > String(item.last_seen_at))) {
       item.last_seen_at = seen;
-      item.sample_booking_code = row.booking_code || item.sample_booking_code || null;
     }
   }
   return [...byKey.values()].sort((a, b) => String(b.last_seen_at || "").localeCompare(String(a.last_seen_at || "")));

--- a/test/customerAppRecovery.test.js
+++ b/test/customerAppRecovery.test.js
@@ -236,7 +236,7 @@ test("Customer App build id is consistent across shell and service worker", () =
   const sw = read("customer-app/sw.js");
   const app = read("customer-app/assets/customer-app.js");
   const manifest = read("customer-app/manifest.webmanifest");
-  const build = "20260710_legacy_claim_v1";
+  const build = "20260710_legacy_claim_v2";
 
   assert.match(index, new RegExp(`customer-app\\.css\\?v=${build}`));
   assert.match(index, new RegExp(`modules\\/api\\.js\\?v=${build}`));
@@ -254,7 +254,7 @@ test("Customer App build id is consistent across shell and service worker", () =
 test("store module is loaded in index.html and precached in the service worker app shell", () => {
   const index = read("customer-app/index.html");
   const sw = read("customer-app/sw.js");
-  const build = "20260710_legacy_claim_v1";
+  const build = "20260710_legacy_claim_v2";
 
   assert.match(index, new RegExp(`modules/store\\.js\\?v=${build}`));
   assert.match(sw, /`\.\/modules\/store\.js\?v=\$\{BUILD_ID\}`/);

--- a/test/customerAppRecovery.test.js
+++ b/test/customerAppRecovery.test.js
@@ -236,7 +236,7 @@ test("Customer App build id is consistent across shell and service worker", () =
   const sw = read("customer-app/sw.js");
   const app = read("customer-app/assets/customer-app.js");
   const manifest = read("customer-app/manifest.webmanifest");
-  const build = "20260709_review_legacy_v1";
+  const build = "20260710_legacy_claim_v1";
 
   assert.match(index, new RegExp(`customer-app\\.css\\?v=${build}`));
   assert.match(index, new RegExp(`modules\\/api\\.js\\?v=${build}`));
@@ -254,7 +254,7 @@ test("Customer App build id is consistent across shell and service worker", () =
 test("store module is loaded in index.html and precached in the service worker app shell", () => {
   const index = read("customer-app/index.html");
   const sw = read("customer-app/sw.js");
-  const build = "20260709_review_legacy_v1";
+  const build = "20260710_legacy_claim_v1";
 
   assert.match(index, new RegExp(`modules/store\\.js\\?v=${build}`));
   assert.match(sw, /`\.\/modules\/store\.js\?v=\$\{BUILD_ID\}`/);

--- a/test/customerAppStorePayment.test.js
+++ b/test/customerAppStorePayment.test.js
@@ -58,7 +58,7 @@ test("store falls back to the LINE hand-off when payment is unconfigured or the 
 test("payment step styles exist and the Customer App payment build id is bumped", () => {
   assert.match(cssSrc, /\.pay-method-btn/);
   assert.match(cssSrc, /\.pay-qr-img/);
-  assert.match(read("customer-app/index.html"), /modules\/store\.js\?v=20260709_review_legacy_v1/);
-  assert.match(read("customer-app/sw.js"), /BUILD_ID = "20260709_review_legacy_v1"/);
+  assert.match(read("customer-app/index.html"), /modules\/store\.js\?v=20260710_legacy_claim_v1/);
+  assert.match(read("customer-app/sw.js"), /BUILD_ID = "20260710_legacy_claim_v1"/);
   assert.match(storeSrc, /payment-security 20260705 loaded/);
 });

--- a/test/customerAppStorePayment.test.js
+++ b/test/customerAppStorePayment.test.js
@@ -58,7 +58,7 @@ test("store falls back to the LINE hand-off when payment is unconfigured or the 
 test("payment step styles exist and the Customer App payment build id is bumped", () => {
   assert.match(cssSrc, /\.pay-method-btn/);
   assert.match(cssSrc, /\.pay-qr-img/);
-  assert.match(read("customer-app/index.html"), /modules\/store\.js\?v=20260710_legacy_claim_v1/);
-  assert.match(read("customer-app/sw.js"), /BUILD_ID = "20260710_legacy_claim_v1"/);
+  assert.match(read("customer-app/index.html"), /modules\/store\.js\?v=20260710_legacy_claim_v2/);
+  assert.match(read("customer-app/sw.js"), /BUILD_ID = "20260710_legacy_claim_v2"/);
   assert.match(storeSrc, /payment-security 20260705 loaded/);
 });

--- a/test/customerBookingAdminNotifications.test.js
+++ b/test/customerBookingAdminNotifications.test.js
@@ -311,10 +311,10 @@ test("admin/customer frontend cache versions are bumped for booking notification
   assert.doesNotMatch(adminReviewHtml, /admin-review-v2\.js\?v=20260707_customer_booking_notify_v2/);
   assert.match(adminReviewHtml, /admin-review-ai-intake\.js\?v=ai-booking-intake-customer-cards-v11-admin-alert-gate/);
   assert.doesNotMatch(adminReviewHtml, /admin-review-ai-intake\.js\?v=ai-booking-intake-customer-cards-v10/);
-  assert.match(customerIndex, /bookingScheduled\.js\?v=20260710_legacy_claim_v1/);
-  assert.match(customerIndex, /state\.js\?v=20260710_legacy_claim_v1/);
-  assert.match(customerSw, /const BUILD_ID = "20260710_legacy_claim_v1"/);
-  assert.match(customerManifest, /20260710_legacy_claim_v1/);
+  assert.match(customerIndex, /bookingScheduled\.js\?v=20260710_legacy_claim_v2/);
+  assert.match(customerIndex, /state\.js\?v=20260710_legacy_claim_v2/);
+  assert.match(customerSw, /const BUILD_ID = "20260710_legacy_claim_v2"/);
+  assert.match(customerManifest, /20260710_legacy_claim_v2/);
 });
 
 test("behavior: review queue only includes customer urgent waiting rows while preserving review statuses", () => {

--- a/test/customerBookingAdminNotifications.test.js
+++ b/test/customerBookingAdminNotifications.test.js
@@ -311,10 +311,10 @@ test("admin/customer frontend cache versions are bumped for booking notification
   assert.doesNotMatch(adminReviewHtml, /admin-review-v2\.js\?v=20260707_customer_booking_notify_v2/);
   assert.match(adminReviewHtml, /admin-review-ai-intake\.js\?v=ai-booking-intake-customer-cards-v11-admin-alert-gate/);
   assert.doesNotMatch(adminReviewHtml, /admin-review-ai-intake\.js\?v=ai-booking-intake-customer-cards-v10/);
-  assert.match(customerIndex, /bookingScheduled\.js\?v=20260709_review_legacy_v1/);
-  assert.match(customerIndex, /state\.js\?v=20260709_review_legacy_v1/);
-  assert.match(customerSw, /const BUILD_ID = "20260709_review_legacy_v1"/);
-  assert.match(customerManifest, /20260709_review_legacy_v1/);
+  assert.match(customerIndex, /bookingScheduled\.js\?v=20260710_legacy_claim_v1/);
+  assert.match(customerIndex, /state\.js\?v=20260710_legacy_claim_v1/);
+  assert.match(customerSw, /const BUILD_ID = "20260710_legacy_claim_v1"/);
+  assert.match(customerManifest, /20260710_legacy_claim_v1/);
 });
 
 test("behavior: review queue only includes customer urgent waiting rows while preserving review statuses", () => {

--- a/test/customerHistoryClaim.test.js
+++ b/test/customerHistoryClaim.test.js
@@ -1,0 +1,356 @@
+"use strict";
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const express = require("express");
+const http = require("node:http");
+const fs = require("node:fs");
+const path = require("node:path");
+const vm = require("node:vm");
+
+const createCustomerHistoryRoutes = require("../server/routes/public/customerHistory");
+const history = require("../server/services/public/customerHistory");
+
+const REPO_ROOT = path.resolve(__dirname, "..");
+
+function makePool({ jobs = [], claims = [], hasClaims = true, hasCustomerSub = true, failInsert = false } = {}) {
+  const state = {
+    jobs: jobs.map((x) => ({ ...x })),
+    claims: claims.map((x) => ({ ...x })),
+    queries: [],
+    hasClaims,
+    hasCustomerSub,
+    failInsert,
+  };
+  async function query(sql, params = []) {
+    const s = String(sql);
+    state.queries.push({ sql: s, params });
+    if (/BEGIN|COMMIT|ROLLBACK/.test(s)) return { rows: [] };
+    if (/to_regclass\('public\.customer_history_claims'\)/.test(s)) {
+      return { rows: [{ has_claims: state.hasClaims, has_customer_sub: state.hasCustomerSub }] };
+    }
+    if (/FROM public\.jobs\s+WHERE upper\(btrim/.test(s)) {
+      const code = String(params[0] || "").toUpperCase();
+      const rows = state.jobs.filter((j) => String(j.booking_code || "").trim().toUpperCase() === code && String(j.customer_phone || "").trim()).slice(0, 2);
+      return { rows };
+    }
+    if (/FROM public\.customer_history_claims/.test(s) && /WHERE phone_norm=\$1/.test(s)) {
+      return { rows: state.claims.filter((c) => c.phone_norm === params[0] && !c.revoked_at).slice(0, 1) };
+    }
+    if (/UPDATE public\.customer_history_claims/.test(s)) {
+      const found = state.claims.find((c) => c.claim_id === params[0]);
+      if (found) found.last_verified_at = "now";
+      return { rows: [] };
+    }
+    if (/FROM public\.customer_history_claims/.test(s) && /WHERE proof_job_id=\$1/.test(s)) {
+      return { rows: state.claims.filter((c) => String(c.proof_job_id) === String(params[0]) && !c.revoked_at).slice(0, 1) };
+    }
+    if (/INSERT INTO public\.customer_history_claims/.test(s)) {
+      if (state.failInsert) throw new Error("db unavailable");
+      state.claims.push({
+        claim_id: state.claims.length + 1,
+        customer_sub: params[0],
+        phone_norm: params[1],
+        phone_last4: params[2],
+        proof_job_id: params[3],
+        claim_method: params[4],
+      });
+      return { rows: [] };
+    }
+    if (/SELECT phone_norm, phone_last4/.test(s)) {
+      return { rows: state.claims.filter((c) => c.customer_sub === params[0] && !c.revoked_at) };
+    }
+    if (/FROM public\.jobs j/.test(s)) {
+      const detail = /j\.job_id::text=\$1/.test(s);
+      const offset = detail ? 1 : 0;
+      const jobId = detail ? String(params[0]) : null;
+      const customerSub = params[offset] && !Array.isArray(params[offset]) ? params[offset] : null;
+      const phoneDigits = params.find(Array.isArray) || [];
+      const rows = state.jobs.filter((j) => {
+        if (detail && String(j.job_id) !== jobId) return false;
+        const direct = customerSub && j.customer_sub === customerSub;
+        const phone = String(j.customer_phone || "").replace(/\D/g, "");
+        return direct || phoneDigits.includes(phone);
+      });
+      return { rows };
+    }
+    return { rows: [] };
+  }
+  return {
+    state,
+    async query(sql, params) { return query(sql, params); },
+    async connect() {
+      return { query, release() {} };
+    },
+  };
+}
+
+function requireCustomerJwtFor(sub) {
+  return (req, res, next) => {
+    if (!sub) return res.status(401).json({ error: "NOT_LOGGED_IN" });
+    req.customer = { sub, provider: "line" };
+    next();
+  };
+}
+
+async function withServer({ pool, sub = "line:u1", logger } = {}, fn) {
+  const app = express();
+  app.use(express.json());
+  app.use(createCustomerHistoryRoutes({
+    pool,
+    requireCustomerJwt: requireCustomerJwtFor(sub),
+    getSecret: () => "test-secret",
+    logger: logger || { warn() {} },
+  }));
+  const server = http.createServer(app);
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  try {
+    return await fn(`http://127.0.0.1:${server.address().port}`);
+  } finally {
+    await new Promise((resolve) => server.close(resolve));
+  }
+}
+
+async function json(res) {
+  return res.json().catch(() => ({}));
+}
+
+const LEGACY_JOB = {
+  job_id: 101,
+  booking_code: "CWFABC123",
+  booking_token: "must-not-leak",
+  customer_sub: null,
+  customer_name: "Customer",
+  customer_phone: "0812345678",
+  job_type: "ล้าง",
+  appointment_datetime: "2026-07-01T03:00:00.000Z",
+  job_status: "เสร็จแล้ว",
+  booking_mode: "scheduled",
+  job_price: 1200,
+  address_text: "Condo A Room 101",
+  maps_url: "https://maps.google.com/?q=13,100",
+  job_zone: "สุขุมวิท",
+};
+
+test("claim phone normalizer supports exact local, dashed, +66, and 0066 only", () => {
+  for (const raw of ["0812345678", "081-234-5678", "+66812345678", "0066812345678"]) {
+    const parsed = history.normalizeClaimPhone(raw);
+    assert.equal(parsed.phone_norm, "0812345678");
+    assert.deepEqual(parsed.match_digits, ["0812345678", "66812345678", "0066812345678"]);
+  }
+  assert.equal(history.normalizeClaimPhone("812345678"), null);
+  assert.equal(history.normalizeClaimPhone("12345678"), null);
+});
+
+test("unauthenticated claim returns 401", async () => {
+  await withServer({ pool: makePool(), sub: null }, async (base) => {
+    const res = await fetch(`${base}/public/customer-history/claim`, { method: "POST", headers: { "content-type": "application/json" }, body: "{}" });
+    assert.equal(res.status, 401);
+  });
+});
+
+test("wrong phone/code cases use generic CLAIM_FAILED and never fallback to partial phone sources", async () => {
+  const pool = makePool({ jobs: [{ ...LEGACY_JOB, customer_note: "0812345678", address_text: "phone 0812345678 but not customer_phone", customer_phone: "0899999999" }] });
+  await withServer({ pool }, async (base) => {
+    for (const body of [
+      { phone: "0812345678", booking_code: "CWFABC123" },
+      { phone: "812345678", booking_code: "CWFABC123" },
+      { phone: "0812345678", booking_code: "NOPE" },
+    ]) {
+      const res = await fetch(`${base}/public/customer-history/claim`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(body),
+      });
+      assert.equal(res.status, 400);
+      assert.equal((await json(res)).error, "CLAIM_FAILED");
+    }
+  });
+});
+
+test("claim succeeds, retries by same account are idempotent, and other accounts cannot claim same phone", async () => {
+  const pool = makePool({ jobs: [LEGACY_JOB] });
+  await withServer({ pool, sub: "line:u1" }, async (base) => {
+    const first = await fetch(`${base}/public/customer-history/claim`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ phone: "+66812345678", booking_code: " cwfabc123 " }),
+    });
+    assert.equal(first.status, 200);
+    assert.equal(pool.state.claims.length, 1);
+    assert.equal(pool.state.claims[0].phone_norm, "0812345678");
+    const second = await fetch(`${base}/public/customer-history/claim`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ phone: "081-234-5678", booking_code: "CWFABC123" }),
+    });
+    assert.equal(second.status, 200);
+    assert.equal((await json(second)).replayed, true);
+    assert.equal(pool.state.claims.length, 1);
+  });
+  await withServer({ pool, sub: "google:u2" }, async (base) => {
+    const res = await fetch(`${base}/public/customer-history/claim`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ phone: "0812345678", booking_code: "CWFABC123" }),
+    });
+    assert.equal(res.status, 400);
+    assert.equal((await json(res)).error, "CLAIM_FAILED");
+  });
+});
+
+test("revoked claim does not authorize history and history rejects phone query", async () => {
+  const pool = makePool({
+    jobs: [LEGACY_JOB],
+    claims: [{ claim_id: 1, customer_sub: "line:u1", phone_norm: "0812345678", phone_last4: "5678", proof_job_id: 101, revoked_at: "2026-01-01" }],
+  });
+  await withServer({ pool }, async (base) => {
+    const phoneQuery = await fetch(`${base}/public/customer-history?phone=0812345678`);
+    assert.equal(phoneQuery.status, 400);
+    const res = await fetch(`${base}/public/customer-history`);
+    assert.equal(res.status, 200);
+    const body = await json(res);
+    assert.equal(body.claimed, false);
+    assert.deepEqual(body.items, []);
+  });
+});
+
+test("history and detail use opaque refs and do not return token, raw job_id, or internal fields", async () => {
+  const pool = makePool({
+    jobs: [LEGACY_JOB],
+    claims: [{ claim_id: 1, customer_sub: "line:u1", phone_norm: "0812345678", phone_last4: "5678", proof_job_id: 101 }],
+  });
+  await withServer({ pool }, async (base) => {
+    const res = await fetch(`${base}/public/customer-history`);
+    assert.equal(res.status, 200);
+    const body = await json(res);
+    assert.equal(body.claimed, true);
+    assert.equal(body.items.length, 1);
+    const item = body.items[0];
+    assert.ok(item.job_ref && !String(item.job_ref).includes("101"));
+    for (const forbidden of ["booking_token", "job_id", "technician_note", "customer_note", "claim_id", "proof_job_id"]) {
+      assert.equal(item[forbidden], undefined);
+    }
+    const detail = await fetch(`${base}/public/customer-history/${encodeURIComponent(item.job_ref)}`);
+    assert.equal(detail.status, 200);
+    const detailBody = await json(detail);
+    for (const forbidden of ["booking_token", "job_id", "technician_note", "customer_note", "claim_id", "proof_job_id"]) {
+      assert.equal(detailBody.item[forbidden], undefined);
+    }
+  });
+});
+
+test("wrong-account job_ref is rejected", async () => {
+  const ref = history.makeJobRef({ secret: "test-secret", customerSub: "line:u1", jobId: 101 });
+  const pool = makePool({
+    jobs: [LEGACY_JOB],
+    claims: [{ claim_id: 1, customer_sub: "google:u2", phone_norm: "0812345678", phone_last4: "5678", proof_job_id: 101 }],
+  });
+  await withServer({ pool, sub: "google:u2" }, async (base) => {
+    const res = await fetch(`${base}/public/customer-history/${encodeURIComponent(ref)}`);
+    assert.equal(res.status, 404);
+  });
+});
+
+test("claim rate limit is split by proof hash and does not log raw phone or code", async () => {
+  const logs = [];
+  const pool = makePool({ jobs: [LEGACY_JOB], failInsert: true });
+  await withServer({ pool, logger: { warn: (...args) => logs.push(args) } }, async (base) => {
+    const res = await fetch(`${base}/public/customer-history/claim`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ phone: "0812345678", booking_code: "CWFABC123" }),
+    });
+    assert.equal(res.status, 500);
+    assert.doesNotMatch(JSON.stringify(logs), /0812345678|CWFABC123/);
+  });
+});
+
+test("locations group exact duplicates but keep ambiguous locations separate", async () => {
+  const pool = makePool({
+    jobs: [
+      LEGACY_JOB,
+      { ...LEGACY_JOB, job_id: 102, booking_code: "CWF2" },
+      { ...LEGACY_JOB, job_id: 103, booking_code: "CWF3", maps_url: "https://maps.google.com/?q=13.1,100.1" },
+    ],
+    claims: [{ claim_id: 1, customer_sub: "line:u1", phone_norm: "0812345678", phone_last4: "5678", proof_job_id: 101 }],
+  });
+  await withServer({ pool }, async (base) => {
+    const res = await fetch(`${base}/public/customer-history/locations`);
+    assert.equal(res.status, 200);
+    const body = await json(res);
+    assert.equal(body.auto_select, false);
+    assert.equal(body.has_multiple_locations, true);
+    assert.equal(body.locations.length, 2);
+    assert.ok(body.locations.some((x) => x.job_count === 2));
+  });
+});
+
+test("migration stores no raw booking code and uses BIGINT-compatible proof_job_id", () => {
+  const sql = fs.readFileSync(path.join(REPO_ROOT, "migrations", "20260710_customer_history_claims.sql"), "utf8");
+  assert.match(sql, /proof_job_id BIGINT NOT NULL REFERENCES public\.jobs\(job_id\)/);
+  assert.doesNotMatch(sql, /proof_booking_code/i);
+  assert.match(sql, /phone_last4 ~ '\^\[0-9\]\{4\}\$'/);
+});
+
+function makeBrowserContext({ fetchImpl } = {}) {
+  const storage = new Map();
+  const window = {
+    CWFCustomerAppV2: {},
+    location: { protocol: "https:", origin: "https://app.example.test", hostname: "app.example.test", search: "", hash: "" },
+    sessionStorage: {
+      getItem(key) { return storage.get(key) || null; },
+      setItem(key, value) { storage.set(key, String(value)); },
+      removeItem(key) { storage.delete(key); },
+    },
+  };
+  const context = { window, fetch: fetchImpl || (async () => ({ ok: true, text: async () => "{}" })), URL, URLSearchParams, console, Intl, Date, setTimeout, clearTimeout };
+  context.globalThis = context;
+  return vm.createContext(context);
+}
+
+function loadModule(context, relativePath) {
+  const src = fs.readFileSync(path.join(REPO_ROOT, relativePath), "utf8");
+  vm.runInContext(src, context, { filename: relativePath });
+  return context.window.CWFCustomerAppV2;
+}
+
+test("Customer App API and state support claim/history without phone query or auto-submit", async () => {
+  const calls = [];
+  const context = makeBrowserContext({
+    fetchImpl: async (url, options = {}) => {
+      calls.push({ url, options });
+      return { ok: true, text: async () => JSON.stringify({ ok: true, items: [], locations: [] }) };
+    },
+  });
+  const root = loadModule(context, "customer-app/modules/api.js");
+  await root.api.claimCustomerHistory({ phone: "081", booking_code: "CWF1" });
+  await root.api.loadCustomerHistory();
+  await root.api.loadCustomerHistoryLocations();
+  assert.equal(calls[0].url, "https://app.example.test/public/customer-history/claim");
+  assert.deepEqual(JSON.parse(calls[0].options.body), { phone: "081", booking_code: "CWF1" });
+  assert.equal(calls[1].url, "https://app.example.test/public/customer-history");
+  assert.equal(calls[2].url, "https://app.example.test/public/customer-history/locations");
+  assert.doesNotMatch(calls.map((x) => x.url).join("\n"), /phone=/);
+
+  const stateContext = makeBrowserContext();
+  const stateRoot = loadModule(stateContext, "customer-app/modules/state.js");
+  assert.equal(stateRoot.state.applyHistoryLocation("scheduled", { address_text: "Old condo", maps_url: "https://maps.example/a", job_zone: "Zone A" }), true);
+  assert.equal(stateRoot.state.draft.scheduled.address_text, "Old condo");
+  assert.equal(stateRoot.state.draft.scheduled.maps_url, "https://maps.example/a");
+  assert.equal(stateRoot.state.draft.scheduled.job_zone, "Zone A");
+});
+
+test("Customer App cache version is bumped consistently", () => {
+  const expected = "20260710_legacy_claim_v1";
+  for (const file of [
+    "customer-app/index.html",
+    "customer-app/sw.js",
+    "customer-app/assets/customer-app.js",
+    "customer-app/manifest.webmanifest",
+  ]) {
+    const src = fs.readFileSync(path.join(REPO_ROOT, file), "utf8");
+    assert.match(src, new RegExp(expected));
+    assert.doesNotMatch(src, /20260709_review_legacy_v1/);
+  }
+});

--- a/test/customerHistoryClaim.test.js
+++ b/test/customerHistoryClaim.test.js
@@ -13,7 +13,7 @@ const history = require("../server/services/public/customerHistory");
 
 const REPO_ROOT = path.resolve(__dirname, "..");
 
-function makePool({ jobs = [], claims = [], hasClaims = true, hasCustomerSub = true, failInsert = false } = {}) {
+function makePool({ jobs = [], claims = [], hasClaims = true, hasCustomerSub = true, failInsert = false, uniqueConflictClaim = null } = {}) {
   const state = {
     jobs: jobs.map((x) => ({ ...x })),
     claims: claims.map((x) => ({ ...x })),
@@ -21,6 +21,7 @@ function makePool({ jobs = [], claims = [], hasClaims = true, hasCustomerSub = t
     hasClaims,
     hasCustomerSub,
     failInsert,
+    uniqueConflictClaim,
   };
   async function query(sql, params = []) {
     const s = String(sql);
@@ -37,6 +38,11 @@ function makePool({ jobs = [], claims = [], hasClaims = true, hasCustomerSub = t
     if (/FROM public\.customer_history_claims/.test(s) && /WHERE phone_norm=\$1/.test(s)) {
       return { rows: state.claims.filter((c) => c.phone_norm === params[0] && !c.revoked_at).slice(0, 1) };
     }
+    if (/phone_norm=\$1 OR proof_job_id=\$2/.test(s)) {
+      return {
+        rows: state.claims.filter((c) => !c.revoked_at && (c.phone_norm === params[0] || String(c.proof_job_id) === String(params[1]))).slice(0, 1),
+      };
+    }
     if (/UPDATE public\.customer_history_claims/.test(s)) {
       const found = state.claims.find((c) => c.claim_id === params[0]);
       if (found) found.last_verified_at = "now";
@@ -47,6 +53,20 @@ function makePool({ jobs = [], claims = [], hasClaims = true, hasCustomerSub = t
     }
     if (/INSERT INTO public\.customer_history_claims/.test(s)) {
       if (state.failInsert) throw new Error("db unavailable");
+      if (state.uniqueConflictClaim) {
+        if (!state.claims.some((c) => c.claim_id === state.uniqueConflictClaim.claim_id)) {
+          state.claims.push({ ...state.uniqueConflictClaim });
+        }
+        const error = new Error("duplicate key value violates unique constraint");
+        error.code = "23505";
+        throw error;
+      }
+      const duplicate = state.claims.find((c) => !c.revoked_at && (c.phone_norm === params[1] || String(c.proof_job_id) === String(params[3])));
+      if (duplicate) {
+        const error = new Error("duplicate key value violates unique constraint");
+        error.code = "23505";
+        throw error;
+      }
       state.claims.push({
         claim_id: state.claims.length + 1,
         customer_sub: params[0],
@@ -177,6 +197,7 @@ test("claim succeeds, retries by same account are idempotent, and other accounts
       body: JSON.stringify({ phone: "+66812345678", booking_code: " cwfabc123 " }),
     });
     assert.equal(first.status, 200);
+    assert.equal(first.headers.get("cache-control"), "private, no-store");
     assert.equal(pool.state.claims.length, 1);
     assert.equal(pool.state.claims[0].phone_norm, "0812345678");
     const second = await fetch(`${base}/public/customer-history/claim`, {
@@ -199,6 +220,97 @@ test("claim succeeds, retries by same account are idempotent, and other accounts
   });
 });
 
+test("concurrent claim requests return replay for same account and generic failure for a different account", async () => {
+  const samePool = makePool({ jobs: [LEGACY_JOB] });
+  await withServer({ pool: samePool, sub: "line:u1" }, async (base) => {
+    const body = JSON.stringify({ phone: "0812345678", booking_code: "CWFABC123" });
+    const responses = await Promise.all([
+      fetch(`${base}/public/customer-history/claim`, { method: "POST", headers: { "content-type": "application/json" }, body }),
+      fetch(`${base}/public/customer-history/claim`, { method: "POST", headers: { "content-type": "application/json" }, body }),
+    ]);
+    assert.deepEqual(responses.map((res) => res.status).sort(), [200, 200]);
+    const payloads = await Promise.all(responses.map(json));
+    assert.equal(payloads.filter((x) => x.replayed).length, 1);
+    assert.equal(samePool.state.claims.length, 1);
+  });
+
+  const differentPool = makePool({ jobs: [LEGACY_JOB] });
+  const app = express();
+  app.use(express.json());
+  app.use("/u1", createCustomerHistoryRoutes({
+    pool: differentPool,
+    requireCustomerJwt: requireCustomerJwtFor("line:u1"),
+    getSecret: () => "test-secret",
+    logger: { warn() {} },
+  }));
+  app.use("/u2", createCustomerHistoryRoutes({
+    pool: differentPool,
+    requireCustomerJwt: requireCustomerJwtFor("google:u2"),
+    getSecret: () => "test-secret",
+    logger: { warn() {} },
+  }));
+  const server = http.createServer(app);
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  try {
+    const base = `http://127.0.0.1:${server.address().port}`;
+    const body = JSON.stringify({ phone: "0812345678", booking_code: "CWFABC123" });
+    const responses = await Promise.all([
+      fetch(`${base}/u1/public/customer-history/claim`, { method: "POST", headers: { "content-type": "application/json" }, body }),
+      fetch(`${base}/u2/public/customer-history/claim`, { method: "POST", headers: { "content-type": "application/json" }, body }),
+    ]);
+    const statuses = responses.map((res) => res.status).sort();
+    assert.deepEqual(statuses, [200, 400]);
+    const payloads = await Promise.all(responses.map(json));
+    assert.ok(payloads.some((x) => x.error === "CLAIM_FAILED"));
+    assert.equal(differentPool.state.claims.length, 1);
+  } finally {
+    await new Promise((resolve) => server.close(resolve));
+  }
+});
+
+test("unique races resolve to replay for same account or generic failure for another account", async () => {
+  const sameAccountPool = makePool({
+    jobs: [LEGACY_JOB],
+    uniqueConflictClaim: {
+      claim_id: 1,
+      customer_sub: "line:u1",
+      phone_norm: "0812345678",
+      phone_last4: "5678",
+      proof_job_id: 101,
+    },
+  });
+  await withServer({ pool: sameAccountPool, sub: "line:u1" }, async (base) => {
+    const res = await fetch(`${base}/public/customer-history/claim`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ phone: "0812345678", booking_code: "CWFABC123" }),
+    });
+    assert.equal(res.status, 200);
+    assert.equal((await json(res)).replayed, true);
+    assert.equal(sameAccountPool.state.claims.length, 1);
+  });
+
+  const otherAccountPool = makePool({
+    jobs: [LEGACY_JOB],
+    uniqueConflictClaim: {
+      claim_id: 1,
+      customer_sub: "line:other",
+      phone_norm: "0812345678",
+      phone_last4: "5678",
+      proof_job_id: 101,
+    },
+  });
+  await withServer({ pool: otherAccountPool, sub: "line:u1" }, async (base) => {
+    const res = await fetch(`${base}/public/customer-history/claim`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ phone: "0812345678", booking_code: "CWFABC123" }),
+    });
+    assert.equal(res.status, 400);
+    assert.equal((await json(res)).error, "CLAIM_FAILED");
+  });
+});
+
 test("revoked claim does not authorize history and history rejects phone query", async () => {
   const pool = makePool({
     jobs: [LEGACY_JOB],
@@ -209,6 +321,7 @@ test("revoked claim does not authorize history and history rejects phone query",
     assert.equal(phoneQuery.status, 400);
     const res = await fetch(`${base}/public/customer-history`);
     assert.equal(res.status, 200);
+    assert.equal(res.headers.get("cache-control"), "private, no-store");
     const body = await json(res);
     assert.equal(body.claimed, false);
     assert.deepEqual(body.items, []);
@@ -233,6 +346,7 @@ test("history and detail use opaque refs and do not return token, raw job_id, or
     }
     const detail = await fetch(`${base}/public/customer-history/${encodeURIComponent(item.job_ref)}`);
     assert.equal(detail.status, 200);
+    assert.equal(detail.headers.get("cache-control"), "private, no-store");
     const detailBody = await json(detail);
     for (const forbidden of ["booking_token", "job_id", "technician_note", "customer_note", "claim_id", "proof_job_id"]) {
       assert.equal(detailBody.item[forbidden], undefined);
@@ -278,11 +392,16 @@ test("locations group exact duplicates but keep ambiguous locations separate", a
   await withServer({ pool }, async (base) => {
     const res = await fetch(`${base}/public/customer-history/locations`);
     assert.equal(res.status, 200);
+    assert.equal(res.headers.get("cache-control"), "private, no-store");
     const body = await json(res);
     assert.equal(body.auto_select, false);
     assert.equal(body.has_multiple_locations, true);
     assert.equal(body.locations.length, 2);
     assert.ok(body.locations.some((x) => x.job_count === 2));
+    for (const loc of body.locations) {
+      assert.equal(loc.sample_booking_code, undefined);
+      assert.equal(loc.location_ref, undefined);
+    }
   });
 });
 
@@ -290,7 +409,8 @@ test("migration stores no raw booking code and uses BIGINT-compatible proof_job_
   const sql = fs.readFileSync(path.join(REPO_ROOT, "migrations", "20260710_customer_history_claims.sql"), "utf8");
   assert.match(sql, /proof_job_id BIGINT NOT NULL REFERENCES public\.jobs\(job_id\)/);
   assert.doesNotMatch(sql, /proof_booking_code/i);
-  assert.match(sql, /phone_last4 ~ '\^\[0-9\]\{4\}\$'/);
+  assert.match(sql, /phone_norm ~ '\^0\[0-9\]\{8,9\}\$'/);
+  assert.match(sql, /phone_last4 ~ '\^\[0-9\]\{4\}\$' AND phone_last4 = right\(phone_norm, 4\)/);
 });
 
 function makeBrowserContext({ fetchImpl } = {}) {
@@ -326,11 +446,13 @@ test("Customer App API and state support claim/history without phone query or au
   const root = loadModule(context, "customer-app/modules/api.js");
   await root.api.claimCustomerHistory({ phone: "081", booking_code: "CWF1" });
   await root.api.loadCustomerHistory();
+  await root.api.loadCustomerHistoryDetail("opaque.ref");
   await root.api.loadCustomerHistoryLocations();
   assert.equal(calls[0].url, "https://app.example.test/public/customer-history/claim");
   assert.deepEqual(JSON.parse(calls[0].options.body), { phone: "081", booking_code: "CWF1" });
   assert.equal(calls[1].url, "https://app.example.test/public/customer-history");
-  assert.equal(calls[2].url, "https://app.example.test/public/customer-history/locations");
+  assert.equal(calls[2].url, "https://app.example.test/public/customer-history/opaque.ref");
+  assert.equal(calls[3].url, "https://app.example.test/public/customer-history/locations");
   assert.doesNotMatch(calls.map((x) => x.url).join("\n"), /phone=/);
 
   const stateContext = makeBrowserContext();
@@ -341,8 +463,88 @@ test("Customer App API and state support claim/history without phone query or au
   assert.equal(stateRoot.state.draft.scheduled.job_zone, "Zone A");
 });
 
+test("Customer App profile opens history detail with opaque job_ref and clears claim booking code after success", async () => {
+  const context = makeBrowserContext();
+  const root = context.window.CWFCustomerAppV2;
+  root.utils = {
+    escapeHtml(value) {
+      return String(value == null ? "" : value).replace(/[&<>"']/g, (ch) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" })[ch]);
+    },
+    icon() { return ""; },
+    routeTo() {},
+  };
+  const detailCalls = [];
+  root.api = {
+    async claimCustomerHistory() { return { ok: true }; },
+    async loadCustomerHistory() { return { claimed: true, items: root.state.customerHistory.items }; },
+    async loadCustomerHistoryLocations() { return { claimed: true, locations: [] }; },
+    async loadCustomerHistoryDetail(jobRef) {
+      detailCalls.push(jobRef);
+      return { item: { booking_code: "CWFABC123", job_status: "done", job_price: 1200, customer_phone_masked: "**** 5678" } };
+    },
+  };
+  root.auth = {
+    renderLoginPanel() { return ""; },
+    displayName() { return "Customer"; },
+    loadCustomer() { return Promise.resolve(); },
+  };
+  root.ui = { supportButtons() { return ""; } };
+  root.router = { refresh() {} };
+  root.state = {
+    authStatus: "success",
+    currentRoute: "profile",
+    customer: { logged_in: true, profile: {} },
+    profileAddressForm: {},
+    customerHistory: {
+      claimed: true,
+      items: [{ job_ref: "opaque.ref", booking_code: "CWFABC123", appointment_datetime: "2026-07-01", job_status: "done" }],
+      locations: [],
+      claimBookingCode: "CWFABC123",
+    },
+    setCustomerHistory(patch) { this.customerHistory = { ...this.customerHistory, ...patch }; },
+  };
+
+  const listeners = [];
+  const container = {
+    _html: "",
+    set innerHTML(value) { this._html = String(value); },
+    get innerHTML() { return this._html; },
+    querySelector(selector) {
+      if (selector === "[data-profile-history]") {
+        return {
+          set innerHTML(value) { container._html = String(value); },
+          get innerHTML() { return container._html; },
+        };
+      }
+      return null;
+    },
+    querySelectorAll(selector) {
+      if (selector !== "[data-history-detail-index]") return [];
+      const matches = [...this._html.matchAll(/data-history-detail-index="([0-9]+)"/g)];
+      return matches.map((m) => ({
+        dataset: {},
+        getAttribute(name) { return name === "data-history-detail-index" ? m[1] : null; },
+        addEventListener(_event, handler) { listeners.push(handler); },
+      }));
+    },
+  };
+
+  loadModule(context, "customer-app/modules/profile.js");
+  root.profile.render(container);
+  assert.equal(listeners.length, 1);
+  await listeners[0]();
+  assert.deepEqual(detailCalls, ["opaque.ref"]);
+  assert.equal(root.state.customerHistory.detail.booking_code, "CWFABC123");
+  assert.equal(root.state.customerHistory.detail.job_id, undefined);
+
+  const submitState = { claimStatus: "saving", claimBookingCode: "CWFABC123" };
+  root.state.setCustomerHistory = (patch) => Object.assign(submitState, patch);
+  root.state.setCustomerHistory({ claimStatus: "success", claimBookingCode: "", claimed: true });
+  assert.equal(submitState.claimBookingCode, "");
+});
+
 test("Customer App cache version is bumped consistently", () => {
-  const expected = "20260710_legacy_claim_v1";
+  const expected = "20260710_legacy_claim_v2";
   for (const file of [
     "customer-app/index.html",
     "customer-app/sw.js",

--- a/test/customerHistoryClaimsMigration.test.js
+++ b/test/customerHistoryClaimsMigration.test.js
@@ -1,0 +1,276 @@
+"use strict";
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+
+const runner = require("../scripts/run-customer-history-claims-migration");
+
+const REPO_ROOT = path.resolve(__dirname, "..");
+
+function logger() {
+  const lines = [];
+  return {
+    lines,
+    log(line) { lines.push(String(line)); },
+    error(line) { lines.push(String(line)); },
+  };
+}
+
+function expectedColumns() {
+  return [
+    ["claim_id", "bigint", "NO"],
+    ["customer_sub", "text", "NO"],
+    ["phone_norm", "text", "NO"],
+    ["phone_last4", "text", "NO"],
+    ["proof_job_id", "bigint", "NO"],
+    ["claim_method", "text", "NO"],
+    ["claimed_at", "timestamp with time zone", "NO"],
+    ["last_verified_at", "timestamp with time zone", "NO"],
+    ["revoked_at", "timestamp with time zone", "YES"],
+    ["revoke_reason", "text", "YES"],
+  ].map(([column_name, data_type, is_nullable]) => ({ column_name, data_type, is_nullable }));
+}
+
+class FakeClient {
+  constructor(options = {}) {
+    this.options = options;
+    this.queries = [];
+    this.connected = false;
+    this.ended = false;
+    this.applied = false;
+  }
+
+  async connect() {
+    this.connected = true;
+    if (this.options.connectError) throw new Error(this.options.connectError);
+  }
+
+  async end() {
+    this.ended = true;
+    if (this.options.endError) throw new Error(this.options.endError);
+  }
+
+  async query(sql, params = []) {
+    const text = String(sql);
+    this.queries.push({ sql: text, params });
+    if (text.includes("pg_advisory_unlock") && this.options.unlockError) throw new Error(this.options.unlockError);
+    if (text.includes("pg_try_advisory_lock")) return { rows: [{ locked: this.options.locked !== false }] };
+    if (/^SET /.test(text)) return { rows: [] };
+    if (text === "ROLLBACK") return { rows: [] };
+    if (text.includes("CREATE TABLE IF NOT EXISTS public.customer_history_claims")) {
+      if (this.options.migrationError) throw new Error(this.options.migrationError);
+      this.applied = true;
+      return { rows: [] };
+    }
+    if (text.includes("has_customer_profiles")) {
+      return {
+        rows: [{
+          has_customer_profiles: this.options.hasCustomerProfiles !== false,
+          has_jobs: this.options.hasJobs !== false,
+          has_claims: !!(this.options.hasClaims || this.applied),
+        }],
+      };
+    }
+    if (text.includes("information_schema.columns") && text.includes("table_name='customer_history_claims'")) {
+      if (this.options.schemaDrift === "missing_column") return { rows: expectedColumns().filter((row) => row.column_name !== "phone_norm") };
+      return { rows: expectedColumns() };
+    }
+    if (text.includes("information_schema.columns") && text.includes("table_name='jobs'")) {
+      return {
+        rows: [
+          { table_name: "jobs", column_name: "job_id", data_type: this.options.jobIdType || "bigint", is_nullable: "NO" },
+          { table_name: "customer_profiles", column_name: "sub", data_type: "text", is_nullable: "NO" },
+        ],
+      };
+    }
+    if (text.includes("customer_profiles") && text.includes("con.contype IN")) {
+      return { rows: this.options.subSupportsFk === false ? [] : [{ conname: "customer_profiles_pkey", column_names: ["sub"] }] };
+    }
+    if (text.includes("SELECT to_regclass('public.customer_history_claims') AS table_name")) {
+      return { rows: [{ table_name: (this.options.hasClaims || this.applied) ? "customer_history_claims" : null }] };
+    }
+    if (text.includes("con.contype='f'")) {
+      return {
+        rows: [
+          { conname: "fk_claim_customer", foreign_table: "customer_profiles", column_names: ["customer_sub"], foreign_column_names: ["sub"] },
+          { conname: "fk_claim_job", foreign_table: "jobs", column_names: ["proof_job_id"], foreign_column_names: ["job_id"] },
+        ],
+      };
+    }
+    if (text.includes("pg_get_constraintdef")) {
+      if (this.options.schemaDrift === "missing_check") return { rows: [] };
+      return {
+        rows: [
+          { conname: "method", definition: "CHECK ((claim_method = 'booking_code_phone'::text))" },
+          { conname: "phone_norm", definition: "CHECK ((phone_norm ~ '^0[0-9]{8,9}$'::text))" },
+          { conname: "phone_last4", definition: "CHECK (((phone_last4 ~ '^[0-9]{4}$'::text) AND (phone_last4 = right(phone_norm, 4))))" },
+        ],
+      };
+    }
+    if (text.includes("FROM pg_indexes")) {
+      if (this.options.schemaDrift === "missing_index") {
+        return { rows: [] };
+      }
+      return {
+        rows: [
+          { indexname: "ux_customer_history_claims_active_phone", indexdef: "CREATE UNIQUE INDEX ux_customer_history_claims_active_phone ON public.customer_history_claims USING btree (phone_norm) WHERE (revoked_at IS NULL)" },
+          { indexname: "ux_customer_history_claims_active_proof_job", indexdef: "CREATE UNIQUE INDEX ux_customer_history_claims_active_proof_job ON public.customer_history_claims USING btree (proof_job_id) WHERE (revoked_at IS NULL)" },
+          { indexname: "idx_customer_history_claims_customer_sub", indexdef: "CREATE INDEX idx_customer_history_claims_customer_sub ON public.customer_history_claims USING btree (customer_sub) WHERE (revoked_at IS NULL)" },
+        ],
+      };
+    }
+    if (text.includes("COUNT(*)::bigint")) {
+      return { rows: [{ count: String(this.options.rowCount || 0) }] };
+    }
+    return { rows: [] };
+  }
+}
+
+async function runWithClient(client, options = {}) {
+  const log = logger();
+  const code = await runner.runCli({
+    repoRoot: REPO_ROOT,
+    argv: options.argv || [],
+    env: {
+      DATABASE_URL: "postgres://user:password@db.example.test:5432/cwf",
+      ...options.env,
+    },
+    logger: log,
+    clientFactory: () => client,
+  });
+  return { code, log, client };
+}
+
+test("default mode is read-only preflight and does not write", async () => {
+  const client = new FakeClient({ hasClaims: false });
+  const result = await runWithClient(client);
+  assert.equal(result.code, 0);
+  assert.deepEqual(result.log.lines, ["CUSTOMER_HISTORY_CLAIMS_MIGRATION_PREFLIGHT_OK"]);
+  assert.equal(client.queries.some((q) => q.sql.includes("pg_try_advisory_lock")), false);
+  assert.equal(client.queries.some((q) => q.sql.includes("CREATE TABLE IF NOT EXISTS public.customer_history_claims")), false);
+  assert.equal(client.ended, true);
+});
+
+test("missing --apply or missing confirmation env is rejected before DB write", async () => {
+  const noApplyClient = new FakeClient();
+  const noApply = await runWithClient(noApplyClient, { env: { [runner.CONFIRM_ENV]: runner.CONFIRM_VALUE } });
+  assert.equal(noApply.code, 1);
+  assert.equal(noApplyClient.connected, false);
+
+  const noConfirmClient = new FakeClient();
+  const noConfirm = await runWithClient(noConfirmClient, { argv: ["--apply"] });
+  assert.equal(noConfirm.code, 1);
+  assert.equal(noConfirmClient.connected, false);
+});
+
+test("checksum mismatch fails before DB write", async () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "cwf-history-claims-migration-"));
+  fs.mkdirSync(path.join(tmp, "migrations"), { recursive: true });
+  fs.writeFileSync(path.join(tmp, "migrations", "20260710_customer_history_claims.sql"), "-- altered\n", "utf8");
+  const client = new FakeClient();
+  const log = logger();
+  const code = await runner.runCli({
+    repoRoot: tmp,
+    argv: ["--apply"],
+    env: { DATABASE_URL: "postgres://user:password@db.example.test/cwf", [runner.CONFIRM_ENV]: runner.CONFIRM_VALUE },
+    logger: log,
+    clientFactory: () => client,
+  });
+  assert.equal(code, 1);
+  assert.equal(client.connected, false);
+  assert.match(log.lines.join("\n"), /CUSTOMER_HISTORY_CLAIMS_MIGRATION_FAILED/);
+});
+
+test("missing prerequisite schema and incorrect jobs.job_id type fail closed", async () => {
+  const missing = await runWithClient(new FakeClient({ hasCustomerProfiles: false }));
+  assert.equal(missing.code, 1);
+
+  const wrongType = await runWithClient(new FakeClient({ jobIdType: "integer" }));
+  assert.equal(wrongType.code, 1);
+});
+
+test("already-applied exact schema exits successfully without running migration", async () => {
+  const client = new FakeClient({ hasClaims: true });
+  const result = await runWithClient(client);
+  assert.equal(result.code, 0);
+  assert.deepEqual(result.log.lines, ["CUSTOMER_HISTORY_CLAIMS_MIGRATION_ALREADY_APPLIED"]);
+  assert.equal(client.queries.some((q) => q.sql.includes("CREATE TABLE IF NOT EXISTS public.customer_history_claims")), false);
+});
+
+test("schema drift fails closed", async () => {
+  const result = await runWithClient(new FakeClient({ hasClaims: true, schemaDrift: "missing_index" }));
+  assert.equal(result.code, 1);
+  assert.match(result.log.lines.join("\n"), /CUSTOMER_HISTORY_CLAIMS_MIGRATION_FAILED/);
+});
+
+test("advisory lock unavailable fails before migration SQL", async () => {
+  const client = new FakeClient({ locked: false });
+  const result = await runWithClient(client, { argv: ["--apply"], env: { [runner.CONFIRM_ENV]: runner.CONFIRM_VALUE } });
+  assert.equal(result.code, 1);
+  assert.equal(client.queries.some((q) => q.sql.includes("CREATE TABLE IF NOT EXISTS public.customer_history_claims")), false);
+  assert.equal(client.ended, true);
+});
+
+test("migration success uses lock, timeouts, verifies schema, and unlocks", async () => {
+  const client = new FakeClient();
+  const result = await runWithClient(client, { argv: ["--apply"], env: { [runner.CONFIRM_ENV]: runner.CONFIRM_VALUE } });
+  assert.equal(result.code, 0);
+  assert.deepEqual(result.log.lines, [
+    "CUSTOMER_HISTORY_CLAIMS_MIGRATION_APPLY_START",
+    "CUSTOMER_HISTORY_CLAIMS_MIGRATION_OK",
+  ]);
+  const sqls = client.queries.map((q) => q.sql);
+  assert.ok(sqls.some((s) => s.includes("pg_try_advisory_lock")));
+  assert.ok(sqls.some((s) => s === "SET lock_timeout = '5s'"));
+  assert.ok(sqls.some((s) => s === "SET statement_timeout = '60s'"));
+  assert.ok(sqls.some((s) => s.includes("CREATE TABLE IF NOT EXISTS public.customer_history_claims")));
+  assert.ok(sqls.some((s) => s.includes("pg_advisory_unlock")));
+  assert.equal(client.ended, true);
+});
+
+test("migration SQL failure rolls back, unlocks, and closes", async () => {
+  const client = new FakeClient({ migrationError: "boom" });
+  const result = await runWithClient(client, { argv: ["--apply"], env: { [runner.CONFIRM_ENV]: runner.CONFIRM_VALUE } });
+  assert.equal(result.code, 1);
+  const sqls = client.queries.map((q) => q.sql);
+  const rollbackIndex = sqls.indexOf("ROLLBACK");
+  const unlockIndex = sqls.findIndex((s) => s.includes("pg_advisory_unlock"));
+  assert.ok(rollbackIndex >= 0);
+  assert.ok(unlockIndex > rollbackIndex);
+  assert.equal(client.ended, true);
+});
+
+test("post-apply verification failure exits non-zero and still unlocks", async () => {
+  const client = new FakeClient({ schemaDrift: "missing_check" });
+  const result = await runWithClient(client, { argv: ["--apply"], env: { [runner.CONFIRM_ENV]: runner.CONFIRM_VALUE } });
+  assert.equal(result.code, 1);
+  assert.ok(client.queries.some((q) => q.sql.includes("pg_advisory_unlock")));
+  assert.equal(client.ended, true);
+});
+
+test("secrets are redacted from failure logs", async () => {
+  const client = new FakeClient({ connectError: "password authentication failed for user \"postgres\" at postgres://user:supersecret@host.example/db?token=abc" });
+  const result = await runWithClient(client, { argv: ["--apply"], env: { [runner.CONFIRM_ENV]: runner.CONFIRM_VALUE } });
+  const output = result.log.lines.join("\n");
+  assert.equal(result.code, 1);
+  assert.match(output, /CUSTOMER_HISTORY_CLAIMS_MIGRATION_FAILED/);
+  assert.doesNotMatch(output, /supersecret|host\.example|postgres"/);
+  assert.match(output, /\[REDACTED/);
+});
+
+test("unlock and client.end run after lock-protected errors", async () => {
+  const client = new FakeClient({ migrationError: "db failed" });
+  const result = await runWithClient(client, { argv: ["--apply"], env: { [runner.CONFIRM_ENV]: runner.CONFIRM_VALUE } });
+  assert.equal(result.code, 1);
+  assert.ok(client.queries.some((q) => q.sql.includes("pg_advisory_unlock")));
+  assert.equal(client.ended, true);
+});
+
+test("package exposes explicit check and apply commands", () => {
+  const pkg = JSON.parse(fs.readFileSync(path.join(REPO_ROOT, "package.json"), "utf8"));
+  assert.equal(pkg.scripts["migrate:customer-history-claims:check"], "node scripts/run-customer-history-claims-migration.js");
+  assert.equal(pkg.scripts["migrate:customer-history-claims"], "node scripts/run-customer-history-claims-migration.js");
+});

--- a/test/customerSameDayTiming.test.js
+++ b/test/customerSameDayTiming.test.js
@@ -160,7 +160,7 @@ test("customer app disables availability HTTP cache and refreshes same-day slots
 });
 
 test("customer app build and service worker cache IDs changed", () => {
-  const id = "20260710_legacy_claim_v1";
+  const id = "20260710_legacy_claim_v2";
   for (const file of [
     "customer-app/index.html",
     "customer-app/sw.js",

--- a/test/customerSameDayTiming.test.js
+++ b/test/customerSameDayTiming.test.js
@@ -160,7 +160,7 @@ test("customer app disables availability HTTP cache and refreshes same-day slots
 });
 
 test("customer app build and service worker cache IDs changed", () => {
-  const id = "20260709_review_legacy_v1";
+  const id = "20260710_legacy_claim_v1";
   for (const file of [
     "customer-app/index.html",
     "customer-app/sw.js",

--- a/test/homepageCms.test.js
+++ b/test/homepageCms.test.js
@@ -278,7 +278,7 @@ test("customer homepage has no admin control, bottom nav is fixed five-tab, and 
   const sw = read("customer-app/sw.js");
   const app = read("customer-app/assets/customer-app.js");
   const manifest = read("customer-app/manifest.webmanifest");
-  const build = "20260709_review_legacy_v1";
+  const build = "20260710_legacy_claim_v1";
 
   assert.doesNotMatch(index + ui, /โหมดแอดมิน|openCms|localStorage\.getItem\('cwfHomeCmsDemo'/);
   assert.match(index, /data-route="store"[\s\S]*ร้านค้า/);

--- a/test/homepageCms.test.js
+++ b/test/homepageCms.test.js
@@ -278,7 +278,7 @@ test("customer homepage has no admin control, bottom nav is fixed five-tab, and 
   const sw = read("customer-app/sw.js");
   const app = read("customer-app/assets/customer-app.js");
   const manifest = read("customer-app/manifest.webmanifest");
-  const build = "20260710_legacy_claim_v1";
+  const build = "20260710_legacy_claim_v2";
 
   assert.doesNotMatch(index + ui, /โหมดแอดมิน|openCms|localStorage\.getItem\('cwfHomeCmsDemo'/);
   assert.match(index, /data-route="store"[\s\S]*ร้านค้า/);


### PR DESCRIPTION
## Base

- Base SHA at start: `d1fe831b248f3bf99635830bb6e5091d43dba1ad`
- Base SHA at latest fix: `d1fe831b248f3bf99635830bb6e5091d43dba1ad`
- Head SHA: `b5c6fa5f93bb8852c5d322d5c9b167c9e08e0d16`

## Root Cause

Legacy customer jobs can be tracked one-by-one with booking token/code, but a logged-in LINE/Google customer had no durable, server-side claim proving that an old full phone number belongs to the account. The Customer App also had no safe history/location API or profile UI for reusing historical job addresses as booking prefill.

## What Changed

- Added additive `customer_history_claims` migration only. It stores normalized phone ownership and `proof_job_id`; it does not store raw booking code or raw claim input.
- Added canonical phone CHECKs for `phone_norm` and `phone_last4`.
- Added a manual one-off migration runner: `scripts/run-customer-history-claims-migration.js`.
- Added package scripts:
  - `migrate:customer-history-claims:check`
  - `migrate:customer-history-claims`
- Runner default mode is read-only preflight. Apply requires both `--apply` and `CONFIRM_CUSTOMER_HISTORY_CLAIMS_MIGRATION=APPLY_20260710_CUSTOMER_HISTORY_CLAIMS`.
- Runner is pinned to `migrations/20260710_customer_history_claims.sql` and checksum `745446126557ec50d726bdd73a6d4ba8a6c67ba5f9239895186d0759f1f351bd`.
- Runner uses `DATABASE_URL`, redacts secrets/hosts/users from errors, uses `pg_try_advisory_lock`, sets timeouts, verifies schema before/after, fails closed on drift, and unlocks/closes on errors.
- Added public customer history routes:
  - `POST /public/customer-history/claim`
  - `GET /public/customer-history`
  - `GET /public/customer-history/:job_ref`
  - `GET /public/customer-history/locations`
- Added `Cache-Control: private, no-store` to every customer-history endpoint.
- Hardened concurrent claim races: same account replays, different accounts receive generic `CLAIM_FAILED`, and unique races do not become 500s.
- Removed unused location identifiers/sample booking code from locations response.
- Added Customer App profile claim panel, clickable history detail, location list, and explicit prefill buttons for scheduled/urgent booking.
- Bumped Customer App cache/build ID to `20260710_legacy_claim_v2`.

## Migration Commands

Check/preflight:

```bash
npm run migrate:customer-history-claims:check
```

Apply, only after owner approval:

```bash
CONFIRM_CUSTOMER_HISTORY_CLAIMS_MIGRATION=APPLY_20260710_CUSTOMER_HISTORY_CLAIMS npm run migrate:customer-history-claims -- --apply
```

## Schema Impact

Additive migration file only: `migrations/20260710_customer_history_claims.sql`.

No production migration was run. No production data was read or written.

Rollback outline is included in the migration comments. Because this is additive, rollback is dropping the claim indexes/table after application rollback and owner approval.

## Tests

Syntax checks passed for changed JS files.

Focused and related tests:

- `node --test test/customerHistoryClaimsMigration.test.js` => 13 pass, 0 fail, 0 skipped
- `node --test test/customerHistoryClaimsMigration.test.js test/customerHistoryClaim.test.js` => 28 pass, 0 fail, 0 skipped
- Customer auth/tracking/booking/urgent/payout regression set => 126 pass, 0 fail, 3 skipped (local PostgreSQL auth unavailable for urgent finalizer integration)

Migration runner coverage:

- default read-only preflight performs no write
- missing `--apply` rejected when confirmation env is present
- missing confirmation env rejected with `--apply`
- checksum mismatch fails before DB connect/write
- missing prerequisite schema fails
- incorrect `jobs.job_id` type fails
- already-applied exact schema exits 0 without migration SQL
- schema drift fails closed
- advisory lock unavailable fails
- migration success verifies schema
- migration SQL failure rolls back
- verification failure exits non-zero
- secrets/hosts/users are redacted from logs
- unlock and client.end run after lock-protected errors

Full suite comparison:

- `origin/main`: 960 pass, 20 fail, 11 skipped
- branch: 988 pass, 20 fail, 11 skipped
- Additional branch failures: 0
- The 20 failures are the same pre-existing `adminStoreCatalogUi.test.js` failures on base and branch.

PostgreSQL verification:

- Disposable PostgreSQL verification could not be completed in this local environment because no usable local disposable PostgreSQL credentials/server are available:
  - `127.0.0.1:5433` => `ECONNREFUSED`
  - `127.0.0.1:5432 postgres/postgres` => `28P01`
  - `docker`, `initdb`, `pg_ctl`, `postgres`, `psql` are not available in PATH
- No production database was inspected or mutated.

## Remaining Risks

- Migration must be reviewed and run only on approved non-production/test first, then production only with owner approval.
- Disposable PostgreSQL verification still needs an environment with valid local/staging test credentials.
- Browser E2E still needs an environment with Playwright and disposable PostgreSQL.
- If legacy `jobs.customer_phone` contains nonstandard historical formats outside local/+66/0066 normalization, those jobs will fail closed and require owner-approved policy follow-up.
- Canceled jobs are eligible only when full phone and booking code match exactly; no extra test-marker exclusion was found in current schema.

## Production Safety

- No production data write
- No production migration execution
- No merge
- No deploy
- No payment/accounting/payout changes