### PR TITLE
Redesign tracking cleanliness score and cleaning-cycle guidance

### DIFF
--- a/customer-app/assets/customer-app.css
+++ b/customer-app/assets/customer-app.css
@@ -1666,33 +1666,187 @@ p { margin: 0; }
   box-shadow: 0 0 0 3px rgba(220, 38, 38, 0.12);
 }
 .unit-inspection-item.is-issue strong { color: #b91c1c; }
-.unit-condition-summary {
+.unit-cleanliness-card {
+  --clean-accent: #0b74d1;
   display: grid;
-  grid-template-columns: minmax(0, 1fr) auto;
-  gap: 10px;
-  padding: 11px 12px;
-  border-left: 4px solid #0b4bb3;
-  border-radius: 10px;
-  background: #fff;
+  gap: 12px;
+  min-width: 0;
+  padding: 14px;
+  overflow: hidden;
+  border: 1px solid #b9d5ef;
+  border-radius: 16px;
+  background: #edf6ff;
+  box-shadow: 0 14px 28px -24px rgba(10, 42, 87, 0.6);
 }
-.unit-condition-summary div {
+.unit-cleanliness-card.tone-excellent,
+.unit-cleanliness-card.tone-good {
+  --clean-accent: #15945e;
+  border-color: #a9dfc1;
+  background: #eaf9f1;
+}
+.unit-cleanliness-card.tone-watch {
+  --clean-accent: #d79208;
+  border-color: #f0d18b;
+  background: #fff8df;
+}
+.unit-cleanliness-card.tone-due {
+  --clean-accent: #dc5a20;
+  border-color: #f1b997;
+  background: #fff1e8;
+}
+.unit-cleanliness-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 10px;
   min-width: 0;
 }
-.unit-condition-summary span,
-.unit-condition-summary strong {
+.unit-cleanliness-head > div {
+  min-width: 0;
+}
+.unit-cleanliness-head span,
+.unit-cleanliness-head strong {
   display: block;
   overflow-wrap: anywhere;
 }
-.unit-condition-summary span {
+.unit-cleanliness-head > div > span {
+  color: #38536f;
+  font-size: 12px;
+  font-weight: 850;
+}
+.unit-cleanliness-head > div > strong {
+  margin-top: 2px;
+  color: #0a2a57;
+  font-size: 18px;
+  font-weight: 950;
+  line-height: 1.25;
+}
+.cleanliness-status-badge {
+  flex: 0 0 auto;
+  max-width: 132px;
+  padding: 5px 9px;
+  border-radius: var(--radius-pill);
+  background: var(--clean-accent);
+  color: #fff;
+  font-size: 11px;
+  font-weight: 950;
+  line-height: 1.25;
+  text-align: center;
+}
+.unit-cleanliness-main {
+  display: grid;
+  grid-template-columns: 104px minmax(0, 1fr);
+  gap: 14px;
+  align-items: center;
+  min-width: 0;
+}
+.cleanliness-ring {
+  position: relative;
+  display: grid;
+  place-items: center;
+  width: 104px;
+  aspect-ratio: 1;
+  flex: 0 0 auto;
+  border-radius: 50%;
+  background: conic-gradient(var(--clean-accent) calc(var(--clean-score) * 1%), #d9e5ef 0);
+  box-shadow: 0 8px 18px -14px rgba(10, 42, 87, 0.8);
+}
+.cleanliness-ring::before {
+  position: absolute;
+  inset: 9px;
+  border-radius: 50%;
+  background: #fff;
+  content: "";
+}
+.cleanliness-ring > div {
+  position: relative;
+  z-index: 1;
+  display: grid;
+  gap: 1px;
+  text-align: center;
+}
+.cleanliness-ring strong {
+  color: #0a2a57;
+  font-size: 25px;
+  font-weight: 950;
+  line-height: 1;
+}
+.cleanliness-ring span {
+  color: #52677d;
+  font-size: 10px;
+  font-weight: 850;
+}
+.cleanliness-summary {
+  display: grid;
+  gap: 9px;
+  min-width: 0;
+}
+.cleanliness-date,
+.cleanliness-recommendation {
+  min-width: 0;
+}
+.cleanliness-date span,
+.cleanliness-date strong,
+.cleanliness-date small,
+.cleanliness-recommendation strong,
+.cleanliness-recommendation p {
+  display: block;
+  overflow-wrap: anywhere;
+}
+.cleanliness-date span {
   color: #52677d;
   font-size: 11px;
   font-weight: 800;
 }
-.unit-condition-summary strong {
-  margin-top: 2px;
+.cleanliness-date strong {
+  margin-top: 1px;
   color: #0a2a57;
-  font-size: 13px;
+  font-size: 14px;
   font-weight: 950;
+}
+.cleanliness-date small {
+  margin-top: 1px;
+  color: #38536f;
+  font-size: 11px;
+  font-weight: 800;
+}
+.cleanliness-recommendation {
+  padding-top: 8px;
+  border-top: 1px solid rgba(10, 42, 87, 0.12);
+}
+.cleanliness-recommendation strong {
+  color: #173a60;
+  font-size: 12px;
+  font-weight: 950;
+  line-height: 1.4;
+}
+.cleanliness-recommendation p {
+  margin: 3px 0 0;
+  color: #52677d;
+  font-size: 11px;
+  font-weight: 750;
+  line-height: 1.4;
+}
+.cleanliness-basis {
+  color: #52677d;
+  font-size: 10px;
+  font-weight: 750;
+  line-height: 1.35;
+}
+@media (max-width: 380px) {
+  .unit-cleanliness-card {
+    padding: 12px;
+  }
+  .unit-cleanliness-main {
+    grid-template-columns: 92px minmax(0, 1fr);
+    gap: 11px;
+  }
+  .cleanliness-ring {
+    width: 92px;
+  }
+  .cleanliness-ring strong {
+    font-size: 22px;
+  }
 }
 .unit-measurements {
   padding: 12px;

--- a/customer-app/assets/customer-app.js
+++ b/customer-app/assets/customer-app.js
@@ -3,7 +3,7 @@
 
   const App = window.CWFCustomerAppV2;
   const BOOT_TIMEOUT_MS = 3500;
-  const BUILD_ID = "20260714_tracking_health_passport_v1";
+  const BUILD_ID = "20260714_tracking_cleanliness_donut_v1";
 
   function withTimeout(promise, timeoutMs) {
     return Promise.race([

--- a/customer-app/index.html
+++ b/customer-app/index.html
@@ -21,10 +21,10 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Noto+Sans+Thai:wght@400;500;600;700;800;900&display=swap" media="print" onload="this.media='all'">
   <noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Noto+Sans+Thai:wght@400;500;600;700;800;900&display=swap"></noscript>
-  <link rel="manifest" href="./manifest.webmanifest?v=20260714_tracking_health_passport_v1">
+  <link rel="manifest" href="./manifest.webmanifest?v=20260714_tracking_cleanliness_donut_v1">
   <link rel="icon" type="image/png" sizes="192x192" href="./assets/icons/cwf-customer-192.png">
   <link rel="apple-touch-icon" sizes="180x180" href="./assets/icons/cwf-customer-180.png">
-  <link rel="stylesheet" href="./assets/customer-app.css?v=20260714_tracking_health_passport_v1">
+  <link rel="stylesheet" href="./assets/customer-app.css?v=20260714_tracking_cleanliness_donut_v1">
 </head>
 <body class="is-app-booting">
   <div class="app-shell" data-app-shell>
@@ -62,22 +62,22 @@
     </nav>
   </div>
 
-  <script src="./modules/state.js?v=20260714_tracking_health_passport_v1"></script>
-  <script src="./modules/utils.js?v=20260714_tracking_health_passport_v1"></script>
-  <script src="./modules/analytics.js?v=20260714_tracking_health_passport_v1"></script>
-  <script src="./modules/api.js?v=20260714_tracking_health_passport_v1"></script>
-  <script src="./modules/pageAvailability.js?v=20260714_tracking_health_passport_v1"></script>
-  <script src="./modules/services.js?v=20260714_tracking_health_passport_v1"></script>
-  <script src="./modules/ui.js?v=20260714_tracking_health_passport_v1"></script>
-  <script src="./modules/store.js?v=20260714_tracking_health_passport_v1"></script>
-  <script src="./modules/auth.js?v=20260714_tracking_health_passport_v1"></script>
-  <script src="./modules/pricing.js?v=20260714_tracking_health_passport_v1"></script>
-  <script src="./modules/availability.js?v=20260714_tracking_health_passport_v1"></script>
-  <script src="./modules/bookingScheduled.js?v=20260714_tracking_health_passport_v1"></script>
-  <script src="./modules/bookingUrgent.js?v=20260714_tracking_health_passport_v1"></script>
-  <script src="./modules/tracking.js?v=20260714_tracking_health_passport_v1"></script>
-  <script src="./modules/profile.js?v=20260714_tracking_health_passport_v1"></script>
-  <script src="./modules/router.js?v=20260714_tracking_health_passport_v1"></script>
-  <script src="./assets/customer-app.js?v=20260714_tracking_health_passport_v1"></script>
+  <script src="./modules/state.js?v=20260714_tracking_cleanliness_donut_v1"></script>
+  <script src="./modules/utils.js?v=20260714_tracking_cleanliness_donut_v1"></script>
+  <script src="./modules/analytics.js?v=20260714_tracking_cleanliness_donut_v1"></script>
+  <script src="./modules/api.js?v=20260714_tracking_cleanliness_donut_v1"></script>
+  <script src="./modules/pageAvailability.js?v=20260714_tracking_cleanliness_donut_v1"></script>
+  <script src="./modules/services.js?v=20260714_tracking_cleanliness_donut_v1"></script>
+  <script src="./modules/ui.js?v=20260714_tracking_cleanliness_donut_v1"></script>
+  <script src="./modules/store.js?v=20260714_tracking_cleanliness_donut_v1"></script>
+  <script src="./modules/auth.js?v=20260714_tracking_cleanliness_donut_v1"></script>
+  <script src="./modules/pricing.js?v=20260714_tracking_cleanliness_donut_v1"></script>
+  <script src="./modules/availability.js?v=20260714_tracking_cleanliness_donut_v1"></script>
+  <script src="./modules/bookingScheduled.js?v=20260714_tracking_cleanliness_donut_v1"></script>
+  <script src="./modules/bookingUrgent.js?v=20260714_tracking_cleanliness_donut_v1"></script>
+  <script src="./modules/tracking.js?v=20260714_tracking_cleanliness_donut_v1"></script>
+  <script src="./modules/profile.js?v=20260714_tracking_cleanliness_donut_v1"></script>
+  <script src="./modules/router.js?v=20260714_tracking_cleanliness_donut_v1"></script>
+  <script src="./assets/customer-app.js?v=20260714_tracking_cleanliness_donut_v1"></script>
 </body>
 </html>

--- a/customer-app/manifest.webmanifest
+++ b/customer-app/manifest.webmanifest
@@ -2,7 +2,7 @@
   "name": "CWF Customer Service",
   "short_name": "CWF Service",
   "description": "แอปลูกค้า Coldwindflow สำหรับเลือกบริการ จองคิว และติดตามงาน",
-  "start_url": "/customer-app/index.html?v=20260714_tracking_health_passport_v1#home",
+  "start_url": "/customer-app/index.html?v=20260714_tracking_cleanliness_donut_v1#home",
   "scope": "/customer-app/",
   "id": "/customer-app/",
   "display": "standalone",

--- a/customer-app/modules/tracking.js
+++ b/customer-app/modules/tracking.js
@@ -267,89 +267,95 @@
     return Math.max(0, Math.min(100, Math.round(score)));
   }
 
-  function cleanlinessRecommendation(lastCleanedAt, rawScore, nowMs = Date.now()) {
-    const date = lastCleanedAt instanceof Date ? lastCleanedAt : parseDate(lastCleanedAt);
+  function cleanlinessRecommendation(serviceCompletedAt, rawScore, profile, nowMs = Date.now()) {
+    const date = serviceCompletedAt instanceof Date ? serviceCompletedAt : parseDate(serviceCompletedAt);
     const numericScore = Number(rawScore);
     const score = Number.isFinite(numericScore) ? Math.max(0, Math.min(100, Math.round(numericScore))) : null;
+    const profileMonths = Number(profile && profile.coilMonths);
+    const cycleDays = Math.max(1, Math.round((Number.isFinite(profileMonths) && profileMonths > 0 ? profileMonths : 5) * 30.4375));
+    const excellentMaxDays = Math.floor(cycleDays * 0.3);
+    const goodMaxDays = Math.floor(cycleDays * 0.6);
+    const cycleText = clean(profile && profile.nextText) || `ประมาณ ${Math.max(1, Math.round(cycleDays / 30.4375))} เดือน`;
     const elapsedDays = daysSince(date, nowMs);
     if (elapsedDays == null) {
       return {
         tone: "unknown",
         status: "ยังประเมินรอบล้างไม่ได้",
         score: null,
+        cycleDays,
+        excellentMaxDays,
+        goodMaxDays,
+        cycleText,
         elapsedDays: null,
-        elapsedText: "ยังไม่มีวันที่ล้างล่าสุด",
-        lastCleanedText: "-",
-        recommendation: "ยังไม่มีวันที่ปิดงานล้างสำหรับคำนวณรอบถัดไป",
+        elapsedText: "ยังไม่มีวันที่จบงานนี้",
+        serviceDateText: "-",
+        recommendation: "ยังไม่มีวันที่จบงานนี้สำหรับคำนวณรอบถัดไป",
         nextText: "ติดตามสภาพการใช้งานและติดต่อ CWF หากต้องการตรวจสอบ",
       };
     }
 
     let result;
-    if (elapsedDays <= 45) {
+    if (elapsedDays <= excellentMaxDays) {
       result = {
         tone: "excellent",
         status: "สะอาดมาก",
         recommendation: "เพิ่งล้างไม่นาน ยังอยู่ในสภาพพร้อมใช้งาน",
-        nextText: `แนะนำติดตามสภาพอีกครั้งในอีก ${approximateFutureText(90 - elapsedDays)}`,
+        nextText: `รอบบริการนี้แนะนำประมาณ ${cycleText} · ติดตามสภาพอีกครั้งในอีก ${approximateFutureText(goodMaxDays - elapsedDays)}`,
       };
-    } else if (elapsedDays <= 90) {
+    } else if (elapsedDays <= goodMaxDays) {
       result = {
         tone: "good",
         status: "ยังอยู่ในสภาพดี",
         recommendation: "ยังใช้งานได้ดี แนะนำติดตามสภาพและล้างตามรอบ",
-        nextText: `วางแผนรอบล้างในอีก ${approximateFutureText(150 - elapsedDays)}`,
+        nextText: `รอบบริการนี้แนะนำประมาณ ${cycleText} · วางแผนรอบล้างในอีก ${approximateFutureText(cycleDays - elapsedDays)}`,
       };
-    } else if (elapsedDays <= 150) {
+    } else if (elapsedDays <= cycleDays) {
       result = {
         tone: "watch",
         status: "ใกล้ถึงรอบล้าง",
         recommendation: "เริ่มเข้าใกล้รอบล้าง แนะนำวางแผนล้างครั้งถัดไป",
-        nextText: elapsedDays === 150
-          ? "ถึงรอบล้างที่แนะนำแล้ว"
-          : `เหลืออีก ${approximateFutureText(150 - elapsedDays)} ถึงรอบล้างที่แนะนำ`,
+        nextText: elapsedDays === cycleDays
+          ? `รอบบริการนี้แนะนำประมาณ ${cycleText} · ถึงรอบล้างที่แนะนำแล้ว`
+          : `รอบบริการนี้แนะนำประมาณ ${cycleText} · เหลืออีก ${approximateFutureText(cycleDays - elapsedDays)} ถึงรอบล้างที่แนะนำ`,
       };
     } else {
       result = {
         tone: "due",
         status: "ควรล้าง",
         recommendation: "ผ่านมาค่อนข้างนาน แนะนำล้างเพื่อคงประสิทธิภาพและความสะอาด",
-        nextText: `เกินรอบแนะนำมาแล้ว ${elapsedCleaningText(elapsedDays - 150)}`,
+        nextText: `รอบบริการนี้แนะนำประมาณ ${cycleText} · เกินรอบแนะนำมาแล้ว ${elapsedCleaningText(elapsedDays - cycleDays)}`,
       };
     }
 
     // Time remains authoritative: a high score cannot hide an overdue service.
-    // A low estimate may raise concern, but never tells a just-cleaned customer
-    // to clean again immediately.
-    if (score != null && elapsedDays > 45 && score < 45 && result.tone !== "due") {
-      result = {
-        tone: "due",
-        status: "ควรวางแผนล้าง",
-        recommendation: "คะแนนประเมินลดลง แนะนำวางแผนล้างเพื่อรักษาความสะอาด",
-        nextText: "เลือกเวลาที่สะดวกสำหรับรอบบริการครั้งถัดไป",
-      };
-    } else if (score != null && elapsedDays > 45 && score < 70 && result.tone === "good") {
-      result = {
-        tone: "watch",
-        status: "ใกล้ถึงรอบล้าง",
-        recommendation: "สภาพโดยประมาณเริ่มลดลง แนะนำติดตามและวางแผนรอบล้าง",
-        nextText: `วางแผนรอบล้างในอีก ${approximateFutureText(150 - elapsedDays)}`,
-      };
-    } else if (score != null && elapsedDays <= 45 && score < 45) {
+    // A low estimate can raise a pre-cycle result to watch, but only elapsed
+    // time beyond the profile cycle can mark the service as due.
+    if (score != null && elapsedDays <= excellentMaxDays && score < 45) {
       result = {
         tone: "watch",
         status: "ควรติดตามสภาพ",
         recommendation: "เพิ่งล้างไม่นาน แต่คะแนนประเมินต่ำกว่าปกติ",
-        nextText: "หากความเย็นหรือแรงลมลดลง ติดต่อ CWF เพื่อตรวจสอบ",
+        nextText: `รอบบริการนี้แนะนำประมาณ ${cycleText} · หากความเย็นหรือแรงลมลดลง ติดต่อ CWF เพื่อตรวจสอบ`,
+      };
+    } else if (score != null && elapsedDays <= cycleDays && score < 70 && (result.tone === "excellent" || result.tone === "good")) {
+      result = {
+        tone: "watch",
+        status: "ใกล้ถึงรอบล้าง",
+        recommendation: "สภาพโดยประมาณเริ่มลดลง แนะนำติดตามและวางแผนรอบล้าง",
+        nextText: `รอบบริการนี้แนะนำประมาณ ${cycleText} · วางแผนรอบล้างในอีก ${approximateFutureText(cycleDays - elapsedDays)}`,
       };
     }
 
     return {
       ...result,
       score,
+      cycleDays,
+      excellentMaxDays,
+      goodMaxDays,
+      cycleText,
       elapsedDays,
       elapsedText: `ผ่านมาแล้ว ${elapsedCleaningText(elapsedDays)}`,
-      lastCleanedText: formatCleaningDate(date),
+      serviceDateText: formatCleaningDate(date),
     };
   }
 
@@ -487,7 +493,7 @@
         <div class="unit-cleanliness-head">
           <div>
             <span>ความสะอาดและรอบล้าง</span>
-            <strong>สภาพความสะอาดปัจจุบัน</strong>
+            <strong>ประมาณการความสะอาดจากงานนี้</strong>
           </div>
           <span class="cleanliness-status-badge">${esc(model.status)}</span>
         </div>
@@ -500,8 +506,8 @@
           </div>
           <div class="cleanliness-summary">
             <div class="cleanliness-date">
-              <span>ล้างล่าสุด</span>
-              <strong>${esc(model.lastCleanedText)}</strong>
+              <span>วันที่ล้างของงานนี้</span>
+              <strong>${esc(model.serviceDateText)}</strong>
               <small>${esc(model.elapsedText)}</small>
             </div>
             <div class="cleanliness-recommendation">
@@ -510,7 +516,7 @@
             </div>
           </div>
         </div>
-        ${hasScore ? `<small class="cleanliness-basis">คะแนนประเมินจากรอบบริการล่าสุด</small>` : ""}
+        <small class="cleanliness-basis">อ้างอิงจากวันที่จบงานนี้และประเภทบริการ</small>
       </section>
     `;
   }
@@ -723,7 +729,7 @@
     const drainAlertMonths = hasDrainRisk(data) ? 4 : 6;
     const drainScore = done ? healthScore(months, drainAlertMonths) : null;
     const cleanliness = done && profile.kind !== "general"
-      ? cleanlinessRecommendation(completedAt, coilScore)
+      ? cleanlinessRecommendation(completedAt, coilScore, profile)
       : null;
     const warranty = warrantyInfo(data, completedAt);
     const units = unitList(data);
@@ -736,7 +742,7 @@
     const warrantyMeta = warranty
       ? `${warranty.active ? `เหลือ ${warranty.daysLeft} วัน` : "ครบ 30 วันแล้ว"} · สิ้นสุด ${root.utils.formatDateTime(warranty.end.toISOString())}`
       : "ยังไม่มีวันที่ปิดงานที่ชัดเจนสำหรับนับประกัน";
-    const estimateBasis = usesAppointmentEstimate ? "วันนัดหมาย" : "วันที่ล้างล่าสุด";
+    const estimateBasis = usesAppointmentEstimate ? "วันนัดหมาย" : "วันที่จบงานนี้";
 
     return `
       <section class="passport-shell">
@@ -1693,6 +1699,7 @@
       renderTimeline,
       cleanlinessRecommendation,
       renderCleanlinessHighlight,
+      serviceProfile,
       structuredMeasurements,
       unitInspection,
     },

--- a/customer-app/modules/tracking.js
+++ b/customer-app/modules/tracking.js
@@ -516,7 +516,7 @@
             </div>
           </div>
         </div>
-        <small class="cleanliness-basis">อ้างอิงจากวันที่จบงานนี้และประเภทบริการ</small>
+        ${model.elapsedDays == null ? "" : `<small class="cleanliness-basis">อ้างอิงจากวันที่จบงานนี้และประเภทบริการ</small>`}
       </section>
     `;
   }

--- a/customer-app/modules/tracking.js
+++ b/customer-app/modules/tracking.js
@@ -213,8 +213,39 @@
     return days / 30.4375;
   }
 
+  function daysSince(date, nowMs = Date.now()) {
+    if (!date || !Number.isFinite(date.getTime())) return null;
+    return Math.max(0, Math.floor((Number(nowMs) - date.getTime()) / 86400000));
+  }
+
+  function elapsedCleaningText(days) {
+    if (!Number.isFinite(days)) return "";
+    if (days === 0) return "วันนี้";
+    if (days < 30) return `${days} วัน`;
+    const months = Math.max(1, Math.floor(days / 30));
+    return `ประมาณ ${months} เดือน`;
+  }
+
+  function approximateFutureText(days) {
+    if (!Number.isFinite(days) || days <= 0) return "ถึงรอบแนะนำแล้ว";
+    if (days < 60) return `${Math.ceil(days)} วัน`;
+    return `ประมาณ ${Math.max(1, Math.round(days / 30))} เดือน`;
+  }
+
+  function formatCleaningDate(date) {
+    if (!date || !Number.isFinite(date.getTime())) return "-";
+    return new Intl.DateTimeFormat("th-TH", {
+      day: "numeric",
+      month: "short",
+      year: "numeric",
+    }).format(date);
+  }
+
   function serviceProfile(data) {
-    const text = clean([data.job_type, data.service_summary, data.items_text].filter(Boolean).join(" ")).toLowerCase();
+    const itemText = Array.isArray(data.service_items)
+      ? data.service_items.map((item) => clean(item && item.item_name)).filter(Boolean).join(" ")
+      : "";
+    const text = clean([data.job_type, data.service_summary, data.items_text, itemText].filter(Boolean).join(" ")).toLowerCase();
     if (/full|heavy|disassembly|overhaul|ถอด|ตัดล้างใหญ่|ล้างใหญ่/.test(text)) {
       return { kind: "heavy", label: "ตัดล้างใหญ่", coilMonths: 10, nextText: "8-12 เดือน" };
     }
@@ -236,13 +267,90 @@
     return Math.max(0, Math.min(100, Math.round(score)));
   }
 
-  function coilLabel(score) {
-    if (score == null) return "รอข้อมูลงานเสร็จ";
-    if (score >= 90) return "สะอาดมาก";
-    if (score >= 70) return "ยังดี";
-    if (score >= 45) return "เริ่มมีฝุ่นสะสม";
-    if (score >= 20) return "ควรล้างเร็ว ๆ นี้";
-    return "เกินรอบแนะนำ";
+  function cleanlinessRecommendation(lastCleanedAt, rawScore, nowMs = Date.now()) {
+    const date = lastCleanedAt instanceof Date ? lastCleanedAt : parseDate(lastCleanedAt);
+    const numericScore = Number(rawScore);
+    const score = Number.isFinite(numericScore) ? Math.max(0, Math.min(100, Math.round(numericScore))) : null;
+    const elapsedDays = daysSince(date, nowMs);
+    if (elapsedDays == null) {
+      return {
+        tone: "unknown",
+        status: "ยังประเมินรอบล้างไม่ได้",
+        score: null,
+        elapsedDays: null,
+        elapsedText: "ยังไม่มีวันที่ล้างล่าสุด",
+        lastCleanedText: "-",
+        recommendation: "ยังไม่มีวันที่ปิดงานล้างสำหรับคำนวณรอบถัดไป",
+        nextText: "ติดตามสภาพการใช้งานและติดต่อ CWF หากต้องการตรวจสอบ",
+      };
+    }
+
+    let result;
+    if (elapsedDays <= 45) {
+      result = {
+        tone: "excellent",
+        status: "สะอาดมาก",
+        recommendation: "เพิ่งล้างไม่นาน ยังอยู่ในสภาพพร้อมใช้งาน",
+        nextText: `แนะนำติดตามสภาพอีกครั้งในอีก ${approximateFutureText(90 - elapsedDays)}`,
+      };
+    } else if (elapsedDays <= 90) {
+      result = {
+        tone: "good",
+        status: "ยังอยู่ในสภาพดี",
+        recommendation: "ยังใช้งานได้ดี แนะนำติดตามสภาพและล้างตามรอบ",
+        nextText: `วางแผนรอบล้างในอีก ${approximateFutureText(150 - elapsedDays)}`,
+      };
+    } else if (elapsedDays <= 150) {
+      result = {
+        tone: "watch",
+        status: "ใกล้ถึงรอบล้าง",
+        recommendation: "เริ่มเข้าใกล้รอบล้าง แนะนำวางแผนล้างครั้งถัดไป",
+        nextText: elapsedDays === 150
+          ? "ถึงรอบล้างที่แนะนำแล้ว"
+          : `เหลืออีก ${approximateFutureText(150 - elapsedDays)} ถึงรอบล้างที่แนะนำ`,
+      };
+    } else {
+      result = {
+        tone: "due",
+        status: "ควรล้าง",
+        recommendation: "ผ่านมาค่อนข้างนาน แนะนำล้างเพื่อคงประสิทธิภาพและความสะอาด",
+        nextText: `เกินรอบแนะนำมาแล้ว ${elapsedCleaningText(elapsedDays - 150)}`,
+      };
+    }
+
+    // Time remains authoritative: a high score cannot hide an overdue service.
+    // A low estimate may raise concern, but never tells a just-cleaned customer
+    // to clean again immediately.
+    if (score != null && elapsedDays > 45 && score < 45 && result.tone !== "due") {
+      result = {
+        tone: "due",
+        status: "ควรวางแผนล้าง",
+        recommendation: "คะแนนประเมินลดลง แนะนำวางแผนล้างเพื่อรักษาความสะอาด",
+        nextText: "เลือกเวลาที่สะดวกสำหรับรอบบริการครั้งถัดไป",
+      };
+    } else if (score != null && elapsedDays > 45 && score < 70 && result.tone === "good") {
+      result = {
+        tone: "watch",
+        status: "ใกล้ถึงรอบล้าง",
+        recommendation: "สภาพโดยประมาณเริ่มลดลง แนะนำติดตามและวางแผนรอบล้าง",
+        nextText: `วางแผนรอบล้างในอีก ${approximateFutureText(150 - elapsedDays)}`,
+      };
+    } else if (score != null && elapsedDays <= 45 && score < 45) {
+      result = {
+        tone: "watch",
+        status: "ควรติดตามสภาพ",
+        recommendation: "เพิ่งล้างไม่นาน แต่คะแนนประเมินต่ำกว่าปกติ",
+        nextText: "หากความเย็นหรือแรงลมลดลง ติดต่อ CWF เพื่อตรวจสอบ",
+      };
+    }
+
+    return {
+      ...result,
+      score,
+      elapsedDays,
+      elapsedText: `ผ่านมาแล้ว ${elapsedCleaningText(elapsedDays)}`,
+      lastCleanedText: formatCleaningDate(date),
+    };
   }
 
   function hasDrainRisk(data) {
@@ -366,6 +474,47 @@
     `;
   }
 
+  function renderCleanlinessHighlight(model) {
+    if (!model) return "";
+    const hasScore = Number.isFinite(model.score);
+    const score = hasScore ? Math.max(0, Math.min(100, Math.round(model.score))) : 0;
+    const ringLabel = hasScore ? `${score}%` : "--";
+    const ringAria = hasScore
+      ? `คะแนนสภาพความสะอาดโดยประมาณ ${score} เปอร์เซ็นต์`
+      : "ยังไม่มีคะแนนสภาพความสะอาด";
+    return `
+      <section class="unit-cleanliness-card tone-${esc(model.tone)}" data-unit-cleanliness>
+        <div class="unit-cleanliness-head">
+          <div>
+            <span>ความสะอาดและรอบล้าง</span>
+            <strong>สภาพความสะอาดปัจจุบัน</strong>
+          </div>
+          <span class="cleanliness-status-badge">${esc(model.status)}</span>
+        </div>
+        <div class="unit-cleanliness-main">
+          <div class="cleanliness-ring" style="--clean-score:${score}" role="img" aria-label="${esc(ringAria)}">
+            <div>
+              <strong>${esc(ringLabel)}</strong>
+              <span>คะแนนประเมิน</span>
+            </div>
+          </div>
+          <div class="cleanliness-summary">
+            <div class="cleanliness-date">
+              <span>ล้างล่าสุด</span>
+              <strong>${esc(model.lastCleanedText)}</strong>
+              <small>${esc(model.elapsedText)}</small>
+            </div>
+            <div class="cleanliness-recommendation">
+              <strong>${esc(model.recommendation)}</strong>
+              <p>${esc(model.nextText)}</p>
+            </div>
+          </div>
+        </div>
+        ${hasScore ? `<small class="cleanliness-basis">คะแนนประเมินจากรอบบริการล่าสุด</small>` : ""}
+      </section>
+    `;
+  }
+
   function structuredMeasurements(unit) {
     const source = unit.measurements && typeof unit.measurements === "object" ? unit.measurements : {};
     const definitions = [
@@ -445,12 +594,7 @@
                     <p>${esc(inspection.overall.detail)}</p>
                   </div>
                   ${inspection.hasMetricData ? `<div class="unit-inspection-grid">${inspection.metrics.map(metricStatusCard).join("")}</div>` : ""}
-                  ${context.coilScore == null ? "" : `
-                    <div class="unit-condition-summary">
-                      <div><span>ความสะอาดหลังบริการ</span><strong>${esc(coilLabel(context.coilScore))}</strong></div>
-                      <div><span>คะแนนประเมิน</span><strong>${context.coilScore}%</strong></div>
-                    </div>
-                  `}
+                  ${renderCleanlinessHighlight(context.cleanliness)}
                   ${measurements.length ? `
                     <section class="unit-measurements" data-unit-measurements>
                       <h4>ค่าตรวจวัดเพิ่มเติม</h4>
@@ -578,6 +722,9 @@
     const coilScore = done ? healthScore(months, profile.coilMonths) : null;
     const drainAlertMonths = hasDrainRisk(data) ? 4 : 6;
     const drainScore = done ? healthScore(months, drainAlertMonths) : null;
+    const cleanliness = done && profile.kind !== "general"
+      ? cleanlinessRecommendation(completedAt, coilScore)
+      : null;
     const warranty = warrantyInfo(data, completedAt);
     const units = unitList(data);
     const next = recommendation(data, coilScore, drainScore, profile, done);
@@ -614,7 +761,7 @@
             ${done && clean(data.technician_note) ? `<div class="passport-note"><b>หมายเหตุจากช่าง</b><p>${esc(data.technician_note)}</p></div>` : ""}
           </article>
 
-          ${renderUnitPassportCards(data, units, { coilScore })}
+          ${renderUnitPassportCards(data, units, { cleanliness })}
 
           <article class="passport-card passport-warranty-card">
             <div class="passport-card-head">
@@ -638,15 +785,17 @@
             </div>
           </article>
 
-          <article class="passport-card passport-recommend-card">
-            <div class="passport-card-head">
-              <span>บริการครั้งถัดไป</span>
-              <strong>คำแนะนำ</strong>
-            </div>
-            <h3>${esc(next.title)}</h3>
-            <p>${esc(next.reason)}</p>
-            <small>คะแนนประเมินอ้างอิงจาก${esc(estimateBasis)}และรอบบริการ ไม่ใช่ค่าจากเครื่องมือวัด</small>
-          </article>
+          ${cleanliness ? "" : `
+            <article class="passport-card passport-recommend-card">
+              <div class="passport-card-head">
+                <span>บริการครั้งถัดไป</span>
+                <strong>คำแนะนำ</strong>
+              </div>
+              <h3>${esc(next.title)}</h3>
+              <p>${esc(next.reason)}</p>
+              <small>คะแนนประเมินอ้างอิงจาก${esc(estimateBasis)}และรอบบริการ ไม่ใช่ค่าจากเครื่องมือวัด</small>
+            </article>
+          `}
         </div>
       </section>
     `;
@@ -1542,6 +1691,8 @@
       renderUnitPassportCards,
       renderTrackingResult,
       renderTimeline,
+      cleanlinessRecommendation,
+      renderCleanlinessHighlight,
       structuredMeasurements,
       unitInspection,
     },

--- a/customer-app/sw.js
+++ b/customer-app/sw.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const BUILD_ID = "20260714_tracking_health_passport_v1";
+const BUILD_ID = "20260714_tracking_cleanliness_donut_v1";
 const CACHE_NAME = `cwf-customer-app-v2-${BUILD_ID}`;
 const APP_SHELL = [
   `./index.html?v=${BUILD_ID}`,

--- a/test/customerAppPageAvailability.test.js
+++ b/test/customerAppPageAvailability.test.js
@@ -281,7 +281,7 @@ test("api exposes loadCustomerAppConfig as a no-store GET to /public/customer-ap
 });
 
 test("build wiring: pageAvailability.js is registered in the HTML shell and the SW cache, with the new build id", () => {
-  const build = "20260714_tracking_health_passport_v1";
+  const build = "20260714_tracking_cleanliness_donut_v1";
   assert.match(indexHtml, new RegExp(`modules/pageAvailability\\.js\\?v=${build}`));
   assert.match(swSrc, new RegExp(`BUILD_ID = "${build}"`));
   assert.match(swSrc, /modules\/pageAvailability\.js\?v=\$\{BUILD_ID\}/);
@@ -294,7 +294,7 @@ test("build wiring: pageAvailability.js is registered in the HTML shell and the 
    RUNTIME tests (execute the real code in a VM — not regex assertions).
    ========================================================================== */
 
-const BUILD = "20260714_tracking_health_passport_v1";
+const BUILD = "20260714_tracking_cleanliness_donut_v1";
 const adminSrc = read("admin-homepage-cms.js");
 
 function reqUrlOf(req) {

--- a/test/customerAppRecovery.test.js
+++ b/test/customerAppRecovery.test.js
@@ -236,7 +236,7 @@ test("Customer App build id is consistent across shell and service worker", () =
   const sw = read("customer-app/sw.js");
   const app = read("customer-app/assets/customer-app.js");
   const manifest = read("customer-app/manifest.webmanifest");
-  const build = "20260714_tracking_health_passport_v1";
+  const build = "20260714_tracking_cleanliness_donut_v1";
 
   assert.match(index, new RegExp(`customer-app\\.css\\?v=${build}`));
   assert.match(index, new RegExp(`modules\\/api\\.js\\?v=${build}`));
@@ -254,7 +254,7 @@ test("Customer App build id is consistent across shell and service worker", () =
 test("store module is loaded in index.html and precached in the service worker app shell", () => {
   const index = read("customer-app/index.html");
   const sw = read("customer-app/sw.js");
-  const build = "20260714_tracking_health_passport_v1";
+  const build = "20260714_tracking_cleanliness_donut_v1";
 
   assert.match(index, new RegExp(`modules/store\\.js\\?v=${build}`));
   assert.match(sw, /`\.\/modules\/store\.js\?v=\$\{BUILD_ID\}`/);

--- a/test/customerAppStorePayment.test.js
+++ b/test/customerAppStorePayment.test.js
@@ -58,7 +58,7 @@ test("store falls back to the LINE hand-off when payment is unconfigured or the 
 test("payment step styles exist and the Customer App payment build id is bumped", () => {
   assert.match(cssSrc, /\.pay-method-btn/);
   assert.match(cssSrc, /\.pay-qr-img/);
-  assert.match(read("customer-app/index.html"), /modules\/store\.js\?v=20260714_tracking_health_passport_v1/);
-  assert.match(read("customer-app/sw.js"), /BUILD_ID = "20260714_tracking_health_passport_v1"/);
+  assert.match(read("customer-app/index.html"), /modules\/store\.js\?v=20260714_tracking_cleanliness_donut_v1/);
+  assert.match(read("customer-app/sw.js"), /BUILD_ID = "20260714_tracking_cleanliness_donut_v1"/);
   assert.match(storeSrc, /payment-security 20260705 loaded/);
 });

--- a/test/customerBookingAdminNotifications.test.js
+++ b/test/customerBookingAdminNotifications.test.js
@@ -311,10 +311,10 @@ test("admin/customer frontend cache versions are bumped for booking notification
   assert.doesNotMatch(adminReviewHtml, /admin-review-v2\.js\?v=20260707_customer_booking_notify_v2/);
   assert.match(adminReviewHtml, /admin-review-ai-intake\.js\?v=ai-booking-intake-customer-cards-v11-admin-alert-gate/);
   assert.doesNotMatch(adminReviewHtml, /admin-review-ai-intake\.js\?v=ai-booking-intake-customer-cards-v10/);
-  assert.match(customerIndex, /bookingScheduled\.js\?v=20260714_tracking_health_passport_v1/);
-  assert.match(customerIndex, /state\.js\?v=20260714_tracking_health_passport_v1/);
-  assert.match(customerSw, /const BUILD_ID = "20260714_tracking_health_passport_v1"/);
-  assert.match(customerManifest, /20260714_tracking_health_passport_v1/);
+  assert.match(customerIndex, /bookingScheduled\.js\?v=20260714_tracking_cleanliness_donut_v1/);
+  assert.match(customerIndex, /state\.js\?v=20260714_tracking_cleanliness_donut_v1/);
+  assert.match(customerSw, /const BUILD_ID = "20260714_tracking_cleanliness_donut_v1"/);
+  assert.match(customerManifest, /20260714_tracking_cleanliness_donut_v1/);
 });
 
 test("behavior: review queue only includes customer urgent waiting rows while preserving review statuses", () => {

--- a/test/customerHistoryClaim.test.js
+++ b/test/customerHistoryClaim.test.js
@@ -544,7 +544,7 @@ test("Customer App profile opens history detail with opaque job_ref and clears c
 });
 
 test("Customer App cache version is bumped consistently", () => {
-  const expected = "20260714_tracking_health_passport_v1";
+  const expected = "20260714_tracking_cleanliness_donut_v1";
   for (const file of [
     "customer-app/index.html",
     "customer-app/sw.js",

--- a/test/customerHomepageFeaturedRotation.test.js
+++ b/test/customerHomepageFeaturedRotation.test.js
@@ -414,6 +414,6 @@ test("compact CSS and cache build remain consistent with six-card rotation", () 
   assert.match(css, /\.homepage-featured-page\s*\{[^}]*grid-area:\s*1\s*\/\s*1/s);
   assert.match(css, /transition:\s*opacity 350ms/);
   assert.match(css, /prefers-reduced-motion:\s*reduce/);
-  const build = "20260714_tracking_health_passport_v1";
+  const build = "20260714_tracking_cleanliness_donut_v1";
   for (const source of [html, sw, boot, manifest]) assert.match(source, new RegExp(build));
 });

--- a/test/customerSameDayTiming.test.js
+++ b/test/customerSameDayTiming.test.js
@@ -160,7 +160,7 @@ test("customer app disables availability HTTP cache and refreshes same-day slots
 });
 
 test("customer app build and service worker cache IDs changed", () => {
-  const id = "20260714_tracking_health_passport_v1";
+  const id = "20260714_tracking_cleanliness_donut_v1";
   for (const file of [
     "customer-app/index.html",
     "customer-app/sw.js",

--- a/test/customerTrackingFullReadUi.test.js
+++ b/test/customerTrackingFullReadUi.test.js
@@ -282,6 +282,7 @@ test("completed cleaning without finished_at renders a neutral donut fallback wi
   assert.match(html, /ยังประเมินรอบล้างไม่ได้/);
   assert.match(html, /ยังไม่มีวันที่จบงานนี้/);
   assert.doesNotMatch(html, /ล้างล่าสุด|วันที่ล้างล่าสุด|สภาพความสะอาดปัจจุบัน/);
+  assert.doesNotMatch(html, /อ้างอิงจากวันที่จบงานนี้และประเภทบริการ/);
   assert.match(html, />--</);
   assert.doesNotMatch(html, />99%|>100%/);
 });

--- a/test/customerTrackingFullReadUi.test.js
+++ b/test/customerTrackingFullReadUi.test.js
@@ -155,18 +155,20 @@ test("completed normal checklist renders one compact green inspection grid witho
 test("cleanliness recommendation is deterministic from last-cleaned date and score", () => {
   const app = loadTrackingRuntime();
   const now = Date.parse("2026-07-31T00:00:00Z");
-  const recent = app.tracking._test.cleanlinessRecommendation("2026-07-01T00:00:00Z", 95, now);
+  const cleanProfile = app.tracking._test.serviceProfile({ job_type: "ล้าง", service_summary: "ล้างปกติ" });
+  const recent = app.tracking._test.cleanlinessRecommendation("2026-07-01T00:00:00Z", 95, cleanProfile, now);
   assert.equal(recent.elapsedDays, 30);
   assert.equal(recent.tone, "excellent");
   assert.equal(recent.status, "สะอาดมาก");
   assert.match(recent.recommendation, /พร้อมใช้งาน/);
   assert.doesNotMatch(recent.recommendation, /ควรล้าง/);
+  assert.match(recent.nextText, /4-6 เดือน/);
 
-  const approaching = app.tracking._test.cleanlinessRecommendation("2026-03-25T00:00:00Z", 72, now);
+  const approaching = app.tracking._test.cleanlinessRecommendation("2026-03-25T00:00:00Z", 72, cleanProfile, now);
   assert.equal(approaching.tone, "watch");
   assert.equal(approaching.status, "ใกล้ถึงรอบล้าง");
 
-  const overdueDespiteHighScore = app.tracking._test.cleanlinessRecommendation("2026-02-21T00:00:00Z", 99, now);
+  const overdueDespiteHighScore = app.tracking._test.cleanlinessRecommendation("2026-02-21T00:00:00Z", 99, cleanProfile, now);
   assert.equal(overdueDespiteHighScore.tone, "due");
   assert.equal(overdueDespiteHighScore.status, "ควรล้าง");
   assert.match(overdueDespiteHighScore.recommendation, /แนะนำล้าง/);
@@ -175,37 +177,81 @@ test("cleanliness recommendation is deterministic from last-cleaned date and sco
 test("missing last-clean date is honest and a low score never recommends immediate recleaning", () => {
   const app = loadTrackingRuntime();
   const now = Date.parse("2026-07-31T00:00:00Z");
-  const missing = app.tracking._test.cleanlinessRecommendation(null, 99, now);
+  const cleanProfile = app.tracking._test.serviceProfile({ job_type: "ล้าง", service_summary: "ล้างปกติ" });
+  const missing = app.tracking._test.cleanlinessRecommendation(null, 99, cleanProfile, now);
   assert.equal(missing.tone, "unknown");
   assert.equal(missing.score, null);
-  assert.match(missing.recommendation, /ยังไม่มีวันที่ปิดงานล้าง/);
+  assert.match(missing.recommendation, /ยังไม่มีวันที่จบงานนี้/);
   assert.doesNotMatch(missing.recommendation, /สะอาดมาก|ควรล้าง/);
 
-  const justCleanedLowScore = app.tracking._test.cleanlinessRecommendation("2026-07-30T00:00:00Z", 30, now);
+  const justCleanedLowScore = app.tracking._test.cleanlinessRecommendation("2026-07-30T00:00:00Z", 30, cleanProfile, now);
   assert.equal(justCleanedLowScore.tone, "watch");
   assert.equal(justCleanedLowScore.status, "ควรติดตามสภาพ");
   assert.doesNotMatch(justCleanedLowScore.recommendation, /ควรล้าง/);
 
-  const olderLowScore = app.tracking._test.cleanlinessRecommendation("2026-05-12T00:00:00Z", 30, now);
-  assert.equal(olderLowScore.tone, "due");
-  assert.equal(olderLowScore.status, "ควรวางแผนล้าง");
+  const olderLowScore = app.tracking._test.cleanlinessRecommendation("2026-05-12T00:00:00Z", 30, cleanProfile, now);
+  assert.equal(olderLowScore.tone, "watch");
+  assert.notEqual(olderLowScore.status, "ควรล้าง");
 });
 
-test("cleanliness day-band boundaries are explicit and high scores never hide elapsed time", () => {
+test("cleanliness cycles follow normal premium deep and heavy service profiles", () => {
   const app = loadTrackingRuntime();
   const now = Date.parse("2026-07-31T00:00:00Z");
   const atDays = (days) => new Date(now - (days * 86400000)).toISOString();
+  const profiles = {
+    clean: app.tracking._test.serviceProfile({ job_type: "ล้าง", service_summary: "ล้างปกติ" }),
+    premium: app.tracking._test.serviceProfile({ job_type: "ล้าง", service_summary: "ล้างพรีเมียม" }),
+    deep: app.tracking._test.serviceProfile({ job_type: "ล้าง", service_summary: "ล้างลึก แขวนคอยล์" }),
+    heavy: app.tracking._test.serviceProfile({ job_type: "ล้าง", service_summary: "ตัดล้างใหญ่" }),
+  };
+
+  const at160 = Object.fromEntries(Object.entries(profiles).map(([key, profile]) => [
+    key,
+    app.tracking._test.cleanlinessRecommendation(atDays(160), 99, profile, now),
+  ]));
+  assert.equal(at160.clean.tone, "due");
+  assert.equal(at160.premium.tone, "watch");
+  assert.equal(at160.deep.tone, "watch");
+  assert.equal(at160.heavy.tone, "good");
+  assert.deepEqual(
+    [at160.clean.cycleDays, at160.premium.cycleDays, at160.deep.cycleDays, at160.heavy.cycleDays],
+    [152, 183, 213, 304],
+  );
+  assert.match(at160.clean.nextText, /4-6 เดือน/);
+  assert.match(at160.premium.nextText, /5-6 เดือน/);
+  assert.match(at160.deep.nextText, /6-8 เดือน/);
+  assert.match(at160.heavy.nextText, /8-12 เดือน/);
+
+  const heavyAtCycle = app.tracking._test.cleanlinessRecommendation(atDays(304), 99, profiles.heavy, now);
+  const heavyAfterCycle = app.tracking._test.cleanlinessRecommendation(atDays(305), 99, profiles.heavy, now);
+  assert.notEqual(heavyAtCycle.tone, "due");
+  assert.equal(heavyAfterCycle.tone, "due");
+  assert.equal(app.tracking._test.cleanlinessRecommendation(atDays(184), 99, profiles.premium, now).tone, "due");
+  assert.notEqual(app.tracking._test.cleanlinessRecommendation(atDays(184), 99, profiles.deep, now).tone, "due");
+});
+
+test("cleanliness profile boundaries are deterministic at 30, 60 and 100 percent", () => {
+  const app = loadTrackingRuntime();
+  const now = Date.parse("2026-07-31T00:00:00Z");
+  const atDays = (days) => new Date(now - (days * 86400000)).toISOString();
+  const profile = app.tracking._test.serviceProfile({ job_type: "ล้าง", service_summary: "ล้างปกติ" });
+  const reference = app.tracking._test.cleanlinessRecommendation(atDays(0), 100, profile, now);
+  assert.deepEqual(
+    [reference.excellentMaxDays, reference.goodMaxDays, reference.cycleDays],
+    [45, 91, 152],
+  );
   const cases = [
     [45, "excellent"],
     [46, "good"],
-    [90, "good"],
-    [91, "watch"],
-    [150, "watch"],
-    [151, "due"],
+    [91, "good"],
+    [92, "watch"],
+    [152, "watch"],
+    [153, "due"],
   ];
   for (const [days, tone] of cases) {
-    assert.equal(app.tracking._test.cleanlinessRecommendation(atDays(days), 100, now).tone, tone, `${days} days`);
+    assert.equal(app.tracking._test.cleanlinessRecommendation(atDays(days), 100, profile, now).tone, tone, `${days} days`);
   }
+  assert.equal(app.tracking._test.cleanlinessRecommendation(atDays(153), 100, profile, now).tone, "due");
 });
 
 test("completed cleaning renders one prominent donut with date elapsed time and recommendation", () => {
@@ -214,9 +260,13 @@ test("completed cleaning renders one prominent donut with date elapsed time and 
   assert.equal((html.match(/data-unit-cleanliness/g) || []).length, 1);
   assert.match(html, /class="cleanliness-ring"/);
   assert.match(html, />100%<|>99%</);
-  assert.match(html, /ล้างล่าสุด/);
+  assert.match(html, /ประมาณการความสะอาดจากงานนี้/);
+  assert.match(html, /วันที่ล้างของงานนี้/);
   assert.match(html, /ผ่านมาแล้ว/);
   assert.match(html, /ยังอยู่ในสภาพพร้อมใช้งาน/);
+  assert.match(html, /อ้างอิงจากวันที่จบงานนี้และประเภทบริการ/);
+  assert.match(html, /4-6 เดือน/);
+  assert.doesNotMatch(html, /ล้างล่าสุด|วันที่ล้างล่าสุด|สภาพความสะอาดปัจจุบัน/);
   assert.doesNotMatch(html, /unit-condition-summary/);
   assert.doesNotMatch(html, /passport-recommend-card/);
   assert.ok(html.indexOf("unit-inspection-grid") < html.indexOf("data-unit-cleanliness"));
@@ -230,7 +280,8 @@ test("completed cleaning without finished_at renders a neutral donut fallback wi
   const html = app.tracking._test.renderPassport(data);
   assert.match(html, /data-unit-cleanliness/);
   assert.match(html, /ยังประเมินรอบล้างไม่ได้/);
-  assert.match(html, /ยังไม่มีวันที่ล้างล่าสุด/);
+  assert.match(html, /ยังไม่มีวันที่จบงานนี้/);
+  assert.doesNotMatch(html, /ล้างล่าสุด|วันที่ล้างล่าสุด|สภาพความสะอาดปัจจุบัน/);
   assert.match(html, />--</);
   assert.doesNotMatch(html, />99%|>100%/);
 });

--- a/test/customerTrackingFullReadUi.test.js
+++ b/test/customerTrackingFullReadUi.test.js
@@ -152,6 +152,89 @@ test("completed normal checklist renders one compact green inspection grid witho
   assert.ok(html.indexOf("passport-units-card") < html.indexOf("passport-warranty-card"));
 });
 
+test("cleanliness recommendation is deterministic from last-cleaned date and score", () => {
+  const app = loadTrackingRuntime();
+  const now = Date.parse("2026-07-31T00:00:00Z");
+  const recent = app.tracking._test.cleanlinessRecommendation("2026-07-01T00:00:00Z", 95, now);
+  assert.equal(recent.elapsedDays, 30);
+  assert.equal(recent.tone, "excellent");
+  assert.equal(recent.status, "สะอาดมาก");
+  assert.match(recent.recommendation, /พร้อมใช้งาน/);
+  assert.doesNotMatch(recent.recommendation, /ควรล้าง/);
+
+  const approaching = app.tracking._test.cleanlinessRecommendation("2026-03-25T00:00:00Z", 72, now);
+  assert.equal(approaching.tone, "watch");
+  assert.equal(approaching.status, "ใกล้ถึงรอบล้าง");
+
+  const overdueDespiteHighScore = app.tracking._test.cleanlinessRecommendation("2026-02-21T00:00:00Z", 99, now);
+  assert.equal(overdueDespiteHighScore.tone, "due");
+  assert.equal(overdueDespiteHighScore.status, "ควรล้าง");
+  assert.match(overdueDespiteHighScore.recommendation, /แนะนำล้าง/);
+});
+
+test("missing last-clean date is honest and a low score never recommends immediate recleaning", () => {
+  const app = loadTrackingRuntime();
+  const now = Date.parse("2026-07-31T00:00:00Z");
+  const missing = app.tracking._test.cleanlinessRecommendation(null, 99, now);
+  assert.equal(missing.tone, "unknown");
+  assert.equal(missing.score, null);
+  assert.match(missing.recommendation, /ยังไม่มีวันที่ปิดงานล้าง/);
+  assert.doesNotMatch(missing.recommendation, /สะอาดมาก|ควรล้าง/);
+
+  const justCleanedLowScore = app.tracking._test.cleanlinessRecommendation("2026-07-30T00:00:00Z", 30, now);
+  assert.equal(justCleanedLowScore.tone, "watch");
+  assert.equal(justCleanedLowScore.status, "ควรติดตามสภาพ");
+  assert.doesNotMatch(justCleanedLowScore.recommendation, /ควรล้าง/);
+
+  const olderLowScore = app.tracking._test.cleanlinessRecommendation("2026-05-12T00:00:00Z", 30, now);
+  assert.equal(olderLowScore.tone, "due");
+  assert.equal(olderLowScore.status, "ควรวางแผนล้าง");
+});
+
+test("cleanliness day-band boundaries are explicit and high scores never hide elapsed time", () => {
+  const app = loadTrackingRuntime();
+  const now = Date.parse("2026-07-31T00:00:00Z");
+  const atDays = (days) => new Date(now - (days * 86400000)).toISOString();
+  const cases = [
+    [45, "excellent"],
+    [46, "good"],
+    [90, "good"],
+    [91, "watch"],
+    [150, "watch"],
+    [151, "due"],
+  ];
+  for (const [days, tone] of cases) {
+    assert.equal(app.tracking._test.cleanlinessRecommendation(atDays(days), 100, now).tone, tone, `${days} days`);
+  }
+});
+
+test("completed cleaning renders one prominent donut with date elapsed time and recommendation", () => {
+  const app = loadTrackingRuntime();
+  const html = app.tracking._test.renderPassport(completedHealthPayload());
+  assert.equal((html.match(/data-unit-cleanliness/g) || []).length, 1);
+  assert.match(html, /class="cleanliness-ring"/);
+  assert.match(html, />100%<|>99%</);
+  assert.match(html, /ล้างล่าสุด/);
+  assert.match(html, /ผ่านมาแล้ว/);
+  assert.match(html, /ยังอยู่ในสภาพพร้อมใช้งาน/);
+  assert.doesNotMatch(html, /unit-condition-summary/);
+  assert.doesNotMatch(html, /passport-recommend-card/);
+  assert.ok(html.indexOf("unit-inspection-grid") < html.indexOf("data-unit-cleanliness"));
+  assert.ok(html.indexOf("data-unit-cleanliness") < html.indexOf("data-unit-evidence"));
+  assert.ok(html.indexOf("passport-units-card") < html.indexOf("passport-warranty-card"));
+});
+
+test("completed cleaning without finished_at renders a neutral donut fallback without a fake score", () => {
+  const app = loadTrackingRuntime();
+  const data = completedHealthPayload({ finished_at: null, job_status: "เสร็จแล้ว" });
+  const html = app.tracking._test.renderPassport(data);
+  assert.match(html, /data-unit-cleanliness/);
+  assert.match(html, /ยังประเมินรอบล้างไม่ได้/);
+  assert.match(html, /ยังไม่มีวันที่ล้างล่าสุด/);
+  assert.match(html, />--</);
+  assert.doesNotMatch(html, />99%|>100%/);
+});
+
 test("pressure and temperature photos remain secondary evidence and never override normal status", () => {
   const app = loadTrackingRuntime();
   const html = app.tracking._test.renderPassport(completedHealthPayload());
@@ -544,7 +627,7 @@ test("tracking UI exposes loading, not-found, rate-limit and offline states", ()
 });
 
 test("tracking assets share the full-read cache build id", () => {
-  const build = "20260714_tracking_health_passport_v1";
+  const build = "20260714_tracking_cleanliness_donut_v1";
   for (const file of [
     "customer-app/index.html",
     "customer-app/sw.js",
@@ -574,4 +657,8 @@ test("tracking mobile CSS provides 360/390-safe wrapping and touch targets", () 
   assert.match(css, /\.unit-inspection-item \{[\s\S]*?min-width: 0/);
   assert.match(css, /\.unit-evidence summary \{[\s\S]*?min-height: 44px/);
   assert.match(css, /\.passport-shell \{[\s\S]*?overflow: hidden/);
+  assert.match(css, /\.unit-cleanliness-card \{[\s\S]*?min-width: 0[\s\S]*?overflow: hidden/);
+  assert.match(css, /\.unit-cleanliness-main \{[\s\S]*?grid-template-columns: 104px minmax\(0, 1fr\)/);
+  assert.match(css, /\.cleanliness-ring \{[\s\S]*?aspect-ratio: 1[\s\S]*?conic-gradient/);
+  assert.match(css, /@media \(max-width: 380px\) \{[\s\S]*?\.unit-cleanliness-main \{[\s\S]*?92px minmax\(0, 1fr\)/);
 });

--- a/test/homepageCms.test.js
+++ b/test/homepageCms.test.js
@@ -296,7 +296,7 @@ test("customer homepage has no admin control, bottom nav is fixed five-tab, and 
   const sw = read("customer-app/sw.js");
   const app = read("customer-app/assets/customer-app.js");
   const manifest = read("customer-app/manifest.webmanifest");
-  const build = "20260714_tracking_health_passport_v1";
+  const build = "20260714_tracking_cleanliness_donut_v1";
 
   assert.doesNotMatch(index + ui, /โหมดแอดมิน|openCms|localStorage\.getItem\('cwfHomeCmsDemo'/);
   assert.match(index, /data-route="store"[\s\S]*ร้านค้า/);


### PR DESCRIPTION
## Summary

- replaces the compact cleanliness percentage row with a prominent customer-facing donut card
- derives cleaning-cycle guidance from the existing per-job `finished_at` value and the detected service profile
- keeps elapsed time authoritative: a high estimated score cannot hide a service beyond its profile cycle
- keeps missing dates neutral and never invents a score or cleaning date
- preserves the inspection grid, warranty placement, Booking Code full-read access, and exact-token document/review gates
- uses Customer App build/cache ID `20260714_tracking_cleanliness_donut_v1`

## Service-profile cycle rules

`cycleDays = round(profile.coilMonths * 30.4375)`

- excellent: elapsed days <= `floor(cycleDays * 0.30)`
- good: elapsed days <= `floor(cycleDays * 0.60)`
- watch: elapsed days <= `cycleDays`
- due: elapsed days > `cycleDays`

Current profile cycles:

- normal cleaning: 152 days, displayed range 4-6 months
- premium cleaning: 183 days, displayed range 5-6 months
- deep / coil-hanging cleaning: 213 days, displayed range 6-8 months
- heavy disassembly cleaning: 304 days, displayed range 8-12 months

A low estimated score may raise a pre-cycle result to watch, but it cannot mark a just-cleaned service as due. Only elapsed time beyond the profile cycle produces due.

## Per-job date wording

The UI no longer claims that the opened job is the customer's latest cleaning or current condition. It now uses:

- “ประมาณการความสะอาดจากงานนี้”
- “วันที่ล้างของงานนี้”
- “อ้างอิงจากวันที่จบงานนี้และประเภทบริการ”

No cross-job history query or privacy-contract expansion was added.

## Changed files

Initial implementation:

- `customer-app/modules/tracking.js`
- `customer-app/assets/customer-app.css`
- Customer App build/cache wiring
- focused Tracking/build contract tests
- seven approved existing test files changed only to expect the new BUILD_ID

Review fix `2a07cce`:

- `customer-app/modules/tracking.js`
- `test/customerTrackingFullReadUi.test.js`

No CSS, BUILD_ID, backend, capability, token, document, review, authentication, or write-authorization change was made in the review fix.

## Verification

- Node syntax checks passed
- Focused cleanliness UI: 32 passed, 0 failed
- Tracking/UI/privacy/review/page-availability/build regressions: 282 passed, 0 failed
- Full suite on exact main `4dde6cd48bbe7641fad711d709f0341c6d1fa7eb`: 1216 total, 1154 passed, 28 failed, 34 skipped
- Full suite on branch: 1222 total, 1160 passed, 28 failed, 34 skipped
- Failure-name delta between base and branch: 0
- Additional failures caused by this branch: 0

The 28 full-suite failures are identical on base and branch and are confined to pre-existing catalog UI contract and customer-history migration checksum tests.

## Visual proof

Responsive fixture screenshots using the production Tracking module and CSS were captured in the Codex conversation for 360, 390, and 412 px. The PR review notes that real-device visual proof accessible from the PR remains a non-code gate. No fixture or customer data is committed.

## Remaining risks

- `finished_at` is the completion time of the opened job, not a guaranteed latest-clean date across customer history; the UI now states this accurately.
- the same job-level completion timestamp is shared by units in a multi-unit job because the current public model has no separate per-unit cleaning timestamp
- cleanliness percentage remains an estimate from service age/profile, not an instrument measurement
- real-device 360/390/412 px smoke evidence still needs to be attached by an owner with access to the target browser/device

No migration, production data write, merge, or deploy was performed.