### PR TITLE
Customer App: locked blurred maintenance for disabled pages (keep menus intact)

### DIFF
--- a/customer-app/assets/customer-app.css
+++ b/customer-app/assets/customer-app.css
@@ -5815,28 +5815,70 @@ textarea.purchase-input { min-height: 66px; resize: vertical; }
 .nav-item-primary.is-active span { color: var(--navy); font-weight: 900; }
 
 /* ============================================================================
-   Page availability — maintenance screen + booking empty state
-   These appear when an admin disables a Customer App page (rollout control,
-   NOT a server kill switch). Kept visually calm and reassuring.
+   Page availability — LOCKED maintenance screen + booking empty state.
+   Menus/CTAs are never hidden: a disabled page shows a static, blurred skeleton
+   (placeholder only — no live data / no API) behind a readable overlay, so the
+   app keeps its full shape and the Bottom Navigation never reflows.
    ========================================================================== */
 .maintenance-screen {
+  position: relative;
+  min-height: 72vh;
+  overflow: hidden;
+  border-radius: var(--radius-lg);
+}
+/* Static placeholder shell — blurred + inert so it reads as "a page behind
+   glass" without ever showing real content. */
+.maintenance-skeleton {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  padding: 16px;
+  filter: blur(7px);
+  opacity: 0.55;
+  pointer-events: none;
+  user-select: none;
+}
+.maintenance-skeleton .sk-block {
+  background: linear-gradient(100deg, #e9eef6 30%, #f4f7fb 50%, #e9eef6 70%);
+  background-size: 200% 100%;
+  animation: cwf-sk-shimmer 1.6s ease-in-out infinite;
+  border-radius: var(--radius);
+}
+.maintenance-skeleton .sk-hero { height: 150px; }
+.maintenance-skeleton .sk-chips { display: flex; gap: 10px; }
+.maintenance-skeleton .sk-chip { height: 64px; flex: 1; border-radius: var(--radius-sm); }
+.maintenance-skeleton .sk-card { height: 96px; }
+.maintenance-skeleton .sk-card-short { height: 60px; width: 65%; }
+@keyframes cwf-sk-shimmer {
+  0% { background-position: 200% 0; }
+  100% { background-position: -200% 0; }
+}
+@media (prefers-reduced-motion: reduce) {
+  .maintenance-skeleton .sk-block { animation: none; }
+}
+/* Readable overlay on top of the blurred shell. */
+.maintenance-overlay {
+  position: absolute;
+  inset: 0;
   display: flex;
   align-items: center;
   justify-content: center;
-  min-height: 60vh;
   padding: 24px 16px;
+  background: rgba(244, 247, 251, 0.55);
+  -webkit-backdrop-filter: blur(2px);
+  backdrop-filter: blur(2px);
 }
 .maintenance-card {
   width: 100%;
-  max-width: 420px;
+  max-width: 380px;
   background: var(--card, #fff);
   border: 1px solid var(--line, #e3e9f2);
   border-radius: var(--radius-lg);
-  padding: 28px 22px;
+  padding: 26px 22px;
   text-align: center;
-  box-shadow: 0 18px 40px -24px rgba(6, 24, 47, 0.35);
+  box-shadow: 0 24px 50px -24px rgba(6, 24, 47, 0.45);
 }
-.maintenance-emoji { font-size: 44px; line-height: 1; margin-bottom: 10px; }
+.maintenance-lock { font-size: 40px; line-height: 1; margin-bottom: 10px; }
 .maintenance-card h2 { font-size: 19px; font-weight: 800; color: var(--navy); margin: 0 0 6px; }
 .maintenance-page { font-size: 14px; color: var(--navy-3); margin: 0 0 4px; }
 .maintenance-card .muted { font-size: 14px; margin: 0 0 18px; }
@@ -5852,7 +5894,3 @@ textarea.purchase-input { min-height: 66px; resize: vertical; }
 .booking-empty-card h2 { font-size: 18px; font-weight: 800; color: var(--navy); margin: 0 0 6px; }
 .booking-empty-card .muted { margin: 0 0 16px; }
 .booking-empty-card .support-strip { justify-content: center; }
-
-/* Availability-hidden controls: belt-and-braces so a [hidden] element that some
-   other rule forces back to display:block still stays out of the layout. */
-[data-cwf-avail="off"] { display: none !important; }

--- a/customer-app/assets/customer-app.js
+++ b/customer-app/assets/customer-app.js
@@ -3,7 +3,7 @@
 
   const App = window.CWFCustomerAppV2;
   const BOOT_TIMEOUT_MS = 3500;
-  const BUILD_ID = "20260712_page_controls_tracking_link_v3";
+  const BUILD_ID = "20260712_page_controls_tracking_link_v4";
 
   function withTimeout(promise, timeoutMs) {
     return Promise.race([

--- a/customer-app/index.html
+++ b/customer-app/index.html
@@ -21,10 +21,10 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Noto+Sans+Thai:wght@400;500;600;700;800;900&display=swap" media="print" onload="this.media='all'">
   <noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Noto+Sans+Thai:wght@400;500;600;700;800;900&display=swap"></noscript>
-  <link rel="manifest" href="./manifest.webmanifest?v=20260712_page_controls_tracking_link_v3">
+  <link rel="manifest" href="./manifest.webmanifest?v=20260712_page_controls_tracking_link_v4">
   <link rel="icon" type="image/png" sizes="192x192" href="./assets/icons/cwf-customer-192.png">
   <link rel="apple-touch-icon" sizes="180x180" href="./assets/icons/cwf-customer-180.png">
-  <link rel="stylesheet" href="./assets/customer-app.css?v=20260712_page_controls_tracking_link_v3">
+  <link rel="stylesheet" href="./assets/customer-app.css?v=20260712_page_controls_tracking_link_v4">
 </head>
 <body class="is-app-booting">
   <div class="app-shell" data-app-shell>
@@ -62,22 +62,22 @@
     </nav>
   </div>
 
-  <script src="./modules/state.js?v=20260712_page_controls_tracking_link_v3"></script>
-  <script src="./modules/utils.js?v=20260712_page_controls_tracking_link_v3"></script>
-  <script src="./modules/analytics.js?v=20260712_page_controls_tracking_link_v3"></script>
-  <script src="./modules/api.js?v=20260712_page_controls_tracking_link_v3"></script>
-  <script src="./modules/pageAvailability.js?v=20260712_page_controls_tracking_link_v3"></script>
-  <script src="./modules/services.js?v=20260712_page_controls_tracking_link_v3"></script>
-  <script src="./modules/ui.js?v=20260712_page_controls_tracking_link_v3"></script>
-  <script src="./modules/store.js?v=20260712_page_controls_tracking_link_v3"></script>
-  <script src="./modules/auth.js?v=20260712_page_controls_tracking_link_v3"></script>
-  <script src="./modules/pricing.js?v=20260712_page_controls_tracking_link_v3"></script>
-  <script src="./modules/availability.js?v=20260712_page_controls_tracking_link_v3"></script>
-  <script src="./modules/bookingScheduled.js?v=20260712_page_controls_tracking_link_v3"></script>
-  <script src="./modules/bookingUrgent.js?v=20260712_page_controls_tracking_link_v3"></script>
-  <script src="./modules/tracking.js?v=20260712_page_controls_tracking_link_v3"></script>
-  <script src="./modules/profile.js?v=20260712_page_controls_tracking_link_v3"></script>
-  <script src="./modules/router.js?v=20260712_page_controls_tracking_link_v3"></script>
-  <script src="./assets/customer-app.js?v=20260712_page_controls_tracking_link_v3"></script>
+  <script src="./modules/state.js?v=20260712_page_controls_tracking_link_v4"></script>
+  <script src="./modules/utils.js?v=20260712_page_controls_tracking_link_v4"></script>
+  <script src="./modules/analytics.js?v=20260712_page_controls_tracking_link_v4"></script>
+  <script src="./modules/api.js?v=20260712_page_controls_tracking_link_v4"></script>
+  <script src="./modules/pageAvailability.js?v=20260712_page_controls_tracking_link_v4"></script>
+  <script src="./modules/services.js?v=20260712_page_controls_tracking_link_v4"></script>
+  <script src="./modules/ui.js?v=20260712_page_controls_tracking_link_v4"></script>
+  <script src="./modules/store.js?v=20260712_page_controls_tracking_link_v4"></script>
+  <script src="./modules/auth.js?v=20260712_page_controls_tracking_link_v4"></script>
+  <script src="./modules/pricing.js?v=20260712_page_controls_tracking_link_v4"></script>
+  <script src="./modules/availability.js?v=20260712_page_controls_tracking_link_v4"></script>
+  <script src="./modules/bookingScheduled.js?v=20260712_page_controls_tracking_link_v4"></script>
+  <script src="./modules/bookingUrgent.js?v=20260712_page_controls_tracking_link_v4"></script>
+  <script src="./modules/tracking.js?v=20260712_page_controls_tracking_link_v4"></script>
+  <script src="./modules/profile.js?v=20260712_page_controls_tracking_link_v4"></script>
+  <script src="./modules/router.js?v=20260712_page_controls_tracking_link_v4"></script>
+  <script src="./assets/customer-app.js?v=20260712_page_controls_tracking_link_v4"></script>
 </body>
 </html>

--- a/customer-app/manifest.webmanifest
+++ b/customer-app/manifest.webmanifest
@@ -2,7 +2,7 @@
   "name": "CWF Customer Service",
   "short_name": "CWF Service",
   "description": "แอปลูกค้า Coldwindflow สำหรับเลือกบริการ จองคิว และติดตามงาน",
-  "start_url": "/customer-app/index.html?v=20260712_page_controls_tracking_link_v3#home",
+  "start_url": "/customer-app/index.html?v=20260712_page_controls_tracking_link_v4#home",
   "scope": "/customer-app/",
   "id": "/customer-app/",
   "display": "standalone",

--- a/customer-app/modules/pageAvailability.js
+++ b/customer-app/modules/pageAvailability.js
@@ -35,7 +35,6 @@
   // before load() resolves, we never accidentally treat a page as enabled.
   let flags = { ...DEGRADED };
   let ready = false;
-  let observer = null;
 
   function isPlainObject(value) {
     return !!value && typeof value === "object" && !Array.isArray(value);
@@ -148,72 +147,25 @@
   }
 
   // ---- disabled-route controls ---------------------------------------------
-  // Hide every control that points at a disabled (or unknown) route. Only ever
-  // touch attributes THIS module set, and restore the element's prior
-  // disabled/hidden state so a control disabled by other business logic is never
-  // silently re-enabled.
-  function markHidden(el) {
-    if (el.getAttribute("data-cwf-avail") === "off") return;
-    el.setAttribute("data-cwf-avail", "off");
-    el.setAttribute("data-cwf-prev-hidden", el.hasAttribute("hidden") ? "1" : "0");
-    el.setAttribute("data-cwf-prev-aria", el.getAttribute("aria-hidden") || "");
-    el.setAttribute("data-cwf-prev-tabindex", el.hasAttribute("tabindex") ? String(el.getAttribute("tabindex")) : "");
-    el.setAttribute("hidden", "hidden");
-    el.setAttribute("aria-hidden", "true");
-    el.setAttribute("tabindex", "-1");
-    if ("disabled" in el) {
-      el.setAttribute("data-cwf-prev-disabled", el.disabled ? "1" : "0");
-      el.disabled = true;
-    }
-  }
+  // Design decision (locked-maintenance model): menus and CTAs are NEVER hidden
+  // or disabled. The full app structure stays intact — the Bottom Navigation
+  // keeps all its items (no reflow / no gaps) and every control remains
+  // clickable. When a control points at a disabled route, the click is caught by
+  // the central router guard, which renders a static "maintenance" screen
+  // instead of running the route handler or its API.
+  //
+  // applyToDom is kept as an intentional no-op purely for API compatibility with
+  // existing callers (router after-render, ui booking refresh, boot).
+  function applyToDom(_scope) { /* no-op: controls are never hidden */ }
 
-  function restoreShown(el) {
-    if (el.getAttribute("data-cwf-avail") !== "off") return; // not ours
-    if (el.getAttribute("data-cwf-prev-hidden") === "1") el.setAttribute("hidden", "hidden");
-    else el.removeAttribute("hidden");
-    const prevAria = el.getAttribute("data-cwf-prev-aria");
-    if (prevAria) el.setAttribute("aria-hidden", prevAria); else el.removeAttribute("aria-hidden");
-    const prevTab = el.getAttribute("data-cwf-prev-tabindex");
-    if (prevTab !== null && prevTab !== "") el.setAttribute("tabindex", prevTab); else el.removeAttribute("tabindex");
-    if ("disabled" in el) el.disabled = el.getAttribute("data-cwf-prev-disabled") === "1";
-    el.removeAttribute("data-cwf-avail");
-    el.removeAttribute("data-cwf-prev-hidden");
-    el.removeAttribute("data-cwf-prev-aria");
-    el.removeAttribute("data-cwf-prev-tabindex");
-    el.removeAttribute("data-cwf-prev-disabled");
-  }
+  // Kept for API compatibility with the boot sequence. Nothing is hidden, so
+  // there is nothing to reapply on DOM mutation — the observer is not started.
+  function startObserver() { /* no-op: nothing to re-hide */ }
 
-  function applyToDom(scope) {
-    if (!ready) return;
-    const target = scope && typeof scope.querySelectorAll === "function" ? scope : document;
-    let nodes;
-    try { nodes = target.querySelectorAll("[data-route]"); } catch (_) { return; }
-    nodes.forEach((el) => {
-      const key = availabilityKey(el.getAttribute("data-route"));
-      const disabled = !key || flags[key] !== true;
-      if (disabled) markHidden(el); else restoreShown(el);
-    });
-  }
-
-  // A single, debounced MutationObserver reapplies the filter to asynchronously
-  // rendered CTAs. It watches childList/subtree only (never attributes), so this
-  // module's own attribute writes cannot retrigger it → no loop, one observer.
-  function startObserver() {
-    if (observer || typeof MutationObserver !== "function") return;
-    const appEl = document.getElementById("app");
-    if (!appEl) return;
-    let scheduled = false;
-    observer = new MutationObserver(() => {
-      if (scheduled) return;
-      scheduled = true;
-      const run = () => { scheduled = false; applyToDom(document); };
-      if (typeof requestAnimationFrame === "function") requestAnimationFrame(run);
-      else setTimeout(run, 16);
-    });
-    observer.observe(appEl, { childList: true, subtree: true });
-  }
-
-  // ---- maintenance screen ---------------------------------------------------
+  // ---- maintenance screen (static blurred skeleton + readable overlay) ------
+  // A generic, STATIC skeleton (no real customer data, no route handler, no API)
+  // sits blurred behind a readable "under maintenance" overlay, so a disabled
+  // page keeps the shape/feel of a real screen without exposing anything live.
   function maintenanceHtml(route) {
     const esc = root.utils.escapeHtml;
     const key = availabilityKey(route);
@@ -221,16 +173,25 @@
     const backRoute = firstEnabledRoute();
     const backLabel = PAGE_LABELS[backRoute] || "หน้าที่ใช้งานได้";
     return `
-      <section class="screen maintenance-screen" role="status" aria-live="polite">
-        <div class="maintenance-card">
-          <div class="maintenance-emoji" aria-hidden="true">🛠️</div>
-          <h2>หน้านี้กำลังปรับปรุง</h2>
-          <p class="maintenance-page">หน้า: <strong>${esc(label)}</strong></p>
-          <p class="muted">ระบบกำลังเตรียมฟีเจอร์นี้ กรุณาใช้เมนูอื่นหรือติดต่อแอดมิน</p>
-          <div class="maintenance-actions">
-            <button class="primary-btn" type="button" data-route="${esc(backRoute)}" data-maintenance-back>กลับไปหน้าที่ใช้งานได้ (${esc(backLabel)})</button>
-            <a class="secondary-btn" href="${LINE_URL}" target="_blank" rel="noopener noreferrer">ติดต่อแอดมินทาง LINE</a>
-            <a class="secondary-btn" href="tel:${PHONE_TEL}">โทร ${PHONE_DISPLAY}</a>
+      <section class="screen maintenance-screen" aria-label="หน้ากำลังปรับปรุง">
+        <div class="maintenance-skeleton" aria-hidden="true">
+          <div class="sk-block sk-hero"></div>
+          <div class="sk-chips"><span class="sk-block sk-chip"></span><span class="sk-block sk-chip"></span><span class="sk-block sk-chip"></span></div>
+          <div class="sk-block sk-card"></div>
+          <div class="sk-block sk-card"></div>
+          <div class="sk-block sk-card sk-card-short"></div>
+        </div>
+        <div class="maintenance-overlay" role="status" aria-live="polite">
+          <div class="maintenance-card">
+            <div class="maintenance-lock" aria-hidden="true">🔒</div>
+            <h2>หน้านี้กำลังปรับปรุง</h2>
+            <p class="maintenance-page">หน้า: <strong>${esc(label)}</strong></p>
+            <p class="muted">ฟีเจอร์นี้ปิดปรับปรุงชั่วคราว เมนูอื่นยังใช้งานได้ตามปกติ</p>
+            <div class="maintenance-actions">
+              <button class="primary-btn" type="button" data-route="${esc(backRoute)}" data-maintenance-back>ไปหน้าที่ใช้งานได้ (${esc(backLabel)})</button>
+              <a class="secondary-btn" href="${LINE_URL}" target="_blank" rel="noopener noreferrer">ติดต่อแอดมินทาง LINE</a>
+              <a class="secondary-btn" href="tel:${PHONE_TEL}">โทร ${PHONE_DISPLAY}</a>
+            </div>
           </div>
         </div>
       </section>
@@ -239,11 +200,9 @@
 
   function renderMaintenance(container, route) {
     if (!container) return;
+    // Pure static markup — no route handler, no API, no live customer data. The
+    // back button carries data-route so it routes through the central guard.
     container.innerHTML = maintenanceHtml(route);
-    // The back button carries data-route, so the normal router click handler
-    // navigates through the central guard — no direct handler call, no loop.
-    // Ensure our own maintenance markup is filtered too (defensive).
-    applyToDom(container);
   }
 
   root.pageAvailability = {

--- a/customer-app/sw.js
+++ b/customer-app/sw.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const BUILD_ID = "20260712_page_controls_tracking_link_v3";
+const BUILD_ID = "20260712_page_controls_tracking_link_v4";
 const CACHE_NAME = `cwf-customer-app-v2-${BUILD_ID}`;
 const APP_SHELL = [
   `./index.html?v=${BUILD_ID}`,

--- a/test/customerAppPageAvailability.test.js
+++ b/test/customerAppPageAvailability.test.js
@@ -2,11 +2,11 @@
 
 // Focused tests for Customer App V2 page-availability (admin rollout control).
 //  - The pageAvailability module: flag validation, route mapping, load
-//    priority (server → cache → degraded), DOM hiding that preserves
-//    business-disabled controls, and the maintenance screen.
-//  - Source contracts for the central router guard, boot order, and the
-//    booking-mode empty state, so a disabled page is truly unreachable and
-//    never calls its handler or page-specific API.
+//    priority (server → cache → degraded), the locked-maintenance model (menus/
+//    CTAs are never hidden — applyToDom is a no-op), and the static blurred
+//    maintenance screen.
+//  - Runtime router-guard tests: a disabled route shows the maintenance screen
+//    with its nav item still present + active, and never runs its handler/API.
 
 const test = require("node:test");
 const assert = require("node:assert/strict");
@@ -182,51 +182,54 @@ test("firstEnabledRoute: honors priority order and always returns an enabled rou
   assert.equal(h.pa.firstEnabledRoute(), "tracking");
 });
 
-// ============================ DOM hiding ==================================
-test("applyToDom hides controls for disabled/unknown routes and restores them when re-enabled", async () => {
+// ============================ locked-maintenance model ====================
+// Menus/CTAs are NEVER hidden: applyToDom must not touch [data-route] controls.
+test("applyToDom does NOT hide [data-route] controls (menus/CTAs stay intact)", async () => {
   const trackingBtn = makeEl({ "data-route": "tracking" });
-  const storeBtn = makeEl({ "data-route": "store" });
+  const storeBtn = makeEl({ "data-route": "store" }); // points at a DISABLED route
   const h = loadModule({ routeEls: [trackingBtn, storeBtn] });
   h.setApi(async () => ({ ok: true, degraded: false, page_availability: { home: true, store: false, booking: false, scheduled: false, urgent: false, tracking: true, profile: false } }));
   await h.pa.load(); // load() calls applyToDom(document)
-  // tracking enabled → visible; store disabled → hidden
-  assert.equal(trackingBtn.hasAttribute("hidden"), false);
-  assert.equal(storeBtn.getAttribute("data-cwf-avail"), "off");
-  assert.equal(storeBtn.hasAttribute("hidden"), true);
-  assert.equal(storeBtn.getAttribute("aria-hidden"), "true");
-
-  // Re-enable store and re-apply → restored.
-  h.setApi(async () => ({ ok: true, degraded: false, page_availability: { ...ALL } }));
-  await h.pa.load();
+  // Neither the enabled nor the disabled control is hidden/disabled/aria-hidden.
+  for (const btn of [trackingBtn, storeBtn]) {
+    assert.equal(btn.hasAttribute("hidden"), false, "must not set hidden");
+    assert.equal(btn.hasAttribute("data-cwf-avail"), false, "must not mark controls off");
+    assert.equal(btn.getAttribute("aria-hidden"), null, "must not aria-hide");
+    assert.equal(btn.getAttribute("tabindex"), null, "must not remove from tab order");
+  }
+  // Explicit applyToDom(scope) is a harmless no-op too.
+  h.pa.applyToDom(h.appEl);
   assert.equal(storeBtn.hasAttribute("hidden"), false);
-  assert.equal(storeBtn.hasAttribute("data-cwf-avail"), false);
 });
 
-test("applyToDom never re-enables a control that other business logic had disabled", async () => {
-  // A booking CTA that was already disabled by business logic, pointing at a
-  // disabled route. When we later restore it, it must stay disabled.
-  const bizDisabled = makeEl({ "data-route": "store" }, { hasDisabled: true, disabled: true });
-  const h = loadModule({ routeEls: [bizDisabled] });
-  h.setApi(async () => ({ ok: true, degraded: false, page_availability: { home: true, store: false, booking: false, scheduled: false, urgent: false, tracking: true, profile: false } }));
-  await h.pa.load();
-  assert.equal(bizDisabled.disabled, true);
-  // Re-enable the store page → restore should recover the PRIOR disabled state.
+test("startObserver is a no-op (nothing is hidden, so nothing to reapply)", async () => {
+  const h = loadModule();
   h.setApi(async () => ({ ok: true, degraded: false, page_availability: { ...ALL } }));
   await h.pa.load();
-  assert.equal(bizDisabled.disabled, true, "must not silently re-enable a business-disabled control");
+  // Must not throw and must not require a MutationObserver.
+  assert.doesNotThrow(() => h.pa.startObserver());
 });
 
 // ============================ maintenance screen ==========================
-test("maintenanceHtml shows the page label, a back button to the first enabled route, LINE + phone", async () => {
+test("maintenanceHtml is a STATIC blurred skeleton + readable overlay (no live data)", async () => {
   const h = loadModule();
   h.setApi(async () => ({ ok: true, degraded: false, page_availability: { home: false, store: false, booking: false, scheduled: false, urgent: false, tracking: true, profile: false } }));
   await h.pa.load();
   const html = h.pa.maintenanceHtml("store");
+  // Static blurred skeleton behind a readable overlay.
+  assert.match(html, /maintenance-skeleton/);
+  assert.match(html, /sk-block/);
+  assert.match(html, /aria-hidden="true"/); // skeleton hidden from a11y tree
+  assert.match(html, /maintenance-overlay/);
+  assert.match(html, /role="status"/);
+  // Message + page label + back-to-enabled + contact actions.
   assert.match(html, /หน้านี้กำลังปรับปรุง/);
   assert.match(html, /ร้านค้า/); // page label for 'store'
-  assert.match(html, /data-route="tracking"/); // firstEnabledRoute
+  assert.match(html, /data-route="tracking"/); // firstEnabledRoute back button
   assert.match(html, /lin\.ee\/fG1Oq7y/);
   assert.match(html, /tel:0988777321/);
+  // The skeleton must be generic placeholder markup — never real customer data.
+  assert.doesNotMatch(html, /booking_code|booking_token|customer_name|address_text|\?q=|\?token=/i);
 });
 
 // ============================ router guard (source) =======================
@@ -278,7 +281,7 @@ test("api exposes loadCustomerAppConfig as a no-store GET to /public/customer-ap
 });
 
 test("build wiring: pageAvailability.js is registered in the HTML shell and the SW cache, with the new build id", () => {
-  const build = "20260712_page_controls_tracking_link_v3";
+  const build = "20260712_page_controls_tracking_link_v4";
   assert.match(indexHtml, new RegExp(`modules/pageAvailability\\.js\\?v=${build}`));
   assert.match(swSrc, new RegExp(`BUILD_ID = "${build}"`));
   assert.match(swSrc, /modules\/pageAvailability\.js\?v=\$\{BUILD_ID\}/);
@@ -291,7 +294,7 @@ test("build wiring: pageAvailability.js is registered in the HTML shell and the 
    RUNTIME tests (execute the real code in a VM — not regex assertions).
    ========================================================================== */
 
-const BUILD = "20260712_page_controls_tracking_link_v3";
+const BUILD = "20260712_page_controls_tracking_link_v4";
 const adminSrc = read("admin-homepage-cms.js");
 
 function reqUrlOf(req) {
@@ -452,13 +455,28 @@ test("SW: activation deletes stale Customer App cache namespaces and keeps the c
 });
 
 // ---- Router guard runtime harness ----------------------------------------
+function makeNavItem(route) {
+  let active = false;
+  const attrs = { "data-route": route };
+  return {
+    getAttribute: (n) => (n in attrs ? attrs[n] : null),
+    setAttribute: (n, v) => { attrs[n] = String(v); },
+    removeAttribute: (n) => { delete attrs[n]; },
+    hasAttribute: (n) => n in attrs,
+    classList: { toggle: (cls, force) => { if (cls === "is-active") active = !!force; } },
+    get isActive() { return active; },
+  };
+}
+
 function loadRouterRuntime() {
   const store = new Map();
   const appEl = { innerHTML: "", dataset: {}, focus() {}, querySelectorAll: () => [] };
   const body = { classList: { add() {}, remove() {}, toggle() {} } };
+  // The real Bottom Navigation (5 fixed items) — none are ever hidden/removed.
+  const navItems = ["home", "store", "booking", "tracking", "profile"].map(makeNavItem);
   const documentObj = {
     getElementById: (id) => (id === "app" ? appEl : null),
-    querySelectorAll: () => [],
+    querySelectorAll: (sel) => (String(sel).includes("nav-item") ? navItems : []),
     addEventListener: () => {},
     body,
   };
@@ -509,25 +527,30 @@ function loadRouterRuntime() {
   vm.runInContext(routerSrc, sandbox); // router
   const root = win.CWFCustomerAppV2;
 
-  const home = () => { handlerCalls.home += 1; };
+  // Real handlers render into the #app container they receive; the spies do too
+  // so a successful (enabled) render overwrites any prior maintenance markup.
+  const paint = (name) => (app) => { if (app) app.innerHTML = `<section data-rendered="${name}">ok</section>`; };
+  const home = (app) => { handlerCalls.home += 1; paint("home")(app); };
   home.onLeave = () => { handlerCalls.homeLeave += 1; };
   root.router.register({
     home,
-    store: () => { handlerCalls.store += 1; apiCalls.store += 1; },
-    storeItem: () => { handlerCalls.storeItem += 1; apiCalls.store += 1; },
-    booking: () => { handlerCalls.booking += 1; },
-    scheduled: () => { handlerCalls.scheduled += 1; root.api.previewPricing(); root.api.loadAvailability(); },
-    urgent: () => { handlerCalls.urgent += 1; root.api.submitUrgentRequest(); },
-    tracking: () => { handlerCalls.tracking += 1; root.api.trackBooking(); },
-    profile: () => { handlerCalls.profile += 1; },
+    store: (app) => { handlerCalls.store += 1; apiCalls.store += 1; paint("store")(app); },
+    storeItem: (app) => { handlerCalls.storeItem += 1; apiCalls.store += 1; paint("storeItem")(app); },
+    booking: (app) => { handlerCalls.booking += 1; paint("booking")(app); },
+    scheduled: (app) => { handlerCalls.scheduled += 1; root.api.previewPricing(); root.api.loadAvailability(); paint("scheduled")(app); },
+    urgent: (app) => { handlerCalls.urgent += 1; root.api.submitUrgentRequest(); paint("urgent")(app); },
+    tracking: (app) => { handlerCalls.tracking += 1; root.api.trackBooking(); paint("tracking")(app); },
+    profile: (app) => { handlerCalls.profile += 1; paint("profile")(app); },
   });
 
   return {
-    root, state, appEl, handlerCalls, apiCalls, routeToCalls,
+    root, state, appEl, handlerCalls, apiCalls, routeToCalls, navItems,
     setFlags: (flags) => { apiResponse = async () => ({ ok: true, degraded: false, page_availability: flags }); },
     load: () => root.pageAvailability.load(),
     render: (requested) => { state.requested = requested; root.router.render({ focus: false }); },
     isMaintenance: () => String(appEl.innerHTML).includes("หน้านี้กำลังปรับปรุง"),
+    navActive: (route) => navItems.find((n) => n.getAttribute("data-route") === route).isActive,
+    navHidden: (route) => navItems.find((n) => n.getAttribute("data-route") === route).hasAttribute("hidden"),
   };
 }
 
@@ -550,6 +573,39 @@ test("router runtime: disabled Tracking never calls the tracking handler or /pub
   assert.equal(h.handlerCalls.tracking, 0, "tracking handler must not run");
   assert.equal(h.apiCalls.track, 0, "no /public/track lookup may fire");
   assert.equal(h.isMaintenance(), true, "maintenance screen shown");
+});
+
+test("router runtime: disabled Booking keeps its Bottom-Nav item present + active, shows maintenance, no booking handler/API", async () => {
+  const h = loadRouterRuntime();
+  h.setFlags(flags({ booking: false }));
+  await h.load();
+  h.render("booking");
+  // DoD: the "จอง" menu item stays in the nav (never hidden/removed) …
+  assert.equal(h.navHidden("booking"), false, "booking nav item must not be hidden");
+  // … and is shown active for the disabled route it points at.
+  assert.equal(h.navActive("booking"), true, "booking nav item must be active");
+  // Route resolves to #booking and shows the locked maintenance screen …
+  assert.equal(h.state.route, "booking", "URL/route stays #booking");
+  assert.equal(h.isMaintenance(), true, "maintenance screen shown");
+  // … without ever running the booking handler (so no scheduled/urgent API).
+  assert.equal(h.handlerCalls.booking, 0);
+  assert.equal(h.apiCalls.pricing, 0);
+  assert.equal(h.apiCalls.availability, 0);
+  assert.equal(h.apiCalls.urgent, 0);
+});
+
+test("router runtime: re-enabling a page restores normal behaviour (handler runs, no maintenance)", async () => {
+  const h = loadRouterRuntime();
+  h.setFlags(flags({ booking: false }));
+  await h.load();
+  h.render("booking");
+  assert.equal(h.isMaintenance(), true);
+  // Admin re-enables booking; a fresh availability load flips the flag.
+  h.setFlags(flags());
+  await h.load();
+  h.render("booking");
+  assert.equal(h.handlerCalls.booking, 1, "handler runs once the page is enabled again");
+  assert.equal(h.isMaintenance(), false, "no maintenance once enabled");
 });
 
 test("router runtime: disabled Scheduled never calls the handler, pricing, or availability", async () => {

--- a/test/customerAppRecovery.test.js
+++ b/test/customerAppRecovery.test.js
@@ -236,7 +236,7 @@ test("Customer App build id is consistent across shell and service worker", () =
   const sw = read("customer-app/sw.js");
   const app = read("customer-app/assets/customer-app.js");
   const manifest = read("customer-app/manifest.webmanifest");
-  const build = "20260712_page_controls_tracking_link_v3";
+  const build = "20260712_page_controls_tracking_link_v4";
 
   assert.match(index, new RegExp(`customer-app\\.css\\?v=${build}`));
   assert.match(index, new RegExp(`modules\\/api\\.js\\?v=${build}`));
@@ -254,7 +254,7 @@ test("Customer App build id is consistent across shell and service worker", () =
 test("store module is loaded in index.html and precached in the service worker app shell", () => {
   const index = read("customer-app/index.html");
   const sw = read("customer-app/sw.js");
-  const build = "20260712_page_controls_tracking_link_v3";
+  const build = "20260712_page_controls_tracking_link_v4";
 
   assert.match(index, new RegExp(`modules/store\\.js\\?v=${build}`));
   assert.match(sw, /`\.\/modules\/store\.js\?v=\$\{BUILD_ID\}`/);

--- a/test/customerAppStorePayment.test.js
+++ b/test/customerAppStorePayment.test.js
@@ -58,7 +58,7 @@ test("store falls back to the LINE hand-off when payment is unconfigured or the 
 test("payment step styles exist and the Customer App payment build id is bumped", () => {
   assert.match(cssSrc, /\.pay-method-btn/);
   assert.match(cssSrc, /\.pay-qr-img/);
-  assert.match(read("customer-app/index.html"), /modules\/store\.js\?v=20260712_page_controls_tracking_link_v3/);
-  assert.match(read("customer-app/sw.js"), /BUILD_ID = "20260712_page_controls_tracking_link_v3"/);
+  assert.match(read("customer-app/index.html"), /modules\/store\.js\?v=20260712_page_controls_tracking_link_v4/);
+  assert.match(read("customer-app/sw.js"), /BUILD_ID = "20260712_page_controls_tracking_link_v4"/);
   assert.match(storeSrc, /payment-security 20260705 loaded/);
 });

--- a/test/customerBookingAdminNotifications.test.js
+++ b/test/customerBookingAdminNotifications.test.js
@@ -311,10 +311,10 @@ test("admin/customer frontend cache versions are bumped for booking notification
   assert.doesNotMatch(adminReviewHtml, /admin-review-v2\.js\?v=20260707_customer_booking_notify_v2/);
   assert.match(adminReviewHtml, /admin-review-ai-intake\.js\?v=ai-booking-intake-customer-cards-v11-admin-alert-gate/);
   assert.doesNotMatch(adminReviewHtml, /admin-review-ai-intake\.js\?v=ai-booking-intake-customer-cards-v10/);
-  assert.match(customerIndex, /bookingScheduled\.js\?v=20260712_page_controls_tracking_link_v3/);
-  assert.match(customerIndex, /state\.js\?v=20260712_page_controls_tracking_link_v3/);
-  assert.match(customerSw, /const BUILD_ID = "20260712_page_controls_tracking_link_v3"/);
-  assert.match(customerManifest, /20260712_page_controls_tracking_link_v3/);
+  assert.match(customerIndex, /bookingScheduled\.js\?v=20260712_page_controls_tracking_link_v4/);
+  assert.match(customerIndex, /state\.js\?v=20260712_page_controls_tracking_link_v4/);
+  assert.match(customerSw, /const BUILD_ID = "20260712_page_controls_tracking_link_v4"/);
+  assert.match(customerManifest, /20260712_page_controls_tracking_link_v4/);
 });
 
 test("behavior: review queue only includes customer urgent waiting rows while preserving review statuses", () => {

--- a/test/customerHistoryClaim.test.js
+++ b/test/customerHistoryClaim.test.js
@@ -544,7 +544,7 @@ test("Customer App profile opens history detail with opaque job_ref and clears c
 });
 
 test("Customer App cache version is bumped consistently", () => {
-  const expected = "20260712_page_controls_tracking_link_v3";
+  const expected = "20260712_page_controls_tracking_link_v4";
   for (const file of [
     "customer-app/index.html",
     "customer-app/sw.js",

--- a/test/customerSameDayTiming.test.js
+++ b/test/customerSameDayTiming.test.js
@@ -160,7 +160,7 @@ test("customer app disables availability HTTP cache and refreshes same-day slots
 });
 
 test("customer app build and service worker cache IDs changed", () => {
-  const id = "20260712_page_controls_tracking_link_v3";
+  const id = "20260712_page_controls_tracking_link_v4";
   for (const file of [
     "customer-app/index.html",
     "customer-app/sw.js",

--- a/test/homepageCms.test.js
+++ b/test/homepageCms.test.js
@@ -290,7 +290,7 @@ test("customer homepage has no admin control, bottom nav is fixed five-tab, and 
   const sw = read("customer-app/sw.js");
   const app = read("customer-app/assets/customer-app.js");
   const manifest = read("customer-app/manifest.webmanifest");
-  const build = "20260712_page_controls_tracking_link_v3";
+  const build = "20260712_page_controls_tracking_link_v4";
 
   assert.doesNotMatch(index + ui, /โหมดแอดมิน|openCms|localStorage\.getItem\('cwfHomeCmsDemo'/);
   assert.match(index, /data-route="store"[\s\S]*ร้านค้า/);


### PR DESCRIPTION
## Summary

Change the Customer App page-availability UX from **hiding** menus/CTAs to **keeping the full app structure** and showing a **locked, blurred "maintenance" screen** when a disabled page is opened. Customers still see the complete app shape — nothing disappears or shifts — but can't use a feature the admin has turned off.

## Behavior change

- **Before:** controls pointing at a disabled route were hidden (`[data-route]` → `hidden`/`disabled`), which could re-flow the Bottom Navigation.
- **After:** menus and CTAs are **never** hidden or disabled. Clicking a disabled route is caught by the existing router guard, which renders a static **blurred skeleton + readable overlay** instead of running the route handler or its API.

## Changed files (all in authorized scope)

- **`customer-app/modules/pageAvailability.js`** — `applyToDom` and `startObserver` are now intentional **no-ops** (controls are never hidden; observer isn't needed). `renderMaintenance`/`maintenanceHtml` produce a **static** blurred skeleton (generic placeholder — no route handler, no API, no live customer data) behind an overlay with a lock icon, page label, "back to an enabled page" button, and LINE/phone contacts.
- **`customer-app/assets/customer-app.css`** — blurred skeleton (shimmer + `filter: blur`, `prefers-reduced-motion` aware), overlay scrim + card; removed the now-dead `[data-cwf-avail="off"]` hide rule.
- **`customer-app/index.html` / `manifest.webmanifest` / `sw.js` / `customer-app.js`** — `BUILD_ID` bumped to **`20260712_page_controls_tracking_link_v4`** (Customer App only; `customer-app.js` = BUILD_ID line only). Technician/root PWA untouched.
- **`customer-app/modules/router.js`** — **unchanged**: the guard already renders maintenance *before* the handler and calls `updateNav(route)`, so the disabled route's nav item stays active and no API fires.

## Definition of Done — how each item is met

| DoD | Result |
|---|---|
| Disable booking → "จอง" stays centered | Nav never hidden; `navHidden("booking")===false` (test) + screenshot |
| Click "จอง" → URL is `#booking` | Guard sets `state.route === "booking"` (test) |
| "จอง" shows active | `updateNav` toggles `is-active`; `navActive("booking")===true` (test) |
| Blurred placeholder + "กำลังปรับปรุง" | Static skeleton + overlay (test + screenshot) |
| No Scheduled/Urgent API called | Booking handler never runs → `pricing/availability/urgent` spies = 0 (test) |
| Disable tracking + token link → no `/public/track` | Guard blocks tracking render before auto-lookup (test) |
| Re-enable → works as before | Re-enable test: handler runs once, no maintenance |
| Direct hash & CTA identical | Both flow through the same router guard (tests) |
| Mobile layout stable, no nav gaps | Nav keeps all 5 items; screenshot @390px |

## Review-checklist compliance

- **Handler is never called then blurred** — the guard `return`s before `handler(app)`; the blurred screen is pure static markup.
- **Bottom Navigation is never hidden/disabled** — `applyToDom` is a no-op; asserted in runtime tests.
- **No real customer data as backdrop** — skeleton is generic placeholder; test asserts the markup contains no `booking_code`/`booking_token`/`customer_name`/`address_text`/`?q=`/`?token=`.
- **Blurred content is a static skeleton** — shimmer blocks, `aria-hidden`, `pointer-events:none`.
- **Overlay readable + mobile-usable** — centered card, full-width actions, `prefers-reduced-motion` respected.
- **No regression to the secure Tracking fragment link** — `index.js`/boot/SW tracking logic untouched; `trackingGpsRecovery` + SW/parse tests still green.

## Tests (actually run)

- `node --check` clean: `pageAvailability.js`, `router.js`, `sw.js`, `customer-app.js`.
- `test/customerAppPageAvailability.test.js` → **49 pass / 0 fail** (incl. new: no-hide `applyToDom`, no-op observer, static-skeleton maintenance, disabled-booking nav-active + no-API, re-enable restores).
- Focused (`customerAppPageAvailability`, `trackingGpsRecovery`, `customerAppRecovery`, `homepageCms`) → **246 pass / 0 fail**.
- Full `npm test` → **1129 pass / 0 fail / 34 skipped** (skipped = live-PG integration).
- Visual proof rendered from the real module + CSS at 390px (attached in the session): blurred locked screen with the Bottom Navigation intact and "จอง" centered/active.

## Do not merge / deploy

Opened as **Draft** — UI rollout control only; does not replace server kill switches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LmdP3TGN5uQrfT8ZYefNco

---
_Generated by [Claude Code](https://claude.ai/code/session_01LmdP3TGN5uQrfT8ZYefNco)_