### PR TITLE
Customer Tracking: full read-only details and mobile UI

### DIFF
--- a/customer-app/assets/customer-app.css
+++ b/customer-app/assets/customer-app.css
@@ -1907,6 +1907,86 @@ p { margin: 0; }
   background: var(--soft-yellow);
   border-color: rgba(255, 210, 59, 0.55);
 }
+
+/* Tracking read experience: compact, touch-safe and stable at 360/390px. */
+.tracking-hero {
+  background: #123f68;
+  border-bottom: 4px solid #f4c542;
+}
+.tracking-hero h1 { margin: 6px 0; font-size: 28px; line-height: 1.2; letter-spacing: 0; }
+.tracking-search-title { margin: 0 0 14px; font-size: 18px; letter-spacing: 0; }
+.tracking-code-input { min-height: 48px; font-size: 17px; text-transform: uppercase; letter-spacing: 0; }
+.field-help { display: block; margin-top: 7px; color: var(--muted); font-size: 12.5px; line-height: 1.5; }
+.tracking-search-btn { min-height: 48px; width: 100%; }
+.tracking-result-shell { min-height: 148px; overflow: hidden; }
+.tracking-empty-state,
+.tracking-error-state {
+  min-height: 132px;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  justify-content: center;
+  gap: 8px;
+  color: var(--muted);
+}
+.tracking-empty-state strong,
+.tracking-error-state strong { color: var(--ink); font-size: 18px; }
+.tracking-error-state .secondary-btn { min-height: 44px; margin-top: 6px; }
+.tracking-error-state.is-rate { border-left: 4px solid #d79000; padding-left: 14px; }
+.tracking-error-state.is-offline { border-left: 4px solid #b83b3b; padding-left: 14px; }
+.tracking-skeleton { display: flex; flex-direction: column; gap: 12px; padding: 8px 0; }
+.skeleton-line,
+.skeleton-grid span {
+  display: block;
+  height: 14px;
+  border-radius: 4px;
+  background: #e7edf2;
+  animation: tracking-skeleton-pulse 1.2s ease-in-out infinite;
+}
+.skeleton-line.is-title { width: 68%; height: 28px; }
+.skeleton-line.is-short { width: 48%; }
+.skeleton-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 10px; }
+.skeleton-grid span { height: 72px; }
+@keyframes tracking-skeleton-pulse { 50% { opacity: 0.48; } }
+.tracking-code-wrap { display: flex; align-items: center; gap: 8px; min-width: 0; }
+.tracking-copy-btn {
+  min-width: 64px;
+  min-height: 44px;
+  border: 1px solid var(--line-strong);
+  border-radius: 6px;
+  background: #fff;
+  color: var(--ink);
+  font-weight: 700;
+}
+.tracking-quick-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+.tracking-quick-grid strong { overflow-wrap: anywhere; }
+.tracking-updated-at { margin: 8px 0 0; color: var(--muted); font-size: 12px; text-align: right; }
+.tracking-service-lines span { text-align: right; line-height: 1.7; }
+.tracking-view-tab { min-height: 58px; }
+.tracking-view-panel { min-width: 0; }
+.tracking-photo-grid img { width: 100%; }
+.support-strip .secondary-btn { min-height: 44px; }
+.tracking-result-card img { max-width: 100%; }
+
+@media (max-width: 420px) {
+  .tracking-hero h1 { font-size: 25px; }
+  .tracking-topline { align-items: flex-start; }
+  .tracking-code-wrap { width: 100%; justify-content: space-between; }
+  .tracking-code-pill { max-width: calc(100% - 76px); overflow-wrap: anywhere; }
+  .tracking-view-tabs { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+  .tracking-view-tab { min-width: 0; padding: 9px 8px; }
+  .tracking-quick-grid { grid-template-columns: 1fr; }
+  .tracking-service-lines { align-items: flex-start; }
+  .tracking-service-lines span { text-align: left; }
+  .support-strip { display: grid; grid-template-columns: 1fr 1fr; }
+  .support-strip .secondary-btn { width: 100%; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .skeleton-line,
+  .skeleton-grid span,
+  .tracking-view-panel.is-active { animation: none !important; }
+}
 .tech-avatar {
   display: grid;
   place-items: center;

--- a/customer-app/assets/customer-app.js
+++ b/customer-app/assets/customer-app.js
@@ -3,7 +3,7 @@
 
   const App = window.CWFCustomerAppV2;
   const BOOT_TIMEOUT_MS = 3500;
-  const BUILD_ID = "20260712_page_controls_tracking_link_v4";
+  const BUILD_ID = "20260712_tracking_full_read_v1";
 
   function withTimeout(promise, timeoutMs) {
     return Promise.race([

--- a/customer-app/index.html
+++ b/customer-app/index.html
@@ -21,10 +21,10 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Noto+Sans+Thai:wght@400;500;600;700;800;900&display=swap" media="print" onload="this.media='all'">
   <noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Noto+Sans+Thai:wght@400;500;600;700;800;900&display=swap"></noscript>
-  <link rel="manifest" href="./manifest.webmanifest?v=20260712_page_controls_tracking_link_v4">
+  <link rel="manifest" href="./manifest.webmanifest?v=20260712_tracking_full_read_v1">
   <link rel="icon" type="image/png" sizes="192x192" href="./assets/icons/cwf-customer-192.png">
   <link rel="apple-touch-icon" sizes="180x180" href="./assets/icons/cwf-customer-180.png">
-  <link rel="stylesheet" href="./assets/customer-app.css?v=20260712_page_controls_tracking_link_v4">
+  <link rel="stylesheet" href="./assets/customer-app.css?v=20260712_tracking_full_read_v1">
 </head>
 <body class="is-app-booting">
   <div class="app-shell" data-app-shell>
@@ -62,22 +62,22 @@
     </nav>
   </div>
 
-  <script src="./modules/state.js?v=20260712_page_controls_tracking_link_v4"></script>
-  <script src="./modules/utils.js?v=20260712_page_controls_tracking_link_v4"></script>
-  <script src="./modules/analytics.js?v=20260712_page_controls_tracking_link_v4"></script>
-  <script src="./modules/api.js?v=20260712_page_controls_tracking_link_v4"></script>
-  <script src="./modules/pageAvailability.js?v=20260712_page_controls_tracking_link_v4"></script>
-  <script src="./modules/services.js?v=20260712_page_controls_tracking_link_v4"></script>
-  <script src="./modules/ui.js?v=20260712_page_controls_tracking_link_v4"></script>
-  <script src="./modules/store.js?v=20260712_page_controls_tracking_link_v4"></script>
-  <script src="./modules/auth.js?v=20260712_page_controls_tracking_link_v4"></script>
-  <script src="./modules/pricing.js?v=20260712_page_controls_tracking_link_v4"></script>
-  <script src="./modules/availability.js?v=20260712_page_controls_tracking_link_v4"></script>
-  <script src="./modules/bookingScheduled.js?v=20260712_page_controls_tracking_link_v4"></script>
-  <script src="./modules/bookingUrgent.js?v=20260712_page_controls_tracking_link_v4"></script>
-  <script src="./modules/tracking.js?v=20260712_page_controls_tracking_link_v4"></script>
-  <script src="./modules/profile.js?v=20260712_page_controls_tracking_link_v4"></script>
-  <script src="./modules/router.js?v=20260712_page_controls_tracking_link_v4"></script>
-  <script src="./assets/customer-app.js?v=20260712_page_controls_tracking_link_v4"></script>
+  <script src="./modules/state.js?v=20260712_tracking_full_read_v1"></script>
+  <script src="./modules/utils.js?v=20260712_tracking_full_read_v1"></script>
+  <script src="./modules/analytics.js?v=20260712_tracking_full_read_v1"></script>
+  <script src="./modules/api.js?v=20260712_tracking_full_read_v1"></script>
+  <script src="./modules/pageAvailability.js?v=20260712_tracking_full_read_v1"></script>
+  <script src="./modules/services.js?v=20260712_tracking_full_read_v1"></script>
+  <script src="./modules/ui.js?v=20260712_tracking_full_read_v1"></script>
+  <script src="./modules/store.js?v=20260712_tracking_full_read_v1"></script>
+  <script src="./modules/auth.js?v=20260712_tracking_full_read_v1"></script>
+  <script src="./modules/pricing.js?v=20260712_tracking_full_read_v1"></script>
+  <script src="./modules/availability.js?v=20260712_tracking_full_read_v1"></script>
+  <script src="./modules/bookingScheduled.js?v=20260712_tracking_full_read_v1"></script>
+  <script src="./modules/bookingUrgent.js?v=20260712_tracking_full_read_v1"></script>
+  <script src="./modules/tracking.js?v=20260712_tracking_full_read_v1"></script>
+  <script src="./modules/profile.js?v=20260712_tracking_full_read_v1"></script>
+  <script src="./modules/router.js?v=20260712_tracking_full_read_v1"></script>
+  <script src="./assets/customer-app.js?v=20260712_tracking_full_read_v1"></script>
 </body>
 </html>

--- a/customer-app/manifest.webmanifest
+++ b/customer-app/manifest.webmanifest
@@ -2,7 +2,7 @@
   "name": "CWF Customer Service",
   "short_name": "CWF Service",
   "description": "แอปลูกค้า Coldwindflow สำหรับเลือกบริการ จองคิว และติดตามงาน",
-  "start_url": "/customer-app/index.html?v=20260712_page_controls_tracking_link_v4#home",
+  "start_url": "/customer-app/index.html?v=20260712_tracking_full_read_v1#home",
   "scope": "/customer-app/",
   "id": "/customer-app/",
   "display": "standalone",

--- a/customer-app/modules/api.js
+++ b/customer-app/modules/api.js
@@ -113,7 +113,7 @@
     },
 
     async trackBooking(q) {
-      return requestJson("/public/track", { query: { q } });
+      return requestJson("/public/track", { query: { q }, cache: "no-store" });
     },
 
     async loadUrgentStatus(q) {

--- a/customer-app/modules/tracking.js
+++ b/customer-app/modules/tracking.js
@@ -2,7 +2,6 @@
   "use strict";
 
   const root = window.CWFCustomerAppV2 = window.CWFCustomerAppV2 || {};
-  console.info("[customer-tracking] full-read-ui v1 loaded");
   const ADMIN_PHONE = "098-877-7321";
   const LINE_URL = "https://lin.ee/fG1Oq7y";
   const WARRANTY_COPY = "รับประกันงานล้าง 30 วัน เฉพาะอาการที่เกี่ยวข้องกับการบริการ ไม่รวมอะไหล่เสีย ระบบรั่ว บอร์ด คอมเพรสเซอร์ ไฟตก หรือปัญหาจากตัวเครื่องเดิม";
@@ -85,6 +84,22 @@
     return !!(data && (data.can_view_full_tracking === true
       || data.capabilities?.can_view_full_tracking === true
       || isTokenAccess(data)));
+  }
+
+  function isCanceled(data) {
+    if (clean(data && data.canceled_at)) return true;
+    const status = clean(data && data.job_status).toLowerCase();
+    return status.includes("ยกเลิก") || ["cancel", "canceled", "cancelled"].includes(status);
+  }
+
+  function paymentStatusLabel(value, paidAt) {
+    const status = clean(value).toLowerCase();
+    if (status === "paid" || (!status && clean(paidAt))) return "ชำระแล้ว";
+    if (status === "unpaid") return "ยังไม่ชำระ";
+    if (status === "partial") return "ชำระบางส่วน";
+    if (["pending", "pending_payment", "payment_processing"].includes(status)) return "รอตรวจสอบการชำระ";
+    if (["failed", "payment_failed"].includes(status)) return "การชำระไม่สำเร็จ";
+    return status ? "กรุณาติดต่อ CWF เพื่อตรวจสอบการชำระ" : "ยังไม่มีข้อมูลการชำระ";
   }
   function canUseTokenActions(data) {
     return !!(data && (data.can_use_token_actions === true
@@ -640,6 +655,7 @@
   function jobPhase(data, mode) {
     const status = clean(data.job_status);
     const noTech = status.includes("ไม่พบช่าง") || status.includes("ตีกลับ");
+    if (isCanceled(data)) return "canceled";
     if (isDone(data)) return "completed";
     if (mode === "urgent" && noTech) return "urgent_no_tech";
     if (clean(data.started_at)) return "started";
@@ -651,6 +667,7 @@
 
   function statusCopy(data, mode) {
     const phase = jobPhase(data, mode);
+    if (phase === "canceled") return "งานนี้ถูกยกเลิกแล้ว";
     if (phase === "completed") return "งานเสร็จแล้ว";
     if (phase === "started") return "กำลังให้บริการ";
     if (phase === "checked_in") return "ช่างถึงหน้างานแล้ว";
@@ -664,7 +681,15 @@
   function statusDetailCopy(data, mode) {
     const phase = jobPhase(data, mode);
     const hasPhotos = hasPhotoContent(data);
+    if (phase === "canceled") {
+      return clean(data.cancel_reason) ? `เหตุผล: ${clean(data.cancel_reason)}` : "งานนี้สิ้นสุดแล้ว หากต้องการความช่วยเหลือกรุณาติดต่อ CWF";
+    }
     if (phase === "completed") {
+      if (!canUseTokenActions(data)) {
+        return hasPhotos
+          ? "งานบริการเสร็จสิ้นแล้ว ดูรูปงาน สรุปงาน และรายละเอียดที่ลูกค้าควรทราบได้ในหน้านี้"
+          : "งานบริการเสร็จสิ้นแล้ว ดูสรุปงานและรายละเอียดที่ลูกค้าควรทราบได้ในหน้านี้";
+      }
       return hasPhotos
         ? "งานบริการเสร็จสิ้นแล้ว สามารถดูรูปงาน เอกสาร การรับประกัน และรีวิวได้"
         : "งานบริการเสร็จสิ้นแล้ว สามารถดูเอกสาร การรับประกัน และการให้คะแนนได้";
@@ -681,12 +706,18 @@
   function nextActionCopy(data, mode) {
     const phase = jobPhase(data, mode);
     const hasPhotos = hasPhotoContent(data);
+    if (phase === "canceled") return "ติดต่อ CWF หากต้องการตรวจสอบหรือจองบริการใหม่";
     if (phase === "completed") {
+      if (!canUseTokenActions(data)) {
+        return hasPhotos ? "ดูรูปงานและสรุปรายละเอียดบริการ" : "ดูสรุปรายละเอียดบริการ หรือติดต่อ CWF";
+      }
       return hasPhotos
         ? "ดูรูปงาน เอกสาร การรับประกัน และรีวิวงานนี้"
         : "ดูเอกสาร การรับประกัน และให้คะแนนงานนี้";
     }
-    if (phase === "started") return "รอทีมช่างทำงานให้เสร็จ หลังจบงานจะเห็นเอกสารหลังบริการ";
+    if (phase === "started") return canUseTokenActions(data)
+      ? "รอทีมช่างทำงานให้เสร็จ หลังจบงานจะเห็นเอกสารหลังบริการ"
+      : "รอทีมช่างทำงานให้เสร็จ หลังจบงานจะเห็นรูปและสรุปบริการ";
     if (phase === "checked_in") return "เตรียมพื้นที่หน้างานให้พร้อมสำหรับเริ่มบริการ";
     if (phase === "traveling") return "รอรับทีมช่างที่กำลังเดินทางไปหน้างาน";
     if (phase === "assigned") return "รอถึงเวลานัด หรือเปิดแผนที่หากต้องการดูสถานที่งาน";
@@ -1147,7 +1178,7 @@
       rows.push(`<div class="data-row tracking-service-lines"><strong>รายการบริการ</strong><span>${serviceItems.map((item) => `${esc(item.item_name || "บริการ")} × ${Number(item.qty) || 1}`).join("<br>")}</span></div>`);
     }
     if (data.payment_status || data.paid_at) {
-      rows.push(`<div class="data-row"><strong>การชำระเงิน</strong><span class="muted">${esc(data.payment_status || (data.paid_at ? "ชำระแล้ว" : "-"))}</span></div>`);
+      rows.push(`<div class="data-row"><strong>การชำระเงิน</strong><span class="muted">${esc(paymentStatusLabel(data.payment_status, data.paid_at))}</span></div>`);
     }
     if (data.cancel_reason) {
       rows.push(`<div class="data-row"><strong>เหตุผลยกเลิก</strong><span class="muted">${esc(data.cancel_reason)}</span></div>`);
@@ -1248,10 +1279,9 @@
     const done = isDone(data);
     const units = unitList(data);
     const appointmentText = data.appointment_datetime ? root.utils.formatDateTime(data.appointment_datetime) : "-";
-    // In code-only mode the status hero uses only reliable timestamp-derived
-    // copy (never technician presence), and the urgent "convert to scheduled"
-    // action is suppressed — it must not be offered merely because technician
-    // fields were redacted.
+    // Read visibility and privileged actions are separate capabilities. A
+    // booking code may show customer-facing assignment details without gaining
+    // document, review, or mutation controls.
     const heroTitle = statusCopy(data, mode);
     const heroDetail = statusDetailCopy(data, mode);
     const nextAction = nextActionCopy(data, mode);
@@ -1331,7 +1361,7 @@
       });
     }
 
-    if (done) {
+    if (done && canUseTokenActions(data)) {
       views.push({
         id: "aftercare",
         label: "เอกสาร",
@@ -1364,26 +1394,36 @@
   function renderTimeline() {
     const data = root.state.tracking.data || {};
     const mode = modeFromData(data);
-    const codeOnly = isCodeOnly(data);
+    const canView = canViewDetails(data);
+    const canUseActions = canUseTokenActions(data);
     const assigned = hasAssignedTech(data);
     const travel = !!clean(data.travel_started_at);
     const checkin = !!clean(data.checkin_at);
     const started = !!clean(data.started_at);
     const done = isDone(data);
+    const canceled = isCanceled(data);
     const steps = [
       {
         title: mode === "urgent" ? "ส่งคำขอคิวด่วนแล้ว" : "รับคำขอจองแล้ว",
-        // Code-only mode uses neutral wording: it must not imply the job is
-        // still waiting for a technician just because identity is redacted.
-        copy: codeOnly
+        copy: canView
           ? "ระบบได้รับคำขอของคุณแล้ว"
           : (mode === "urgent" ? "ระบบรับคำขอแล้ว แต่ยังไม่ถือว่ายืนยันงานจนกว่าจะมีช่างรับหรือแอดมินยืนยัน" : "รอแอดมินตรวจสอบคิวและรายละเอียด"),
         ok: true,
       },
     ];
-    // The assignment step relies on technician presence, which is redacted in
-    // code-only mode — omit it entirely there rather than claim "no technician".
-    if (!codeOnly) {
+
+    if (canceled) {
+      steps.push({
+        title: "งานถูกยกเลิก",
+        copy: clean(data.cancel_reason)
+          ? `เหตุผล: ${clean(data.cancel_reason)}`
+          : (data.canceled_at ? root.utils.formatDateTime(data.canceled_at) : "งานนี้สิ้นสุดแล้ว"),
+        ok: true,
+      });
+      return root.utils.timeline(steps.map((step) => ({ title: step.title, copy: step.copy, kind: "" })));
+    }
+
+    if (canView) {
       steps.push({
         title: mode === "urgent" ? "ช่างรับงาน / แอดมินยืนยัน" : "ยืนยันคิวและมอบหมายทีม",
         copy: assigned ? "มีทีมดูแลงานนี้แล้ว" : "แอดมินกำลังช่วยจัดคิวให้",
@@ -1394,7 +1434,13 @@
       { title: "ช่างกำลังเดินทาง", copy: data.travel_started_at ? root.utils.formatDateTime(data.travel_started_at) : "จะแสดงเมื่อช่างเริ่มเดินทาง", ok: travel },
       { title: "ถึงหน้างาน", copy: data.checkin_at ? root.utils.formatDateTime(data.checkin_at) : "จะแสดงเมื่อทีมเช็กอิน", ok: checkin },
       { title: "เริ่มให้บริการ", copy: data.started_at ? root.utils.formatDateTime(data.started_at) : "จะแสดงเมื่อทีมเริ่มงาน", ok: started },
-      { title: "งานเสร็จแล้ว", copy: data.finished_at ? root.utils.formatDateTime(data.finished_at) : "หลังจบงานจะแสดงรูป เอกสาร รีวิว และเงื่อนไขรับประกัน", ok: done },
+      {
+        title: "งานเสร็จแล้ว",
+        copy: data.finished_at
+          ? root.utils.formatDateTime(data.finished_at)
+          : (canUseActions ? "หลังจบงานจะแสดงรูป เอกสาร รีวิว และเงื่อนไขรับประกัน" : "หลังจบงานจะแสดงรูปและสรุปรายละเอียดบริการ"),
+        ok: done,
+      },
     );
     const firstPending = steps.findIndex((step) => !step.ok);
     return root.utils.timeline(steps.map((step, index) => ({
@@ -1665,10 +1711,14 @@
     _test: {
       canViewDetails,
       canUseTokenActions,
+      isCanceled,
+      jobPhase,
+      paymentStatusLabel,
       receiptUrl,
       renderReview,
       renderCatalogReview,
       renderTrackingResult,
+      renderTimeline,
     },
   };
 })();

--- a/customer-app/modules/tracking.js
+++ b/customer-app/modules/tracking.js
@@ -947,21 +947,25 @@
     `;
   }
 
-  function renderReview(data) {
-    if (!isDone(data)) return "";
+  function renderExistingTechnicianReviewSummary(data) {
     const review = data.review || {};
-    if (review.already_reviewed) {
-      return `
-        <section class="tracking-extra-card review-summary-card">
-          <div class="section-head compact">
-            <span class="section-kicker">Review</span>
-            <h2>รีวิวของคุณ</h2>
-          </div>
-          <p><strong>${esc(review.rating || "-")} / 5</strong></p>
-          ${review.review_text ? `<p class="muted preserve-lines">${esc(review.review_text)}</p>` : ""}
-        </section>
-      `;
-    }
+    if (!isDone(data) || !review.already_reviewed) return "";
+    return `
+      <section class="tracking-extra-card review-summary-card">
+        <div class="section-head compact">
+          <span class="section-kicker">Technician Review</span>
+          <h2>รีวิวทีมช่าง</h2>
+        </div>
+        <p><strong>${esc(review.rating || "-")} / 5</strong></p>
+        ${review.review_text ? `<p class="muted preserve-lines">${esc(review.review_text)}</p>` : ""}
+        ${review.complaint_text ? `<p class="muted preserve-lines"><strong>ข้อเสนอแนะ:</strong> ${esc(review.complaint_text)}</p>` : ""}
+        ${review.reviewed_at ? `<p class="muted">ส่งเมื่อ ${esc(root.utils.formatDateTime(review.reviewed_at))}</p>` : ""}
+      </section>
+    `;
+  }
+
+  function renderTechnicianReviewForm(data) {
+    if (!isDone(data) || data.review?.already_reviewed) return "";
     // Reviewing is a WRITE. Two authorised shapes, mirroring the server policy:
     //  - token lookup (access_level "token"): the exact booking_token authorises,
     //    posted as a hidden field. No PII entry needed.
@@ -1022,34 +1026,45 @@
     `;
   }
 
+  function renderReview(data) {
+    return renderExistingTechnicianReviewSummary(data) || renderTechnicianReviewForm(data);
+  }
+
   // Separate, additional section from renderReview() above (which rates the
   // technician via jobs.customer_rating/technician_reviews). This one rates
   // the catalog item/service via public.catalog_item_reviews, authorized by
   // the same tracking token -- no Customer App login required. Server is the
   // sole source of truth for eligibility/target; this only reflects data.catalog_review.
-  function renderCatalogReview(data) {
+  function catalogReviewStatusLabel(value) {
+    const status = clean(value).toLowerCase();
+    if (status === "approved") return "เผยแพร่แล้ว";
+    if (status === "rejected") return "ไม่ผ่านการตรวจสอบ";
+    if (["pending", "pending_review"].includes(status)) return "รอตรวจสอบ";
+    if (status === "hidden") return "ซ่อนจากหน้าสาธารณะ";
+    return "ส่งรีวิวแล้ว";
+  }
+
+  function renderExistingCatalogReviewSummary(data) {
+    const catalogReview = data.catalog_review;
+    if (!isDone(data) || !catalogReview?.already_reviewed) return "";
+    const review = catalogReview.review || {};
+    return `
+      <section class="tracking-extra-card catalog-review-summary-card">
+        <div class="section-head compact">
+          <span class="section-kicker">Service Review</span>
+          <h2>รีวิวบริการนี้</h2>
+        </div>
+        <p><strong>${esc(review.rating || "-")} / 5</strong> &middot; <span class="muted">${esc(catalogReviewStatusLabel(review.moderation_status))}</span></p>
+        ${review.comment ? `<p class="muted preserve-lines">${esc(review.comment)}</p>` : ""}
+        ${review.created_at ? `<p class="muted">ส่งเมื่อ ${esc(root.utils.formatDateTime(review.created_at))}</p>` : ""}
+      </section>
+    `;
+  }
+
+  function renderCatalogReviewForm(data) {
     if (!isDone(data)) return "";
     const catalogReview = data.catalog_review;
-    if (!catalogReview) return "";
-
-    if (catalogReview.already_reviewed) {
-      const review = catalogReview.review || {};
-      const statusLabel = review.moderation_status === "approved"
-        ? "ได้รับการอนุมัติ"
-        : review.moderation_status === "rejected"
-          ? "ไม่ผ่านการตรวจสอบ"
-          : "รอแอดมินตรวจสอบ";
-      return `
-        <section class="tracking-extra-card catalog-review-summary-card">
-          <div class="section-head compact">
-            <span class="section-kicker">Service Review</span>
-            <h2>รีวิวบริการนี้</h2>
-          </div>
-          <p><strong>${esc(review.rating || "-")} / 5</strong> &middot; <span class="muted">${esc(statusLabel)}</span></p>
-          ${review.comment ? `<p class="muted preserve-lines">${esc(review.comment)}</p>` : ""}
-        </section>
-      `;
-    }
+    if (!catalogReview || catalogReview.already_reviewed) return "";
 
     if (!catalogReview.eligible || !canUseTokenActions(data)) return "";
     // The private write credential is injected from state
@@ -1081,6 +1096,10 @@
         </form>
       </section>
     `;
+  }
+
+  function renderCatalogReview(data) {
+    return renderExistingCatalogReviewSummary(data) || renderCatalogReviewForm(data);
   }
 
   function renderWarranty(data) {
@@ -1121,18 +1140,25 @@
   }
 
   function renderAftercare(data) {
-    // Only one review form may ever be on screen at a time. The catalog
-    // review (server-derived item/service_type/overall target) is the
-    // primary form once available; the legacy technician-review form is
-    // shown only as a fallback when data.catalog_review is absent entirely
-    // (older API shape / migration not yet applied on this deployment).
-    const catalogReviewAvailable = data.catalog_review != null;
-    const content = [
-      renderReceipt(data),
-      catalogReviewAvailable ? "" : renderReview(data),
-      renderCatalogReview(data),
+    // Existing review summaries and warranty terms are read-only. Render both
+    // summary types when they coexist, independently of token capabilities.
+    const readOnlyContent = [
+      renderExistingTechnicianReviewSummary(data),
+      renderExistingCatalogReviewSummary(data),
       renderWarranty(data),
-    ].filter(Boolean).join("");
+    ];
+
+    // Documents and new-review forms remain exact-token actions. Keep the
+    // existing single-form rule: catalog review is primary when its API shape
+    // exists; technician review is the legacy fallback only when absent.
+    const catalogReviewAvailable = data.catalog_review != null;
+    const privilegedContent = canUseTokenActions(data)
+      ? [
+          renderReceipt(data),
+          catalogReviewAvailable ? renderCatalogReviewForm(data) : renderTechnicianReviewForm(data),
+        ]
+      : [];
+    const content = [...readOnlyContent, ...privilegedContent].filter(Boolean).join("");
     return content || root.utils.stateBox("", "รายละเอียดหลังบริการจะแสดงหลังงานเสร็จ");
   }
 
@@ -1361,11 +1387,11 @@
       });
     }
 
-    if (done && canUseTokenActions(data)) {
+    if (done) {
       views.push({
         id: "aftercare",
-        label: "เอกสาร",
-        meta: "รีวิว/ประกัน",
+        label: "หลังบริการ",
+        meta: canUseTokenActions(data) ? "เอกสารและรีวิว" : "สรุปและรับประกัน",
         content: renderAftercare(data),
       });
     }
@@ -1717,6 +1743,7 @@
       receiptUrl,
       renderReview,
       renderCatalogReview,
+      renderAftercare,
       renderTrackingResult,
       renderTimeline,
     },

--- a/customer-app/modules/tracking.js
+++ b/customer-app/modules/tracking.js
@@ -2,6 +2,7 @@
   "use strict";
 
   const root = window.CWFCustomerAppV2 = window.CWFCustomerAppV2 || {};
+  console.info("[customer-tracking] full-read-ui v1 loaded");
   const ADMIN_PHONE = "098-877-7321";
   const LINE_URL = "https://lin.ee/fG1Oq7y";
   const WARRANTY_COPY = "รับประกันงานล้าง 30 วัน เฉพาะอาการที่เกี่ยวข้องกับการบริการ ไม่รวมอะไหล่เสีย ระบบรั่ว บอร์ด คอมเพรสเซอร์ ไฟตก หรือปัญหาจากตัวเครื่องเดิม";
@@ -80,7 +81,17 @@
   // never be interpreted as "no technician assigned" — hidden identity is not
   // the same as an unassigned job.
   function isTokenAccess(data) { return data && data.access_level === "token"; }
-  function isCodeOnly(data) { return !!(data && data.access_level === "code"); }
+  function canViewDetails(data) {
+    return !!(data && (data.can_view_full_tracking === true
+      || data.capabilities?.can_view_full_tracking === true
+      || isTokenAccess(data)));
+  }
+  function canUseTokenActions(data) {
+    return !!(data && (data.can_use_token_actions === true
+      || data.capabilities?.can_use_token_actions === true
+      || isTokenAccess(data)));
+  }
+  function isCodeOnly(data) { return !!(data && !canUseTokenActions(data)); }
 
   function limitedAccessNoticeHtml() {
     return `
@@ -122,12 +133,18 @@
       return `https://www.google.com/maps/dir/?api=1&destination=${encodeURIComponent(`${lat},${lng}`)}&travelmode=driving`;
     }
     const direct = clean(data.maps_url || data.map_url);
-    if (direct) return direct;
+    if (direct) {
+      try {
+        const parsed = new URL(direct);
+        if (parsed.protocol === "http:" || parsed.protocol === "https:") return parsed.href;
+      } catch (_) { /* fall through to address search */ }
+    }
     const address = clean(data.address_text);
     return address ? `https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(address)}` : "";
   }
 
   function receiptUrl(data) {
+    if (!canUseTokenActions(data)) return "";
     // The receipt document now requires the booking_token as an access key
     // (?key=...) — a bare job_id link would just 404. Only build the fallback
     // when we actually hold the token (token-based lookups).
@@ -814,7 +831,7 @@
     // Code-only access redacts technician identity. Never render the "no
     // technician yet" empty card here — that would misrepresent a possibly
     // assigned job as unassigned. Show a neutral limited-data note instead.
-    if (isCodeOnly(data)) {
+    if (isCodeOnly(data) && !canViewDetails(data)) {
       return `
         <div class="tracking-tech-card is-limited" data-tech-limited>
           <div>
@@ -922,8 +939,8 @@
     //    typing their FULL phone, posted as booking_code + customer_phone.
     // A tokened job accessed by code is NOT legacy-eligible, so it never shows
     // the legacy form (the server would reject a downgrade anyway).
-    const reviewToken = data.access_level === "token" ? (data.booking_token || "") : "";
-    const legacyEligible = !reviewToken && data.legacy_review_eligible === true;
+    const reviewToken = canUseTokenActions(data) ? (data.booking_token || "") : "";
+    const legacyEligible = !reviewToken && canUseTokenActions(data) && data.legacy_review_eligible === true;
     if (!reviewToken && !legacyEligible) return "";
     // For token access the booking_token is NOT written into the form (it would
     // leak into rendered HTML). The form is marked data-review-token and the
@@ -1003,10 +1020,10 @@
       `;
     }
 
-    if (!catalogReview.eligible) return "";
-    // The write credential (booking_token / booking_code) is injected from state
+    if (!catalogReview.eligible || !canUseTokenActions(data)) return "";
+    // The private write credential is injected from state
     // at submit — never embedded in the DOM.
-    if (!(data.booking_token || data.booking_code)) return "";
+    if (!data.booking_token) return "";
     return `
       <section class="tracking-extra-card catalog-review-form-card">
         <div class="section-head compact">
@@ -1095,7 +1112,7 @@
     // pretend data is missing: it shows only the fields the privacy response
     // actually returned, plus a clear notice explaining the secure link is
     // needed for full details. No hidden field is reconstructed on the client.
-    const isFull = data.access_level === "token";
+    const isFull = canViewDetails(data);
     const rows = [];
     rows.push(`<div class="data-row"><strong>รหัสติดตาม</strong><span class="muted">${esc(trackingKey || data.booking_code || "-")}</span></div>`);
     if (isFull && data.customer_name) {
@@ -1125,8 +1142,17 @@
       rows.push(`<div class="data-row"><strong>แผนที่</strong><span><a class="mini-link" href="${esc(maps)}" target="_blank" rel="noopener">นำทางไปหน้างาน</a></span></div>`);
     }
     rows.push(`<div class="data-row"><strong>หลังจบงาน</strong><span class="muted">รูปงาน ${photos.length} รายการ ${data.receipt_url ? "และมีเอกสารหลังบริการ" : ""}</span></div>`);
-    const limitedNotice = !isFull ? limitedAccessNoticeHtml() : "";
-    return `${limitedNotice}<div class="data-list tracking-summary-list">${rows.join("")}</div>`;
+    const serviceItems = Array.isArray(data.service_items) ? data.service_items : [];
+    if (serviceItems.length) {
+      rows.push(`<div class="data-row tracking-service-lines"><strong>รายการบริการ</strong><span>${serviceItems.map((item) => `${esc(item.item_name || "บริการ")} × ${Number(item.qty) || 1}`).join("<br>")}</span></div>`);
+    }
+    if (data.payment_status || data.paid_at) {
+      rows.push(`<div class="data-row"><strong>การชำระเงิน</strong><span class="muted">${esc(data.payment_status || (data.paid_at ? "ชำระแล้ว" : "-"))}</span></div>`);
+    }
+    if (data.cancel_reason) {
+      rows.push(`<div class="data-row"><strong>เหตุผลยกเลิก</strong><span class="muted">${esc(data.cancel_reason)}</span></div>`);
+    }
+    return `<div class="data-list tracking-summary-list">${rows.join("")}</div>`;
   }
 
   function renderPhotoView(data) {
@@ -1190,9 +1216,26 @@
 
   function renderTrackingResult() {
     const state = root.state.tracking;
-    if (state.status === "idle") return root.utils.stateBox("", "กรอกเลขงานหรือรหัสติดตามเพื่อดูสถานะจากระบบ");
-    if (state.status === "loading") return root.utils.stateBox("loading", "กำลังค้นหาสถานะงาน...");
-    if (state.status === "error") return root.utils.stateBox("error", state.error || "ไม่พบข้อมูลงาน");
+    if (state.status === "idle") return `<div class="tracking-empty-state"><strong>ค้นหางานของคุณ</strong><span>กรอกเลขติดตามที่อยู่ในข้อความยืนยันนัดหมาย</span></div>`;
+    if (state.status === "loading") return `
+      <div class="tracking-skeleton" role="status" aria-live="polite" aria-label="กำลังค้นหางาน">
+        <span class="skeleton-line is-title"></span>
+        <span class="skeleton-line"></span>
+        <span class="skeleton-line is-short"></span>
+        <div class="skeleton-grid"><span></span><span></span></div>
+      </div>`;
+    if (state.status === "error") {
+      const rateLimited = state.errorKind === "rate";
+      const offline = state.errorKind === "network";
+      const title = rateLimited ? "ค้นหาบ่อยเกินไป" : offline ? "เชื่อมต่อระบบไม่ได้" : "ไม่พบงานนี้";
+      const detail = rateLimited
+        ? `กรุณารอ ${Number(state.retryAfter || 60)} วินาที แล้วลองอีกครั้ง`
+        : offline ? "ตรวจสอบอินเทอร์เน็ตแล้วลองใหม่อีกครั้ง" : "ตรวจสอบเลขติดตาม แล้วลองค้นหาใหม่";
+      return `<div class="tracking-error-state is-${rateLimited ? "rate" : offline ? "offline" : "not-found"}" role="alert">
+        <strong>${esc(title)}</strong><span>${esc(detail)}</span>
+        <button class="secondary-btn" type="button" data-action="track-retry">ลองอีกครั้ง</button>
+      </div>`;
+    }
 
     const data = state.data || {};
     const mode = modeFromData(data);
@@ -1203,19 +1246,17 @@
     // credential (used for refresh/receipt/review requests), never rendered.
     const trackingKey = data.booking_code || "";
     const done = isDone(data);
-    const codeOnly = isCodeOnly(data);
     const units = unitList(data);
     const appointmentText = data.appointment_datetime ? root.utils.formatDateTime(data.appointment_datetime) : "-";
     // In code-only mode the status hero uses only reliable timestamp-derived
     // copy (never technician presence), and the urgent "convert to scheduled"
     // action is suppressed — it must not be offered merely because technician
     // fields were redacted.
-    const heroTitle = codeOnly ? limitedStatusCopy(data) : statusCopy(data, mode);
-    const heroDetail = codeOnly ? limitedStatusDetail(data) : statusDetailCopy(data, mode);
-    const nextAction = codeOnly ? limitedNextAction(data) : nextActionCopy(data, mode);
+    const heroTitle = statusCopy(data, mode);
+    const heroDetail = statusDetailCopy(data, mode);
+    const nextAction = nextActionCopy(data, mode);
     const overview = `
       <div class="tracking-premium-overview">
-        ${codeOnly ? limitedAccessNoticeHtml() : ""}
         <div class="status-hero is-${mode}">
           <strong>${esc(heroTitle)}</strong>
           <span>${esc(heroDetail)}</span>
@@ -1229,6 +1270,14 @@
             <span>ขั้นตอนถัดไป</span>
             <strong>${esc(nextAction)}</strong>
           </div>
+          <div>
+            <span>บริการ</span>
+            <strong>${esc(serviceSummary(data))}</strong>
+          </div>
+          <div>
+            <span>ราคา</span>
+            <strong>${esc(money(data.job_price))}</strong>
+          </div>
         </div>
         ${renderTechnicianCard(data)}
         <div class="support-strip">
@@ -1236,8 +1285,9 @@
           <button class="secondary-btn" type="button" data-action="track-refresh">รีเฟรช</button>
           <a class="secondary-btn" href="tel:${ADMIN_PHONE}">โทรหา CWF</a>
           <a class="secondary-btn" href="${LINE_URL}" target="_blank" rel="noopener">LINE หา CWF</a>
-          ${!codeOnly && mode === "urgent" && !hasAssignedTech(data) ? `<button class="secondary-btn" type="button" data-route="scheduled">เปลี่ยนเป็นจองล่วงหน้า</button>` : ""}
+          ${canUseTokenActions(data) && mode === "urgent" && !hasAssignedTech(data) ? `<button class="secondary-btn" type="button" data-route="scheduled">เปลี่ยนเป็นจองล่วงหน้า</button>` : ""}
         </div>
+        <p class="tracking-updated-at">อัปเดตล่าสุด <time>${esc(new Date().toLocaleTimeString("th-TH", { hour: "2-digit", minute: "2-digit" }))}</time></p>
         <p class="muted support-note">ต้องการแก้ไขเวลา เลื่อนนัด หรือยกเลิกงาน กรุณาติดต่อแอดมิน CWF</p>
       </div>
     `;
@@ -1296,7 +1346,10 @@
       <div class="tracking-result-card">
         <div class="tracking-topline">
           <span class="mode-badge is-${mode}">${mode === "urgent" ? "คิวด่วน" : "จองล่วงหน้า"}</span>
-          <div class="tracking-code-pill">${esc(data.booking_code || "ไม่พบเลขงาน")}</div>
+          <div class="tracking-code-wrap">
+            <div class="tracking-code-pill">${esc(data.booking_code || "ไม่พบเลขงาน")}</div>
+            ${data.booking_code ? `<button class="tracking-copy-btn" type="button" data-action="copy-tracking-code" data-code="${esc(data.booking_code)}" aria-label="คัดลอกเลขติดตาม">คัดลอก</button>` : ""}
+          </div>
         </div>
         <div class="tracking-view-tabs" role="tablist" aria-label="Tracking views">
           ${views.map((view) => renderTrackingViewButton(view.id, view.label, view.meta, view.id === activeView)).join("")}
@@ -1362,9 +1415,10 @@
     opts = opts || {};
     const input = container.querySelector("#tracking-code");
     const usingPrivate = opts.credential != null;
-    const q = usingPrivate
+    const qRaw = usingPrivate
       ? String(opts.credential || "").trim()
       : String((input && input.value) || "").trim();
+    const q = !usingPrivate && /^CWF[A-Z0-9]{7}$/i.test(qRaw) ? qRaw.toUpperCase() : qRaw;
     // The active credential future refreshes/reviews reuse is always the one
     // actually used for THIS request. A private credential (token) is preserved;
     // a manual read replaces it with the typed value.
@@ -1382,11 +1436,11 @@
     // Store order codes look like "CWF-XXXX" — route them to the order lookup
     // instead of the job/booking tracker.
     if (/^CWF-/i.test(q)) { await lookupOrder(container, q); return; }
-    root.state.setTracking({ status: "loading", data: null, error: "" });
+    root.state.setTracking({ status: "loading", data: null, error: "", errorKind: "", retryAfter: 0 });
     container.querySelector("[data-tracking-result]").innerHTML = renderTrackingResult();
     try {
       const data = await root.api.trackBooking(q);
-      root.state.setTracking({ status: "success", data, error: "" });
+      root.state.setTracking({ status: "success", data, error: "", errorKind: "", retryAfter: 0 });
       // Privacy: the request may have used the private booking_token. Only ever
       // put the human-facing booking_code into the visible input/draft — the
       // token stays solely in activeCredential + state as the request credential.
@@ -1395,7 +1449,14 @@
         if (input) input.value = String(data.booking_code);
       }
     } catch (error) {
-      root.state.setTracking({ status: "error", data: null, error: error.message });
+      const status = Number(error && error.status);
+      root.state.setTracking({
+        status: "error",
+        data: null,
+        error: error && error.message,
+        errorKind: status === 429 ? "rate" : status === 404 ? "not-found" : "network",
+        retryAfter: Number(error?.data?.retry_after_s || 0),
+      });
       // A failed private lookup must not leave the token anywhere visible — it
       // was never written to the input/draft, so nothing to clear here.
     }
@@ -1455,6 +1516,22 @@
     const refresh = container.querySelector("[data-action='track-refresh']");
     if (refresh) refresh.addEventListener("click", () => reloadCurrent(container), { once: true });
 
+    const retry = container.querySelector("[data-action='track-retry']");
+    if (retry) retry.addEventListener("click", () => reloadCurrent(container), { once: true });
+
+    const copyCode = container.querySelector("[data-action='copy-tracking-code']");
+    if (copyCode) {
+      copyCode.addEventListener("click", async () => {
+        const code = copyCode.getAttribute("data-code") || "";
+        try {
+          await navigator.clipboard.writeText(code);
+          copyCode.textContent = "คัดลอกแล้ว";
+        } catch (_) {
+          copyCode.textContent = code;
+        }
+      });
+    }
+
     // E-slip opens with a URL built from state at click time (the token, if any,
     // travels only in that request URL — never rendered into the DOM).
     const eslipBtn = container.querySelector("[data-action='open-eslip']");
@@ -1506,7 +1583,8 @@
         const formData = Object.fromEntries(new FormData(catalogForm).entries());
         // Credential from state, not the DOM.
         const d = root.state.tracking.data || {};
-        const token = d.booking_token || d.booking_code || "";
+        if (!canUseTokenActions(d) || !d.booking_token) return;
+        const token = d.booking_token;
         if (status) status.textContent = "กำลังส่งรีวิว...";
         if (submit) submit.disabled = true;
         try {
@@ -1531,36 +1609,39 @@
         <section class="screen">
           ${root.ui?.pageHeaderHtml ? root.ui.pageHeaderHtml("tracking") : ""}
           <div class="hero tracking-hero">
-            <div class="hero-badge">Live status</div>
-            <h2>ติดตามงาน / คำสั่งซื้อ</h2>
-            <p>ใส่เลขงาน รหัสติดตาม หรือเลขคำสั่งซื้อ (CWF-...) เพื่อดูสถานะตั้งแต่ต้นจนจบ</p>
+            <div class="hero-badge">CWF Tracking</div>
+            <h1>ติดตามสถานะงาน</h1>
+            <p>ดูสถานะ นัดหมาย และรายละเอียดงานล่าสุดได้จากเลขติดตามของคุณ</p>
           </div>
-          <section class="card lookup-card">
-            <div class="section-head">
-              <span class="section-kicker">Tracking</span>
-              <h2>ค้นหางานของคุณ</h2>
-            </div>
+          <section class="card lookup-card" aria-labelledby="tracking-search-title">
+            <h2 id="tracking-search-title" class="tracking-search-title">ค้นหางาน</h2>
             <div class="field">
-              <label for="tracking-code">เลขงาน / รหัสติดตาม / เลขคำสั่งซื้อ</label>
-              <input id="tracking-code" class="input" placeholder="เช่น CWFXXXXXXX หรือ CWF-XXXX" value="${esc(code)}">
+              <label for="tracking-code">เลขติดตามงาน</label>
+              <input id="tracking-code" class="input tracking-code-input" placeholder="CWFXXXXXXX" value="${esc(code)}"
+                inputmode="text" autocomplete="off" autocapitalize="characters" spellcheck="false" maxlength="32">
+              <span class="field-help">เลขติดตามอยู่ในข้อความยืนยันนัดหมายจาก CWF</span>
             </div>
             <div class="button-row">
-              <button class="primary-btn" type="button" data-action="track-read">ตรวจสอบสถานะ</button>
+              <button class="primary-btn tracking-search-btn" type="button" data-action="track-read">ค้นหางาน</button>
             </div>
           </section>
-          <section class="card">
-            <div class="section-head">
-              <span class="section-kicker">Result</span>
-              <h2>ผลการติดตาม</h2>
-            </div>
+          <section class="card tracking-result-shell" aria-live="polite">
             <div data-tracking-result>${renderTrackingResult()}</div>
           </section>
         </section>
       `;
       root.ui?.bindPageHeader?.(container);
       container.querySelector("[data-action='track-read']").addEventListener("click", () => lookup(container));
-      container.querySelector("#tracking-code").addEventListener("change", (event) => {
-        root.state.updateDraft("tracking", { trackingCode: event.target.value });
+      container.querySelector("#tracking-code").addEventListener("input", (event) => {
+        const value = String(event.target.value || "").trimStart().toUpperCase();
+        event.target.value = value;
+        root.state.updateDraft("tracking", { trackingCode: value });
+      });
+      container.querySelector("#tracking-code").addEventListener("keydown", (event) => {
+        if (event.key === "Enter") {
+          event.preventDefault();
+          lookup(container);
+        }
       });
       bindResultActions(container);
       if (pendingAutoLookup && activeCredential && root.state.tracking.status === "idle") {
@@ -1580,6 +1661,14 @@
       if (!cred) return;
       setActiveCredential(cred);
       pendingAutoLookup = true;
+    },
+    _test: {
+      canViewDetails,
+      canUseTokenActions,
+      receiptUrl,
+      renderReview,
+      renderCatalogReview,
+      renderTrackingResult,
     },
   };
 })();

--- a/customer-app/sw.js
+++ b/customer-app/sw.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const BUILD_ID = "20260712_page_controls_tracking_link_v4";
+const BUILD_ID = "20260712_tracking_full_read_v1";
 const CACHE_NAME = `cwf-customer-app-v2-${BUILD_ID}`;
 const APP_SHELL = [
   `./index.html?v=${BUILD_ID}`,

--- a/index.js
+++ b/index.js
@@ -26209,6 +26209,9 @@ app.get("/public/urgent-status", async (req, res) => {
 });
 
 app.get("/public/track", async (req, res) => {
+  res.set("Cache-Control", "no-store, no-cache, must-revalidate, max-age=0");
+  res.set("Pragma", "no-cache");
+  res.set("Expires", "0");
   // Anti-enumeration: booking codes are short; without a budget an attacker
   // could sweep the keyspace. Real customers do a handful of lookups a minute.
   const trackRate = publicTrackRateLimiter.check(trackingPrivacy.clientIpKey(req));
@@ -26219,7 +26222,10 @@ app.get("/public/track", async (req, res) => {
       retry_after_s: trackRate.retry_after_s,
     });
   }
-  const q = (req.query.q || req.query.token || req.query.booking_code || "").toString().trim();
+  const rawQuery = (req.query.q || req.query.token || req.query.booking_code || "").toString().trim();
+  // Booking codes are case-insensitive for customer input. Token casing is
+  // private and significant, so only normalize a value with the exact code shape.
+  const q = /^CWF[A-Z0-9]{7}$/i.test(rawQuery) ? rawQuery.toUpperCase() : rawQuery;
   if (!q) return res.status(400).json({ error: "ต้องส่ง q (token หรือ booking_code)" });
 
   try {
@@ -26229,7 +26235,7 @@ app.get("/public/track", async (req, res) => {
         j.job_id, j.booking_code, j.booking_token,
         j.customer_name, j.customer_phone, j.job_type,
         j.appointment_datetime, j.job_status, j.booking_mode, j.dispatch_mode,
-        j.duration_min, j.job_price,
+        j.duration_min, j.job_price, j.payment_status, j.paid_at, j.created_at,
         j.address_text, j.gps_latitude, j.gps_longitude, j.maps_url, j.job_zone,
         j.technician_username, j.technician_team,
         j.travel_started_at, j.checkin_at, j.started_at, j.finished_at, j.canceled_at, j.cancel_reason,
@@ -26248,6 +26254,20 @@ app.get("/public/track", async (req, res) => {
 
     const row = r.rows[0];
     const origin = `${req.protocol}://${req.get("host")}`;
+
+    let serviceItems = [];
+    try {
+      const itemR = await pool.query(
+        `SELECT item_name, qty, unit_price, line_total
+           FROM public.job_items
+          WHERE job_id=$1
+          ORDER BY job_item_id ASC`,
+        [row.job_id]
+      );
+      serviceItems = itemR.rows || [];
+    } catch (e) {
+      console.warn("[public_track_items] load failed", { job_id: row.job_id, error: e.message });
+    }
 
     // ✅ รูป/หมายเหตุ แสดงเฉพาะหลังปิดงาน
     const isDone = String(row.job_status || "").trim() === "เสร็จแล้ว";
@@ -26307,6 +26327,30 @@ app.get("/public/track", async (req, res) => {
     }
 
     let publicUnits = [];
+    if (!isDone) {
+      try {
+        const unitR = await pool.query(
+          `SELECT unit_no, unit_code, item_name, ac_type, wash_type, btu, location_label
+             FROM public.job_units
+            WHERE job_id=$1
+              AND LOWER(COALESCE(NULLIF(status,''),'pending')) NOT IN ('cancelled','removed','deleted','void','inactive')
+            ORDER BY unit_no ASC, unit_id ASC`,
+          [row.job_id]
+        );
+        publicUnits = (unitR.rows || []).map((unit) => ({
+          unit_no: unit.unit_no,
+          unit_code: unit.unit_code || null,
+          label: [`เครื่องที่ ${unit.unit_no || "-"}`, unit.location_label].filter(Boolean).join(" / "),
+          btu: unit.btu || null,
+          ac_type: unit.ac_type || null,
+          service_type: unit.wash_type || unit.item_name || null,
+          checklist_summary: null,
+          photos: [],
+        }));
+      } catch (e) {
+        console.warn("[public_track_units] basic load failed", { job_id: row.job_id, error: e.message });
+      }
+    }
     if (isDone) {
       try {
         const unitsR = await pool.query(
@@ -26503,6 +26547,14 @@ if (FLAG_SHOW_TECH_TEAM_ON_TRACKING && canShowPublicTechnician) {
       !!row.technician_username;
     const trackPayload = {
       access_level: fullAccess ? "token" : "code",
+      capabilities: {
+        can_view_full_tracking: true,
+        can_use_token_actions: fullAccess,
+        can_view_documents: fullAccess,
+        can_submit_review: fullAccess,
+      },
+      can_view_full_tracking: true,
+      can_use_token_actions: fullAccess,
       legacy_review_eligible: legacyReviewEligible,
       job_id: row.job_id,
       booking_code: row.booking_code || null,
@@ -26516,6 +26568,15 @@ if (FLAG_SHOW_TECH_TEAM_ON_TRACKING && canShowPublicTechnician) {
       dispatch_mode: row.dispatch_mode || null,
       duration_min: row.duration_min == null ? null : Number(row.duration_min),
       job_price: row.job_price == null ? null : Number(row.job_price),
+      payment_status: row.payment_status || null,
+      paid_at: row.paid_at || null,
+      created_at: row.created_at || null,
+      service_items: serviceItems.map((item) => ({
+        item_name: item.item_name || null,
+        qty: item.qty == null ? null : Number(item.qty),
+        unit_price: item.unit_price == null ? null : Number(item.unit_price),
+        line_total: item.line_total == null ? null : Number(item.line_total),
+      })),
       address_text: row.address_text,
       maps_url: row.maps_url || null,
       job_zone: row.job_zone || null,

--- a/server/routes/catalog/reviews.js
+++ b/server/routes/catalog/reviews.js
@@ -214,6 +214,17 @@ module.exports = function createCatalogReviewRoutes(deps = {}) {
     return r.rows[0] || null;
   }
 
+  async function findJobByExactBookingToken(db, token, { forUpdate = false } = {}) {
+    const r = await db.query(
+      `SELECT job_id, job_type, job_status, canceled_at, catalog_item_id, customer_name
+         FROM public.jobs
+        WHERE booking_token = $1
+        LIMIT 1${forUpdate ? "\n        FOR UPDATE" : ""}`,
+      [token]
+    );
+    return r.rows[0] || null;
+  }
+
   // Returns the customer's completed, catalog-linked, not-yet-reviewed jobs
   // for this item — the source of truth for both "is eligible at all" and
   // "which job should this review be attached to". Never trusts client input
@@ -499,7 +510,7 @@ module.exports = function createCatalogReviewRoutes(deps = {}) {
         // Lock the job row for the duration of the transaction so two
         // concurrent submissions against the same token can't both see it
         // as eligible before either commits.
-        job = await findJobByTrackingToken(client, token, { forUpdate: true });
+        job = await findJobByExactBookingToken(client, token, { forUpdate: true });
         if (!job || !isJobReviewEligible(job)) {
           await client.query("ROLLBACK");
           return res.status(403).json({ error: "งานนี้ยังไม่เสร็จสมบูรณ์ หรือ token ไม่ถูกต้อง" });

--- a/server/services/public/trackingPrivacy.js
+++ b/server/services/public/trackingPrivacy.js
@@ -4,11 +4,10 @@
 // /public/urgent-status, /docs/receipt, /docs/eslip).
 //
 // Threat model: booking_code is a short, human-readable code (CWF + 7 chars)
-// that customers write down and read aloud to staff — it WILL leak. It must
-// therefore never unlock full personal data by itself:
-//   - full access (raw phone, address, GPS, maps link, receipt) requires the
-//     long random booking_token the app received at booking time
-//   - a booking_code lookup still works, but PII comes back masked/omitted
+// that customers write down and read aloud to staff. It grants a deliberately
+// allowlisted, read-only visit view, but never unlocks credentials or actions:
+//   - documents and writes require the long random booking_token
+//   - booking_code responses omit internal IDs, booking_token and URLs carrying it
 //   - every public lookup endpoint is rate-limited per client IP so neither
 //     codes nor tokens can be brute-forced
 //
@@ -26,8 +25,7 @@ function timingSafeEqualStr(a, b) {
   return crypto.timingSafeEqual(bufA, bufB);
 }
 
-// Full access only when the query string equals the job's booking_token.
-// A booking_code match (or anything else) is treated as limited access.
+// Privileged/token action access only when the query equals booking_token.
 function isFullAccessQuery(q, row) {
   const token = row && row.booking_token;
   if (!token) return false;
@@ -51,40 +49,137 @@ function shortenAddress(text, keepChars = 24) {
   return `${value.slice(0, keepChars)}…`;
 }
 
-// Build the response for a booking_code lookup with an explicit ALLOWLIST
-// (not a blacklist). A booking code is a short, shareable identifier, so a code
-// lookup returns only the minimum needed to answer "what state is my job in?"
-// plus a masked confirmation value. Anything not named here — customer_name,
-// exact/partial address, GPS, maps link, sequential job_id, technician notes,
-// job/unit photos, unit location/checklist data, cancel reason, review/complaint
-// text, receipt link, the booking_token, technician identity, and ANY field
-// added in future — is dropped by construction. Full detail requires the token.
+// Nested public projections intentionally omit database IDs and upstream fields
+// that are not part of the customer-facing tracking contract.
+function publicPhoto(photo) {
+  if (!photo || typeof photo !== "object") return null;
+  return {
+    phase: photo.phase || null,
+    photo_category: photo.photo_category || null,
+    created_at: photo.created_at || null,
+    uploaded_at: photo.uploaded_at || null,
+    public_url: photo.public_url || null,
+  };
+}
+
+function publicTechnician(technician) {
+  if (!technician || typeof technician !== "object") return null;
+  return {
+    full_name: technician.full_name || null,
+    photo: technician.photo || null,
+    rank_level: technician.rank_level == null ? null : technician.rank_level,
+    rank_key: technician.rank_key || null,
+    rating: technician.rating == null ? null : technician.rating,
+    grade: technician.grade || null,
+    phone: technician.phone || null,
+  };
+}
+
+function publicUnit(unit) {
+  if (!unit || typeof unit !== "object") return null;
+  return {
+    unit_no: unit.unit_no == null ? null : unit.unit_no,
+    unit_code: unit.unit_code || null,
+    label: unit.label || null,
+    btu: unit.btu == null ? null : unit.btu,
+    ac_type: unit.ac_type || null,
+    service_type: unit.service_type || null,
+    checklist_summary: unit.checklist_summary && typeof unit.checklist_summary === "object"
+      ? {
+          pre_completed: unit.checklist_summary.pre_completed === true,
+          post_completed: unit.checklist_summary.post_completed === true,
+          issue_count: Number(unit.checklist_summary.issue_count || 0),
+        }
+      : null,
+    photos: Array.isArray(unit.photos) ? unit.photos.map(publicPhoto).filter(Boolean) : [],
+  };
+}
+
+function publicReview(review) {
+  const source = review && typeof review === "object" ? review : {};
+  return {
+    already_reviewed: source.already_reviewed === true,
+    rating: source.rating == null ? null : source.rating,
+    review_text: source.review_text || null,
+    complaint_text: source.complaint_text || null,
+    reviewed_at: source.reviewed_at || null,
+  };
+}
+
+function publicCatalogReview(review) {
+  if (!review || typeof review !== "object") return null;
+  const existing = review.review && typeof review.review === "object" ? review.review : null;
+  return {
+    eligible: false,
+    already_reviewed: review.already_reviewed === true,
+    review: existing
+      ? {
+          rating: existing.rating == null ? null : existing.rating,
+          comment: existing.comment || "",
+          created_at: existing.created_at || null,
+        }
+      : null,
+  };
+}
+
+// Booking-code lookups receive the ordinary customer-facing read model, but
+// no private credential, internal identifier, document URL, or write ability.
+// This remains an allowlist so future upstream fields stay denied by default.
 function redactPublicTrackPayload(payload) {
   const source = payload && typeof payload === "object" ? payload : {};
-  const out = {
+  return {
     access_level: "code",
-    // Non-sensitive: whether a LEGACY (tokenless) job can be reviewed via code +
-    // full phone. Reveals only that a review is possible — no PII, no token — so
-    // the tracking UI can offer the legacy review form on a booking_code lookup.
-    legacy_review_eligible: source.legacy_review_eligible === true,
-    // The customer typed this in, so echoing it back is not a disclosure.
+    capabilities: {
+      can_view_full_tracking: true,
+      can_use_token_actions: false,
+      can_view_documents: false,
+      can_submit_review: false,
+    },
+    can_view_full_tracking: true,
+    can_use_token_actions: false,
+    legacy_review_eligible: false,
     booking_code: source.booking_code || null,
-    // Status lane — enough to render progress, no PII.
+    customer_name: source.customer_name || null,
+    customer_phone: source.customer_phone || null,
+    job_type: source.job_type || null,
     job_status: source.job_status || null,
     booking_mode: source.booking_mode || null,
     dispatch_mode: source.dispatch_mode || null,
     appointment_datetime: source.appointment_datetime || null,
     duration_min: source.duration_min == null ? null : source.duration_min,
-    // Progress signals (timestamps only — no free-text reasons).
+    job_price: source.job_price == null ? null : source.job_price,
+    payment_status: source.payment_status || null,
+    paid_at: source.paid_at || null,
+    address_text: source.address_text || null,
+    maps_url: source.maps_url || null,
+    job_zone: source.job_zone || null,
+    gps_latitude: source.gps_latitude == null ? null : source.gps_latitude,
+    gps_longitude: source.gps_longitude == null ? null : source.gps_longitude,
+    created_at: source.created_at || null,
     travel_started_at: source.travel_started_at || null,
     checkin_at: source.checkin_at || null,
     started_at: source.started_at || null,
     finished_at: source.finished_at || null,
     canceled_at: source.canceled_at || null,
-    // A masked confirmation aid so the customer recognises their own booking.
-    customer_phone: maskPhone(source.customer_phone),
+    cancel_reason: source.cancel_reason || null,
+    technician_note: source.technician_note || null,
+    service_items: Array.isArray(source.service_items)
+      ? source.service_items.map((item) => ({
+          item_name: item && item.item_name ? item.item_name : null,
+          qty: item && item.qty != null ? item.qty : null,
+          unit_price: item && item.unit_price != null ? item.unit_price : null,
+          line_total: item && item.line_total != null ? item.line_total : null,
+        }))
+      : [],
+    photos: Array.isArray(source.photos) ? source.photos.map(publicPhoto).filter(Boolean) : [],
+    units: Array.isArray(source.units) ? source.units.map(publicUnit).filter(Boolean) : [],
+    technician: publicTechnician(source.technician),
+    technician_team: Array.isArray(source.technician_team)
+      ? source.technician_team.map(publicTechnician).filter(Boolean)
+      : [],
+    review: publicReview(source.review),
+    catalog_review: publicCatalogReview(source.catalog_review),
   };
-  return out;
 }
 
 // Fixed-window in-memory rate limiter with an LRU cap so the map can never

--- a/test/catalogReviewRoutes.test.js
+++ b/test/catalogReviewRoutes.test.js
@@ -44,6 +44,12 @@ function makePool({ schemaReady = true, trackingSchemaReady = false, items = [],
       return { rows: [{ cnt: schemaReady ? 1 : 0 }] };
     }
 
+    if (s.includes("FROM public.jobs") && s.includes("WHERE booking_token = $1") && !s.includes("OR booking_code = $1")) {
+      const [token] = params;
+      const job = state.jobs.find((j) => j.booking_token === token);
+      return { rows: job ? [{ ...job }] : [] };
+    }
+
     if (s.includes("FROM public.jobs") && s.includes("WHERE booking_token = $1 OR booking_code = $1")) {
       const [token] = params;
       const job = state.jobs.find((j) => j.booking_token === token || j.booking_code === token);
@@ -872,6 +878,56 @@ test("POST /public/catalog-reviews never trusts client-supplied job_id/item_id a
     assert.equal(pool.state.reviews[0].review_source, "tracking");
     assert.equal(pool.state.reviews[0].moderation_status, "pending");
     assert.equal(body.moderation_status, "pending");
+  });
+});
+
+test("POST /public/catalog-reviews rejects booking_code and near-miss credentials but accepts the exact booking_token", async () => {
+  const pool = makePool({
+    trackingSchemaReady: true,
+    jobs: [{
+      job_id: 201,
+      job_type: "ล้าง",
+      catalog_item_id: 1,
+      job_status: DONE_STATUS,
+      canceled_at: null,
+      booking_token: "exact-private-token-201",
+      booking_code: "CWFABC1234",
+      customer_name: "สมชาย",
+    }],
+  });
+  const router = createCatalogReviewRoutes({ pool, requireCustomerJwt: requireCustomerJwtFor(null), requireAdminSession: denyAdmin });
+  await withServer(router, async (base) => {
+    for (const credential of ["CWFABC1234", "exact-private-token-20", "wrong-private-token"]) {
+      const denied = await fetch(`${base}/public/catalog-reviews`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ token: credential, rating: 5 }),
+      });
+      assert.equal(denied.status, 403);
+      assert.equal(pool.state.reviews.length, 0);
+    }
+
+    const accepted = await fetch(`${base}/public/catalog-reviews`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ token: "exact-private-token-201", rating: 5, comment: "ดีมาก" }),
+    });
+    assert.equal(accepted.status, 201);
+    assert.equal(pool.state.reviews.length, 1);
+  });
+});
+
+test("GET tracking review status keeps its read lookup behavior for booking codes", async () => {
+  const pool = makePool({
+    trackingSchemaReady: true,
+    jobs: [{ job_id: 202, job_type: "ล้าง", catalog_item_id: 1, job_status: DONE_STATUS, canceled_at: null, booking_token: "tok-202", booking_code: "CWFREAD202", customer_name: "สมหญิง" }],
+  });
+  const router = createCatalogReviewRoutes({ pool, requireCustomerJwt: requireCustomerJwtFor(null), requireAdminSession: denyAdmin });
+  await withServer(router, async (base) => {
+    const res = await fetch(`${base}/public/catalog-reviews/status?token=CWFREAD202`);
+    const body = await res.json();
+    assert.equal(res.status, 200);
+    assert.equal(body.eligible, true);
   });
 });
 

--- a/test/customerAppPageAvailability.test.js
+++ b/test/customerAppPageAvailability.test.js
@@ -281,7 +281,7 @@ test("api exposes loadCustomerAppConfig as a no-store GET to /public/customer-ap
 });
 
 test("build wiring: pageAvailability.js is registered in the HTML shell and the SW cache, with the new build id", () => {
-  const build = "20260712_page_controls_tracking_link_v4";
+  const build = "20260712_tracking_full_read_v1";
   assert.match(indexHtml, new RegExp(`modules/pageAvailability\\.js\\?v=${build}`));
   assert.match(swSrc, new RegExp(`BUILD_ID = "${build}"`));
   assert.match(swSrc, /modules\/pageAvailability\.js\?v=\$\{BUILD_ID\}/);
@@ -294,7 +294,7 @@ test("build wiring: pageAvailability.js is registered in the HTML shell and the 
    RUNTIME tests (execute the real code in a VM — not regex assertions).
    ========================================================================== */
 
-const BUILD = "20260712_page_controls_tracking_link_v4";
+const BUILD = "20260712_tracking_full_read_v1";
 const adminSrc = read("admin-homepage-cms.js");
 
 function reqUrlOf(req) {

--- a/test/customerAppRecovery.test.js
+++ b/test/customerAppRecovery.test.js
@@ -236,7 +236,7 @@ test("Customer App build id is consistent across shell and service worker", () =
   const sw = read("customer-app/sw.js");
   const app = read("customer-app/assets/customer-app.js");
   const manifest = read("customer-app/manifest.webmanifest");
-  const build = "20260712_page_controls_tracking_link_v4";
+  const build = "20260712_tracking_full_read_v1";
 
   assert.match(index, new RegExp(`customer-app\\.css\\?v=${build}`));
   assert.match(index, new RegExp(`modules\\/api\\.js\\?v=${build}`));
@@ -254,7 +254,7 @@ test("Customer App build id is consistent across shell and service worker", () =
 test("store module is loaded in index.html and precached in the service worker app shell", () => {
   const index = read("customer-app/index.html");
   const sw = read("customer-app/sw.js");
-  const build = "20260712_page_controls_tracking_link_v4";
+  const build = "20260712_tracking_full_read_v1";
 
   assert.match(index, new RegExp(`modules/store\\.js\\?v=${build}`));
   assert.match(sw, /`\.\/modules\/store\.js\?v=\$\{BUILD_ID\}`/);
@@ -2789,16 +2789,18 @@ test("tracking full (token) access renders the customer-information section", ()
   assert.doesNotMatch(html, /tracking-limited-note/);
 });
 
-test("tracking code-only access shows a limited-access notice instead of blank rows", () => {
+test("tracking code-only access renders the full read model without token actions", () => {
   const root = loadTrackingFrontend();
   const html = renderTracking(root, {
-    access_level: "code", booking_code: "BK1", job_status: "กำลังดำเนินการ",
-    appointment_datetime: "2026-06-20T10:00:00Z", customer_phone: "•••• 5678",
+    access_level: "code", can_view_full_tracking: true, can_use_token_actions: false,
+    booking_code: "BK1", job_status: "กำลังดำเนินการ",
+    appointment_datetime: "2026-06-20T10:00:00Z", customer_phone: "0812345678",
+    customer_name: "คุณสมชาย", address_text: "อ่อนนุช กทม",
   });
-  assert.match(html, /tracking-limited-note/);
-  assert.match(html, /ลิงก์ติดตามงาน/);
-  assert.match(html, /•••• 5678/); // masked phone may still show
-  assert.doesNotMatch(html, /ชื่อลูกค้า/); // no misleading customer-name row in limited mode
+  assert.match(html, /คุณสมชาย/);
+  assert.match(html, /0812345678/);
+  assert.match(html, /อ่อนนุช กทม/);
+  assert.doesNotMatch(html, /data-review-form|open-eslip|\/docs\/receipt/);
 });
 
 // Blocker 1: the booking_token is a private request credential and must never
@@ -2973,18 +2975,17 @@ test("Blocker 2: technician-review success reloads with the private token", asyn
   assert.equal(calls[calls.length - 1], SECRET, "review success must reload using the private token");
 });
 
-test("Blocker 3: code-only Overview explains limited access and never claims 'no technician'", () => {
+test("code-only Overview uses read capability and suppresses privileged actions", () => {
   const root = loadTrackingFrontend();
   const html = renderTracking(root, {
-    access_level: "code", booking_code: "BKCODE", booking_mode: "urgent",
+    access_level: "code", can_view_full_tracking: true, can_use_token_actions: false,
+    booking_code: "BKCODE", booking_mode: "urgent",
     job_status: "กำลังดำเนินการ", appointment_datetime: "2026-06-20T10:00:00Z",
-    customer_phone: "•••• 5678",
+    customer_phone: "0812345678", technician: { full_name: "ช่างสมชาย" },
   });
-  assert.match(html, /โหมดจำกัดข้อมูล/);
-  assert.match(html, /ข้อมูลทีมช่างจะแสดงเมื่อเปิดจากลิงก์ติดตามงาน/);
-  assert.doesNotMatch(html, /ยังไม่มีช่างยืนยันงานนี้/);
-  assert.doesNotMatch(html, /รอช่างรับงาน/);
-  assert.doesNotMatch(html, /แอดมินกำลังช่วยจัดคิวให้/);
+  assert.match(html, /ช่างสมชาย/);
+  assert.doesNotMatch(html, /โหมดจำกัดข้อมูล/);
+  assert.doesNotMatch(html, /data-review-form|open-eslip/);
   assert.doesNotMatch(html, /เปลี่ยนเป็นจองล่วงหน้า/);
 });
 

--- a/test/customerAppStorePayment.test.js
+++ b/test/customerAppStorePayment.test.js
@@ -58,7 +58,7 @@ test("store falls back to the LINE hand-off when payment is unconfigured or the 
 test("payment step styles exist and the Customer App payment build id is bumped", () => {
   assert.match(cssSrc, /\.pay-method-btn/);
   assert.match(cssSrc, /\.pay-qr-img/);
-  assert.match(read("customer-app/index.html"), /modules\/store\.js\?v=20260712_page_controls_tracking_link_v4/);
-  assert.match(read("customer-app/sw.js"), /BUILD_ID = "20260712_page_controls_tracking_link_v4"/);
+  assert.match(read("customer-app/index.html"), /modules\/store\.js\?v=20260712_tracking_full_read_v1/);
+  assert.match(read("customer-app/sw.js"), /BUILD_ID = "20260712_tracking_full_read_v1"/);
   assert.match(storeSrc, /payment-security 20260705 loaded/);
 });

--- a/test/customerBookingAdminNotifications.test.js
+++ b/test/customerBookingAdminNotifications.test.js
@@ -311,10 +311,10 @@ test("admin/customer frontend cache versions are bumped for booking notification
   assert.doesNotMatch(adminReviewHtml, /admin-review-v2\.js\?v=20260707_customer_booking_notify_v2/);
   assert.match(adminReviewHtml, /admin-review-ai-intake\.js\?v=ai-booking-intake-customer-cards-v11-admin-alert-gate/);
   assert.doesNotMatch(adminReviewHtml, /admin-review-ai-intake\.js\?v=ai-booking-intake-customer-cards-v10/);
-  assert.match(customerIndex, /bookingScheduled\.js\?v=20260712_page_controls_tracking_link_v4/);
-  assert.match(customerIndex, /state\.js\?v=20260712_page_controls_tracking_link_v4/);
-  assert.match(customerSw, /const BUILD_ID = "20260712_page_controls_tracking_link_v4"/);
-  assert.match(customerManifest, /20260712_page_controls_tracking_link_v4/);
+  assert.match(customerIndex, /bookingScheduled\.js\?v=20260712_tracking_full_read_v1/);
+  assert.match(customerIndex, /state\.js\?v=20260712_tracking_full_read_v1/);
+  assert.match(customerSw, /const BUILD_ID = "20260712_tracking_full_read_v1"/);
+  assert.match(customerManifest, /20260712_tracking_full_read_v1/);
 });
 
 test("behavior: review queue only includes customer urgent waiting rows while preserving review statuses", () => {

--- a/test/customerHistoryClaim.test.js
+++ b/test/customerHistoryClaim.test.js
@@ -544,7 +544,7 @@ test("Customer App profile opens history detail with opaque job_ref and clears c
 });
 
 test("Customer App cache version is bumped consistently", () => {
-  const expected = "20260712_page_controls_tracking_link_v4";
+  const expected = "20260712_tracking_full_read_v1";
   for (const file of [
     "customer-app/index.html",
     "customer-app/sw.js",

--- a/test/customerSameDayTiming.test.js
+++ b/test/customerSameDayTiming.test.js
@@ -160,7 +160,7 @@ test("customer app disables availability HTTP cache and refreshes same-day slots
 });
 
 test("customer app build and service worker cache IDs changed", () => {
-  const id = "20260712_page_controls_tracking_link_v4";
+  const id = "20260712_tracking_full_read_v1";
   for (const file of [
     "customer-app/index.html",
     "customer-app/sw.js",

--- a/test/customerTrackingFullReadUi.test.js
+++ b/test/customerTrackingFullReadUi.test.js
@@ -121,6 +121,81 @@ test("exact-token capability retains document and review behavior", () => {
   assert.match(app.tracking._test.renderReview(data), /data-review-token/);
 });
 
+test("canceled jobs render a terminal canceled hero and timeline", () => {
+  const app = loadTrackingRuntime();
+  const data = {
+    ...codeReadPayload(),
+    canceled_at: "2026-07-14T08:30:00+07:00",
+    cancel_reason: "ลูกค้าแจ้งยกเลิกนัด",
+  };
+  app.state.tracking = { status: "success", data, error: "" };
+  const html = app.tracking._test.renderTrackingResult();
+  const timeline = app.tracking._test.renderTimeline();
+  assert.match(html, /งานนี้ถูกยกเลิกแล้ว/);
+  assert.match(html, /ลูกค้าแจ้งยกเลิกนัด/);
+  assert.match(timeline, /งานถูกยกเลิก/);
+  assert.match(timeline, /ลูกค้าแจ้งยกเลิกนัด/);
+  assert.doesNotMatch(timeline, /ช่างกำลังเดินทาง|ถึงหน้างาน|เริ่มให้บริการ|งานเสร็จแล้ว/);
+  assert.equal(app.tracking._test.jobPhase(data, "scheduled"), "canceled");
+});
+
+test("a canceled status is terminal even when canceled_at is absent", () => {
+  const app = loadTrackingRuntime();
+  const data = { ...codeReadPayload(), job_status: "ยกเลิก", canceled_at: null };
+  app.state.tracking = { status: "success", data, error: "" };
+  assert.equal(app.tracking._test.isCanceled(data), true);
+  assert.match(app.tracking._test.renderTimeline(), /งานถูกยกเลิก/);
+  assert.doesNotMatch(app.tracking._test.renderTimeline(), /รอทีมช่าง|ช่างกำลังเดินทาง/);
+});
+
+test("booking-code full read shows real technician assignment in timeline", () => {
+  const app = loadTrackingRuntime();
+  const data = codeReadPayload();
+  app.state.tracking = { status: "success", data, error: "" };
+  const timeline = app.tracking._test.renderTimeline();
+  assert.match(timeline, /ยืนยันคิวและมอบหมายทีม/);
+  assert.match(timeline, /มีทีมดูแลงานนี้แล้ว/);
+  assert.equal(app.tracking._test.canViewDetails(data), true);
+  assert.equal(app.tracking._test.canUseTokenActions(data), false);
+});
+
+test("completed copy follows read versus privileged-action capability", () => {
+  const app = loadTrackingRuntime();
+  const codeData = {
+    ...codeReadPayload(),
+    job_status: "เสร็จแล้ว",
+    finished_at: "2026-07-15T11:00:00+07:00",
+    photos: [{ url: "https://example.test/after.jpg", phase: "after" }],
+  };
+  app.state.tracking = { status: "success", data: codeData, error: "" };
+  const codeHtml = app.tracking._test.renderTrackingResult();
+  assert.match(codeHtml, /ดูรูปงาน สรุปงาน และรายละเอียด/);
+  assert.doesNotMatch(codeHtml, />เอกสาร<|รีวิว\/ประกัน|ดูรูปงาน เอกสาร|ดูเอกสาร/);
+
+  const tokenData = {
+    ...codeData,
+    access_level: "token",
+    can_use_token_actions: true,
+    capabilities: { can_view_full_tracking: true, can_use_token_actions: true },
+    booking_token: "private-token",
+    job_id: 88,
+    receipt_url: "/docs/receipt/88?key=private-token",
+  };
+  app.state.tracking = { status: "success", data: tokenData, error: "" };
+  const tokenHtml = app.tracking._test.renderTrackingResult();
+  assert.match(tokenHtml, />เอกสาร</);
+  assert.match(tokenHtml, /รีวิว\/ประกัน/);
+});
+
+test("payment statuses are customer-facing Thai and unknown values are hidden", () => {
+  const app = loadTrackingRuntime();
+  assert.equal(app.tracking._test.paymentStatusLabel("unpaid"), "ยังไม่ชำระ");
+  assert.equal(app.tracking._test.paymentStatusLabel("paid"), "ชำระแล้ว");
+  assert.equal(app.tracking._test.paymentStatusLabel("partial"), "ชำระบางส่วน");
+  assert.equal(app.tracking._test.paymentStatusLabel("pending"), "รอตรวจสอบการชำระ");
+  assert.equal(app.tracking._test.paymentStatusLabel("provider_internal_state"), "กรุณาติดต่อ CWF เพื่อตรวจสอบการชำระ");
+});
+
 test("tracking UI exposes loading, not-found, rate-limit and offline states", () => {
   const app = loadTrackingRuntime();
   app.state.tracking = { status: "loading", data: null, error: "" };

--- a/test/customerTrackingFullReadUi.test.js
+++ b/test/customerTrackingFullReadUi.test.js
@@ -1,0 +1,166 @@
+"use strict";
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const vm = require("node:vm");
+
+const ROOT = path.resolve(__dirname, "..");
+const TRACKING_SOURCE = fs.readFileSync(path.join(ROOT, "customer-app/modules/tracking.js"), "utf8");
+
+function escapeHtml(value) {
+  return String(value == null ? "" : value)
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#039;");
+}
+
+function loadTrackingRuntime() {
+  const app = {
+    state: {
+      tracking: { status: "idle", data: null, error: "" },
+      draft: { tracking: { trackingCode: "" } },
+      setTracking(patch) { this.tracking = { ...this.tracking, ...patch }; },
+      updateDraft() {},
+    },
+    utils: {
+      escapeHtml,
+      formatDateTime: (value) => value ? `DATE:${value}` : "-",
+      formatBaht: (value) => `${Number(value) || 0} บาท`,
+      stateBox: (status, message) => `<div class="${escapeHtml(status)}">${escapeHtml(message)}</div>`,
+      timeline: (items) => items.map((item) => `<div>${escapeHtml(item.title)}:${escapeHtml(item.copy)}</div>`).join(""),
+    },
+    api: { getApiBase: () => "https://example.test" },
+  };
+  const sandbox = {
+    window: {
+      CWFCustomerAppV2: app,
+      location: { origin: "https://example.test", href: "https://example.test/customer-app/#tracking" },
+      open() {},
+    },
+    navigator: { clipboard: { writeText: async () => {} } },
+    URL,
+    console: { info() {}, warn() {}, error() {} },
+    FormData,
+    fetch: async () => { throw new Error("unexpected fetch"); },
+    setTimeout,
+    clearTimeout,
+    Date,
+  };
+  vm.runInNewContext(TRACKING_SOURCE, sandbox, { filename: "tracking.js" });
+  return app;
+}
+
+function codeReadPayload() {
+  return {
+    access_level: "code",
+    can_view_full_tracking: true,
+    can_use_token_actions: false,
+    capabilities: {
+      can_view_full_tracking: true,
+      can_use_token_actions: false,
+      can_view_documents: false,
+      can_submit_review: false,
+    },
+    booking_code: "CWFABC1234",
+    customer_name: "คุณลูกค้า",
+    customer_phone: "0812345678",
+    address_text: "99/1 ถนนสุขุมวิท กรุงเทพฯ",
+    maps_url: "https://maps.google.com/?q=13.7,100.6",
+    job_type: "ล้างแอร์",
+    job_status: "รอดำเนินการ",
+    booking_mode: "scheduled",
+    appointment_datetime: "2026-07-15T09:00:00+07:00",
+    duration_min: 90,
+    job_price: 1200,
+    payment_status: "unpaid",
+    service_items: [{ item_name: "ล้างแอร์เปลือยใต้ฝ้า", qty: 1, unit_price: 1200, line_total: 1200 }],
+    technician: { full_name: "ช่างสมชาย", phone: "0899999999", grade: "A" },
+    technician_team: [],
+    photos: [],
+    units: [],
+    review: { already_reviewed: false },
+    catalog_review: { eligible: false, already_reviewed: false, review: null },
+  };
+}
+
+test("code-only result renders full read details but no document or write controls", () => {
+  const app = loadTrackingRuntime();
+  app.state.tracking = { status: "success", data: codeReadPayload(), error: "" };
+  const html = app.tracking._test.renderTrackingResult();
+  assert.match(html, /CWFABC1234/);
+  assert.match(html, /คุณลูกค้า/);
+  assert.match(html, /0812345678/);
+  assert.match(html, /99\/1 ถนนสุขุมวิท/);
+  assert.match(html, /ล้างแอร์เปลือยใต้ฝ้า/);
+  assert.match(html, /ช่างสมชาย/);
+  assert.doesNotMatch(html, /open-eslip|data-review-form|data-catalog-review-form/);
+  assert.doesNotMatch(html, /booking_token|\/docs\/receipt|\/docs\/quote|\/docs\/eslip/);
+  assert.doesNotMatch(html, />undefined<|>null</);
+  assert.equal(app.tracking._test.receiptUrl(codeReadPayload()), "");
+});
+
+test("exact-token capability retains document and review behavior", () => {
+  const app = loadTrackingRuntime();
+  const data = {
+    ...codeReadPayload(),
+    access_level: "token",
+    can_use_token_actions: true,
+    capabilities: { can_view_full_tracking: true, can_use_token_actions: true },
+    booking_token: "private-token",
+    job_id: 88,
+    job_status: "เสร็จแล้ว",
+    finished_at: "2026-07-15T11:00:00+07:00",
+    receipt_url: "/docs/receipt/88?key=private-token",
+    catalog_review: null,
+  };
+  assert.match(app.tracking._test.receiptUrl(data), /\/docs\/receipt\/88\?key=private-token/);
+  assert.match(app.tracking._test.renderReview(data), /data-review-token/);
+});
+
+test("tracking UI exposes loading, not-found, rate-limit and offline states", () => {
+  const app = loadTrackingRuntime();
+  app.state.tracking = { status: "loading", data: null, error: "" };
+  assert.match(app.tracking._test.renderTrackingResult(), /tracking-skeleton/);
+
+  app.state.tracking = { status: "error", errorKind: "not-found", error: "not found" };
+  assert.match(app.tracking._test.renderTrackingResult(), /ไม่พบงานนี้/);
+
+  app.state.tracking = { status: "error", errorKind: "rate", retryAfter: 42 };
+  assert.match(app.tracking._test.renderTrackingResult(), /42 วินาที/);
+
+  app.state.tracking = { status: "error", errorKind: "network" };
+  assert.match(app.tracking._test.renderTrackingResult(), /เชื่อมต่อระบบไม่ได้/);
+  assert.match(app.tracking._test.renderTrackingResult(), /data-action="track-retry"/);
+});
+
+test("tracking assets share the full-read cache build id", () => {
+  const build = "20260712_tracking_full_read_v1";
+  for (const file of [
+    "customer-app/index.html",
+    "customer-app/sw.js",
+    "customer-app/assets/customer-app.js",
+    "customer-app/manifest.webmanifest",
+  ]) {
+    const source = fs.readFileSync(path.join(ROOT, file), "utf8");
+    assert.match(source, new RegExp(build), `${file} missing build id`);
+  }
+  assert.doesNotMatch(fs.readFileSync(path.join(ROOT, "customer-app/index.html"), "utf8"), /20260712_page_controls_tracking_link_v4/);
+});
+
+test("tracking API lookup is explicitly no-store", () => {
+  const api = fs.readFileSync(path.join(ROOT, "customer-app/modules/api.js"), "utf8");
+  assert.match(api, /requestJson\("\/public\/track", \{ query: \{ q \}, cache: "no-store" \}\)/);
+});
+
+test("tracking mobile CSS provides 360/390-safe wrapping and touch targets", () => {
+  const css = fs.readFileSync(path.join(ROOT, "customer-app/assets/customer-app.css"), "utf8");
+  assert.match(css, /@media \(max-width: 420px\)/);
+  assert.match(css, /\.tracking-code-wrap \{[\s\S]*?min-width: 0/);
+  assert.match(css, /\.tracking-copy-btn \{[\s\S]*?min-height: 44px/);
+  assert.match(css, /\.tracking-code-pill \{[\s\S]*?overflow-wrap: anywhere/);
+  assert.match(css, /@media \(prefers-reduced-motion: reduce\)/);
+});

--- a/test/customerTrackingFullReadUi.test.js
+++ b/test/customerTrackingFullReadUi.test.js
@@ -183,8 +183,152 @@ test("completed copy follows read versus privileged-action capability", () => {
   };
   app.state.tracking = { status: "success", data: tokenData, error: "" };
   const tokenHtml = app.tracking._test.renderTrackingResult();
-  assert.match(tokenHtml, />เอกสาร</);
-  assert.match(tokenHtml, /รีวิว\/ประกัน/);
+  assert.match(tokenHtml, />หลังบริการ</);
+  assert.match(tokenHtml, /เอกสารและรีวิว/);
+});
+
+function assertNoPrivilegedAftercare(html) {
+  assert.doesNotMatch(html, /booking_token|\/docs\/receipt|\/docs\/quote|\/docs\/eslip/);
+  assert.doesNotMatch(html, /data-review-form|data-catalog-review-form|open-eslip/);
+  assert.doesNotMatch(html, /ให้คะแนนงานนี้|ส่งรีวิว/);
+}
+
+test("code-only completed shows existing technician review and warranty read-only", () => {
+  const app = loadTrackingRuntime();
+  const data = {
+    ...codeReadPayload(),
+    job_status: "เสร็จแล้ว",
+    finished_at: "2026-07-15T11:00:00+07:00",
+    review: {
+      already_reviewed: true,
+      rating: 4,
+      review_text: "ช่างตรงเวลาและทำงานเรียบร้อย",
+      complaint_text: "ขอให้โทรก่อนเข้าหน้างาน",
+      reviewed_at: "2026-07-15T12:00:00+07:00",
+    },
+  };
+  app.state.tracking = { status: "success", data, error: "" };
+  const html = app.tracking._test.renderTrackingResult();
+  assert.match(html, />หลังบริการ</);
+  assert.match(html, /รีวิวทีมช่าง/);
+  assert.match(html, /4 \/ 5/);
+  assert.match(html, /ช่างตรงเวลาและทำงานเรียบร้อย/);
+  assert.match(html, /ขอให้โทรก่อนเข้าหน้างาน/);
+  assert.match(html, /DATE:2026-07-15T12:00:00\+07:00/);
+  assert.match(html, /เงื่อนไขรับประกัน/);
+  assertNoPrivilegedAftercare(html);
+});
+
+test("code-only completed shows existing catalog review and warranty read-only", () => {
+  const app = loadTrackingRuntime();
+  const data = {
+    ...codeReadPayload(),
+    job_status: "เสร็จแล้ว",
+    finished_at: "2026-07-15T11:00:00+07:00",
+    catalog_review: {
+      eligible: false,
+      already_reviewed: true,
+      review: {
+        rating: 5,
+        comment: "บริการล้างละเอียดมาก",
+        moderation_status: "approved",
+        created_at: "2026-07-15T12:30:00+07:00",
+      },
+    },
+  };
+  app.state.tracking = { status: "success", data, error: "" };
+  const html = app.tracking._test.renderTrackingResult();
+  assert.match(html, /รีวิวบริการนี้/);
+  assert.match(html, /5 \/ 5/);
+  assert.match(html, /บริการล้างละเอียดมาก/);
+  assert.match(html, /เผยแพร่แล้ว/);
+  assert.match(html, /DATE:2026-07-15T12:30:00\+07:00/);
+  assert.match(html, /เงื่อนไขรับประกัน/);
+  assertNoPrivilegedAftercare(html);
+});
+
+test("code-only completed preserves both existing review summaries", () => {
+  const app = loadTrackingRuntime();
+  const data = {
+    ...codeReadPayload(),
+    job_status: "เสร็จแล้ว",
+    finished_at: "2026-07-15T11:00:00+07:00",
+    review: { already_reviewed: true, rating: 4, review_text: "รีวิวทีมช่าง" },
+    catalog_review: {
+      eligible: false,
+      already_reviewed: true,
+      review: { rating: 5, comment: "รีวิวตัวบริการ", moderation_status: "pending" },
+    },
+  };
+  app.state.tracking = { status: "success", data, error: "" };
+  const html = app.tracking._test.renderTrackingResult();
+  assert.match(html, /รีวิวทีมช่าง/);
+  assert.match(html, /รีวิวตัวบริการ/);
+  assert.match(html, /รอตรวจสอบ/);
+  assertNoPrivilegedAftercare(html);
+});
+
+test("code-only completed with no review still shows warranty without review invitation", () => {
+  const app = loadTrackingRuntime();
+  const data = {
+    ...codeReadPayload(),
+    job_status: "เสร็จแล้ว",
+    finished_at: "2026-07-15T11:00:00+07:00",
+  };
+  app.state.tracking = { status: "success", data, error: "" };
+  const html = app.tracking._test.renderTrackingResult();
+  assert.match(html, />หลังบริการ</);
+  assert.match(html, /เงื่อนไขรับประกัน/);
+  assertNoPrivilegedAftercare(html);
+});
+
+test("token completed retains documents and one eligible write-review flow", () => {
+  const app = loadTrackingRuntime();
+  const data = {
+    ...codeReadPayload(),
+    access_level: "token",
+    can_use_token_actions: true,
+    capabilities: { can_view_full_tracking: true, can_use_token_actions: true },
+    booking_token: "private-token",
+    job_id: 88,
+    job_status: "เสร็จแล้ว",
+    finished_at: "2026-07-15T11:00:00+07:00",
+    receipt_url: "/docs/receipt/88?key=private-token",
+    catalog_review: { eligible: true, already_reviewed: false, review: null },
+  };
+  app.state.tracking = { status: "success", data, error: "" };
+  const html = app.tracking._test.renderTrackingResult();
+  assert.match(html, /data-action="open-eslip"/);
+  assert.match(html, /data-catalog-review-form/);
+  assert.doesNotMatch(html, /data-review-form/);
+  assert.match(html, /เงื่อนไขรับประกัน/);
+});
+
+test("token completed with existing reviews shows both summaries and no duplicate form", () => {
+  const app = loadTrackingRuntime();
+  const data = {
+    ...codeReadPayload(),
+    access_level: "token",
+    can_use_token_actions: true,
+    capabilities: { can_view_full_tracking: true, can_use_token_actions: true },
+    booking_token: "private-token",
+    job_id: 88,
+    job_status: "เสร็จแล้ว",
+    finished_at: "2026-07-15T11:00:00+07:00",
+    receipt_url: "/docs/receipt/88?key=private-token",
+    review: { already_reviewed: true, rating: 4, review_text: "ทีมช่างดี" },
+    catalog_review: {
+      eligible: false,
+      already_reviewed: true,
+      review: { rating: 5, comment: "บริการดี", moderation_status: "approved" },
+    },
+  };
+  app.state.tracking = { status: "success", data, error: "" };
+  const html = app.tracking._test.renderTrackingResult();
+  assert.match(html, /ทีมช่างดี/);
+  assert.match(html, /บริการดี/);
+  assert.match(html, /data-action="open-eslip"/);
+  assert.doesNotMatch(html, /data-review-form|data-catalog-review-form/);
 });
 
 test("payment statuses are customer-facing Thai and unknown values are hidden", () => {

--- a/test/customerTrackingPrivacy.test.js
+++ b/test/customerTrackingPrivacy.test.js
@@ -50,37 +50,53 @@ function richPayload() {
     technician_note: "ลูกค้าไม่อยู่บ้าน",
     technician: { username: "tech1", full_name: "ช่าง หนึ่ง", phone: "0899999999" },
     technician_team: [{ username: "tech1", phone: "0899999999" }],
-    photos: [{ public_url: "https://x/y.jpg" }],
-    units: [{ location_label: "ห้องนอน", checklist: [{ issue: "ตัน" }] }],
+    photos: [{ photo_id: 900, public_url: "https://x/y.jpg", phase: "after" }],
+    units: [{ unit_id: 700, unit_no: 1, unit_code: "AC-01", label: "ห้องนอน", photos: [{ photo_id: 901, public_url: "https://x/u.jpg" }] }],
     cancel_reason: "ลูกค้ายกเลิก",
     review: { review_text: "ดีมาก" },
+    catalog_review: { eligible: true, already_reviewed: true, review: { rating: 5, comment: "ดี", moderation_status: "pending", created_at: "2026-07-10" } },
     customer_complaint: "ช้า",
   };
 }
 
-// Fields a booking_code lookup is ALLOWED to return — everything else must be absent.
+// Booking-code reads use a customer-facing allowlist. Nested projectors also
+// remove internal identifiers and write/document metadata.
 const ALLOWED_CODE_KEYS = new Set([
-  "access_level", "legacy_review_eligible", "booking_code", "job_status",
-  "booking_mode", "dispatch_mode", "appointment_datetime", "duration_min",
+  "access_level", "capabilities", "can_view_full_tracking", "can_use_token_actions",
+  "legacy_review_eligible", "booking_code", "customer_name", "customer_phone",
+  "job_type", "job_status", "booking_mode", "dispatch_mode", "appointment_datetime",
+  "duration_min", "job_price", "payment_status", "paid_at", "address_text",
+  "maps_url", "job_zone", "gps_latitude", "gps_longitude", "created_at",
   "travel_started_at", "checkin_at", "started_at", "finished_at", "canceled_at",
-  "customer_phone",
+  "cancel_reason", "technician_note", "service_items", "photos", "units",
+  "technician", "technician_team", "review", "catalog_review",
 ]);
 
-test("booking_code redaction returns ONLY the allowlisted keys (blacklist-proof)", () => {
+test("booking_code gets full customer-facing detail without privileged fields", () => {
   const redacted = trackingPrivacy.redactPublicTrackPayload(richPayload());
   for (const key of Object.keys(redacted)) {
     assert.ok(ALLOWED_CODE_KEYS.has(key), `unexpected key leaked to code lookup: ${key}`);
   }
-  // Spot-check the sensitive ones are truly gone.
-  for (const gone of ["booking_token", "customer_name", "address_text", "maps_url",
-    "gps_latitude", "gps_longitude", "job_id", "technician_note", "technician",
-    "technician_team", "photos", "units", "cancel_reason", "review", "customer_complaint", "receipt_url"]) {
+  for (const gone of ["booking_token", "job_id", "receipt_url", "document_key", "auth_token", "customer_complaint"]) {
     assert.equal(redacted[gone], undefined, `${gone} must not be present for a code lookup`);
   }
   assert.equal(redacted.access_level, "code");
-  assert.equal(redacted.customer_phone, "•••• 5678"); // masked confirmation aid
+  assert.equal(redacted.can_view_full_tracking, true);
+  assert.equal(redacted.can_use_token_actions, false);
+  assert.equal(redacted.capabilities.can_view_documents, false);
+  assert.equal(redacted.capabilities.can_submit_review, false);
+  assert.equal(redacted.customer_name, richPayload().customer_name);
+  assert.equal(redacted.customer_phone, "0812345678");
+  assert.equal(redacted.address_text, richPayload().address_text);
   assert.equal(redacted.job_status, "รอดำเนินการ");
   assert.equal(redacted.booking_code, "CWFABCDEFG");
+  assert.equal(redacted.technician.username, undefined);
+  assert.equal(redacted.technician.full_name, richPayload().technician.full_name);
+  assert.equal(redacted.photos[0].photo_id, undefined);
+  assert.equal(redacted.units[0].unit_id, undefined);
+  assert.equal(redacted.units[0].photos[0].photo_id, undefined);
+  assert.equal(redacted.catalog_review.eligible, false);
+  assert.equal(redacted.catalog_review.review.moderation_status, undefined);
 });
 
 test("a brand-new sensitive field added upstream does NOT leak through code redaction", () => {
@@ -89,13 +105,10 @@ test("a brand-new sensitive field added upstream does NOT leak through code reda
   assert.equal(redacted.some_future_pii_field, undefined);
 });
 
-test("legacy_review_eligible passes through as a non-sensitive boolean (default false, no token leak)", () => {
-  // Absent upstream -> false, never undefined/truthy by accident.
+test("booking-code read model never advertises legacy or catalog write eligibility", () => {
   assert.equal(trackingPrivacy.redactPublicTrackPayload(richPayload()).legacy_review_eligible, false);
-  // Explicit true is surfaced so the UI can offer the legacy phone form...
   const eligible = trackingPrivacy.redactPublicTrackPayload({ ...richPayload(), legacy_review_eligible: true });
-  assert.equal(eligible.legacy_review_eligible, true);
-  // ...but it must never carry the token alongside it.
+  assert.equal(eligible.legacy_review_eligible, false);
   assert.equal(eligible.booking_token, undefined);
 });
 
@@ -233,8 +246,11 @@ test("the customer app only builds receipt links + review form on full (token) a
   // constructed at click time from state (receiptUrl(data)) instead of being
   // interpolated into rendered HTML — see Blocker 1.
   assert.match(trackingClientSrc, /`\/docs\/receipt\/\$\{encodeURIComponent\(data\.job_id\)\}\?key=\$\{encodeURIComponent\(data\.booking_token\)\}`/);
-  // The review form only offers the token-write path on full (token) access.
-  assert.match(trackingClientSrc, /data\.access_level === "token" \? \(data\.booking_token \|\| ""\) : ""/);
+  // Read and write capabilities are separate; code-only reads cannot create
+  // document links or review forms.
+  assert.match(trackingClientSrc, /if \(!canUseTokenActions\(data\)\) return "";/);
+  assert.match(trackingClientSrc, /const reviewToken = canUseTokenActions\(data\)/);
+  assert.match(trackingClientSrc, /if \(!catalogReview\.eligible \|\| !canUseTokenActions\(data\)\) return "";/);
   // Blocker 1: the booking_token must NOT be embedded in rendered HTML as a
   // hidden input. It is injected from state at submit time and the form is only
   // flagged with data-review-token.

--- a/test/e2e/run-booking-e2e.js
+++ b/test/e2e/run-booking-e2e.js
@@ -921,30 +921,45 @@ async function main() {
     assert(got429, "rate limit never tripped — a rotating spoofed XFF bypassed it");
   });
 
-  // S16) A booking_code lookup is a minimal allowlist. Beyond the phone-masking
-  // already checked in S11, prove the sensitive fields are absent by
-  // construction — name, address, internal job_id, technician notes, photos,
-  // unit data, cancel reason, and any review text must never appear.
-  await record("S16 booking_code lookup leaks no name/address/job_id/notes/photos/units/review", async () => {
+  // S16) A booking_code grants the customer-facing read model, never a private
+  // credential, internal identifier, document capability, or write capability.
+  await record("S16 booking_code returns full read details without privileged fields", async () => {
     const red = await (await fetch(`${BASE_A}/public/track?q=${encodeURIComponent(bookingCode1)}`,
       { headers: { "x-forwarded-for": "198.51.100.7" } })).json();
-    assert(red.access_level === "code", "expected a limited (code) lookup");
+    assert(red.access_level === "code", "expected booking-code read access");
+    assert(red.can_view_full_tracking === true, "code lookup must allow customer-facing details");
+    assert(red.can_use_token_actions === false, "code lookup must deny privileged actions");
+    assert(red.capabilities?.can_view_full_tracking === true, "nested read capability must be explicit");
+    assert(red.capabilities?.can_view_documents === false, "code lookup must deny documents");
+    assert(red.capabilities?.can_submit_review === false, "code lookup must deny review writes");
+
+    // Positive contract: full customer-facing fields are present even when a
+    // particular seeded job has null/empty optional values.
+    for (const key of [
+      "customer_name", "customer_phone", "address_text", "maps_url", "job_type",
+      "job_status", "appointment_datetime", "job_price", "payment_status",
+      "service_items", "photos", "units", "technician", "technician_team",
+    ]) {
+      assert(Object.prototype.hasOwnProperty.call(red, key), `code lookup missing read field: ${key}`);
+    }
+    assert(Array.isArray(red.service_items), "service_items must be an array");
+    assert(Array.isArray(red.photos), "photos must be an array");
+    assert(Array.isArray(red.units), "units must be an array");
+    assert(Array.isArray(red.technician_team), "technician_team must be an array");
+
     const forbidden = [
-      "customer_name", "customer_fullname", "name",
-      "address_text", "address", "address_prefix", "maps_url", "gps_latitude", "gps_longitude",
-      "job_id", "id",
-      "technician_note", "technician_notes", "notes", "note", "admin_note",
-      "photos", "job_photos", "photo_urls",
-      "units", "job_items", "items", "machine_count", "unit_data",
-      "cancel_reason", "canceled_reason",
-      "customer_review", "review_text", "customer_complaint", "complaint_text",
-      "technician_username", "technician_name", "receipt_url",
+      "booking_token", "job_id", "receipt_url", "quote_url", "eslip_url",
+      "document_key", "auth_token", "session", "session_id", "privileged_url",
+      "payment_secret", "webhook_data", "private_key", "admin_note",
     ];
     const leaked = forbidden.filter((k) => red[k] !== undefined && red[k] !== null);
     assert(leaked.length === 0, `booking_code lookup leaked fields: ${leaked.join(", ")}`);
-    // Positive: it still returns the minimal, useful status surface.
+    const serialized = JSON.stringify(red);
+    for (const nestedKey of ["photo_id", "unit_id", "technician_username", "tracking_token_hash"]) {
+      assert(!serialized.includes(`\"${nestedKey}\"`), `booking_code lookup leaked nested field: ${nestedKey}`);
+    }
     assert(red.booking_code === bookingCode1, "code lookup must echo the booking_code");
-    assert(typeof red.job_status === "string", "code lookup must return a status");
+    assert(typeof red.job_status === "string", "code lookup must return status");
   });
 
   // S17) /public/review is a WRITE. A tokened job must NOT be reviewable via the

--- a/test/homepageCms.test.js
+++ b/test/homepageCms.test.js
@@ -290,7 +290,7 @@ test("customer homepage has no admin control, bottom nav is fixed five-tab, and 
   const sw = read("customer-app/sw.js");
   const app = read("customer-app/assets/customer-app.js");
   const manifest = read("customer-app/manifest.webmanifest");
-  const build = "20260712_page_controls_tracking_link_v4";
+  const build = "20260712_tracking_full_read_v1";
 
   assert.doesNotMatch(index + ui, /โหมดแอดมิน|openCms|localStorage\.getItem\('cwfHomeCmsDemo'/);
   assert.match(index, /data-route="store"[\s\S]*ร้านค้า/);

--- a/test/trackingGpsRecovery.test.js
+++ b/test/trackingGpsRecovery.test.js
@@ -106,13 +106,12 @@ test("track.html escapes customer/technician/address/photo/phone values", () => 
 
 // ============================ A3. Customer App tracking rendering =========
 
-test("customer-app tracking is access-level aware (full customer info vs limited notice)", () => {
-  assert.match(trackingJs, /const isFull = data\.access_level === "token"/);
+test("customer-app separates full tracking reads from token-only actions", () => {
+  assert.match(trackingJs, /const isFull = canViewDetails\(data\)/);
   assert.match(trackingJs, /if \(isFull && data\.customer_name\)/);
   assert.match(trackingJs, /if \(isFull && data\.address_text\)/);
-  assert.match(trackingJs, /tracking-limited-note/);
-  // The limited notice appears only when NOT full access.
-  assert.match(trackingJs, /const limitedNotice = !isFull \?/);
+  assert.match(trackingJs, /function canUseTokenActions\(data\)/);
+  assert.match(trackingJs, /if \(!canUseTokenActions\(data\)\) return "";/);
 });
 
 // ============================ B6. Backend coordinate validation ===========
@@ -392,14 +391,25 @@ test("track.html (token): token absent from rendered HTML + #q shows booking_cod
   assert.ok(resultEl.innerHTML.includes("data-nav"));
 });
 
-test("track.html (code): limited mode shows notice, hides address/nav, no dash rows", async () => {
-  const data = { access_level: "code", booking_code: "CWF777", job_status: "กำลังดำเนินการ", appointment_datetime: "2026-06-20T10:00:00Z", customer_phone: "•••• 5678" };
+test("track.html (code): full read details render while token actions stay unavailable", async () => {
+  const data = {
+    access_level: "code",
+    can_view_full_tracking: true,
+    can_use_token_actions: false,
+    booking_code: "CWF777",
+    job_status: "กำลังดำเนินการ",
+    appointment_datetime: "2026-06-20T10:00:00Z",
+    customer_name: "คุณลูกค้า",
+    customer_phone: "0812345678",
+    address_text: "99 ถนนสุขุมวิท",
+  };
   const { track, qEl, resultEl } = loadTrackHtml({ data });
   await track("CWF777");
-  assert.ok(resultEl.innerHTML.includes("โหมดจำกัดข้อมูล"), "must show the limited-access notice");
-  assert.ok(resultEl.innerHTML.includes("•••• 5678"), "masked phone may show");
-  assert.ok(!resultEl.innerHTML.includes("data-nav"), "no navigation control in limited mode");
-  assert.ok(!resultEl.innerHTML.includes("ชื่อลูกค้า"), "no misleading customer-name row");
+  assert.ok(resultEl.innerHTML.includes("คุณลูกค้า"));
+  assert.ok(resultEl.innerHTML.includes("99 ถนนสุขุมวิท"));
+  assert.ok(resultEl.innerHTML.includes("data-nav"));
+  assert.ok(!resultEl.innerHTML.includes("data-review-submit"));
+  assert.ok(!resultEl.innerHTML.includes("SECRETTOKEN"));
   assert.equal(qEl.value, "CWF777");
 });
 

--- a/track.html
+++ b/track.html
@@ -148,8 +148,11 @@ function isDoneStatus(jobStatus){
 // ✅ สร้าง URL ใบเสร็จเดิมให้ปลอดภัย (กัน backend ส่ง localhost / คนละโดเมน)
 // - เป้าหมาย: ป้องกัน Error 'Failed to fetch' ในมือถือ/PWA
 function buildReceiptUrl(jobData){
+  const canUseTokenActions = jobData?.can_use_token_actions === true || jobData?.capabilities?.can_use_token_actions === true || jobData?.access_level === "token";
+  if (!canUseTokenActions) return "";
   const id = jobData?.job_id;
-  const fallback = id ? `${API}/docs/receipt/${encodeURIComponent(id)}` : "";
+  const token = String(jobData?.booking_token || "").trim();
+  const fallback = id && token ? `${API}/docs/receipt/${encodeURIComponent(id)}?key=${encodeURIComponent(token)}` : "";
   const raw = String(jobData?.receipt_url || "").trim();
   if(!raw) return fallback;
 
@@ -398,6 +401,8 @@ function reviewHTML(d){
       </div>
     `;
   }
+  const canUseTokenActions = d.can_use_token_actions === true || d.capabilities?.can_use_token_actions === true || d.access_level === "token";
+  if (!canUseTokenActions || !d.booking_token) return '';
   return `
     <div class="card tight" style="margin-top:10px;border-style:dashed;">
       <b>⭐ ให้คะแนนช่าง</b>
@@ -513,7 +518,7 @@ async function track(credOverride){
     // True code-only limited mode: a booking_code lookup returns redacted data,
     // so show status + masked phone + a clear explanation, NOT misleading dash
     // rows or navigation/technician controls that cannot work.
-    if (data.access_level !== "token") {
+    if (!(data.can_view_full_tracking === true || data.capabilities?.can_view_full_tracking === true || data.access_level === "token")) {
       box.innerHTML = `
         <div class="job-card">
           <div style="display:flex;justify-content:space-between;align-items:center;gap:10px;">
@@ -697,7 +702,8 @@ async function track(credOverride){
     const rev = target.closest("[data-review-submit]");
     if (rev) {
       const d = CURRENT_TRACK_DATA || {};
-      submitReview(d.booking_token || d.booking_code || "");
+      const canUseTokenActions = d.can_use_token_actions === true || d.capabilities?.can_use_token_actions === true || d.access_level === "token";
+      if (canUseTokenActions && d.booking_token) submitReview(d.booking_token);
       return;
     }
   });


### PR DESCRIPTION
Refs #157

## Base and head

- Base: `main@8afd57aa68f34a4569c94ef260237ab21045e2b9`
- Head: `4c594745f76c2cfcda5ddc4f400206ab06daa40c`
- Branch: `codex/customer-tracking-full-read-ui`

## Summary

Booking/Tracking Code lookups receive a complete allowlisted customer-facing tracking read model. Read access and privileged token actions remain separate capabilities. The final review fixes add a terminal canceled phase, technician assignment in Booking Code timelines, capability-specific completed copy, customer-facing payment labels, and the updated S16 E2E contract.

## Capability model

- Booking Code: `can_view_full_tracking=true`, `can_use_token_actions=false`
- Exact booking token: retains existing full tracking and token action behavior
- Booking Code responses omit `booking_token`, raw `job_id`, document URLs/keys, auth/session fields, and internal nested IDs
- `POST /public/catalog-reviews` resolves only exact `booking_token`; Booking Code, near-miss, and wrong tokens receive the same generic denial

## Review fixes

- A job is canceled when either `canceled_at` exists or its canonical status indicates cancellation.
- Canceled jobs show a canceled hero, cancellation reason, and a terminal timeline with no travel/start/completion prompts.
- Booking Code full-read timelines show the assignment phase and real customer-facing technician/team data.
- Code-only completed jobs mention only photos, service summary, details, and contact. Document/review copy and controls remain token-only.
- Payment states are mapped to readable Thai; unknown provider values are never rendered raw.
- Removed the tracking debug `console.info`.
- E2E S16 now verifies the full customer read model and denies credentials/internal/privileged fields; S17 was not changed.

## Round-two aftercare fix

- Completed Booking Code reads now include a `หลังบริการ` tab.
- Warranty and existing technician/catalog review summaries are read-only and independent of token capabilities.
- Both existing review types render when they coexist, including rating, customer-facing text, date when supplied, and a Thai moderation label.
- Documents and new-review forms remain behind `can_use_token_actions`; the existing single write-form selection is preserved.
- Exact-token access retains E-slip and eligible review submission behavior.

## Changed files

Implementation:
- `server/services/public/trackingPrivacy.js`
- `server/routes/catalog/reviews.js`
- `index.js` (public tracking route only)
- `customer-app/modules/tracking.js`
- `customer-app/modules/api.js`
- `customer-app/assets/customer-app.css`
- `track.html`
- Customer App cache/build files

Tests:
- tracking privacy, GPS/recovery, catalog review, page availability, build consistency
- `test/customerTrackingFullReadUi.test.js`
- `test/e2e/run-booking-e2e.js` (S16 only in final review round)

## Cache

Customer App build: `20260712_tracking_full_read_v1`

## Tests

- Final-review syntax checks: 3/3 passed
- Round-two runtime UI tests: 17/17 passed
- Focused tracking/review/security suite: 271/271 passed
- Latest main full suite: 1163 tests, 1101 pass, 28 fail, 34 skipped
- Branch full suite: 1182 tests, 1120 pass, 28 fail, 34 skipped
- Additional branch failures: 0
- Failure-name sets match. Existing failures are the same Admin Store Catalog UI assertions and customer-history migration-runner environment tests.

## Local visual verification

No browser backend is available in the execution environment. Owner can run the real app shell and modules without committing fixture data:

```powershell
git switch codex/customer-tracking-full-read-ui
npm ci --ignore-scripts
npx --yes http-server . -p 4173 -c-1
```

Open `http://127.0.0.1:4173/customer-app/index.html#tracking`. In DevTools, use the loaded module/state only:

```js
const App = window.CWFCustomerAppV2;
App.state.setTracking({ status: "success", data: YOUR_LOCAL_FIXTURE, error: "" });
App.tracking.render(document.querySelector("#app"));
```

For error states set `status:"loading"`, or `status:"error"` with `errorKind:"not-found"`, `"rate"` (plus `retryAfter:42`), or `"network"`. Use only synthetic local fixtures in DevTools. Required owner captures at both 360px and 390px: search, success, canceled, completed code-only, 404, 429, and offline.

## Remaining risks

- Actual 360px/390px screenshot review remains required in a browser-capable environment.
- S16 is updated but the PostgreSQL-backed E2E runner was not executed locally; its contract is syntax checked and the equivalent focused route/runtime tests pass.
- The in-memory tracking rate limit remains per process, matching current production behavior.
- Full suite remains red because of 28 pre-existing failures listed above.

## Safety

No migration, schema change, production data/config change, ZIP, merge, or deploy was performed.