### PR TITLE
hotfix: restore secure Tracking data + technician GPS Check-in

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,7 +1,7 @@
 
 
 // CWF Technician App: payout no-pay status display fix
-window.__CWF_TECH_APP_VERSION__ = "20260710_payout_no_pay_status_v1";
+window.__CWF_TECH_APP_VERSION__ = "20260711_tracking_gps_recovery_v1";
 try { console.info('[CWF_TECH_APP_VERSION]', window.__CWF_TECH_APP_VERSION__); } catch (_) {}
 
 // ✅ งานปัจจุบัน: งานล่วงหน้า (sub-tab)
@@ -1235,7 +1235,7 @@ function setPushUi(state, text) {
 
 async function ensureServiceWorkerForPush() {
   if (!('serviceWorker' in navigator)) throw new Error('เครื่องนี้ไม่รองรับ Service Worker');
-  const reg = await navigator.serviceWorker.register('/sw.js?v=20260710_payout_no_pay_status_v1', { updateViaCache: 'none' });
+  const reg = await navigator.serviceWorker.register('/sw.js?v=20260711_tracking_gps_recovery_v1', { updateViaCache: 'none' });
   try { await navigator.serviceWorker.ready; } catch (_) {}
   return reg;
 }
@@ -6536,50 +6536,169 @@ async function closeJob(jobId) {
 // =======================================
 // 📍 CHECK-IN
 // =======================================
-function checkin(jobId) {
-  if (!navigator.geolocation) return alert("เครื่องนี้ไม่รองรับ GPS");
+// Robust geolocation for Check-in. Resolves with a Position; rejects with a
+// normalized { code, message } object carrying a clear Thai message. Tries a
+// high-accuracy fix first, then retries ONCE (low-accuracy fallback) only for a
+// timeout or position-unavailable — never loops forever.
+function cwfGetCheckinPosition() {
+  return new Promise((resolve, reject) => {
+    if (!navigator.geolocation || typeof navigator.geolocation.getCurrentPosition !== "function") {
+      reject({ code: "UNSUPPORTED", message: "อุปกรณ์หรือเบราว์เซอร์นี้ไม่รองรับการระบุตำแหน่ง" });
+      return;
+    }
+    // GPS normally requires a secure (HTTPS/localhost) context.
+    if (typeof window !== "undefined" && window.isSecureContext === false) {
+      reject({ code: "INSECURE_CONTEXT", message: "ต้องเปิดแอปผ่านการเชื่อมต่อ HTTPS จึงจะใช้ GPS ได้" });
+      return;
+    }
+    const HIGH = { enableHighAccuracy: true, maximumAge: 15000, timeout: 20000 };
+    const LOW = { enableHighAccuracy: false, maximumAge: 60000, timeout: 15000 };
+    const mapErr = (err) => {
+      const c = err && err.code;
+      if (c === 1) return { code: "PERMISSION_DENIED", message: "ยังไม่ได้อนุญาตให้แอปใช้ตำแหน่ง กรุณาเปิดสิทธิ์ตำแหน่งของ Chrome/PWA แล้วกดลองใหม่" };
+      if (c === 2) return { code: "POSITION_UNAVAILABLE", message: "เครื่องยังหาตำแหน่งไม่ได้ กรุณาเปิดตำแหน่งและออกไปในจุดที่รับสัญญาณได้ดีขึ้น" };
+      if (c === 3) return { code: "TIMEOUT", message: "ใช้เวลาหาตำแหน่งนานเกินไป กรุณากดลองใหม่" };
+      return { code: "LOCATION_ERROR", message: (err && err.message) ? `ขอตำแหน่งไม่สำเร็จ: ${err.message}` : "ขอตำแหน่งไม่สำเร็จ กรุณากดลองใหม่" };
+    };
+    let attempt = 0;
+    const tryGet = (opts) => {
+      attempt += 1;
+      let settled = false;
+      try {
+        navigator.geolocation.getCurrentPosition(
+          (pos) => { if (!settled) { settled = true; resolve(pos); } },
+          (err) => {
+            if (settled) return;
+            settled = true;
+            const e = mapErr(err);
+            if (attempt === 1 && (e.code === "TIMEOUT" || e.code === "POSITION_UNAVAILABLE")) {
+              tryGet(LOW); // one retry only
+              return;
+            }
+            reject(e);
+          },
+          opts
+        );
+      } catch (thrown) {
+        if (!settled) { settled = true; reject({ code: "LOCATION_ERROR", message: "ขอตำแหน่งไม่สำเร็จ กรุณากดลองใหม่" }); }
+      }
+    };
+    // Best-effort permission inspection (never mandatory).
+    if (navigator.permissions && typeof navigator.permissions.query === "function") {
+      navigator.permissions.query({ name: "geolocation" })
+        .then((st) => {
+          if (st && st.state === "denied") {
+            reject({ code: "PERMISSION_DENIED", message: "ยังไม่ได้อนุญาตให้แอปใช้ตำแหน่ง กรุณาเปิดสิทธิ์ตำแหน่งของ Chrome/PWA แล้วกดลองใหม่" });
+            return;
+          }
+          tryGet(HIGH);
+        })
+        .catch(() => tryGet(HIGH));
+    } else {
+      tryGet(HIGH);
+    }
+  });
+}
+
+// Map a server Check-in error (structured code first, HTTP status fallback) to a
+// clear actionable Thai message.
+function mapCheckinServerError(data, status) {
+  const code = data && data.code;
+  const CODE_MSG = {
+    INVALID_COORDINATES: "พิกัด GPS ไม่ถูกต้อง กรุณากดลองใหม่",
+    INVALID_JOB_REFERENCE: "ไม่พบงานนี้ กรุณารีเฟรชแล้วลองใหม่",
+    AUTH_REQUIRED: "เซสชันหมดอายุ กรุณาเข้าสู่ระบบใหม่แล้วลองอีกครั้ง",
+    TECH_NOT_ASSIGNED: "คุณยังไม่ได้ถูกมอบหมายให้ทำงานนี้",
+    LOCATION_ACCURACY_TOO_LOW: "สัญญาณ GPS ยังไม่แม่นพอ กรุณาออกไปที่โล่งแล้วกดลองใหม่",
+    JOB_SITE_LOCATION_MISSING: "งานนี้ยังไม่มีพิกัดหน้างาน กรุณาติดต่อแอดมิน",
+    ALREADY_CHECKED_IN: "เช็คอินงานนี้ไปแล้ว",
+    CHECKIN_FAILED: "บันทึกเช็คอินไม่สำเร็จ กรุณากดลองใหม่",
+  };
+  if (code === "OUTSIDE_CHECKIN_RADIUS") {
+    return (data && data.distance != null)
+      ? `อยู่นอกพื้นที่หน้างาน (ห่างประมาณ ${data.distance} เมตร) กรุณาเข้าใกล้จุดนัดหมายแล้วลองใหม่`
+      : "อยู่นอกพื้นที่หน้างาน กรุณาเข้าใกล้จุดนัดหมายแล้วลองใหม่";
+  }
+  if (code && CODE_MSG[code]) return CODE_MSG[code];
+  if (Number(status) === 401) return "เซสชันหมดอายุ กรุณาเข้าสู่ระบบใหม่แล้วลองอีกครั้ง";
+  if (Number(status) === 403) return "คุณยังไม่ได้ถูกมอบหมายให้ทำงานนี้";
+  return (data && data.error) ? String(data.error) : "บันทึกเช็คอินไม่สำเร็จ กรุณากดลองใหม่";
+}
+
+async function checkin(jobId) {
   const key = String(jobId || '').trim();
-  if (!key) return alert("ไม่พบรหัสงาน");
-  if (window.__CWF_CHECKIN_BUSY && window.__CWF_CHECKIN_BUSY[key]) return;
+  if (!key) { alert("ไม่พบรหัสงาน"); return; }
   window.__CWF_CHECKIN_BUSY = window.__CWF_CHECKIN_BUSY || {};
+  // A genuinely in-flight request for THIS job blocks duplicate taps; every exit
+  // path below clears the flag in `finally`, so a retry always works immediately.
+  if (window.__CWF_CHECKIN_BUSY[key]) return;
   window.__CWF_CHECKIN_BUSY[key] = true;
 
-  const btn = document.querySelector(`[data-role="workflow"][data-jobkey="${CSS.escape(key)}"]`);
-  const oldText = btn ? btn.innerHTML : '';
-  if (btn) { btn.disabled = true; btn.innerHTML = '📍 กำลังเช็คอิน...'; }
-  const hint = document.getElementById(`travel-hint-${key}`) || document.getElementById(`checkin-status-${key}`);
-  if (hint) hint.innerHTML = '📍 กำลังขอพิกัด GPS...';
+  let btn = null;
+  let oldText = '';
+  let hint = null;
+  try {
+    // cssEscapeCompat() never throws even on old Android WebViews without
+    // native CSS.escape — the previous direct CSS.escape() call could throw
+    // here and strand the busy lock forever.
+    try {
+      btn = document.querySelector(`[data-role="workflow"][data-jobkey="${cssEscapeCompat(key)}"]`);
+    } catch (_) { btn = null; }
+    oldText = btn ? btn.innerHTML : '';
+    if (btn) { btn.disabled = true; btn.innerHTML = '📍 กำลังเช็คอิน...'; }
+    hint = document.getElementById(`travel-hint-${key}`) || document.getElementById(`checkin-status-${key}`);
+    if (hint) hint.innerHTML = '📍 กำลังขอพิกัด GPS...';
 
-  const finish = () => {
-    window.__CWF_CHECKIN_BUSY[key] = false;
-    if (btn) { btn.disabled = false; btn.innerHTML = oldText || '📍 เช็คอิน'; }
-  };
+    let pos;
+    try {
+      pos = await cwfGetCheckinPosition();
+    } catch (geoErr) {
+      const msg = (geoErr && geoErr.message) || "ขอตำแหน่งไม่สำเร็จ กรุณากดลองใหม่";
+      if (hint) hint.innerHTML = `❌ ${msg}`;
+      alert(`❌ ${msg}`);
+      return;
+    }
 
-  navigator.geolocation.getCurrentPosition(
-    (pos) => {
-      const lat = pos.coords.latitude;
-      const lng = pos.coords.longitude;
-      if (hint) hint.innerHTML = '📍 ได้พิกัดแล้ว กำลังบันทึกเช็คอิน...';
-      fetch(`${API_BASE}/jobs/${encodeURIComponent(String(key))}/checkin`, {
+    const lat = pos && pos.coords ? pos.coords.latitude : NaN;
+    const lng = pos && pos.coords ? pos.coords.longitude : NaN;
+    const accuracy = pos && pos.coords && Number.isFinite(pos.coords.accuracy) ? pos.coords.accuracy : null;
+    if (!Number.isFinite(lat) || !Number.isFinite(lng) || lat < -90 || lat > 90 || lng < -180 || lng > 180) {
+      const m = "พิกัด GPS ไม่ถูกต้อง กรุณากดลองใหม่";
+      if (hint) hint.innerHTML = `❌ ${m}`;
+      alert(`❌ ${m}`);
+      return;
+    }
+    const captured_at = new Date(pos && pos.timestamp ? pos.timestamp : Date.now()).toISOString();
+    if (hint) hint.innerHTML = '📍 ได้พิกัดแล้ว กำลังบันทึกเช็คอิน...';
+
+    let res, data;
+    try {
+      res = await fetch(`${API_BASE}/jobs/${encodeURIComponent(String(key))}/checkin`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ lat, lng }),
-      })
-        .then(async (res) => {
-          const data = await res.json().catch(() => ({}));
-          if (!res.ok) throw new Error(data.error || "เช็คอินไม่สำเร็จ");
-          return data;
-        })
-        .then(() => {
-          if (hint) hint.innerHTML = "✅ เช็คอินสำเร็จ";
-          setTimeout(()=>loadJobs(), 150);
-        })
-        .catch((e) => alert(`❌ ${e.message}`))
-        .finally(finish);
-    },
-    (err) => { finish(); alert(err?.message ? `ขอสิทธิ์ GPS ไม่สำเร็จ: ${err.message}` : "ขอสิทธิ์ GPS ไม่สำเร็จ/ถูกปฏิเสธ"); },
-    { enableHighAccuracy: false, maximumAge: 60000, timeout: 8000 }
-  );
+        body: JSON.stringify({ lat, lng, accuracy, captured_at }),
+      });
+      data = await res.json().catch(() => ({}));
+    } catch (netErr) {
+      const m = "บันทึกเช็คอินไม่สำเร็จ (เครือข่ายมีปัญหา) กรุณากดลองใหม่";
+      if (hint) hint.innerHTML = `❌ ${m}`;
+      alert(`❌ ${m}`);
+      return;
+    }
+    if (!res.ok) {
+      const m = mapCheckinServerError(data, res.status);
+      if (hint) hint.innerHTML = `❌ ${m}`;
+      alert(`❌ ${m}`);
+      return;
+    }
+    if (hint) hint.innerHTML = "✅ เช็คอินสำเร็จ";
+    setTimeout(() => loadJobs(), 150);
+  } finally {
+    // Guaranteed cleanup — no selector failure, GPS error, network error, or
+    // server rejection can leave the job permanently locked.
+    window.__CWF_CHECKIN_BUSY[key] = false;
+    if (btn) { btn.disabled = false; btn.innerHTML = oldText || '📍 เช็คอิน'; }
+  }
 }
 
 // =======================================

--- a/customer-app/assets/customer-app.js
+++ b/customer-app/assets/customer-app.js
@@ -37,7 +37,11 @@
     const params = new URLSearchParams(window.location.search || "");
     const trackingKey = String(params.get("q") || params.get("token") || "").trim();
     if (trackingKey) {
-      App.state.updateDraft("tracking", { trackingCode: trackingKey });
+      // The deep-link value may be the private booking_token. Hand it to the
+      // tracking module as a PRIVATE credential — never write it into the
+      // visible tracking draft/input (it would be rendered before/while the
+      // lookup runs). The tracking module consumes it on its first render.
+      App.tracking?.setInitialCredential?.(trackingKey);
       if (!window.location.hash || App.state.readRouteFromHash() === "home") {
         window.location.hash = "#tracking";
       }

--- a/customer-app/assets/customer-app.js
+++ b/customer-app/assets/customer-app.js
@@ -3,7 +3,7 @@
 
   const App = window.CWFCustomerAppV2;
   const BOOT_TIMEOUT_MS = 3500;
-  const BUILD_ID = "20260710_legacy_claim_v2";
+  const BUILD_ID = "20260711_tracking_gps_recovery_v1";
 
   function withTimeout(promise, timeoutMs) {
     return Promise.race([

--- a/customer-app/index.html
+++ b/customer-app/index.html
@@ -17,10 +17,10 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Noto+Sans+Thai:wght@400;500;600;700;800;900&display=swap" media="print" onload="this.media='all'">
   <noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Noto+Sans+Thai:wght@400;500;600;700;800;900&display=swap"></noscript>
-  <link rel="manifest" href="./manifest.webmanifest?v=20260710_legacy_claim_v2">
+  <link rel="manifest" href="./manifest.webmanifest?v=20260711_tracking_gps_recovery_v1">
   <link rel="icon" type="image/png" sizes="192x192" href="./assets/icons/cwf-customer-192.png">
   <link rel="apple-touch-icon" sizes="180x180" href="./assets/icons/cwf-customer-180.png">
-  <link rel="stylesheet" href="./assets/customer-app.css?v=20260710_legacy_claim_v2">
+  <link rel="stylesheet" href="./assets/customer-app.css?v=20260711_tracking_gps_recovery_v1">
 </head>
 <body class="is-app-booting">
   <div class="app-shell" data-app-shell>
@@ -58,21 +58,21 @@
     </nav>
   </div>
 
-  <script src="./modules/state.js?v=20260710_legacy_claim_v2"></script>
-  <script src="./modules/utils.js?v=20260710_legacy_claim_v2"></script>
-  <script src="./modules/analytics.js?v=20260710_legacy_claim_v2"></script>
-  <script src="./modules/api.js?v=20260710_legacy_claim_v2"></script>
-  <script src="./modules/services.js?v=20260710_legacy_claim_v2"></script>
-  <script src="./modules/ui.js?v=20260710_legacy_claim_v2"></script>
-  <script src="./modules/store.js?v=20260710_legacy_claim_v2"></script>
-  <script src="./modules/auth.js?v=20260710_legacy_claim_v2"></script>
-  <script src="./modules/pricing.js?v=20260710_legacy_claim_v2"></script>
-  <script src="./modules/availability.js?v=20260710_legacy_claim_v2"></script>
-  <script src="./modules/bookingScheduled.js?v=20260710_legacy_claim_v2"></script>
-  <script src="./modules/bookingUrgent.js?v=20260710_legacy_claim_v2"></script>
-  <script src="./modules/tracking.js?v=20260710_legacy_claim_v2"></script>
-  <script src="./modules/profile.js?v=20260710_legacy_claim_v2"></script>
-  <script src="./modules/router.js?v=20260710_legacy_claim_v2"></script>
-  <script src="./assets/customer-app.js?v=20260710_legacy_claim_v2"></script>
+  <script src="./modules/state.js?v=20260711_tracking_gps_recovery_v1"></script>
+  <script src="./modules/utils.js?v=20260711_tracking_gps_recovery_v1"></script>
+  <script src="./modules/analytics.js?v=20260711_tracking_gps_recovery_v1"></script>
+  <script src="./modules/api.js?v=20260711_tracking_gps_recovery_v1"></script>
+  <script src="./modules/services.js?v=20260711_tracking_gps_recovery_v1"></script>
+  <script src="./modules/ui.js?v=20260711_tracking_gps_recovery_v1"></script>
+  <script src="./modules/store.js?v=20260711_tracking_gps_recovery_v1"></script>
+  <script src="./modules/auth.js?v=20260711_tracking_gps_recovery_v1"></script>
+  <script src="./modules/pricing.js?v=20260711_tracking_gps_recovery_v1"></script>
+  <script src="./modules/availability.js?v=20260711_tracking_gps_recovery_v1"></script>
+  <script src="./modules/bookingScheduled.js?v=20260711_tracking_gps_recovery_v1"></script>
+  <script src="./modules/bookingUrgent.js?v=20260711_tracking_gps_recovery_v1"></script>
+  <script src="./modules/tracking.js?v=20260711_tracking_gps_recovery_v1"></script>
+  <script src="./modules/profile.js?v=20260711_tracking_gps_recovery_v1"></script>
+  <script src="./modules/router.js?v=20260711_tracking_gps_recovery_v1"></script>
+  <script src="./assets/customer-app.js?v=20260711_tracking_gps_recovery_v1"></script>
 </body>
 </html>

--- a/customer-app/manifest.webmanifest
+++ b/customer-app/manifest.webmanifest
@@ -2,7 +2,7 @@
   "name": "CWF Customer Service",
   "short_name": "CWF Service",
   "description": "แอปลูกค้า Coldwindflow สำหรับเลือกบริการ จองคิว และติดตามงาน",
-  "start_url": "/customer-app/index.html?v=20260710_legacy_claim_v2#home",
+  "start_url": "/customer-app/index.html?v=20260711_tracking_gps_recovery_v1#home",
   "scope": "/customer-app/",
   "id": "/customer-app/",
   "display": "standalone",

--- a/customer-app/modules/tracking.js
+++ b/customer-app/modules/tracking.js
@@ -819,15 +819,17 @@
   }
 
   function renderReceipt(data) {
-    const url = receiptUrl(data);
-    if (!url) return "";
+    // Only offer the button when a receipt URL can be built; the URL (which may
+    // carry the booking_token as ?key=) is constructed at click time from state,
+    // NOT embedded in the DOM, so the token never appears in rendered HTML.
+    if (!receiptUrl(data)) return "";
     return `
       <section class="tracking-extra-card receipt-card">
         <div>
           <strong>เอกสารหลังบริการ</strong>
           <p class="muted">เปิดใบรับเงินหรือ E-slip จากข้อมูลเดิมของระบบ</p>
         </div>
-        <a class="secondary-btn" href="${esc(url)}" target="_blank" rel="noopener">เปิด E-slip</a>
+        <button class="secondary-btn" type="button" data-action="open-eslip">เปิด E-slip</button>
       </section>
     `;
   }
@@ -858,8 +860,12 @@
     const reviewToken = data.access_level === "token" ? (data.booking_token || "") : "";
     const legacyEligible = !reviewToken && data.legacy_review_eligible === true;
     if (!reviewToken && !legacyEligible) return "";
+    // For token access the booking_token is NOT written into the form (it would
+    // leak into rendered HTML). The form is marked data-review-token and the
+    // handler injects the token from state at submit time. The legacy path only
+    // ever uses the public booking_code + the customer's phone.
     const credentialFields = reviewToken
-      ? `<input type="hidden" name="booking_token" value="${esc(reviewToken)}">`
+      ? ""
       : `<input type="hidden" name="booking_code" value="${esc(data.booking_code || "")}">
           <label class="field">
             <span>เบอร์โทรที่ใช้จอง (ยืนยันตัวตน)</span>
@@ -876,7 +882,7 @@
           <h2>ให้คะแนนงานนี้</h2>
         </div>
         ${legacyHint}
-        <form data-review-form>
+        <form data-review-form${reviewToken ? " data-review-token" : ""}>
           ${credentialFields}
           <label class="field">
             <span>คะแนน</span>
@@ -933,8 +939,9 @@
     }
 
     if (!catalogReview.eligible) return "";
-    const key = data.booking_token || data.booking_code || "";
-    if (!key) return "";
+    // The write credential (booking_token / booking_code) is injected from state
+    // at submit — never embedded in the DOM.
+    if (!(data.booking_token || data.booking_code)) return "";
     return `
       <section class="tracking-extra-card catalog-review-form-card">
         <div class="section-head compact">
@@ -942,7 +949,6 @@
           <h2>รีวิวบริการนี้</h2>
         </div>
         <form data-catalog-review-form>
-          <input type="hidden" name="token" value="${esc(key)}">
           <label class="field">
             <span>คะแนนบริการ</span>
             <select class="input" name="rating">
@@ -1131,7 +1137,10 @@
     const mode = modeFromData(data);
     const photos = photoList(data);
     const maps = mapUrl(data);
-    const trackingKey = data.booking_token || data.booking_code || "";
+    // The VISIBLE tracking number is always the short booking_code — never the
+    // long secret booking_token. The token stays only in state as the request
+    // credential (used for refresh/receipt/review requests), never rendered.
+    const trackingKey = data.booking_code || "";
     const done = isDone(data);
     const units = unitList(data);
     const appointmentText = data.appointment_datetime ? root.utils.formatDateTime(data.appointment_datetime) : "-";
@@ -1278,6 +1287,13 @@
     try {
       const data = await root.api.trackBooking(q);
       root.state.setTracking({ status: "success", data, error: "" });
+      // Privacy: the lookup may have used the private booking_token as the
+      // credential. Never leave the token echoed in the visible search field —
+      // normalise it back to the human-facing booking_code once we have it.
+      if (data && data.booking_code) {
+        root.state.updateDraft("tracking", { trackingCode: String(data.booking_code) });
+        if (input) input.value = String(data.booking_code);
+      }
     } catch (error) {
       root.state.setTracking({ status: "error", data: null, error: error.message });
     }
@@ -1328,6 +1344,17 @@
 
     const refresh = container.querySelector("[data-action='track-refresh']");
     if (refresh) refresh.addEventListener("click", () => lookup(container), { once: true });
+
+    // E-slip opens with a URL built from state at click time (the token, if any,
+    // travels only in that request URL — never rendered into the DOM).
+    const eslipBtn = container.querySelector("[data-action='open-eslip']");
+    if (eslipBtn) {
+      eslipBtn.addEventListener("click", () => {
+        const url = receiptUrl(root.state.tracking.data || {});
+        if (url) window.open(url, "_blank", "noopener");
+      });
+    }
+
     const form = container.querySelector("[data-review-form]");
     if (form) {
       form.addEventListener("submit", async (event) => {
@@ -1335,6 +1362,11 @@
         const status = form.querySelector("[data-review-status]");
         const submit = form.querySelector("button[type='submit']");
         const payload = Object.fromEntries(new FormData(form).entries());
+        // Token credential is injected from state, never read from the DOM.
+        if (form.hasAttribute("data-review-token")) {
+          const token = (root.state.tracking.data || {}).booking_token || "";
+          if (token) payload.booking_token = token;
+        }
         payload.rating = Number(payload.rating || 5);
         if (status) status.textContent = "กำลังส่งรีวิว...";
         if (submit) submit.disabled = true;
@@ -1362,7 +1394,9 @@
         const status = catalogForm.querySelector("[data-catalog-review-status]");
         const submit = catalogForm.querySelector("button[type='submit']");
         const formData = Object.fromEntries(new FormData(catalogForm).entries());
-        const token = formData.token || "";
+        // Credential from state, not the DOM.
+        const d = root.state.tracking.data || {};
+        const token = d.booking_token || d.booking_code || "";
         if (status) status.textContent = "กำลังส่งรีวิว...";
         if (submit) submit.disabled = true;
         try {

--- a/customer-app/modules/tracking.js
+++ b/customer-app/modules/tracking.js
@@ -6,6 +6,20 @@
   const LINE_URL = "https://lin.ee/fG1Oq7y";
   const WARRANTY_COPY = "รับประกันงานล้าง 30 วัน เฉพาะอาการที่เกี่ยวข้องกับการบริการ ไม่รวมอะไหล่เสีย ระบบรั่ว บอร์ด คอมเพรสเซอร์ ไฟตก หรือปัญหาจากตัวเครื่องเดิม";
 
+  // Private, in-memory lookup credential. It may be the long secret
+  // booking_token (from the ?q=/?token= deep link) or a customer-typed code.
+  // It is NEVER written into the draft, the visible input, or rendered HTML.
+  // Refresh and post-review reloads reuse THIS value so a token session is not
+  // silently downgraded to code-only access. A manual "ตรวจสอบสถานะ" replaces it
+  // with whatever the customer explicitly typed.
+  let activeCredential = "";
+  // Set when a deep-link credential is waiting for the first auto-lookup.
+  let pendingAutoLookup = false;
+
+  function setActiveCredential(value) {
+    activeCredential = String(value == null ? "" : value).trim();
+  }
+
   function esc(value) {
     return root.utils.escapeHtml(value == null ? "" : String(value));
   }
@@ -59,6 +73,44 @@
 
   function hasAssignedTech(data) {
     return techList(data).length > 0 || !!clean(data.assigned_at || data.accepted_at);
+  }
+
+  // Access-level awareness. A booking_code lookup returns access_level "code"
+  // with technician identity redacted. Redacted (absent) technician fields must
+  // never be interpreted as "no technician assigned" — hidden identity is not
+  // the same as an unassigned job.
+  function isTokenAccess(data) { return data && data.access_level === "token"; }
+  function isCodeOnly(data) { return !!(data && data.access_level === "code"); }
+
+  function limitedAccessNoticeHtml() {
+    return `
+      <div class="tracking-limited-note" data-limited-access role="note">
+        <strong>โหมดจำกัดข้อมูล (ค้นด้วยเลขงาน)</strong>
+        <p class="muted">เพื่อความปลอดภัย การค้นด้วยเลขงานจะแสดงเฉพาะสถานะและข้อมูลเบื้องต้น ข้อมูลทีมช่างจะแสดงเมื่อเปิดจากลิงก์ติดตามงานที่ได้รับในข้อความยืนยัน</p>
+      </div>`;
+  }
+
+  // Code-only status copy is derived ONLY from reliable, allow-listed timestamps
+  // (travel/checkin/started/finished) plus job_status "done" — never from
+  // technician presence, so a redacted technician cannot flip these to a
+  // "waiting for a technician" message.
+  function limitedStatusCopy(data) {
+    if (isDone(data)) return "งานเสร็จแล้ว";
+    if (clean(data.started_at)) return "กำลังให้บริการ";
+    if (clean(data.checkin_at)) return "ช่างถึงหน้างานแล้ว";
+    if (clean(data.travel_started_at)) return "ช่างกำลังเดินทาง";
+    return "กำลังติดตามสถานะงาน";
+  }
+  function limitedStatusDetail(data) {
+    if (isDone(data)) return "งานบริการเสร็จสิ้นแล้ว";
+    if (clean(data.started_at)) return "ทีมช่างกำลังให้บริการ";
+    if (clean(data.checkin_at)) return "ทีมช่างถึงหน้างานแล้ว";
+    if (clean(data.travel_started_at)) return "ช่างกำลังเดินทางไปยังสถานที่นัดหมาย";
+    return "ข้อมูลทีมช่างและรายละเอียดเต็มจะแสดงเมื่อเปิดจากลิงก์ติดตามงานในข้อความยืนยัน";
+  }
+  function limitedNextAction(data) {
+    if (isDone(data)) return "ดูเอกสารและการรับประกันได้จากลิงก์ติดตามงานในข้อความยืนยัน";
+    return "เปิดจากลิงก์ติดตามงานในข้อความยืนยันเพื่อดูข้อมูลทีมช่างและรายละเอียดเต็ม";
   }
 
   function mapUrl(data) {
@@ -759,6 +811,19 @@
   }
 
   function renderTechnicianCard(data) {
+    // Code-only access redacts technician identity. Never render the "no
+    // technician yet" empty card here — that would misrepresent a possibly
+    // assigned job as unassigned. Show a neutral limited-data note instead.
+    if (isCodeOnly(data)) {
+      return `
+        <div class="tracking-tech-card is-limited" data-tech-limited>
+          <div>
+            <strong>ข้อมูลทีมช่าง</strong>
+            <span class="muted">ข้อมูลทีมช่างจะแสดงเมื่อเปิดจากลิงก์ติดตามงานที่ได้รับในข้อความยืนยัน</span>
+          </div>
+        </div>
+      `;
+    }
     const list = techList(data);
     if (!list.length) {
       return `
@@ -1060,11 +1125,7 @@
       rows.push(`<div class="data-row"><strong>แผนที่</strong><span><a class="mini-link" href="${esc(maps)}" target="_blank" rel="noopener">นำทางไปหน้างาน</a></span></div>`);
     }
     rows.push(`<div class="data-row"><strong>หลังจบงาน</strong><span class="muted">รูปงาน ${photos.length} รายการ ${data.receipt_url ? "และมีเอกสารหลังบริการ" : ""}</span></div>`);
-    const limitedNotice = !isFull ? `
-      <div class="tracking-limited-note" data-limited-access role="note">
-        <strong>โหมดจำกัดข้อมูล (ค้นด้วยเลขงาน)</strong>
-        <p class="muted">เพื่อความปลอดภัย การค้นด้วยเลขงานจะแสดงเฉพาะสถานะและข้อมูลเบื้องต้น หากต้องการดูข้อมูลลูกค้า ที่อยู่ รายละเอียดช่าง และข้อมูลเต็ม กรุณาเปิดจาก “ลิงก์ติดตามงาน” ในข้อความยืนยันที่ได้รับ</p>
-      </div>` : "";
+    const limitedNotice = !isFull ? limitedAccessNoticeHtml() : "";
     return `${limitedNotice}<div class="data-list tracking-summary-list">${rows.join("")}</div>`;
   }
 
@@ -1142,13 +1203,22 @@
     // credential (used for refresh/receipt/review requests), never rendered.
     const trackingKey = data.booking_code || "";
     const done = isDone(data);
+    const codeOnly = isCodeOnly(data);
     const units = unitList(data);
     const appointmentText = data.appointment_datetime ? root.utils.formatDateTime(data.appointment_datetime) : "-";
+    // In code-only mode the status hero uses only reliable timestamp-derived
+    // copy (never technician presence), and the urgent "convert to scheduled"
+    // action is suppressed — it must not be offered merely because technician
+    // fields were redacted.
+    const heroTitle = codeOnly ? limitedStatusCopy(data) : statusCopy(data, mode);
+    const heroDetail = codeOnly ? limitedStatusDetail(data) : statusDetailCopy(data, mode);
+    const nextAction = codeOnly ? limitedNextAction(data) : nextActionCopy(data, mode);
     const overview = `
       <div class="tracking-premium-overview">
+        ${codeOnly ? limitedAccessNoticeHtml() : ""}
         <div class="status-hero is-${mode}">
-          <strong>${esc(statusCopy(data, mode))}</strong>
-          <span>${esc(statusDetailCopy(data, mode))}</span>
+          <strong>${esc(heroTitle)}</strong>
+          <span>${esc(heroDetail)}</span>
         </div>
         <div class="tracking-quick-grid">
           <div>
@@ -1157,7 +1227,7 @@
           </div>
           <div>
             <span>ขั้นตอนถัดไป</span>
-            <strong>${esc(nextActionCopy(data, mode))}</strong>
+            <strong>${esc(nextAction)}</strong>
           </div>
         </div>
         ${renderTechnicianCard(data)}
@@ -1166,7 +1236,7 @@
           <button class="secondary-btn" type="button" data-action="track-refresh">รีเฟรช</button>
           <a class="secondary-btn" href="tel:${ADMIN_PHONE}">โทรหา CWF</a>
           <a class="secondary-btn" href="${LINE_URL}" target="_blank" rel="noopener">LINE หา CWF</a>
-          ${mode === "urgent" && !hasAssignedTech(data) ? `<button class="secondary-btn" type="button" data-route="scheduled">เปลี่ยนเป็นจองล่วงหน้า</button>` : ""}
+          ${!codeOnly && mode === "urgent" && !hasAssignedTech(data) ? `<button class="secondary-btn" type="button" data-route="scheduled">เปลี่ยนเป็นจองล่วงหน้า</button>` : ""}
         </div>
         <p class="muted support-note">ต้องการแก้ไขเวลา เลื่อนนัด หรือยกเลิกงาน กรุณาติดต่อแอดมิน CWF</p>
       </div>
@@ -1241,6 +1311,7 @@
   function renderTimeline() {
     const data = root.state.tracking.data || {};
     const mode = modeFromData(data);
+    const codeOnly = isCodeOnly(data);
     const assigned = hasAssignedTech(data);
     const travel = !!clean(data.travel_started_at);
     const checkin = !!clean(data.checkin_at);
@@ -1249,19 +1320,29 @@
     const steps = [
       {
         title: mode === "urgent" ? "ส่งคำขอคิวด่วนแล้ว" : "รับคำขอจองแล้ว",
-        copy: mode === "urgent" ? "ระบบรับคำขอแล้ว แต่ยังไม่ถือว่ายืนยันงานจนกว่าจะมีช่างรับหรือแอดมินยืนยัน" : "รอแอดมินตรวจสอบคิวและรายละเอียด",
+        // Code-only mode uses neutral wording: it must not imply the job is
+        // still waiting for a technician just because identity is redacted.
+        copy: codeOnly
+          ? "ระบบได้รับคำขอของคุณแล้ว"
+          : (mode === "urgent" ? "ระบบรับคำขอแล้ว แต่ยังไม่ถือว่ายืนยันงานจนกว่าจะมีช่างรับหรือแอดมินยืนยัน" : "รอแอดมินตรวจสอบคิวและรายละเอียด"),
         ok: true,
       },
-      {
+    ];
+    // The assignment step relies on technician presence, which is redacted in
+    // code-only mode — omit it entirely there rather than claim "no technician".
+    if (!codeOnly) {
+      steps.push({
         title: mode === "urgent" ? "ช่างรับงาน / แอดมินยืนยัน" : "ยืนยันคิวและมอบหมายทีม",
         copy: assigned ? "มีทีมดูแลงานนี้แล้ว" : "แอดมินกำลังช่วยจัดคิวให้",
         ok: assigned,
-      },
+      });
+    }
+    steps.push(
       { title: "ช่างกำลังเดินทาง", copy: data.travel_started_at ? root.utils.formatDateTime(data.travel_started_at) : "จะแสดงเมื่อช่างเริ่มเดินทาง", ok: travel },
       { title: "ถึงหน้างาน", copy: data.checkin_at ? root.utils.formatDateTime(data.checkin_at) : "จะแสดงเมื่อทีมเช็กอิน", ok: checkin },
       { title: "เริ่มให้บริการ", copy: data.started_at ? root.utils.formatDateTime(data.started_at) : "จะแสดงเมื่อทีมเริ่มงาน", ok: started },
       { title: "งานเสร็จแล้ว", copy: data.finished_at ? root.utils.formatDateTime(data.finished_at) : "หลังจบงานจะแสดงรูป เอกสาร รีวิว และเงื่อนไขรับประกัน", ok: done },
-    ];
+    );
     const firstPending = steps.findIndex((step) => !step.ok);
     return root.utils.timeline(steps.map((step, index) => ({
       title: step.title,
@@ -1270,10 +1351,29 @@
     })));
   }
 
-  async function lookup(container) {
+  // lookup(container, opts)
+  //   opts.credential : an explicit PRIVATE credential (deep-link token, or the
+  //                     preserved active credential for refresh / review reload).
+  //                     When provided it is used for the request and is NEVER
+  //                     written to the draft or the visible input.
+  //   (no opts)       : manual "ตรวจสอบสถานะ" — use whatever the customer typed
+  //                     in the visible input and make it the new active credential.
+  async function lookup(container, opts) {
+    opts = opts || {};
     const input = container.querySelector("#tracking-code");
-    const q = String(input.value || "").trim();
-    root.state.updateDraft("tracking", { trackingCode: q });
+    const usingPrivate = opts.credential != null;
+    const q = usingPrivate
+      ? String(opts.credential || "").trim()
+      : String((input && input.value) || "").trim();
+    // The active credential future refreshes/reviews reuse is always the one
+    // actually used for THIS request. A private credential (token) is preserved;
+    // a manual read replaces it with the typed value.
+    setActiveCredential(q);
+    // Only the visible typed value is persisted to the draft — a private
+    // credential must never enter the draft (it would re-render into the input).
+    if (!usingPrivate) {
+      root.state.updateDraft("tracking", { trackingCode: q });
+    }
     if (!q) {
       root.state.setTracking({ status: "error", data: null, error: "กรุณากรอกเลขงานหรือรหัสติดตาม" });
       container.querySelector("[data-tracking-result]").innerHTML = renderTrackingResult();
@@ -1287,20 +1387,30 @@
     try {
       const data = await root.api.trackBooking(q);
       root.state.setTracking({ status: "success", data, error: "" });
-      // Privacy: the lookup may have used the private booking_token as the
-      // credential. Never leave the token echoed in the visible search field —
-      // normalise it back to the human-facing booking_code once we have it.
+      // Privacy: the request may have used the private booking_token. Only ever
+      // put the human-facing booking_code into the visible input/draft — the
+      // token stays solely in activeCredential + state as the request credential.
       if (data && data.booking_code) {
         root.state.updateDraft("tracking", { trackingCode: String(data.booking_code) });
         if (input) input.value = String(data.booking_code);
       }
     } catch (error) {
       root.state.setTracking({ status: "error", data: null, error: error.message });
+      // A failed private lookup must not leave the token anywhere visible — it
+      // was never written to the input/draft, so nothing to clear here.
     }
     container.querySelector("[data-tracking-result]").innerHTML = renderTrackingResult();
     const timeline = container.querySelector("[data-tracking-timeline]");
     if (timeline) timeline.innerHTML = renderTimeline();
     bindResultActions(container);
+  }
+
+  // Refresh / post-review reloads reuse the private active credential so a
+  // token session keeps full access instead of silently downgrading to the
+  // visible booking_code.
+  function reloadCurrent(container) {
+    if (activeCredential) return lookup(container, { credential: activeCredential });
+    return lookup(container);
   }
 
   function bindResultActions(container) {
@@ -1343,7 +1453,7 @@
     }
 
     const refresh = container.querySelector("[data-action='track-refresh']");
-    if (refresh) refresh.addEventListener("click", () => lookup(container), { once: true });
+    if (refresh) refresh.addEventListener("click", () => reloadCurrent(container), { once: true });
 
     // E-slip opens with a URL built from state at click time (the token, if any,
     // travels only in that request URL — never rendered into the DOM).
@@ -1379,7 +1489,7 @@
           const data = await response.json().catch(() => ({}));
           if (!response.ok) throw new Error(data.error || "ส่งรีวิวไม่สำเร็จ");
           if (status) status.textContent = "ส่งรีวิวเรียบร้อย ขอบคุณครับ";
-          setTimeout(() => lookup(container), 500);
+          setTimeout(() => reloadCurrent(container), 500);
         } catch (error) {
           if (status) status.textContent = error.message || "ส่งรีวิวไม่สำเร็จ";
           if (submit) submit.disabled = false;
@@ -1405,7 +1515,7 @@
             comment: formData.comment || "",
           });
           if (status) status.textContent = "ส่งรีวิวแล้ว รอแอดมินตรวจสอบ";
-          setTimeout(() => lookup(container), 500);
+          setTimeout(() => reloadCurrent(container), 500);
         } catch (error) {
           if (status) status.textContent = (error && error.message) || "ส่งรีวิวไม่สำเร็จ";
           if (submit) submit.disabled = false;
@@ -1453,9 +1563,23 @@
         root.state.updateDraft("tracking", { trackingCode: event.target.value });
       });
       bindResultActions(container);
-      if (code && root.state.tracking.status === "idle") {
+      if (pendingAutoLookup && activeCredential && root.state.tracking.status === "idle") {
+        // Deep-link (?q=/?token=): run the first lookup with the PRIVATE
+        // credential — it is never placed in the visible input above.
+        pendingAutoLookup = false;
+        setTimeout(() => lookup(container, { credential: activeCredential }), 0);
+      } else if (code && root.state.tracking.status === "idle") {
         setTimeout(() => lookup(container), 0);
       }
+    },
+    // Called by the app bootstrap with a ?q=/?token= deep-link value. The
+    // credential is held privately and consumed by the first render's
+    // auto-lookup; it is NEVER written to the draft or the visible input.
+    setInitialCredential(value) {
+      const cred = String(value == null ? "" : value).trim();
+      if (!cred) return;
+      setActiveCredential(cred);
+      pendingAutoLookup = true;
     },
   };
 })();

--- a/customer-app/modules/tracking.js
+++ b/customer-app/modules/tracking.js
@@ -1018,19 +1018,48 @@
   }
 
   function renderJobDetails(data, photos, maps, trackingKey) {
-    return `
-      <div class="data-list tracking-summary-list">
-        <div class="data-row"><strong>รหัสติดตาม</strong><span class="muted">${esc(trackingKey || "-")}</span></div>
-        <div class="data-row"><strong>นัดหมาย</strong><span class="muted">${root.utils.formatDateTime(data.appointment_datetime)}</span></div>
-        <div class="data-row"><strong>บริการ</strong><span class="muted">${esc(serviceSummary(data))}</span></div>
-        <div class="data-row"><strong>ราคาโดยประมาณ</strong><span class="muted">${esc(money(data.job_price || data.base_total))}</span></div>
-        <div class="data-row"><strong>ระยะเวลา</strong><span class="muted">${data.duration_min ? `${Number(data.duration_min)} นาที` : "-"}</span></div>
-        <div class="data-row"><strong>ที่อยู่</strong><span class="muted">${esc(data.address_text || "-")}</span></div>
-        ${data.job_zone ? `<div class="data-row"><strong>พื้นที่</strong><span class="muted">${esc(data.job_zone)}</span></div>` : ""}
-        ${maps ? `<div class="data-row"><strong>แผนที่</strong><span><a class="mini-link" href="${esc(maps)}" target="_blank" rel="noopener">นำทางไปหน้างาน</a></span></div>` : ""}
-        <div class="data-row"><strong>หลังจบงาน</strong><span class="muted">รูปงาน ${photos.length} รายการ ${data.receipt_url ? "และมีเอกสารหลังบริการ" : ""}</span></div>
-      </div>
-    `;
+    // Access-level aware. Full (token) access — opened from the secure link in
+    // the confirmation message — shows the customer-information section, address,
+    // and map. A booking_code (limited) lookup must NOT render blank rows that
+    // pretend data is missing: it shows only the fields the privacy response
+    // actually returned, plus a clear notice explaining the secure link is
+    // needed for full details. No hidden field is reconstructed on the client.
+    const isFull = data.access_level === "token";
+    const rows = [];
+    rows.push(`<div class="data-row"><strong>รหัสติดตาม</strong><span class="muted">${esc(trackingKey || data.booking_code || "-")}</span></div>`);
+    if (isFull && data.customer_name) {
+      rows.push(`<div class="data-row"><strong>ชื่อลูกค้า</strong><span class="muted">${esc(data.customer_name)}</span></div>`);
+    }
+    // Masked phone may be present even in limited mode; the full number only in token mode.
+    if (data.customer_phone) {
+      rows.push(`<div class="data-row"><strong>เบอร์โทร</strong><span class="muted">${esc(data.customer_phone)}</span></div>`);
+    }
+    rows.push(`<div class="data-row"><strong>นัดหมาย</strong><span class="muted">${esc(root.utils.formatDateTime(data.appointment_datetime))}</span></div>`);
+    if (isFull || serviceSummary(data)) {
+      rows.push(`<div class="data-row"><strong>บริการ</strong><span class="muted">${esc(serviceSummary(data) || "-")}</span></div>`);
+    }
+    if (isFull && (data.job_price != null || data.base_total != null)) {
+      rows.push(`<div class="data-row"><strong>ราคาโดยประมาณ</strong><span class="muted">${esc(money(data.job_price || data.base_total))}</span></div>`);
+    }
+    if (data.duration_min) {
+      rows.push(`<div class="data-row"><strong>ระยะเวลา</strong><span class="muted">${Number(data.duration_min)} นาที</span></div>`);
+    }
+    if (isFull && data.address_text) {
+      rows.push(`<div class="data-row"><strong>ที่อยู่</strong><span class="muted">${esc(data.address_text)}</span></div>`);
+    }
+    if (isFull && data.job_zone) {
+      rows.push(`<div class="data-row"><strong>พื้นที่</strong><span class="muted">${esc(data.job_zone)}</span></div>`);
+    }
+    if (isFull && maps) {
+      rows.push(`<div class="data-row"><strong>แผนที่</strong><span><a class="mini-link" href="${esc(maps)}" target="_blank" rel="noopener">นำทางไปหน้างาน</a></span></div>`);
+    }
+    rows.push(`<div class="data-row"><strong>หลังจบงาน</strong><span class="muted">รูปงาน ${photos.length} รายการ ${data.receipt_url ? "และมีเอกสารหลังบริการ" : ""}</span></div>`);
+    const limitedNotice = !isFull ? `
+      <div class="tracking-limited-note" data-limited-access role="note">
+        <strong>โหมดจำกัดข้อมูล (ค้นด้วยเลขงาน)</strong>
+        <p class="muted">เพื่อความปลอดภัย การค้นด้วยเลขงานจะแสดงเฉพาะสถานะและข้อมูลเบื้องต้น หากต้องการดูข้อมูลลูกค้า ที่อยู่ รายละเอียดช่าง และข้อมูลเต็ม กรุณาเปิดจาก “ลิงก์ติดตามงาน” ในข้อความยืนยันที่ได้รับ</p>
+      </div>` : "";
+    return `${limitedNotice}<div class="data-list tracking-summary-list">${rows.join("")}</div>`;
   }
 
   function renderPhotoView(data) {

--- a/customer-app/sw.js
+++ b/customer-app/sw.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const BUILD_ID = "20260710_legacy_claim_v2";
+const BUILD_ID = "20260711_tracking_gps_recovery_v1";
 const CACHE_NAME = `cwf-customer-app-v2-${BUILD_ID}`;
 const APP_SHELL = [
   `./index.html?v=${BUILD_ID}`,

--- a/customer.html
+++ b/customer.html
@@ -1365,9 +1365,13 @@ async function book(){
     window.__cwfSchedKey = null;
     try { sessionStorage.removeItem("cwf_sched_key"); } catch (_) {}
     const box = document.getElementById("result");
-    const token = data.token;
-    const code = data.booking_code || token || '';
-    const trackUrl = `${API}/track.html?q=${encodeURIComponent(code)}`;
+    // The VISIBLE booking number is always the short booking_code — never the
+    // secret booking_token. The token is used ONLY as the Tracking credential in
+    // the link / LINE share / calendar url, and is never displayed or copied.
+    const token = data.token || '';
+    const code = data.booking_code || '';
+    const cred = token || code; // request credential for the Tracking link
+    const trackUrl = `${API}/track.html?q=${encodeURIComponent(cred)}`;
     box.innerHTML = `<div class="success-card">
       <div class="success-title">✅ จองสำเร็จ</div>
       <div class="success-row"><span class="k">เลข Booking/Tracking</span><span class="v"><b style="font-size:18px;">${code || '-'}</b></span></div>
@@ -1375,13 +1379,14 @@ async function book(){
       <div class="success-row"><span class="k">เวลาโดยประมาณ</span><span class="v">${data.duration_min || '-'} นาที</span></div>
       <div class="success-actions">
         <button type="button" class="secondary action-btn" onclick="copyText('${code.replace(/'/g,"\\'")}')">📋 คัดลอกเลข</button>
-        <button type="button" class="secondary action-btn" onclick="shareLine('${code.replace(/'/g,"\\'")}')">💬 ส่งเข้า LINE</button>
+        <button type="button" class="secondary action-btn" onclick="shareLine()">💬 ส่งเข้า LINE</button>
         <button type="button" class="secondary action-btn" onclick="downloadIcsForBooking()">📅 เพิ่มเข้าปฏิทิน</button>
         <button type="button" class="secondary action-btn" onclick="location.href='${trackUrl}'">🔎 ไปหน้าติดตามงาน</button>
       </div>
     </div>`;
 
-    // stash for calendar button (ไม่กระทบ flow เดิม)
+    // stash for calendar + LINE share button (ไม่กระทบ flow เดิม).
+    // track_url carries the token credential; code is the visible booking number.
     window.__lastBookingForIcs = {
       code,
       date: document.getElementById('date')?.value || '',
@@ -1428,12 +1433,16 @@ function toast(msg){
   setTimeout(()=>{ el.classList.remove('show'); setTimeout(()=> el.remove(), 250); }, 1600);
 }
 
-function shareLine(code){
+function shareLine(){
   try{
-    const c = String(code||'').trim();
-    if(!c) return;
-    const trackUrl = `${API}/track.html?q=${encodeURIComponent(c)}`;
-    const msg = `เลข Booking: ${c}\nติดตามงาน: ${trackUrl}`;
+    // Share the VISIBLE booking_code as the number and the token-credentialed
+    // Tracking URL (from the stashed booking) as the link — never the token as
+    // the booking number.
+    const b = window.__lastBookingForIcs || {};
+    const c = String(b.code || '').trim();
+    const trackUrl = String(b.track_url || (c ? `${API}/track.html?q=${encodeURIComponent(c)}` : '')).trim();
+    if(!c && !trackUrl) return;
+    const msg = `เลข Booking: ${c || '-'}\nติดตามงาน: ${trackUrl}`;
     // ใช้ได้ดีบนมือถือ (LINE app จะรับต่อ)
     const u = `https://line.me/R/msg/text/?${encodeURIComponent(msg)}`;
     window.open(u, '_blank', 'noopener');

--- a/cwf-pwa.js
+++ b/cwf-pwa.js
@@ -1,6 +1,6 @@
 (function(){
   'use strict';
-  var VERSION = '20260710_payout_no_pay_status_v1';
+  var VERSION = '20260711_tracking_gps_recovery_v1';
   try { window.__CWF_PWA_BUILD__ = VERSION; } catch (_) {}
   function register(){
     if (!('serviceWorker' in navigator)) return;

--- a/index.js
+++ b/index.js
@@ -19185,15 +19185,34 @@ app.post("/jobs/:job_id/travel-start", requireTechnicianSession, async (req, res
 // =======================================
 // 📍 CHECK-IN
 // =======================================
+// A GPS fix coarser than this (metres) cannot be trusted for a 500 m boundary
+// decision — reject as retryable rather than pass a nominal-but-unusable point.
+const MAX_CHECKIN_ACCURACY_M = 200;
+
+// STRICT numeric parse: accept only a real JS number or a numeric string.
+// null/undefined/""/whitespace/booleans/arrays/objects all become NaN and are
+// rejected — Number(null)===0 / Number([])===0 must never slip through as (0,0).
+// A genuine real zero (0 or "0") is preserved as a valid coordinate value.
+function strictNumericOrNaN(v) {
+  if (typeof v === "number") return Number.isFinite(v) ? v : NaN;
+  if (typeof v === "string") {
+    const s = v.trim();
+    if (!/^[+-]?(?:\d+\.?\d*|\.\d+)(?:[eE][+-]?\d+)?$/.test(s)) return NaN;
+    const n = Number(s);
+    return Number.isFinite(n) ? n : NaN;
+  }
+  return NaN;
+}
+
 app.post("/jobs/:job_id/checkin", requireTechnicianSession, async (req, res) => {
   const { job_id } = req.params;
   const body = req.body || {};
-  const lat = Number(body.lat);
-  const lng = Number(body.lng);
+  const lat = strictNumericOrNaN(body.lat);
+  const lng = strictNumericOrNaN(body.lng);
   // accuracy (metres) is optional but, when present, must be a valid non-negative
   // number so we can reason about GPS confidence near the 500 m boundary.
   const hasAccuracy = body.accuracy !== undefined && body.accuracy !== null && body.accuracy !== "";
-  const accuracy = hasAccuracy ? Number(body.accuracy) : null;
+  const accuracy = hasAccuracy ? strictNumericOrNaN(body.accuracy) : null;
   // captured_at is advisory only; validate loosely and ignore when unparseable.
   const capturedAt = (() => {
     const v = body.captured_at;
@@ -19202,9 +19221,9 @@ app.post("/jobs/:job_id/checkin", requireTechnicianSession, async (req, res) => 
     return Number.isFinite(d.getTime()) ? d.toISOString() : null;
   })();
 
-  // ✅ Strict client-coordinate validation (structured codes for the app to map
-  // to clear Thai messages). Number(null/'') === 0 previously slipped through the
-  // null check and forced a (0,0) comparison — now rejected as invalid.
+  // ✅ Strict client-coordinate validation. Rejects missing/null/empty/
+  // whitespace/boolean/array/object/non-numeric BEFORE any distance math; a real
+  // zero coordinate is still accepted (0 is a valid latitude/longitude value).
   if (!Number.isFinite(lat) || !Number.isFinite(lng) || lat < -90 || lat > 90 || lng < -180 || lng > 180) {
     return res.status(400).json({ error: "พิกัด GPS ไม่ถูกต้อง กรุณากดลองใหม่", code: "INVALID_COORDINATES" });
   }
@@ -19327,6 +19346,18 @@ app.post("/jobs/:job_id/checkin", requireTechnicianSession, async (req, res) => 
 
       const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
       distance = R * c;
+
+      // Absolute accuracy gate: when the site is enforced, a fix coarser than the
+      // usable threshold cannot confirm the tech is at the site — even a nominal
+      // point INSIDE 500 m must be retried rather than accepted.
+      if (hasAccuracy && Number.isFinite(accuracy) && accuracy > MAX_CHECKIN_ACCURACY_M) {
+        console.log("[checkin]", { job_id: realId, tech: technician_username, site_required: true, distance_m: Math.round(distance), ...diag, result: "accuracy_too_low_abs" });
+        return res.status(400).json({
+          error: "สัญญาณ GPS ยังไม่แม่นพอที่จะยืนยันตำแหน่ง กรุณาออกไปที่โล่งแล้วกดลองใหม่",
+          code: "LOCATION_ACCURACY_TOO_LOW",
+          accuracy: Math.round(accuracy),
+        });
+      }
 
       if (distance > 500) {
         // ✅ Precision recovery: if stored coords are wrong but maps_url is correct,
@@ -26217,8 +26248,10 @@ if (FLAG_SHOW_TECH_TEAM_ON_TRACKING && canShowPublicTechnician) {
         [row.job_id]
       );
       fromAssign = (jaR.rows || []).map((x) => String(x.technician_username || "").trim()).filter(Boolean);
-    } catch (_) {
-      // ตารางอาจยังไม่มีในบางฐาน — ไม่ให้ tracking ล่ม
+    } catch (e) {
+      // Do not fail tracking, but do NOT swallow silently — log a sanitized
+      // warning (job_id + message only; never token/PII/address/coordinates).
+      console.warn("[public/track] job_assignments aggregation failed", { job_id: row.job_id, message: e && e.message });
       fromAssign = [];
     }
 

--- a/index.js
+++ b/index.js
@@ -1873,12 +1873,12 @@ async function assertTechBelongsToJob(clientOrPool, job_id, username) {
 async function requireTechOwnsResolvedJob(req, res, realId, clientOrPool = pool) {
   const tech = _authUsername(req);
   if (!tech) {
-    res.status(401).json({ error: 'UNAUTHORIZED' });
+    res.status(401).json({ error: 'UNAUTHORIZED', code: 'AUTH_REQUIRED' });
     return null;
   }
   const ok = await assertTechBelongsToJob(clientOrPool, realId, tech);
   if (!ok) {
-    res.status(403).json({ error: 'ช่างคนนี้ไม่ได้อยู่ในทีมของงานนี้' });
+    res.status(403).json({ error: 'ช่างคนนี้ไม่ได้อยู่ในทีมของงานนี้', code: 'TECH_NOT_ASSIGNED' });
     return null;
   }
   return tech;
@@ -18287,9 +18287,16 @@ function buildCustomerConfirmationVars({ job, items, origin, ddTH, ttTH, ddEN, t
       ...promoLinesEN(it),
     ].join('\n');
   });
+  // The official Tracking link must carry the long random booking_token when the
+  // job has one, so the customer opening it from the confirmation message gets
+  // FULL (token) access. The short booking_code only yields limited/redacted
+  // data after the tracking-privacy change. The visible job number below stays
+  // booking_code; the token is used solely as the URL credential and is never
+  // rendered as visible text or logged.
+  const trackingCredential = String(job.booking_token || '').trim() || String(job.booking_code || '') || String(job.job_id || '');
   return {
     booking_code: booking,
-    tracking_url: `${origin}/track.html?q=${encodeURIComponent(job.booking_code || String(job.job_id || ''))}`,
+    tracking_url: `${origin}/track.html?q=${encodeURIComponent(trackingCredential)}`,
     customer_name: _safeMsgText(job.customer_name),
     customer_phone: _safeMsgText(job.customer_phone),
     appointment_th: `${ddTH} เวลา ${ttTH} น.`,
@@ -18310,7 +18317,7 @@ app.get("/jobs/:job_id/summary", async (req, res) => {
 
   try {
     const jobR = await pool.query(
-      `SELECT job_id, booking_code, customer_name, customer_phone, appointment_datetime, address_text, job_type, job_price
+      `SELECT job_id, booking_code, booking_token, customer_name, customer_phone, appointment_datetime, address_text, job_type, job_price
        FROM public.jobs WHERE job_id=$1`,
       [job_id]
     );
@@ -18318,7 +18325,7 @@ app.get("/jobs/:job_id/summary", async (req, res) => {
 
     const job = jobR.rows[0];
 
-    // ✅ ใช้ทำลิงก์ Tracking ให้ลูกค้า
+    // ✅ ใช้ทำลิงก์ Tracking ให้ลูกค้า (ใช้ booking_token เป็น credential เมื่อมี)
     const origin = `${req.protocol}://${req.get("host")}`;
 
     let itemsR;
@@ -19180,13 +19187,38 @@ app.post("/jobs/:job_id/travel-start", requireTechnicianSession, async (req, res
 // =======================================
 app.post("/jobs/:job_id/checkin", requireTechnicianSession, async (req, res) => {
   const { job_id } = req.params;
-  const { lat, lng } = req.body || {};
+  const body = req.body || {};
+  const lat = Number(body.lat);
+  const lng = Number(body.lng);
+  // accuracy (metres) is optional but, when present, must be a valid non-negative
+  // number so we can reason about GPS confidence near the 500 m boundary.
+  const hasAccuracy = body.accuracy !== undefined && body.accuracy !== null && body.accuracy !== "";
+  const accuracy = hasAccuracy ? Number(body.accuracy) : null;
+  // captured_at is advisory only; validate loosely and ignore when unparseable.
+  const capturedAt = (() => {
+    const v = body.captured_at;
+    if (v === undefined || v === null || v === "") return null;
+    const d = new Date(v);
+    return Number.isFinite(d.getTime()) ? d.toISOString() : null;
+  })();
 
-  if (lat == null || lng == null) return res.status(400).json({ error: "พิกัด GPS ไม่ครบ" });
+  // ✅ Strict client-coordinate validation (structured codes for the app to map
+  // to clear Thai messages). Number(null/'') === 0 previously slipped through the
+  // null check and forced a (0,0) comparison — now rejected as invalid.
+  if (!Number.isFinite(lat) || !Number.isFinite(lng) || lat < -90 || lat > 90 || lng < -180 || lng > 180) {
+    return res.status(400).json({ error: "พิกัด GPS ไม่ถูกต้อง กรุณากดลองใหม่", code: "INVALID_COORDINATES" });
+  }
+  if (hasAccuracy && (!Number.isFinite(accuracy) || accuracy < 0)) {
+    return res.status(400).json({ error: "พิกัด GPS ไม่ถูกต้อง กรุณากดลองใหม่", code: "INVALID_COORDINATES" });
+  }
+
+  // Sanitized diagnostics only — never log raw coordinates, token, phone, name,
+  // or address. Rounded accuracy is safe and useful for triage.
+  const diag = { has_accuracy: hasAccuracy, accuracy_m: hasAccuracy ? Math.round(accuracy) : null };
 
   try {
     const realId = await resolveJobIdAny(pool, job_id);
-    if (!realId) return res.status(400).json({ error: "job_id ไม่ถูกต้อง" });
+    if (!realId) return res.status(400).json({ error: "job_id ไม่ถูกต้อง", code: "INVALID_JOB_REFERENCE" });
     const technician_username = await requireTechOwnsResolvedJob(req, res, realId, pool);
     if (!technician_username) return;
     await assertJobActionableForTechnician(pool, realId);
@@ -19334,20 +19366,40 @@ app.post("/jobs/:job_id/checkin", requireTechnicianSession, async (req, res) => 
           // then do not block check-in.
           // Here, if the only coordinates were invalid/sentinel and we couldn't derive a valid one,
           // `hasSiteLatLng` would be false and we wouldn't be inside this block.
-          return res.status(400).json({ error: "อยู่นอกพื้นที่หน้างาน", distance: Math.round(distance) });
+          //
+          // Poor-accuracy guard: only reject as "outside" when we are confident —
+          // i.e. the tech is beyond 500 m even after allowing for the GPS error
+          // radius. If the boundary sits within the accuracy error, ask for a
+          // retry instead of a false rejection (an assigned tech at the site with
+          // a weak fix must not be blocked).
+          if (hasAccuracy && Number.isFinite(accuracy) && (distance - accuracy) <= 500) {
+            console.log("[checkin]", { job_id: realId, tech: technician_username, site_required: true, distance_m: Math.round(distance), ...diag, result: "accuracy_too_low" });
+            return res.status(400).json({
+              error: "สัญญาณ GPS ยังไม่แม่นพอที่จะยืนยันตำแหน่ง กรุณาออกไปที่โล่งแล้วกดลองใหม่",
+              code: "LOCATION_ACCURACY_TOO_LOW",
+              accuracy: Math.round(accuracy),
+            });
+          }
+          console.log("[checkin]", { job_id: realId, tech: technician_username, site_required: true, distance_m: Math.round(distance), ...diag, result: "outside_radius" });
+          return res.status(400).json({ error: "อยู่นอกพื้นที่หน้างาน", code: "OUTSIDE_CHECKIN_RADIUS", distance: Math.round(distance) });
         }
       }
     }
 
+    // Idempotent: preserve the FIRST check-in timestamp so re-tapping does not
+    // reset it or move unrelated job timing; still record the latest coordinates.
     await pool.query(
-      `UPDATE public.jobs SET checkin_latitude=$1, checkin_longitude=$2, checkin_at=NOW() WHERE job_id=$3`,
+      `UPDATE public.jobs
+          SET checkin_latitude=$1, checkin_longitude=$2, checkin_at=COALESCE(checkin_at, NOW())
+        WHERE job_id=$3`,
       [lat, lng, realId]
     );
 
-    res.json({ success: true, distance: distance == null ? null : Math.round(distance), site_required: hasSiteLatLng });
+    console.log("[checkin]", { job_id: realId, tech: technician_username, site_required: hasSiteLatLng, distance_m: distance == null ? null : Math.round(distance), ...diag, result: "ok" });
+    res.json({ success: true, distance: distance == null ? null : Math.round(distance), site_required: hasSiteLatLng, captured_at: capturedAt });
   } catch (e) {
-    console.error(e);
-    res.status(Number(e.status || 500)).json({ error: e.message || "เช็คอินไม่สำเร็จ", code: e.code || undefined });
+    console.error("[checkin] error", { job_id: String(job_id), message: e && e.message });
+    res.status(Number(e.status || 500)).json({ error: e.message || "เช็คอินไม่สำเร็จ", code: e.code || "CHECKIN_FAILED" });
   }
 });
 
@@ -26154,12 +26206,40 @@ if (FLAG_SHOW_TECH_TEAM_ON_TRACKING && canShowPublicTechnician) {
     );
     const fromJoin = (tmR.rows || []).map((x) => String(x.username || "").trim()).filter(Boolean);
 
-    // รองรับ legacy fields
-    const legacy = [row.technician_username, row.technician_team]
+    // ดึงช่างจาก job_assignments ด้วย (โปรดักชันบางงาน assign ผ่านตารางนี้เท่านั้น).
+    // job_assignments มีสถานะ in_progress/done เท่านั้น — ทั้งสองถือว่าถูก assign จริง
+    // (การปฏิเสธ/หมดอายุอยู่ที่ job_offers ซึ่งไม่ใช่แหล่ง assignment).
+    let fromAssign = [];
+    try {
+      const jaR = await pool.query(
+        `SELECT technician_username FROM public.job_assignments
+          WHERE job_id=$1 AND COALESCE(status,'in_progress') IN ('in_progress','done')`,
+        [row.job_id]
+      );
+      fromAssign = (jaR.rows || []).map((x) => String(x.technician_username || "").trim()).filter(Boolean);
+    } catch (_) {
+      // ตารางอาจยังไม่มีในบางฐาน — ไม่ให้ tracking ล่ม
+      fromAssign = [];
+    }
+
+    // รองรับ legacy fields — technician_team อาจเก็บหลาย username คั่นด้วย comma
+    const legacy = [
+      row.technician_username,
+      ...String(row.technician_team || "").split(","),
+    ]
       .map((x) => String(x || "").trim())
       .filter(Boolean);
 
-    const uniq = Array.from(new Set([...fromJoin, ...legacy]));
+    // Deduplicate by normalized (lower-cased) username while keeping the first
+    // seen display casing; primary technician (technician_username) stays first.
+    const seen = new Set();
+    const uniq = [];
+    for (const u of [...legacy, ...fromJoin, ...fromAssign]) {
+      const norm = u.toLowerCase();
+      if (seen.has(norm)) continue;
+      seen.add(norm);
+      uniq.push(u);
+    }
     if (uniq.length) {
       const detR = await pool.query(
         `

--- a/sw.js
+++ b/sw.js
@@ -1,5 +1,5 @@
 /* CWF root service worker: Tech App shell/cache refresh */
-const CWF_TECH_BUILD_ID = "20260710_payout_no_pay_status_v1";
+const CWF_TECH_BUILD_ID = "20260711_tracking_gps_recovery_v1";
 const CWF_ACCOUNTING_CACHE_BUMP = "20260703_accounting_payout_adjustment_v1";
 const CACHE_PREFIX = "cwf-root-tech-app-";
 const CACHE_NAME = `${CACHE_PREFIX}${CWF_TECH_BUILD_ID}-${CWF_ACCOUNTING_CACHE_BUMP}`;

--- a/tech.html
+++ b/tech.html
@@ -8,10 +8,10 @@
   <link rel="manifest" href="/manifest.json">
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-  <meta name="cwf-tech-build" content="20260710_payout_no_pay_status_v1">
+  <meta name="cwf-tech-build" content="20260711_tracking_gps_recovery_v1">
   <title>หน้าช่าง - CWF</title>
   <link rel="stylesheet" href="style.css">
-  <script defer src="/cwf-pwa.js?v=20260710_payout_no_pay_status_v1"></script>
+  <script defer src="/cwf-pwa.js?v=20260711_tracking_gps_recovery_v1"></script>
 
   <style>
     :root{
@@ -3433,7 +3433,7 @@
     }
   </style>
 
-<script src="app.js?v=20260710_payout_no_pay_status_v1"></script>
+<script src="app.js?v=20260711_tracking_gps_recovery_v1"></script>
   <script src="tech-onboarding.js?v=phase2a-fix-restore-onboarding-panel"></script>
   <script>
         function goEditProfile(){ location.href = '/edit-profile.html'; }

--- a/test/customerAppRecovery.test.js
+++ b/test/customerAppRecovery.test.js
@@ -2800,3 +2800,29 @@ test("tracking code-only access shows a limited-access notice instead of blank r
   assert.match(html, /•••• 5678/); // masked phone may still show
   assert.doesNotMatch(html, /ชื่อลูกค้า/); // no misleading customer-name row in limited mode
 });
+
+// Blocker 1: the booking_token is a private request credential and must never
+// be rendered into the tracking UI (it is not a human-facing tracking number).
+// After a successful lookup the visible search field is normalised to the
+// booking_code (see lookup()), so the render path must emit the code — never
+// the token — anywhere: receipt link, review forms, timeline, or search input.
+test("tracking never renders the booking_token into the customer HTML", () => {
+  const SECRET_TOKEN = "TOKEN_SECRET_ZZZ_9x8y7z";
+  const data = {
+    access_level: "token", booking_token: SECRET_TOKEN, booking_code: "BK1",
+    job_status: "เสร็จแล้ว", finished_at: "2026-06-20T10:00:00Z",
+    appointment_datetime: "2026-06-20T10:00:00Z",
+    customer_name: "คุณสมชาย", customer_phone: "0812345678", address_text: "อ่อนนุช กทม",
+    review: { already_reviewed: false },
+  };
+  const root = loadTrackingFrontend();
+  // Post-lookup state: the search field holds the human-facing booking_code,
+  // the token stays only inside root.state.tracking.data as the credential.
+  root.state.updateDraft("tracking", { trackingCode: data.booking_code });
+  root.state.setTracking({ status: "success", data, error: "" });
+  const container = new TrackingContainer();
+  root.tracking.render(container);
+  const html = container.innerHTML;
+  assert.ok(!html.includes(SECRET_TOKEN), "rendered tracking HTML must not contain the booking_token");
+  assert.match(html, /BK1/); // the visible tracking number stays booking_code
+});

--- a/test/customerAppRecovery.test.js
+++ b/test/customerAppRecovery.test.js
@@ -2826,3 +2826,175 @@ test("tracking never renders the booking_token into the customer HTML", () => {
   assert.ok(!html.includes(SECRET_TOKEN), "rendered tracking HTML must not contain the booking_token");
   assert.match(html, /BK1/); // the visible tracking number stays booking_code
 });
+
+// ==========================================================================
+// Round-3 blockers: private token-credential lifecycle + code-only "no tech"
+// ==========================================================================
+
+const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+// A live DOM-ish element that records innerHTML/value and captures listeners so
+// tests can drive clicks/submits. querySelector maps to a fixed child registry.
+function makeLiveEl(children, extra) {
+  const listeners = {};
+  const el = {
+    value: "", dataset: {}, _html: "", _children: children || {},
+    set innerHTML(v) { this._html = String(v == null ? "" : v); },
+    get innerHTML() { return this._html; },
+    addEventListener(type, fn) { listeners[type] = fn; },
+    async fire(type, event) { if (listeners[type]) await listeners[type](event || { preventDefault() {} }); },
+    setAttribute() {}, getAttribute() { return null; },
+    hasAttribute(name) { return !!(extra && extra._attrs && extra._attrs[name]); },
+    closest() { return null; },
+    querySelector(sel) { return this._children[sel] || null; },
+    querySelectorAll() { return []; },
+  };
+  return Object.assign(el, extra || {});
+}
+
+// A container whose querySelector returns a stable set of live elements for the
+// selectors tracking.render()/lookup()/bindResultActions() actually query.
+function makeLiveTrackingContainer(opts) {
+  opts = opts || {};
+  const input = makeLiveEl();
+  const result = makeLiveEl();
+  const timeline = makeLiveEl();
+  const readBtn = makeLiveEl();
+  const refreshBtn = makeLiveEl();
+  const map = {
+    "#tracking-code": input,
+    "[data-tracking-result]": result,
+    "[data-tracking-timeline]": timeline,
+    "[data-action='track-read']": readBtn,
+    "[data-action='track-refresh']": refreshBtn,
+  };
+  if (opts.reviewForm) map["[data-review-form]"] = opts.reviewForm;
+  const container = {
+    _html: "",
+    set innerHTML(v) { this._html = String(v == null ? "" : v); },
+    get innerHTML() { return this._html; },
+    querySelector(sel) { return map[sel] || null; },
+    querySelectorAll() { return []; },
+  };
+  return { container, input, result, timeline, readBtn, refreshBtn };
+}
+
+// Record every credential the app actually sends to trackBooking.
+function installRecordingApi(root, responder) {
+  const calls = [];
+  root.api.trackBooking = async (q) => { calls.push(q); return responder(q); };
+  return { calls };
+}
+
+const SECRET = "TOKEN_SECRET_LIFECYCLE_9zx";
+
+test("Blocker 1: ?q token stays out of the visible UI while the lookup is pending", async () => {
+  const root = loadTrackingFrontend();
+  let release;
+  const gate = new Promise((resolve) => { release = resolve; });
+  const { calls } = installRecordingApi(root, async () => { await gate; return { access_level: "token", booking_code: "BKLIVE", booking_token: SECRET }; });
+  const { container, input, result } = makeLiveTrackingContainer();
+
+  root.tracking.setInitialCredential(SECRET);
+  root.tracking.render(container);
+  await delay(5); // let the render's auto-lookup start and reach the pending await
+
+  assert.equal(calls[0], SECRET, "the lookup must use the private token credential");
+  assert.equal(input.value, "", "the search input must be blank while the token lookup is pending");
+  assert.ok(!container.innerHTML.includes(SECRET), "container HTML must not contain the token while pending");
+  assert.ok(!result.innerHTML.includes(SECRET), "result HTML must not contain the token while pending");
+  assert.ok(!String(root.state.draft.tracking.trackingCode || "").includes(SECRET), "the draft must never hold the token");
+
+  release();
+  await delay(5);
+  assert.equal(input.value, "BKLIVE", "after success the input shows the booking_code");
+  assert.ok(!result.innerHTML.includes(SECRET), "the token never appears after success");
+});
+
+test("Blocker 1: a failed token lookup still keeps the token out of the visible UI", async () => {
+  const root = loadTrackingFrontend();
+  const { calls } = installRecordingApi(root, async () => { throw new Error("ไม่พบข้อมูลงาน"); });
+  const { container, input, result } = makeLiveTrackingContainer();
+
+  root.tracking.setInitialCredential(SECRET);
+  root.tracking.render(container);
+  await delay(5);
+
+  assert.equal(calls[0], SECRET);
+  assert.equal(input.value, "", "input stays blank on a failed token lookup");
+  assert.ok(!container.innerHTML.includes(SECRET));
+  assert.ok(!result.innerHTML.includes(SECRET), "the token must not leak into the error UI");
+  assert.ok(!String(root.state.draft.tracking.trackingCode || "").includes(SECRET));
+});
+
+test("Blocker 2: Refresh reuses the private token and preserves full (token) access", async () => {
+  const root = loadTrackingFrontend();
+  const { calls } = installRecordingApi(root, async (q) => {
+    if (q === SECRET) return { access_level: "token", booking_code: "BKLIVE", booking_token: SECRET, customer_name: "คุณเอ", customer_phone: "0812345678", technician: { full_name: "ช่างบี", username: "tech_b" } };
+    return { access_level: "code", booking_code: "BKLIVE", customer_phone: "•••• 5678" };
+  });
+  const { container, input, refreshBtn } = makeLiveTrackingContainer();
+
+  root.tracking.setInitialCredential(SECRET);
+  root.tracking.render(container);
+  await delay(5);
+  assert.equal(calls[0], SECRET);
+  assert.equal(input.value, "BKLIVE", "input normalised to booking_code after the token lookup");
+  assert.equal(root.state.tracking.data.access_level, "token");
+
+  await refreshBtn.fire("click");
+  await delay(5);
+  assert.equal(calls[1], SECRET, "Refresh must reuse the private token, not the visible booking_code");
+  assert.equal(root.state.tracking.data.access_level, "token", "access stays full after Refresh");
+  assert.equal(root.state.tracking.data.customer_name, "คุณเอ", "customer details remain visible after Refresh");
+});
+
+test("Blocker 2: technician-review success reloads with the private token", async () => {
+  const context = makeContext();
+  context.FormData = class { constructor() { this._e = [["rating", "5"]]; } entries() { return this._e; } };
+  context.fetch = async () => ({ ok: true, json: async () => ({}) });
+  const root = loadTrackingFrontend(context);
+  const { calls } = installRecordingApi(root, async (q) => {
+    if (q === SECRET) return { access_level: "token", booking_code: "BKLIVE", booking_token: SECRET, job_status: "เสร็จแล้ว", finished_at: "2026-06-20T10:00:00Z", review: { already_reviewed: false } };
+    return { access_level: "code", booking_code: "BKLIVE" };
+  });
+  const status = makeLiveEl();
+  const submit = makeLiveEl();
+  const reviewForm = makeLiveEl({ "[data-review-status]": status, "button[type='submit']": submit }, { _attrs: { "data-review-token": true } });
+  const { container } = makeLiveTrackingContainer({ reviewForm });
+
+  root.tracking.setInitialCredential(SECRET);
+  root.tracking.render(container);
+  await delay(5);
+  assert.equal(calls[0], SECRET);
+
+  await reviewForm.fire("submit");
+  await delay(560); // handler reloads via setTimeout(reloadCurrent, 500)
+  assert.equal(calls[calls.length - 1], SECRET, "review success must reload using the private token");
+});
+
+test("Blocker 3: code-only Overview explains limited access and never claims 'no technician'", () => {
+  const root = loadTrackingFrontend();
+  const html = renderTracking(root, {
+    access_level: "code", booking_code: "BKCODE", booking_mode: "urgent",
+    job_status: "กำลังดำเนินการ", appointment_datetime: "2026-06-20T10:00:00Z",
+    customer_phone: "•••• 5678",
+  });
+  assert.match(html, /โหมดจำกัดข้อมูล/);
+  assert.match(html, /ข้อมูลทีมช่างจะแสดงเมื่อเปิดจากลิงก์ติดตามงาน/);
+  assert.doesNotMatch(html, /ยังไม่มีช่างยืนยันงานนี้/);
+  assert.doesNotMatch(html, /รอช่างรับงาน/);
+  assert.doesNotMatch(html, /แอดมินกำลังช่วยจัดคิวให้/);
+  assert.doesNotMatch(html, /เปลี่ยนเป็นจองล่วงหน้า/);
+});
+
+test("Blocker 3: token (full) access still shows the real technician", () => {
+  const root = loadTrackingFrontend();
+  const html = renderTracking(root, {
+    access_level: "token", booking_code: "BKFULL", booking_token: "T1",
+    job_status: "กำลังดำเนินการ", appointment_datetime: "2026-06-20T10:00:00Z",
+    technician: { full_name: "ช่างสมชาย", username: "somchai", phone: "0899999999" },
+  });
+  assert.match(html, /ช่างสมชาย/, "the actual technician is shown on full access");
+  assert.doesNotMatch(html, /โหมดจำกัดข้อมูล/, "no limited-access notice on full access");
+});

--- a/test/customerAppRecovery.test.js
+++ b/test/customerAppRecovery.test.js
@@ -236,7 +236,7 @@ test("Customer App build id is consistent across shell and service worker", () =
   const sw = read("customer-app/sw.js");
   const app = read("customer-app/assets/customer-app.js");
   const manifest = read("customer-app/manifest.webmanifest");
-  const build = "20260710_legacy_claim_v2";
+  const build = "20260711_tracking_gps_recovery_v1";
 
   assert.match(index, new RegExp(`customer-app\\.css\\?v=${build}`));
   assert.match(index, new RegExp(`modules\\/api\\.js\\?v=${build}`));
@@ -254,7 +254,7 @@ test("Customer App build id is consistent across shell and service worker", () =
 test("store module is loaded in index.html and precached in the service worker app shell", () => {
   const index = read("customer-app/index.html");
   const sw = read("customer-app/sw.js");
-  const build = "20260710_legacy_claim_v2";
+  const build = "20260711_tracking_gps_recovery_v1";
 
   assert.match(index, new RegExp(`modules/store\\.js\\?v=${build}`));
   assert.match(sw, /`\.\/modules\/store\.js\?v=\$\{BUILD_ID\}`/);
@@ -2773,4 +2773,30 @@ test("store performance guard: navigating from the loaded list to a product deta
 
   assert.equal(detailCalls, 1, "detail must fetch the routed item exactly once");
   assert.equal(listCalls, 1, "an already-loaded catalog list must never be refetched just to populate siblings/related items on the detail page");
+});
+
+// ---- Tracking hotfix: access-level aware customer information -------------
+test("tracking full (token) access renders the customer-information section", () => {
+  const root = loadTrackingFrontend();
+  const html = renderTracking(root, {
+    access_level: "token", booking_token: "TOK1", booking_code: "BK1",
+    job_status: "กำลังดำเนินการ", appointment_datetime: "2026-06-20T10:00:00Z",
+    customer_name: "คุณสมชาย", customer_phone: "0812345678", address_text: "อ่อนนุช กทม",
+  });
+  assert.match(html, /คุณสมชาย/);
+  assert.match(html, /0812345678/);
+  assert.match(html, /อ่อนนุช กทม/);
+  assert.doesNotMatch(html, /tracking-limited-note/);
+});
+
+test("tracking code-only access shows a limited-access notice instead of blank rows", () => {
+  const root = loadTrackingFrontend();
+  const html = renderTracking(root, {
+    access_level: "code", booking_code: "BK1", job_status: "กำลังดำเนินการ",
+    appointment_datetime: "2026-06-20T10:00:00Z", customer_phone: "•••• 5678",
+  });
+  assert.match(html, /tracking-limited-note/);
+  assert.match(html, /ลิงก์ติดตามงาน/);
+  assert.match(html, /•••• 5678/); // masked phone may still show
+  assert.doesNotMatch(html, /ชื่อลูกค้า/); // no misleading customer-name row in limited mode
 });

--- a/test/customerAppStorePayment.test.js
+++ b/test/customerAppStorePayment.test.js
@@ -58,7 +58,7 @@ test("store falls back to the LINE hand-off when payment is unconfigured or the 
 test("payment step styles exist and the Customer App payment build id is bumped", () => {
   assert.match(cssSrc, /\.pay-method-btn/);
   assert.match(cssSrc, /\.pay-qr-img/);
-  assert.match(read("customer-app/index.html"), /modules\/store\.js\?v=20260710_legacy_claim_v2/);
-  assert.match(read("customer-app/sw.js"), /BUILD_ID = "20260710_legacy_claim_v2"/);
+  assert.match(read("customer-app/index.html"), /modules\/store\.js\?v=20260711_tracking_gps_recovery_v1/);
+  assert.match(read("customer-app/sw.js"), /BUILD_ID = "20260711_tracking_gps_recovery_v1"/);
   assert.match(storeSrc, /payment-security 20260705 loaded/);
 });

--- a/test/customerBookingAdminNotifications.test.js
+++ b/test/customerBookingAdminNotifications.test.js
@@ -311,10 +311,10 @@ test("admin/customer frontend cache versions are bumped for booking notification
   assert.doesNotMatch(adminReviewHtml, /admin-review-v2\.js\?v=20260707_customer_booking_notify_v2/);
   assert.match(adminReviewHtml, /admin-review-ai-intake\.js\?v=ai-booking-intake-customer-cards-v11-admin-alert-gate/);
   assert.doesNotMatch(adminReviewHtml, /admin-review-ai-intake\.js\?v=ai-booking-intake-customer-cards-v10/);
-  assert.match(customerIndex, /bookingScheduled\.js\?v=20260710_legacy_claim_v2/);
-  assert.match(customerIndex, /state\.js\?v=20260710_legacy_claim_v2/);
-  assert.match(customerSw, /const BUILD_ID = "20260710_legacy_claim_v2"/);
-  assert.match(customerManifest, /20260710_legacy_claim_v2/);
+  assert.match(customerIndex, /bookingScheduled\.js\?v=20260711_tracking_gps_recovery_v1/);
+  assert.match(customerIndex, /state\.js\?v=20260711_tracking_gps_recovery_v1/);
+  assert.match(customerSw, /const BUILD_ID = "20260711_tracking_gps_recovery_v1"/);
+  assert.match(customerManifest, /20260711_tracking_gps_recovery_v1/);
 });
 
 test("behavior: review queue only includes customer urgent waiting rows while preserving review statuses", () => {

--- a/test/customerHistoryClaim.test.js
+++ b/test/customerHistoryClaim.test.js
@@ -544,7 +544,7 @@ test("Customer App profile opens history detail with opaque job_ref and clears c
 });
 
 test("Customer App cache version is bumped consistently", () => {
-  const expected = "20260710_legacy_claim_v2";
+  const expected = "20260711_tracking_gps_recovery_v1";
   for (const file of [
     "customer-app/index.html",
     "customer-app/sw.js",

--- a/test/customerSameDayTiming.test.js
+++ b/test/customerSameDayTiming.test.js
@@ -160,7 +160,7 @@ test("customer app disables availability HTTP cache and refreshes same-day slots
 });
 
 test("customer app build and service worker cache IDs changed", () => {
-  const id = "20260710_legacy_claim_v2";
+  const id = "20260711_tracking_gps_recovery_v1";
   for (const file of [
     "customer-app/index.html",
     "customer-app/sw.js",

--- a/test/customerTrackingPrivacy.test.js
+++ b/test/customerTrackingPrivacy.test.js
@@ -229,8 +229,17 @@ test("all three job-doc routes share one gate helper + sensitive headers", () =>
 });
 
 test("the customer app only builds receipt links + review form on full (token) access", () => {
-  assert.match(trackingClientSrc, /data\.booking_token\s*\?\s*`\/docs\/receipt\/\$\{encodeURIComponent\(data\.job_id\)\}\?key=/);
+  // The receipt URL still carries the booking_token as ?key=, but it is now
+  // constructed at click time from state (receiptUrl(data)) instead of being
+  // interpolated into rendered HTML — see Blocker 1.
+  assert.match(trackingClientSrc, /`\/docs\/receipt\/\$\{encodeURIComponent\(data\.job_id\)\}\?key=\$\{encodeURIComponent\(data\.booking_token\)\}`/);
+  // The review form only offers the token-write path on full (token) access.
   assert.match(trackingClientSrc, /data\.access_level === "token" \? \(data\.booking_token \|\| ""\) : ""/);
-  assert.match(trackingClientSrc, /name="booking_token"/);
+  // Blocker 1: the booking_token must NOT be embedded in rendered HTML as a
+  // hidden input. It is injected from state at submit time and the form is only
+  // flagged with data-review-token.
+  assert.doesNotMatch(trackingClientSrc, /name="booking_token"/);
+  assert.match(trackingClientSrc, /data-review-token/);
+  assert.match(trackingClientSrc, /payload\.booking_token = token/);
   assert.doesNotMatch(trackingClientSrc, /<input type="hidden" name="q"/);
 });

--- a/test/homepageCms.test.js
+++ b/test/homepageCms.test.js
@@ -278,7 +278,7 @@ test("customer homepage has no admin control, bottom nav is fixed five-tab, and 
   const sw = read("customer-app/sw.js");
   const app = read("customer-app/assets/customer-app.js");
   const manifest = read("customer-app/manifest.webmanifest");
-  const build = "20260710_legacy_claim_v2";
+  const build = "20260711_tracking_gps_recovery_v1";
 
   assert.doesNotMatch(index + ui, /โหมดแอดมิน|openCms|localStorage\.getItem\('cwfHomeCmsDemo'/);
   assert.match(index, /data-route="store"[\s\S]*ร้านค้า/);

--- a/test/techCacheBuild.test.js
+++ b/test/techCacheBuild.test.js
@@ -4,7 +4,7 @@ const fs = require("node:fs");
 const path = require("node:path");
 
 const root = path.join(__dirname, "..");
-const BUILD = "20260710_payout_no_pay_status_v1";
+const BUILD = "20260711_tracking_gps_recovery_v1";
 
 function read(file) {
   return fs.readFileSync(path.join(root, file), "utf8");

--- a/test/trackingGpsRecovery.test.js
+++ b/test/trackingGpsRecovery.test.js
@@ -74,7 +74,7 @@ test("track.html escapes customer/technician/address/photo/phone values", () => 
   assert.match(trackHtml, /ที่อยู่:<\/b> \$\{esc\(data\.address_text/);
   assert.match(trackHtml, /src="\$\{esc\(photo\)\}"/);
   assert.match(trackHtml, /tel:\$\{esc\(phone\)\}/);
-  assert.match(trackHtml, /tel:\$\{esc\(firstTel\)\}/);
+  assert.match(trackHtml, /data-tel="\$\{esc\(firstTel\)\}"/);
 });
 
 // ============================ A3. Customer App tracking rendering =========
@@ -102,7 +102,7 @@ test("checkin backend validates coordinates + accuracy with structured codes", (
   // idempotent: preserve the first check-in timestamp.
   assert.match(route, /checkin_at=COALESCE\(checkin_at, NOW\(\)\)/);
   // reads accuracy + captured_at from the body.
-  assert.match(route, /const accuracy = hasAccuracy \? Number\(body\.accuracy\) : null/);
+  assert.match(route, /const accuracy = hasAccuracy \? strictNumericOrNaN\(body\.accuracy\) : null/);
   assert.match(route, /captured_at/);
   // never logs raw coordinates.
   assert.doesNotMatch(route, /console\.[a-z]+\([^)]*\blat\b[^)]*\blng\b/);
@@ -270,4 +270,135 @@ test("checkin() uses cssEscapeCompat and a high-accuracy-first geolocation strat
   assert.match(block, /enableHighAccuracy: true/);
   assert.match(block, /body: JSON\.stringify\(\{ lat, lng, accuracy, captured_at \}\)/);
   assert.match(block, /finally \{/);
+});
+
+// ============ Review-round blockers ======================================
+
+// Blocker 3: strict raw coordinate validation (unit test of the real parser).
+test("strictNumericOrNaN rejects null/empty/whitespace/boolean/array/object; accepts real zero", () => {
+  const src = sliceBetween(indexSrc, "function strictNumericOrNaN(v) {", "\napp.post(\"/jobs/:job_id/checkin\"");
+  const sandbox = { Number, String };
+  vm.createContext(sandbox);
+  vm.runInContext(`${src}\nglobalThis.__f = strictNumericOrNaN;`, sandbox);
+  const f = sandbox.__f;
+  for (const bad of [null, undefined, "", "   ", "\t", true, false, [], {}, [5], "abc", "12abc", NaN, {}]) {
+    assert.ok(Number.isNaN(f(bad)), `expected NaN for ${JSON.stringify(bad)}`);
+  }
+  assert.equal(f(0), 0);
+  assert.equal(f("0"), 0);
+  assert.equal(f(13.7), 13.7);
+  assert.equal(f("-100.5"), -100.5);
+  assert.equal(f("100"), 100);
+});
+
+// Blocker 3 + 7: route wiring (validation, structured codes, accuracy gates).
+test("checkin route: strict validation + absolute & boundary accuracy gates + 500 m preserved", () => {
+  const route = sliceBetween(indexSrc, 'app.post("/jobs/:job_id/checkin"', "// 📷 PHOTOS");
+  assert.match(route, /const lat = strictNumericOrNaN\(body\.lat\)/);
+  assert.match(route, /const lng = strictNumericOrNaN\(body\.lng\)/);
+  assert.match(route, /code: "INVALID_COORDINATES"/);
+  // Absolute accuracy gate: unusable fix inside 500 m is rejected.
+  assert.match(indexSrc, /const MAX_CHECKIN_ACCURACY_M = 200/);
+  assert.match(route, /accuracy > MAX_CHECKIN_ACCURACY_M/);
+  // Boundary overlap gate.
+  assert.match(route, /\(distance - accuracy\) <= 500/);
+  // Confident-outside rejection + 500 m threshold intact.
+  assert.match(route, /code: "OUTSIDE_CHECKIN_RADIUS"/);
+  assert.match(route, /distance > 500/);
+});
+
+// Blocker 7: the accuracy decision rule (inside good / inside unusable / boundary / outside).
+test("accuracy decision: good passes, unusable-inside and boundary-overlap are retryable, confident-outside rejected", () => {
+  const MAX = 200;
+  const decide = (distance, accuracy) => {
+    if (accuracy > MAX) return "ACCURACY";
+    if (distance > 500) {
+      if ((distance - accuracy) <= 500) return "ACCURACY";
+      return "OUTSIDE";
+    }
+    return "OK";
+  };
+  assert.equal(decide(120, 20), "OK");       // inside + good
+  assert.equal(decide(120, 3000), "ACCURACY"); // inside + unusable
+  assert.equal(decide(560, 100), "ACCURACY"); // boundary overlap
+  assert.equal(decide(900, 20), "OUTSIDE");   // confidently outside
+});
+
+// ---- track.html behavioural (vm) : blockers 2, 4, 6 ----------------------
+function loadTrackHtml({ data }) {
+  const escSrc = sliceBetween(trackHtml, "function esc(s){", "\nfunction renderRankLine");
+  const trackSrc = sliceBetween(trackHtml, "let CURRENT_TRACK_DATA = null;", "\n// 🏅");
+  const qEl = { value: "" };
+  const resultEl = { innerHTML: "", textContent: "" };
+  const els = { q: qEl, result: resultEl };
+  const stub = () => "";
+  const sandbox = {
+    API: "http://test",
+    document: { getElementById: (id) => els[id] || null },
+    fetch: async () => ({ ok: true, json: async () => data }),
+    alert: () => {},
+    window: {}, location: {}, console,
+    statusBadge: stub, timelineHTML: stub, photosHTML: stub, reviewHTML: stub,
+    warrantyHTML: stub, renderRankLine: stub, renderCustomerESlip: async () => {}, openNav: () => {}, submitReview: () => {}, qs: () => "",
+    Number, String, Array, Math, JSON, Date, encodeURIComponent, RegExp, Boolean,
+  };
+  vm.createContext(sandbox);
+  vm.runInContext(`${escSrc}\n${trackSrc}\nglobalThis.__track = track;`, sandbox);
+  return { track: sandbox.__track, qEl, resultEl };
+}
+
+test("track.html (token): token absent from rendered HTML + #q shows booking_code; XSS payloads escaped", async () => {
+  const data = {
+    access_level: "token", booking_code: "CWF123ABC", booking_token: "SECRETTOKEN9",
+    customer_name: `<img src=x onerror=alert(1)>`, address_text: `'"><script>alert(1)</script>`,
+    job_type: "ล้าง", appointment_datetime: "2026-06-20T10:00:00Z",
+    technician_team: [{ full_name: `<b>evil</b>`, phone: `0812345678` }],
+  };
+  const { track, qEl, resultEl } = loadTrackHtml({ data });
+  await track("SECRETTOKEN9");
+  assert.ok(!resultEl.innerHTML.includes("SECRETTOKEN9"), "booking_token must not appear in rendered HTML");
+  assert.equal(qEl.value, "CWF123ABC", "#q must show the booking_code, not the token");
+  assert.ok(!resultEl.innerHTML.includes("<script>"), "script payload must be escaped");
+  assert.ok(!resultEl.innerHTML.includes("<img src=x"), "img/onerror payload must be escaped");
+  assert.ok(resultEl.innerHTML.includes("&lt;script&gt;") || resultEl.innerHTML.includes("&lt;img"), "payload should be HTML-escaped");
+  // Uses data-attribute handlers, not interpolated inline JS.
+  assert.ok(resultEl.innerHTML.includes("data-nav"));
+});
+
+test("track.html (code): limited mode shows notice, hides address/nav, no dash rows", async () => {
+  const data = { access_level: "code", booking_code: "CWF777", job_status: "กำลังดำเนินการ", appointment_datetime: "2026-06-20T10:00:00Z", customer_phone: "•••• 5678" };
+  const { track, qEl, resultEl } = loadTrackHtml({ data });
+  await track("CWF777");
+  assert.ok(resultEl.innerHTML.includes("โหมดจำกัดข้อมูล"), "must show the limited-access notice");
+  assert.ok(resultEl.innerHTML.includes("•••• 5678"), "masked phone may show");
+  assert.ok(!resultEl.innerHTML.includes("data-nav"), "no navigation control in limited mode");
+  assert.ok(!resultEl.innerHTML.includes("ชื่อลูกค้า"), "no misleading customer-name row");
+  assert.equal(qEl.value, "CWF777");
+});
+
+// ---- track.html source contract : blockers 2, 4 -------------------------
+test("track.html has no interpolated inline onclick for address/phone/token and keeps the credential private", () => {
+  assert.doesNotMatch(trackHtml, /onclick="openNav\(/);
+  assert.doesNotMatch(trackHtml, /onclick="location\.href='tel:\$\{/);
+  assert.doesNotMatch(trackHtml, /submitReview\('\$\{/);
+  assert.match(trackHtml, /data-nav/);
+  assert.match(trackHtml, /data-tel="\$\{esc/);
+  assert.match(trackHtml, /data-review-submit/);
+  // Auto-load passes the credential to track(), never into #q.
+  assert.match(trackHtml, /if\(q0\)\{\s*\n\s*track\(q0\);/);
+  assert.doesNotMatch(trackHtml, /getElementById\("q"\)\.value = q0/);
+});
+
+// ---- customer.html source contract : blocker 5 --------------------------
+test("customer.html shows booking_code as the number and uses data.token for the tracking link", () => {
+  const html = read("customer.html");
+  // Visible number is booking_code only — never falls back to the token.
+  assert.match(html, /const code = data\.booking_code \|\| '';/);
+  assert.doesNotMatch(html, /const code = data\.booking_code \|\| token/);
+  // Credential prefers the token; the Tracking link uses it.
+  assert.match(html, /const cred = token \|\| code;/);
+  assert.match(html, /const trackUrl = `\$\{API\}\/track\.html\?q=\$\{encodeURIComponent\(cred\)\}`/);
+  // LINE share + ICS use the token-credentialed track_url, code is the number.
+  assert.match(html, /function shareLine\(\)/);
+  assert.match(html, /track_url: trackUrl/);
 });

--- a/test/trackingGpsRecovery.test.js
+++ b/test/trackingGpsRecovery.test.js
@@ -1,0 +1,273 @@
+"use strict";
+
+// Focused tests for the tracking + technician GPS check-in production hotfix.
+//  - Secure tracking link uses booking_token; booking_code stays limited.
+//  - /public/track aggregates the technician from every assignment source.
+//  - track.html falls back from an empty technician_team and escapes values.
+//  - Technician checkin() never strands the busy lock and maps errors to Thai.
+//  - Backend /jobs/:job_id/checkin validates coordinates + structured codes.
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const vm = require("node:vm");
+
+const ROOT = path.resolve(__dirname, "..");
+const read = (rel) => fs.readFileSync(path.join(ROOT, rel), "utf8");
+
+const indexSrc = read("index.js");
+const appSrc = read("app.js");
+const trackHtml = read("track.html");
+const trackingJs = read("customer-app/modules/tracking.js");
+
+// ---- helpers to slice a contiguous source region -------------------------
+function sliceBetween(src, startMarker, endMarker) {
+  const a = src.indexOf(startMarker);
+  assert.notEqual(a, -1, `missing start marker: ${startMarker}`);
+  const b = src.indexOf(endMarker, a + startMarker.length);
+  assert.notEqual(b, -1, `missing end marker: ${endMarker}`);
+  return src.slice(a, b);
+}
+
+// ============================ A. Secure tracking link =====================
+
+test("official confirmation tracking_url uses booking_token when present (not booking_code)", () => {
+  assert.match(indexSrc, /const trackingCredential = String\(job\.booking_token \|\| ''\)\.trim\(\)/);
+  assert.match(indexSrc, /tracking_url: `\$\{origin\}\/track\.html\?q=\$\{encodeURIComponent\(trackingCredential\)\}`/);
+  // The visible job number stays booking_code.
+  assert.match(indexSrc, /booking_code: booking,/);
+  // The summary query must actually load booking_token to build the link.
+  assert.match(indexSrc, /SELECT job_id, booking_code, booking_token, customer_name/);
+});
+
+test("booking_token is never rendered as visible confirmation text nor logged", () => {
+  const fn = sliceBetween(indexSrc, "function buildCustomerConfirmationVars(", "\napp.get(\"/jobs/:job_id/summary\"");
+  // token appears only as the URL credential, never as its own visible var.
+  assert.doesNotMatch(fn, /booking_token: /);
+  assert.doesNotMatch(fn, /console\.[a-z]+\([^)]*booking_token/);
+});
+
+// ============================ A5. Technician aggregation ==================
+
+test("/public/track technician aggregation includes job_assignments (active only) + dedup", () => {
+  const region = sliceBetween(indexSrc, "TEAM (Public Tracking)", "Access level: the long random booking_token");
+  assert.match(region, /FROM public\.job_assignments/);
+  assert.match(region, /COALESCE\(status,'in_progress'\) IN \('in_progress','done'\)/);
+  assert.match(region, /job_team_members/);
+  // Deduplicate by normalized username; keep primary technician first.
+  assert.match(region, /const seen = new Set\(\)/);
+  assert.match(region, /norm = u\.toLowerCase\(\)/);
+  // Assigned username kept even without a technician_profiles row.
+  assert.match(region, /const d = byU\.get\(u\) \|\| \{\}/);
+});
+
+// ============================ A4. track.html fallback + escaping ==========
+
+test("track.html uses technician_team only when it is a non-empty array, else falls back", () => {
+  assert.match(trackHtml, /Array\.isArray\(data\.technician_team\) && data\.technician_team\.length/);
+  assert.match(trackHtml, /:\s*\(data\.technician \? \[data\.technician\] : \[\]\)/);
+});
+
+test("track.html escapes customer/technician/address/photo/phone values", () => {
+  assert.match(trackHtml, /ชื่อลูกค้า:<\/b> \$\{esc\(data\.customer_name/);
+  assert.match(trackHtml, /ที่อยู่:<\/b> \$\{esc\(data\.address_text/);
+  assert.match(trackHtml, /src="\$\{esc\(photo\)\}"/);
+  assert.match(trackHtml, /tel:\$\{esc\(phone\)\}/);
+  assert.match(trackHtml, /tel:\$\{esc\(firstTel\)\}/);
+});
+
+// ============================ A3. Customer App tracking rendering =========
+
+test("customer-app tracking is access-level aware (full customer info vs limited notice)", () => {
+  assert.match(trackingJs, /const isFull = data\.access_level === "token"/);
+  assert.match(trackingJs, /if \(isFull && data\.customer_name\)/);
+  assert.match(trackingJs, /if \(isFull && data\.address_text\)/);
+  assert.match(trackingJs, /tracking-limited-note/);
+  // The limited notice appears only when NOT full access.
+  assert.match(trackingJs, /const limitedNotice = !isFull \?/);
+});
+
+// ============================ B6. Backend coordinate validation ===========
+
+test("checkin backend validates coordinates + accuracy with structured codes", () => {
+  const route = sliceBetween(indexSrc, 'app.post("/jobs/:job_id/checkin"', "// 📷 PHOTOS");
+  assert.match(route, /!Number\.isFinite\(lat\) \|\| !Number\.isFinite\(lng\) \|\| lat < -90 \|\| lat > 90 \|\| lng < -180 \|\| lng > 180/);
+  assert.match(route, /code: "INVALID_COORDINATES"/);
+  assert.match(route, /code: "INVALID_JOB_REFERENCE"/);
+  assert.match(route, /code: "OUTSIDE_CHECKIN_RADIUS"/);
+  assert.match(route, /code: "LOCATION_ACCURACY_TOO_LOW"/);
+  // accuracy gate: only reject as outside when confidently outside.
+  assert.match(route, /\(distance - accuracy\) <= 500/);
+  // idempotent: preserve the first check-in timestamp.
+  assert.match(route, /checkin_at=COALESCE\(checkin_at, NOW\(\)\)/);
+  // reads accuracy + captured_at from the body.
+  assert.match(route, /const accuracy = hasAccuracy \? Number\(body\.accuracy\) : null/);
+  assert.match(route, /captured_at/);
+  // never logs raw coordinates.
+  assert.doesNotMatch(route, /console\.[a-z]+\([^)]*\blat\b[^)]*\blng\b/);
+});
+
+test("ownership helper returns structured codes without weakening the check", () => {
+  const fn = sliceBetween(indexSrc, "async function requireTechOwnsResolvedJob(", "async function auditLog(");
+  assert.match(fn, /code: 'AUTH_REQUIRED'/);
+  assert.match(fn, /code: 'TECH_NOT_ASSIGNED'/);
+  assert.match(fn, /assertTechBelongsToJob\(clientOrPool, realId, tech\)/);
+});
+
+// ============================ B1-B5. Technician checkin() behaviour ========
+// Evaluate the real checkin() (+ helpers) from app.js in a controlled sandbox
+// with mocked geolocation / DOM / fetch so we can assert the busy-lock lifecycle.
+
+function loadCheckin({ geo, fetchImpl, cssBroken = false } = {}) {
+  const cssEscape = sliceBetween(appSrc, "function cssEscapeCompat(value) {", "\n// ✅ เปิดปุ่ม");
+  const checkinBlock = sliceBetween(appSrc, "// Robust geolocation for Check-in.", "// 📝 NOTE");
+
+  const alerts = [];
+  const busy = {};
+  const btn = { disabled: false, innerHTML: "เช็คอิน" };
+  const hint = { innerHTML: "" };
+  const doc = {
+    querySelector() {
+      if (cssBroken) throw new Error("CSS.escape missing");
+      return btn;
+    },
+    getElementById() { return hint; },
+  };
+  const win = { isSecureContext: true, __CWF_CHECKIN_BUSY: busy };
+  const navigator = {
+    geolocation: geo === null ? undefined : (geo || {
+      getCurrentPosition: (ok) => ok({ coords: { latitude: 13.7, longitude: 100.5, accuracy: 12 }, timestamp: Date.now() }),
+    }),
+  };
+  const sandbox = {
+    window: win,
+    document: doc,
+    navigator,
+    alert: (m) => alerts.push(String(m)),
+    fetch: fetchImpl || (async () => ({ ok: true, status: 200, json: async () => ({ success: true }) })),
+    setTimeout: () => {},
+    loadJobs: () => {},
+    API_BASE: "http://test",
+    console: { log() {}, info() {}, warn() {}, error() {} },
+    Promise, Number, String, Date, JSON, Math, encodeURIComponent, Set,
+    CSS: cssBroken ? undefined : { escape: (s) => s },
+  };
+  vm.createContext(sandbox);
+  const code = `${cssEscape}\n${checkinBlock}\nglobalThis.__api = { checkin, cwfGetCheckinPosition, mapCheckinServerError };`;
+  vm.runInContext(code, sandbox);
+  return { api: sandbox.__api, alerts, busy, btn, hint, win };
+}
+
+test("16/17: a synchronous selector failure (no CSS.escape) still releases the busy lock", async () => {
+  const h = loadCheckin({ cssBroken: true });
+  await h.api.checkin("J1");
+  assert.equal(h.busy["J1"], false, "busy lock must be cleared after a selector failure");
+});
+
+test("18: unsupported geolocation releases the busy lock and warns", async () => {
+  const h = loadCheckin({ geo: null });
+  await h.api.checkin("J2");
+  assert.equal(h.busy["J2"], false);
+  assert.ok(h.alerts.some((a) => /ไม่รองรับ/.test(a)));
+});
+
+test("19: permission denied releases the busy lock with a clear Thai message", async () => {
+  const geo = { getCurrentPosition: (_ok, err) => err({ code: 1, message: "denied" }) };
+  const h = loadCheckin({ geo });
+  await h.api.checkin("J3");
+  assert.equal(h.busy["J3"], false);
+  assert.ok(h.alerts.some((a) => /อนุญาต|สิทธิ์ตำแหน่ง/.test(a)));
+});
+
+test("20/22: timeout / position-unavailable retries exactly once then can succeed", async () => {
+  let calls = 0;
+  const geo = {
+    getCurrentPosition: (ok, err) => {
+      calls += 1;
+      if (calls === 1) return err({ code: 3, message: "timeout" });
+      return ok({ coords: { latitude: 13.7, longitude: 100.5, accuracy: 20 }, timestamp: Date.now() });
+    },
+  };
+  const h = loadCheckin({ geo });
+  await h.api.checkin("J4");
+  assert.equal(calls, 2, "should retry exactly once");
+  assert.equal(h.busy["J4"], false);
+});
+
+test("21: a failed retry still releases the busy lock", async () => {
+  let calls = 0;
+  const geo = { getCurrentPosition: (_ok, err) => { calls += 1; err({ code: 3, message: "timeout" }); } };
+  const h = loadCheckin({ geo });
+  await h.api.checkin("J5");
+  assert.equal(calls, 2, "one initial + one retry");
+  assert.equal(h.busy["J5"], false);
+  assert.ok(h.alerts.some((a) => /นานเกินไป|ลองใหม่/.test(a)));
+});
+
+test("23: a successful position sends lat, lng, accuracy and captured_at", async () => {
+  let sent = null;
+  const fetchImpl = async (_url, opts) => { sent = JSON.parse(opts.body); return { ok: true, status: 200, json: async () => ({ success: true }) }; };
+  const h = loadCheckin({ fetchImpl });
+  await h.api.checkin("J6");
+  assert.equal(typeof sent.lat, "number");
+  assert.equal(typeof sent.lng, "number");
+  assert.equal(sent.accuracy, 12);
+  assert.match(String(sent.captured_at), /\dT\d/);
+  assert.equal(h.busy["J6"], false);
+});
+
+test("24: a network failure releases the busy lock", async () => {
+  const fetchImpl = async () => { throw new Error("network down"); };
+  const h = loadCheckin({ fetchImpl });
+  await h.api.checkin("J7");
+  assert.equal(h.busy["J7"], false);
+  assert.ok(h.alerts.some((a) => /เครือข่าย|ลองใหม่/.test(a)));
+});
+
+test("25: a server rejection releases the busy lock and maps the code to Thai", async () => {
+  const fetchImpl = async () => ({ ok: false, status: 400, json: async () => ({ error: "x", code: "OUTSIDE_CHECKIN_RADIUS", distance: 820 }) });
+  const h = loadCheckin({ fetchImpl });
+  await h.api.checkin("J8");
+  assert.equal(h.busy["J8"], false);
+  assert.ok(h.alerts.some((a) => /นอกพื้นที่หน้างาน/.test(a) && /820/.test(a)));
+});
+
+test("26/27: a second tap while active does not duplicate; a tap after failure can retry", async () => {
+  // Hold the first request open so the lock is genuinely active.
+  let release;
+  let fetchCalls = 0;
+  const gate = new Promise((r) => { release = r; });
+  const fetchImpl = async () => { fetchCalls += 1; await gate; return { ok: true, status: 200, json: async () => ({ success: true }) }; };
+  const h = loadCheckin({ fetchImpl });
+  const first = h.api.checkin("J9");
+  const second = h.api.checkin("J9"); // must be ignored while in-flight
+  await second;
+  assert.equal(fetchCalls, 1, "second tap while active must not create a duplicate request");
+  release({});
+  await first;
+  assert.equal(h.busy["J9"], false);
+  // After completion a fresh tap works again.
+  await h.api.checkin("J9");
+  assert.equal(fetchCalls, 2, "a tap after completion can retry");
+});
+
+// ---- server-error mapper (unit) ------------------------------------------
+test("mapCheckinServerError maps important codes to actionable Thai", () => {
+  const h = loadCheckin();
+  const m = h.api.mapCheckinServerError;
+  assert.match(m({ code: "AUTH_REQUIRED" }, 401), /เข้าสู่ระบบใหม่/);
+  assert.match(m({ code: "TECH_NOT_ASSIGNED" }, 403), /ยังไม่ได้ถูกมอบหมาย/);
+  assert.match(m({ code: "LOCATION_ACCURACY_TOO_LOW" }, 400), /ไม่แม่นพอ/);
+  assert.match(m({ code: "INVALID_COORDINATES" }, 400), /ไม่ถูกต้อง/);
+});
+
+// ---- geolocation options (contract) --------------------------------------
+test("checkin() uses cssEscapeCompat and a high-accuracy-first geolocation strategy", () => {
+  const block = sliceBetween(appSrc, "// Robust geolocation for Check-in.", "// 📝 NOTE");
+  assert.match(block, /cssEscapeCompat\(key\)/);
+  assert.doesNotMatch(block, /CSS\.escape\(key\)/);
+  assert.match(block, /enableHighAccuracy: true/);
+  assert.match(block, /body: JSON\.stringify\(\{ lat, lng, accuracy, captured_at \}\)/);
+  assert.match(block, /finally \{/);
+});

--- a/test/trackingGpsRecovery.test.js
+++ b/test/trackingGpsRecovery.test.js
@@ -338,7 +338,7 @@ function loadTrackHtml({ data }) {
     fetch: async () => ({ ok: true, json: async () => data }),
     alert: () => {},
     window: {}, location: {}, console,
-    statusBadge: stub, timelineHTML: stub, photosHTML: stub, reviewHTML: stub,
+    statusBadge: stub, timelineHTML: stub, timelineLimitedHTML: stub, derivedStatusLimited: stub, photosHTML: stub, reviewHTML: stub,
     warrantyHTML: stub, renderRankLine: stub, renderCustomerESlip: async () => {}, openNav: () => {}, submitReview: () => {}, qs: () => "",
     Number, String, Array, Math, JSON, Date, encodeURIComponent, RegExp, Boolean,
   };

--- a/track.html
+++ b/track.html
@@ -377,7 +377,7 @@ function reviewHTML(d){
           <option value="2">2 - ควรปรับปรุง</option>
           <option value="1">1 - แย่</option>
         </select>
-        <button type="button" onclick="submitReview('${d.booking_token || d.booking_code || ''}')">ส่งรีวิว</button>
+        <button type="button" data-review-submit>ส่งรีวิว</button>
       </div>
       <textarea id="review_text" rows="3" style="margin-top:8px;" placeholder="เขียนรีวิว (ถ้ามี)"></textarea>
       <textarea id="complaint_text" rows="2" style="margin-top:8px;" placeholder="ร้องเรียน/ข้อเสนอแนะ (ถ้ามี)"></textarea>
@@ -446,9 +446,15 @@ function openNav(lat,lng,addr){
   window.open(url,"_blank");
 }
 
-async function track(){
+// The credential used for the request (may be a secret booking_token from the
+// official link, or a short booking_code the user typed) is kept ONLY in JS
+// memory — never written into the visible #q input. Click handlers read the
+// loaded response from here instead of interpolating values into inline HTML.
+let CURRENT_TRACK_DATA = null;
+
+async function track(credOverride){
   const qEl = document.getElementById("q");
-  const q = (qEl.value || "").trim();
+  const q = (credOverride != null ? String(credOverride) : (qEl.value || "")).trim();
   if(!q) return alert("ใส่เลข Booking หรือ token");
 
   const box = document.getElementById("result");
@@ -458,6 +464,33 @@ async function track(){
     const res = await fetch(`${API}/public/track?q=${encodeURIComponent(q)}`);
     const data = await res.json().catch(()=>({}));
     if(!res.ok) throw new Error(data.error || "ค้นหาไม่สำเร็จ");
+    CURRENT_TRACK_DATA = data;
+
+    // After a lookup show the PUBLIC booking_code in the input — never leave a
+    // secret token/credential visible in the search box.
+    if (data.booking_code) qEl.value = data.booking_code;
+
+    // True code-only limited mode: a booking_code lookup returns redacted data,
+    // so show status + masked phone + a clear explanation, NOT misleading dash
+    // rows or navigation/technician controls that cannot work.
+    if (data.access_level !== "token") {
+      box.innerHTML = `
+        <div class="job-card">
+          <div style="display:flex;justify-content:space-between;align-items:center;gap:10px;">
+            <b>📌 Booking: ${esc(data.booking_code || "-")}</b>
+            ${statusBadge(data.job_status)}
+          </div>
+          ${data.customer_phone ? `<p style="margin-top:10px;"><b>เบอร์โทร:</b> ${esc(data.customer_phone)}</p>` : ``}
+          ${timelineHTML(data)}
+          <div class="alert" style="margin-top:12px;background:#eff6ff;border:1px solid rgba(37,99,235,0.25);color:#1e3a8a;">
+            <b>โหมดจำกัดข้อมูล (ค้นด้วยเลขงาน)</b>
+            <div class="muted" style="margin-top:4px;">เพื่อความปลอดภัย การค้นด้วยเลขงานจะแสดงเฉพาะสถานะและข้อมูลเบื้องต้น หากต้องการดูข้อมูลลูกค้า ที่อยู่ ช่าง และรายละเอียดเต็ม กรุณาเปิดจาก “ลิงก์ติดตามงาน” ในข้อความยืนยันที่ได้รับ</div>
+          </div>
+          <div class="muted" style="margin-top:10px;">* ถ้าต้องการช่วยเหลือ โทร 098-877-7321 หรือ LINE OA: @cwfair</div>
+        </div>
+      `;
+      return;
+    }
 
     const dt = data.appointment_datetime ? new Date(data.appointment_datetime).toLocaleString("th-TH") : "-";
     // Only treat technician_team as the team when it is a NON-EMPTY array;
@@ -469,7 +502,7 @@ async function track(){
 
     // ปุ่มโทร (เลือกเบอร์แรกที่มี) — escape the number used inside the attribute.
     const firstTel = techTeam.find(t => t && t.phone) ? String(techTeam.find(t => t && t.phone).phone).trim() : "";
-    const telBtn = firstTel ? `<button class="secondary" type="button" onclick="location.href='tel:${esc(firstTel)}'">📞 โทรหาช่าง</button>` : "";
+    const telBtn = firstTel ? `<button class="secondary" type="button" data-tel="${esc(firstTel)}">📞 โทรหาช่าง</button>` : "";
     // ❌ ตาม requirement: ห้ามแสดงเอกสารก่อนเสร็จ และแทนที่ใบเสร็จเดิมด้วย E-Slip ใหม่
     const receiptBtn = "";
 
@@ -494,7 +527,7 @@ async function track(){
         <p><b>ที่อยู่:</b> ${esc(data.address_text || "-")}</p>
 
         <div class="row" style="margin-top:10px;gap:10px;flex-wrap:wrap;">
-          <button class="secondary" type="button" onclick="openNav(${Number.isFinite(Number(data.gps_latitude)) ? Number(data.gps_latitude) : "null"}, ${Number.isFinite(Number(data.gps_longitude)) ? Number(data.gps_longitude) : "null"}, '${esc(String(data.address_text||"")).replace(/'/g,"\\'")}')">🧭 นำทาง</button>
+          <button class="secondary" type="button" data-nav>🧭 นำทาง</button>
           ${receiptBtn}
           ${telBtn}
         </div>
@@ -524,7 +557,7 @@ async function track(){
                         ${phone ? `☎️ <a href="${telLink}">${esc(phone)}</a>` : `☎️ ยังไม่มีเบอร์โทร`}
                       </div>
                     </div>
-                    ${phone ? `<button class="secondary" type="button" style="width:auto;" onclick="location.href='${telLink}'">โทร</button>` : ``}
+                    ${phone ? `<button class="secondary" type="button" style="width:auto;" data-tel="${esc(phone)}">โทร</button>` : ``}
                   </div>
                 `;
               }).join('')}
@@ -535,7 +568,7 @@ async function track(){
         ${data.technician_note ? `
           <div class="card tight" style="margin-top:10px;">
             <b>📝 หมายเหตุจากช่าง (แสดงหลังเสร็จสิ้น)</b>
-            <div class="muted" style="margin-top:6px;white-space:pre-wrap;">${String(data.technician_note).replace(/</g,'&lt;')}</div>
+            <div class="muted" style="margin-top:6px;white-space:pre-wrap;">${esc(data.technician_note)}</div>
           </div>
         ` : ``}
 
@@ -599,11 +632,43 @@ async function track(){
   });
 })();
 
-// auto load from query string
+// Delegated handlers for the result card — read values from CURRENT_TRACK_DATA
+// (JS memory), never from interpolated inline JavaScript, so untrusted address/
+// phone/token strings can never break out into executable code.
+(function bindResultActions(){
+  const box = document.getElementById("result");
+  if (!box) return;
+  box.addEventListener("click", (e) => {
+    const target = e.target && e.target.closest ? e.target : null;
+    if (!target) return;
+    const nav = target.closest("[data-nav]");
+    if (nav) {
+      const d = CURRENT_TRACK_DATA || {};
+      const la = Number(d.gps_latitude), lo = Number(d.gps_longitude);
+      openNav(Number.isFinite(la) ? la : null, Number.isFinite(lo) ? lo : null, String(d.address_text || ""));
+      return;
+    }
+    const tel = target.closest("[data-tel]");
+    if (tel) {
+      const num = String(tel.getAttribute("data-tel") || "").replace(/[^0-9+]/g, "");
+      if (num) location.href = "tel:" + num;
+      return;
+    }
+    const rev = target.closest("[data-review-submit]");
+    if (rev) {
+      const d = CURRENT_TRACK_DATA || {};
+      submitReview(d.booking_token || d.booking_code || "");
+      return;
+    }
+  });
+})();
+
+// Auto-load from the query string. The credential (booking_token from the
+// official link, or a booking_code) is passed straight to track() and kept in
+// memory — it is NOT written into the visible #q input.
 const q0 = qs("q") || qs("token") || "";
 if(q0){
-  document.getElementById("q").value = q0;
-  track();
+  track(q0);
 }
 
 // PWA update toast

--- a/track.html
+++ b/track.html
@@ -337,6 +337,39 @@ function timelineHTML(d){
   `;
 }
 
+// Code-only status: derived ONLY from reliable timestamps/status, never from
+// d.technician (which is redacted for booking_code lookups). Redacted identity
+// must not be reported as "รอช่างรับงาน".
+function derivedStatusLimited(d){
+  const s = String(d.job_status || '').trim();
+  if (s === 'ยกเลิก') return 'ยกเลิก';
+  if (s === 'เสร็จแล้ว') return 'เสร็จสิ้น';
+  if (d.started_at) return 'กำลังทำงาน';
+  if (d.checkin_at) return 'ถึงหน้างานแล้ว';
+  if (d.travel_started_at) return 'กำลังเดินทาง';
+  return 'กำลังติดตามสถานะงาน';
+}
+
+// Limited timeline for code-only access: omit the "รับงาน" step (it depends on
+// the redacted d.technician) and use only travel/checkin/start/done timestamps.
+function timelineLimitedHTML(d){
+  const steps = [
+    { k: 'travel', label: 'กำลังเดินทาง', ok: !!d.travel_started_at },
+    { k: 'checkin', label: 'ถึงหน้างาน (เช็คอิน)', ok: !!d.checkin_at },
+    { k: 'start', label: 'เริ่มทำงาน', ok: !!d.started_at },
+    { k: 'done', label: 'เสร็จสิ้น', ok: String(d.job_status||'').trim()==='เสร็จแล้ว' },
+  ];
+  return `
+    <div class="card tight" style="margin-top:10px;">
+      <b>📍 ไทม์ไลน์สถานะ</b>
+      <div class="muted" style="margin-top:6px;">สถานะปัจจุบัน: <b>${derivedStatusLimited(d)}</b></div>
+      <ul style="margin:10px 0 0 18px;">
+        ${steps.map(s => `<li style="margin:6px 0;">${s.ok ? '✅' : '⏳'} ${s.label}</li>`).join('')}
+      </ul>
+    </div>
+  `;
+}
+
 function photosHTML(d){
   if (!Array.isArray(d.photos) || !d.photos.length) return '';
   return `
@@ -426,8 +459,9 @@ async function submitReview(key){
     const data = await res.json().catch(()=>({}));
     if (!res.ok) throw new Error(data.error || 'ส่งรีวิวไม่สำเร็จ');
     if (status) status.textContent = '✅ ส่งรีวิวเรียบร้อย ขอบคุณครับ';
-    // refresh
-    setTimeout(()=>track(), 600);
+    // Reload using the PRIVATE active credential (the token, if this was a token
+    // session) so review success does not downgrade to code-only access.
+    setTimeout(()=>track(ACTIVE_CREDENTIAL || undefined), 600);
   }catch(e){
     if (status) status.textContent = `❌ ${e.message}`;
   }
@@ -451,11 +485,17 @@ function openNav(lat,lng,addr){
 // memory — never written into the visible #q input. Click handlers read the
 // loaded response from here instead of interpolating values into inline HTML.
 let CURRENT_TRACK_DATA = null;
+// The active lookup credential (token or code) is preserved here so a Refresh
+// or post-review reload reuses it and does NOT downgrade a token session to the
+// visible booking_code. A manual "ค้นหา" (track() with no override) replaces it
+// with whatever the customer typed.
+let ACTIVE_CREDENTIAL = "";
 
 async function track(credOverride){
   const qEl = document.getElementById("q");
   const q = (credOverride != null ? String(credOverride) : (qEl.value || "")).trim();
   if(!q) return alert("ใส่เลข Booking หรือ token");
+  ACTIVE_CREDENTIAL = q;
 
   const box = document.getElementById("result");
   box.textContent = "กำลังค้นหา...";
@@ -481,10 +521,10 @@ async function track(credOverride){
             ${statusBadge(data.job_status)}
           </div>
           ${data.customer_phone ? `<p style="margin-top:10px;"><b>เบอร์โทร:</b> ${esc(data.customer_phone)}</p>` : ``}
-          ${timelineHTML(data)}
+          ${timelineLimitedHTML(data)}
           <div class="alert" style="margin-top:12px;background:#eff6ff;border:1px solid rgba(37,99,235,0.25);color:#1e3a8a;">
             <b>โหมดจำกัดข้อมูล (ค้นด้วยเลขงาน)</b>
-            <div class="muted" style="margin-top:4px;">เพื่อความปลอดภัย การค้นด้วยเลขงานจะแสดงเฉพาะสถานะและข้อมูลเบื้องต้น หากต้องการดูข้อมูลลูกค้า ที่อยู่ ช่าง และรายละเอียดเต็ม กรุณาเปิดจาก “ลิงก์ติดตามงาน” ในข้อความยืนยันที่ได้รับ</div>
+            <div class="muted" style="margin-top:4px;">เพื่อความปลอดภัย การค้นด้วยเลขงานจะแสดงเฉพาะสถานะและข้อมูลเบื้องต้น ข้อมูลทีมช่างจะแสดงเมื่อเปิดจาก “ลิงก์ติดตามงาน” ในข้อความยืนยันที่ได้รับ</div>
           </div>
           <div class="muted" style="margin-top:10px;">* ถ้าต้องการช่วยเหลือ โทร 098-877-7321 หรือ LINE OA: @cwfair</div>
         </div>

--- a/track.html
+++ b/track.html
@@ -460,13 +460,16 @@ async function track(){
     if(!res.ok) throw new Error(data.error || "ค้นหาไม่สำเร็จ");
 
     const dt = data.appointment_datetime ? new Date(data.appointment_datetime).toLocaleString("th-TH") : "-";
-    const techTeam = Array.isArray(data.technician_team)
+    // Only treat technician_team as the team when it is a NON-EMPTY array;
+    // an empty [] (single-tech jobs with no team rows) must fall back to
+    // data.technician so the assigned technician still shows.
+    const techTeam = (Array.isArray(data.technician_team) && data.technician_team.length)
       ? data.technician_team
       : (data.technician ? [data.technician] : []);
 
-    // ปุ่มโทร (เลือกเบอร์แรกที่มี)
+    // ปุ่มโทร (เลือกเบอร์แรกที่มี) — escape the number used inside the attribute.
     const firstTel = techTeam.find(t => t && t.phone) ? String(techTeam.find(t => t && t.phone).phone).trim() : "";
-    const telBtn = firstTel ? `<button class="secondary" type="button" onclick="location.href='tel:${firstTel}'">📞 โทรหาช่าง</button>` : "";
+    const telBtn = firstTel ? `<button class="secondary" type="button" onclick="location.href='tel:${esc(firstTel)}'">📞 โทรหาช่าง</button>` : "";
     // ❌ ตาม requirement: ห้ามแสดงเอกสารก่อนเสร็จ และแทนที่ใบเสร็จเดิมด้วย E-Slip ใหม่
     const receiptBtn = "";
 
@@ -476,7 +479,7 @@ async function track(){
     box.innerHTML = `
       <div class="job-card">
         <div style="display:flex;justify-content:space-between;align-items:center;gap:10px;">
-          <b>📌 Booking: ${data.booking_code || "-"}</b>
+          <b>📌 Booking: ${esc(data.booking_code || "-")}</b>
           ${statusBadge(data.job_status)}
         </div>
 
@@ -485,13 +488,13 @@ async function track(){
             ตอนนี้ยังไม่พบช่างรับงานด่วน ระบบกำลังให้แอดมินช่วยจัดคิวให้ใหม่ หรือคุณสามารถติดต่อเราได้ทันทีค่ะ
           </div>
         ` : ``}
-        <p style="margin-top:10px;"><b>ชื่อลูกค้า:</b> ${data.customer_name || "-"}</p>
-        <p><b>ประเภทงาน:</b> ${data.job_type || "-"}</p>
-        <p><b>นัดหมาย:</b> ${dt}</p>
-        <p><b>ที่อยู่:</b> ${data.address_text || "-"}</p>
+        <p style="margin-top:10px;"><b>ชื่อลูกค้า:</b> ${esc(data.customer_name || "-")}</p>
+        <p><b>ประเภทงาน:</b> ${esc(data.job_type || "-")}</p>
+        <p><b>นัดหมาย:</b> ${esc(dt)}</p>
+        <p><b>ที่อยู่:</b> ${esc(data.address_text || "-")}</p>
 
         <div class="row" style="margin-top:10px;gap:10px;flex-wrap:wrap;">
-          <button class="secondary" type="button" onclick="openNav(${data.gps_latitude ?? "null"}, ${data.gps_longitude ?? "null"}, '${String(data.address_text||"").replace(/'/g,"\\'")}')">🧭 นำทาง</button>
+          <button class="secondary" type="button" onclick="openNav(${Number.isFinite(Number(data.gps_latitude)) ? Number(data.gps_latitude) : "null"}, ${Number.isFinite(Number(data.gps_longitude)) ? Number(data.gps_longitude) : "null"}, '${esc(String(data.address_text||"")).replace(/'/g,"\\'")}')">🧭 นำทาง</button>
           ${receiptBtn}
           ${telBtn}
         </div>
@@ -508,14 +511,15 @@ async function track(){
                 const name = t.full_name || t.username || "-";
                 const photo = t.photo || "/logo.png";
                 const phone = t.phone ? String(t.phone).trim() : "";
-                const telLink = phone ? `tel:${phone}` : "";
+                const telLink = phone ? `tel:${esc(phone)}` : "";
+                const rating = Number.isFinite(Number(t.rating)) ? Number(t.rating) : 0;
                 return `
                   <div style="display:flex;gap:10px;align-items:center;">
-                    <img src="${photo}" style="width:56px;height:56px;border-radius:999px;object-fit:cover;border:2px solid rgba(37,99,235,0.25);background:#fff;">
+                    <img src="${esc(photo)}" style="width:56px;height:56px;border-radius:999px;object-fit:cover;border:2px solid rgba(37,99,235,0.25);background:#fff;">
                     <div style="flex:1;min-width:0;">
                       <div><b>${esc(name)}</b></div>
                       ${renderRankLine(t)}
-                      <div class=\"muted\">⭐ ${t.rating ?? 0} · เกรด ${esc(t.grade || "-")}</div>
+                      <div class=\"muted\">⭐ ${rating} · เกรด ${esc(t.grade || "-")}</div>
                       <div class="muted" style="margin-top:4px;">
                         ${phone ? `☎️ <a href="${telLink}">${esc(phone)}</a>` : `☎️ ยังไม่มีเบอร์โทร`}
                       </div>


### PR DESCRIPTION
Production hotfix for two incidents — customer Tracking pages showing no info, and technicians unable to press GPS Check-in — hardened over three review rounds. Branched from `origin/main@1833a6f`; **0 behind / no conflicts. Draft — not deployed.** No migration, no production data/config change, no payment/pricing/payout/auth changes.

**Current head:** `ff5a292e1cdb8a0e47baad641fa74197c092d233`

## Changed files (21)
- **Backend:** `index.js`
- **Customer tracking (frontend):** `customer-app/modules/tracking.js`, `customer-app/assets/customer-app.js`, `track.html`, `customer.html`
- **Technician GPS check-in / PWA:** `app.js`, `tech.html`, `cwf-pwa.js`, `sw.js`, `customer-app/index.html`, `customer-app/sw.js`, `customer-app/manifest.webmanifest`
- **Tests:** `test/trackingGpsRecovery.test.js`, `test/customerAppRecovery.test.js`, `test/customerTrackingPrivacy.test.js`, plus build-id assertions in `test/{customerAppStorePayment,customerBookingAdminNotifications,customerHistoryClaim,customerSameDayTiming,homepageCms,techCacheBuild}.test.js`

## What this fixes

**A. Secure Tracking data**
- Confirmation `tracking_url` uses `booking_token` when present (visible number stays `booking_code`; token never shown or logged).
- `/public/track` aggregates the technician from `technician_username` + `technician_team` + `job_team_members` + active `job_assignments`, deduped by normalized username; `job_assignments` aggregation failures now log a sanitized warning (job_id + message only).
- Customer App / `track.html` tracking is access-level aware.

**B. Technician GPS Check-in**
- `cssEscapeCompat()` instead of `CSS.escape()`; busy lock released in a guaranteed `finally` on every exit path; robust geolocation (high-accuracy first, one retry, best-effort permission/secure-context detection); sends `lat/lng/accuracy/captured_at`; every error maps to an actionable Thai message.
- Backend: strict coordinate + accuracy validation with structured codes, a usable-accuracy gate, the 500 m policy preserved, idempotent `checkin_at`, and sanitized diagnostics.

**C. PWA delivery** — coordinated build-id `20260711_tracking_gps_recovery_v1` across technician and Customer App bundles. (This id has not shipped to production, so it carries the complete fix set on deploy; no further bump needed.)

## Review-round resolution

**Round 1 (8 blockers) — all addressed:** visible number is always `booking_code`; strict raw-coordinate validation; untrusted values removed from inline `onclick` (data-attributes + `addEventListener`); `customer.html` tracking/LINE/ICS links use `data.token`; true code-only limited mode; usable accuracy threshold (`LOCATION_ACCURACY_TOO_LOW`); sanitized `job_assignments` warning.

**Round 2 (3 blockers) — all addressed:**
1. **Token no longer visible before lookup completes.** The `?q`/`?token` deep-link value is handed to the tracking module as a *private in-memory credential* (`setInitialCredential`), never written to `draft.tracking.trackingCode` or the input. The visible input starts blank and only ever shows `booking_code` after success — the token is absent before, during, and after the lookup (including on failure).
2. **Refresh / post-review no longer downgrade token access.** The private active credential is kept separate from the human-visible `booking_code`. Manual "ตรวจสอบสถานะ" uses the typed value and replaces the active credential; **Refresh** and **both review-success reloads** reuse the private token (`reloadCurrent`). `track.html` gets the same fix via `ACTIVE_CREDENTIAL`.
3. **Code-only mode never interprets redaction as "no technician".** The Overview shows the limited-access explanation prominently, renders a neutral technician note instead of the empty "no technician yet" card, suppresses the urgent convert-to-scheduled action, derives status from reliable timestamps only, and omits the assignment timeline step. `track.html` adds `derivedStatusLimited()` / `timelineLimitedHTML()` so its code-only branch never claims "รอช่างรับงาน".

## Security
`booking_code` stays limited; full PII only via exact `booking_token`. The token is a request credential only — never rendered as text, never placed in the visible input/draft/HTML, never logged. Ownership check unchanged (all 4 sources); 500 m rule intact; no coordinates/token/phone/name/address in logs.

## Tests
- `node --check` clean on every changed JS.
- Full `npm test` (real PostgreSQL): **1054 pass / 0 fail / 0 skipped**.
- Behavioral coverage includes: token-credential lifecycle (pending / failed / success), Refresh-and-review-reload reuse the private token, code-only "never says no technician", strict coordinate validation, and the accuracy decision matrix — via vm-sandbox harnesses (no jsdom) plus source contracts.

## Remaining risks
- Old `booking_code`-only links stay privacy-limited by design; an old customer may need the confirmation message resent to receive a secure token link. A `booking_code` + full-phone unlock flow remains a separate future scope.
- Full on-device backend ownership/distance acceptance (assigned/team/`job_assignments` success paths, inside/outside 500 m, poor accuracy, double-tap, retry-after-failure) is exercised via route logic + the suite; the manual matrix below is recommended before shipping.
- The `job_assignments` status filter treats only `in_progress`/`done` as active, matching the ownership check; other lifecycle states are intentionally excluded from technician display.

## Manual acceptance (on device)
Technician: allow/deny location, PWA install, indoor timeout→retry, primary/team/`job_assignments` tech, inside/outside 500 m, poor accuracy, double-tap, retry-after-failure, reopen PWA → new build id.
Tracking: open from confirmation (token) → full info incl. technician, then Refresh → still full; submit review → still full; open by `booking_code` → limited notice with neutral technician wording; reopen Customer App PWA → new build id.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LmdP3TGN5uQrfT8ZYefNco)_