### PR TITLE
Customer App page controls and secure Tracking deep link

### DIFF
--- a/admin-homepage-cms.html
+++ b/admin-homepage-cms.html
@@ -171,6 +171,22 @@
     }
     .ep-body{padding:14px;display:grid;gap:12px}
 
+    /* page-availability editor */
+    .pa-callout{font-size:12px;line-height:1.6;color:#3a4a60;background:#eef3fb;border:1px solid var(--line);border-radius:10px;padding:10px 12px}
+    .pa-list{display:grid;gap:8px}
+    .pa-row{display:flex;align-items:center;gap:12px;justify-content:space-between;border:1.5px solid var(--line);border-radius:12px;padding:11px 13px;background:#fff}
+    .pa-row.is-off{background:#fbfcfe;border-color:#e7ecf4}
+    .pa-row-tracking{border-color:#cddcff}
+    .pa-info{min-width:0}
+    .pa-name{font-weight:900;font-size:14px;color:var(--ink);display:flex;align-items:center;gap:8px}
+    .pa-hint{font-size:12px;color:var(--muted);line-height:1.5;margin-top:2px}
+    .pa-badge-off{font-size:10px;font-weight:900;color:#a23b3b;background:#fdeaea;border-radius:999px;padding:2px 7px}
+    .pa-note{border-radius:10px;padding:10px 12px;font-size:12px;line-height:1.6}
+    .pa-note ul{margin:6px 0 0;padding-left:18px}
+    .pa-note li{margin:2px 0}
+    .pa-note-warn{background:#fff6e9;border:1px solid #f2d9a8;color:#7a5a1e}
+    .pa-note-bad{background:#fdeaea;border:1px solid #f0b9b9;color:#932020}
+
     /* form fields */
     label.field{display:grid;gap:5px;font-size:12px;font-weight:900;color:#3a4a60}
     input.fi,textarea.fi,select.fi{

--- a/admin-homepage-cms.js
+++ b/admin-homepage-cms.js
@@ -43,6 +43,17 @@
     return out;
   }
 
+  // Pure decision for a page-availability toggle. Turning a page OFF is refused
+  // when it is the LAST enabled page, so the UI can never reach an all-disabled
+  // state (backend validation + publish guard remain as defense-in-depth).
+  // Returns true when the toggle is allowed to apply.
+  function pageAvailabilityToggleAllowed(pa, key, checked) {
+    if (checked) return true;
+    if (pa[key] !== true) return true; // already off — no-op, harmless
+    const enabledCount = PAGE_AVAILABILITY_KEYS.filter((route) => pa[route] === true).length;
+    return enabledCount > 1;
+  }
+
   const TYPE_ICONS = {
     hero: "🏠", quick: "⚡", promo_banner: "🎨",
     active_job: "🔧", announcements: "📣", featured_services: "⭐",
@@ -1079,9 +1090,18 @@
     const target = event.target;
     if (target.matches("[data-page-availability]")) {
       config.page_availability = normalizePageAvailability(config.page_availability);
+      const key = target.dataset.pageAvailability;
+      // Never let the UI reach an all-disabled state: refuse to turn off the
+      // last enabled page. Revert the checkbox, keep config unchanged, and show
+      // the same message the publish guard uses.
+      if (!pageAvailabilityToggleAllowed(config.page_availability, key, target.checked)) {
+        target.checked = true;
+        setStatus("ต้องเปิดอย่างน้อย 1 หน้า", "bad");
+        return;
+      }
       // Only ever change the one page the admin toggled — never auto-toggle a
       // related page. Re-render the editor so notes/warnings update live.
-      config.page_availability[target.dataset.pageAvailability] = target.checked;
+      config.page_availability[key] = target.checked;
       renderEditor();
       return;
     }

--- a/admin-homepage-cms.js
+++ b/admin-homepage-cms.js
@@ -15,7 +15,33 @@
       { id: "social", type: "social", enabled: true, sort_order: 75, title: "ติดตามเราบนโซเชียล", body: "อัปเดตล่าสุดจาก Facebook และ YouTube ของ Coldwindflow", items: [] },
       { id: "trust", type: "trust", enabled: true, sort_order: 80, title: "มาตรฐานที่ลูกค้าวางใจ", body: "", items: [{ title: "แจ้งราคาก่อนทำ", body: "ระบบคำนวณจากข้อมูลบริการจริง" }, { title: "ช่างผ่านมาตรฐาน", body: "ทีมงานได้รับการตรวจสอบก่อนรับงาน" }, { title: "ติดตามงานได้", body: "ดูสถานะสำคัญด้วย Booking Code" }, { title: "ติดต่อแอดมินง่าย", body: "รองรับ LINE และโทรศัพท์" }] },
     ],
+    // Per-page rollout switches for Customer App V2. All-enabled by default; a
+    // page turned off here is hidden + unreachable in the app. This is a UI
+    // rollout control only — it never replaces the server booking kill switches.
+    page_availability: { home: true, store: true, booking: true, scheduled: true, urgent: true, tracking: true, profile: true },
   };
+
+  // Customer App pages that can be toggled, in display order. Labels/hints are
+  // Thai. `scheduled`/`urgent` note the server kill-switch relationship.
+  const PAGE_AVAILABILITY_KEYS = ["home", "store", "booking", "scheduled", "urgent", "tracking", "profile"];
+  const PAGE_AVAILABILITY_META = {
+    home: ["หน้าแรก", "หน้าแรกของแอป (แบนเนอร์ เมนูด่วน ทางลัด)"],
+    store: ["ร้านค้า", "แคตตาล็อกสินค้า/บริการ และหน้ารายละเอียดสินค้า"],
+    booking: ["เลือกประเภทการจอง", "หน้ารวมที่ให้ลูกค้าเลือกจองล่วงหน้าหรือคิวด่วน"],
+    scheduled: ["จองล่วงหน้า", "ฟอร์มจองล้างแอร์ล่วงหน้า — ต้องเปิด kill switch ฝั่งเซิร์ฟเวอร์ด้วยจึงจะจองสำเร็จ"],
+    urgent: ["คิวด่วน", "ส่งคำขอด่วนให้ช่างกดรับ — ต้องเปิด kill switch ฝั่งเซิร์ฟเวอร์ด้วยจึงจะส่งได้"],
+    tracking: ["ติดตามงาน", "หน้าติดตามงาน และเป็นปลายทางของลิงก์ยืนยันนัดหมายที่ส่งให้ลูกค้า"],
+    profile: ["บัญชีลูกค้า", "หน้าโปรไฟล์และประวัติงานของลูกค้า"],
+  };
+
+  // Legacy/missing → all enabled. Present keys coerced to booleans; a missing
+  // key defaults to enabled (never silently disable a page).
+  function normalizePageAvailability(raw) {
+    const src = raw && typeof raw === "object" && !Array.isArray(raw) ? raw : {};
+    const out = {};
+    PAGE_AVAILABILITY_KEYS.forEach((key) => { out[key] = key in src ? src[key] === true : true; });
+    return out;
+  }
 
   const TYPE_ICONS = {
     hero: "🏠", quick: "⚡", promo_banner: "🎨",
@@ -90,6 +116,7 @@
       };
     });
     next.theme = next.theme && typeof next.theme === "object" && !Array.isArray(next.theme) ? next.theme : {};
+    next.page_availability = normalizePageAvailability(next.page_availability);
     return next;
   }
   function setStatus(text, kind) { $("status").textContent = text; $("status").className = `status-chip ${kind || ""}`; }
@@ -227,6 +254,25 @@
   }
 
   async function publish() {
+    config.page_availability = normalizePageAvailability(config.page_availability);
+    const pa = config.page_availability;
+    const enabledCount = PAGE_AVAILABILITY_KEYS.filter((k) => pa[k]).length;
+    // Hard guard: refuse to publish an all-disabled app (matches the server,
+    // which also rejects it). Steer the admin to the availability editor.
+    if (enabledCount === 0) {
+      selected = "page-availability";
+      render();
+      if (window.innerWidth <= 880) switchTab("editor");
+      setStatus("ต้องเปิดอย่างน้อย 1 หน้าก่อน Publish", "bad");
+      return;
+    }
+    // Tracking is the destination of the customer confirmation link — confirm
+    // before publishing it in the off state.
+    if (pa.tracking === false && !window.confirm(
+      "คุณกำลังจะปิดหน้า “ติดตามงาน”\n\nลิงก์ยืนยันนัดหมายที่ส่งให้ลูกค้าชี้มาที่หน้านี้ ลูกค้าที่กดลิงก์จะเห็นหน้ากำลังปรับปรุงแทนสถานะงานจริง\n\nยืนยันที่จะ Publish หรือไม่?")) {
+      setStatus("ยกเลิกการ Publish", "");
+      return;
+    }
     setStatus("กำลัง Publish...", "");
     const data = await requestJson("/admin/homepage-cms/publish", { method: "POST", body: JSON.stringify({ config }) });
     setStatus(`Publish แล้ว v${data.version}`, "ok");
@@ -288,16 +334,39 @@
           </div>
         </div>
       </div>`;
+    const availabilityRow = `
+      <div class="sec-row ${selected === "page-availability" ? "is-active" : ""}">
+        <div class="sec-row-body" data-edit="page-availability">
+          <div class="sec-icon">🚦</div>
+          <div class="sec-info">
+            <div class="sec-name">สถานะหน้าแอปลูกค้า</div>
+            <div class="sec-type">เปิด/ปิดหน้าแต่ละหน้า</div>
+          </div>
+        </div>
+      </div>`;
     $("sectionList").innerHTML += `<div class="nav-hd" style="margin-top:8px">แบนเนอร์หัวหน้า (แยกแต่ละหน้า)</div>${headerRows}`
+      + `<div class="nav-hd" style="margin-top:8px">การเผยแพร่หน้า</div>${availabilityRow}`
       + `<div class="nav-hd" style="margin-top:8px">รูปลักษณ์</div>${themeRow}`;
     $("sectionPicker").innerHTML = list.map((section) => `<option value="${esc(section.id)}">${esc(section.title || section.type)}</option>`).join("")
       + PAGE_HEADER_META.map(([key, label]) => `<option value="head:${key}">${esc(label)}</option>`).join("")
+      + `<option value="page-availability">สถานะหน้าแอปลูกค้า</option>`
       + `<option value="theme">ธีม / สีแบรนด์</option>`;
     $("sectionPicker").value = selected;
   }
 
   /* ── editor header ── */
   function renderEditorHeader() {
+    if (selected === "page-availability") {
+      $("editorHeader").innerHTML = `
+        <div class="editor-hd">
+          <div class="editor-hd-icon">🚦</div>
+          <div>
+            <div class="editor-hd-title">สถานะหน้าแอปลูกค้า</div>
+            <div class="editor-hd-sub">เปิด/ปิดหน้าแต่ละหน้าในแอปลูกค้า · มีผลหลังกด Publish</div>
+          </div>
+        </div>`;
+      return;
+    }
     if (selected === "theme") {
       $("editorHeader").innerHTML = `
         <div class="editor-hd">
@@ -629,7 +698,71 @@
       </div>`;
   }
 
+  // Non-blocking relationship warnings for the page-availability editor. These
+  // never auto-toggle anything — they only advise the admin.
+  function pageAvailabilityWarnings(pa) {
+    const warns = [];
+    if (pa.booking && !pa.scheduled && !pa.urgent) {
+      warns.push("เปิดหน้า “เลือกประเภทการจอง” แต่ปิดทั้ง “จองล่วงหน้า” และ “คิวด่วน” — ลูกค้าจะเห็นหน้าจองที่ไม่มีตัวเลือกให้กด");
+    }
+    if (!pa.booking && (pa.scheduled || pa.urgent)) {
+      warns.push("เปิดหน้าจอง (ล่วงหน้า/ด่วน) แต่ปิดหน้า “เลือกประเภทการจอง” — ลูกค้าจะเข้าหน้าจองจากเมนูปกติไม่ได้");
+    }
+    if (pa.store === false) {
+      // storeItem detail inherits the store flag; note it so admins aren't
+      // surprised that product-detail deep links also close.
+      warns.push("ปิด “ร้านค้า” จะปิดหน้ารายละเอียดสินค้าทั้งหมดด้วย (ลิงก์สินค้าจะเข้าไม่ได้)");
+    }
+    return warns;
+  }
+
+  function renderPageAvailabilityEditor() {
+    config.page_availability = normalizePageAvailability(config.page_availability);
+    const pa = config.page_availability;
+    const enabledCount = PAGE_AVAILABILITY_KEYS.filter((k) => pa[k]).length;
+    const rows = PAGE_AVAILABILITY_KEYS.map((key) => {
+      const [label, hint] = PAGE_AVAILABILITY_META[key];
+      const isTracking = key === "tracking";
+      return `
+        <div class="pa-row ${pa[key] ? "" : "is-off"} ${isTracking ? "pa-row-tracking" : ""}">
+          <div class="pa-info">
+            <div class="pa-name">${esc(label)} ${pa[key] ? "" : '<span class="pa-badge-off">ปิดอยู่</span>'}</div>
+            <div class="pa-hint">${esc(hint)}</div>
+          </div>
+          <label class="tog"><input type="checkbox" data-page-availability="${key}" ${pa[key] ? "checked" : ""}><span></span></label>
+        </div>`;
+    }).join("");
+
+    const warnings = pageAvailabilityWarnings(pa);
+    const warnHtml = warnings.length
+      ? `<div class="pa-note pa-note-warn"><strong>ข้อควรระวัง</strong><ul>${warnings.map((w) => `<li>${esc(w)}</li>`).join("")}</ul></div>`
+      : "";
+    const allDisabledHtml = enabledCount === 0
+      ? `<div class="pa-note pa-note-bad"><strong>ต้องเปิดอย่างน้อย 1 หน้า</strong><div>ตอนนี้ปิดทุกหน้า จะยังไม่สามารถ Publish ได้จนกว่าจะเปิดอย่างน้อยหนึ่งหน้า</div></div>`
+      : "";
+    const trackingOffHtml = pa.tracking === false
+      ? `<div class="pa-note pa-note-bad"><strong>คำเตือน: ปิดหน้า “ติดตามงาน”</strong><div>ลิงก์ยืนยันนัดหมายที่ส่งให้ลูกค้าชี้มาที่หน้านี้ ถ้าปิด ลูกค้าที่กดลิงก์จะเห็นหน้ากำลังปรับปรุงแทนสถานะงานจริง</div></div>`
+      : "";
+
+    $("editor").innerHTML = `
+      <div class="ep">
+        <div class="ep-head">สถานะหน้าแอปลูกค้า</div>
+        <div class="ep-body">
+          <p style="font-size:13px;color:var(--muted);line-height:1.6;margin:0 0 10px">
+            เปิด/ปิดแต่ละหน้าของแอปลูกค้า หน้าที่ปิดจะถูกซ่อนจากเมนู เข้าผ่านลิงก์ตรงไม่ได้ และจะแสดงหน้า “กำลังปรับปรุง”
+            แทน · <strong>การเปลี่ยนแปลงมีผลหลังกด Publish เท่านั้น</strong>
+          </p>
+          <div class="pa-callout">หมายเหตุ: นี่คือปุ่มควบคุมการเผยแพร่ (UI) เท่านั้น ไม่ได้แทนที่ kill switch ฝั่งเซิร์ฟเวอร์ของการจอง — การเปิดหน้า “จองล่วงหน้า/คิวด่วน” ยังต้องเปิด kill switch ที่เซิร์ฟเวอร์ด้วย</div>
+          ${allDisabledHtml}
+          ${trackingOffHtml}
+          <div class="pa-list">${rows}</div>
+          ${warnHtml}
+        </div>
+      </div>`;
+  }
+
   function renderEditor() {
+    if (selected === "page-availability") { renderPageAvailabilityEditor(); return; }
     if (selected === "theme") { renderThemeEditor(); return; }
     if (headKey()) { renderHeadEditor(); return; }
     const section = current();
@@ -944,6 +1077,14 @@
 
   document.addEventListener("change", (event) => {
     const target = event.target;
+    if (target.matches("[data-page-availability]")) {
+      config.page_availability = normalizePageAvailability(config.page_availability);
+      // Only ever change the one page the admin toggled — never auto-toggle a
+      // related page. Re-render the editor so notes/warnings update live.
+      config.page_availability[target.dataset.pageAvailability] = target.checked;
+      renderEditor();
+      return;
+    }
     if (target.matches("select[data-item]")) { current().items[Number(target.dataset.item)][target.dataset.prop] = target.value; if (target.dataset.prop === "platform") render(); else renderPreview(); }
     if (target.matches("select[data-field]")) { current()[target.dataset.field] = target.value; renderPreview(); }
     if (target.matches("[data-toggle]")) { const s = sections().find((row) => row.id === target.dataset.toggle); if (s) s.enabled = target.checked; renderPreview(); }

--- a/customer-app/assets/customer-app.css
+++ b/customer-app/assets/customer-app.css
@@ -5813,3 +5813,46 @@ textarea.purchase-input { min-height: 66px; resize: vertical; }
   font-weight: 800;
 }
 .nav-item-primary.is-active span { color: var(--navy); font-weight: 900; }
+
+/* ============================================================================
+   Page availability — maintenance screen + booking empty state
+   These appear when an admin disables a Customer App page (rollout control,
+   NOT a server kill switch). Kept visually calm and reassuring.
+   ========================================================================== */
+.maintenance-screen {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 60vh;
+  padding: 24px 16px;
+}
+.maintenance-card {
+  width: 100%;
+  max-width: 420px;
+  background: var(--card, #fff);
+  border: 1px solid var(--line, #e3e9f2);
+  border-radius: var(--radius-lg);
+  padding: 28px 22px;
+  text-align: center;
+  box-shadow: 0 18px 40px -24px rgba(6, 24, 47, 0.35);
+}
+.maintenance-emoji { font-size: 44px; line-height: 1; margin-bottom: 10px; }
+.maintenance-card h2 { font-size: 19px; font-weight: 800; color: var(--navy); margin: 0 0 6px; }
+.maintenance-page { font-size: 14px; color: var(--navy-3); margin: 0 0 4px; }
+.maintenance-card .muted { font-size: 14px; margin: 0 0 18px; }
+.maintenance-actions { display: flex; flex-direction: column; gap: 10px; }
+.maintenance-actions .primary-btn,
+.maintenance-actions .secondary-btn { width: 100%; text-align: center; justify-content: center; }
+
+.booking-empty-card {
+  text-align: center;
+  padding: 26px 20px;
+}
+.booking-empty-emoji { font-size: 40px; line-height: 1; margin-bottom: 8px; }
+.booking-empty-card h2 { font-size: 18px; font-weight: 800; color: var(--navy); margin: 0 0 6px; }
+.booking-empty-card .muted { margin: 0 0 16px; }
+.booking-empty-card .support-strip { justify-content: center; }
+
+/* Availability-hidden controls: belt-and-braces so a [hidden] element that some
+   other rule forces back to display:block still stays out of the layout. */
+[data-cwf-avail="off"] { display: none !important; }

--- a/customer-app/assets/customer-app.js
+++ b/customer-app/assets/customer-app.js
@@ -3,7 +3,7 @@
 
   const App = window.CWFCustomerAppV2;
   const BOOT_TIMEOUT_MS = 3500;
-  const BUILD_ID = "20260712_page_controls_tracking_link_v1";
+  const BUILD_ID = "20260712_page_controls_tracking_link_v2";
 
   function withTimeout(promise, timeoutMs) {
     return Promise.race([

--- a/customer-app/assets/customer-app.js
+++ b/customer-app/assets/customer-app.js
@@ -3,7 +3,7 @@
 
   const App = window.CWFCustomerAppV2;
   const BOOT_TIMEOUT_MS = 3500;
-  const BUILD_ID = "20260711_tracking_gps_recovery_v1";
+  const BUILD_ID = "20260712_page_controls_tracking_link_v1";
 
   function withTimeout(promise, timeoutMs) {
     return Promise.race([
@@ -36,15 +36,26 @@
 
     const params = new URLSearchParams(window.location.search || "");
     const trackingKey = String(params.get("q") || params.get("token") || "").trim();
+    let requestedTracking = false;
     if (trackingKey) {
       // The deep-link value may be the private booking_token. Hand it to the
       // tracking module as a PRIVATE credential — never write it into the
       // visible tracking draft/input (it would be rendered before/while the
       // lookup runs). The tracking module consumes it on its first render.
       App.tracking?.setInitialCredential?.(trackingKey);
+      requestedTracking = true;
       if (!window.location.hash || App.state.readRouteFromHash() === "home") {
         window.location.hash = "#tracking";
       }
+    }
+
+    // Load the page-availability config and WAIT for it to be ready before the
+    // router initialises, so the very first render already knows which pages
+    // are open. load() always resolves to a ready state (server → cache →
+    // degraded fail-safe) and never rejects.
+    const pa = App.pageAvailability;
+    if (pa && typeof pa.load === "function") {
+      await pa.load();
     }
 
     App.router.register({
@@ -58,13 +69,28 @@
       profile: App.profile.render,
     });
 
+    // If nothing sent us to an explicit route and the landing page is disabled,
+    // start on the first enabled route instead of bouncing through a disabled
+    // home render.
+    if (pa && typeof pa.isReady === "function" && pa.isReady()) {
+      const hasExplicitHash = !!window.location.hash && App.state.readRouteFromHash() !== "home";
+      if (!requestedTracking && !hasExplicitHash && !pa.isEnabled("home")) {
+        window.location.hash = `#${pa.firstEnabledRoute()}`;
+      }
+    }
+
+    // Only prefetch Home when Home is actually enabled AND is (still) the
+    // initial route — avoids a wasted/hidden home fetch for a disabled page.
+    const homeEnabled = !pa || typeof pa.isEnabled !== "function" || pa.isEnabled("home");
+    const initialRouteHome = App.state.readRouteFromHash() === "home";
     const bootWork = Promise.allSettled([
       App.auth.bootstrap(),
-      App.ui.prefetchHome(),
+      homeEnabled && initialRouteHome ? App.ui.prefetchHome() : Promise.resolve(),
     ]);
 
     await withTimeout(bootWork, BOOT_TIMEOUT_MS);
     App.ui.updateAccountChrome();
+    if (pa && typeof pa.startObserver === "function") pa.startObserver();
     App.router.init();
 
     requestAnimationFrame(() => {

--- a/customer-app/assets/customer-app.js
+++ b/customer-app/assets/customer-app.js
@@ -3,13 +3,67 @@
 
   const App = window.CWFCustomerAppV2;
   const BOOT_TIMEOUT_MS = 3500;
-  const BUILD_ID = "20260712_page_controls_tracking_link_v2";
+  const BUILD_ID = "20260712_page_controls_tracking_link_v3";
 
   function withTimeout(promise, timeoutMs) {
     return Promise.race([
       promise,
       new Promise((resolve) => setTimeout(resolve, timeoutMs)),
     ]);
+  }
+
+  // Parse the (private) tracking credential out of the boot URL and return a
+  // scrubbed URL that no longer contains it. Pure + side-effect free so it can
+  // be unit-tested directly.
+  //
+  //  - Official format (credential in the FRAGMENT, never sent to the server):
+  //      /customer-app/index.html#tracking?q=<credential>
+  //      /customer-app/index.html#tracking?token=<credential>
+  //  - Legacy format (credential in the query — still supported, still scrubbed):
+  //      /customer-app/index.html?q=<credential>#tracking
+  //      /customer-app/index.html?token=<credential>#tracking
+  //
+  // Unrelated query params (e.g. ?utm_source=line) are preserved. When a
+  // credential is captured the route is normalised to a clean "#tracking".
+  function parseTrackingBoot(href) {
+    const result = { credential: "", isTracking: false, cleanUrl: href, changed: false };
+    let url;
+    try { url = new URL(href); } catch (_) { return result; }
+
+    // ---- fragment first (the official, server-invisible location) ----------
+    const rawHash = url.hash.charAt(0) === "#" ? url.hash.slice(1) : url.hash;
+    const qIndex = rawHash.indexOf("?");
+    const hashRoute = qIndex >= 0 ? rawHash.slice(0, qIndex) : rawHash;
+    let fragHadCred = false;
+    if (qIndex >= 0) {
+      const fp = new URLSearchParams(rawHash.slice(qIndex + 1));
+      const fragCred = String(fp.get("q") || fp.get("token") || "").trim();
+      if (fp.has("q") || fp.has("token")) fragHadCred = true;
+      if (fragCred) result.credential = fragCred;
+      fp.delete("q"); fp.delete("token");
+      const rest = fp.toString();
+      url.hash = rest ? `${hashRoute}?${rest}` : hashRoute;
+    }
+    if (hashRoute === "tracking") result.isTracking = true;
+
+    // ---- legacy query fallback --------------------------------------------
+    const sp = url.searchParams;
+    const queryHadCred = sp.has("q") || sp.has("token");
+    if (!result.credential) {
+      const queryCred = String(sp.get("q") || sp.get("token") || "").trim();
+      if (queryCred) result.credential = queryCred;
+    }
+    sp.delete("q"); sp.delete("token");
+
+    // A captured credential always lands on a clean #tracking route.
+    if (result.credential) {
+      url.hash = "tracking";
+      result.isTracking = true;
+    }
+
+    result.cleanUrl = url.toString();
+    result.changed = fragHadCred || queryHadCred;
+    return result;
   }
 
   function registerServiceWorker() {
@@ -32,19 +86,30 @@
   }
 
   async function init() {
+    // Capture + SCRUB the private tracking credential BEFORE state.init() so the
+    // router never sees a route like "tracking?q=..." and the credential never
+    // lingers in the address bar / history. Fragment form is preferred (never
+    // sent to the server); legacy query form is still honoured and scrubbed.
+    const boot = parseTrackingBoot(window.location.href);
+    if (boot.changed) {
+      // replaceState (not a new history entry) drops ?q=/#tracking?q= from the
+      // URL bar while preserving unrelated query params (e.g. utm_source).
+      try { window.history.replaceState(null, "", boot.cleanUrl); } catch (_) { /* non-fatal */ }
+    }
+
     App.state.init();
 
-    const params = new URLSearchParams(window.location.search || "");
-    const trackingKey = String(params.get("q") || params.get("token") || "").trim();
     let requestedTracking = false;
-    if (trackingKey) {
+    if (boot.credential) {
       // The deep-link value may be the private booking_token. Hand it to the
       // tracking module as a PRIVATE credential — never write it into the
-      // visible tracking draft/input (it would be rendered before/while the
-      // lookup runs). The tracking module consumes it on its first render.
-      App.tracking?.setInitialCredential?.(trackingKey);
+      // visible tracking draft/input, never persist it. The tracking module
+      // consumes it on its first render. It is NOT kept anywhere serialisable.
+      App.tracking?.setInitialCredential?.(boot.credential);
       requestedTracking = true;
-      if (!window.location.hash || App.state.readRouteFromHash() === "home") {
+      // cleanUrl already ends in #tracking; ensure the route resolves to it even
+      // if replaceState was unavailable.
+      if (App.state.readRouteFromHash() !== "tracking") {
         window.location.hash = "#tracking";
       }
     }

--- a/customer-app/index.html
+++ b/customer-app/index.html
@@ -17,10 +17,10 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Noto+Sans+Thai:wght@400;500;600;700;800;900&display=swap" media="print" onload="this.media='all'">
   <noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Noto+Sans+Thai:wght@400;500;600;700;800;900&display=swap"></noscript>
-  <link rel="manifest" href="./manifest.webmanifest?v=20260712_page_controls_tracking_link_v1">
+  <link rel="manifest" href="./manifest.webmanifest?v=20260712_page_controls_tracking_link_v2">
   <link rel="icon" type="image/png" sizes="192x192" href="./assets/icons/cwf-customer-192.png">
   <link rel="apple-touch-icon" sizes="180x180" href="./assets/icons/cwf-customer-180.png">
-  <link rel="stylesheet" href="./assets/customer-app.css?v=20260712_page_controls_tracking_link_v1">
+  <link rel="stylesheet" href="./assets/customer-app.css?v=20260712_page_controls_tracking_link_v2">
 </head>
 <body class="is-app-booting">
   <div class="app-shell" data-app-shell>
@@ -58,22 +58,22 @@
     </nav>
   </div>
 
-  <script src="./modules/state.js?v=20260712_page_controls_tracking_link_v1"></script>
-  <script src="./modules/utils.js?v=20260712_page_controls_tracking_link_v1"></script>
-  <script src="./modules/analytics.js?v=20260712_page_controls_tracking_link_v1"></script>
-  <script src="./modules/api.js?v=20260712_page_controls_tracking_link_v1"></script>
-  <script src="./modules/pageAvailability.js?v=20260712_page_controls_tracking_link_v1"></script>
-  <script src="./modules/services.js?v=20260712_page_controls_tracking_link_v1"></script>
-  <script src="./modules/ui.js?v=20260712_page_controls_tracking_link_v1"></script>
-  <script src="./modules/store.js?v=20260712_page_controls_tracking_link_v1"></script>
-  <script src="./modules/auth.js?v=20260712_page_controls_tracking_link_v1"></script>
-  <script src="./modules/pricing.js?v=20260712_page_controls_tracking_link_v1"></script>
-  <script src="./modules/availability.js?v=20260712_page_controls_tracking_link_v1"></script>
-  <script src="./modules/bookingScheduled.js?v=20260712_page_controls_tracking_link_v1"></script>
-  <script src="./modules/bookingUrgent.js?v=20260712_page_controls_tracking_link_v1"></script>
-  <script src="./modules/tracking.js?v=20260712_page_controls_tracking_link_v1"></script>
-  <script src="./modules/profile.js?v=20260712_page_controls_tracking_link_v1"></script>
-  <script src="./modules/router.js?v=20260712_page_controls_tracking_link_v1"></script>
-  <script src="./assets/customer-app.js?v=20260712_page_controls_tracking_link_v1"></script>
+  <script src="./modules/state.js?v=20260712_page_controls_tracking_link_v2"></script>
+  <script src="./modules/utils.js?v=20260712_page_controls_tracking_link_v2"></script>
+  <script src="./modules/analytics.js?v=20260712_page_controls_tracking_link_v2"></script>
+  <script src="./modules/api.js?v=20260712_page_controls_tracking_link_v2"></script>
+  <script src="./modules/pageAvailability.js?v=20260712_page_controls_tracking_link_v2"></script>
+  <script src="./modules/services.js?v=20260712_page_controls_tracking_link_v2"></script>
+  <script src="./modules/ui.js?v=20260712_page_controls_tracking_link_v2"></script>
+  <script src="./modules/store.js?v=20260712_page_controls_tracking_link_v2"></script>
+  <script src="./modules/auth.js?v=20260712_page_controls_tracking_link_v2"></script>
+  <script src="./modules/pricing.js?v=20260712_page_controls_tracking_link_v2"></script>
+  <script src="./modules/availability.js?v=20260712_page_controls_tracking_link_v2"></script>
+  <script src="./modules/bookingScheduled.js?v=20260712_page_controls_tracking_link_v2"></script>
+  <script src="./modules/bookingUrgent.js?v=20260712_page_controls_tracking_link_v2"></script>
+  <script src="./modules/tracking.js?v=20260712_page_controls_tracking_link_v2"></script>
+  <script src="./modules/profile.js?v=20260712_page_controls_tracking_link_v2"></script>
+  <script src="./modules/router.js?v=20260712_page_controls_tracking_link_v2"></script>
+  <script src="./assets/customer-app.js?v=20260712_page_controls_tracking_link_v2"></script>
 </body>
 </html>

--- a/customer-app/index.html
+++ b/customer-app/index.html
@@ -3,6 +3,10 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+  <!-- Never send a Referer header. Placed before every resource tag so a legacy
+       q=credential deep link cannot leak the credential as the Referer of a
+       same-origin CSS / JS / icon / font request. -->
+  <meta name="referrer" content="no-referrer">
   <meta name="theme-color" content="#071B38">
   <meta name="application-name" content="CWF Service">
   <meta name="apple-mobile-web-app-capable" content="yes">
@@ -17,10 +21,10 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Noto+Sans+Thai:wght@400;500;600;700;800;900&display=swap" media="print" onload="this.media='all'">
   <noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Noto+Sans+Thai:wght@400;500;600;700;800;900&display=swap"></noscript>
-  <link rel="manifest" href="./manifest.webmanifest?v=20260712_page_controls_tracking_link_v2">
+  <link rel="manifest" href="./manifest.webmanifest?v=20260712_page_controls_tracking_link_v3">
   <link rel="icon" type="image/png" sizes="192x192" href="./assets/icons/cwf-customer-192.png">
   <link rel="apple-touch-icon" sizes="180x180" href="./assets/icons/cwf-customer-180.png">
-  <link rel="stylesheet" href="./assets/customer-app.css?v=20260712_page_controls_tracking_link_v2">
+  <link rel="stylesheet" href="./assets/customer-app.css?v=20260712_page_controls_tracking_link_v3">
 </head>
 <body class="is-app-booting">
   <div class="app-shell" data-app-shell>
@@ -58,22 +62,22 @@
     </nav>
   </div>
 
-  <script src="./modules/state.js?v=20260712_page_controls_tracking_link_v2"></script>
-  <script src="./modules/utils.js?v=20260712_page_controls_tracking_link_v2"></script>
-  <script src="./modules/analytics.js?v=20260712_page_controls_tracking_link_v2"></script>
-  <script src="./modules/api.js?v=20260712_page_controls_tracking_link_v2"></script>
-  <script src="./modules/pageAvailability.js?v=20260712_page_controls_tracking_link_v2"></script>
-  <script src="./modules/services.js?v=20260712_page_controls_tracking_link_v2"></script>
-  <script src="./modules/ui.js?v=20260712_page_controls_tracking_link_v2"></script>
-  <script src="./modules/store.js?v=20260712_page_controls_tracking_link_v2"></script>
-  <script src="./modules/auth.js?v=20260712_page_controls_tracking_link_v2"></script>
-  <script src="./modules/pricing.js?v=20260712_page_controls_tracking_link_v2"></script>
-  <script src="./modules/availability.js?v=20260712_page_controls_tracking_link_v2"></script>
-  <script src="./modules/bookingScheduled.js?v=20260712_page_controls_tracking_link_v2"></script>
-  <script src="./modules/bookingUrgent.js?v=20260712_page_controls_tracking_link_v2"></script>
-  <script src="./modules/tracking.js?v=20260712_page_controls_tracking_link_v2"></script>
-  <script src="./modules/profile.js?v=20260712_page_controls_tracking_link_v2"></script>
-  <script src="./modules/router.js?v=20260712_page_controls_tracking_link_v2"></script>
-  <script src="./assets/customer-app.js?v=20260712_page_controls_tracking_link_v2"></script>
+  <script src="./modules/state.js?v=20260712_page_controls_tracking_link_v3"></script>
+  <script src="./modules/utils.js?v=20260712_page_controls_tracking_link_v3"></script>
+  <script src="./modules/analytics.js?v=20260712_page_controls_tracking_link_v3"></script>
+  <script src="./modules/api.js?v=20260712_page_controls_tracking_link_v3"></script>
+  <script src="./modules/pageAvailability.js?v=20260712_page_controls_tracking_link_v3"></script>
+  <script src="./modules/services.js?v=20260712_page_controls_tracking_link_v3"></script>
+  <script src="./modules/ui.js?v=20260712_page_controls_tracking_link_v3"></script>
+  <script src="./modules/store.js?v=20260712_page_controls_tracking_link_v3"></script>
+  <script src="./modules/auth.js?v=20260712_page_controls_tracking_link_v3"></script>
+  <script src="./modules/pricing.js?v=20260712_page_controls_tracking_link_v3"></script>
+  <script src="./modules/availability.js?v=20260712_page_controls_tracking_link_v3"></script>
+  <script src="./modules/bookingScheduled.js?v=20260712_page_controls_tracking_link_v3"></script>
+  <script src="./modules/bookingUrgent.js?v=20260712_page_controls_tracking_link_v3"></script>
+  <script src="./modules/tracking.js?v=20260712_page_controls_tracking_link_v3"></script>
+  <script src="./modules/profile.js?v=20260712_page_controls_tracking_link_v3"></script>
+  <script src="./modules/router.js?v=20260712_page_controls_tracking_link_v3"></script>
+  <script src="./assets/customer-app.js?v=20260712_page_controls_tracking_link_v3"></script>
 </body>
 </html>

--- a/customer-app/index.html
+++ b/customer-app/index.html
@@ -17,10 +17,10 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Noto+Sans+Thai:wght@400;500;600;700;800;900&display=swap" media="print" onload="this.media='all'">
   <noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Noto+Sans+Thai:wght@400;500;600;700;800;900&display=swap"></noscript>
-  <link rel="manifest" href="./manifest.webmanifest?v=20260711_tracking_gps_recovery_v1">
+  <link rel="manifest" href="./manifest.webmanifest?v=20260712_page_controls_tracking_link_v1">
   <link rel="icon" type="image/png" sizes="192x192" href="./assets/icons/cwf-customer-192.png">
   <link rel="apple-touch-icon" sizes="180x180" href="./assets/icons/cwf-customer-180.png">
-  <link rel="stylesheet" href="./assets/customer-app.css?v=20260711_tracking_gps_recovery_v1">
+  <link rel="stylesheet" href="./assets/customer-app.css?v=20260712_page_controls_tracking_link_v1">
 </head>
 <body class="is-app-booting">
   <div class="app-shell" data-app-shell>
@@ -58,21 +58,22 @@
     </nav>
   </div>
 
-  <script src="./modules/state.js?v=20260711_tracking_gps_recovery_v1"></script>
-  <script src="./modules/utils.js?v=20260711_tracking_gps_recovery_v1"></script>
-  <script src="./modules/analytics.js?v=20260711_tracking_gps_recovery_v1"></script>
-  <script src="./modules/api.js?v=20260711_tracking_gps_recovery_v1"></script>
-  <script src="./modules/services.js?v=20260711_tracking_gps_recovery_v1"></script>
-  <script src="./modules/ui.js?v=20260711_tracking_gps_recovery_v1"></script>
-  <script src="./modules/store.js?v=20260711_tracking_gps_recovery_v1"></script>
-  <script src="./modules/auth.js?v=20260711_tracking_gps_recovery_v1"></script>
-  <script src="./modules/pricing.js?v=20260711_tracking_gps_recovery_v1"></script>
-  <script src="./modules/availability.js?v=20260711_tracking_gps_recovery_v1"></script>
-  <script src="./modules/bookingScheduled.js?v=20260711_tracking_gps_recovery_v1"></script>
-  <script src="./modules/bookingUrgent.js?v=20260711_tracking_gps_recovery_v1"></script>
-  <script src="./modules/tracking.js?v=20260711_tracking_gps_recovery_v1"></script>
-  <script src="./modules/profile.js?v=20260711_tracking_gps_recovery_v1"></script>
-  <script src="./modules/router.js?v=20260711_tracking_gps_recovery_v1"></script>
-  <script src="./assets/customer-app.js?v=20260711_tracking_gps_recovery_v1"></script>
+  <script src="./modules/state.js?v=20260712_page_controls_tracking_link_v1"></script>
+  <script src="./modules/utils.js?v=20260712_page_controls_tracking_link_v1"></script>
+  <script src="./modules/analytics.js?v=20260712_page_controls_tracking_link_v1"></script>
+  <script src="./modules/api.js?v=20260712_page_controls_tracking_link_v1"></script>
+  <script src="./modules/pageAvailability.js?v=20260712_page_controls_tracking_link_v1"></script>
+  <script src="./modules/services.js?v=20260712_page_controls_tracking_link_v1"></script>
+  <script src="./modules/ui.js?v=20260712_page_controls_tracking_link_v1"></script>
+  <script src="./modules/store.js?v=20260712_page_controls_tracking_link_v1"></script>
+  <script src="./modules/auth.js?v=20260712_page_controls_tracking_link_v1"></script>
+  <script src="./modules/pricing.js?v=20260712_page_controls_tracking_link_v1"></script>
+  <script src="./modules/availability.js?v=20260712_page_controls_tracking_link_v1"></script>
+  <script src="./modules/bookingScheduled.js?v=20260712_page_controls_tracking_link_v1"></script>
+  <script src="./modules/bookingUrgent.js?v=20260712_page_controls_tracking_link_v1"></script>
+  <script src="./modules/tracking.js?v=20260712_page_controls_tracking_link_v1"></script>
+  <script src="./modules/profile.js?v=20260712_page_controls_tracking_link_v1"></script>
+  <script src="./modules/router.js?v=20260712_page_controls_tracking_link_v1"></script>
+  <script src="./assets/customer-app.js?v=20260712_page_controls_tracking_link_v1"></script>
 </body>
 </html>

--- a/customer-app/manifest.webmanifest
+++ b/customer-app/manifest.webmanifest
@@ -2,7 +2,7 @@
   "name": "CWF Customer Service",
   "short_name": "CWF Service",
   "description": "แอปลูกค้า Coldwindflow สำหรับเลือกบริการ จองคิว และติดตามงาน",
-  "start_url": "/customer-app/index.html?v=20260712_page_controls_tracking_link_v1#home",
+  "start_url": "/customer-app/index.html?v=20260712_page_controls_tracking_link_v2#home",
   "scope": "/customer-app/",
   "id": "/customer-app/",
   "display": "standalone",

--- a/customer-app/manifest.webmanifest
+++ b/customer-app/manifest.webmanifest
@@ -2,7 +2,7 @@
   "name": "CWF Customer Service",
   "short_name": "CWF Service",
   "description": "แอปลูกค้า Coldwindflow สำหรับเลือกบริการ จองคิว และติดตามงาน",
-  "start_url": "/customer-app/index.html?v=20260711_tracking_gps_recovery_v1#home",
+  "start_url": "/customer-app/index.html?v=20260712_page_controls_tracking_link_v1#home",
   "scope": "/customer-app/",
   "id": "/customer-app/",
   "display": "standalone",

--- a/customer-app/manifest.webmanifest
+++ b/customer-app/manifest.webmanifest
@@ -2,7 +2,7 @@
   "name": "CWF Customer Service",
   "short_name": "CWF Service",
   "description": "แอปลูกค้า Coldwindflow สำหรับเลือกบริการ จองคิว และติดตามงาน",
-  "start_url": "/customer-app/index.html?v=20260712_page_controls_tracking_link_v2#home",
+  "start_url": "/customer-app/index.html?v=20260712_page_controls_tracking_link_v3#home",
   "scope": "/customer-app/",
   "id": "/customer-app/",
   "display": "standalone",

--- a/customer-app/modules/api.js
+++ b/customer-app/modules/api.js
@@ -136,6 +136,12 @@
       return requestJson("/public/homepage/active-job", { cache: "no-store" });
     },
 
+    // Page-availability rollout control (admin toggle) — always fetched fresh so
+    // a page turned off in the CMS takes effect without a cache round-trip.
+    async loadCustomerAppConfig() {
+      return requestJson("/public/customer-app-config", { cache: "no-store" });
+    },
+
     async createOrder(payload) {
       return requestJson("/public/orders", { method: "POST", body: payload || {} });
     },

--- a/customer-app/modules/pageAvailability.js
+++ b/customer-app/modules/pageAvailability.js
@@ -1,0 +1,268 @@
+(function () {
+  "use strict";
+
+  const root = window.CWFCustomerAppV2 = window.CWFCustomerAppV2 || {};
+
+  // Customer App page-availability (admin rollout control, NOT a server kill
+  // switch). Source of truth is the published Homepage CMS config, read via the
+  // lightweight /public/customer-app-config endpoint. This module never becomes
+  // the source of truth; localStorage is only a last-known-good cache.
+  const PAGE_KEYS = ["home", "store", "booking", "scheduled", "urgent", "tracking", "profile"];
+  const DEFAULT_ALL_ENABLED = Object.freeze({
+    home: true, store: true, booking: true, scheduled: true, urgent: true, tracking: true, profile: true,
+  });
+  // Fail-safe: keep the landing page and Tracking reachable, close the
+  // transactional/unfinished flows when we truly have nothing to trust.
+  const DEGRADED = Object.freeze({
+    home: true, store: false, booking: false, scheduled: false, urgent: false, tracking: true, profile: false,
+  });
+  const CACHE_KEY = "cwf_customer_app_page_availability_v1";
+  const CACHE_VERSION = 1;
+  const LOAD_TIMEOUT_MS = 3000;
+  // First-enabled priority for the initial route and the maintenance "back"
+  // action. Validation guarantees at least one page is enabled.
+  const ROUTE_PRIORITY = ["home", "tracking", "store", "booking", "profile", "scheduled", "urgent"];
+  const DYNAMIC_STORE_PATTERN = /^storeItem-(\d+)$/;
+  const LINE_URL = "https://lin.ee/fG1Oq7y";
+  const PHONE_DISPLAY = "098-877-7321";
+  const PHONE_TEL = "0988777321";
+  const PAGE_LABELS = {
+    home: "หน้าแรก", store: "ร้านค้า", booking: "เลือกประเภทการจอง", scheduled: "จองล่วงหน้า",
+    urgent: "คิวด่วน", tracking: "ติดตามงาน", profile: "บัญชีลูกค้า",
+  };
+
+  // Start from the degraded fail-safe so that, even if something calls isEnabled()
+  // before load() resolves, we never accidentally treat a page as enabled.
+  let flags = { ...DEGRADED };
+  let ready = false;
+  let observer = null;
+
+  function isPlainObject(value) {
+    return !!value && typeof value === "object" && !Array.isArray(value);
+  }
+
+  // A valid page_availability map: exactly the 7 boolean keys, no unknown/missing
+  // keys, and at least one page enabled.
+  function isValidFlags(pa) {
+    if (!isPlainObject(pa)) return false;
+    const keys = Object.keys(pa);
+    if (keys.length !== PAGE_KEYS.length) return false;
+    for (const key of keys) if (!PAGE_KEYS.includes(key)) return false;
+    let anyEnabled = false;
+    for (const key of PAGE_KEYS) {
+      if (typeof pa[key] !== "boolean") return false;
+      if (pa[key]) anyEnabled = true;
+    }
+    return anyEnabled;
+  }
+
+  function cloneFlags(pa) {
+    const out = {};
+    for (const key of PAGE_KEYS) out[key] = pa[key] === true;
+    return out;
+  }
+
+  // ---- last-known-good cache -----------------------------------------------
+  function readCache() {
+    try {
+      const raw = window.localStorage.getItem(CACHE_KEY);
+      if (!raw) return null;
+      const parsed = JSON.parse(raw);
+      if (!parsed || parsed.version !== CACHE_VERSION) return null;
+      if (!isValidFlags(parsed.page_availability)) return null;
+      return cloneFlags(parsed.page_availability);
+    } catch (_) {
+      return null;
+    }
+  }
+
+  function writeCache(pa) {
+    try {
+      if (!isValidFlags(pa)) return;
+      window.localStorage.setItem(CACHE_KEY, JSON.stringify({
+        version: CACHE_VERSION,
+        saved_at: Date.now(),
+        page_availability: cloneFlags(pa),
+      }));
+    } catch (_) {
+      /* storage unavailable — cache is optional */
+    }
+  }
+
+  // ---- route mapping --------------------------------------------------------
+  // Map any router route to its availability key. Unknown routes return null and
+  // must NEVER be treated as enabled.
+  function availabilityKey(route) {
+    const requested = String(route == null ? "" : route).trim();
+    if (DYNAMIC_STORE_PATTERN.test(requested)) return "store";
+    if (PAGE_KEYS.includes(requested)) return requested;
+    return null;
+  }
+
+  function isEnabled(route) {
+    const key = availabilityKey(route);
+    if (!key) return false;
+    return flags[key] === true;
+  }
+
+  function firstEnabledRoute() {
+    for (const key of ROUTE_PRIORITY) if (flags[key] === true) return key;
+    return "home";
+  }
+
+  function isReady() { return ready; }
+  function getFlags() { return cloneFlags(flags); }
+
+  // ---- config load ----------------------------------------------------------
+  function withTimeout(promise, ms) {
+    return Promise.race([
+      Promise.resolve(promise),
+      new Promise((_, reject) => setTimeout(() => reject(new Error("timeout")), ms)),
+    ]);
+  }
+
+  // Priority: valid non-degraded server config → last-known-good cache → server
+  // degraded fallback → built-in degraded. Always resolves to a ready state.
+  async function load() {
+    let serverFlags = null;
+    try {
+      const resp = await withTimeout(root.api.loadCustomerAppConfig(), LOAD_TIMEOUT_MS);
+      const degraded = resp && resp.degraded === true;
+      if (resp && resp.ok === true && !degraded && isValidFlags(resp.page_availability)) {
+        serverFlags = cloneFlags(resp.page_availability);
+      }
+    } catch (_) {
+      /* fail / hang / invalid JSON / invalid flags → fall through */
+    }
+
+    if (serverFlags) {
+      flags = serverFlags;
+      writeCache(serverFlags); // cache only a valid, non-degraded server response
+    } else {
+      const cached = readCache();
+      flags = cached || { ...DEGRADED };
+    }
+    ready = true;
+    applyToDom(document);
+    return getFlags();
+  }
+
+  // ---- disabled-route controls ---------------------------------------------
+  // Hide every control that points at a disabled (or unknown) route. Only ever
+  // touch attributes THIS module set, and restore the element's prior
+  // disabled/hidden state so a control disabled by other business logic is never
+  // silently re-enabled.
+  function markHidden(el) {
+    if (el.getAttribute("data-cwf-avail") === "off") return;
+    el.setAttribute("data-cwf-avail", "off");
+    el.setAttribute("data-cwf-prev-hidden", el.hasAttribute("hidden") ? "1" : "0");
+    el.setAttribute("data-cwf-prev-aria", el.getAttribute("aria-hidden") || "");
+    el.setAttribute("data-cwf-prev-tabindex", el.hasAttribute("tabindex") ? String(el.getAttribute("tabindex")) : "");
+    el.setAttribute("hidden", "hidden");
+    el.setAttribute("aria-hidden", "true");
+    el.setAttribute("tabindex", "-1");
+    if ("disabled" in el) {
+      el.setAttribute("data-cwf-prev-disabled", el.disabled ? "1" : "0");
+      el.disabled = true;
+    }
+  }
+
+  function restoreShown(el) {
+    if (el.getAttribute("data-cwf-avail") !== "off") return; // not ours
+    if (el.getAttribute("data-cwf-prev-hidden") === "1") el.setAttribute("hidden", "hidden");
+    else el.removeAttribute("hidden");
+    const prevAria = el.getAttribute("data-cwf-prev-aria");
+    if (prevAria) el.setAttribute("aria-hidden", prevAria); else el.removeAttribute("aria-hidden");
+    const prevTab = el.getAttribute("data-cwf-prev-tabindex");
+    if (prevTab !== null && prevTab !== "") el.setAttribute("tabindex", prevTab); else el.removeAttribute("tabindex");
+    if ("disabled" in el) el.disabled = el.getAttribute("data-cwf-prev-disabled") === "1";
+    el.removeAttribute("data-cwf-avail");
+    el.removeAttribute("data-cwf-prev-hidden");
+    el.removeAttribute("data-cwf-prev-aria");
+    el.removeAttribute("data-cwf-prev-tabindex");
+    el.removeAttribute("data-cwf-prev-disabled");
+  }
+
+  function applyToDom(scope) {
+    if (!ready) return;
+    const target = scope && typeof scope.querySelectorAll === "function" ? scope : document;
+    let nodes;
+    try { nodes = target.querySelectorAll("[data-route]"); } catch (_) { return; }
+    nodes.forEach((el) => {
+      const key = availabilityKey(el.getAttribute("data-route"));
+      const disabled = !key || flags[key] !== true;
+      if (disabled) markHidden(el); else restoreShown(el);
+    });
+  }
+
+  // A single, debounced MutationObserver reapplies the filter to asynchronously
+  // rendered CTAs. It watches childList/subtree only (never attributes), so this
+  // module's own attribute writes cannot retrigger it → no loop, one observer.
+  function startObserver() {
+    if (observer || typeof MutationObserver !== "function") return;
+    const appEl = document.getElementById("app");
+    if (!appEl) return;
+    let scheduled = false;
+    observer = new MutationObserver(() => {
+      if (scheduled) return;
+      scheduled = true;
+      const run = () => { scheduled = false; applyToDom(document); };
+      if (typeof requestAnimationFrame === "function") requestAnimationFrame(run);
+      else setTimeout(run, 16);
+    });
+    observer.observe(appEl, { childList: true, subtree: true });
+  }
+
+  // ---- maintenance screen ---------------------------------------------------
+  function maintenanceHtml(route) {
+    const esc = root.utils.escapeHtml;
+    const key = availabilityKey(route);
+    const label = PAGE_LABELS[key] || PAGE_LABELS[String(route || "")] || "หน้านี้";
+    const backRoute = firstEnabledRoute();
+    const backLabel = PAGE_LABELS[backRoute] || "หน้าที่ใช้งานได้";
+    return `
+      <section class="screen maintenance-screen" role="status" aria-live="polite">
+        <div class="maintenance-card">
+          <div class="maintenance-emoji" aria-hidden="true">🛠️</div>
+          <h2>หน้านี้กำลังปรับปรุง</h2>
+          <p class="maintenance-page">หน้า: <strong>${esc(label)}</strong></p>
+          <p class="muted">ระบบกำลังเตรียมฟีเจอร์นี้ กรุณาใช้เมนูอื่นหรือติดต่อแอดมิน</p>
+          <div class="maintenance-actions">
+            <button class="primary-btn" type="button" data-route="${esc(backRoute)}" data-maintenance-back>กลับไปหน้าที่ใช้งานได้ (${esc(backLabel)})</button>
+            <a class="secondary-btn" href="${LINE_URL}" target="_blank" rel="noopener noreferrer">ติดต่อแอดมินทาง LINE</a>
+            <a class="secondary-btn" href="tel:${PHONE_TEL}">โทร ${PHONE_DISPLAY}</a>
+          </div>
+        </div>
+      </section>
+    `;
+  }
+
+  function renderMaintenance(container, route) {
+    if (!container) return;
+    container.innerHTML = maintenanceHtml(route);
+    // The back button carries data-route, so the normal router click handler
+    // navigates through the central guard — no direct handler call, no loop.
+    // Ensure our own maintenance markup is filtered too (defensive).
+    applyToDom(container);
+  }
+
+  root.pageAvailability = {
+    PAGE_KEYS,
+    DEFAULT_ALL_ENABLED,
+    DEGRADED,
+    load,
+    isReady,
+    isEnabled,
+    availabilityKey,
+    firstEnabledRoute,
+    getFlags,
+    applyToDom,
+    startObserver,
+    renderMaintenance,
+    maintenanceHtml,
+    // Exposed for tests: pure validators (no DOM/network).
+    _isValidFlags: isValidFlags,
+    _readCache: readCache,
+    _writeCache: writeCache,
+  };
+})();

--- a/customer-app/modules/router.js
+++ b/customer-app/modules/router.js
@@ -49,6 +49,25 @@
     },
     render(options = {}) {
       const requestedRoute = root.state.readRouteFromHash();
+      const pa = root.pageAvailability;
+      const paReady = !!pa && typeof pa.isReady === "function" && pa.isReady();
+
+      // Central availability guard. Runs before canonicalisation and before any
+      // route handler, so a disabled page can never call its handler or fire its
+      // page-specific API — regardless of whether the route was reached via a
+      // menu, a direct URL/hash, or a JS routeTo() call.
+      if (paReady) {
+        // Truly unknown route → redirect to the first enabled page instead of
+        // silently falling back to (a possibly disabled) home.
+        if (!pa.availabilityKey(requestedRoute)) {
+          const fallback = pa.firstEnabledRoute();
+          if (String(requestedRoute || "").trim() !== fallback) {
+            root.utils.routeTo(fallback);
+            return;
+          }
+        }
+      }
+
       const route = this.canonicalRoute(requestedRoute);
       const handler = this.resolveHandler(route);
       const app = document.getElementById("app");
@@ -57,6 +76,27 @@
       if (requestedRoute !== route) {
         history.replaceState(null, "", `#${route}`);
       }
+
+      // Disabled page → maintenance screen. We intentionally do NOT call the
+      // route handler (so its page-specific network lookup never fires) and do
+      // NOT reveal the page content.
+      if (paReady && !pa.isEnabled(route)) {
+        const routeChangedOff = this.lastRoute !== route;
+        if (routeChangedOff) {
+          const prevHandler = this.resolveHandler(this.lastRoute);
+          if (typeof prevHandler?.onLeave === "function") prevHandler.onLeave();
+        }
+        this.lastRoute = route;
+        root.state.setRoute(route);
+        this.updateNav(route);
+        pa.renderMaintenance(app, route);
+        app.dataset.currentRoute = route;
+        if (options.focus === true && routeChangedOff) {
+          requestAnimationFrame(() => app.focus({ preventScroll: true }));
+        }
+        return;
+      }
+
       const routeChanged = this.lastRoute !== route;
       if (routeChanged) {
         const prevHandler = this.resolveHandler(this.lastRoute);
@@ -66,6 +106,9 @@
       root.state.setRoute(route);
       this.updateNav(route);
       handler(app);
+      // Re-hide any control that points at a disabled route (CTAs rendered by
+      // the handler just now).
+      if (paReady && typeof pa.applyToDom === "function") pa.applyToDom(app);
       app.dataset.currentRoute = route;
       if (options.focus === true && routeChanged) {
         requestAnimationFrame(() => app.focus({ preventScroll: true }));

--- a/customer-app/modules/ui.js
+++ b/customer-app/modules/ui.js
@@ -1331,6 +1331,8 @@
       if (card) mount.innerHTML = renderQuickPrice(card);
     });
     bindHomepage(container);
+    // Re-hide any CTA pointing at a disabled route that this refresh re-rendered.
+    root.pageAvailability?.applyToDom?.(container);
   }
 
   function updateAccountChrome() {
@@ -1382,6 +1384,42 @@
     },
 
     renderBookingMode(container) {
+      // Page-availability gates each booking-mode card independently. This is a
+      // UI rollout control layered on top of — never a replacement for — the
+      // server booking kill switches.
+      const pa = root.pageAvailability;
+      const paReady = !!pa && typeof pa.isReady === "function" && pa.isReady();
+      const scheduledOn = !paReady || pa.isEnabled("scheduled");
+      const urgentOn = !paReady || pa.isEnabled("urgent");
+
+      const scheduledCard = scheduledOn ? `
+            <button class="mode-card is-scheduled" type="button" data-route="scheduled">
+              <span class="mode-kicker">เปิดจองในแอป</span>
+              <strong>จองล้างแอร์</strong>
+              <span>รองรับแอร์ผนัง แอร์สี่ทิศทาง แอร์แขวน และแอร์เปลือยใต้ฝ้า</span>
+              <span class="mode-foot">ดูราคาและคิวว่าง</span>
+            </button>` : "";
+      const urgentCard = urgentOn ? `
+            <button class="mode-card is-urgent" type="button" data-route="urgent">
+              <span class="mode-kicker">คำขอด่วน</span>
+              <strong>คิวด่วน</strong>
+              <span>ส่งรายละเอียดให้พาร์ทเนอร์ช่างกดรับ และติดตามผลด้วย Booking Code</span>
+              <span class="mode-foot">ยังไม่ถือว่ายืนยันงานจนกว่าจะมีช่างรับ</span>
+            </button>` : "";
+
+      const bookingBody = (scheduledOn || urgentOn) ? `
+          <div class="card-grid">${scheduledCard}${urgentCard}
+          </div>` : `
+          <section class="card booking-empty-card" role="status">
+            <div class="booking-empty-emoji" aria-hidden="true">🛠️</div>
+            <h2>ระบบจองออนไลน์กำลังปรับปรุง</h2>
+            <p class="muted">ขออภัยในความไม่สะดวก กรุณาติดต่อแอดมินเพื่อจองหรือสอบถามคิวช่าง</p>
+            <div class="support-strip">
+              <a class="primary-btn" href="https://lin.ee/fG1Oq7y" target="_blank" rel="noopener noreferrer">แชท LINE @cwfair</a>
+              <a class="secondary-btn" href="tel:0988777321">โทร 098-877-7321</a>
+            </div>
+          </section>`;
+
       container.innerHTML = `
         <section class="screen">
           ${pageHeaderHtml("booking")}
@@ -1390,20 +1428,7 @@
             <h2>จองล้างแอร์ล่วงหน้า</h2>
             <p>เลือกประเภทการล้าง ดูราคา และเลือกวันเวลาจากคิวช่างที่ว่างจริง</p>
           </div>
-          <div class="card-grid">
-            <button class="mode-card is-scheduled" type="button" data-route="scheduled">
-              <span class="mode-kicker">เปิดจองในแอป</span>
-              <strong>จองล้างแอร์</strong>
-              <span>รองรับแอร์ผนัง แอร์สี่ทิศทาง แอร์แขวน และแอร์เปลือยใต้ฝ้า</span>
-              <span class="mode-foot">ดูราคาและคิวว่าง</span>
-            </button>
-            <button class="mode-card is-urgent" type="button" data-route="urgent">
-              <span class="mode-kicker">คำขอด่วน</span>
-              <strong>คิวด่วน</strong>
-              <span>ส่งรายละเอียดให้พาร์ทเนอร์ช่างกดรับ และติดตามผลด้วย Booking Code</span>
-              <span class="mode-foot">ยังไม่ถือว่ายืนยันงานจนกว่าจะมีช่างรับ</span>
-            </button>
-          </div>
+          ${bookingBody}
           <section class="card support-card">
             <h2>งานซ่อม ติดตั้ง ย้ายแอร์ หรือตรวจอาการ</h2>
             <p class="muted">ยังไม่เปิดจองอัตโนมัติ กรุณาติดต่อแอดมินเพื่อประเมินอาการ ราคา และเวลาที่เหมาะสม</p>

--- a/customer-app/sw.js
+++ b/customer-app/sw.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const BUILD_ID = "20260712_page_controls_tracking_link_v1";
+const BUILD_ID = "20260712_page_controls_tracking_link_v2";
 const CACHE_NAME = `cwf-customer-app-v2-${BUILD_ID}`;
 const APP_SHELL = [
   `./index.html?v=${BUILD_ID}`,
@@ -56,6 +56,22 @@ self.addEventListener("fetch", (event) => {
     return;
   }
   if (!url.pathname.startsWith("/customer-app/")) return;
+
+  // Secure Tracking deep link: a navigation that carries the PRIVATE tracking
+  // credential (?q= or ?token=) must NEVER touch Cache Storage — the credential
+  // would otherwise become part of a cache key. Fetch network-only and return
+  // the response directly: no cache.put, and no caches.match on this
+  // credential-bearing request. Offline → fall back to the canonical cached app
+  // shell (a credential-free key); the in-app boot re-reads ?q= from the URL.
+  // The credential is never logged.
+  const hasTrackingCredential = url.searchParams.has("q") || url.searchParams.has("token");
+  if (request.mode === "navigate" && hasTrackingCredential) {
+    event.respondWith(
+      fetch(request, { cache: "no-store" })
+        .catch(() => caches.match(`./index.html?v=${BUILD_ID}`))
+    );
+    return;
+  }
 
   event.respondWith(
     fetch(request, { cache: "no-store" })

--- a/customer-app/sw.js
+++ b/customer-app/sw.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const BUILD_ID = "20260712_page_controls_tracking_link_v2";
+const BUILD_ID = "20260712_page_controls_tracking_link_v3";
 const CACHE_NAME = `cwf-customer-app-v2-${BUILD_ID}`;
 const APP_SHELL = [
   `./index.html?v=${BUILD_ID}`,

--- a/customer-app/sw.js
+++ b/customer-app/sw.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const BUILD_ID = "20260711_tracking_gps_recovery_v1";
+const BUILD_ID = "20260712_page_controls_tracking_link_v1";
 const CACHE_NAME = `cwf-customer-app-v2-${BUILD_ID}`;
 const APP_SHELL = [
   `./index.html?v=${BUILD_ID}`,
@@ -12,6 +12,7 @@ const APP_SHELL = [
   `./modules/utils.js?v=${BUILD_ID}`,
   `./modules/analytics.js?v=${BUILD_ID}`,
   `./modules/api.js?v=${BUILD_ID}`,
+  `./modules/pageAvailability.js?v=${BUILD_ID}`,
   `./modules/services.js?v=${BUILD_ID}`,
   `./modules/ui.js?v=${BUILD_ID}`,
   `./modules/store.js?v=${BUILD_ID}`,

--- a/index.js
+++ b/index.js
@@ -18446,12 +18446,15 @@ function buildCustomerConfirmationVars({ job, items, origin, ddTH, ttTH, ddEN, t
   const trackingCredential = String(job.booking_token || '').trim() || String(job.booking_code || '') || String(job.job_id || '');
   return {
     booking_code: booking,
-    // Official confirmation link now opens the Customer App V2 Tracking screen
-    // (query BEFORE hash so the app boot reads ?q= then routes to #tracking).
+    // Official confirmation link opens the Customer App V2 Tracking screen with
+    // the credential in the URL FRAGMENT (after #), which browsers never send to
+    // the server (no access logs, no Referer leak). The app boot reads it from
+    // location.hash, then scrubs the URL to a clean #tracking. Legacy
+    // ?q=...#tracking links still work and are also scrubbed on boot.
     // The credential selection above is unchanged: booking_token when present
     // (full access), never rendered as visible text or logged. Legacy track.html
     // is intentionally left in place for rollback.
-    tracking_url: `${origin}/customer-app/index.html?q=${encodeURIComponent(trackingCredential)}#tracking`,
+    tracking_url: `${origin}/customer-app/index.html#tracking?q=${encodeURIComponent(trackingCredential)}`,
     customer_name: _safeMsgText(job.customer_name),
     customer_phone: _safeMsgText(job.customer_phone),
     appointment_th: `${ddTH} เวลา ${ttTH} น.`,

--- a/index.js
+++ b/index.js
@@ -18446,7 +18446,12 @@ function buildCustomerConfirmationVars({ job, items, origin, ddTH, ttTH, ddEN, t
   const trackingCredential = String(job.booking_token || '').trim() || String(job.booking_code || '') || String(job.job_id || '');
   return {
     booking_code: booking,
-    tracking_url: `${origin}/track.html?q=${encodeURIComponent(trackingCredential)}`,
+    // Official confirmation link now opens the Customer App V2 Tracking screen
+    // (query BEFORE hash so the app boot reads ?q= then routes to #tracking).
+    // The credential selection above is unchanged: booking_token when present
+    // (full access), never rendered as visible text or logged. Legacy track.html
+    // is intentionally left in place for rollback.
+    tracking_url: `${origin}/customer-app/index.html?q=${encodeURIComponent(trackingCredential)}#tracking`,
     customer_name: _safeMsgText(job.customer_name),
     customer_phone: _safeMsgText(job.customer_phone),
     appointment_th: `${ddTH} เวลา ${ttTH} น.`,

--- a/server/routes/homepage.js
+++ b/server/routes/homepage.js
@@ -27,6 +27,71 @@ const INTERNAL_ROUTES = new Set(["home", "booking", "scheduled", "urgent", "trac
 // Per-page header banners the admin manages independently of the homepage hero.
 const PAGE_HEADER_KEYS = ["store", "booking", "tracking"];
 const FOCAL_POSITIONS = new Set(["top", "center", "bottom"]);
+
+// ---- Customer App page availability (rollout control, NOT a kill switch) -----
+// Which Customer App V2 top-level pages are enabled. Stored inside the same
+// Homepage CMS config (published_config) — no new table/migration. Legacy
+// configs without this field are interpreted as all-enabled.
+const PAGE_AVAILABILITY_KEYS = ["home", "store", "booking", "scheduled", "urgent", "tracking", "profile"];
+const DEFAULT_PAGE_AVAILABILITY = Object.freeze({
+  home: true, store: true, booking: true, scheduled: true, urgent: true, tracking: true, profile: true,
+});
+// Fail-safe when there is no config AND no valid client cache: keep the landing
+// page and Tracking reachable, close transactional/unfinished flows.
+const DEGRADED_PAGE_AVAILABILITY = Object.freeze({
+  home: true, store: false, booking: false, scheduled: false, urgent: false, tracking: true, profile: false,
+});
+
+// Strict validation for an admin-supplied page_availability object. Absent =
+// legacy = all-enabled (not an error). When present it must be a plain object
+// with exactly the 7 boolean keys, no unknown/missing keys, and at least one
+// page enabled. Errors are pushed into `errors`; the returned object is always a
+// complete 7-key map so callers never crash on it.
+function normalizePageAvailability(raw, errors) {
+  if (raw === undefined || raw === null) return { ...DEFAULT_PAGE_AVAILABILITY };
+  if (typeof raw !== "object" || Array.isArray(raw)) {
+    errors.push("page_availability must be an object");
+    return { ...DEFAULT_PAGE_AVAILABILITY };
+  }
+  for (const key of Object.keys(raw)) {
+    if (!PAGE_AVAILABILITY_KEYS.includes(key)) errors.push(`page_availability.${key} is not a valid page`);
+  }
+  const out = {};
+  let anyEnabled = false;
+  for (const key of PAGE_AVAILABILITY_KEYS) {
+    if (!Object.prototype.hasOwnProperty.call(raw, key)) {
+      errors.push(`page_availability.${key} is required`);
+      out[key] = true;
+      continue;
+    }
+    const v = raw[key];
+    if (typeof v !== "boolean") {
+      errors.push(`page_availability.${key} must be a boolean`);
+      out[key] = true;
+      continue;
+    }
+    out[key] = v;
+    if (v) anyEnabled = true;
+  }
+  if (!anyEnabled) errors.push("page_availability must keep at least one page enabled");
+  return out;
+}
+
+// Non-throwing read for public responses. A published config is either legacy
+// (no field → all-enabled) or already validated; defensively coerce anything
+// odd to a safe complete map, and never emit an all-disabled result.
+function readPageAvailability(config) {
+  const raw = config && typeof config === "object" ? config.page_availability : null;
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) return { ...DEFAULT_PAGE_AVAILABILITY };
+  const out = {};
+  let anyEnabled = false;
+  for (const key of PAGE_AVAILABILITY_KEYS) {
+    const v = raw[key];
+    out[key] = typeof v === "boolean" ? v : true;
+    if (out[key]) anyEnabled = true;
+  }
+  return anyEnabled ? out : { ...DEFAULT_PAGE_AVAILABILITY };
+}
 const ASPECT_MODES = new Set(["contain", "cover"]);
 const MAX_PROMO_BANNERS = 8;
 const MAX_SOCIAL_ITEMS = 8;
@@ -45,6 +110,7 @@ const SOCIAL_HOST_PATTERNS = {
 
 const DEFAULT_CONFIG = {
   version: 1,
+  page_availability: { home: true, store: true, booking: true, scheduled: true, urgent: true, tracking: true, profile: true },
   sections: [
     {
       id: "hero",
@@ -431,6 +497,7 @@ function validateConfig(input) {
     sections: normalizedSections.sort((a, b) => a.sort_order - b.sort_order),
     page_headers: normalizePageHeaders(input?.page_headers, errors),
     theme: normalizeTheme(input?.theme, errors),
+    page_availability: normalizePageAvailability(input?.page_availability, errors),
   };
   return { ok: errors.length === 0, errors, config: normalized };
 }
@@ -512,7 +579,9 @@ function stripPublicConfig(config) {
     page_headers[key] = cleanHeader;
   }
   const theme = config?.theme && typeof config.theme === "object" && !Array.isArray(config.theme) ? config.theme : {};
-  return { version: 1, sections, page_headers, theme };
+  // Page availability travels to the public config as a normalized 7-key boolean
+  // map (legacy configs → all-enabled). No admin metadata is included.
+  return { version: 1, sections, page_headers, theme, page_availability: readPageAvailability(config) };
 }
 
 async function hydrateAutoSyncArticles(pool, publicConfig) {
@@ -576,11 +645,21 @@ function hydrateDraftConfig(rawConfig) {
   const base = rawConfig && typeof rawConfig === "object" && Array.isArray(rawConfig.sections) ? rawConfig : DEFAULT_CONFIG;
   const existingTypes = new Set(base.sections.map((section) => section && (section.type || section.id)));
   const missing = DEFAULT_CONFIG.sections.filter((defaultSection) => !existingTypes.has(defaultSection.type));
-  if (!missing.length) return base;
-  return {
+  // Preserve EVERY existing top-level field (page_headers, theme,
+  // page_availability, version, …). Only append missing default sections and
+  // backfill page_availability for a legacy draft that predates it. Never reduce
+  // the config to just { version, sections } (that dropped page_headers/theme).
+  const hydrated = {
+    ...base,
     version: base.version || 1,
-    sections: [...base.sections, ...missing.map((section) => JSON.parse(JSON.stringify(section)))],
+    sections: missing.length
+      ? [...base.sections, ...missing.map((section) => JSON.parse(JSON.stringify(section)))]
+      : base.sections,
   };
+  if (!hydrated.page_availability || typeof hydrated.page_availability !== "object" || Array.isArray(hydrated.page_availability)) {
+    hydrated.page_availability = { ...DEFAULT_PAGE_AVAILABILITY };
+  }
+  return hydrated;
 }
 
 async function loadPublished(pool) {
@@ -650,6 +729,49 @@ function createHomepageRoutes(deps = {}) {
       }
       console.error("[homepage/public] failed", error);
       res.status(500).json({ error: "โหลดหน้าแรกไม่สำเร็จ" });
+    }
+  });
+
+  // Lightweight public read of the Customer App page-availability flags. Reads
+  // the SAME published Homepage CMS config; returns only the page flags + safe
+  // metadata (no Draft, no updated_by, no admin/customer data). Never 500s — on
+  // any DB/schema/unexpected error it returns the degraded fail-safe with HTTP
+  // 200 so the app can still boot into Home + Tracking.
+  router.get("/public/customer-app-config", async (_req, res) => {
+    res.set("Cache-Control", "no-store");
+    try {
+      const row = await loadPublished(pool);
+      if (!row || !row.published_config) {
+        // No published config yet → default all-enabled (fallback, not degraded).
+        return res.json({
+          ok: true,
+          page_availability: { ...DEFAULT_PAGE_AVAILABILITY },
+          config_version: null,
+          published_at: null,
+          fallback: true,
+          degraded: false,
+        });
+      }
+      // Legacy published config with no page_availability → all-enabled, not a fallback.
+      return res.json({
+        ok: true,
+        page_availability: readPageAvailability(row.published_config),
+        config_version: row.version ?? null,
+        published_at: row.published_at ?? null,
+        fallback: false,
+        degraded: false,
+      });
+    } catch (error) {
+      // Never crash the app: DB/schema/unexpected → degraded fail-safe, HTTP 200.
+      console.warn("[customer-app-config] degraded fallback", { message: error && error.message });
+      return res.json({
+        ok: true,
+        page_availability: { ...DEGRADED_PAGE_AVAILABILITY },
+        config_version: null,
+        published_at: null,
+        fallback: true,
+        degraded: true,
+      });
     }
   });
 
@@ -861,8 +983,14 @@ module.exports = {
   DEFAULT_CONFIG,
   MAX_IMAGE_BYTES,
   SECTION_TYPES,
+  PAGE_AVAILABILITY_KEYS,
+  DEFAULT_PAGE_AVAILABILITY,
+  DEGRADED_PAGE_AVAILABILITY,
   activeNow,
   createHomepageRoutes,
+  hydrateDraftConfig,
+  normalizePageAvailability,
+  readPageAvailability,
   stripPublicConfig,
   validateConfig,
 };

--- a/test/customerAppPageAvailability.test.js
+++ b/test/customerAppPageAvailability.test.js
@@ -1,0 +1,288 @@
+"use strict";
+
+// Focused tests for Customer App V2 page-availability (admin rollout control).
+//  - The pageAvailability module: flag validation, route mapping, load
+//    priority (server → cache → degraded), DOM hiding that preserves
+//    business-disabled controls, and the maintenance screen.
+//  - Source contracts for the central router guard, boot order, and the
+//    booking-mode empty state, so a disabled page is truly unreachable and
+//    never calls its handler or page-specific API.
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const vm = require("node:vm");
+
+const ROOT = path.resolve(__dirname, "..");
+const read = (rel) => fs.readFileSync(path.join(ROOT, rel), "utf8");
+
+const moduleSrc = read("customer-app/modules/pageAvailability.js");
+const routerSrc = read("customer-app/modules/router.js");
+const bootSrc = read("customer-app/assets/customer-app.js");
+const uiSrc = read("customer-app/modules/ui.js");
+const apiSrc = read("customer-app/modules/api.js");
+const indexHtml = read("customer-app/index.html");
+const swSrc = read("customer-app/sw.js");
+
+const ALL = { home: true, store: true, booking: true, scheduled: true, urgent: true, tracking: true, profile: true };
+const DEGRADED = { home: true, store: false, booking: false, scheduled: false, urgent: false, tracking: true, profile: false };
+
+// getFlags() objects are created inside the vm realm, so strict deepEqual would
+// fail on prototype identity — normalize both sides to plain test-realm objects.
+function assertFlags(actual, expected) {
+  assert.deepEqual(JSON.parse(JSON.stringify(actual)), expected);
+}
+
+// ---- minimal DOM + window sandbox ---------------------------------------
+function makeEl(attrs, opts = {}) {
+  const store = { ...attrs };
+  const el = {
+    _attrs: store,
+    getAttribute(name) { return name in store ? store[name] : null; },
+    setAttribute(name, val) { store[name] = String(val); },
+    hasAttribute(name) { return name in store; },
+    removeAttribute(name) { delete store[name]; },
+  };
+  if (opts.hasDisabled) el.disabled = !!opts.disabled;
+  return el;
+}
+
+function loadModule({ routeEls = [] } = {}) {
+  const store = new Map();
+  const appEl = makeEl({ id: "app" });
+  const documentEls = routeEls;
+  const documentObj = {
+    getElementById(id) { return id === "app" ? appEl : null; },
+    querySelectorAll(sel) {
+      assert.equal(sel, "[data-route]");
+      return documentEls.filter((el) => el.hasAttribute("data-route"));
+    },
+  };
+  let apiResponse = { impl: async () => { throw new Error("no api set"); } };
+  const win = {};
+  win.localStorage = {
+    getItem: (k) => (store.has(k) ? store.get(k) : null),
+    setItem: (k, v) => store.set(k, String(v)),
+    removeItem: (k) => store.delete(k),
+  };
+  win.CWFCustomerAppV2 = {
+    api: { loadCustomerAppConfig: (...a) => apiResponse.impl(...a) },
+    utils: { escapeHtml: (s) => String(s == null ? "" : s) },
+  };
+  const sandbox = {
+    window: win,
+    document: documentObj,
+    MutationObserver: function () { this.observe = () => {}; },
+    requestAnimationFrame: (fn) => setTimeout(fn, 0),
+    setTimeout,
+    clearTimeout,
+    Promise, Object, Array, String, Number, Boolean, JSON, Date, Set, Error, Math,
+    console: { log() {}, warn() {}, error() {}, info() {} },
+  };
+  vm.createContext(sandbox);
+  vm.runInContext(moduleSrc, sandbox);
+  const pa = win.CWFCustomerAppV2.pageAvailability;
+  return {
+    pa,
+    appEl,
+    storage: store,
+    setApi: (impl) => { apiResponse.impl = impl; },
+    rawCache: () => (store.has("cwf_customer_app_page_availability_v1") ? JSON.parse(store.get("cwf_customer_app_page_availability_v1")) : null),
+  };
+}
+
+// ============================ flag validation =============================
+test("isValidFlags: exactly 7 boolean keys, ≥1 enabled; rejects unknown/missing/non-bool/all-off", () => {
+  const { pa } = loadModule();
+  assert.equal(pa._isValidFlags({ ...ALL }), true);
+  assert.equal(pa._isValidFlags({ ...DEGRADED }), true);
+  // missing a key
+  const missing = { ...ALL }; delete missing.profile;
+  assert.equal(pa._isValidFlags(missing), false);
+  // unknown extra key
+  assert.equal(pa._isValidFlags({ ...ALL, extra: true }), false);
+  // non-boolean
+  assert.equal(pa._isValidFlags({ ...ALL, home: "yes" }), false);
+  // all disabled
+  assert.equal(pa._isValidFlags({ home: false, store: false, booking: false, scheduled: false, urgent: false, tracking: false, profile: false }), false);
+  // not an object
+  assert.equal(pa._isValidFlags(null), false);
+  assert.equal(pa._isValidFlags([]), false);
+});
+
+// ============================ route mapping ===============================
+test("availabilityKey: storeItem-<n> inherits store; known routes map to self; unknown → null", () => {
+  const { pa } = loadModule();
+  assert.equal(pa.availabilityKey("storeItem-123"), "store");
+  assert.equal(pa.availabilityKey("store"), "store");
+  assert.equal(pa.availabilityKey("tracking"), "tracking");
+  assert.equal(pa.availabilityKey("home"), "home");
+  assert.equal(pa.availabilityKey("bogus"), null);
+  assert.equal(pa.availabilityKey("storeItem-abc"), null); // non-numeric id
+  assert.equal(pa.availabilityKey(""), null);
+  assert.equal(pa.availabilityKey(null), null);
+});
+
+// ============================ load priority ===============================
+test("load: a valid non-degraded server config wins and is cached", async () => {
+  const flags = { home: true, store: false, booking: false, scheduled: false, urgent: false, tracking: true, profile: false };
+  const h = loadModule();
+  h.setApi(async () => ({ ok: true, degraded: false, page_availability: flags }));
+  await h.pa.load();
+  assert.equal(h.pa.isReady(), true);
+  assertFlags(h.pa.getFlags(), flags);
+  assert.equal(h.pa.isEnabled("tracking"), true);
+  assert.equal(h.pa.isEnabled("store"), false);
+  assert.equal(h.pa.isEnabled("storeItem-9"), false); // inherits store
+  // cached
+  assertFlags(h.rawCache().page_availability, flags);
+});
+
+test("load: server degraded:true is ignored → falls through to cache/degraded", async () => {
+  const h = loadModule();
+  h.setApi(async () => ({ ok: true, degraded: true, page_availability: { ...DEGRADED } }));
+  await h.pa.load();
+  assertFlags(h.pa.getFlags(), DEGRADED); // built-in degraded (no cache)
+  assert.equal(h.rawCache(), null, "a degraded server response must not be cached");
+});
+
+test("load: server failure with a valid cache uses the last-known-good cache", async () => {
+  const cachedFlags = { home: true, store: true, booking: true, scheduled: false, urgent: false, tracking: true, profile: true };
+  const h = loadModule();
+  h.storage.set("cwf_customer_app_page_availability_v1", JSON.stringify({ version: 1, saved_at: 1, page_availability: cachedFlags }));
+  h.setApi(async () => { throw new Error("network down"); });
+  await h.pa.load();
+  assertFlags(h.pa.getFlags(), cachedFlags);
+});
+
+test("load: nothing trustworthy → built-in degraded (Home + Tracking only)", async () => {
+  const h = loadModule();
+  h.setApi(async () => ({ ok: false }));
+  await h.pa.load();
+  assertFlags(h.pa.getFlags(), DEGRADED);
+  assert.equal(h.pa.isEnabled("home"), true);
+  assert.equal(h.pa.isEnabled("tracking"), true);
+  assert.equal(h.pa.isEnabled("booking"), false);
+});
+
+test("load: an invalid all-disabled server config is rejected (falls to degraded)", async () => {
+  const h = loadModule();
+  h.setApi(async () => ({ ok: true, degraded: false, page_availability: { home: false, store: false, booking: false, scheduled: false, urgent: false, tracking: false, profile: false } }));
+  await h.pa.load();
+  assertFlags(h.pa.getFlags(), DEGRADED);
+});
+
+// ============================ firstEnabledRoute ===========================
+test("firstEnabledRoute: honors priority order and always returns an enabled route", async () => {
+  const h = loadModule();
+  h.setApi(async () => ({ ok: true, degraded: false, page_availability: { home: false, store: true, booking: false, scheduled: false, urgent: false, tracking: true, profile: false } }));
+  await h.pa.load();
+  // priority: home, tracking, store... → tracking beats store
+  assert.equal(h.pa.firstEnabledRoute(), "tracking");
+});
+
+// ============================ DOM hiding ==================================
+test("applyToDom hides controls for disabled/unknown routes and restores them when re-enabled", async () => {
+  const trackingBtn = makeEl({ "data-route": "tracking" });
+  const storeBtn = makeEl({ "data-route": "store" });
+  const h = loadModule({ routeEls: [trackingBtn, storeBtn] });
+  h.setApi(async () => ({ ok: true, degraded: false, page_availability: { home: true, store: false, booking: false, scheduled: false, urgent: false, tracking: true, profile: false } }));
+  await h.pa.load(); // load() calls applyToDom(document)
+  // tracking enabled → visible; store disabled → hidden
+  assert.equal(trackingBtn.hasAttribute("hidden"), false);
+  assert.equal(storeBtn.getAttribute("data-cwf-avail"), "off");
+  assert.equal(storeBtn.hasAttribute("hidden"), true);
+  assert.equal(storeBtn.getAttribute("aria-hidden"), "true");
+
+  // Re-enable store and re-apply → restored.
+  h.setApi(async () => ({ ok: true, degraded: false, page_availability: { ...ALL } }));
+  await h.pa.load();
+  assert.equal(storeBtn.hasAttribute("hidden"), false);
+  assert.equal(storeBtn.hasAttribute("data-cwf-avail"), false);
+});
+
+test("applyToDom never re-enables a control that other business logic had disabled", async () => {
+  // A booking CTA that was already disabled by business logic, pointing at a
+  // disabled route. When we later restore it, it must stay disabled.
+  const bizDisabled = makeEl({ "data-route": "store" }, { hasDisabled: true, disabled: true });
+  const h = loadModule({ routeEls: [bizDisabled] });
+  h.setApi(async () => ({ ok: true, degraded: false, page_availability: { home: true, store: false, booking: false, scheduled: false, urgent: false, tracking: true, profile: false } }));
+  await h.pa.load();
+  assert.equal(bizDisabled.disabled, true);
+  // Re-enable the store page → restore should recover the PRIOR disabled state.
+  h.setApi(async () => ({ ok: true, degraded: false, page_availability: { ...ALL } }));
+  await h.pa.load();
+  assert.equal(bizDisabled.disabled, true, "must not silently re-enable a business-disabled control");
+});
+
+// ============================ maintenance screen ==========================
+test("maintenanceHtml shows the page label, a back button to the first enabled route, LINE + phone", async () => {
+  const h = loadModule();
+  h.setApi(async () => ({ ok: true, degraded: false, page_availability: { home: false, store: false, booking: false, scheduled: false, urgent: false, tracking: true, profile: false } }));
+  await h.pa.load();
+  const html = h.pa.maintenanceHtml("store");
+  assert.match(html, /หน้านี้กำลังปรับปรุง/);
+  assert.match(html, /ร้านค้า/); // page label for 'store'
+  assert.match(html, /data-route="tracking"/); // firstEnabledRoute
+  assert.match(html, /lin\.ee\/fG1Oq7y/);
+  assert.match(html, /tel:0988777321/);
+});
+
+// ============================ router guard (source) =======================
+test("router guard runs before the handler: disabled → maintenance, no handler/API call", () => {
+  // Guard checks readiness and enablement before resolving/invoking the handler.
+  assert.match(routerSrc, /const paReady = !!pa && typeof pa\.isReady === "function" && pa\.isReady\(\)/);
+  // Unknown route → redirect to first enabled route (not silent home fallback).
+  assert.match(routerSrc, /if \(!pa\.availabilityKey\(requestedRoute\)\)/);
+  assert.match(routerSrc, /root\.utils\.routeTo\(fallback\)/);
+  // Disabled route → renderMaintenance and RETURN before handler(app).
+  assert.match(routerSrc, /if \(paReady && !pa\.isEnabled\(route\)\)/);
+  assert.match(routerSrc, /pa\.renderMaintenance\(app, route\)/);
+  // The maintenance branch returns before the handler call further below.
+  const guardIdx = routerSrc.indexOf("pa.renderMaintenance(app, route)");
+  const handlerIdx = routerSrc.indexOf("handler(app);");
+  assert.ok(guardIdx !== -1 && handlerIdx !== -1 && guardIdx < handlerIdx, "maintenance render must precede the handler call");
+  // After a successful handler render, re-hide disabled CTAs.
+  assert.match(routerSrc, /if \(paReady && typeof pa\.applyToDom === "function"\) pa\.applyToDom\(app\)/);
+});
+
+// ============================ boot order (source) =========================
+test("boot loads availability before router.init, gates Home prefetch, and starts the observer", () => {
+  // Await load() (ready) BEFORE registering routes / router.init.
+  assert.match(bootSrc, /const pa = App\.pageAvailability;[\s\S]*await pa\.load\(\);/);
+  const loadIdx = bootSrc.indexOf("await pa.load();");
+  const initIdx = bootSrc.indexOf("App.router.init();");
+  assert.ok(loadIdx !== -1 && initIdx !== -1 && loadIdx < initIdx, "pa.load() must be awaited before router.init()");
+  // Home prefetch only when home enabled AND initial route is home.
+  assert.match(bootSrc, /homeEnabled && initialRouteHome \? App\.ui\.prefetchHome\(\) : Promise\.resolve\(\)/);
+  // If home disabled and no explicit route, land on the first enabled route.
+  assert.match(bootSrc, /!pa\.isEnabled\("home"\)\) \{[\s\S]*firstEnabledRoute\(\)/);
+  // Observer started.
+  assert.match(bootSrc, /pa\.startObserver\(\)/);
+});
+
+// ============================ booking-mode empty state ====================
+test("renderBookingMode gates each card and shows an empty state when both are disabled", () => {
+  assert.match(uiSrc, /const scheduledOn = !paReady \|\| pa\.isEnabled\("scheduled"\)/);
+  assert.match(uiSrc, /const urgentOn = !paReady \|\| pa\.isEnabled\("urgent"\)/);
+  assert.match(uiSrc, /ระบบจองออนไลน์กำลังปรับปรุง/);
+  // Empty-state offers LINE + phone.
+  assert.match(uiSrc, /booking-empty-card/);
+});
+
+// ============================ api + build wiring ==========================
+test("api exposes loadCustomerAppConfig as a no-store GET to /public/customer-app-config", () => {
+  assert.match(apiSrc, /loadCustomerAppConfig\(\)/);
+  assert.match(apiSrc, /"\/public\/customer-app-config", \{ cache: "no-store" \}/);
+});
+
+test("build wiring: pageAvailability.js is registered in the HTML shell and the SW cache, with the new build id", () => {
+  const build = "20260712_page_controls_tracking_link_v1";
+  assert.match(indexHtml, new RegExp(`modules/pageAvailability\\.js\\?v=${build}`));
+  assert.match(swSrc, new RegExp(`BUILD_ID = "${build}"`));
+  assert.match(swSrc, /modules\/pageAvailability\.js\?v=\$\{BUILD_ID\}/);
+  // Loaded after api.js, before services.js (dependency order).
+  assert.ok(indexHtml.indexOf("modules/api.js") < indexHtml.indexOf("modules/pageAvailability.js"));
+  assert.ok(indexHtml.indexOf("modules/pageAvailability.js") < indexHtml.indexOf("modules/services.js"));
+});

--- a/test/customerAppPageAvailability.test.js
+++ b/test/customerAppPageAvailability.test.js
@@ -278,11 +278,396 @@ test("api exposes loadCustomerAppConfig as a no-store GET to /public/customer-ap
 });
 
 test("build wiring: pageAvailability.js is registered in the HTML shell and the SW cache, with the new build id", () => {
-  const build = "20260712_page_controls_tracking_link_v1";
+  const build = "20260712_page_controls_tracking_link_v2";
   assert.match(indexHtml, new RegExp(`modules/pageAvailability\\.js\\?v=${build}`));
   assert.match(swSrc, new RegExp(`BUILD_ID = "${build}"`));
   assert.match(swSrc, /modules\/pageAvailability\.js\?v=\$\{BUILD_ID\}/);
   // Loaded after api.js, before services.js (dependency order).
   assert.ok(indexHtml.indexOf("modules/api.js") < indexHtml.indexOf("modules/pageAvailability.js"));
   assert.ok(indexHtml.indexOf("modules/pageAvailability.js") < indexHtml.indexOf("modules/services.js"));
+});
+
+/* ==========================================================================
+   RUNTIME tests (execute the real code in a VM — not regex assertions).
+   ========================================================================== */
+
+const BUILD = "20260712_page_controls_tracking_link_v2";
+const adminSrc = read("admin-homepage-cms.js");
+
+function reqUrlOf(req) {
+  return req && typeof req === "object" && "url" in req ? String(req.url) : String(req);
+}
+
+// Extract a full brace-balanced function body from source text.
+function extractFn(src, signature) {
+  const start = src.indexOf(signature);
+  assert.notEqual(start, -1, `signature not found: ${signature}`);
+  let i = src.indexOf("{", start);
+  let depth = 0;
+  for (; i < src.length; i += 1) {
+    if (src[i] === "{") depth += 1;
+    else if (src[i] === "}") { depth -= 1; if (depth === 0) return src.slice(start, i + 1); }
+  }
+  throw new Error("unbalanced braces");
+}
+
+// ---- Service worker harness ----------------------------------------------
+function loadServiceWorker() {
+  const rec = { put: [], match: [], open: [], deleted: [] };
+  const handlers = {};
+  let existingCacheKeys = [];
+  let fetchImpl = async () => ({ ok: true, clone: () => ({ __clone: true }) });
+
+  function cacheObj() {
+    return {
+      addAll: () => Promise.resolve(),
+      put: (request) => { rec.put.push(reqUrlOf(request)); return Promise.resolve(); },
+      match: (request) => { rec.match.push(reqUrlOf(request)); return Promise.resolve(undefined); },
+    };
+  }
+  const caches = {
+    open: (name) => { rec.open.push(name); return Promise.resolve(cacheObj()); },
+    keys: () => Promise.resolve(existingCacheKeys.slice()),
+    delete: (key) => { rec.deleted.push(key); return Promise.resolve(true); },
+    // Top-level fallback lookup: return a shell marker only for the canonical
+    // credential-free shell path, undefined otherwise.
+    match: (request) => {
+      const u = reqUrlOf(request);
+      rec.match.push(u);
+      return Promise.resolve(u.includes("index.html") ? { __shell: true } : undefined);
+    },
+  };
+  const selfObj = {
+    addEventListener: (type, fn) => { handlers[type] = fn; },
+    skipWaiting: () => {},
+    clients: { claim: () => Promise.resolve() },
+    location: { origin: "https://cwf.example.com" },
+  };
+  const sandbox = {
+    self: selfObj,
+    caches,
+    fetch: (request, opts) => fetchImpl(request, opts),
+    URL,
+    Response: { error: () => ({ __error: true }) },
+    Promise,
+    console: { log() {}, warn() {}, error() {}, info() {} },
+  };
+  vm.createContext(sandbox);
+  vm.runInContext(swSrc, sandbox);
+  return {
+    handlers,
+    rec,
+    origin: selfObj.location.origin,
+    setFetch: (fn) => { fetchImpl = fn; },
+    setExistingCacheKeys: (keys) => { existingCacheKeys = keys; },
+  };
+}
+
+function swRequest(sw, pathAndQuery, { mode = "navigate", method = "GET" } = {}) {
+  return { url: sw.origin + pathAndQuery, mode, method };
+}
+
+async function swFetch(sw, request) {
+  let responded;
+  sw.handlers.fetch({ request, respondWith: (p) => { responded = p; } });
+  return responded === undefined ? { __noRespond: true } : responded;
+}
+
+const TOKEN = "PRIVATE_TOKEN_9xZ";
+
+test("SW: navigation with ?q=<token> is network-only and never written to Cache Storage", async () => {
+  const sw = loadServiceWorker();
+  const marker = { ok: true, __net: true, clone: () => ({}) };
+  sw.setFetch(async () => marker);
+  const res = await swFetch(sw, swRequest(sw, `/customer-app/index.html?q=${TOKEN}#tracking`));
+  assert.equal(res, marker, "must return the network response directly");
+  assert.equal(sw.rec.put.length, 0, "must never cache.put a credential-bearing navigation");
+  assert.equal(sw.rec.match.length, 0, "must not caches.match the credential-bearing request on success");
+  const allKeys = [...sw.rec.put, ...sw.rec.match].join(" | ");
+  assert.ok(!allKeys.includes(TOKEN), "no cache key/lookup may contain the token");
+});
+
+test("SW: navigation with ?token=<token> is network-only and never cached", async () => {
+  const sw = loadServiceWorker();
+  const marker = { ok: true, clone: () => ({}) };
+  sw.setFetch(async () => marker);
+  const res = await swFetch(sw, swRequest(sw, `/customer-app/index.html?token=${TOKEN}#tracking`));
+  assert.equal(res, marker);
+  assert.equal(sw.rec.put.length, 0);
+  const allKeys = [...sw.rec.put, ...sw.rec.match, ...sw.rec.open].join(" | ");
+  assert.ok(!allKeys.includes(TOKEN), "token must never appear in any cache key");
+});
+
+test("SW: offline sensitive navigation falls back to the canonical credential-free app shell", async () => {
+  const sw = loadServiceWorker();
+  sw.setFetch(async () => { throw new Error("offline"); });
+  const res = await swFetch(sw, swRequest(sw, `/customer-app/index.html?q=${TOKEN}#tracking`));
+  assert.deepEqual(res, { __shell: true }, "offline → cached app shell");
+  assert.equal(sw.rec.put.length, 0, "still no cache.put on the credential-bearing request");
+  // The only cache lookup is for the credential-free shell.
+  assert.deepEqual(sw.rec.match, [`./index.html?v=${BUILD}`]);
+  assert.ok(!sw.rec.match.join(" ").includes(TOKEN));
+});
+
+test("SW: a normal versioned asset still caches (put) on success", async () => {
+  const sw = loadServiceWorker();
+  const marker = { ok: true, clone: () => ({ __copy: true }) };
+  sw.setFetch(async () => marker);
+  const assetUrl = `/customer-app/modules/router.js?v=${BUILD}`;
+  const res = await swFetch(sw, swRequest(sw, assetUrl, { mode: "no-cors" }));
+  assert.equal(res, marker);
+  assert.deepEqual(sw.rec.put, [sw.origin + assetUrl], "normal asset must be cached");
+});
+
+test("SW: a plain navigation WITHOUT a credential still uses the caching path", async () => {
+  const sw = loadServiceWorker();
+  const marker = { ok: true, clone: () => ({ __copy: true }) };
+  sw.setFetch(async () => marker);
+  const res = await swFetch(sw, swRequest(sw, `/customer-app/index.html?v=${BUILD}`));
+  assert.equal(res, marker);
+  assert.deepEqual(sw.rec.put, [`${sw.origin}/customer-app/index.html?v=${BUILD}`]);
+});
+
+test("SW: /public/ requests stay network-only (never cached)", async () => {
+  const sw = loadServiceWorker();
+  const marker = { ok: true, clone: () => ({}) };
+  sw.setFetch(async () => marker);
+  const res = await swFetch(sw, swRequest(sw, `/public/track?q=${TOKEN}`, { mode: "cors" }));
+  assert.equal(res, marker, "network response returned directly");
+  assert.equal(sw.rec.put.length, 0, "/public/ must never be cached");
+  assert.ok(![...sw.rec.put, ...sw.rec.match].join(" ").includes(TOKEN));
+});
+
+test("SW: activation deletes stale Customer App cache namespaces and keeps the current one", async () => {
+  const sw = loadServiceWorker();
+  const current = `cwf-customer-app-v2-${BUILD}`;
+  const stale = "cwf-customer-app-v2-20260101_old";
+  sw.setExistingCacheKeys([stale, current, "some-other-cache"]);
+  let captured;
+  sw.handlers.activate({ waitUntil: (p) => { captured = p; } });
+  await captured;
+  assert.ok(sw.rec.deleted.includes(stale), "stale Customer App cache must be deleted");
+  assert.ok(!sw.rec.deleted.includes(current), "current cache must be kept");
+  assert.ok(!sw.rec.deleted.includes("some-other-cache"), "unrelated caches untouched");
+});
+
+// ---- Router guard runtime harness ----------------------------------------
+function loadRouterRuntime() {
+  const store = new Map();
+  const appEl = { innerHTML: "", dataset: {}, focus() {}, querySelectorAll: () => [] };
+  const body = { classList: { add() {}, remove() {}, toggle() {} } };
+  const documentObj = {
+    getElementById: (id) => (id === "app" ? appEl : null),
+    querySelectorAll: () => [],
+    addEventListener: () => {},
+    body,
+  };
+  const history = { replaceState: () => {} };
+  const routeToCalls = [];
+  const handlerCalls = { home: 0, store: 0, storeItem: 0, booking: 0, scheduled: 0, urgent: 0, tracking: 0, profile: 0, homeLeave: 0 };
+  const apiCalls = { track: 0, pricing: 0, availability: 0, urgent: 0, store: 0 };
+  let apiResponse = async () => ({ ok: false });
+
+  const state = {
+    requested: "home",
+    route: null,
+    readRouteFromHash: () => state.requested,
+    setRoute: (r) => { state.route = r; },
+  };
+  const win = {
+    localStorage: {
+      getItem: (k) => (store.has(k) ? store.get(k) : null),
+      setItem: (k, v) => store.set(k, String(v)),
+      removeItem: (k) => store.delete(k),
+    },
+    addEventListener: () => {},
+  };
+  win.CWFCustomerAppV2 = {
+    api: {
+      loadCustomerAppConfig: (...a) => apiResponse(...a),
+      trackBooking: () => { apiCalls.track += 1; },
+      previewPricing: () => { apiCalls.pricing += 1; },
+      loadAvailability: () => { apiCalls.availability += 1; },
+      submitUrgentRequest: () => { apiCalls.urgent += 1; },
+    },
+    utils: { escapeHtml: (s) => String(s == null ? "" : s), routeTo: (r) => { routeToCalls.push(r); } },
+    state,
+  };
+  const sandbox = {
+    window: win,
+    document: documentObj,
+    history,
+    MutationObserver: function () { this.observe = () => {}; },
+    requestAnimationFrame: (fn) => setTimeout(fn, 0),
+    setTimeout,
+    clearTimeout,
+    Promise, Object, Array, String, Number, Boolean, JSON, Date, Set, Error, Math,
+    console: { log() {}, warn() {}, error() {}, info() {} },
+  };
+  vm.createContext(sandbox);
+  vm.runInContext(moduleSrc, sandbox); // pageAvailability
+  vm.runInContext(routerSrc, sandbox); // router
+  const root = win.CWFCustomerAppV2;
+
+  const home = () => { handlerCalls.home += 1; };
+  home.onLeave = () => { handlerCalls.homeLeave += 1; };
+  root.router.register({
+    home,
+    store: () => { handlerCalls.store += 1; apiCalls.store += 1; },
+    storeItem: () => { handlerCalls.storeItem += 1; apiCalls.store += 1; },
+    booking: () => { handlerCalls.booking += 1; },
+    scheduled: () => { handlerCalls.scheduled += 1; root.api.previewPricing(); root.api.loadAvailability(); },
+    urgent: () => { handlerCalls.urgent += 1; root.api.submitUrgentRequest(); },
+    tracking: () => { handlerCalls.tracking += 1; root.api.trackBooking(); },
+    profile: () => { handlerCalls.profile += 1; },
+  });
+
+  return {
+    root, state, appEl, handlerCalls, apiCalls, routeToCalls,
+    setFlags: (flags) => { apiResponse = async () => ({ ok: true, degraded: false, page_availability: flags }); },
+    load: () => root.pageAvailability.load(),
+    render: (requested) => { state.requested = requested; root.router.render({ focus: false }); },
+    isMaintenance: () => String(appEl.innerHTML).includes("หน้านี้กำลังปรับปรุง"),
+  };
+}
+
+const flags = (over) => ({ home: true, store: true, booking: true, scheduled: true, urgent: true, tracking: true, profile: true, ...over });
+
+test("router runtime: an ENABLED route calls its handler exactly once", async () => {
+  const h = loadRouterRuntime();
+  h.setFlags(flags());
+  await h.load();
+  h.render("home");
+  assert.equal(h.handlerCalls.home, 1);
+  assert.equal(h.isMaintenance(), false);
+});
+
+test("router runtime: disabled Tracking never calls the tracking handler or /public/track", async () => {
+  const h = loadRouterRuntime();
+  h.setFlags(flags({ tracking: false }));
+  await h.load();
+  h.render("tracking");
+  assert.equal(h.handlerCalls.tracking, 0, "tracking handler must not run");
+  assert.equal(h.apiCalls.track, 0, "no /public/track lookup may fire");
+  assert.equal(h.isMaintenance(), true, "maintenance screen shown");
+});
+
+test("router runtime: disabled Scheduled never calls the handler, pricing, or availability", async () => {
+  const h = loadRouterRuntime();
+  h.setFlags(flags({ scheduled: false }));
+  await h.load();
+  h.render("scheduled");
+  assert.equal(h.handlerCalls.scheduled, 0);
+  assert.equal(h.apiCalls.pricing, 0);
+  assert.equal(h.apiCalls.availability, 0);
+});
+
+test("router runtime: disabled Urgent never calls the urgent handler/API", async () => {
+  const h = loadRouterRuntime();
+  h.setFlags(flags({ urgent: false }));
+  await h.load();
+  h.render("urgent");
+  assert.equal(h.handlerCalls.urgent, 0);
+  assert.equal(h.apiCalls.urgent, 0);
+});
+
+test("router runtime: disabled Store never calls the store handler", async () => {
+  const h = loadRouterRuntime();
+  h.setFlags(flags({ store: false }));
+  await h.load();
+  h.render("store");
+  assert.equal(h.handlerCalls.store, 0);
+  assert.equal(h.isMaintenance(), true);
+});
+
+test("router runtime: disabled storeItem-123 never calls the store-detail handler", async () => {
+  const h = loadRouterRuntime();
+  h.setFlags(flags({ store: false }));
+  await h.load();
+  h.render("storeItem-123");
+  assert.equal(h.handlerCalls.storeItem, 0);
+  assert.equal(h.isMaintenance(), true);
+});
+
+test("router runtime: reaching a disabled route (as via routeTo/hash) cannot bypass the guard", async () => {
+  const h = loadRouterRuntime();
+  h.setFlags(flags({ store: false }));
+  await h.load();
+  // Simulate routeTo('store') landing (it sets the hash → render reads it).
+  h.render("store");
+  assert.equal(h.handlerCalls.store, 0, "guard blocks regardless of navigation source");
+  assert.equal(h.isMaintenance(), true);
+});
+
+test("router runtime: a direct disabled hash renders the maintenance screen", async () => {
+  const h = loadRouterRuntime();
+  h.setFlags(flags({ profile: false }));
+  await h.load();
+  h.render("profile");
+  assert.equal(h.handlerCalls.profile, 0);
+  assert.equal(h.isMaintenance(), true);
+});
+
+test("router runtime: an unknown route redirects to the first enabled route (no handler run)", async () => {
+  const h = loadRouterRuntime();
+  h.setFlags(flags()); // all enabled → firstEnabledRoute = home
+  await h.load();
+  h.render("totally-bogus");
+  assert.deepEqual(h.routeToCalls, ["home"], "unknown → firstEnabledRoute");
+  assert.equal(h.handlerCalls.home, 0, "redirect returns before any handler runs");
+});
+
+test("router runtime: onLeave of the previous route fires on navigation, and the new enabled handler runs", async () => {
+  const h = loadRouterRuntime();
+  h.setFlags(flags());
+  await h.load();
+  h.render("home");
+  assert.equal(h.handlerCalls.home, 1);
+  const leaveBase = h.handlerCalls.homeLeave;
+  h.render("store");
+  assert.equal(h.handlerCalls.homeLeave, leaveBase + 1, "home.onLeave fires when leaving home");
+  assert.equal(h.handlerCalls.store, 1, "enabled handler still runs after the guard");
+});
+
+// ---- CMS final-toggle pure decision (runtime) ----------------------------
+function loadToggleDecision() {
+  const src = extractFn(adminSrc, "function pageAvailabilityToggleAllowed(");
+  const sandbox = {
+    PAGE_AVAILABILITY_KEYS: ["home", "store", "booking", "scheduled", "urgent", "tracking", "profile"],
+  };
+  vm.createContext(sandbox);
+  vm.runInContext(`${src}\nglobalThis.__fn = pageAvailabilityToggleAllowed;`, sandbox);
+  return sandbox.__fn;
+}
+
+test("CMS toggle decision: turning off one of many enabled pages is allowed", () => {
+  const allow = loadToggleDecision();
+  const pa = { home: true, store: true, booking: true, scheduled: true, urgent: true, tracking: true, profile: true };
+  assert.equal(allow(pa, "store", false), true);
+});
+
+test("CMS toggle decision: turning off the LAST enabled page is refused (never all-disabled)", () => {
+  const allow = loadToggleDecision();
+  const pa = { home: true, store: false, booking: false, scheduled: false, urgent: false, tracking: false, profile: false };
+  assert.equal(allow(pa, "home", false), false, "cannot disable the final enabled page");
+  // Applying the guard leaves config unchanged (simulate the handler).
+  const before = { ...pa };
+  if (allow(pa, "home", false)) pa.home = false;
+  assert.deepEqual(pa, before, "config must not become all-disabled");
+});
+
+test("CMS toggle decision: turning a page ON is always allowed", () => {
+  const allow = loadToggleDecision();
+  const pa = { home: true, store: false, booking: false, scheduled: false, urgent: false, tracking: false, profile: false };
+  assert.equal(allow(pa, "store", true), true);
+});
+
+test("CMS toggle handler reverts the checkbox + shows the message, and backend guards remain", () => {
+  // Handler wiring (checkbox revert + status) — supporting source assertions.
+  assert.match(adminSrc, /if \(!pageAvailabilityToggleAllowed\(config\.page_availability, key, target\.checked\)\) \{/);
+  assert.match(adminSrc, /target\.checked = true;/);
+  assert.match(adminSrc, /setStatus\("ต้องเปิดอย่างน้อย 1 หน้า", "bad"\)/);
+  // Defense-in-depth: publish still refuses an all-disabled config.
+  assert.match(adminSrc, /enabledCount === 0/);
+  assert.match(adminSrc, /ต้องเปิดอย่างน้อย 1 หน้าก่อน Publish/);
 });

--- a/test/customerAppPageAvailability.test.js
+++ b/test/customerAppPageAvailability.test.js
@@ -278,7 +278,7 @@ test("api exposes loadCustomerAppConfig as a no-store GET to /public/customer-ap
 });
 
 test("build wiring: pageAvailability.js is registered in the HTML shell and the SW cache, with the new build id", () => {
-  const build = "20260712_page_controls_tracking_link_v2";
+  const build = "20260712_page_controls_tracking_link_v3";
   assert.match(indexHtml, new RegExp(`modules/pageAvailability\\.js\\?v=${build}`));
   assert.match(swSrc, new RegExp(`BUILD_ID = "${build}"`));
   assert.match(swSrc, /modules\/pageAvailability\.js\?v=\$\{BUILD_ID\}/);
@@ -291,7 +291,7 @@ test("build wiring: pageAvailability.js is registered in the HTML shell and the 
    RUNTIME tests (execute the real code in a VM — not regex assertions).
    ========================================================================== */
 
-const BUILD = "20260712_page_controls_tracking_link_v2";
+const BUILD = "20260712_page_controls_tracking_link_v3";
 const adminSrc = read("admin-homepage-cms.js");
 
 function reqUrlOf(req) {
@@ -670,4 +670,130 @@ test("CMS toggle handler reverts the checkbox + shows the message, and backend g
   // Defense-in-depth: publish still refuses an all-disabled config.
   assert.match(adminSrc, /enabledCount === 0/);
   assert.match(adminSrc, /ต้องเปิดอย่างน้อย 1 หน้าก่อน Publish/);
+});
+
+/* ==========================================================================
+   Secure tracking deep link — fragment credential parse + URL scrub (runtime),
+   referrer policy, and boot wiring.
+   ========================================================================== */
+
+// Execute the real parseTrackingBoot() from customer-app.js in a VM.
+function loadParseTrackingBoot() {
+  const src = extractFn(bootSrc, "function parseTrackingBoot(");
+  const sandbox = { URL, URLSearchParams, String };
+  vm.createContext(sandbox);
+  vm.runInContext(`${src}\nglobalThis.__fn = parseTrackingBoot;`, sandbox);
+  return sandbox.__fn;
+}
+
+const ORIGIN = "https://cwf.example.com";
+const BASE = `${ORIGIN}/customer-app/index.html`;
+const CRED = "PRIVATE_TOKEN_9xZ";
+
+test("parseTrackingBoot: official fragment form #tracking?q= captures + scrubs the credential", () => {
+  const parse = loadParseTrackingBoot();
+  const r = parse(`${BASE}#tracking?q=${CRED}`);
+  assert.equal(r.credential, CRED);
+  assert.equal(r.isTracking, true);
+  assert.equal(r.changed, true);
+  assert.ok(!r.cleanUrl.includes(CRED), "cleanUrl must not contain the credential");
+  assert.ok(!r.cleanUrl.includes("q="), "cleanUrl must not contain q=");
+  assert.equal(r.cleanUrl, `${BASE}#tracking`, "scrubbed to a clean #tracking");
+});
+
+test("parseTrackingBoot: official fragment form #tracking?token= is captured + scrubbed", () => {
+  const parse = loadParseTrackingBoot();
+  const r = parse(`${BASE}#tracking?token=${CRED}`);
+  assert.equal(r.credential, CRED);
+  assert.equal(r.cleanUrl, `${BASE}#tracking`);
+  assert.ok(!r.cleanUrl.includes(CRED));
+});
+
+test("parseTrackingBoot: legacy query ?q=...#tracking still works and is scrubbed", () => {
+  const parse = loadParseTrackingBoot();
+  const r = parse(`${BASE}?q=${CRED}#tracking`);
+  assert.equal(r.credential, CRED);
+  assert.equal(r.isTracking, true);
+  assert.equal(r.changed, true);
+  assert.equal(r.cleanUrl, `${BASE}#tracking`);
+  assert.ok(!r.cleanUrl.includes(CRED));
+  assert.ok(!/\?q=|\?token=/.test(r.cleanUrl), "no credential query remains");
+});
+
+test("parseTrackingBoot: legacy query ?token=...#tracking still works and is scrubbed", () => {
+  const parse = loadParseTrackingBoot();
+  const r = parse(`${BASE}?token=${CRED}#tracking`);
+  assert.equal(r.credential, CRED);
+  assert.equal(r.cleanUrl, `${BASE}#tracking`);
+  assert.ok(!r.cleanUrl.includes(CRED));
+});
+
+test("parseTrackingBoot: unrelated query params are preserved (fragment form)", () => {
+  const parse = loadParseTrackingBoot();
+  const r = parse(`${BASE}?utm_source=line#tracking?q=${CRED}`);
+  assert.equal(r.credential, CRED);
+  assert.ok(r.cleanUrl.includes("utm_source=line"), "utm param preserved");
+  assert.ok(r.cleanUrl.endsWith("#tracking"));
+  assert.ok(!r.cleanUrl.includes(CRED));
+});
+
+test("parseTrackingBoot: unrelated query params are preserved (legacy form)", () => {
+  const parse = loadParseTrackingBoot();
+  const r = parse(`${BASE}?utm_source=line&q=${CRED}#tracking`);
+  assert.equal(r.credential, CRED);
+  assert.ok(r.cleanUrl.includes("utm_source=line"));
+  assert.ok(!r.cleanUrl.includes(CRED));
+  assert.ok(!/[?&]q=/.test(r.cleanUrl), "q removed but utm kept");
+});
+
+test("parseTrackingBoot: a normal URL without a credential is left unchanged", () => {
+  const parse = loadParseTrackingBoot();
+  const r = parse(`${BASE}?utm_source=line#home`);
+  assert.equal(r.credential, "");
+  assert.equal(r.changed, false, "no scrub needed → no replaceState");
+});
+
+test("parseTrackingBoot: the credential never survives in cleanUrl across all sensitive forms", () => {
+  const parse = loadParseTrackingBoot();
+  const forms = [
+    `${BASE}#tracking?q=${CRED}`,
+    `${BASE}#tracking?token=${CRED}`,
+    `${BASE}?q=${CRED}#tracking`,
+    `${BASE}?token=${CRED}#tracking`,
+    `${BASE}?utm_source=line#tracking?q=${CRED}`,
+  ];
+  for (const href of forms) {
+    const r = parse(href);
+    assert.equal(r.credential, CRED, `captured for ${href}`);
+    assert.ok(!r.cleanUrl.includes(CRED), `scrubbed for ${href}`);
+    assert.ok(r.isTracking, `tracking route for ${href}`);
+  }
+});
+
+test("boot wiring: scrub-before-init, single setInitialCredential, replaceState (no new history entry)", () => {
+  // Parse + scrub happens before App.state.init().
+  const parseIdx = bootSrc.indexOf("parseTrackingBoot(window.location.href)");
+  const stateInitIdx = bootSrc.indexOf("App.state.init();");
+  assert.ok(parseIdx !== -1 && stateInitIdx !== -1 && parseIdx < stateInitIdx, "parse+scrub must precede state.init()");
+  // Uses history.replaceState (not a new history entry) to drop the credential.
+  assert.match(bootSrc, /window\.history\.replaceState\(null, "", boot\.cleanUrl\)/);
+  // The credential is handed over exactly once, from the parsed value.
+  const occurrences = (bootSrc.match(/setInitialCredential\?\.\(boot\.credential\)/g) || []).length;
+  assert.equal(occurrences, 1, "setInitialCredential called exactly once with the parsed credential");
+  // The credential path must NOT persist the token anywhere serialisable.
+  assert.doesNotMatch(bootSrc, /localStorage\.setItem\([^)]*boot\.credential/);
+  assert.doesNotMatch(bootSrc, /sessionStorage\.setItem\([^)]*boot\.credential/);
+});
+
+test("referrer policy: index.html sets no-referrer before any resource link/script, exactly once", () => {
+  assert.match(indexHtml, /<meta name="referrer" content="no-referrer">/);
+  const metaIdx = indexHtml.indexOf('<meta name="referrer"');
+  const firstLink = indexHtml.indexOf("<link");
+  const firstScript = indexHtml.indexOf("<script");
+  assert.ok(metaIdx !== -1);
+  assert.ok(firstLink === -1 || metaIdx < firstLink, "referrer meta must precede the first <link>");
+  assert.ok(firstScript === -1 || metaIdx < firstScript, "referrer meta must precede the first <script>");
+  const count = (indexHtml.match(/name="referrer"/g) || []).length;
+  assert.equal(count, 1, "exactly one referrer policy (no duplicate/conflicting)");
+  assert.doesNotMatch(indexHtml, /http-equiv="referrer"/i, "no conflicting http-equiv referrer");
 });

--- a/test/customerAppRecovery.test.js
+++ b/test/customerAppRecovery.test.js
@@ -236,7 +236,7 @@ test("Customer App build id is consistent across shell and service worker", () =
   const sw = read("customer-app/sw.js");
   const app = read("customer-app/assets/customer-app.js");
   const manifest = read("customer-app/manifest.webmanifest");
-  const build = "20260711_tracking_gps_recovery_v1";
+  const build = "20260712_page_controls_tracking_link_v1";
 
   assert.match(index, new RegExp(`customer-app\\.css\\?v=${build}`));
   assert.match(index, new RegExp(`modules\\/api\\.js\\?v=${build}`));
@@ -254,7 +254,7 @@ test("Customer App build id is consistent across shell and service worker", () =
 test("store module is loaded in index.html and precached in the service worker app shell", () => {
   const index = read("customer-app/index.html");
   const sw = read("customer-app/sw.js");
-  const build = "20260711_tracking_gps_recovery_v1";
+  const build = "20260712_page_controls_tracking_link_v1";
 
   assert.match(index, new RegExp(`modules/store\\.js\\?v=${build}`));
   assert.match(sw, /`\.\/modules\/store\.js\?v=\$\{BUILD_ID\}`/);

--- a/test/customerAppRecovery.test.js
+++ b/test/customerAppRecovery.test.js
@@ -236,7 +236,7 @@ test("Customer App build id is consistent across shell and service worker", () =
   const sw = read("customer-app/sw.js");
   const app = read("customer-app/assets/customer-app.js");
   const manifest = read("customer-app/manifest.webmanifest");
-  const build = "20260712_page_controls_tracking_link_v1";
+  const build = "20260712_page_controls_tracking_link_v2";
 
   assert.match(index, new RegExp(`customer-app\\.css\\?v=${build}`));
   assert.match(index, new RegExp(`modules\\/api\\.js\\?v=${build}`));
@@ -254,7 +254,7 @@ test("Customer App build id is consistent across shell and service worker", () =
 test("store module is loaded in index.html and precached in the service worker app shell", () => {
   const index = read("customer-app/index.html");
   const sw = read("customer-app/sw.js");
-  const build = "20260712_page_controls_tracking_link_v1";
+  const build = "20260712_page_controls_tracking_link_v2";
 
   assert.match(index, new RegExp(`modules/store\\.js\\?v=${build}`));
   assert.match(sw, /`\.\/modules\/store\.js\?v=\$\{BUILD_ID\}`/);

--- a/test/customerAppRecovery.test.js
+++ b/test/customerAppRecovery.test.js
@@ -236,7 +236,7 @@ test("Customer App build id is consistent across shell and service worker", () =
   const sw = read("customer-app/sw.js");
   const app = read("customer-app/assets/customer-app.js");
   const manifest = read("customer-app/manifest.webmanifest");
-  const build = "20260712_page_controls_tracking_link_v2";
+  const build = "20260712_page_controls_tracking_link_v3";
 
   assert.match(index, new RegExp(`customer-app\\.css\\?v=${build}`));
   assert.match(index, new RegExp(`modules\\/api\\.js\\?v=${build}`));
@@ -254,7 +254,7 @@ test("Customer App build id is consistent across shell and service worker", () =
 test("store module is loaded in index.html and precached in the service worker app shell", () => {
   const index = read("customer-app/index.html");
   const sw = read("customer-app/sw.js");
-  const build = "20260712_page_controls_tracking_link_v2";
+  const build = "20260712_page_controls_tracking_link_v3";
 
   assert.match(index, new RegExp(`modules/store\\.js\\?v=${build}`));
   assert.match(sw, /`\.\/modules\/store\.js\?v=\$\{BUILD_ID\}`/);

--- a/test/customerAppStorePayment.test.js
+++ b/test/customerAppStorePayment.test.js
@@ -58,7 +58,7 @@ test("store falls back to the LINE hand-off when payment is unconfigured or the 
 test("payment step styles exist and the Customer App payment build id is bumped", () => {
   assert.match(cssSrc, /\.pay-method-btn/);
   assert.match(cssSrc, /\.pay-qr-img/);
-  assert.match(read("customer-app/index.html"), /modules\/store\.js\?v=20260712_page_controls_tracking_link_v2/);
-  assert.match(read("customer-app/sw.js"), /BUILD_ID = "20260712_page_controls_tracking_link_v2"/);
+  assert.match(read("customer-app/index.html"), /modules\/store\.js\?v=20260712_page_controls_tracking_link_v3/);
+  assert.match(read("customer-app/sw.js"), /BUILD_ID = "20260712_page_controls_tracking_link_v3"/);
   assert.match(storeSrc, /payment-security 20260705 loaded/);
 });

--- a/test/customerAppStorePayment.test.js
+++ b/test/customerAppStorePayment.test.js
@@ -58,7 +58,7 @@ test("store falls back to the LINE hand-off when payment is unconfigured or the 
 test("payment step styles exist and the Customer App payment build id is bumped", () => {
   assert.match(cssSrc, /\.pay-method-btn/);
   assert.match(cssSrc, /\.pay-qr-img/);
-  assert.match(read("customer-app/index.html"), /modules\/store\.js\?v=20260711_tracking_gps_recovery_v1/);
-  assert.match(read("customer-app/sw.js"), /BUILD_ID = "20260711_tracking_gps_recovery_v1"/);
+  assert.match(read("customer-app/index.html"), /modules\/store\.js\?v=20260712_page_controls_tracking_link_v1/);
+  assert.match(read("customer-app/sw.js"), /BUILD_ID = "20260712_page_controls_tracking_link_v1"/);
   assert.match(storeSrc, /payment-security 20260705 loaded/);
 });

--- a/test/customerAppStorePayment.test.js
+++ b/test/customerAppStorePayment.test.js
@@ -58,7 +58,7 @@ test("store falls back to the LINE hand-off when payment is unconfigured or the 
 test("payment step styles exist and the Customer App payment build id is bumped", () => {
   assert.match(cssSrc, /\.pay-method-btn/);
   assert.match(cssSrc, /\.pay-qr-img/);
-  assert.match(read("customer-app/index.html"), /modules\/store\.js\?v=20260712_page_controls_tracking_link_v1/);
-  assert.match(read("customer-app/sw.js"), /BUILD_ID = "20260712_page_controls_tracking_link_v1"/);
+  assert.match(read("customer-app/index.html"), /modules\/store\.js\?v=20260712_page_controls_tracking_link_v2/);
+  assert.match(read("customer-app/sw.js"), /BUILD_ID = "20260712_page_controls_tracking_link_v2"/);
   assert.match(storeSrc, /payment-security 20260705 loaded/);
 });

--- a/test/customerBookingAdminNotifications.test.js
+++ b/test/customerBookingAdminNotifications.test.js
@@ -311,10 +311,10 @@ test("admin/customer frontend cache versions are bumped for booking notification
   assert.doesNotMatch(adminReviewHtml, /admin-review-v2\.js\?v=20260707_customer_booking_notify_v2/);
   assert.match(adminReviewHtml, /admin-review-ai-intake\.js\?v=ai-booking-intake-customer-cards-v11-admin-alert-gate/);
   assert.doesNotMatch(adminReviewHtml, /admin-review-ai-intake\.js\?v=ai-booking-intake-customer-cards-v10/);
-  assert.match(customerIndex, /bookingScheduled\.js\?v=20260712_page_controls_tracking_link_v1/);
-  assert.match(customerIndex, /state\.js\?v=20260712_page_controls_tracking_link_v1/);
-  assert.match(customerSw, /const BUILD_ID = "20260712_page_controls_tracking_link_v1"/);
-  assert.match(customerManifest, /20260712_page_controls_tracking_link_v1/);
+  assert.match(customerIndex, /bookingScheduled\.js\?v=20260712_page_controls_tracking_link_v2/);
+  assert.match(customerIndex, /state\.js\?v=20260712_page_controls_tracking_link_v2/);
+  assert.match(customerSw, /const BUILD_ID = "20260712_page_controls_tracking_link_v2"/);
+  assert.match(customerManifest, /20260712_page_controls_tracking_link_v2/);
 });
 
 test("behavior: review queue only includes customer urgent waiting rows while preserving review statuses", () => {

--- a/test/customerBookingAdminNotifications.test.js
+++ b/test/customerBookingAdminNotifications.test.js
@@ -311,10 +311,10 @@ test("admin/customer frontend cache versions are bumped for booking notification
   assert.doesNotMatch(adminReviewHtml, /admin-review-v2\.js\?v=20260707_customer_booking_notify_v2/);
   assert.match(adminReviewHtml, /admin-review-ai-intake\.js\?v=ai-booking-intake-customer-cards-v11-admin-alert-gate/);
   assert.doesNotMatch(adminReviewHtml, /admin-review-ai-intake\.js\?v=ai-booking-intake-customer-cards-v10/);
-  assert.match(customerIndex, /bookingScheduled\.js\?v=20260711_tracking_gps_recovery_v1/);
-  assert.match(customerIndex, /state\.js\?v=20260711_tracking_gps_recovery_v1/);
-  assert.match(customerSw, /const BUILD_ID = "20260711_tracking_gps_recovery_v1"/);
-  assert.match(customerManifest, /20260711_tracking_gps_recovery_v1/);
+  assert.match(customerIndex, /bookingScheduled\.js\?v=20260712_page_controls_tracking_link_v1/);
+  assert.match(customerIndex, /state\.js\?v=20260712_page_controls_tracking_link_v1/);
+  assert.match(customerSw, /const BUILD_ID = "20260712_page_controls_tracking_link_v1"/);
+  assert.match(customerManifest, /20260712_page_controls_tracking_link_v1/);
 });
 
 test("behavior: review queue only includes customer urgent waiting rows while preserving review statuses", () => {

--- a/test/customerBookingAdminNotifications.test.js
+++ b/test/customerBookingAdminNotifications.test.js
@@ -311,10 +311,10 @@ test("admin/customer frontend cache versions are bumped for booking notification
   assert.doesNotMatch(adminReviewHtml, /admin-review-v2\.js\?v=20260707_customer_booking_notify_v2/);
   assert.match(adminReviewHtml, /admin-review-ai-intake\.js\?v=ai-booking-intake-customer-cards-v11-admin-alert-gate/);
   assert.doesNotMatch(adminReviewHtml, /admin-review-ai-intake\.js\?v=ai-booking-intake-customer-cards-v10/);
-  assert.match(customerIndex, /bookingScheduled\.js\?v=20260712_page_controls_tracking_link_v2/);
-  assert.match(customerIndex, /state\.js\?v=20260712_page_controls_tracking_link_v2/);
-  assert.match(customerSw, /const BUILD_ID = "20260712_page_controls_tracking_link_v2"/);
-  assert.match(customerManifest, /20260712_page_controls_tracking_link_v2/);
+  assert.match(customerIndex, /bookingScheduled\.js\?v=20260712_page_controls_tracking_link_v3/);
+  assert.match(customerIndex, /state\.js\?v=20260712_page_controls_tracking_link_v3/);
+  assert.match(customerSw, /const BUILD_ID = "20260712_page_controls_tracking_link_v3"/);
+  assert.match(customerManifest, /20260712_page_controls_tracking_link_v3/);
 });
 
 test("behavior: review queue only includes customer urgent waiting rows while preserving review statuses", () => {

--- a/test/customerHistoryClaim.test.js
+++ b/test/customerHistoryClaim.test.js
@@ -544,7 +544,7 @@ test("Customer App profile opens history detail with opaque job_ref and clears c
 });
 
 test("Customer App cache version is bumped consistently", () => {
-  const expected = "20260712_page_controls_tracking_link_v1";
+  const expected = "20260712_page_controls_tracking_link_v2";
   for (const file of [
     "customer-app/index.html",
     "customer-app/sw.js",

--- a/test/customerHistoryClaim.test.js
+++ b/test/customerHistoryClaim.test.js
@@ -544,7 +544,7 @@ test("Customer App profile opens history detail with opaque job_ref and clears c
 });
 
 test("Customer App cache version is bumped consistently", () => {
-  const expected = "20260712_page_controls_tracking_link_v2";
+  const expected = "20260712_page_controls_tracking_link_v3";
   for (const file of [
     "customer-app/index.html",
     "customer-app/sw.js",

--- a/test/customerHistoryClaim.test.js
+++ b/test/customerHistoryClaim.test.js
@@ -544,7 +544,7 @@ test("Customer App profile opens history detail with opaque job_ref and clears c
 });
 
 test("Customer App cache version is bumped consistently", () => {
-  const expected = "20260711_tracking_gps_recovery_v1";
+  const expected = "20260712_page_controls_tracking_link_v1";
   for (const file of [
     "customer-app/index.html",
     "customer-app/sw.js",

--- a/test/customerSameDayTiming.test.js
+++ b/test/customerSameDayTiming.test.js
@@ -160,7 +160,7 @@ test("customer app disables availability HTTP cache and refreshes same-day slots
 });
 
 test("customer app build and service worker cache IDs changed", () => {
-  const id = "20260712_page_controls_tracking_link_v1";
+  const id = "20260712_page_controls_tracking_link_v2";
   for (const file of [
     "customer-app/index.html",
     "customer-app/sw.js",

--- a/test/customerSameDayTiming.test.js
+++ b/test/customerSameDayTiming.test.js
@@ -160,7 +160,7 @@ test("customer app disables availability HTTP cache and refreshes same-day slots
 });
 
 test("customer app build and service worker cache IDs changed", () => {
-  const id = "20260711_tracking_gps_recovery_v1";
+  const id = "20260712_page_controls_tracking_link_v1";
   for (const file of [
     "customer-app/index.html",
     "customer-app/sw.js",

--- a/test/customerSameDayTiming.test.js
+++ b/test/customerSameDayTiming.test.js
@@ -160,7 +160,7 @@ test("customer app disables availability HTTP cache and refreshes same-day slots
 });
 
 test("customer app build and service worker cache IDs changed", () => {
-  const id = "20260712_page_controls_tracking_link_v2";
+  const id = "20260712_page_controls_tracking_link_v3";
   for (const file of [
     "customer-app/index.html",
     "customer-app/sw.js",

--- a/test/homepageCms.test.js
+++ b/test/homepageCms.test.js
@@ -290,7 +290,7 @@ test("customer homepage has no admin control, bottom nav is fixed five-tab, and 
   const sw = read("customer-app/sw.js");
   const app = read("customer-app/assets/customer-app.js");
   const manifest = read("customer-app/manifest.webmanifest");
-  const build = "20260712_page_controls_tracking_link_v1";
+  const build = "20260712_page_controls_tracking_link_v2";
 
   assert.doesNotMatch(index + ui, /โหมดแอดมิน|openCms|localStorage\.getItem\('cwfHomeCmsDemo'/);
   assert.match(index, /data-route="store"[\s\S]*ร้านค้า/);
@@ -1687,7 +1687,10 @@ test("admin CMS wires the page-availability editor (toggles, publish guard, trac
   assert.match(adminJs, /renderPageAvailabilityEditor/);
   assert.match(adminJs, /data-page-availability="/);
   // Never auto-toggle: only the toggled key changes.
-  assert.match(adminJs, /config\.page_availability\[target\.dataset\.pageAvailability\] = target\.checked/);
+  assert.match(adminJs, /config\.page_availability\[key\] = target\.checked/);
+  // Cannot disable the last enabled page (UI guard), and publish guards remain.
+  assert.match(adminJs, /function pageAvailabilityToggleAllowed\(/);
+  assert.match(adminJs, /if \(!pageAvailabilityToggleAllowed\(config\.page_availability, key, target\.checked\)\)/);
   // Publish guards: all-disabled blocked, tracking-off confirm.
   assert.match(adminJs, /ต้องเปิดอย่างน้อย 1 หน้า/);
   assert.match(adminJs, /pa\.tracking === false && !window\.confirm/);

--- a/test/homepageCms.test.js
+++ b/test/homepageCms.test.js
@@ -4,7 +4,19 @@ const fs = require("node:fs");
 const path = require("node:path");
 const express = require("express");
 
-const { DEFAULT_CONFIG, createHomepageRoutes, validateConfig, activeNow, stripPublicConfig } = require("../server/routes/homepage");
+const {
+  DEFAULT_CONFIG,
+  createHomepageRoutes,
+  validateConfig,
+  activeNow,
+  stripPublicConfig,
+  PAGE_AVAILABILITY_KEYS,
+  DEFAULT_PAGE_AVAILABILITY,
+  DEGRADED_PAGE_AVAILABILITY,
+  hydrateDraftConfig,
+  normalizePageAvailability,
+  readPageAvailability,
+} = require("../server/routes/homepage");
 
 const REPO_ROOT = path.resolve(__dirname, "..");
 
@@ -278,7 +290,7 @@ test("customer homepage has no admin control, bottom nav is fixed five-tab, and 
   const sw = read("customer-app/sw.js");
   const app = read("customer-app/assets/customer-app.js");
   const manifest = read("customer-app/manifest.webmanifest");
-  const build = "20260711_tracking_gps_recovery_v1";
+  const build = "20260712_page_controls_tracking_link_v1";
 
   assert.doesNotMatch(index + ui, /โหมดแอดมิน|openCms|localStorage\.getItem\('cwfHomeCmsDemo'/);
   assert.match(index, /data-route="store"[\s\S]*ร้านค้า/);
@@ -1481,4 +1493,204 @@ test("admin-homepage-cms.js wires the articles auto-sync editor: toggle, source_
   assert.match(admin, /\/admin\/homepage-cms\/sync-articles/);
   assert.match(admin, /\/admin\/homepage-cms\/synced-articles/);
   assert.match(admin, /itemTypes\.includes\(section\.type\) && !\(section\.type === "articles" && section\.auto_sync\)/);
+});
+
+/* ==========================================================================
+   Page availability (Customer App V2 rollout control, stored in the SAME
+   Homepage CMS published_config — no new table). Locked defaults: legacy /
+   missing → all enabled; degraded fail-safe = Home + Tracking only.
+   ========================================================================== */
+
+test("page_availability: exports have the locked 7 keys and default shapes", () => {
+  assert.deepEqual(PAGE_AVAILABILITY_KEYS, ["home", "store", "booking", "scheduled", "urgent", "tracking", "profile"]);
+  assert.deepEqual({ ...DEFAULT_PAGE_AVAILABILITY }, { home: true, store: true, booking: true, scheduled: true, urgent: true, tracking: true, profile: true });
+  // Degraded fail-safe keeps only the landing page and Tracking reachable.
+  assert.deepEqual({ ...DEGRADED_PAGE_AVAILABILITY }, { home: true, store: false, booking: false, scheduled: false, urgent: false, tracking: true, profile: false });
+});
+
+test("page_availability: DEFAULT_CONFIG ships all-enabled", () => {
+  assert.deepEqual(DEFAULT_CONFIG.page_availability, { home: true, store: true, booking: true, scheduled: true, urgent: true, tracking: true, profile: true });
+});
+
+test("page_availability: absent block validates to all-enabled (legacy safe), not an error", () => {
+  const out = validateConfig({ sections: [{ id: "hero", type: "hero", enabled: true, sort_order: 1, title: "x", items: [] }] });
+  assert.equal(out.ok, true);
+  assert.deepEqual(out.config.page_availability, { home: true, store: true, booking: true, scheduled: true, urgent: true, tracking: true, profile: true });
+});
+
+test("page_availability: a valid explicit block is preserved as booleans", () => {
+  const pa = { home: true, store: false, booking: true, scheduled: false, urgent: true, tracking: true, profile: false };
+  const out = validateConfig({ page_availability: pa, sections: [{ id: "hero", type: "hero", enabled: true, sort_order: 1, title: "x", items: [] }] });
+  assert.equal(out.ok, true);
+  assert.deepEqual(out.config.page_availability, pa);
+});
+
+test("page_availability: rejects missing key, unknown key, non-boolean value, and all-disabled", () => {
+  const base = [{ id: "hero", type: "hero", enabled: true, sort_order: 1, title: "x", items: [] }];
+  const missingKey = validateConfig({ page_availability: { home: true, store: true, booking: true, scheduled: true, urgent: true, tracking: true }, sections: base });
+  assert.equal(missingKey.ok, false);
+
+  const unknownKey = validateConfig({ page_availability: { home: true, store: true, booking: true, scheduled: true, urgent: true, tracking: true, profile: true, extra: true }, sections: base });
+  assert.equal(unknownKey.ok, false);
+
+  const nonBool = validateConfig({ page_availability: { home: "yes", store: true, booking: true, scheduled: true, urgent: true, tracking: true, profile: true }, sections: base });
+  assert.equal(nonBool.ok, false);
+
+  const allDisabled = validateConfig({ page_availability: { home: false, store: false, booking: false, scheduled: false, urgent: false, tracking: false, profile: false }, sections: base });
+  assert.equal(allDisabled.ok, false);
+});
+
+test("page_availability: readPageAvailability never returns all-disabled and legacy → all-enabled", () => {
+  assert.deepEqual(readPageAvailability({}), { ...DEFAULT_PAGE_AVAILABILITY });
+  assert.deepEqual(readPageAvailability({ page_availability: null }), { ...DEFAULT_PAGE_AVAILABILITY });
+  // A corrupt all-disabled map is coerced back to the all-enabled safe default.
+  assert.deepEqual(
+    readPageAvailability({ page_availability: { home: false, store: false, booking: false, scheduled: false, urgent: false, tracking: false, profile: false } }),
+    { ...DEFAULT_PAGE_AVAILABILITY },
+  );
+  // A valid partial-off map is honoured.
+  const partial = { home: true, store: false, booking: false, scheduled: false, urgent: false, tracking: true, profile: false };
+  assert.deepEqual(readPageAvailability({ page_availability: partial }), partial);
+});
+
+test("page_availability: stripPublicConfig includes normalized flags and never admin-only fields", () => {
+  const pub = stripPublicConfig({
+    version: 1,
+    sections: [{ id: "hero", type: "hero", enabled: true, sort_order: 1, title: "x", items: [], image_public_id: "secret" }],
+    page_availability: { home: true, store: false, booking: true, scheduled: true, urgent: true, tracking: true, profile: true },
+  });
+  assert.deepEqual(pub.page_availability, { home: true, store: false, booking: true, scheduled: true, urgent: true, tracking: true, profile: true });
+  assert.doesNotMatch(JSON.stringify(pub), /secret|updated_by/);
+});
+
+test("page_availability: hydrateDraftConfig preserves sections/theme/page_headers and backfills flags", () => {
+  const hydrated = hydrateDraftConfig({
+    version: 3,
+    sections: [{ id: "hero", type: "hero", enabled: true, sort_order: 1, title: "keep me", items: [] }],
+    theme: { primary: "#123456" },
+    page_headers: { tracking: { enabled: true, title: "T" } },
+    // no page_availability → legacy, must backfill all-enabled
+  });
+  assert.match(JSON.stringify(hydrated.sections), /keep me/);
+  assert.deepEqual(hydrated.theme, { primary: "#123456" });
+  assert.equal(hydrated.page_headers.tracking.title, "T");
+  assert.deepEqual(hydrated.page_availability, { ...DEFAULT_PAGE_AVAILABILITY });
+});
+
+test("GET /public/customer-app-config: no published config → all-enabled fallback, no admin leak", async () => {
+  const pool = createPool();
+  pool.state.row.published_config = null;
+  const server = await withServer(pool, (_req, _res, next) => next());
+  try {
+    const res = await fetch(`${server.base}/public/customer-app-config`);
+    const data = await res.json();
+    assert.equal(res.status, 200);
+    assert.equal(res.headers.get("cache-control"), "no-store");
+    assert.equal(data.ok, true);
+    assert.equal(data.fallback, true);
+    assert.equal(data.degraded, false);
+    assert.deepEqual(data.page_availability, { ...DEFAULT_PAGE_AVAILABILITY });
+    assert.doesNotMatch(JSON.stringify(data), /draft_config|updated_by|sections/);
+  } finally {
+    await server.close();
+  }
+});
+
+test("GET /public/customer-app-config: legacy published (no flags) → all-enabled, not fallback", async () => {
+  const pool = createPool();
+  pool.state.row.published_config = { version: 2, sections: [{ id: "hero", type: "hero", enabled: true, sort_order: 1, title: "x", items: [] }] };
+  pool.state.row.version = 2;
+  const server = await withServer(pool, (_req, _res, next) => next());
+  try {
+    const res = await fetch(`${server.base}/public/customer-app-config`);
+    const data = await res.json();
+    assert.equal(res.status, 200);
+    assert.equal(data.fallback, false);
+    assert.equal(data.degraded, false);
+    assert.deepEqual(data.page_availability, { ...DEFAULT_PAGE_AVAILABILITY });
+  } finally {
+    await server.close();
+  }
+});
+
+test("GET /public/customer-app-config: published flags are returned verbatim", async () => {
+  const pool = createPool();
+  const pa = { home: true, store: false, booking: false, scheduled: false, urgent: false, tracking: true, profile: false };
+  pool.state.row.published_config = { version: 5, page_availability: pa, sections: [{ id: "hero", type: "hero", enabled: true, sort_order: 1, title: "x", items: [] }] };
+  pool.state.row.version = 5;
+  const server = await withServer(pool, (_req, _res, next) => next());
+  try {
+    const res = await fetch(`${server.base}/public/customer-app-config`);
+    const data = await res.json();
+    assert.equal(res.status, 200);
+    assert.equal(data.fallback, false);
+    assert.deepEqual(data.page_availability, pa);
+  } finally {
+    await server.close();
+  }
+});
+
+test("GET /public/customer-app-config: DB failure → degraded fail-safe with HTTP 200 (never 500)", async () => {
+  const pool = {
+    async query() {
+      const error = new Error("missing table");
+      error.code = "42P01";
+      throw error;
+    },
+  };
+  const server = await withServer(pool, (_req, _res, next) => next());
+  try {
+    const res = await fetch(`${server.base}/public/customer-app-config`);
+    const data = await res.json();
+    assert.equal(res.status, 200);
+    assert.equal(data.degraded, true);
+    assert.equal(data.fallback, true);
+    assert.deepEqual(data.page_availability, { ...DEGRADED_PAGE_AVAILABILITY });
+  } finally {
+    await server.close();
+  }
+});
+
+test("page_availability: Draft save does not publish flags until Publish is called", async () => {
+  const pool = createPool();
+  const allow = await withServer(pool, (req, _res, next) => { req.actor = { username: "admin", role: "admin" }; next(); });
+  try {
+    const draftConfig = {
+      version: 1,
+      page_availability: { home: true, store: false, booking: false, scheduled: false, urgent: false, tracking: true, profile: false },
+      sections: [{ id: "hero", type: "hero", enabled: true, sort_order: 1, title: "x", items: [] }],
+    };
+    await fetch(`${allow.base}/admin/homepage-cms/draft`, {
+      method: "PUT", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ config: draftConfig }),
+    });
+    // Public config still all-enabled — Draft is not published.
+    let res = await fetch(`${allow.base}/public/customer-app-config`);
+    let data = await res.json();
+    assert.deepEqual(data.page_availability, { ...DEFAULT_PAGE_AVAILABILITY });
+
+    await fetch(`${allow.base}/admin/homepage-cms/publish`, {
+      method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ config: draftConfig }),
+    });
+    res = await fetch(`${allow.base}/public/customer-app-config`);
+    data = await res.json();
+    assert.deepEqual(data.page_availability, { home: true, store: false, booking: false, scheduled: false, urgent: false, tracking: true, profile: false });
+  } finally {
+    await allow.close();
+  }
+});
+
+test("admin CMS wires the page-availability editor (toggles, publish guard, tracking-off confirm)", () => {
+  const adminJs = read("admin-homepage-cms.js");
+  const adminHtml = read("admin-homepage-cms.html");
+  // Editor + nav entry.
+  assert.match(adminJs, /data-edit="page-availability"/);
+  assert.match(adminJs, /renderPageAvailabilityEditor/);
+  assert.match(adminJs, /data-page-availability="/);
+  // Never auto-toggle: only the toggled key changes.
+  assert.match(adminJs, /config\.page_availability\[target\.dataset\.pageAvailability\] = target\.checked/);
+  // Publish guards: all-disabled blocked, tracking-off confirm.
+  assert.match(adminJs, /ต้องเปิดอย่างน้อย 1 หน้า/);
+  assert.match(adminJs, /pa\.tracking === false && !window\.confirm/);
+  // CSS present for the editor.
+  assert.match(adminHtml, /\.pa-row/);
 });

--- a/test/homepageCms.test.js
+++ b/test/homepageCms.test.js
@@ -290,7 +290,7 @@ test("customer homepage has no admin control, bottom nav is fixed five-tab, and 
   const sw = read("customer-app/sw.js");
   const app = read("customer-app/assets/customer-app.js");
   const manifest = read("customer-app/manifest.webmanifest");
-  const build = "20260712_page_controls_tracking_link_v2";
+  const build = "20260712_page_controls_tracking_link_v3";
 
   assert.doesNotMatch(index + ui, /โหมดแอดมิน|openCms|localStorage\.getItem\('cwfHomeCmsDemo'/);
   assert.match(index, /data-route="store"[\s\S]*ร้านค้า/);

--- a/test/trackingGpsRecovery.test.js
+++ b/test/trackingGpsRecovery.test.js
@@ -34,11 +34,35 @@ function sliceBetween(src, startMarker, endMarker) {
 
 test("official confirmation tracking_url uses booking_token when present (not booking_code)", () => {
   assert.match(indexSrc, /const trackingCredential = String\(job\.booking_token \|\| ''\)\.trim\(\)/);
-  assert.match(indexSrc, /tracking_url: `\$\{origin\}\/track\.html\?q=\$\{encodeURIComponent\(trackingCredential\)\}`/);
   // The visible job number stays booking_code.
   assert.match(indexSrc, /booking_code: booking,/);
   // The summary query must actually load booking_token to build the link.
   assert.match(indexSrc, /SELECT job_id, booking_code, booking_token, customer_name/);
+});
+
+test("official confirmation tracking_url now opens Customer App V2 Tracking (query BEFORE #tracking, encoded)", () => {
+  // Destination changed to the Customer App deep link; the ?q= credential must
+  // come BEFORE the #tracking hash so the app reads it at boot, and it must be
+  // URL-encoded via the SAME unchanged trackingCredential.
+  assert.match(
+    indexSrc,
+    /tracking_url: `\$\{origin\}\/customer-app\/index\.html\?q=\$\{encodeURIComponent\(trackingCredential\)\}#tracking`/,
+  );
+  // Sanity on ordering: ?q= appears before #tracking in the template.
+  const line = indexSrc.split("\n").find((l) => l.includes("tracking_url:"));
+  assert.ok(line, "tracking_url line present");
+  assert.ok(line.indexOf("?q=") < line.indexOf("#tracking"), "?q= must precede #tracking");
+});
+
+test("only the official confirmation link changed — track.html still exists and is NOT globally replaced", () => {
+  // Legacy tracking page must remain for rollback.
+  assert.ok(fs.existsSync(path.join(ROOT, "track.html")), "track.html must still exist");
+  // The /track route/redirect and track.html references elsewhere must survive:
+  // this task only repoints buildCustomerConfirmationVars, not a global swap.
+  assert.match(indexSrc, /app\.get\("\/track"/, "GET /track route must remain");
+  // customer.html (legacy) still points at track.html — proof of no global replace.
+  const customerHtml = read("customer.html");
+  assert.match(customerHtml, /\/track\.html\?q=/, "legacy customer.html must still use track.html");
 });
 
 test("booking_token is never rendered as visible confirmation text nor logged", () => {

--- a/test/trackingGpsRecovery.test.js
+++ b/test/trackingGpsRecovery.test.js
@@ -40,18 +40,21 @@ test("official confirmation tracking_url uses booking_token when present (not bo
   assert.match(indexSrc, /SELECT job_id, booking_code, booking_token, customer_name/);
 });
 
-test("official confirmation tracking_url now opens Customer App V2 Tracking (query BEFORE #tracking, encoded)", () => {
-  // Destination changed to the Customer App deep link; the ?q= credential must
-  // come BEFORE the #tracking hash so the app reads it at boot, and it must be
-  // URL-encoded via the SAME unchanged trackingCredential.
+test("official confirmation tracking_url puts the credential in the FRAGMENT (#tracking?q=), not the query", () => {
+  // The credential now lives AFTER the # so browsers never send it to the
+  // server (no access logs / Referer leak). Same unchanged trackingCredential,
+  // still URL-encoded.
   assert.match(
     indexSrc,
-    /tracking_url: `\$\{origin\}\/customer-app\/index\.html\?q=\$\{encodeURIComponent\(trackingCredential\)\}#tracking`/,
+    /tracking_url: `\$\{origin\}\/customer-app\/index\.html#tracking\?q=\$\{encodeURIComponent\(trackingCredential\)\}`/,
   );
-  // Sanity on ordering: ?q= appears before #tracking in the template.
+  // Ordering: #tracking appears BEFORE ?q= in the template (credential in the
+  // fragment), and there is no credential in the query segment before the #.
   const line = indexSrc.split("\n").find((l) => l.includes("tracking_url:"));
   assert.ok(line, "tracking_url line present");
-  assert.ok(line.indexOf("?q=") < line.indexOf("#tracking"), "?q= must precede #tracking");
+  assert.ok(line.indexOf("#tracking") < line.indexOf("?q="), "#tracking must precede ?q= (credential in fragment)");
+  const beforeHash = line.slice(line.indexOf("index.html"), line.indexOf("#tracking"));
+  assert.ok(!/\?q=|\?token=/.test(beforeHash), "no credential may appear in the query segment before #");
 });
 
 test("only the official confirmation link changed — track.html still exists and is NOT globally replaced", () => {


### PR DESCRIPTION
## Summary

Two owner-approved changes to Customer App V2:

1. **Secure Tracking deep link** — the official appointment-confirmation link opens **Customer App V2 Tracking**. The private credential now travels in the **URL fragment** (`/customer-app/index.html#tracking?q=<credential>`), which browsers never send to the server; the app reads it at boot and scrubs the URL to a clean `#tracking`.
2. **Per-page availability control** — admins enable/disable each of the 7 Customer App pages. A disabled page is hidden, unreachable by URL/hash/JS, never calls its handler or page-specific API, and shows a maintenance screen.

## Architecture

- `page_availability` lives **inside the existing Homepage CMS `published_config`** — **no new table / migration**. Draft → Publish.
- Legacy configs → **all enabled**; degraded fail-safe → `{ home, tracking }` only; `localStorage` is a last-known-good cache only.
- Page availability is a **UI rollout control**, never a replacement for the server booking kill switches.

## Tracking security (current posture)

- Credential in the **URL fragment** → not sent in the document request, not in server/CDN access logs.
- `<meta name="referrer" content="no-referrer">` (before every resource tag) → no credential leak via `Referer` on same-origin subresources.
- Boot **scrubs** the URL via `history.replaceState()` before `state.init()` → no credential in the address bar/history, and the router never sees `tracking?q=…`.
- Service worker: legacy `?q=`/`?token=` navigations stay **network-only, never cached**; the new fragment link never appears in `event.request.url` (uses the normal app-shell path, no token in any cache key).
- Credential never rendered, logged, sent to analytics, or stored in DOM/`localStorage`/`sessionStorage`/Cache Storage.
- Credential **selection unchanged** (`booking_token` preferred), `booking_code` still the visible number; `track.html` + `/public/track` untouched; no global replacement.
- Tracking disabled → router blocks the render **before** the auto-lookup, so no `/public/track` fires (fragment or legacy link).

## Review round 2 — fragment credential + scrub + referrer policy

- **Part A `index.js`** — `tracking_url` → `…/index.html#tracking?q=${encodeURIComponent(cred)}` (credential in the fragment).
- **Part B `customer-app/assets/customer-app.js`** — pure `parseTrackingBoot()` reads the credential from the fragment (official) or legacy query, returns a scrubbed `cleanUrl`; boot applies it with `replaceState()` before `state.init()`, hands the credential to `setInitialCredential()` once, preserves unrelated query params (e.g. `utm_source`).
- **Part C `customer-app/index.html`** — `no-referrer` meta before all resource tags.
- **Part D `customer-app/sw.js`** — round-1 sensitive-navigation guard retained; `BUILD_ID` → **`20260712_page_controls_tracking_link_v3`** (Technician/root PWA untouched).

## Review round 1 (still in place)

- `sw.js` never writes a credential-bearing navigation to Cache Storage (network-only; offline → credential-free shell).
- CMS cannot disable the **last** enabled page (`pageAvailabilityToggleAllowed`), with backend validation + publish guard as defense-in-depth.

## URL-scrub proof (runtime)

`parseTrackingBoot()` executed in a VM across all forms:

| input | credential captured | cleanUrl |
|---|---|---|
| `#tracking?q=<cred>` | ✅ | `…/index.html#tracking` |
| `#tracking?token=<cred>` | ✅ | `…/index.html#tracking` |
| `?q=<cred>#tracking` (legacy) | ✅ | `…/index.html#tracking` |
| `?token=<cred>#tracking` (legacy) | ✅ | `…/index.html#tracking` |
| `?utm_source=line#tracking?q=<cred>` | ✅ | `…/index.html?utm_source=line#tracking` |
| `?utm_source=line#home` (no cred) | — | unchanged (`changed=false`) |

In every sensitive form the credential is absent from `cleanUrl`; `utm_source` is preserved; boot uses `replaceState` (no new history entry).

## Referrer-policy proof

`<meta name="referrer" content="no-referrer">` present, positioned before the first `<link>`/`<script>`, exactly once, with no conflicting `http-equiv` — asserted in `test/customerAppPageAvailability.test.js`.

## Cache-security regression (runtime, round-1 kept green)

Executing the real `sw.js` in a VM: legacy `?q=`/`?token=` navigations → no `cache.put`, no cache key contains the token, offline → credential-free shell; normal assets still cache; `/public/` network-only; `activate` deletes the stale `cwf-customer-app-v2-*` namespace.

> Verification is the executed-code VM harness (no live browser with an installed SW is available here). Recommended device smoke: open `#tracking?q=TEST` → Network document Request URL has no token; subresource `Referer` has no token; Cache Storage has no token; address bar becomes `#tracking`; Tracking auto-loads; legacy `?q=TEST#tracking` still works and is scrubbed; with Tracking disabled no `/public/track` fires.

## Test results (actually run)

- `node --check` clean: `index.js`, `customer-app/assets/customer-app.js`, `customer-app/sw.js`.
- `test/customerAppPageAvailability.test.js` → **47 pass / 0 fail**.
- Focused (`trackingGpsRecovery`, `customerAppPageAvailability`, `customerAppRecovery`, `customerBookingAdminNotifications`) → **193 pass / 0 fail**.
- Full `npm test` → **1127 pass / 0 fail / 34 skipped** (skipped = live-PG integration).

## Do not merge / deploy

Keep as **Draft**. This is a rollout/UI control only and does not replace server kill switches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LmdP3TGN5uQrfT8ZYefNco