### PR TITLE
hotfix: job-location round-trip (add → edit → tech navigation, never 0,0)

### DIFF
--- a/admin-add-v2.html
+++ b/admin-add-v2.html
@@ -592,7 +592,7 @@
   </div>
 
   <script src="admin-v2-common.js?v=20260428_allpages_ui1"></script>
-  <script src="admin-add-v2.js?v=20260520_generic_price_campaign_v1"></script>
+  <script src="admin-add-v2.js?v=20260712_job_location_roundtrip_v1"></script>
   <script src="admin-add-ai-intake-prefill.js?v=line-ai-prefill-real-v8"></script>
 </body>
 </html>

--- a/admin-add-v2.js
+++ b/admin-add-v2.js
@@ -2856,6 +2856,24 @@ async function submitBooking() {
     return;
   }
 
+  // Client-side guard: a job-site coordinate must be a complete, valid, non-(0,0)
+  // pair — never one field alone, and never an out-of-range/garbage value.
+  {
+    const latRaw = String(el("gps_latitude")?.value || "").trim();
+    const lngRaw = String(el("gps_longitude")?.value || "").trim();
+    if (latRaw || lngRaw) {
+      const num = (s) => (/^[+-]?(?:\d+\.?\d*|\.\d+)$/.test(s) ? Number(s) : NaN);
+      const la = num(latRaw), ln = num(lngRaw);
+      const validPair = latRaw && lngRaw && Number.isFinite(la) && Number.isFinite(ln)
+        && Math.abs(la) <= 90 && Math.abs(ln) <= 180 && !(la === 0 && ln === 0);
+      if (!validPair) {
+        showToast('พิกัดหน้างานไม่ถูกต้อง กรุณากรอก Lat และ Lng ให้ครบทั้งคู่และถูกต้อง (ไม่ใช่ 0,0) หรือเว้นว่างทั้งคู่', 'error');
+        el("btnSubmit").disabled = false;
+        return;
+      }
+    }
+  }
+
   try {
     el("btnSubmit").disabled = true;
     if (DEBUG_ENABLED) {

--- a/admin-add-v2.js
+++ b/admin-add-v2.js
@@ -2684,6 +2684,48 @@ async function verifyCreatedAdminJob(jobId, payload, expectedSingleTechnician) {
     }
   }
 
+  // Location round-trip check: confirm the location fields the admin actually
+  // submitted survived into the stored job. Only fields that were provided are
+  // asserted (an address-only job legitimately has no coordinates). service_zone
+  // is verified only when the admin set an explicit override, because the backend
+  // may auto-detect a different-but-valid zone otherwise.
+  const locationMismatches = [];
+  const submittedStr = (v) => String(v == null ? '' : v).trim();
+  const numOrNull = (v) => {
+    const s = submittedStr(v);
+    if (!s) return null;
+    const n = Number(s);
+    return Number.isFinite(n) ? n : null;
+  };
+  const checkText = (field) => {
+    const want = submittedStr(payload[field]);
+    if (!want) return;
+    if (submittedStr(job[field]) !== want) {
+      locationMismatches.push({ field, expected: want, actual: submittedStr(job[field]) });
+    }
+  };
+  checkText('address_text');
+  checkText('maps_url');
+  checkText('job_zone');
+  if (submittedStr(payload.service_zone_code)) checkText('service_zone_code');
+  // Coordinates: only assert when the admin supplied a valid (non-0,0) pair.
+  const wantLat = numOrNull(payload.gps_latitude);
+  const wantLng = numOrNull(payload.gps_longitude);
+  const suppliedValidPair = wantLat != null && wantLng != null && !(wantLat === 0 && wantLng === 0);
+  if (suppliedValidPair) {
+    const gotLat = numOrNull(job.gps_latitude);
+    const gotLng = numOrNull(job.gps_longitude);
+    const close = (a, b) => a != null && b != null && Math.abs(a - b) < 1e-6;
+    if (!close(gotLat, wantLat) || !close(gotLng, wantLng)) {
+      locationMismatches.push({ field: 'gps', expected: [wantLat, wantLng], actual: [gotLat, gotLng] });
+    }
+  }
+
+  if (locationMismatches.length) {
+    console.warn('[admin-add] post-save location mismatch', { job_id: jobId, locationMismatches });
+    return { ok: false, locationIncomplete: true, mismatches: locationMismatches, detail };
+  }
+
   if (mismatches.length) {
     console.warn('[admin-add] post-save verification mismatch', { job_id: jobId, mismatches, payload, detail });
     return { ok: false, mismatches, detail };
@@ -2846,7 +2888,10 @@ async function submitBooking() {
       return { ok: true, skipped: true };
     });
     if (!verify.ok) {
-      showToast('บันทึกสำเร็จแต่ข้อมูลไม่ตรงที่เลือก กรุณาตรวจสอบใบงานก่อนส่งลูกค้า', 'error');
+      const msg = verify.locationIncomplete
+        ? 'บันทึกงานแล้ว แต่ข้อมูลสถานที่ไม่ครบ กรุณาตรวจสอบใบงานก่อนส่งให้ช่าง'
+        : 'บันทึกสำเร็จแต่ข้อมูลไม่ตรงที่เลือก กรุณาตรวจสอบใบงานก่อนส่งลูกค้า';
+      showToast(msg, 'error');
       return;
     }
     if(uiMode === 'urgent') {

--- a/admin-job-view-v2.html
+++ b/admin-job-view-v2.html
@@ -31,6 +31,6 @@
 
   <script src="/admin-v2-common.js?v=20260428_allpages_ui1"></script>
   <script src="/admin-job-edit-price-state.js?v=20260707_price_state_v2"></script>
-  <script src="/admin-job-view-v2.js?v=20260707_saved_price_stability_review_fix2"></script>
+  <script src="/admin-job-view-v2.js?v=20260712_job_location_roundtrip_v1"></script>
 </body>
 </html>

--- a/admin-job-view-v2.js
+++ b/admin-job-view-v2.js
@@ -1696,8 +1696,9 @@ async function loadJob(){
             updated: 'บันทึกพิกัดใหม่',
           };
           const gpsNote = result && GPS_ACTION_MSG[result.gps_action] ? ` • ${GPS_ACTION_MSG[result.gps_action]}` : '';
-          showToast('บันทึกใบงานครบแล้ว' + gpsNote, 'success');
-          if (msg) msg.textContent = `✅ บันทึกใบงานครบแล้ว${done.length ? `: ${done.join(' / ')}` : ''}${gpsNote}`;
+          const mapsNote = result && result.maps_action === 'cleared' ? ' • ล้างลิงก์แผนที่เดิม (สถานที่เปลี่ยน)' : '';
+          showToast('บันทึกใบงานครบแล้ว' + gpsNote + mapsNote, 'success');
+          if (msg) msg.textContent = `✅ บันทึกใบงานครบแล้ว${done.length ? `: ${done.join(' / ')}` : ''}${gpsNote}${mapsNote}`;
           await loadJob();
         }catch(e){
           console.error(e);

--- a/admin-job-view-v2.js
+++ b/admin-job-view-v2.js
@@ -615,7 +615,7 @@ async function loadJob(){
 
         <div class="row" style="margin-top:10px;gap:10px;flex-wrap:wrap;align-items:flex-end">
           <div style="flex:1;min-width:220px">
-            <label>โซน</label>
+            <label>โซน (ข้อความอิสระ)</label>
             <input id="edit_zone" value="${escapeHtml(safe(job.job_zone||''))}" />
           </div>
           <div style="flex:1;min-width:220px">
@@ -624,12 +624,17 @@ async function loadJob(){
           </div>
           <div style="width:160px">
             <label>Lat</label>
-            <input id="edit_lat" value="${escapeHtml(safe(job.latitude||''))}" />
+            <input id="edit_lat" value="${escapeHtml(safe(job.gps_latitude ?? job.latitude ?? ''))}" />
           </div>
           <div style="width:160px">
             <label>Lng</label>
-            <input id="edit_lng" value="${escapeHtml(safe(job.longitude||''))}" />
+            <input id="edit_lng" value="${escapeHtml(safe(job.gps_longitude ?? job.longitude ?? ''))}" />
           </div>
+        </div>
+        <div class="muted" style="margin-top:6px;font-size:12px;">
+          🗺️ โซนบริการที่ระบบตรวจได้:
+          <b>${escapeHtml(safe(job.service_zone_code || '—'))}</b>${job.service_zone_source ? ` <span style="opacity:.75">(${escapeHtml(safe(job.service_zone_source))})</span>` : ''}
+          <span style="opacity:.75">— ช่องนี้เป็นโซนของระบบ (แยกจากช่อง “โซน” ที่พิมพ์เอง)</span>
         </div>
 
         <div style="margin-top:12px">
@@ -1589,8 +1594,11 @@ async function loadJob(){
             address_text: String(el('edit_address')?.value||'').trim(),
             job_zone: String(el('edit_zone')?.value||'').trim(),
             maps_url: String(el('edit_maps_url')?.value||'').trim(),
-            latitude: String(el('edit_lat')?.value||'').trim(),
-            longitude: String(el('edit_lng')?.value||'').trim(),
+            // Send canonical gps_* keys (backend also accepts legacy latitude/longitude).
+            // Empty strings are preserved server-side (COALESCE) so an untouched
+            // location is never erased or turned into 0,0.
+            gps_latitude: String(el('edit_lat')?.value||'').trim(),
+            gps_longitude: String(el('edit_lng')?.value||'').trim(),
             // IMPORTANT (Timezone): <input type="datetime-local"> has no timezone.
             // Using Date(...).toISOString() will convert to UTC ("Z") and cause 09:00 -> 16:00/18:00 shifts.
             // Treat the picked wall-clock time as Bangkok (+07:00).

--- a/admin-job-view-v2.js
+++ b/admin-job-view-v2.js
@@ -1595,10 +1595,26 @@ async function loadJob(){
             job_zone: String(el('edit_zone')?.value||'').trim(),
             maps_url: String(el('edit_maps_url')?.value||'').trim(),
             // Send canonical gps_* keys (backend also accepts legacy latitude/longitude).
-            // Empty strings are preserved server-side (COALESCE) so an untouched
-            // location is never erased or turned into 0,0.
-            gps_latitude: String(el('edit_lat')?.value||'').trim(),
-            gps_longitude: String(el('edit_lng')?.value||'').trim(),
+            // If the admin changed the map/address but did NOT manually edit the
+            // pin, send blank coordinates so the backend recalculates (or clears)
+            // from the new location — never resubmit the old GPS with a new place.
+            ...(function(){
+              const latNow = String(el('edit_lat')?.value||'').trim();
+              const lngNow = String(el('edit_lng')?.value||'').trim();
+              const mapsNow = String(el('edit_maps_url')?.value||'').trim();
+              const addrNow = String(el('edit_address')?.value||'').trim();
+              const origMaps = String(job.maps_url||'').trim();
+              const origAddr = String(job.address_text||'').trim();
+              const origLat = String(job.gps_latitude ?? job.latitude ?? '').trim();
+              const origLng = String(job.gps_longitude ?? job.longitude ?? '').trim();
+              const locationTextChanged = (mapsNow !== origMaps) || (addrNow !== origAddr);
+              const coordsManuallyEdited = (latNow !== origLat) || (lngNow !== origLng);
+              const dropStaleGps = locationTextChanged && !coordsManuallyEdited;
+              return {
+                gps_latitude: dropStaleGps ? '' : latNow,
+                gps_longitude: dropStaleGps ? '' : lngNow,
+              };
+            })(),
             // IMPORTANT (Timezone): <input type="datetime-local"> has no timezone.
             // Using Date(...).toISOString() will convert to UTC ("Z") and cause 09:00 -> 16:00/18:00 shifts.
             // Treat the picked wall-clock time as Bangkok (+07:00).
@@ -1674,8 +1690,14 @@ async function loadJob(){
             return;
           }
 
-          showToast('บันทึกใบงานครบแล้ว', 'success');
-          if (msg) msg.textContent = `✅ บันทึกใบงานครบแล้ว${done.length ? `: ${done.join(' / ')}` : ''}`;
+          const GPS_ACTION_MSG = {
+            recalculated: 'อัปเดตพิกัดจากแผนที่/ที่อยู่ใหม่',
+            cleared: 'ล้างพิกัดเดิม (หาพิกัดจากสถานที่ใหม่ไม่ได้) — กรุณาตรวจสอบ',
+            updated: 'บันทึกพิกัดใหม่',
+          };
+          const gpsNote = result && GPS_ACTION_MSG[result.gps_action] ? ` • ${GPS_ACTION_MSG[result.gps_action]}` : '';
+          showToast('บันทึกใบงานครบแล้ว' + gpsNote, 'success');
+          if (msg) msg.textContent = `✅ บันทึกใบงานครบแล้ว${done.length ? `: ${done.join(' / ')}` : ''}${gpsNote}`;
           await loadJob();
         }catch(e){
           console.error(e);

--- a/admin-review-v2.html
+++ b/admin-review-v2.html
@@ -174,7 +174,7 @@
   </div>
 
   <script src="admin-v2-common.js?v=20260428_allpages_ui1"></script>
-  <script src="admin-review-v2.js?v=20260707_customer_booking_notify_v3_xss_guard"></script>
+  <script src="admin-review-v2.js?v=20260712_job_location_roundtrip_v1"></script>
   <script src="admin-review-ai-intake.js?v=ai-booking-intake-customer-cards-v11-admin-alert-gate"></script>
 </body>
 </html>

--- a/admin-review-v2.js
+++ b/admin-review-v2.js
@@ -878,7 +878,9 @@ async function saveJob(){
       cleared: "ล้างพิกัดเดิมแล้ว (หาพิกัดจากสถานที่ใหม่ไม่ได้) กรุณาตรวจสอบ",
       updated: "บันทึกพิกัดใหม่แล้ว",
     };
-    showToast("บันทึกใบงานแล้ว" + (resp && GPS_ACTION_MSG[resp.gps_action] ? ` • ${GPS_ACTION_MSG[resp.gps_action]}` : ""), "success");
+    const gpsNote = resp && GPS_ACTION_MSG[resp.gps_action] ? ` • ${GPS_ACTION_MSG[resp.gps_action]}` : "";
+    const mapsNote = resp && resp.maps_action === "cleared" ? " • ล้างลิงก์แผนที่เดิม (สถานที่เปลี่ยน)" : "";
+    showToast("บันทึกใบงานแล้ว" + gpsNote + mapsNote, "success");
     await loadQueue();
   }catch(e){
     showToast(e.message||"บันทึกไม่สำเร็จ","error");

--- a/admin-review-v2.js
+++ b/admin-review-v2.js
@@ -284,6 +284,27 @@ function stopPollingForAuth(){
   catch (_) { location.href = "/login.html"; }
 }
 
+// Strict validation for a STORED coordinate pair. Rejects null/undefined/""/
+// whitespace/non-numeric/out-of-range and the (0,0) null-island pair so a
+// missing coordinate is never treated as a real pin.
+function strictStoredLatLng(latRaw, lngRaw){
+  const parse = (v) => {
+    if (typeof v === 'number') return Number.isFinite(v) ? v : NaN;
+    if (typeof v === 'string') {
+      const s = v.trim();
+      if (!/^[+-]?(?:\d+\.?\d*|\.\d+)(?:[eE][+-]?\d+)?$/.test(s)) return NaN;
+      const n = Number(s);
+      return Number.isFinite(n) ? n : NaN;
+    }
+    return NaN;
+  };
+  const lat = parse(latRaw), lng = parse(lngRaw);
+  if (!Number.isFinite(lat) || !Number.isFinite(lng)) return null;
+  if (Math.abs(lat) > 90 || Math.abs(lng) > 180) return null;
+  if (lat === 0 && lng === 0) return null;
+  return { lat, lng };
+}
+
 function parseLatLngClient(input){
   const s = String(input||'').trim();
   if(!s) return null;
@@ -699,23 +720,37 @@ async function openJob(jobId){
     if (!row) throw new Error("ไม่พบงาน");
     acknowledgeNewJob(jobId);
 
+    // The queue row is abbreviated and may lack the stored gps_latitude/
+    // gps_longitude/service_zone_* fields. Fetch the full job so the edit modal
+    // shows the REAL stored location instead of re-deriving coordinates from the
+    // address text. Fail-open to the queue row if the detail call fails.
+    let full = row;
+    try {
+      const detail = await apiFetch(`/admin/job_v2/${encodeURIComponent(row.job_id)}`);
+      if (detail && detail.job) full = Object.assign({}, row, detail.job);
+    } catch (e) { /* fail-open to the queue row */ }
+
     CURRENT = {
-      job_id: row.job_id,
-      booking_code: row.booking_code,
-      booking_mode: String(row.booking_mode||"scheduled").toLowerCase(),
-      job_status: row.job_status,
-      job_type: row.job_type,
-      duration_min: Number(row.duration_min||0) || 60,
-      appointment_datetime: row.appointment_datetime,
-      customer_name: row.customer_name,
-      customer_phone: row.customer_phone,
-      address_text: row.address_text,
-      maps_url: row.maps_url,
-      customer_note: row.customer_note,
-      job_zone: row.job_zone,
-      technician_username: row.technician_username || "",
+      job_id: full.job_id,
+      booking_code: full.booking_code,
+      booking_mode: String(full.booking_mode||"scheduled").toLowerCase(),
+      job_status: full.job_status,
+      job_type: full.job_type,
+      duration_min: Number(full.duration_min||0) || 60,
+      appointment_datetime: full.appointment_datetime,
+      customer_name: full.customer_name,
+      customer_phone: full.customer_phone,
+      address_text: full.address_text,
+      maps_url: full.maps_url,
+      customer_note: full.customer_note,
+      job_zone: full.job_zone,
+      gps_latitude: full.gps_latitude,
+      gps_longitude: full.gps_longitude,
+      service_zone_code: full.service_zone_code,
+      service_zone_source: full.service_zone_source,
+      technician_username: full.technician_username || "",
       team_members: [],
-      admin_action_required: row.admin_action_required !== false,
+      admin_action_required: full.admin_action_required !== false,
     };
 
     // team
@@ -736,9 +771,17 @@ async function openJob(jobId){
     $("mAddress").value = text(CURRENT.address_text||"");
     $("mMaps").value = text(CURRENT.maps_url||"");
     $("mZone").value = text(CURRENT.job_zone||"");
-    // auto parse lat/lng (fail-open)
-    const ll = parseLatLngClient($("mMaps").value) || parseLatLngClient($("mAddress").value);
-    if (ll) { $("mLat").value = String(ll.lat); $("mLng").value = String(ll.lng); }
+    // Prefer REAL stored coordinates. Only derive lat/lng from the maps_url /
+    // address text when the job has no usable stored pin — never overwrite a
+    // stored coordinate with one parsed from the address.
+    const stored = strictStoredLatLng(CURRENT.gps_latitude, CURRENT.gps_longitude);
+    if (stored) {
+      $("mLat").value = String(stored.lat);
+      $("mLng").value = String(stored.lng);
+    } else {
+      const ll = parseLatLngClient($("mMaps").value) || parseLatLngClient($("mAddress").value);
+      if (ll) { $("mLat").value = String(ll.lat); $("mLng").value = String(ll.lng); }
+    }
 
     $("mNote").value = text(CURRENT.customer_note||"");
 

--- a/admin-review-v2.js
+++ b/admin-review-v2.js
@@ -725,10 +725,12 @@ async function openJob(jobId){
     // shows the REAL stored location instead of re-deriving coordinates from the
     // address text. Fail-open to the queue row if the detail call fails.
     let full = row;
+    let detailLoadFailed = false;
     try {
       const detail = await apiFetch(`/admin/job_v2/${encodeURIComponent(row.job_id)}`);
       if (detail && detail.job) full = Object.assign({}, row, detail.job);
-    } catch (e) { /* fail-open to the queue row */ }
+      else detailLoadFailed = true;
+    } catch (e) { detailLoadFailed = true; /* fail-open to the queue row */ }
 
     CURRENT = {
       job_id: full.job_id,
@@ -768,12 +770,22 @@ async function openJob(jobId){
     $("mJobType").value = text(CURRENT.job_type||"");
     $("mBookingCode").value = text(CURRENT.booking_code||"");
     $("mAppt").value = toLocalInputDatetime(CURRENT.appointment_datetime);
+    // Clear EVERY location field before populating so values from a previously
+    // opened job can never leak into this one (esp. Lat/Lng, which were only set
+    // conditionally and otherwise kept their stale value).
+    $("mAddress").value = "";
+    $("mMaps").value = "";
+    $("mZone").value = "";
+    $("mLat").value = "";
+    $("mLng").value = "";
+
     $("mAddress").value = text(CURRENT.address_text||"");
     $("mMaps").value = text(CURRENT.maps_url||"");
     $("mZone").value = text(CURRENT.job_zone||"");
     // Prefer REAL stored coordinates. Only derive lat/lng from the maps_url /
     // address text when the job has no usable stored pin — never overwrite a
-    // stored coordinate with one parsed from the address.
+    // stored coordinate with one parsed from the address. When neither exists the
+    // fields stay blank (cleared above).
     const stored = strictStoredLatLng(CURRENT.gps_latitude, CURRENT.gps_longitude);
     if (stored) {
       $("mLat").value = String(stored.lat);
@@ -781,6 +793,19 @@ async function openJob(jobId){
     } else {
       const ll = parseLatLngClient($("mMaps").value) || parseLatLngClient($("mAddress").value);
       if (ll) { $("mLat").value = String(ll.lat); $("mLng").value = String(ll.lng); }
+    }
+
+    // Snapshot the loaded location so save() can tell whether the admin changed
+    // the map/address (and therefore must not resubmit the old GPS pair).
+    CURRENT.__origLocation = {
+      maps_url: $("mMaps").value.trim(),
+      address_text: $("mAddress").value.trim(),
+      lat: $("mLat").value.trim(),
+      lng: $("mLng").value.trim(),
+    };
+
+    if (detailLoadFailed) {
+      showToast("โหลดรายละเอียดงานเต็มไม่สำเร็จ — พิกัด/สถานที่อาจไม่ครบ กรุณาตรวจสอบก่อนบันทึก", "error");
     }
 
     $("mNote").value = text(CURRENT.customer_note||"");
@@ -823,21 +848,37 @@ async function loadPricing(){
 async function saveJob(){
   if (!CURRENT) return;
   if (blockReadOnlyMutation()) return;
+  const latNow = $("mLat").value.trim();
+  const lngNow = $("mLng").value.trim();
+  const mapsNow = $("mMaps").value.trim();
+  const addrNow = $("mAddress").value.trim();
+  const orig = CURRENT.__origLocation || {};
+  const locationTextChanged = (mapsNow !== (orig.maps_url || "")) || (addrNow !== (orig.address_text || ""));
+  const coordsManuallyEdited = (latNow !== (orig.lat || "")) || (lngNow !== (orig.lng || ""));
+  // If the admin changed the map/address but did NOT manually edit the pin, do
+  // not resubmit the old coordinates — send blank so the backend recalculates
+  // (or clears) from the new location instead of keeping the old GPS.
+  const dropStaleGps = locationTextChanged && !coordsManuallyEdited;
   const payload = {
     customer_name: $("mCustomerName").value.trim() || null,
     customer_phone: $("mCustomerPhone").value.trim() || null,
     job_type: $("mJobType").value.trim() || null,
     appointment_datetime: $("mAppt").value ? localDatetimeToBangkokISO($("mAppt").value) : null,
-    address_text: $("mAddress").value.trim() || null,
+    address_text: addrNow || null,
     customer_note: $("mNote").value.trim() || null,
-    maps_url: $("mMaps").value.trim() || null,
+    maps_url: mapsNow || null,
     job_zone: $("mZone").value.trim() || null,
-    gps_latitude: $("mLat").value.trim() || null,
-    gps_longitude: $("mLng").value.trim() || null,
+    gps_latitude: dropStaleGps ? "" : (latNow || null),
+    gps_longitude: dropStaleGps ? "" : (lngNow || null),
   };
   try{
-    await apiFetch(`/jobs/${CURRENT.job_id}/admin-edit`, { method:"PUT", body: JSON.stringify(payload) });
-    showToast("บันทึกใบงานแล้ว","success");
+    const resp = await apiFetch(`/jobs/${CURRENT.job_id}/admin-edit`, { method:"PUT", body: JSON.stringify(payload) });
+    const GPS_ACTION_MSG = {
+      recalculated: "อัปเดตพิกัดจากแผนที่/ที่อยู่ใหม่แล้ว",
+      cleared: "ล้างพิกัดเดิมแล้ว (หาพิกัดจากสถานที่ใหม่ไม่ได้) กรุณาตรวจสอบ",
+      updated: "บันทึกพิกัดใหม่แล้ว",
+    };
+    showToast("บันทึกใบงานแล้ว" + (resp && GPS_ACTION_MSG[resp.gps_action] ? ` • ${GPS_ACTION_MSG[resp.gps_action]}` : ""), "success");
     await loadQueue();
   }catch(e){
     showToast(e.message||"บันทึกไม่สำเร็จ","error");

--- a/app.js
+++ b/app.js
@@ -1,7 +1,7 @@
 
 
 // CWF Technician App: payout no-pay status display fix
-window.__CWF_TECH_APP_VERSION__ = "20260711_tracking_gps_recovery_v1";
+window.__CWF_TECH_APP_VERSION__ = "20260712_job_location_roundtrip_v1";
 try { console.info('[CWF_TECH_APP_VERSION]', window.__CWF_TECH_APP_VERSION__); } catch (_) {}
 
 // ✅ งานปัจจุบัน: งานล่วงหน้า (sub-tab)
@@ -1235,7 +1235,7 @@ function setPushUi(state, text) {
 
 async function ensureServiceWorkerForPush() {
   if (!('serviceWorker' in navigator)) throw new Error('เครื่องนี้ไม่รองรับ Service Worker');
-  const reg = await navigator.serviceWorker.register('/sw.js?v=20260711_tracking_gps_recovery_v1', { updateViaCache: 'none' });
+  const reg = await navigator.serviceWorker.register('/sw.js?v=20260712_job_location_roundtrip_v1', { updateViaCache: 'none' });
   try { await navigator.serviceWorker.ready; } catch (_) {}
   return reg;
 }
@@ -3063,9 +3063,11 @@ function offerAreaText(o) {
 function offerMapUrl(o) {
   const maps = String(o?.maps_url || "").trim();
   if (maps) return maps;
-  const lat = Number(o?.gps_latitude);
-  const lng = Number(o?.gps_longitude);
-  if (Number.isFinite(lat) && Number.isFinite(lng)) return `https://www.google.com/maps?q=${lat},${lng}`;
+  // Use the same strict validation as navigation so missing/null coordinates
+  // never resolve to a q=0,0 pin (Number(null)===0).
+  if (_hasUsableLatLng(o?.gps_latitude, o?.gps_longitude)) {
+    return `https://www.google.com/maps?q=${_strictCoordNum(o.gps_latitude)},${_strictCoordNum(o.gps_longitude)}`;
+  }
   const address = String(o?.address_text || "").trim();
   if (address) return `https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(address)}`;
   return "";
@@ -3950,10 +3952,29 @@ function _normalizeMapsUrl(input){
   return `https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(s)}`;
 }
 
+// STRICT single-value coordinate parse. Accepts only a real finite JS number or
+// a numeric string. null / undefined / "" / whitespace / booleans / arrays /
+// objects all become NaN — Number(null)===0 and Number("")===0 must NEVER slip
+// through and make the app navigate to destination=0,0.
+function _strictCoordNum(v) {
+  if (typeof v === "number") return Number.isFinite(v) ? v : NaN;
+  if (typeof v === "string") {
+    const s = v.trim();
+    if (!s) return NaN;
+    if (!/^[+-]?(?:\d+\.?\d*|\.\d+)(?:[eE][+-]?\d+)?$/.test(s)) return NaN;
+    const n = Number(s);
+    return Number.isFinite(n) ? n : NaN;
+  }
+  return NaN;
+}
+
 function _hasUsableLatLng(lat, lng) {
-  const a = Number(lat);
-  const b = Number(lng);
-  return Number.isFinite(a) && Number.isFinite(b) && Math.abs(a) <= 90 && Math.abs(b) <= 180;
+  const a = _strictCoordNum(lat);
+  const b = _strictCoordNum(lng);
+  if (!Number.isFinite(a) || !Number.isFinite(b)) return false; // null/empty/NaN/infinity/bool/array/object
+  if (Math.abs(a) > 90 || Math.abs(b) > 180) return false;      // out of valid coordinate range
+  if (a === 0 && b === 0) return false;                          // the (0,0) null-island pair = missing data
+  return true;
 }
 
 function _findJobForMap(jobKey) {

--- a/cwf-pwa.js
+++ b/cwf-pwa.js
@@ -1,6 +1,6 @@
 (function(){
   'use strict';
-  var VERSION = '20260711_tracking_gps_recovery_v1';
+  var VERSION = '20260712_job_location_roundtrip_v1';
   try { window.__CWF_PWA_BUILD__ = VERSION; } catch (_) {}
   function register(){
     if (!('serviceWorker' in navigator)) return;

--- a/index.js
+++ b/index.js
@@ -14343,17 +14343,23 @@ async function handleAdminBookV2(req, res) {
   const standard_price = Number(customerPrice.active_price ?? customerPrice.standard_price ?? 0);
 
 
-// ✅ Parse lat/lng from maps_url or address_text (fail-open)
-const parsedAdminLL = parseLatLngFromText(maps_url) || parseLatLngFromText(address_text);
-const parsed_lat = parsedAdminLL ? parsedAdminLL.lat : null;
-const parsed_lng = parsedAdminLL ? parsedAdminLL.lng : null;
-console.log("[latlng_parse]", { ok: !!parsedAdminLL });
+// ✅ Coordinate resolution order (never convert missing values to zero):
+//   1) explicit admin-supplied gps_latitude/gps_longitude (STRICT: null/""/
+//      boolean/object are rejected, (0,0) is rejected)
+//   2) coordinates parsed from maps_url / address_text
+//   3) best-effort resolution of a short Google Maps link
+//   4) null
+const explicitAdminLL = strictLatLngPairOrNull(body.gps_latitude, body.gps_longitude);
+const parsedAdminLL = explicitAdminLL ? null : (parseLatLngFromText(maps_url) || parseLatLngFromText(address_text));
+console.log("[latlng_parse]", { explicit: !!explicitAdminLL, parsed: !!parsedAdminLL });
 
-  // ✅ Best-effort resolve short Google Maps links to precise lat/lng (fail-open)
-  // - ensures check-in / navigation uses correct pin coordinates
-  let final_lat = Number.isFinite(Number(parsed_lat)) ? Number(parsed_lat) : null;
-  let final_lng = Number.isFinite(Number(parsed_lng)) ? Number(parsed_lng) : null;
-  if ((final_lat == null || final_lng == null) && maps_url) {
+  let final_lat = explicitAdminLL ? explicitAdminLL.lat
+    : (parsedAdminLL && Number.isFinite(Number(parsedAdminLL.lat)) ? Number(parsedAdminLL.lat) : null);
+  let final_lng = explicitAdminLL ? explicitAdminLL.lng
+    : (parsedAdminLL && Number.isFinite(Number(parsedAdminLL.lng)) ? Number(parsedAdminLL.lng) : null);
+  // The maps_url itself is always persisted below regardless of resolution, so a
+  // short Google Maps link stays saved even when coordinate resolution fails.
+  if (!explicitAdminLL && (final_lat == null || final_lng == null) && maps_url) {
     const m = String(maps_url || '').trim();
     if (m && /maps\.app\.goo\.gl|goo\.gl/i.test(m)) {
       try {
@@ -17234,17 +17240,17 @@ app.put("/jobs/:job_id/admin-edit", async (req, res) => {
   const wantsTeamSave = Array.isArray(nextTeamRaw) || primary_username !== undefined || technician_username !== undefined;
   const desiredPrimaryFromBody = String(primary_username || technician_username || '').trim() || null;
 
-  // Backward-compatible mapping (do not break existing callers)
-  const toFiniteOrNull = (v) => {
-    if (v === null || v === undefined) return null;
-    const s = typeof v === 'string' ? v.trim() : v;
-    if (s === '') return null;
-    const n = Number(s);
-    return Number.isFinite(n) ? n : null;
-  };
-
-  const gpsLat = gps_latitude !== undefined ? toFiniteOrNull(gps_latitude) : toFiniteOrNull(latitude);
-  const gpsLng = gps_longitude !== undefined ? toFiniteOrNull(gps_longitude) : toFiniteOrNull(longitude);
+  // STRICT pair validation (canonical gps_* first, legacy latitude/longitude as
+  // fallback). null/""/whitespace/boolean/object and the (0,0) pair all resolve
+  // to null so the UPDATE's COALESCE preserves the existing stored coordinates
+  // instead of erasing them or writing 0,0. Only a valid non-(0,0) in-range pair
+  // updates the columns.
+  const editGpsPair = strictLatLngPairOrNull(
+    gps_latitude !== undefined ? gps_latitude : latitude,
+    gps_longitude !== undefined ? gps_longitude : longitude
+  );
+  const gpsLat = editGpsPair ? editGpsPair.lat : null;
+  const gpsLng = editGpsPair ? editGpsPair.lng : null;
 
   // ✅ FIX TIMEZONE: ถ้ามีการแก้วันนัด ให้ normalize เป็นเวลาไทยก่อนบันทึก
   const appointment_dt =
@@ -19202,6 +19208,19 @@ function strictNumericOrNaN(v) {
     return Number.isFinite(n) ? n : NaN;
   }
   return NaN;
+}
+
+// STRICT coordinate-PAIR validation for admin-supplied gps fields. Returns
+// {lat,lng} only when BOTH are real finite numbers in valid range and not the
+// (0,0) null-island pair; otherwise null. null / "" / whitespace / boolean /
+// array / object never become 0 — Number(null)===0 must never persist as (0,0).
+function strictLatLngPairOrNull(latRaw, lngRaw) {
+  const lat = strictNumericOrNaN(latRaw);
+  const lng = strictNumericOrNaN(lngRaw);
+  if (!Number.isFinite(lat) || !Number.isFinite(lng)) return null;
+  if (Math.abs(lat) > 90 || Math.abs(lng) > 180) return null;
+  if (lat === 0 && lng === 0) return null;
+  return { lat, lng };
 }
 
 app.post("/jobs/:job_id/checkin", requireTechnicianSession, async (req, res) => {

--- a/index.js
+++ b/index.js
@@ -17240,17 +17240,27 @@ app.put("/jobs/:job_id/admin-edit", async (req, res) => {
   const wantsTeamSave = Array.isArray(nextTeamRaw) || primary_username !== undefined || technician_username !== undefined;
   const desiredPrimaryFromBody = String(primary_username || technician_username || '').trim() || null;
 
-  // STRICT pair validation (canonical gps_* first, legacy latitude/longitude as
-  // fallback). null/""/whitespace/boolean/object and the (0,0) pair all resolve
-  // to null so the UPDATE's COALESCE preserves the existing stored coordinates
-  // instead of erasing them or writing 0,0. Only a valid non-(0,0) in-range pair
-  // updates the columns.
-  const editGpsPair = strictLatLngPairOrNull(
-    gps_latitude !== undefined ? gps_latitude : latitude,
-    gps_longitude !== undefined ? gps_longitude : longitude
-  );
-  const gpsLat = editGpsPair ? editGpsPair.lat : null;
-  const gpsLng = editGpsPair ? editGpsPair.lng : null;
+  // --- Job-site coordinate validation (strict, canonical gps_* first) --------
+  // Reject a partial or invalid explicit pair instead of silently preserving the
+  // old coordinates while returning success. Both blank/omitted = "no explicit
+  // GPS edit"; both valid = update; anything else (one field only, invalid,
+  // out-of-range, 0,0) = HTTP 400.
+  const latRaw = gps_latitude !== undefined ? gps_latitude : latitude;
+  const lngRaw = gps_longitude !== undefined ? gps_longitude : longitude;
+  const coordProvided = (v) => v !== undefined && v !== null && String(v).trim() !== '';
+  const latProvided = coordProvided(latRaw);
+  const lngProvided = coordProvided(lngRaw);
+  const INVALID_COORD_MSG = 'พิกัดหน้างานไม่ถูกต้อง กรุณาระบุ Lat และ Lng ให้ครบทั้งคู่และอยู่ในช่วงที่ถูกต้อง (ไม่ใช่ 0,0) หรือเว้นว่างทั้งคู่';
+  let editGpsPair = null;
+  if (latProvided || lngProvided) {
+    if (!(latProvided && lngProvided)) {
+      return res.status(400).json({ code: 'INVALID_JOB_SITE_COORDINATES', error: INVALID_COORD_MSG });
+    }
+    editGpsPair = strictLatLngPairOrNull(latRaw, lngRaw);
+    if (!editGpsPair) {
+      return res.status(400).json({ code: 'INVALID_JOB_SITE_COORDINATES', error: INVALID_COORD_MSG });
+    }
+  }
 
   // ✅ FIX TIMEZONE: ถ้ามีการแก้วันนัด ให้ normalize เป็นเวลาไทยก่อนบันทึก
   const appointment_dt =
@@ -17279,6 +17289,44 @@ try {
       }
 
       const cur = curR.rows[0];
+
+      // --- Coordinate write decision (never keep old GPS with a new location) ---
+      //   1) valid explicit pair            → update
+      //   2) maps_url/address changed w/o an explicit pair → recalculate from the
+      //      NEW location; save if resolvable, otherwise CLEAR to NULL (the old
+      //      coordinates belong to the old place and must not be retained)
+      //   3) otherwise                       → preserve
+      // gpsForce drives the UPDATE's CASE so we can write NULL deliberately
+      // (clearing) as opposed to COALESCE-preserving.
+      let gpsForce = false, gpsWriteLat = null, gpsWriteLng = null, gpsAction = 'preserved';
+      if (editGpsPair) {
+        gpsForce = true; gpsWriteLat = editGpsPair.lat; gpsWriteLng = editGpsPair.lng; gpsAction = 'updated';
+      } else {
+        const curMaps = String(cur.maps_url || '').trim();
+        const curAddr = String(cur.address_text || '').trim();
+        const newMaps = maps_url !== undefined ? String(maps_url || '').trim() : curMaps;
+        const newAddr = address_text !== undefined ? String(address_text || '').trim() : curAddr;
+        const mapsChanged = maps_url !== undefined && newMaps !== curMaps;
+        const addrChanged = address_text !== undefined && newAddr !== curAddr;
+        if (mapsChanged || addrChanged) {
+          let resolved = parseLatLngFromText(newMaps) || parseLatLngFromText(newAddr);
+          if (!resolved && newMaps && /maps\.app\.goo\.gl|goo\.gl/i.test(newMaps)) {
+            try {
+              const rr = await resolveMapsUrlToLatLng(newMaps);
+              if (rr && Number.isFinite(Number(rr.lat)) && Number.isFinite(Number(rr.lng))) {
+                resolved = { lat: Number(rr.lat), lng: Number(rr.lng) };
+              }
+            } catch (_) { /* fail-open: leave unresolved → cleared */ }
+          }
+          gpsForce = true;
+          if (resolved && Number.isFinite(Number(resolved.lat)) && Number.isFinite(Number(resolved.lng))) {
+            gpsWriteLat = Number(resolved.lat); gpsWriteLng = Number(resolved.lng); gpsAction = 'recalculated';
+          } else {
+            gpsWriteLat = null; gpsWriteLng = null; gpsAction = 'cleared';
+          }
+        }
+      }
+
       const apptToUse = appointment_dt || cur.appointment_datetime;
       const durToUse = Number(cur.duration_min || 60);
       const jobTypeToUse = (job_type ?? cur.job_type);
@@ -17320,11 +17368,11 @@ try {
           customer_note = COALESCE($6, customer_note),
           maps_url = COALESCE(NULLIF($7, ''), maps_url),
           job_zone = COALESCE(NULLIF($8, ''), job_zone),
-          gps_latitude = COALESCE($9, gps_latitude),
-          gps_longitude = COALESCE($10, gps_longitude),
-          technician_username = COALESCE(NULLIF($11, ''), technician_username),
-          technician_team = COALESCE(NULLIF($11, ''), technician_team)
-      WHERE job_id=$12
+          gps_latitude = CASE WHEN $9 THEN $10 ELSE gps_latitude END,
+          gps_longitude = CASE WHEN $9 THEN $11 ELSE gps_longitude END,
+          technician_username = COALESCE(NULLIF($12, ''), technician_username),
+          technician_team = COALESCE(NULLIF($12, ''), technician_team)
+      WHERE job_id=$13
       `,
       [
         customer_name ?? null,
@@ -17335,8 +17383,9 @@ try {
         customer_note ?? null,
         maps_url ?? null,
         job_zone ?? null,
-        gpsLat,
-        gpsLng,
+        gpsForce,
+        gpsWriteLat,
+        gpsWriteLng,
         headerPrimaryToSave,
         job_id,
       ]
@@ -17382,6 +17431,9 @@ try {
         },
         pricing,
         team: savedTeam,
+        // How the job-site coordinates were resolved on this save so the admin
+        // UI can tell the user: preserved | updated | recalculated | cleared.
+        gps_action: gpsAction,
       });
     } catch (innerErr) {
       try { await client.query("ROLLBACK"); } catch (_) {}

--- a/index.js
+++ b/index.js
@@ -14344,35 +14344,33 @@ async function handleAdminBookV2(req, res) {
 
 
 // ✅ Coordinate resolution order (never convert missing values to zero):
-//   1) explicit admin-supplied gps_latitude/gps_longitude (STRICT: null/""/
-//      boolean/object are rejected, (0,0) is rejected)
+//   1) explicit admin-supplied gps_latitude/gps_longitude
 //   2) coordinates parsed from maps_url / address_text
 //   3) best-effort resolution of a short Google Maps link
 //   4) null
+// EVERY candidate pair — explicit, parsed, or resolved — is passed through the
+// SAME strict validator, so 0,0 / out-of-range / partial / NaN / non-numeric
+// derived coordinates are never persisted.
 const explicitAdminLL = strictLatLngPairOrNull(body.gps_latitude, body.gps_longitude);
-const parsedAdminLL = explicitAdminLL ? null : (parseLatLngFromText(maps_url) || parseLatLngFromText(address_text));
-console.log("[latlng_parse]", { explicit: !!explicitAdminLL, parsed: !!parsedAdminLL });
-
-  let final_lat = explicitAdminLL ? explicitAdminLL.lat
-    : (parsedAdminLL && Number.isFinite(Number(parsedAdminLL.lat)) ? Number(parsedAdminLL.lat) : null);
-  let final_lng = explicitAdminLL ? explicitAdminLL.lng
-    : (parsedAdminLL && Number.isFinite(Number(parsedAdminLL.lng)) ? Number(parsedAdminLL.lng) : null);
+let derivedAdminLL = null;
+if (!explicitAdminLL) {
+  const p = parseLatLngFromText(maps_url) || parseLatLngFromText(address_text);
+  derivedAdminLL = p ? strictLatLngPairOrNull(p.lat, p.lng) : null;
   // The maps_url itself is always persisted below regardless of resolution, so a
   // short Google Maps link stays saved even when coordinate resolution fails.
-  if (!explicitAdminLL && (final_lat == null || final_lng == null) && maps_url) {
-    const m = String(maps_url || '').trim();
-    if (m && /maps\.app\.goo\.gl|goo\.gl/i.test(m)) {
-      try {
-        const rr = await resolveMapsUrlToLatLng(m);
-        if (rr && Number.isFinite(Number(rr.lat)) && Number.isFinite(Number(rr.lng))) {
-          final_lat = Number(rr.lat);
-          final_lng = Number(rr.lng);
-        }
-      } catch (e) {
-        // fail-open
-      }
-    }
+  const m = String(maps_url || '').trim();
+  if (!derivedAdminLL && m && /maps\.app\.goo\.gl|goo\.gl/i.test(m)) {
+    try {
+      const rr = await resolveMapsUrlToLatLng(m);
+      if (rr) derivedAdminLL = strictLatLngPairOrNull(rr.lat, rr.lng);
+    } catch (e) { /* fail-open */ }
   }
+}
+const chosenAdminLL = explicitAdminLL || derivedAdminLL;
+console.log("[latlng_parse]", { explicit: !!explicitAdminLL, derived: !!derivedAdminLL });
+
+  let final_lat = chosenAdminLL ? chosenAdminLL.lat : null;
+  let final_lng = chosenAdminLL ? chosenAdminLL.lng : null;
 
 
   // sanitize items
@@ -17278,7 +17276,10 @@ try {
         `SELECT appointment_datetime,
                 COALESCE(duration_min,60) AS duration_min,
                 technician_username,
-                job_type
+                job_type,
+                maps_url,
+                address_text,
+                job_zone
          FROM public.jobs WHERE job_id=$1
          FOR UPDATE`,
         [job_id]
@@ -17290,41 +17291,88 @@ try {
 
       const cur = curR.rows[0];
 
-      // --- Coordinate write decision (never keep old GPS with a new location) ---
+      // ---- Effective location resolution (maps_url / address / GPS / zone) ----
+      // These four must stay mutually consistent. Presence flags distinguish an
+      // OMITTED field (preserve) from an EXPLICITLY supplied empty one (clear).
+      const curMaps = String(cur.maps_url || '').trim();
+      const curAddr = String(cur.address_text || '').trim();
+      const mapsProvided = maps_url !== undefined;
+      const addrProvided = address_text !== undefined;
+      const newMaps = mapsProvided ? String(maps_url || '').trim() : curMaps;
+      const newAddr = addrProvided ? String(address_text || '').trim() : curAddr;
+      const mapsChanged = mapsProvided && newMaps !== curMaps;
+      const addrChanged = addrProvided && newAddr !== curAddr;
+      const newJobZone = job_zone !== undefined ? String(job_zone || '').trim() : String(cur.job_zone || '').trim();
+
+      // Blocker 1 + 2: maps_url write semantics.
+      //   omitted             → preserve
+      //   supplied non-empty  → replace
+      //   supplied empty/null → clear to NULL
+      //   address changed without a replacement URL → clear the stale URL, so a
+      //   new address can never keep the old location's Maps URL (nav uses it first)
+      let mapsForce = false, mapsWrite = null, mapsAction = 'preserved';
+      if (mapsProvided) {
+        mapsForce = true;
+        mapsWrite = newMaps || null;
+        mapsAction = mapsWrite ? (mapsChanged ? 'replaced' : 'preserved') : 'cleared';
+      }
+      if (addrChanged && !mapsChanged) {
+        mapsForce = true;
+        mapsWrite = null;
+        mapsAction = 'cleared';
+      }
+      // The Maps URL that will actually be stored — the source for GPS/zone recompute.
+      const effectiveMaps = mapsForce ? String(mapsWrite || '') : curMaps;
+      // Only a change to a NEW non-empty Maps URL is a "location moved" signal.
+      // Merely CLEARING the URL must not recompute GPS/zone — the stored pin stays
+      // valid so technician navigation can fall back to it (Blocker 1).
+      const mapsMovedToNew = mapsChanged && newMaps !== '';
+      const locationMoved = mapsMovedToNew || addrChanged;
+
+      // Blocker 4: strict validation for EVERY derived coordinate pair (parsed
+      // from text or resolved from a short link) — 0,0 / out-of-range / partial /
+      // NaN are rejected, exactly like an explicit admin pair.
+      async function resolveStrictLatLng(mapsText, addrText) {
+        const p = parseLatLngFromText(mapsText) || parseLatLngFromText(addrText);
+        let pair = p ? strictLatLngPairOrNull(p.lat, p.lng) : null;
+        if (!pair && mapsText && /maps\.app\.goo\.gl|goo\.gl/i.test(mapsText)) {
+          try {
+            const rr = await resolveMapsUrlToLatLng(mapsText);
+            if (rr) pair = strictLatLngPairOrNull(rr.lat, rr.lng);
+          } catch (_) { /* fail-open → null (cleared) */ }
+        }
+        return pair;
+      }
+
+      // GPS decision:
       //   1) valid explicit pair            → update
-      //   2) maps_url/address changed w/o an explicit pair → recalculate from the
-      //      NEW location; save if resolvable, otherwise CLEAR to NULL (the old
-      //      coordinates belong to the old place and must not be retained)
-      //   3) otherwise                       → preserve
-      // gpsForce drives the UPDATE's CASE so we can write NULL deliberately
-      // (clearing) as opposed to COALESCE-preserving.
+      //   2) maps_url/address changed       → recalculate from the NEW effective
+      //      location; save if strictly valid, else CLEAR to NULL
+      //   3) otherwise                      → preserve
       let gpsForce = false, gpsWriteLat = null, gpsWriteLng = null, gpsAction = 'preserved';
       if (editGpsPair) {
         gpsForce = true; gpsWriteLat = editGpsPair.lat; gpsWriteLng = editGpsPair.lng; gpsAction = 'updated';
-      } else {
-        const curMaps = String(cur.maps_url || '').trim();
-        const curAddr = String(cur.address_text || '').trim();
-        const newMaps = maps_url !== undefined ? String(maps_url || '').trim() : curMaps;
-        const newAddr = address_text !== undefined ? String(address_text || '').trim() : curAddr;
-        const mapsChanged = maps_url !== undefined && newMaps !== curMaps;
-        const addrChanged = address_text !== undefined && newAddr !== curAddr;
-        if (mapsChanged || addrChanged) {
-          let resolved = parseLatLngFromText(newMaps) || parseLatLngFromText(newAddr);
-          if (!resolved && newMaps && /maps\.app\.goo\.gl|goo\.gl/i.test(newMaps)) {
-            try {
-              const rr = await resolveMapsUrlToLatLng(newMaps);
-              if (rr && Number.isFinite(Number(rr.lat)) && Number.isFinite(Number(rr.lng))) {
-                resolved = { lat: Number(rr.lat), lng: Number(rr.lng) };
-              }
-            } catch (_) { /* fail-open: leave unresolved → cleared */ }
-          }
-          gpsForce = true;
-          if (resolved && Number.isFinite(Number(resolved.lat)) && Number.isFinite(Number(resolved.lng))) {
-            gpsWriteLat = Number(resolved.lat); gpsWriteLng = Number(resolved.lng); gpsAction = 'recalculated';
-          } else {
-            gpsWriteLat = null; gpsWriteLng = null; gpsAction = 'cleared';
-          }
-        }
+      } else if (locationMoved) {
+        const pair = await resolveStrictLatLng(effectiveMaps, newAddr);
+        gpsForce = true;
+        if (pair) { gpsWriteLat = pair.lat; gpsWriteLng = pair.lng; gpsAction = 'recalculated'; }
+        else { gpsWriteLat = null; gpsWriteLng = null; gpsAction = 'cleared'; }
+      }
+
+      // Blocker 3: recompute the SYSTEM service zone from the new effective
+      // location whenever the location changed. Never keep the old zone; clear it
+      // (NULL) when the new location cannot be classified. Free-text job_zone is
+      // handled separately by the UPDATE below.
+      let zoneForce = false, zoneCodeWrite = null, zoneSourceWrite = null;
+      if (locationMoved || !!editGpsPair) {
+        const zoneMapsInput = editGpsPair ? `${editGpsPair.lat},${editGpsPair.lng}` : effectiveMaps;
+        let zoneDetected = null;
+        try {
+          zoneDetected = await detectServiceZoneFromText({ address_text: newAddr, job_zone: newJobZone, maps_url: zoneMapsInput });
+        } catch (_) { zoneDetected = null; }
+        zoneForce = true;
+        zoneCodeWrite = zoneDetected?.service_zone_code || null;
+        zoneSourceWrite = zoneDetected?.service_zone_source || null;
       }
 
       const apptToUse = appointment_dt || cur.appointment_datetime;
@@ -17366,13 +17414,15 @@ try {
           appointment_datetime = COALESCE($4, appointment_datetime),
           address_text = COALESCE($5, address_text),
           customer_note = COALESCE($6, customer_note),
-          maps_url = COALESCE(NULLIF($7, ''), maps_url),
-          job_zone = COALESCE(NULLIF($8, ''), job_zone),
-          gps_latitude = CASE WHEN $9 THEN $10 ELSE gps_latitude END,
-          gps_longitude = CASE WHEN $9 THEN $11 ELSE gps_longitude END,
-          technician_username = COALESCE(NULLIF($12, ''), technician_username),
-          technician_team = COALESCE(NULLIF($12, ''), technician_team)
-      WHERE job_id=$13
+          maps_url = CASE WHEN $7 THEN $8 ELSE maps_url END,
+          job_zone = COALESCE(NULLIF($9, ''), job_zone),
+          gps_latitude = CASE WHEN $10 THEN $11 ELSE gps_latitude END,
+          gps_longitude = CASE WHEN $10 THEN $12 ELSE gps_longitude END,
+          service_zone_code = CASE WHEN $13 THEN $14 ELSE service_zone_code END,
+          service_zone_source = CASE WHEN $13 THEN $15 ELSE service_zone_source END,
+          technician_username = COALESCE(NULLIF($16, ''), technician_username),
+          technician_team = COALESCE(NULLIF($16, ''), technician_team)
+      WHERE job_id=$17
       `,
       [
         customer_name ?? null,
@@ -17381,11 +17431,15 @@ try {
         appointment_dt,
         address_text ?? null,
         customer_note ?? null,
-        maps_url ?? null,
+        mapsForce,
+        mapsWrite,
         job_zone ?? null,
         gpsForce,
         gpsWriteLat,
         gpsWriteLng,
+        zoneForce,
+        zoneCodeWrite,
+        zoneSourceWrite,
         headerPrimaryToSave,
         job_id,
       ]
@@ -17431,9 +17485,12 @@ try {
         },
         pricing,
         team: savedTeam,
-        // How the job-site coordinates were resolved on this save so the admin
-        // UI can tell the user: preserved | updated | recalculated | cleared.
+        // How the location fields were resolved on this save so the admin UI can
+        // tell the user what happened.
+        //   gps_action  : preserved | updated | recalculated | cleared
+        //   maps_action : preserved | replaced | cleared
         gps_action: gpsAction,
+        maps_action: mapsAction,
       });
     } catch (innerErr) {
       try { await client.query("ROLLBACK"); } catch (_) {}

--- a/index.js
+++ b/index.js
@@ -14343,6 +14343,20 @@ async function handleAdminBookV2(req, res) {
   const standard_price = Number(customerPrice.active_price ?? customerPrice.standard_price ?? 0);
 
 
+// Blocker: explicit admin coordinates must be validated at the BACKEND, not just
+// the UI — a stale cached admin page or a direct API caller can send a partial or
+// invalid pair. One-field-only / invalid / out-of-range / 0,0 → HTTP 400 instead
+// of silently falling back to maps/address derivation. Both blank = no explicit GPS.
+{
+  const latProvided = coordFieldProvided(body.gps_latitude);
+  const lngProvided = coordFieldProvided(body.gps_longitude);
+  if (latProvided || lngProvided) {
+    if (!(latProvided && lngProvided) || !strictLatLngPairOrNull(body.gps_latitude, body.gps_longitude)) {
+      return res.status(400).json({ code: 'INVALID_JOB_SITE_COORDINATES', error: INVALID_JOB_SITE_COORDINATES_MSG });
+    }
+  }
+}
+
 // ✅ Coordinate resolution order (never convert missing values to zero):
 //   1) explicit admin-supplied gps_latitude/gps_longitude
 //   2) coordinates parsed from maps_url / address_text
@@ -17279,7 +17293,9 @@ try {
                 job_type,
                 maps_url,
                 address_text,
-                job_zone
+                job_zone,
+                gps_latitude,
+                gps_longitude
          FROM public.jobs WHERE job_id=$1
          FOR UPDATE`,
         [job_id]
@@ -17304,36 +17320,39 @@ try {
       const addrChanged = addrProvided && newAddr !== curAddr;
       const newJobZone = job_zone !== undefined ? String(job_zone || '').trim() : String(cur.job_zone || '').trim();
 
+      // Did the admin supply an explicit pin that differs from the stored one?
+      // (editGpsPair is already strictly validated / 400'd earlier.) An explicit
+      // GPS that MOVES the pin is itself a location change.
+      const curPair = strictLatLngPairOrNull(cur.gps_latitude, cur.gps_longitude);
+      const gpsMovedByExplicit = !!editGpsPair && !(curPair && Math.abs(curPair.lat - editGpsPair.lat) < 1e-9 && Math.abs(curPair.lng - editGpsPair.lng) < 1e-9);
+      // A change to a NEW non-empty Maps URL is a "location moved" signal. Merely
+      // CLEARING the URL is not (the stored pin stays valid for nav fallback).
+      const mapsMovedToNew = mapsChanged && newMaps !== '';
+
       // Blocker 1 + 2: maps_url write semantics.
-      //   omitted             → preserve
-      //   supplied non-empty  → replace
-      //   supplied empty/null → clear to NULL
-      //   address changed without a replacement URL → clear the stale URL, so a
-      //   new address can never keep the old location's Maps URL (nav uses it first)
+      //   omitted                                   → preserve
+      //   supplied non-empty                        → replace
+      //   supplied empty/null                       → clear to NULL
+      //   address OR explicit-GPS moved w/o a real replacement URL → clear the
+      //   stale URL, so a new location can never keep the old Maps URL (which
+      //   technician navigation prioritises before GPS).
       let mapsForce = false, mapsWrite = null, mapsAction = 'preserved';
       if (mapsProvided) {
         mapsForce = true;
         mapsWrite = newMaps || null;
         mapsAction = mapsWrite ? (mapsChanged ? 'replaced' : 'preserved') : 'cleared';
       }
-      if (addrChanged && !mapsChanged) {
+      if ((addrChanged || gpsMovedByExplicit) && !mapsMovedToNew) {
         mapsForce = true;
         mapsWrite = null;
         mapsAction = 'cleared';
       }
-      // The Maps URL that will actually be stored — the source for GPS/zone recompute.
-      const effectiveMaps = mapsForce ? String(mapsWrite || '') : curMaps;
-      // Only a change to a NEW non-empty Maps URL is a "location moved" signal.
-      // Merely CLEARING the URL must not recompute GPS/zone — the stored pin stays
-      // valid so technician navigation can fall back to it (Blocker 1).
-      const mapsMovedToNew = mapsChanged && newMaps !== '';
-      const locationMoved = mapsMovedToNew || addrChanged;
 
       // Blocker 4: strict validation for EVERY derived coordinate pair (parsed
-      // from text or resolved from a short link) — 0,0 / out-of-range / partial /
-      // NaN are rejected, exactly like an explicit admin pair.
-      async function resolveStrictLatLng(mapsText, addrText) {
-        const p = parseLatLngFromText(mapsText) || parseLatLngFromText(addrText);
+      // from text or resolved from a short link). Source-SPECIFIC (Blocker 2): a
+      // new Maps URL never falls back to the unchanged old address.
+      async function deriveStrictLatLng(mapsText, addrText) {
+        const p = parseLatLngFromText(mapsText) || (addrText ? parseLatLngFromText(addrText) : null);
         let pair = p ? strictLatLngPairOrNull(p.lat, p.lng) : null;
         if (!pair && mapsText && /maps\.app\.goo\.gl|goo\.gl/i.test(mapsText)) {
           try {
@@ -17344,31 +17363,47 @@ try {
         return pair;
       }
 
+      // Choose the NEW effective coordinate source (never the old one after a move):
+      //   - maps moved to new + address changed → new maps, address as fallback
+      //   - maps moved to new only              → new maps ONLY
+      //   - address changed only                → new address only
+      let srcMaps = '', srcAddr = '';
+      if (mapsMovedToNew && addrChanged) { srcMaps = newMaps; srcAddr = newAddr; }
+      else if (mapsMovedToNew) { srcMaps = newMaps; srcAddr = ''; }
+      else if (addrChanged) { srcMaps = ''; srcAddr = newAddr; }
+      const locationMoved = mapsMovedToNew || addrChanged;
+
       // GPS decision:
-      //   1) valid explicit pair            → update
-      //   2) maps_url/address changed       → recalculate from the NEW effective
-      //      location; save if strictly valid, else CLEAR to NULL
-      //   3) otherwise                      → preserve
+      //   1) explicit pair (already validated)  → update
+      //   2) location moved                     → derive from the NEW source only;
+      //      save if strictly valid, else CLEAR to NULL
+      //   3) otherwise                          → preserve
       let gpsForce = false, gpsWriteLat = null, gpsWriteLng = null, gpsAction = 'preserved';
       if (editGpsPair) {
         gpsForce = true; gpsWriteLat = editGpsPair.lat; gpsWriteLng = editGpsPair.lng; gpsAction = 'updated';
       } else if (locationMoved) {
-        const pair = await resolveStrictLatLng(effectiveMaps, newAddr);
+        const pair = await deriveStrictLatLng(srcMaps, srcAddr);
         gpsForce = true;
         if (pair) { gpsWriteLat = pair.lat; gpsWriteLng = pair.lng; gpsAction = 'recalculated'; }
         else { gpsWriteLat = null; gpsWriteLng = null; gpsAction = 'cleared'; }
       }
 
-      // Blocker 3: recompute the SYSTEM service zone from the new effective
-      // location whenever the location changed. Never keep the old zone; clear it
-      // (NULL) when the new location cannot be classified. Free-text job_zone is
-      // handled separately by the UPDATE below.
+      // Blocker 3: recompute the SYSTEM service zone from the NEW effective source
+      // whenever the location moved (new maps/address or an explicit pin). Never
+      // keep the old zone; clear it (NULL) when the new location cannot be
+      // classified. The old, unchanged job_zone/address are NOT used as evidence
+      // for the new zone. Free-text job_zone is preserved separately by the UPDATE.
+      const jobZoneChanged = job_zone !== undefined && newJobZone !== String(cur.job_zone || '').trim();
       let zoneForce = false, zoneCodeWrite = null, zoneSourceWrite = null;
-      if (locationMoved || !!editGpsPair) {
-        const zoneMapsInput = editGpsPair ? `${editGpsPair.lat},${editGpsPair.lng}` : effectiveMaps;
+      if (locationMoved || gpsMovedByExplicit) {
+        const zoneMapsInput = editGpsPair ? `${editGpsPair.lat},${editGpsPair.lng}` : srcMaps;
         let zoneDetected = null;
         try {
-          zoneDetected = await detectServiceZoneFromText({ address_text: newAddr, job_zone: newJobZone, maps_url: zoneMapsInput });
+          zoneDetected = await detectServiceZoneFromText({
+            address_text: srcAddr,
+            job_zone: jobZoneChanged ? newJobZone : '',
+            maps_url: zoneMapsInput,
+          });
         } catch (_) { zoneDetected = null; }
         zoneForce = true;
         zoneCodeWrite = zoneDetected?.service_zone_code || null;
@@ -19331,6 +19366,14 @@ function strictLatLngPairOrNull(latRaw, lngRaw) {
   if (lat === 0 && lng === 0) return null;
   return { lat, lng };
 }
+
+// A coordinate field counts as "provided" only when it is a non-blank value.
+// undefined / null / "" / whitespace = not provided.
+function coordFieldProvided(v) {
+  return v !== undefined && v !== null && String(v).trim() !== '';
+}
+// Shared actionable Thai message for an invalid job-site coordinate pair.
+const INVALID_JOB_SITE_COORDINATES_MSG = 'พิกัดหน้างานไม่ถูกต้อง กรุณาระบุ Lat และ Lng ให้ครบทั้งคู่และอยู่ในช่วงที่ถูกต้อง (ไม่ใช่ 0,0) หรือเว้นว่างทั้งคู่';
 
 app.post("/jobs/:job_id/checkin", requireTechnicianSession, async (req, res) => {
   const { job_id } = req.params;

--- a/sw.js
+++ b/sw.js
@@ -1,5 +1,5 @@
 /* CWF root service worker: Tech App shell/cache refresh */
-const CWF_TECH_BUILD_ID = "20260711_tracking_gps_recovery_v1";
+const CWF_TECH_BUILD_ID = "20260712_job_location_roundtrip_v1";
 const CWF_ACCOUNTING_CACHE_BUMP = "20260703_accounting_payout_adjustment_v1";
 const CACHE_PREFIX = "cwf-root-tech-app-";
 const CACHE_NAME = `${CACHE_PREFIX}${CWF_TECH_BUILD_ID}-${CWF_ACCOUNTING_CACHE_BUMP}`;

--- a/tech.html
+++ b/tech.html
@@ -8,10 +8,10 @@
   <link rel="manifest" href="/manifest.json">
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-  <meta name="cwf-tech-build" content="20260711_tracking_gps_recovery_v1">
+  <meta name="cwf-tech-build" content="20260712_job_location_roundtrip_v1">
   <title>หน้าช่าง - CWF</title>
   <link rel="stylesheet" href="style.css">
-  <script defer src="/cwf-pwa.js?v=20260711_tracking_gps_recovery_v1"></script>
+  <script defer src="/cwf-pwa.js?v=20260712_job_location_roundtrip_v1"></script>
 
   <style>
     :root{
@@ -3433,7 +3433,7 @@
     }
   </style>
 
-<script src="app.js?v=20260711_tracking_gps_recovery_v1"></script>
+<script src="app.js?v=20260712_job_location_roundtrip_v1"></script>
   <script src="tech-onboarding.js?v=phase2a-fix-restore-onboarding-panel"></script>
   <script>
         function goEditProfile(){ location.href = '/edit-profile.html'; }

--- a/test/adminJobEditPriceStability.test.js
+++ b/test/adminJobEditPriceStability.test.js
@@ -306,7 +306,7 @@ test("post-save verification detects unit_price, qty, line_total, and assignee m
 
 test("HTML loads the shared helper and references the new JS cache version", () => {
   assert.match(html, /admin-job-edit-price-state\.js\?v=20260707_price_state_v2/);
-  assert.match(html, /admin-job-view-v2\.js\?v=20260707_saved_price_stability_review_fix2/);
+  assert.match(html, /admin-job-view-v2\.js\?v=20260712_job_location_roundtrip_v1/);
 });
 
 test("backend helper preserves submitted saved prices when frontend marks the row overridden", () => {

--- a/test/customerBookingAdminNotifications.test.js
+++ b/test/customerBookingAdminNotifications.test.js
@@ -307,7 +307,7 @@ test("admin review new-job notification uses first-load baseline and one sound p
 });
 
 test("admin/customer frontend cache versions are bumped for booking notification changes", () => {
-  assert.match(adminReviewHtml, /admin-review-v2\.js\?v=20260707_customer_booking_notify_v3_xss_guard/);
+  assert.match(adminReviewHtml, /admin-review-v2\.js\?v=20260712_job_location_roundtrip_v1/);
   assert.doesNotMatch(adminReviewHtml, /admin-review-v2\.js\?v=20260707_customer_booking_notify_v2/);
   assert.match(adminReviewHtml, /admin-review-ai-intake\.js\?v=ai-booking-intake-customer-cards-v11-admin-alert-gate/);
   assert.doesNotMatch(adminReviewHtml, /admin-review-ai-intake\.js\?v=ai-booking-intake-customer-cards-v10/);

--- a/test/jobLocationRoundtrip.test.js
+++ b/test/jobLocationRoundtrip.test.js
@@ -1,0 +1,361 @@
+"use strict";
+
+// Job-location round-trip hotfix coverage.
+//
+//   Admin Add → /admin/book_v2 → jobs DB → Admin Job Edit → Technician job API
+//   → Technician Google Maps navigation → GPS check-in site coordinate.
+//
+// The technician navigation functions are the real production functions loaded
+// out of app.js into a vm sandbox (no jsdom) so their actual behavior — never
+// destination=0,0 — is exercised. The DB persistence/preservation contract is
+// exercised against a real local Postgres using the exact column list the
+// production routes use, self-skipping when Postgres is unavailable. The
+// remaining wiring is locked with source contracts.
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const vm = require("node:vm");
+const { Pool } = require("pg");
+
+const REPO_ROOT = path.resolve(__dirname, "..");
+const read = (rel) => fs.readFileSync(path.join(REPO_ROOT, rel), "utf8");
+
+// ---------------------------------------------------------------------------
+// Technician navigation — real app.js functions in a vm sandbox
+// ---------------------------------------------------------------------------
+function sliceBetween(src, startMarker, endMarker) {
+  const a = src.indexOf(startMarker);
+  const b = src.indexOf(endMarker, a + startMarker.length);
+  if (a < 0 || b < 0) throw new Error(`markers not found: ${startMarker} .. ${endMarker}`);
+  return src.slice(a, b);
+}
+
+function loadNav() {
+  const appSrc = read("app.js");
+  const offerSrc = sliceBetween(appSrc, "function offerMapUrl(o) {", "\nfunction openOfferMap");
+  const navSrc = sliceBetween(appSrc, "function _safeOpenUrl(url){", "\nwindow.openMaps = openMaps;");
+  const opened = [];
+  const alerts = [];
+  const sandbox = {
+    console,
+    setTimeout: (fn) => { /* no-op for a.remove() */ return 0; },
+    alert: (m) => { alerts.push(String(m)); },
+    document: {
+      body: { appendChild() {}, },
+      createElement: () => ({ style: {}, click() {}, remove() {}, set href(_v) {}, }),
+    },
+    window: {
+      open: (url) => { opened.push(String(url)); return { opener: null }; },
+      location: { set href(v) { opened.push(String(v)); } },
+    },
+    encodeURIComponent,
+    String, Number, Math, RegExp, Boolean,
+  };
+  vm.createContext(sandbox);
+  vm.runInContext(`${navSrc}\n${offerSrc}\nglobalThis.__nav = { openMaps, offerMapUrl, _hasUsableLatLng };`, sandbox);
+  return { nav: sandbox.__nav, opened, alerts };
+}
+
+test("Test 12: valid GPS opens a coordinate destination (not 0,0)", () => {
+  const { nav, opened } = loadNav();
+  nav.openMaps("13.7460", "100.5340", "อ่อนนุช กทม", "");
+  assert.equal(opened.length, 1);
+  assert.match(opened[0], /destination=13\.746(%2C|,)100\.534/);
+  assert.doesNotMatch(opened[0], /0%2C0|0,0/);
+});
+
+test("Test 8: maps_url present opens the Maps URL directly", () => {
+  const { nav, opened } = loadNav();
+  nav.openMaps("13.7460", "100.5340", "อ่อนนุช", "https://maps.app.goo.gl/abc123");
+  assert.equal(opened.length, 1);
+  assert.match(opened[0], /maps\.app\.goo\.gl\/abc123/);
+});
+
+test("Test 9: null GPS never becomes 0,0 — falls back to address search", () => {
+  const { nav, opened } = loadNav();
+  assert.equal(nav._hasUsableLatLng(null, null), false);
+  nav.openMaps(null, null, "อ่อนนุช สุขุมวิท 77", "");
+  assert.equal(opened.length, 1);
+  assert.match(opened[0], /\/maps\/search\/\?api=1&query=/);
+  assert.doesNotMatch(opened[0], /destination=0|0%2C0|q=0,0/);
+});
+
+test("Test 10: empty-string GPS never becomes 0,0 — falls back to address search", () => {
+  const { nav, opened } = loadNav();
+  assert.equal(nav._hasUsableLatLng("", ""), false);
+  assert.equal(nav._hasUsableLatLng("   ", "  "), false);
+  nav.openMaps("", "", "สุขุมวิท 101", "");
+  assert.equal(opened.length, 1);
+  assert.match(opened[0], /\/maps\/search\/\?api=1&query=/);
+  assert.doesNotMatch(opened[0], /0%2C0|destination=0/);
+});
+
+test("Test 11: the (0,0) pair falls back to the address", () => {
+  const { nav, opened } = loadNav();
+  assert.equal(nav._hasUsableLatLng(0, 0), false);
+  assert.equal(nav._hasUsableLatLng("0", "0"), false);
+  nav.openMaps("0", "0", "บางนา", "");
+  assert.equal(opened.length, 1);
+  assert.match(opened[0], /\/maps\/search\/\?api=1&query=/);
+});
+
+test("no maps_url, no coords, no address → actionable Thai error, opens nothing", () => {
+  const { nav, opened, alerts } = loadNav();
+  nav.openMaps(null, null, "", "");
+  assert.equal(opened.length, 0);
+  assert.equal(alerts.length, 1);
+  assert.match(alerts[0], /นำทาง/);
+});
+
+test("_hasUsableLatLng strictly rejects booleans/arrays/objects/NaN/out-of-range", () => {
+  const { nav } = loadNav();
+  assert.equal(nav._hasUsableLatLng(true, true), false);
+  assert.equal(nav._hasUsableLatLng([], []), false);
+  assert.equal(nav._hasUsableLatLng({}, {}), false);
+  assert.equal(nav._hasUsableLatLng(NaN, NaN), false);
+  assert.equal(nav._hasUsableLatLng(Infinity, 100), false);
+  assert.equal(nav._hasUsableLatLng(200, 100), false); // lat out of range
+  assert.equal(nav._hasUsableLatLng(13.7, 500), false); // lng out of range
+  assert.equal(nav._hasUsableLatLng(13.7, 100.5), true);
+  assert.equal(nav._hasUsableLatLng("13.7", "100.5"), true);
+});
+
+test("offerMapUrl never emits q=0,0 for missing coordinates", () => {
+  const { nav } = loadNav();
+  assert.equal(nav.offerMapUrl({ gps_latitude: null, gps_longitude: null, address_text: "รามคำแหง" }),
+    "https://www.google.com/maps/search/?api=1&query=" + encodeURIComponent("รามคำแหง"));
+  assert.equal(nav.offerMapUrl({ maps_url: "https://maps.app.goo.gl/x" }), "https://maps.app.goo.gl/x");
+  assert.match(nav.offerMapUrl({ gps_latitude: 13.7, gps_longitude: 100.5 }), /maps\?q=13\.7,100\.5/);
+  assert.doesNotMatch(nav.offerMapUrl({ gps_latitude: null, gps_longitude: null }) || "", /0,0/);
+});
+
+// ---------------------------------------------------------------------------
+// Source contracts — the wiring across the pipeline
+// ---------------------------------------------------------------------------
+test("Test 4: admin job edit reads gps_latitude ?? latitude and shows the system zone", () => {
+  const src = read("admin-job-view-v2.js");
+  assert.match(src, /edit_lat"\s+value="\$\{escapeHtml\(safe\(job\.gps_latitude \?\? job\.latitude \?\? ''\)\)\}"/);
+  assert.match(src, /edit_lng"\s+value="\$\{escapeHtml\(safe\(job\.gps_longitude \?\? job\.longitude \?\? ''\)\)\}"/);
+  // system-detected service zone shown separately from the free-text job_zone
+  assert.match(src, /โซนบริการที่ระบบตรวจได้/);
+  assert.match(src, /job\.service_zone_code/);
+  // save sends canonical gps_* keys
+  assert.match(src, /gps_latitude: String\(el\('edit_lat'\)\?\.value\|\|''\)\.trim\(\)/);
+  assert.match(src, /gps_longitude: String\(el\('edit_lng'\)\?\.value\|\|''\)\.trim\(\)/);
+});
+
+test("Test 1: admin add payload carries maps_url/job_zone/service_zone/gps", () => {
+  const src = read("admin-add-v2.js");
+  assert.match(src, /maps_url: \(el\("maps_url"\)\.value \|\| ""\)\.trim\(\)/);
+  assert.match(src, /job_zone: \(el\("job_zone"\)\.value \|\| ""\)\.trim\(\)/);
+  assert.match(src, /service_zone_code:/);
+  assert.match(src, /service_zone_source:/);
+  assert.match(src, /gps_latitude: \(el\("gps_latitude"\)\?\.value \|\| ""\)\.trim\(\) \|\| null/);
+  assert.match(src, /gps_longitude: \(el\("gps_longitude"\)\?\.value \|\| ""\)\.trim\(\) \|\| null/);
+});
+
+test("admin add post-save verifies location + shows the location Thai warning", () => {
+  const src = read("admin-add-v2.js");
+  assert.match(src, /checkText\('address_text'\)/);
+  assert.match(src, /checkText\('maps_url'\)/);
+  assert.match(src, /checkText\('job_zone'\)/);
+  assert.match(src, /locationIncomplete: true/);
+  assert.match(src, /บันทึกงานแล้ว แต่ข้อมูลสถานที่ไม่ครบ กรุณาตรวจสอบใบงานก่อนส่งให้ช่าง/);
+});
+
+test("Test 6: admin review modal fetches the full job and prefers stored coords", () => {
+  const src = read("admin-review-v2.js");
+  assert.match(src, /apiFetch\(`\/admin\/job_v2\/\$\{encodeURIComponent\(row\.job_id\)\}`\)/);
+  assert.match(src, /gps_latitude: full\.gps_latitude/);
+  assert.match(src, /gps_longitude: full\.gps_longitude/);
+  // stored coords win over parsing from the address
+  assert.match(src, /const stored = strictStoredLatLng\(CURRENT\.gps_latitude, CURRENT\.gps_longitude\)/);
+  assert.match(src, /function strictStoredLatLng/);
+});
+
+test("Test 7: technician job API returns maps_url/gps/address", () => {
+  const src = read("index.js");
+  assert.match(src, /j\.gps_latitude, j\.gps_longitude/);
+  assert.match(src, /j\.maps_url, j\.job_zone/);
+  assert.match(src, /j\.address_text/);
+});
+
+test("Test 5/E: book_v2 accepts explicit gps first; admin-edit preserves via COALESCE", () => {
+  const src = read("index.js");
+  // strict helpers
+  assert.match(src, /function strictLatLngPairOrNull\(latRaw, lngRaw\)/);
+  assert.match(src, /if \(lat === 0 && lng === 0\) return null;/);
+  // resolution order: explicit gps first
+  assert.match(src, /const explicitAdminLL = strictLatLngPairOrNull\(body\.gps_latitude, body\.gps_longitude\)/);
+  assert.match(src, /let final_lat = explicitAdminLL \? explicitAdminLL\.lat/);
+  // admin-edit uses the strict pair and preserves with COALESCE/NULLIF
+  assert.match(src, /const editGpsPair = strictLatLngPairOrNull\(/);
+  assert.match(src, /gps_latitude = COALESCE\(\$9, gps_latitude\)/);
+  assert.match(src, /maps_url = COALESCE\(NULLIF\(\$7, ''\), maps_url\)/);
+  assert.match(src, /job_zone = COALESCE\(NULLIF\(\$8, ''\), job_zone\)/);
+});
+
+test("Test 14: check-in 500 m + accuracy policy is unchanged", () => {
+  const src = read("index.js");
+  assert.match(src, /const MAX_CHECKIN_ACCURACY_M = 200/);
+  assert.match(src, /distance > 500/);
+  assert.match(src, /\(distance - accuracy\) <= 500/);
+});
+
+test("Test 15: PWA + admin cache build IDs are bumped consistently", () => {
+  const BUILD = "20260712_job_location_roundtrip_v1";
+  assert.match(read("app.js"), new RegExp(`__CWF_TECH_APP_VERSION__ = "${BUILD}"`));
+  assert.match(read("sw.js"), new RegExp(`CWF_TECH_BUILD_ID = "${BUILD}"`));
+  assert.match(read("cwf-pwa.js"), new RegExp(`VERSION = '${BUILD}'`));
+  assert.match(read("tech.html"), new RegExp(`app\\.js\\?v=${BUILD}`));
+  assert.match(read("admin-add-v2.html"), new RegExp(`admin-add-v2\\.js\\?v=${BUILD}`));
+  assert.match(read("admin-job-view-v2.html"), new RegExp(`admin-job-view-v2\\.js\\?v=${BUILD}`));
+  assert.match(read("admin-review-v2.html"), new RegExp(`admin-review-v2\\.js\\?v=${BUILD}`));
+});
+
+// ---------------------------------------------------------------------------
+// DB round-trip (real Postgres) — persistence + preservation contract.
+// Mirrors the exact production column list used by /admin/book_v2 INSERT and
+// PUT /jobs/:job_id/admin-edit UPDATE. Self-skips when Postgres is unavailable.
+// ---------------------------------------------------------------------------
+const PG_CONFIG = {
+  host: process.env.PGHOST || "127.0.0.1",
+  port: Number(process.env.PGPORT || 5432),
+  user: process.env.PGUSER || "postgres",
+  password: process.env.PGPASSWORD || "postgres",
+  database: process.env.PGDATABASE || "cwf_test",
+};
+
+let pool = null;
+let dbDown = "";
+
+test.before(async () => {
+  pool = new Pool(PG_CONFIG);
+  try {
+    await pool.query("SELECT 1");
+    await pool.query(`
+      CREATE TABLE IF NOT EXISTS public.job_location_roundtrip_probe (
+        job_id BIGSERIAL PRIMARY KEY,
+        address_text TEXT,
+        maps_url TEXT,
+        job_zone TEXT,
+        gps_latitude DOUBLE PRECISION,
+        gps_longitude DOUBLE PRECISION,
+        service_zone_code TEXT,
+        service_zone_source TEXT
+      )
+    `);
+    await pool.query("TRUNCATE public.job_location_roundtrip_probe RESTART IDENTITY");
+  } catch (e) {
+    dbDown = e.message || "postgres unavailable";
+    if (pool) await pool.end().catch(() => {});
+    pool = null;
+  }
+});
+
+test.after(async () => {
+  if (pool) {
+    await pool.query("DROP TABLE IF EXISTS public.job_location_roundtrip_probe").catch(() => {});
+    await pool.end().catch(() => {});
+  }
+});
+
+async function insertProbe(vals) {
+  const r = await pool.query(
+    `INSERT INTO public.job_location_roundtrip_probe
+       (address_text, maps_url, job_zone, gps_latitude, gps_longitude, service_zone_code, service_zone_source)
+     VALUES ($1,$2,$3,$4,$5,$6,$7) RETURNING job_id`,
+    [vals.address_text, vals.maps_url, vals.job_zone, vals.gps_latitude, vals.gps_longitude, vals.service_zone_code, vals.service_zone_source]
+  );
+  return r.rows[0].job_id;
+}
+
+// The exact admin-edit UPDATE preservation shape (COALESCE + NULLIF for text).
+async function adminEditProbe(jobId, p) {
+  await pool.query(
+    `UPDATE public.job_location_roundtrip_probe
+        SET address_text = COALESCE($1, address_text),
+            maps_url     = COALESCE(NULLIF($2,''), maps_url),
+            job_zone     = COALESCE(NULLIF($3,''), job_zone),
+            gps_latitude = COALESCE($4, gps_latitude),
+            gps_longitude= COALESCE($5, gps_longitude)
+      WHERE job_id=$6`,
+    [p.address_text ?? null, p.maps_url ?? null, p.job_zone ?? null, p.gpsLat, p.gpsLng, jobId]
+  );
+}
+
+test("Tests 2+3: DB stores exact location values and they read back exactly", async (t) => {
+  if (dbDown) { t.skip(`postgres unavailable: ${dbDown}`); return; }
+  const jobId = await insertProbe({
+    address_text: "99/1 อ่อนนุช 17 กทม",
+    maps_url: "https://maps.app.goo.gl/roundtripABC",
+    job_zone: "อ่อนนุช",
+    gps_latitude: 13.71234,
+    gps_longitude: 100.61234,
+    service_zone_code: "C",
+    service_zone_source: "admin_override",
+  });
+  const { rows } = await pool.query("SELECT * FROM public.job_location_roundtrip_probe WHERE job_id=$1", [jobId]);
+  const j = rows[0];
+  assert.equal(j.address_text, "99/1 อ่อนนุช 17 กทม");
+  assert.equal(j.maps_url, "https://maps.app.goo.gl/roundtripABC");
+  assert.equal(j.job_zone, "อ่อนนุช");
+  assert.equal(Number(j.gps_latitude), 13.71234);
+  assert.equal(Number(j.gps_longitude), 100.61234);
+  assert.equal(j.service_zone_code, "C");
+});
+
+test("Test 5: saving with omitted/empty location fields preserves them (never erased or 0,0)", async (t) => {
+  if (dbDown) { t.skip(`postgres unavailable: ${dbDown}`); return; }
+  const jobId = await insertProbe({
+    address_text: "12 สุขุมวิท 101",
+    maps_url: "https://maps.app.goo.gl/keepme",
+    job_zone: "ปุณณวิถี",
+    gps_latitude: 13.68,
+    gps_longitude: 100.60,
+    service_zone_code: "C",
+    service_zone_source: "auto_detect",
+  });
+  // Admin edits only the customer note-equivalent: location omitted (null) / empty.
+  // gpsLat/gpsLng resolve to null for empty input in production (strict pair) → preserve.
+  await adminEditProbe(jobId, { address_text: null, maps_url: "", job_zone: "", gpsLat: null, gpsLng: null });
+  const { rows } = await pool.query("SELECT * FROM public.job_location_roundtrip_probe WHERE job_id=$1", [jobId]);
+  const j = rows[0];
+  assert.equal(j.maps_url, "https://maps.app.goo.gl/keepme", "maps_url preserved");
+  assert.equal(j.job_zone, "ปุณณวิถี", "job_zone preserved");
+  assert.equal(Number(j.gps_latitude), 13.68, "lat preserved, not turned into 0");
+  assert.equal(Number(j.gps_longitude), 100.60, "lng preserved, not turned into 0");
+  assert.notEqual(Number(j.gps_latitude), 0);
+});
+
+test("Test 13: short Maps URL is preserved even when no coordinates resolve", async (t) => {
+  if (dbDown) { t.skip(`postgres unavailable: ${dbDown}`); return; }
+  // Production stores maps_url regardless of coordinate resolution; a short link
+  // with no parseable coords keeps final_lat/lng null but the URL is saved.
+  const jobId = await insertProbe({
+    address_text: "ไม่มีพิกัด",
+    maps_url: "https://maps.app.goo.gl/shortNoCoords",
+    job_zone: "",
+    gps_latitude: null,
+    gps_longitude: null,
+    service_zone_code: null,
+    service_zone_source: null,
+  });
+  const { rows } = await pool.query("SELECT * FROM public.job_location_roundtrip_probe WHERE job_id=$1", [jobId]);
+  assert.equal(rows[0].maps_url, "https://maps.app.goo.gl/shortNoCoords");
+  assert.equal(rows[0].gps_latitude, null);
+});
+
+test("edit updates coordinates when a valid new pair is supplied", async (t) => {
+  if (dbDown) { t.skip(`postgres unavailable: ${dbDown}`); return; }
+  const jobId = await insertProbe({
+    address_text: "a", maps_url: "", job_zone: "", gps_latitude: 13.1, gps_longitude: 100.1,
+    service_zone_code: null, service_zone_source: null,
+  });
+  await adminEditProbe(jobId, { address_text: null, maps_url: "", job_zone: "", gpsLat: 13.99, gpsLng: 100.99 });
+  const { rows } = await pool.query("SELECT * FROM public.job_location_roundtrip_probe WHERE job_id=$1", [jobId]);
+  assert.equal(Number(rows[0].gps_latitude), 13.99);
+  assert.equal(Number(rows[0].gps_longitude), 100.99);
+});

--- a/test/jobLocationRoundtrip.test.js
+++ b/test/jobLocationRoundtrip.test.js
@@ -182,21 +182,28 @@ test("Test 7: technician job API returns maps_url/gps/address", () => {
   assert.match(src, /j\.address_text/);
 });
 
-test("Test 5/E: book_v2 accepts explicit gps first; admin-edit preserves via COALESCE", () => {
+test("Test 5/E: book_v2 + admin-edit strictly validate/resolve every coordinate source", () => {
   const src = read("index.js");
   // strict helpers
   assert.match(src, /function strictLatLngPairOrNull\(latRaw, lngRaw\)/);
   assert.match(src, /if \(lat === 0 && lng === 0\) return null;/);
-  // resolution order: explicit gps first
+  // book_v2: explicit gps first, and EVERY derived pair (parsed + resolved) is
+  // passed through the strict validator (Blocker 4).
   assert.match(src, /const explicitAdminLL = strictLatLngPairOrNull\(body\.gps_latitude, body\.gps_longitude\)/);
-  assert.match(src, /let final_lat = explicitAdminLL \? explicitAdminLL\.lat/);
-  // admin-edit validates a strict pair, rejects partial/invalid, and forces a
-  // deliberate write (CASE) so it can clear to NULL rather than COALESCE-preserve.
+  assert.match(src, /derivedAdminLL = p \? strictLatLngPairOrNull\(p\.lat, p\.lng\) : null/);
+  assert.match(src, /derivedAdminLL = strictLatLngPairOrNull\(rr\.lat, rr\.lng\)/);
+  // admin-edit: strict pair, 400 on partial/invalid, and force-CASE writes so it
+  // can deliberately clear maps_url / gps / service_zone to NULL.
   assert.match(src, /editGpsPair = strictLatLngPairOrNull\(latRaw, lngRaw\)/);
   assert.match(src, /code: 'INVALID_JOB_SITE_COORDINATES'/);
-  assert.match(src, /gps_latitude = CASE WHEN \$9 THEN \$10 ELSE gps_latitude END/);
-  assert.match(src, /maps_url = COALESCE\(NULLIF\(\$7, ''\), maps_url\)/);
-  assert.match(src, /job_zone = COALESCE\(NULLIF\(\$8, ''\), job_zone\)/);
+  assert.match(src, /maps_url = CASE WHEN \$7 THEN \$8 ELSE maps_url END/);
+  assert.match(src, /gps_latitude = CASE WHEN \$10 THEN \$11 ELSE gps_latitude END/);
+  assert.match(src, /service_zone_code = CASE WHEN \$13 THEN \$14 ELSE service_zone_code END/);
+  // derived coords in admin-edit also go through the strict validator.
+  assert.match(src, /pair = p \? strictLatLngPairOrNull\(p\.lat, p\.lng\) : null/);
+  assert.match(src, /pair = strictLatLngPairOrNull\(rr\.lat, rr\.lng\)/);
+  // zone recompute on location change.
+  assert.match(src, /zoneDetected = await detectServiceZoneFromText\(/);
 });
 
 test("Test 14: check-in 500 m + accuracy policy is unchanged", () => {

--- a/test/jobLocationRoundtrip.test.js
+++ b/test/jobLocationRoundtrip.test.js
@@ -141,9 +141,9 @@ test("Test 4: admin job edit reads gps_latitude ?? latitude and shows the system
   // system-detected service zone shown separately from the free-text job_zone
   assert.match(src, /โซนบริการที่ระบบตรวจได้/);
   assert.match(src, /job\.service_zone_code/);
-  // save sends canonical gps_* keys
-  assert.match(src, /gps_latitude: String\(el\('edit_lat'\)\?\.value\|\|''\)\.trim\(\)/);
-  assert.match(src, /gps_longitude: String\(el\('edit_lng'\)\?\.value\|\|''\)\.trim\(\)/);
+  // save sends canonical gps_* keys via the drop-stale-GPS decision
+  assert.match(src, /gps_latitude: dropStaleGps \? '' : latNow/);
+  assert.match(src, /gps_longitude: dropStaleGps \? '' : lngNow/);
 });
 
 test("Test 1: admin add payload carries maps_url/job_zone/service_zone/gps", () => {
@@ -190,9 +190,11 @@ test("Test 5/E: book_v2 accepts explicit gps first; admin-edit preserves via COA
   // resolution order: explicit gps first
   assert.match(src, /const explicitAdminLL = strictLatLngPairOrNull\(body\.gps_latitude, body\.gps_longitude\)/);
   assert.match(src, /let final_lat = explicitAdminLL \? explicitAdminLL\.lat/);
-  // admin-edit uses the strict pair and preserves with COALESCE/NULLIF
-  assert.match(src, /const editGpsPair = strictLatLngPairOrNull\(/);
-  assert.match(src, /gps_latitude = COALESCE\(\$9, gps_latitude\)/);
+  // admin-edit validates a strict pair, rejects partial/invalid, and forces a
+  // deliberate write (CASE) so it can clear to NULL rather than COALESCE-preserve.
+  assert.match(src, /editGpsPair = strictLatLngPairOrNull\(latRaw, lngRaw\)/);
+  assert.match(src, /code: 'INVALID_JOB_SITE_COORDINATES'/);
+  assert.match(src, /gps_latitude = CASE WHEN \$9 THEN \$10 ELSE gps_latitude END/);
   assert.match(src, /maps_url = COALESCE\(NULLIF\(\$7, ''\), maps_url\)/);
   assert.match(src, /job_zone = COALESCE\(NULLIF\(\$8, ''\), job_zone\)/);
 });
@@ -358,4 +360,74 @@ test("edit updates coordinates when a valid new pair is supplied", async (t) => 
   const { rows } = await pool.query("SELECT * FROM public.job_location_roundtrip_probe WHERE job_id=$1", [jobId]);
   assert.equal(Number(rows[0].gps_latitude), 13.99);
   assert.equal(Number(rows[0].gps_longitude), 100.99);
+});
+
+// ---------------------------------------------------------------------------
+// Round-2 frontend blockers: modal field clearing + drop-stale-GPS decision
+// ---------------------------------------------------------------------------
+
+// Extract and execute the REAL admin-job-view save decision that chooses whether
+// to resubmit the pin or drop it so the backend recalculates. Load-bearing: if
+// the old (valid) pair were resubmitted with a changed map, the backend's
+// "valid explicit pair → update" branch would keep the stale coordinates.
+function loadJobViewGpsDecision() {
+  const src = read("admin-job-view-v2.js");
+  const start = src.indexOf("...(function(){");
+  const end = src.indexOf("})(),", start);
+  const body = src.slice(src.indexOf("{", start) + 1, src.lastIndexOf("return", end));
+  const retSrc = src.slice(src.indexOf("return", start), end);
+  // eslint-disable-next-line no-new-func
+  const fn = new Function("el", "job", `${body}\n${retSrc}`);
+  return (fields, job) => fn((id) => ({ value: fields[id] ?? "" }), job);
+}
+
+test("Blocker 2 FE (job view): changed map without a manual pin edit drops the stale GPS", () => {
+  const decide = loadJobViewGpsDecision();
+  const job = { maps_url: "https://maps.google.com/?q=13.1,100.1", address_text: "A", gps_latitude: 13.1, gps_longitude: 100.1 };
+  // Admin changed the maps URL but did NOT touch Lat/Lng (still the loaded pin).
+  const out = decide({
+    edit_maps_url: "https://maps.google.com/?q=14.5,101.5", edit_address: "A",
+    edit_lat: "13.1", edit_lng: "100.1",
+  }, job);
+  assert.equal(out.gps_latitude, "", "stale lat dropped so backend recalculates");
+  assert.equal(out.gps_longitude, "");
+});
+
+test("Blocker 2 FE (job view): a manual pin edit is submitted as-is", () => {
+  const decide = loadJobViewGpsDecision();
+  const job = { maps_url: "m", address_text: "A", gps_latitude: 13.1, gps_longitude: 100.1 };
+  const out = decide({ edit_maps_url: "m2", edit_address: "A", edit_lat: "15.2", edit_lng: "102.3" }, job);
+  assert.equal(out.gps_latitude, "15.2");
+  assert.equal(out.gps_longitude, "102.3");
+});
+
+test("Blocker 2 FE (job view): no location change resubmits the existing pin", () => {
+  const decide = loadJobViewGpsDecision();
+  const job = { maps_url: "m", address_text: "A", gps_latitude: 13.1, gps_longitude: 100.1 };
+  const out = decide({ edit_maps_url: "m", edit_address: "A", edit_lat: "13.1", edit_lng: "100.1" }, job);
+  assert.equal(out.gps_latitude, "13.1");
+  assert.equal(out.gps_longitude, "100.1");
+});
+
+test("Blocker 1 (review modal): location fields are cleared before populating", () => {
+  const src = read("admin-review-v2.js");
+  // Every location field is blanked before the conditional population, so a
+  // previously opened job's Lat/Lng cannot leak into the next one.
+  const clearIdx = src.indexOf('$("mLat").value = "";');
+  const popIdx = src.indexOf("const stored = strictStoredLatLng(CURRENT.gps_latitude");
+  assert.ok(clearIdx > 0 && popIdx > clearIdx, "mLat/mLng cleared before population");
+  assert.match(src, /\$\("mLng"\)\.value = "";/);
+  // A failed full-detail load warns instead of leaving stale values.
+  assert.match(src, /detailLoadFailed/);
+  assert.match(src, /โหลดรายละเอียดงานเต็มไม่สำเร็จ/);
+  // Save drops the stale pin when the map/address changed but the pin was not edited.
+  assert.match(src, /const dropStaleGps = locationTextChanged && !coordsManuallyEdited/);
+  assert.match(src, /gps_latitude: dropStaleGps \? "" : \(latNow \|\| null\)/);
+});
+
+test("Blocker 3 FE (admin add): incomplete/invalid GPS pair is blocked before submit", () => {
+  const src = read("admin-add-v2.js");
+  assert.match(src, /const validPair = latRaw && lngRaw/);
+  assert.match(src, /!\(la === 0 && ln === 0\)/);
+  assert.match(src, /พิกัดหน้างานไม่ถูกต้อง/);
 });

--- a/test/jobLocationRoute.integration.test.js
+++ b/test/jobLocationRoute.integration.test.js
@@ -369,3 +369,80 @@ test("Proofs 1+2: /admin/book_v2 persists explicit GPS and never stores 0,0 for 
   // No coordinates supplied and no parseable maps/address → NULL, never 0,0.
   assert.ok(!(Number(rowB.gps_latitude) === 0 && Number(rowB.gps_longitude) === 0), "missing GPS must not persist as 0,0");
 });
+
+// ---- Round-3 location-consistency proofs (real routes) --------------------
+
+test("R3-B1: explicitly clearing maps_url writes NULL and keeps the valid GPS", async (t) => {
+  if (dbUnavailable) { t.skip(dbUnavailable); return; }
+  const jobId = await seedJob({ address_text: "A", maps_url: "https://maps.app.goo.gl/keepGps", gps_latitude: 13.4, gps_longitude: 100.4 });
+  const { status, json } = await putEdit(jobId, { maps_url: "" });
+  assert.equal(status, 200);
+  assert.equal(json.maps_action, "cleared");
+  const row = await withDb((db) => db.query("SELECT * FROM public.jobs WHERE job_id=$1", [jobId]).then((r) => r.rows[0]));
+  assert.equal(row.maps_url, null, "maps_url cleared to NULL");
+  // Clearing the URL alone must NOT wipe the pin — nav falls back to it.
+  assert.equal(Number(row.gps_latitude), 13.4, "valid GPS retained for navigation fallback");
+  assert.equal(Number(row.gps_longitude), 100.4);
+});
+
+test("R3-B2: changing only the address clears the stale Maps URL (never keeps location A's URL)", async (t) => {
+  if (dbUnavailable) { t.skip(dbUnavailable); return; }
+  const jobId = await seedJob({ address_text: "loc A", maps_url: "https://maps.google.com/?q=13.1,100.1", gps_latitude: 13.1, gps_longitude: 100.1 });
+  // Admin changes the address only (Maps URL omitted / left as the old value).
+  const { status, json } = await putEdit(jobId, { address_text: "loc B ที่อยู่ใหม่" });
+  assert.equal(status, 200);
+  assert.equal(json.maps_action, "cleared");
+  const row = await withDb((db) => db.query("SELECT * FROM public.jobs WHERE job_id=$1", [jobId]).then((r) => r.rows[0]));
+  assert.equal(row.maps_url, null, "old Maps URL A cleared");
+  // Address B has no parseable coordinates → GPS cleared (never keeps A).
+  assert.ok(row.gps_latitude === null || Math.abs(Number(row.gps_latitude) - 13.1) > 1e-6, "GPS is not location A");
+});
+
+test("R3-B2b: address change while re-sending the OLD Maps URL still clears it", async (t) => {
+  if (dbUnavailable) { t.skip(dbUnavailable); return; }
+  const oldUrl = "https://maps.google.com/?q=13.1,100.1";
+  const jobId = await seedJob({ address_text: "loc A", maps_url: oldUrl, gps_latitude: 13.1, gps_longitude: 100.1 });
+  const { status } = await putEdit(jobId, { address_text: "loc B", maps_url: oldUrl });
+  assert.equal(status, 200);
+  const row = await withDb((db) => db.query("SELECT * FROM public.jobs WHERE job_id=$1", [jobId]).then((r) => r.rows[0]));
+  assert.equal(row.maps_url, null, "old URL not retained when address changed without a real replacement");
+});
+
+test("R3-B3: a location change recomputes the system service zone (old zone A not retained)", async (t) => {
+  if (dbUnavailable) { t.skip(dbUnavailable); return; }
+  const jobId = await seedJob({
+    address_text: "loc A", maps_url: "https://maps.google.com/?q=13.1,100.1",
+    gps_latitude: 13.1, gps_longitude: 100.1, service_zone_code: "ZONE_A", service_zone_source: "admin_override",
+  });
+  const { status } = await putEdit(jobId, { maps_url: "https://maps.google.com/?q=15.5,101.5" });
+  assert.equal(status, 200);
+  const row = await withDb((db) => db.query("SELECT * FROM public.jobs WHERE job_id=$1", [jobId]).then((r) => r.rows[0]));
+  assert.notEqual(row.service_zone_code, "ZONE_A", "old system zone must not be retained after a location change");
+});
+
+test("R3-B4: derived coordinates that resolve to 0,0 or out-of-range are rejected (not persisted)", async (t) => {
+  if (dbUnavailable) { t.skip(dbUnavailable); return; }
+  // maps_url parses to 0,0 → strict validator rejects → GPS cleared, never 0,0.
+  const jobZero = await seedJob({ address_text: "x", maps_url: "https://maps.google.com/?q=13.2,100.2", gps_latitude: 13.2, gps_longitude: 100.2 });
+  await putEdit(jobZero, { maps_url: "https://maps.google.com/?q=0.000000,0.000000" });
+  const rZero = await withDb((db) => db.query("SELECT * FROM public.jobs WHERE job_id=$1", [jobZero]).then((r) => r.rows[0]));
+  // NULL (not the number 0) — a 0,0 derived pair must be rejected, never stored.
+  assert.equal(rZero.gps_latitude, null, "0,0 derived pair not persisted");
+  assert.equal(rZero.gps_longitude, null);
+
+  // maps_url parses to an out-of-range latitude → rejected → cleared.
+  const jobOor = await seedJob({ address_text: "x", maps_url: "https://maps.google.com/?q=13.2,100.2", gps_latitude: 13.2, gps_longitude: 100.2 });
+  await putEdit(jobOor, { maps_url: "https://maps.google.com/?q=200.000000,100.500000" });
+  const rOor = await withDb((db) => db.query("SELECT * FROM public.jobs WHERE job_id=$1", [jobOor]).then((r) => r.rows[0]));
+  assert.equal(rOor.gps_latitude, null, "out-of-range derived pair not persisted");
+});
+
+test("R3-B4b: a valid derived pair from the new Maps URL is persisted", async (t) => {
+  if (dbUnavailable) { t.skip(dbUnavailable); return; }
+  const jobId = await seedJob({ address_text: "x", maps_url: "https://maps.google.com/?q=13.2,100.2", gps_latitude: 13.2, gps_longitude: 100.2 });
+  const { json } = await putEdit(jobId, { maps_url: "https://maps.google.com/?q=15.500000,101.500000" });
+  assert.equal(json.gps_action, "recalculated");
+  const row = await withDb((db) => db.query("SELECT * FROM public.jobs WHERE job_id=$1", [jobId]).then((r) => r.rows[0]));
+  assert.ok(Math.abs(Number(row.gps_latitude) - 15.5) < 1e-6);
+  assert.ok(Math.abs(Number(row.gps_longitude) - 101.5) < 1e-6);
+});

--- a/test/jobLocationRoute.integration.test.js
+++ b/test/jobLocationRoute.integration.test.js
@@ -83,6 +83,23 @@ async function buildSchema(adminless) {
     const idx = src.match(/CREATE (?:UNIQUE )?INDEX IF NOT EXISTS [^`;]+/g) || [];
     for (const i of idx) { if (!i.includes("${")) { try { await db.query(i); } catch (_) {} } }
   }
+  // Belt-and-suspenders columns the /admin/book_v2 write path needs but that the
+  // core schema / regex-extracted ALTERs may not add (production self-heals these
+  // at boot via template-string ALTERs the extractor skips).
+  const ensure = [
+    `ALTER TABLE public.job_team_members ADD COLUMN IF NOT EXISTS is_primary BOOLEAN DEFAULT FALSE`,
+    `ALTER TABLE public.job_team_members ADD COLUMN IF NOT EXISTS added_at TIMESTAMPTZ DEFAULT NOW()`,
+    `ALTER TABLE public.job_assignments ADD COLUMN IF NOT EXISTS status TEXT`,
+    `ALTER TABLE public.jobs ADD COLUMN IF NOT EXISTS per_unit_evidence_enabled BOOLEAN DEFAULT FALSE`,
+    `ALTER TABLE public.job_items ADD COLUMN IF NOT EXISTS assigned_technician_username TEXT`,
+    `ALTER TABLE public.job_items ADD COLUMN IF NOT EXISTS is_service BOOLEAN DEFAULT TRUE`,
+    `ALTER TABLE public.job_items ADD COLUMN IF NOT EXISTS customer_price_rule_id BIGINT`,
+    `ALTER TABLE public.job_items ADD COLUMN IF NOT EXISTS normal_unit_price NUMERIC`,
+    `ALTER TABLE public.job_items ADD COLUMN IF NOT EXISTS customer_price_label TEXT`,
+    `ALTER TABLE public.job_items ADD COLUMN IF NOT EXISTS customer_campaign_name TEXT`,
+    `ALTER TABLE public.job_items ADD COLUMN IF NOT EXISTS customer_price_source TEXT`,
+  ];
+  for (const s of ensure) { try { await db.query(s); } catch (_) {} }
   await db.end();
 }
 
@@ -333,42 +350,9 @@ test("valid explicit pair updates the coordinates (real route)", async (t) => {
   assert.ok(Math.abs(Number(row.gps_longitude) - 100.999999) < 1e-6);
 });
 
-test("Proofs 1+2: /admin/book_v2 persists explicit GPS and never stores 0,0 for missing GPS", async (t) => {
-  if (dbUnavailable) { t.skip(dbUnavailable); return; }
-  const base = {
-    customer_name: "ลูกค้าทดสอบ", customer_phone: "0800000001",
-    job_type: "ล้าง", ac_type: "ผนัง", btu: 12000, machine_count: 1, wash_variant: "ล้างธรรมดา",
-    appointment_datetime: new Date(Date.now() + 2 * 86400000).toISOString().slice(0, 19),
-    address_text: "123 สุขุมวิท", maps_url: "", job_zone: "พระโขนง",
-    booking_mode: "scheduled", tech_type: "company",
-    // Forced single assignment to a seeded technician avoids the auto-availability
-    // search (which needs a full calendar/zone stack) so the route is exercisable.
-    assign_mode: "single", dispatch_mode: "forced", technician_username: "e2e_tech",
-    services: [{ job_type: "ล้าง", ac_type: "ผนัง", btu: 12000, machine_count: 1, wash_variant: "ล้างธรรมดา" }],
-  };
-  const withGps = await fetch(`${BASE}/admin/book_v2`, {
-    method: "POST", headers: adminHeaders,
-    body: JSON.stringify({ ...base, gps_latitude: "13.744000", gps_longitude: "100.534000" }),
-  });
-  const wj = await withGps.json().catch(() => ({}));
-  if (!withGps.ok || !wj.job_id) {
-    t.skip(`book_v2 not exercisable in this schema (status ${withGps.status}: ${wj.error || "no job_id"})`);
-    return;
-  }
-  const rowA = await withDb((db) => db.query("SELECT * FROM public.jobs WHERE job_id=$1", [wj.job_id]).then((r) => r.rows[0]));
-  assert.ok(Math.abs(Number(rowA.gps_latitude) - 13.744) < 1e-6, "explicit GPS persisted");
-  assert.ok(Math.abs(Number(rowA.gps_longitude) - 100.534) < 1e-6);
-
-  const noGps = await fetch(`${BASE}/admin/book_v2`, {
-    method: "POST", headers: adminHeaders,
-    body: JSON.stringify({ ...base, customer_phone: "0800000002" }),
-  });
-  const nj = await noGps.json().catch(() => ({}));
-  assert.ok(noGps.ok && nj.job_id, `second booking should succeed: ${nj.error || ""}`);
-  const rowB = await withDb((db) => db.query("SELECT * FROM public.jobs WHERE job_id=$1", [nj.job_id]).then((r) => r.rows[0]));
-  // No coordinates supplied and no parseable maps/address → NULL, never 0,0.
-  assert.ok(!(Number(rowB.gps_latitude) === 0 && Number(rowB.gps_longitude) === 0), "missing GPS must not persist as 0,0");
-});
+// (book_v2 add-path "explicit GPS persists / missing GPS never 0,0" is proven by
+// the canonical real-route test "R4-B3b" below, which staggers appointment times
+// to avoid technician collisions.)
 
 // ---- Round-3 location-consistency proofs (real routes) --------------------
 
@@ -445,4 +429,116 @@ test("R3-B4b: a valid derived pair from the new Maps URL is persisted", async (t
   const row = await withDb((db) => db.query("SELECT * FROM public.jobs WHERE job_id=$1", [jobId]).then((r) => r.rows[0]));
   assert.ok(Math.abs(Number(row.gps_latitude) - 15.5) < 1e-6);
   assert.ok(Math.abs(Number(row.gps_longitude) - 101.5) < 1e-6);
+});
+
+// ---- Round-4 location-source consistency proofs (real routes) -------------
+
+test("R4-B1: an explicit GPS edit clears the stale Maps URL (no URL A + GPS B)", async (t) => {
+  if (dbUnavailable) { t.skip(dbUnavailable); return; }
+  const jobId = await seedJob({ address_text: "A", maps_url: "https://maps.google.com/?q=13.1,100.1", gps_latitude: 13.1, gps_longitude: 100.1 });
+  // Admin supplies ONLY a new explicit pin (no Maps URL).
+  const { status, json } = await putEdit(jobId, { gps_latitude: "14.500000", gps_longitude: "101.500000" });
+  assert.equal(status, 200);
+  assert.equal(json.gps_action, "updated");
+  assert.equal(json.maps_action, "cleared");
+  const row = await withDb((db) => db.query("SELECT * FROM public.jobs WHERE job_id=$1", [jobId]).then((r) => r.rows[0]));
+  assert.ok(Math.abs(Number(row.gps_latitude) - 14.5) < 1e-6, "GPS becomes B");
+  assert.equal(row.maps_url, null, "stale Maps URL A cleared — nav now uses GPS B");
+});
+
+test("R4-B1b: explicit GPS + a new Maps URL in the same request keeps both", async (t) => {
+  if (dbUnavailable) { t.skip(dbUnavailable); return; }
+  const jobId = await seedJob({ address_text: "A", maps_url: "https://maps.google.com/?q=13.1,100.1", gps_latitude: 13.1, gps_longitude: 100.1 });
+  const newUrl = "https://maps.google.com/?q=16.200000,102.200000";
+  const { status } = await putEdit(jobId, { maps_url: newUrl, gps_latitude: "16.200000", gps_longitude: "102.200000" });
+  assert.equal(status, 200);
+  const row = await withDb((db) => db.query("SELECT * FROM public.jobs WHERE job_id=$1", [jobId]).then((r) => r.rows[0]));
+  assert.equal(row.maps_url, newUrl, "supplied new Maps URL kept");
+  assert.ok(Math.abs(Number(row.gps_latitude) - 16.2) < 1e-6, "supplied new GPS kept");
+});
+
+test("R4-B2: a new (unresolvable) Maps URL never falls back to the unchanged old address", async (t) => {
+  if (dbUnavailable) { t.skip(dbUnavailable); return; }
+  // Old address parses to 13.5,100.5; old maps/pin is 13.1,100.1.
+  const jobId = await seedJob({
+    address_text: "@13.500000,100.500000", maps_url: "https://maps.google.com/?q=13.1,100.1",
+    gps_latitude: 13.1, gps_longitude: 100.1, service_zone_code: "ZONE_A", service_zone_source: "admin_override",
+  });
+  // Change ONLY the Maps URL to an unresolvable one (address unchanged).
+  const { status, json } = await putEdit(jobId, { maps_url: "https://example.com/unresolvable-B" });
+  assert.equal(status, 200);
+  assert.equal(json.gps_action, "cleared");
+  const row = await withDb((db) => db.query("SELECT * FROM public.jobs WHERE job_id=$1", [jobId]).then((r) => r.rows[0]));
+  assert.equal(row.gps_latitude, null, "GPS must be NULL — never the old address's 13.5 or the old pin's 13.1");
+  assert.notEqual(row.service_zone_code, "ZONE_A", "old zone A must not remain");
+});
+
+test("R4-B2b: an address-only change derives GPS from the new address", async (t) => {
+  if (dbUnavailable) { t.skip(dbUnavailable); return; }
+  const jobId = await seedJob({ address_text: "@13.100000,100.100000", gps_latitude: 13.1, gps_longitude: 100.1 });
+  const { status } = await putEdit(jobId, { address_text: "@15.900000,101.900000" });
+  assert.equal(status, 200);
+  const row = await withDb((db) => db.query("SELECT * FROM public.jobs WHERE job_id=$1", [jobId]).then((r) => r.rows[0]));
+  assert.ok(Math.abs(Number(row.gps_latitude) - 15.9) < 1e-6, "GPS derived from the NEW address");
+});
+
+// ---- Round-4 Blocker 3: /admin/book_v2 rejects invalid explicit GPS --------
+const BOOK_BASE = {
+  customer_name: "ลูกค้าทดสอบ", customer_phone: "0800000001",
+  job_type: "ล้าง", ac_type: "ผนัง", btu: 12000, machine_count: 1, wash_variant: "ล้างธรรมดา",
+  address_text: "123 สุขุมวิท", maps_url: "", job_zone: "พระโขนง",
+  booking_mode: "scheduled", tech_type: "company",
+  assign_mode: "single", dispatch_mode: "forced", technician_username: "e2e_tech",
+  services: [{ job_type: "ล้าง", ac_type: "ผนัง", btu: 12000, machine_count: 1, wash_variant: "ล้างธรรมดา" }],
+};
+// Each successful booking reserves the technician, so stagger appointment times
+// far apart to avoid a legitimate collision (409) between successive bookings.
+let bookApptSeq = 0;
+function nextBookingAppt() {
+  const t = new Date(Date.now() + (3 + bookApptSeq * 2) * 86400000);
+  bookApptSeq += 1;
+  t.setHours(10, 0, 0, 0);
+  return t.toISOString().slice(0, 19);
+}
+async function postBook(extra) {
+  const res = await fetch(`${BASE}/admin/book_v2`, {
+    method: "POST", headers: adminHeaders,
+    body: JSON.stringify({ ...BOOK_BASE, appointment_datetime: nextBookingAppt(), ...extra }),
+  });
+  const json = await res.json().catch(() => ({}));
+  return { status: res.status, json };
+}
+
+test("R4-B3: /admin/book_v2 rejects partial/invalid explicit GPS with 400 (backend, not just UI)", async (t) => {
+  if (dbUnavailable) { t.skip(dbUnavailable); return; }
+  const cases = [
+    { gps_latitude: "13.7", gps_longitude: "" },     // lat only
+    { gps_latitude: "", gps_longitude: "100.5" },    // lng only
+    { gps_latitude: "abc", gps_longitude: "100.5" }, // invalid string
+    { gps_latitude: "200", gps_longitude: "100.5" }, // out of range
+    { gps_latitude: "0", gps_longitude: "0" },       // 0,0
+  ];
+  for (const gps of cases) {
+    const { status, json } = await postBook(gps);
+    assert.equal(status, 400, `expected 400 for ${JSON.stringify(gps)} (got ${status})`);
+    assert.equal(json.code, "INVALID_JOB_SITE_COORDINATES");
+    assert.ok(json.error && json.error.length, "Thai error present");
+  }
+});
+
+test("R4-B3b: /admin/book_v2 accepts a valid explicit pair and never persists 0,0 for missing GPS", async (t) => {
+  if (dbUnavailable) { t.skip(dbUnavailable); return; }
+  const withGps = await postBook({ customer_phone: "0800000010", gps_latitude: "13.744000", gps_longitude: "100.534000" });
+  if (!(withGps.status >= 200 && withGps.status < 300) || !withGps.json.job_id) {
+    t.skip(`book_v2 success path not exercisable in this schema (status ${withGps.status}: ${withGps.json.error || "no job_id"})`);
+    return;
+  }
+  const rowA = await withDb((db) => db.query("SELECT * FROM public.jobs WHERE job_id=$1", [withGps.json.job_id]).then((r) => r.rows[0]));
+  assert.ok(Math.abs(Number(rowA.gps_latitude) - 13.744) < 1e-6, "explicit GPS persisted");
+
+  const noGps = await postBook({ customer_phone: "0800000011" });
+  assert.ok(noGps.status >= 200 && noGps.status < 300 && noGps.json.job_id, `both-omitted booking should succeed: ${noGps.json.error || ""}`);
+  const rowB = await withDb((db) => db.query("SELECT * FROM public.jobs WHERE job_id=$1", [noGps.json.job_id]).then((r) => r.rows[0]));
+  // No coords + no parseable maps/address → NULL (never the number 0,0).
+  assert.ok(rowB.gps_latitude === null || !(Number(rowB.gps_latitude) === 0 && Number(rowB.gps_longitude) === 0), "missing GPS must not persist as 0,0");
 });

--- a/test/jobLocationRoute.integration.test.js
+++ b/test/jobLocationRoute.integration.test.js
@@ -1,0 +1,371 @@
+"use strict";
+
+// REAL route-level integration coverage for the job-location round-trip.
+//
+// Boots the actual application (`node index.js`) in a child process against a
+// DISPOSABLE local PostgreSQL database (never production), following the same
+// safety model as test/e2e/run-booking-e2e.js: local-host only, a freshly
+// CREATEd database that is DROPped on teardown. It drives the real HTTP routes
+// with a real admin session and re-reads the actual `jobs` row.
+//
+// Proves, through the production routes:
+//   1. Add job with explicit GPS persists it.
+//   2. Add job with missing GPS does not persist 0,0.
+//   3. Edit without a location change preserves the pair.
+//   4. Edit with a new map/address does not retain stale coordinates.
+//   5. Invalid / partial GPS is rejected with HTTP 400.
+//   6. (modal A→B leak is covered behaviorally in jobLocationRoundtrip.test.js)
+//
+// Self-skips (does not fail) when PostgreSQL is unavailable.
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const crypto = require("node:crypto");
+const { spawn } = require("node:child_process");
+const { Client } = require("pg");
+
+const REPO_ROOT = path.resolve(__dirname, "..");
+const PG = {
+  host: process.env.PGHOST || "127.0.0.1",
+  port: Number(process.env.PGPORT || 5432),
+  user: process.env.PGUSER || "postgres",
+  password: process.env.PGPASSWORD || "postgres",
+};
+const LOCAL_HOSTS = new Set(["127.0.0.1", "localhost", "::1", "0.0.0.0"]);
+const DB_NAME = `cwf_jobloc_it_${process.pid}`;
+const PORT = Number(process.env.JOBLOC_IT_PORT || 4732);
+const BASE = `http://127.0.0.1:${PORT}`;
+const ADMIN_COOKIE_TOKEN = crypto.randomBytes(24).toString("hex");
+
+let child = null;
+let dbUnavailable = "";
+
+function extractBalanced(src, headerRe) {
+  const out = [];
+  let m;
+  const re = new RegExp(headerRe, "g");
+  while ((m = re.exec(src))) {
+    let i = re.lastIndex;
+    let depth = 1;
+    while (i < src.length && depth > 0) {
+      if (src[i] === "(") depth += 1;
+      else if (src[i] === ")") depth -= 1;
+      i += 1;
+    }
+    const stmt = src.slice(m.index, i);
+    if (!stmt.includes("${")) out.push(stmt);
+  }
+  return out;
+}
+
+async function buildSchema(adminless) {
+  const db = new Client({ ...PG, database: DB_NAME });
+  await db.connect();
+  const schemaSql = fs.readFileSync(path.join(__dirname, "e2e", "schema-core.sql"), "utf8");
+  await db.query(schemaSql).catch(() => {});
+  const sources = ["index.js", path.join("server", "customerPricing.js")]
+    .map((f) => { try { return fs.readFileSync(path.join(REPO_ROOT, f), "utf8"); } catch { return ""; } });
+  // CREATE TABLE IF NOT EXISTS public.<name> ( ... )
+  for (const src of sources) {
+    for (const stmt of extractBalanced(src, "CREATE TABLE IF NOT EXISTS public\\.[a-z_]+\\s*\\(")) {
+      try { await db.query(stmt); } catch (_) { /* unrelated table — fine */ }
+    }
+  }
+  // ALTER TABLE ... ADD COLUMN IF NOT EXISTS (self-heal like boot)
+  for (const src of sources) {
+    const alters = src.match(/ALTER TABLE public\.[a-z_]+ ADD COLUMN IF NOT EXISTS [^`;)]+/g) || [];
+    for (const a of alters) { if (!a.includes("${")) { try { await db.query(a); } catch (_) {} } }
+  }
+  // Indexes several routes rely on.
+  for (const src of sources) {
+    const idx = src.match(/CREATE (?:UNIQUE )?INDEX IF NOT EXISTS [^`;]+/g) || [];
+    for (const i of idx) { if (!i.includes("${")) { try { await db.query(i); } catch (_) {} } }
+  }
+  await db.end();
+}
+
+async function seedAdminSession() {
+  const db = new Client({ ...PG, database: DB_NAME });
+  await db.connect();
+  await db.query(
+    `INSERT INTO public.users (username, role) VALUES ('e2e_admin','admin')
+       ON CONFLICT (username) DO UPDATE SET role='admin'`
+  );
+  // A company technician so a forced-single booking has someone to assign.
+  await db.query(
+    `INSERT INTO public.users (username, role) VALUES ('e2e_tech','technician')
+       ON CONFLICT (username) DO UPDATE SET role='technician'`
+  );
+  await db.query(
+    `INSERT INTO public.technician_profiles (username, full_name, phone)
+     VALUES ('e2e_tech','ช่างทดสอบ','0810000000')
+       ON CONFLICT (username) DO NOTHING`
+  ).catch(() => {});
+  await db.query(`ALTER TABLE public.auth_sessions ADD COLUMN IF NOT EXISTS impersonated_username TEXT`).catch(() => {});
+  await db.query(`ALTER TABLE public.auth_sessions ADD COLUMN IF NOT EXISTS impersonated_role TEXT`).catch(() => {});
+  await db.query(`ALTER TABLE public.auth_sessions ADD COLUMN IF NOT EXISTS last_seen_at TIMESTAMPTZ`).catch(() => {});
+  await db.query(
+    `INSERT INTO public.auth_sessions (session_token, username, role, expires_at)
+     VALUES ($1,'e2e_admin','admin', NOW() + INTERVAL '1 day')
+       ON CONFLICT (session_token) DO NOTHING`,
+    [ADMIN_COOKIE_TOKEN]
+  );
+  await db.end();
+}
+
+async function withDb(fn) {
+  const db = new Client({ ...PG, database: DB_NAME });
+  await db.connect();
+  try { return await fn(db); } finally { await db.end(); }
+}
+
+// Insert a job row directly so the GET/PUT routes have something to operate on
+// (booking a job through /admin/book_v2 needs the full pricing/catalog stack;
+// the location-preservation logic under review lives in the edit route).
+async function seedJob(loc) {
+  return withDb(async (db) => {
+    const r = await db.query(
+      `INSERT INTO public.jobs
+         (customer_name, customer_phone, job_type, appointment_datetime, job_status,
+          address_text, maps_url, job_zone, gps_latitude, gps_longitude,
+          service_zone_code, service_zone_source, booking_mode, duration_min, job_price)
+       VALUES ('ทดสอบ','0800000000','ล้าง', NOW() + INTERVAL '1 day', 'รอดำเนินการ',
+          $1,$2,$3,$4,$5,$6,$7,'scheduled',60,0)
+       RETURNING job_id`,
+      [loc.address_text ?? null, loc.maps_url ?? null, loc.job_zone ?? null,
+       loc.gps_latitude ?? null, loc.gps_longitude ?? null,
+       loc.service_zone_code ?? null, loc.service_zone_source ?? null]
+    );
+    return Number(r.rows[0].job_id);
+  });
+}
+
+const adminHeaders = { "content-type": "application/json", cookie: `cwf_session=${ADMIN_COOKIE_TOKEN}` };
+
+async function putEdit(jobId, body) {
+  const res = await fetch(`${BASE}/jobs/${jobId}/admin-edit`, {
+    method: "PUT", headers: { "content-type": "application/json" }, body: JSON.stringify(body),
+  });
+  const json = await res.json().catch(() => ({}));
+  return { status: res.status, json };
+}
+
+async function waitForReady(timeoutMs = 60000) {
+  const started = Date.now();
+  for (;;) {
+    if (Date.now() - started > timeoutMs) throw new Error(`app not ready in ${timeoutMs}ms`);
+    try {
+      const res = await fetch(`${BASE}/public/pricing_preview`, {
+        method: "POST", headers: { "content-type": "application/json" },
+        body: JSON.stringify({ job_type: "ล้างแอร์", ac_type: "ผนัง", btu: 12000, machine_count: 1, wash_variant: "ล้างธรรมดา" }),
+      });
+      if (res.ok) return;
+    } catch (_) { /* not up yet */ }
+    await new Promise((r) => setTimeout(r, 500));
+  }
+}
+
+test.before(async () => {
+  if (!LOCAL_HOSTS.has(PG.host)) { dbUnavailable = `refusing non-local PG host ${PG.host}`; return; }
+  const admin = new Client({ ...PG, database: "postgres" });
+  try {
+    await admin.connect();
+    await admin.query("SELECT 1");
+  } catch (e) {
+    dbUnavailable = e.message || "postgres unavailable";
+    await admin.end().catch(() => {});
+    return;
+  }
+  try {
+    await admin.query(`DROP DATABASE IF EXISTS ${DB_NAME}`);
+    await admin.query(`CREATE DATABASE ${DB_NAME} ENCODING 'UTF8'`);
+  } finally {
+    await admin.end().catch(() => {});
+  }
+  await buildSchema();
+  await seedAdminSession();
+
+  const logFile = path.join(__dirname, `jobloc-it-app-${PORT}.log`);
+  const out = fs.openSync(logFile, "w");
+  child = spawn(process.execPath, ["index.js"], {
+    cwd: REPO_ROOT,
+    env: {
+      ...process.env,
+      DB_HOST: PG.host, DB_PORT: String(PG.port), DB_USER: PG.user, DB_PASSWORD: PG.password, DB_NAME,
+      PGHOST: PG.host, PGPORT: String(PG.port), PGUSER: PG.user, PGPASSWORD: PG.password, PGDATABASE: DB_NAME,
+      PORT: String(PORT),
+      CWF_JWT_SECRET: "jobloc-it-secret",
+      NODE_ENV: "test", CWF_E2E_TEST_MODE: "1",
+      OPENAI_API_KEY: "", ANTHROPIC_API_KEY: "",
+      CLOUDINARY_URL: "", CLOUDINARY_CLOUD_NAME: "",
+      // Force all third-party outbound (e.g. short-link resolution) to fail
+      // deterministically so the "changed link is unresolvable → cleared" path
+      // is exercised. Local DB traffic bypasses the proxy via NO_PROXY.
+      HTTPS_PROXY: "http://127.0.0.1:9", HTTP_PROXY: "http://127.0.0.1:9",
+      https_proxy: "http://127.0.0.1:9", http_proxy: "http://127.0.0.1:9",
+      NO_PROXY: "127.0.0.1,localhost,::1", no_proxy: "127.0.0.1,localhost,::1",
+    },
+    stdio: ["ignore", out, out],
+  });
+  await waitForReady();
+});
+
+test.after(async () => {
+  if (child) { try { child.kill("SIGKILL"); } catch (_) {} }
+  await new Promise((r) => setTimeout(r, 300));
+  if (!dbUnavailable) {
+    const admin = new Client({ ...PG, database: "postgres" });
+    try {
+      await admin.connect();
+      await admin.query(`DROP DATABASE IF EXISTS ${DB_NAME} WITH (FORCE)`).catch(async () => {
+        await admin.query(`DROP DATABASE IF EXISTS ${DB_NAME}`).catch(() => {});
+      });
+    } finally { await admin.end().catch(() => {}); }
+  }
+});
+
+test("GET /admin/job_v2 returns the stored location fields (real route + session)", async (t) => {
+  if (dbUnavailable) { t.skip(dbUnavailable); return; }
+  const jobId = await seedJob({
+    address_text: "99 อ่อนนุช", maps_url: "https://maps.app.goo.gl/getcheck",
+    job_zone: "อ่อนนุช", gps_latitude: 13.71, gps_longitude: 100.61,
+    service_zone_code: "C", service_zone_source: "admin_override",
+  });
+  const res = await fetch(`${BASE}/admin/job_v2/${jobId}`, { headers: adminHeaders });
+  assert.equal(res.status, 200);
+  const body = await res.json();
+  const job = body.job;
+  assert.equal(Number(job.gps_latitude), 13.71);
+  assert.equal(Number(job.gps_longitude), 100.61);
+  assert.equal(job.maps_url, "https://maps.app.goo.gl/getcheck");
+  assert.equal(job.job_zone, "อ่อนนุช");
+  assert.equal(job.service_zone_code, "C");
+});
+
+test("Proof 3: edit without a location change preserves the GPS pair", async (t) => {
+  if (dbUnavailable) { t.skip(dbUnavailable); return; }
+  const jobId = await seedJob({ address_text: "a", maps_url: "https://maps.app.goo.gl/keep", job_zone: "z", gps_latitude: 13.5, gps_longitude: 100.5 });
+  const { status, json } = await putEdit(jobId, { customer_note: "แก้ไขโน้ตอย่างเดียว" });
+  assert.equal(status, 200);
+  assert.equal(json.gps_action, "preserved");
+  const row = await withDb((db) => db.query("SELECT * FROM public.jobs WHERE job_id=$1", [jobId]).then((r) => r.rows[0]));
+  assert.equal(Number(row.gps_latitude), 13.5);
+  assert.equal(Number(row.gps_longitude), 100.5);
+  assert.equal(row.maps_url, "https://maps.app.goo.gl/keep");
+});
+
+test("Proof 4: changing maps_url to a coordinate URL replaces stale GPS (never keeps old)", async (t) => {
+  if (dbUnavailable) { t.skip(dbUnavailable); return; }
+  const jobId = await seedJob({ address_text: "loc A", maps_url: "https://maps.google.com/?q=13.100000,100.100000", gps_latitude: 13.1, gps_longitude: 100.1 });
+  // New maps_url points at location B (14.5, 101.5); admin did not touch Lat/Lng.
+  const { status, json } = await putEdit(jobId, { maps_url: "https://www.google.com/maps/place/@14.500000,101.500000,17z" });
+  assert.equal(status, 200);
+  assert.equal(json.gps_action, "recalculated");
+  const row = await withDb((db) => db.query("SELECT * FROM public.jobs WHERE job_id=$1", [jobId]).then((r) => r.rows[0]));
+  assert.ok(Math.abs(Number(row.gps_latitude) - 14.5) < 1e-6, `lat became B, got ${row.gps_latitude}`);
+  assert.ok(Math.abs(Number(row.gps_longitude) - 101.5) < 1e-6, `lng became B, got ${row.gps_longitude}`);
+  assert.notEqual(Number(row.gps_latitude), 13.1); // never keeps location A
+});
+
+test("Proof 4b: changing maps_url to an unresolvable link clears the old GPS to NULL (deterministic)", async (t) => {
+  if (dbUnavailable) { t.skip(dbUnavailable); return; }
+  const jobId = await seedJob({ address_text: "loc A", maps_url: "https://maps.google.com/?q=13.100000,100.100000", gps_latitude: 13.1, gps_longitude: 100.1 });
+  // A changed maps_url with no parseable coordinates and not a resolvable short
+  // link → coordinates cannot be recalculated → the stale pair must be CLEARED,
+  // never retained. (No network dependency: a non-goo.gl URL isn't remote-resolved.)
+  const newLink = "https://example.com/place/no-coords-here";
+  const { status, json } = await putEdit(jobId, { maps_url: newLink });
+  assert.equal(status, 200);
+  assert.equal(json.gps_action, "cleared");
+  const row = await withDb((db) => db.query("SELECT * FROM public.jobs WHERE job_id=$1", [jobId]).then((r) => r.rows[0]));
+  assert.equal(row.gps_latitude, null, "old GPS cleared, not retained");
+  assert.equal(row.gps_longitude, null);
+  assert.equal(row.maps_url, newLink, "the changed link is still saved");
+});
+
+test("Proof 4c: a changed short Google Maps link is always saved and never keeps the old GPS", async (t) => {
+  if (dbUnavailable) { t.skip(dbUnavailable); return; }
+  const jobId = await seedJob({ address_text: "loc A", maps_url: "https://maps.google.com/?q=13.100000,100.100000", gps_latitude: 13.1, gps_longitude: 100.1 });
+  const shortLink = "https://maps.app.goo.gl/someShortLink123";
+  const { status, json } = await putEdit(jobId, { maps_url: shortLink });
+  assert.equal(status, 200);
+  // Depending on whether the short link resolves, the action is recalculated or
+  // cleared — but it must never be "preserved" (which would keep location A).
+  assert.ok(["recalculated", "cleared"].includes(json.gps_action), `unexpected action ${json.gps_action}`);
+  const row = await withDb((db) => db.query("SELECT * FROM public.jobs WHERE job_id=$1", [jobId]).then((r) => r.rows[0]));
+  assert.equal(row.maps_url, shortLink, "the changed short link is still saved");
+  // Never retains the old location-A coordinates.
+  assert.ok(row.gps_latitude === null || Math.abs(Number(row.gps_latitude) - 13.1) > 1e-6, "old GPS not retained");
+});
+
+test("Proof 5: partial / invalid / 0,0 GPS is rejected with 400 INVALID_JOB_SITE_COORDINATES", async (t) => {
+  if (dbUnavailable) { t.skip(dbUnavailable); return; }
+  const jobId = await seedJob({ address_text: "x", gps_latitude: 13.2, gps_longitude: 100.2 });
+  const cases = [
+    { gps_latitude: "13.7", gps_longitude: "" },     // lat only
+    { gps_latitude: "", gps_longitude: "100.5" },    // lng only
+    { gps_latitude: "abc", gps_longitude: "100.5" }, // invalid string
+    { gps_latitude: "200", gps_longitude: "100.5" }, // out of range
+    { gps_latitude: "0", gps_longitude: "0" },       // 0,0
+  ];
+  for (const body of cases) {
+    const { status, json } = await putEdit(jobId, body);
+    assert.equal(status, 400, `expected 400 for ${JSON.stringify(body)}`);
+    assert.equal(json.code, "INVALID_JOB_SITE_COORDINATES");
+    assert.ok(json.error && json.error.length, "Thai error message present");
+  }
+  // The stored pair is untouched by the rejected requests.
+  const row = await withDb((db) => db.query("SELECT * FROM public.jobs WHERE job_id=$1", [jobId]).then((r) => r.rows[0]));
+  assert.equal(Number(row.gps_latitude), 13.2);
+  assert.equal(Number(row.gps_longitude), 100.2);
+});
+
+test("valid explicit pair updates the coordinates (real route)", async (t) => {
+  if (dbUnavailable) { t.skip(dbUnavailable); return; }
+  const jobId = await seedJob({ address_text: "x", gps_latitude: 13.2, gps_longitude: 100.2 });
+  const { status, json } = await putEdit(jobId, { gps_latitude: "13.999999", gps_longitude: "100.999999" });
+  assert.equal(status, 200);
+  assert.equal(json.gps_action, "updated");
+  const row = await withDb((db) => db.query("SELECT * FROM public.jobs WHERE job_id=$1", [jobId]).then((r) => r.rows[0]));
+  assert.ok(Math.abs(Number(row.gps_latitude) - 13.999999) < 1e-6);
+  assert.ok(Math.abs(Number(row.gps_longitude) - 100.999999) < 1e-6);
+});
+
+test("Proofs 1+2: /admin/book_v2 persists explicit GPS and never stores 0,0 for missing GPS", async (t) => {
+  if (dbUnavailable) { t.skip(dbUnavailable); return; }
+  const base = {
+    customer_name: "ลูกค้าทดสอบ", customer_phone: "0800000001",
+    job_type: "ล้าง", ac_type: "ผนัง", btu: 12000, machine_count: 1, wash_variant: "ล้างธรรมดา",
+    appointment_datetime: new Date(Date.now() + 2 * 86400000).toISOString().slice(0, 19),
+    address_text: "123 สุขุมวิท", maps_url: "", job_zone: "พระโขนง",
+    booking_mode: "scheduled", tech_type: "company",
+    // Forced single assignment to a seeded technician avoids the auto-availability
+    // search (which needs a full calendar/zone stack) so the route is exercisable.
+    assign_mode: "single", dispatch_mode: "forced", technician_username: "e2e_tech",
+    services: [{ job_type: "ล้าง", ac_type: "ผนัง", btu: 12000, machine_count: 1, wash_variant: "ล้างธรรมดา" }],
+  };
+  const withGps = await fetch(`${BASE}/admin/book_v2`, {
+    method: "POST", headers: adminHeaders,
+    body: JSON.stringify({ ...base, gps_latitude: "13.744000", gps_longitude: "100.534000" }),
+  });
+  const wj = await withGps.json().catch(() => ({}));
+  if (!withGps.ok || !wj.job_id) {
+    t.skip(`book_v2 not exercisable in this schema (status ${withGps.status}: ${wj.error || "no job_id"})`);
+    return;
+  }
+  const rowA = await withDb((db) => db.query("SELECT * FROM public.jobs WHERE job_id=$1", [wj.job_id]).then((r) => r.rows[0]));
+  assert.ok(Math.abs(Number(rowA.gps_latitude) - 13.744) < 1e-6, "explicit GPS persisted");
+  assert.ok(Math.abs(Number(rowA.gps_longitude) - 100.534) < 1e-6);
+
+  const noGps = await fetch(`${BASE}/admin/book_v2`, {
+    method: "POST", headers: adminHeaders,
+    body: JSON.stringify({ ...base, customer_phone: "0800000002" }),
+  });
+  const nj = await noGps.json().catch(() => ({}));
+  assert.ok(noGps.ok && nj.job_id, `second booking should succeed: ${nj.error || ""}`);
+  const rowB = await withDb((db) => db.query("SELECT * FROM public.jobs WHERE job_id=$1", [nj.job_id]).then((r) => r.rows[0]));
+  // No coordinates supplied and no parseable maps/address → NULL, never 0,0.
+  assert.ok(!(Number(rowB.gps_latitude) === 0 && Number(rowB.gps_longitude) === 0), "missing GPS must not persist as 0,0");
+});

--- a/test/techCacheBuild.test.js
+++ b/test/techCacheBuild.test.js
@@ -4,7 +4,7 @@ const fs = require("node:fs");
 const path = require("node:path");
 
 const root = path.join(__dirname, "..");
-const BUILD = "20260711_tracking_gps_recovery_v1";
+const BUILD = "20260712_job_location_roundtrip_v1";
 
 function read(file) {
   return fs.readFileSync(path.join(root, file), "utf8");


### PR DESCRIPTION
Fixes the complete job-location pipeline: Admin Add → `/admin/book_v2` → jobs DB → Admin Job Edit → Technician job API → Technician Google Maps navigation → GPS check-in. Branched from `origin/main@d97e2d9`. **Draft — not deployed.** No migration, no production data change, no payment/auth changes, 500 m check-in policy untouched.

**Current head:** `78e3df96970f03b601cf8c9c7d71f720bbfa089e`

## Rounds 1–3 — resolved (preserved)
Navigation never opens `destination=0,0`; Admin Job Edit reads `gps_latitude ?? latitude` + shows the system zone; the modal no longer leaks the previous job's GPS; a changed map/address doesn't retain old GPS; partial/invalid/(0,0) GPS on edit → **HTTP 400 `INVALID_JOB_SITE_COORDINATES`**; maps_url clear/preserve/replace; address change clears the stale URL; service zone recomputed on a location move; every derived coordinate strictly validated.

## Round 4 — 3 final consistency blockers, all resolved

**Blocker 1 — an explicit GPS edit can no longer keep a stale Maps URL.** An explicit pin that *moves* is a location change: the old `maps_url` is cleared to NULL (navigation uses maps_url before GPS, so a stale URL A would route the technician to A while check-in validates B) and the service zone is recomputed from the new pin. When a new Maps URL **and** a new GPS are supplied in the same request, both are kept.

**Blocker 2 — a new Maps URL never falls back to the old address.** Source-specific derivation: a changed Maps URL derives GPS only from that URL (parse → short-link resolve) and clears to NULL if unresolvable — it does not fall back to the unchanged old address; an address-only change derives from the new address; both-changed prefers the new URL with the new address as fallback; explicit GPS wins. The system zone follows the same new source and never uses the old, unchanged `job_zone`/address as evidence.

**Blocker 3 — `/admin/book_v2` rejects invalid explicit GPS at the backend.** Presence-based validation up front (before the transaction): one-field-only / invalid / out-of-range / 0,0 → **HTTP 400 `INVALID_JOB_SITE_COORDINATES`** with the Thai message, instead of silently falling back to maps/address. Both blank → derive as before. This no longer relies on frontend validation (a stale cached admin page or a direct API caller is covered).

### Exact maps/GPS source precedence
1. **Explicit GPS** (validated) wins → stale Maps URL cleared unless a replacement URL is supplied in the same request.
2. **New non-empty Maps URL** → GPS from that URL only (parse → resolve), else NULL.
3. **New address** (no effective URL) → GPS from the new address.
4. Both changed → prefer the new URL, address as fallback.
5. Nothing moved → preserve.

### Exact service-zone behavior
Recomputed from the same new effective source on any location move (new URL / new address / explicit pin); cleared to NULL when unclassifiable; old zone never retained; free-text `job_zone` preserved separately.

## Changed files (16)
- Backend: `index.js`
- Admin frontend: `admin-add-v2.js`, `admin-job-view-v2.js`, `admin-review-v2.js`, `admin-add-v2.html`, `admin-job-view-v2.html`, `admin-review-v2.html`
- Technician navigation / PWA: `app.js`, `tech.html`, `cwf-pwa.js`, `sw.js`
- Tests: `test/jobLocationRoute.integration.test.js`, `test/jobLocationRoundtrip.test.js`, and cache-version updates in `test/{adminJobEditPriceStability,customerBookingAdminNotifications,techCacheBuild}.test.js`

## Tests / commands
- `node --check` clean on every changed JS.
- `node --test test/jobLocationRoute.integration.test.js` — **real app + disposable PostgreSQL**, real admin session, drives `POST /admin/book_v2`, `GET /admin/job_v2`, `PUT /jobs/:id/admin-edit`: **19 pass / 0 skip**. The `book_v2` add-path now executes end-to-end (explicit GPS persists; missing GPS → NULL, never 0,0) and rejects lat-only / lng-only / invalid / out-of-range / 0,0 with 400. Explicit-GPS-clears-URL, new-URL-no-old-address-fallback, address-only-from-address, and the round-1–3 proofs all pass.
- `node --test test/jobLocationRoundtrip.test.js` — real `app.js` navigation via vm, real FE drop-stale-GPS decision, SQL round-trip, source contracts: **25 pass**.
- Full `npm test` (real PostgreSQL): **1098 pass / 0 fail / 0 skipped**.

### Evidence
- **Explicit GPS cannot coexist with a stale Maps URL** — `R4-B1`: submit GPS B only → DB GPS B, `maps_url` NULL; `R4-B1b`: URL B + GPS B together → both kept.
- **A new Maps URL cannot fall back to the old address** — `R4-B2`: change to an unresolvable URL (address unchanged) → GPS NULL (never the old address's coords or the old pin), old zone not retained; `R4-B2b`: address-only change → GPS from the new address.
- **`/admin/book_v2` rejects partial/invalid explicit GPS** — `R4-B3`: all five cases → 400; `R4-B3b`: valid pair persisted, missing GPS → NULL.

## New cache/build IDs
`20260712_job_location_roundtrip_v1` across technician (`app.js`, `tech.html`, `cwf-pwa.js`, `sw.js`) and the three admin HTML asset query strings (unchanged this round — the PR is undeployed, so the id carries the complete fix set on deploy).

## Manual acceptance
1. Job with URL A + GPS A → edit only the pin to B → the Maps URL is cleared, nav uses GPS B.
2. Change the Maps URL to an unresolvable one → GPS clears (never the old address); zone recomputes/clears.
3. Change the address only → GPS/zone derive from the new address.
4. `/admin/book_v2` with only Lat / out-of-range / 0,0 → 400 Thai error.
5. Technician PWA nav follows the new effective location, never 0,0.
6. GPS Check-in still works.

Keep this PR **Draft** — do not merge or deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)