### PR TITLE
Add Customer Smart Advisor and Tracking motion

### DIFF
--- a/customer-app/assets/customer-app.css
+++ b/customer-app/assets/customer-app.css
@@ -6044,6 +6044,471 @@ textarea.purchase-input { min-height: 66px; resize: vertical; }
 @media (prefers-reduced-motion: reduce) {
   .maintenance-skeleton .sk-block { animation: none; }
 }
+
+/* Customer Smart Advisor */
+.smart-advisor-section {
+  position: relative;
+  isolation: isolate;
+  min-width: 0;
+  overflow: hidden;
+  padding: 18px;
+  border: 1px solid #b9d4ed;
+  border-radius: 16px;
+  background: linear-gradient(145deg, #f5fbff 0%, #fff 56%, #fff9dd 100%);
+  box-shadow: 0 16px 34px -30px rgba(5, 46, 91, 0.8);
+}
+.advisor-aura {
+  position: absolute;
+  inset: 0;
+  z-index: -1;
+  pointer-events: none;
+  overflow: hidden;
+}
+.advisor-aura span {
+  position: absolute;
+  right: -12%;
+  width: 55%;
+  height: 1px;
+  background: linear-gradient(90deg, transparent, rgba(25, 112, 198, 0.24), transparent);
+  transform: rotate(-20deg);
+  animation: advisor-accent-pass 4.8s ease-in-out 1 both;
+}
+.advisor-aura span:nth-child(1) { top: 17%; }
+.advisor-aura span:nth-child(2) { top: 29%; animation-delay: 120ms; }
+.advisor-aura span:nth-child(3) { top: 41%; animation-delay: 240ms; }
+.advisor-heading {
+  display: flex;
+  gap: 12px;
+  align-items: flex-start;
+  min-width: 0;
+}
+.advisor-brand-mark {
+  display: grid;
+  place-items: center;
+  flex: 0 0 44px;
+  width: 44px;
+  height: 44px;
+  border-radius: 12px;
+  background: #0c5ca8;
+  color: #fff;
+  box-shadow: 0 8px 18px -12px rgba(4, 45, 90, 0.9);
+}
+.advisor-heading > div:last-child { min-width: 0; }
+.advisor-heading h2 {
+  margin: 3px 0 0;
+  color: #092d58;
+  font-size: 20px;
+  line-height: 1.3;
+  overflow-wrap: anywhere;
+}
+.advisor-heading p {
+  margin: 5px 0 0;
+  color: #52677d;
+  font-size: 13px;
+  line-height: 1.5;
+}
+.advisor-progress {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 6px;
+  margin: 16px 0 14px;
+}
+.advisor-progress span {
+  height: 5px;
+  border-radius: 99px;
+  background: #dbe7f1;
+  transition: background 220ms ease, transform 220ms ease;
+}
+.advisor-progress span.is-active {
+  background: #f0be22;
+  transform: scaleY(1.18);
+}
+.advisor-body {
+  min-width: 0;
+  padding: 15px;
+  border: 1px solid rgba(16, 76, 132, 0.13);
+  border-radius: 14px;
+  background: rgba(255, 255, 255, 0.88);
+}
+.advisor-step,
+.advisor-result {
+  min-width: 0;
+  animation: advisor-step-in 280ms cubic-bezier(0.22, 0.61, 0.36, 1) both;
+}
+.advisor-step-copy > span,
+.advisor-result-hero > div > span {
+  color: #1870bb;
+  font-size: 11px;
+  font-weight: 900;
+}
+.advisor-step-copy h3 {
+  margin: 3px 0 0;
+  color: #0a2a57;
+  font-size: 18px;
+  line-height: 1.3;
+}
+.advisor-step-copy p {
+  margin: 4px 0 0;
+  color: #5c7084;
+  font-size: 12px;
+  line-height: 1.45;
+}
+.advisor-choice-grid,
+.advisor-chip-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 8px;
+  margin-top: 13px;
+  min-width: 0;
+}
+.advisor-choice,
+.advisor-chip {
+  min-width: 0;
+  min-height: 44px;
+  border: 1px solid #cbdce9;
+  border-radius: 10px;
+  background: #fff;
+  color: #173a60;
+  font: inherit;
+  font-size: 12px;
+  font-weight: 850;
+  line-height: 1.35;
+  cursor: pointer;
+  transition: transform 120ms ease, border-color 180ms ease, background 180ms ease, box-shadow 180ms ease;
+}
+.advisor-choice { padding: 9px 10px; }
+.advisor-chip {
+  display: flex;
+  gap: 7px;
+  align-items: center;
+  padding: 8px 9px;
+  text-align: left;
+}
+.advisor-choice:active,
+.advisor-chip:active { transform: scale(0.98); }
+.advisor-choice.is-selected,
+.advisor-chip.is-selected {
+  border-color: #1670bd;
+  background: #eaf5ff;
+  box-shadow: 0 0 0 3px rgba(22, 112, 189, 0.1);
+  color: #074c8c;
+}
+.advisor-chip-check {
+  display: grid;
+  place-items: center;
+  flex: 0 0 22px;
+  width: 22px;
+  height: 22px;
+  border-radius: 50%;
+  background: #eaf0f5;
+  color: #4b647d;
+  font-size: 12px;
+  font-weight: 950;
+}
+.advisor-chip.is-selected .advisor-chip-check {
+  background: #1670bd;
+  color: #fff;
+}
+.advisor-choice:focus-visible,
+.advisor-chip:focus-visible,
+.advisor-reset-btn:focus-visible {
+  outline: 3px solid rgba(240, 190, 34, 0.55);
+  outline-offset: 2px;
+}
+.advisor-step-actions,
+.advisor-result-footer {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 9px;
+  align-items: center;
+  margin-top: 15px;
+}
+.advisor-step-actions .primary-btn,
+.advisor-step-actions .secondary-btn,
+.advisor-result-footer .secondary-btn,
+.advisor-catalog-empty .primary-btn {
+  min-height: 44px;
+}
+.advisor-step-actions .primary-btn:disabled {
+  opacity: 0.48;
+  cursor: not-allowed;
+  transform: none;
+}
+.advisor-result-hero {
+  display: grid;
+  grid-template-columns: 44px minmax(0, 1fr);
+  gap: 10px;
+  align-items: center;
+}
+.advisor-result-mark {
+  display: grid;
+  place-items: center;
+  width: 44px;
+  height: 44px;
+  border-radius: 12px;
+  background: #e8f7ee;
+  color: #19834a;
+}
+.advisor-result.tone-repair .advisor-result-mark {
+  background: #fff0e7;
+  color: #b74d16;
+}
+.advisor-result.tone-neutral .advisor-result-mark {
+  background: #edf3f8;
+  color: #42617e;
+}
+.advisor-result-hero h3 {
+  margin: 2px 0 0;
+  color: #092d58;
+  font-size: 19px;
+  line-height: 1.25;
+  overflow-wrap: anywhere;
+}
+.advisor-result-hero p {
+  margin: 3px 0 0;
+  color: #52677d;
+  font-size: 12px;
+}
+.advisor-confidence {
+  grid-column: 1 / -1;
+  justify-self: start;
+  padding: 5px 9px;
+  border-radius: 99px;
+  background: #fff3bd;
+  color: #735400;
+  font-size: 11px;
+  font-weight: 900;
+}
+.advisor-reason-list {
+  display: grid;
+  gap: 7px;
+  margin-top: 13px;
+}
+.advisor-reason-list > div {
+  display: flex;
+  gap: 7px;
+  align-items: flex-start;
+  color: #294b6e;
+  font-size: 12px;
+  line-height: 1.45;
+}
+.advisor-reason-list .cwf-ico { color: #19834a; }
+.advisor-alternative {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  justify-content: space-between;
+  margin-top: 12px;
+  padding: 9px 10px;
+  border-radius: 9px;
+  background: #f3f7fa;
+  color: #536a81;
+  font-size: 11px;
+}
+.advisor-alternative strong { color: #173a60; font-size: 12px; }
+.advisor-note {
+  margin: 11px 0 0;
+  color: #5b6f82;
+  font-size: 11px;
+  line-height: 1.45;
+}
+.advisor-catalog {
+  margin-top: 15px;
+  padding-top: 13px;
+  border-top: 1px solid #dbe5ed;
+}
+.advisor-catalog-head {
+  display: flex;
+  gap: 4px;
+  flex-direction: column;
+  margin-bottom: 9px;
+}
+.advisor-catalog-head strong { color: #0a2a57; font-size: 14px; }
+.advisor-catalog-head span { color: #687b8c; font-size: 11px; }
+.advisor-result-products { display: grid; gap: 9px; }
+.advisor-product {
+  display: grid;
+  grid-template-columns: 80px minmax(0, 1fr);
+  gap: 10px;
+  min-width: 0;
+  padding: 9px;
+  border: 1px solid #d2e0eb;
+  border-radius: 11px;
+  background: #fff;
+  animation: advisor-product-in 300ms ease both;
+}
+.advisor-product:nth-child(2) { animation-delay: 60ms; }
+.advisor-product:nth-child(3) { animation-delay: 120ms; }
+.advisor-product.is-exact { border-color: #8fc7aa; }
+.advisor-product-image {
+  display: grid;
+  place-items: center;
+  width: 80px;
+  aspect-ratio: 1;
+  overflow: hidden;
+  border-radius: 8px;
+  background: #eaf2f8;
+  color: #1670bd;
+}
+.advisor-product-image img { width: 100%; height: 100%; object-fit: cover; }
+.advisor-product-body { min-width: 0; }
+.advisor-product-body > span { color: #19834a; font-size: 10px; font-weight: 900; }
+.advisor-product-body h4 {
+  margin: 2px 0 0;
+  color: #0c2f56;
+  font-size: 13px;
+  line-height: 1.35;
+  overflow-wrap: anywhere;
+}
+.advisor-product-body p { margin: 3px 0 0; color: #0b6a43; font-size: 12px; font-weight: 900; }
+.advisor-product-actions {
+  display: grid;
+  grid-template-columns: 1fr 1.2fr;
+  gap: 6px;
+  margin-top: 8px;
+}
+.advisor-product-actions button { min-height: 44px; padding: 7px; font-size: 11px; }
+.advisor-catalog-empty {
+  padding: 12px;
+  border-radius: 10px;
+  background: #f4f7fa;
+  text-align: center;
+}
+.advisor-catalog-empty strong { color: #173a60; font-size: 13px; }
+.advisor-catalog-empty p { margin: 4px 0 10px; color: #65798c; font-size: 11px; line-height: 1.45; }
+.advisor-catalog-empty .primary-btn { width: 100%; }
+.advisor-catalog-loading { display: grid; gap: 6px; }
+.advisor-catalog-loading span {
+  display: block;
+  height: 12px;
+  border-radius: 6px;
+  background: #e7eef4;
+}
+.advisor-catalog-loading span:nth-child(2) { width: 72%; }
+.advisor-catalog-loading p { margin: 2px 0 0; color: #65798c; font-size: 11px; }
+.advisor-reset-btn {
+  min-height: 44px;
+  border: 0;
+  background: transparent;
+  color: #1768ac;
+  font: inherit;
+  font-size: 12px;
+  font-weight: 900;
+  cursor: pointer;
+}
+
+/* Health Passport motion and next-service guidance */
+@property --clean-progress {
+  syntax: "<number>";
+  inherits: false;
+  initial-value: 0;
+}
+.has-health-motion .cleanliness-ring {
+  --clean-progress: var(--clean-score);
+  background: conic-gradient(var(--clean-accent) calc(var(--clean-progress) * 1%), #d9e5ef 0);
+  animation: health-ring-sweep 820ms cubic-bezier(0.22, 0.61, 0.36, 1) both;
+}
+.has-health-motion .unit-inspection-item,
+.has-health-motion .next-service-guidance,
+.tracking-timeline-panel .timeline-item {
+  animation: health-item-in 340ms cubic-bezier(0.22, 0.61, 0.36, 1) both;
+}
+.has-health-motion .unit-inspection-item:nth-child(2) { animation-delay: 55ms; }
+.has-health-motion .unit-inspection-item:nth-child(3) { animation-delay: 110ms; }
+.has-health-motion .unit-inspection-item:nth-child(4) { animation-delay: 165ms; }
+.has-health-motion .next-service-guidance { animation-delay: 180ms; }
+.tracking-timeline-panel .timeline-item:nth-child(2) { animation-delay: 45ms; }
+.tracking-timeline-panel .timeline-item:nth-child(3) { animation-delay: 90ms; }
+.tracking-timeline-panel .timeline-item:nth-child(4) { animation-delay: 135ms; }
+.tracking-timeline-panel .timeline-item:nth-child(5) { animation-delay: 180ms; }
+.cleanliness-status-badge { animation: health-badge-in 420ms cubic-bezier(0.22, 1.25, 0.36, 1) both 120ms; }
+.next-service-guidance {
+  position: relative;
+  min-width: 0;
+  padding: 11px 12px 11px 15px;
+  overflow: hidden;
+  border: 1px solid #bcd9ef;
+  border-radius: 11px;
+  background: #eff8ff;
+}
+.next-service-guidance::before {
+  position: absolute;
+  inset: 0 auto 0 0;
+  width: 4px;
+  background: #1670bd;
+  content: "";
+}
+.next-service-guidance.tone-good { border-color: #b8dec8; background: #effaf3; }
+.next-service-guidance.tone-good::before { background: #21945b; }
+.next-service-guidance.tone-watch { border-color: #efd68c; background: #fff9e7; }
+.next-service-guidance.tone-watch::before,
+.next-service-guidance.tone-due::before { background: #d89516; }
+.next-service-guidance.tone-repair { border-color: #efb79e; background: #fff3ed; }
+.next-service-guidance.tone-repair::before { background: #c84f1c; }
+.next-service-guidance > span,
+.next-service-guidance > strong,
+.next-service-guidance > p,
+.next-service-guidance > small { display: block; overflow-wrap: anywhere; }
+.next-service-guidance > span { color: #526b82; font-size: 10px; font-weight: 850; }
+.next-service-guidance > strong { margin-top: 2px; color: #0b315d; font-size: 13px; line-height: 1.35; }
+.next-service-guidance > p { margin: 3px 0 0; color: #385570; font-size: 11px; line-height: 1.45; }
+.next-service-guidance > small { margin-top: 5px; color: #6a7c8d; font-size: 9.5px; line-height: 1.4; }
+
+@keyframes advisor-step-in {
+  from { opacity: 0; transform: translateY(8px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+@keyframes advisor-product-in {
+  from { opacity: 0; transform: translateY(7px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+@keyframes advisor-accent-pass {
+  from { opacity: 0; transform: translateX(26px) rotate(-20deg); }
+  to { opacity: 1; transform: translateX(0) rotate(-20deg); }
+}
+@keyframes health-ring-sweep {
+  from { --clean-progress: 0; }
+  to { --clean-progress: var(--clean-score); }
+}
+@keyframes health-item-in {
+  from { opacity: 0; transform: translateY(7px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+@keyframes health-badge-in {
+  from { opacity: 0; transform: scale(0.9); }
+  to { opacity: 1; transform: scale(1); }
+}
+
+@media (max-width: 380px) {
+  .smart-advisor-section { padding: 14px; }
+  .advisor-body { padding: 12px; }
+  .advisor-heading h2 { font-size: 18px; }
+  .advisor-choice,
+  .advisor-chip { font-size: 11px; }
+  .advisor-product { grid-template-columns: 68px minmax(0, 1fr); }
+  .advisor-product-image { width: 68px; }
+  .advisor-product-actions { grid-template-columns: 1fr; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .advisor-aura span,
+  .advisor-step,
+  .advisor-result,
+  .advisor-product,
+  .has-health-motion .cleanliness-ring,
+  .has-health-motion .unit-inspection-item,
+  .has-health-motion .next-service-guidance,
+  .tracking-timeline-panel .timeline-item,
+  .cleanliness-status-badge {
+    animation: none !important;
+    transition: none !important;
+    transform: none !important;
+  }
+  .has-health-motion .cleanliness-ring { --clean-progress: var(--clean-score); }
+  .advisor-choice,
+  .advisor-chip,
+  .advisor-progress span { transition: none !important; }
+}
 /* Readable overlay on top of the blurred shell. */
 .maintenance-overlay {
   position: absolute;

--- a/customer-app/assets/customer-app.js
+++ b/customer-app/assets/customer-app.js
@@ -3,7 +3,7 @@
 
   const App = window.CWFCustomerAppV2;
   const BOOT_TIMEOUT_MS = 3500;
-  const BUILD_ID = "20260714_tracking_cleanliness_donut_v1";
+  const BUILD_ID = "20260714_customer_smart_advisor_motion_v1";
 
   function withTimeout(promise, timeoutMs) {
     return Promise.race([

--- a/customer-app/index.html
+++ b/customer-app/index.html
@@ -21,10 +21,10 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Noto+Sans+Thai:wght@400;500;600;700;800;900&display=swap" media="print" onload="this.media='all'">
   <noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Noto+Sans+Thai:wght@400;500;600;700;800;900&display=swap"></noscript>
-  <link rel="manifest" href="./manifest.webmanifest?v=20260714_tracking_cleanliness_donut_v1">
+  <link rel="manifest" href="./manifest.webmanifest?v=20260714_customer_smart_advisor_motion_v1">
   <link rel="icon" type="image/png" sizes="192x192" href="./assets/icons/cwf-customer-192.png">
   <link rel="apple-touch-icon" sizes="180x180" href="./assets/icons/cwf-customer-180.png">
-  <link rel="stylesheet" href="./assets/customer-app.css?v=20260714_tracking_cleanliness_donut_v1">
+  <link rel="stylesheet" href="./assets/customer-app.css?v=20260714_customer_smart_advisor_motion_v1">
 </head>
 <body class="is-app-booting">
   <div class="app-shell" data-app-shell>
@@ -62,22 +62,23 @@
     </nav>
   </div>
 
-  <script src="./modules/state.js?v=20260714_tracking_cleanliness_donut_v1"></script>
-  <script src="./modules/utils.js?v=20260714_tracking_cleanliness_donut_v1"></script>
-  <script src="./modules/analytics.js?v=20260714_tracking_cleanliness_donut_v1"></script>
-  <script src="./modules/api.js?v=20260714_tracking_cleanliness_donut_v1"></script>
-  <script src="./modules/pageAvailability.js?v=20260714_tracking_cleanliness_donut_v1"></script>
-  <script src="./modules/services.js?v=20260714_tracking_cleanliness_donut_v1"></script>
-  <script src="./modules/ui.js?v=20260714_tracking_cleanliness_donut_v1"></script>
-  <script src="./modules/store.js?v=20260714_tracking_cleanliness_donut_v1"></script>
-  <script src="./modules/auth.js?v=20260714_tracking_cleanliness_donut_v1"></script>
-  <script src="./modules/pricing.js?v=20260714_tracking_cleanliness_donut_v1"></script>
-  <script src="./modules/availability.js?v=20260714_tracking_cleanliness_donut_v1"></script>
-  <script src="./modules/bookingScheduled.js?v=20260714_tracking_cleanliness_donut_v1"></script>
-  <script src="./modules/bookingUrgent.js?v=20260714_tracking_cleanliness_donut_v1"></script>
-  <script src="./modules/tracking.js?v=20260714_tracking_cleanliness_donut_v1"></script>
-  <script src="./modules/profile.js?v=20260714_tracking_cleanliness_donut_v1"></script>
-  <script src="./modules/router.js?v=20260714_tracking_cleanliness_donut_v1"></script>
-  <script src="./assets/customer-app.js?v=20260714_tracking_cleanliness_donut_v1"></script>
+  <script src="./modules/state.js?v=20260714_customer_smart_advisor_motion_v1"></script>
+  <script src="./modules/utils.js?v=20260714_customer_smart_advisor_motion_v1"></script>
+  <script src="./modules/analytics.js?v=20260714_customer_smart_advisor_motion_v1"></script>
+  <script src="./modules/api.js?v=20260714_customer_smart_advisor_motion_v1"></script>
+  <script src="./modules/pageAvailability.js?v=20260714_customer_smart_advisor_motion_v1"></script>
+  <script src="./modules/services.js?v=20260714_customer_smart_advisor_motion_v1"></script>
+  <script src="./modules/advisor.js?v=20260714_customer_smart_advisor_motion_v1"></script>
+  <script src="./modules/ui.js?v=20260714_customer_smart_advisor_motion_v1"></script>
+  <script src="./modules/store.js?v=20260714_customer_smart_advisor_motion_v1"></script>
+  <script src="./modules/auth.js?v=20260714_customer_smart_advisor_motion_v1"></script>
+  <script src="./modules/pricing.js?v=20260714_customer_smart_advisor_motion_v1"></script>
+  <script src="./modules/availability.js?v=20260714_customer_smart_advisor_motion_v1"></script>
+  <script src="./modules/bookingScheduled.js?v=20260714_customer_smart_advisor_motion_v1"></script>
+  <script src="./modules/bookingUrgent.js?v=20260714_customer_smart_advisor_motion_v1"></script>
+  <script src="./modules/tracking.js?v=20260714_customer_smart_advisor_motion_v1"></script>
+  <script src="./modules/profile.js?v=20260714_customer_smart_advisor_motion_v1"></script>
+  <script src="./modules/router.js?v=20260714_customer_smart_advisor_motion_v1"></script>
+  <script src="./assets/customer-app.js?v=20260714_customer_smart_advisor_motion_v1"></script>
 </body>
 </html>

--- a/customer-app/manifest.webmanifest
+++ b/customer-app/manifest.webmanifest
@@ -2,7 +2,7 @@
   "name": "CWF Customer Service",
   "short_name": "CWF Service",
   "description": "แอปลูกค้า Coldwindflow สำหรับเลือกบริการ จองคิว และติดตามงาน",
-  "start_url": "/customer-app/index.html?v=20260714_tracking_cleanliness_donut_v1#home",
+  "start_url": "/customer-app/index.html?v=20260714_customer_smart_advisor_motion_v1#home",
   "scope": "/customer-app/",
   "id": "/customer-app/",
   "display": "standalone",

--- a/customer-app/modules/advisor.js
+++ b/customer-app/modules/advisor.js
@@ -259,23 +259,43 @@
     const intent = recommendation && recommendation.catalogIntent;
     if (!intent) return [];
     const adapter = typeof options.adapter === "function" ? options.adapter : null;
+    const alternativeVariant = recommendation.alternative && VERDICT_META[recommendation.alternative]
+      ? VERDICT_META[recommendation.alternative].variant
+      : null;
     return eligibleCatalogItems(items).map((item, index) => {
       const job = canonicalJobCategory(item);
       const acType = canonicalAcType(item);
       const variant = canonicalWashVariant(item);
       let rank = 99;
-      let exact = false;
+      let matchType = null;
       if (intent.kind === "repair") {
-        if (job === "repair") { rank = 0; exact = true; }
-        else if (job === "inspection") { rank = 1; exact = true; }
+        if (job === "repair") { rank = 0; matchType = "primary"; }
+        else if (job === "inspection") { rank = 1; matchType = "primary"; }
       } else if (intent.kind === "clean" && job === "wash") {
-        if (acType === intent.acType && (!intent.variant || variant === intent.variant)) { rank = 0; exact = true; }
-        else if (acType === intent.acType) rank = 2;
-        else rank = 5;
+        if (acType !== intent.acType) return null;
+        if (!intent.variant || variant === intent.variant) {
+          rank = 0;
+          matchType = "primary";
+        } else if (alternativeVariant && variant === alternativeVariant) {
+          rank = 1;
+          matchType = "alternative";
+        }
       }
-      if (rank === 99) return null;
-      const draft = intent.kind === "clean" && item.booking_mode === "bookable" && adapter ? adapter(item) : null;
-      return { item, exact, directBook: Boolean(draft), rank: rank + (draft ? 0 : 0.5), index };
+      if (rank === 99 || !matchType) return null;
+      const mayBook = intent.kind === "clean"
+        && matchType === "primary"
+        && item.booking_mode === "bookable"
+        && (recommendation.action === "catalog" || recommendation.action === "catalog_or_contact");
+      const draft = mayBook && adapter ? adapter(item) : null;
+      return {
+        item,
+        exact: matchType === "primary",
+        matchType,
+        directBook: Boolean(draft),
+        draft,
+        rank: rank + (draft ? 0 : 0.5),
+        index,
+      };
     }).filter(Boolean).sort((a, b) => a.rank - b.rank || a.index - b.index).slice(0, 3);
   }
 
@@ -335,7 +355,7 @@
         <div class="advisor-catalog-empty">
           <strong>ยังไม่มีรายการที่ตรงสำหรับจองอัตโนมัติ</strong>
           <p>ให้ทีม CWF ตรวจชนิดเครื่องและอาการก่อนเลือกบริการ</p>
-          <button class="primary-btn" type="button" data-advisor-contact>${icon("chat", 18)} ติดต่อให้ทีมประเมิน</button>
+          <button class="primary-btn" type="button" data-advisor-contact>${icon("chat", 18)} ให้ทีมช่วยประเมิน</button>
         </div>
       `;
     }
@@ -345,13 +365,13 @@
         <span>เลือกดูรายละเอียดหรือดำเนินการต่อ</span>
       </div>
       <div class="advisor-result-products">
-        ${matches.map(({ item, directBook, exact }) => {
+        ${matches.map(({ item, directBook, exact, matchType }) => {
           const image = firstImage(item);
           return `
             <article class="advisor-product ${exact ? "is-exact" : ""}" data-advisor-product="${esc(item.item_id)}">
               <div class="advisor-product-image">${image ? `<img src="${esc(image)}" alt="" loading="lazy">` : icon("sparkle", 24)}</div>
               <div class="advisor-product-body">
-                <span>${exact ? "ตรงกับผลประเมิน" : "ตัวเลือกที่เกี่ยวข้อง"}</span>
+                <span>${matchType === "alternative" ? "ทางเลือกสำรอง" : "ตรงกับผลประเมิน"}</span>
                 <h4>${esc(item.item_name)}</h4>
                 <p>${esc(priceText(item))}${item.unit_label ? ` / ${esc(item.unit_label)}` : ""}</p>
                 <div class="advisor-product-actions">
@@ -365,6 +385,11 @@
           `;
         }).join("")}
       </div>
+      ${recommendation.confidence === "assessment" || String(recommendation.action || "").includes("contact") ? `
+        <div class="advisor-assessment-cta">
+          <button class="primary-btn" type="button" data-advisor-contact>${icon("chat", 18)} ให้ทีมช่วยประเมิน</button>
+        </div>
+      ` : ""}
     `;
   }
 
@@ -524,16 +549,22 @@
         root.utils.routeTo(`storeItem-${button.getAttribute("data-advisor-detail")}`);
       } else if (button.hasAttribute("data-advisor-item-action")) {
         const id = button.getAttribute("data-advisor-item-action");
-        const item = (catalogState().items || []).find((row) => String(row.item_id) === String(id));
         if (state.recommendation?.verdict === "repair_check") {
-          contact(item && item.item_name);
+          contact();
           return;
         }
-        const draft = item ? root.services.catalogItemToCommerceDraft(item) : null;
-        if (draft && root.services.applyCommerceDraft("scheduled", draft)) {
+        const allowedMatches = mapCatalogItems(state.recommendation, catalogState().items, {
+          adapter: (item) => root.services.catalogItemToCommerceDraft(item),
+        });
+        const match = allowedMatches.find((candidate) => String(candidate.item.item_id) === String(id));
+        if (!match || !match.directBook || !match.draft) {
+          contact(match && match.item.item_name);
+          return;
+        }
+        if (root.services.applyCommerceDraft("scheduled", match.draft)) {
           root.utils.routeTo("scheduled");
         } else {
-          contact(item && item.item_name);
+          contact(match.item.item_name);
         }
       } else if (button.hasAttribute("data-advisor-contact")) {
         contact();

--- a/customer-app/modules/advisor.js
+++ b/customer-app/modules/advisor.js
@@ -1,0 +1,598 @@
+(function () {
+  "use strict";
+
+  const root = window.CWFCustomerAppV2 = window.CWFCustomerAppV2 || {};
+  const controllers = new WeakMap();
+
+  const AC_TYPES = Object.freeze([
+    { value: "wall", label: "แอร์ผนัง", bookingValue: "ผนัง" },
+    { value: "fourway", label: "แอร์สี่ทิศทาง", bookingValue: "สี่ทิศทาง" },
+    { value: "hanging", label: "แอร์แขวน", bookingValue: "แขวน" },
+    { value: "ceiling", label: "แอร์เปลือยใต้ฝ้า", bookingValue: "เปลือยใต้ฝ้า" },
+    { value: "unknown", label: "ไม่แน่ใจ", bookingValue: null },
+  ]);
+
+  const MONTH_BANDS = Object.freeze([
+    { value: "recent", label: "ไม่เกิน 3 เดือน" },
+    { value: "m4_5", label: "4–5 เดือน" },
+    { value: "m6_8", label: "6–8 เดือน" },
+    { value: "m9_12", label: "9–12 เดือน" },
+    { value: "over12", label: "เกิน 1 ปี" },
+    { value: "unknown", label: "จำไม่ได้ / ไม่แน่ใจ" },
+  ]);
+
+  const SYMPTOMS = Object.freeze([
+    { value: "routine", label: "ไม่มีอาการ แค่ถึงรอบล้าง" },
+    { value: "reduced_cooling", label: "เย็นน้อยลง" },
+    { value: "weak_airflow", label: "ลมอ่อน" },
+    { value: "odor", label: "มีกลิ่น" },
+    { value: "drain", label: "น้ำหยด / ระบายน้ำไม่ดี" },
+    { value: "dusty", label: "มีฝุ่นหรือคราบมาก" },
+    { value: "heavy_dirt", label: "สกปรกหนัก / หมักหมม" },
+    { value: "noise", label: "เสียงดัง" },
+    { value: "heavy_use", label: "ใช้งานหนักทุกวัน" },
+    { value: "pets", label: "มีสัตว์เลี้ยง" },
+    { value: "allergy", label: "มีผู้แพ้ง่ายหรือเด็กเล็ก" },
+    { value: "never_deep", label: "ไม่เคยล้างลึก" },
+  ]);
+
+  const REPAIR_SIGNALS = Object.freeze([
+    { value: "error_code", label: "มี Error Code" },
+    { value: "ac_not_running", label: "แอร์ไม่ทำงาน" },
+    { value: "outdoor_not_running", label: "คอยร้อนไม่ทำงาน" },
+    { value: "indoor_not_running", label: "คอยล์เย็นไม่ทำงาน" },
+    { value: "breaker_trip", label: "เบรกเกอร์ตัด" },
+    { value: "burning_smell", label: "มีเสียงหรือกลิ่นไหม้" },
+    { value: "none", label: "ไม่มีอาการเหล่านี้" },
+  ]);
+
+  const VERDICT_META = Object.freeze({
+    standard_clean: { label: "ล้างธรรมดา", short: "ดูแลตามรอบ", variant: "normal", tone: "good" },
+    premium_clean: { label: "ล้างพรีเมียม", short: "ดูแลละเอียดขึ้น", variant: "premium", tone: "premium" },
+    hanging_coil: { label: "ล้างแขวนคอยล์", short: "จัดการคราบสะสมลึก", variant: "coil", tone: "watch" },
+    big_wash: { label: "ตัดล้าง / ล้างใหญ่", short: "ฟื้นฟูเครื่องที่สะสมหนัก", variant: "overhaul", tone: "due" },
+    repair_check: { label: "ตรวจเช็ค / ซ่อมก่อน", short: "ตรวจหาสาเหตุก่อนเลือกล้าง", variant: null, tone: "repair" },
+    needs_assessment: { label: "ให้ทีมช่วยประเมิน", short: "ยืนยันชนิดเครื่องและอาการก่อน", variant: null, tone: "neutral" },
+  });
+
+  const CONFIDENCE_LABELS = Object.freeze({
+    high: "สูง",
+    medium: "ปานกลาง",
+    assessment: "ต้องประเมินเพิ่ม",
+  });
+
+  function uniqueValues(values) {
+    return Array.from(new Set((Array.isArray(values) ? values : []).map((value) => String(value || "").trim()).filter(Boolean)));
+  }
+
+  function result(verdict, confidence, reasons, options = {}) {
+    return {
+      verdict,
+      confidence,
+      reasons: uniqueValues(reasons).slice(0, 4),
+      alternative: options.alternative || null,
+      catalogIntent: options.catalogIntent || null,
+      action: options.action || "contact",
+      note: options.note || "คำแนะนำเบื้องต้น อาการจริงหน้างานอาจทำให้รูปแบบบริการเปลี่ยนได้",
+    };
+  }
+
+  function evaluateRecommendation(rawInput = {}) {
+    const acType = String(rawInput.acType || "").trim();
+    const monthsBand = String(rawInput.monthsBand || "").trim();
+    const symptoms = uniqueValues(rawInput.symptoms);
+    const repairSignals = uniqueValues(rawInput.repairSignals);
+    const actualRepairSignals = repairSignals.filter((signal) => signal !== "none");
+    const conflictingSymptoms = symptoms.includes("routine") && symptoms.length > 1;
+    const conflictingRepair = repairSignals.includes("none") && actualRepairSignals.length > 0;
+
+    if (actualRepairSignals.length) {
+      return result("repair_check", "high", [
+        "พบอาการที่อาจเกี่ยวกับระบบไฟฟ้า การควบคุม หรืออุปกรณ์ภายใน",
+        "การล้างเพียงอย่างเดียวอาจไม่แก้สาเหตุของอาการนี้",
+      ], {
+        catalogIntent: { kind: "repair", acType },
+        action: "contact",
+        note: "ควรหยุดใช้งานหากมีเบรกเกอร์ตัด กลิ่นไหม้ หรือเสียงผิดปกติ และให้ช่างตรวจเช็คก่อน",
+      });
+    }
+
+    if (!acType || acType === "unknown" || conflictingSymptoms || conflictingRepair) {
+      const reasons = [];
+      if (!acType || acType === "unknown") reasons.push("ยังไม่ทราบชนิดแอร์ที่แน่นอน");
+      if (conflictingSymptoms || conflictingRepair) reasons.push("ตัวเลือกอาการยังขัดกันและควรยืนยันเพิ่มเติม");
+      return result("needs_assessment", "assessment", reasons, {
+        catalogIntent: null,
+        action: "contact",
+      });
+    }
+
+    if (acType !== "wall") {
+      const acLabel = AC_TYPES.find((item) => item.value === acType)?.label || "ชนิดเครื่องนี้";
+      return result("needs_assessment", monthsBand === "unknown" ? "assessment" : "medium", [
+        `${acLabel}ต้องเลือกบริการให้ตรงรูปแบบเครื่องและสภาพหน้างาน`,
+        monthsBand === "unknown" ? "ยังไม่ทราบระยะจากการล้างครั้งก่อน" : "ระบบจะค้นหารายการ Catalog ที่ตรงชนิดเครื่องก่อน",
+      ], {
+        catalogIntent: { kind: "clean", acType },
+        action: "catalog_or_contact",
+        note: "แนะนำล้างตามชนิดเครื่องและให้ทีมประเมินรูปแบบหน้างาน ไม่ใช้วิธีล้างของแอร์ผนังแทนกัน",
+      });
+    }
+
+    if (!monthsBand || monthsBand === "unknown") {
+      return result("needs_assessment", "assessment", [
+        "ยังไม่ทราบระยะจากการล้างครั้งก่อน",
+        symptoms.length ? "มีข้อมูลอาการ แต่ยังต้องประเมินระดับความสะสมร่วมด้วย" : "ยังไม่มีข้อมูลอาการเพียงพอสำหรับเลือกวิธีล้าง",
+      ], { action: "contact" });
+    }
+
+    const has = (value) => symptoms.includes(value);
+    const accumulationSymptoms = ["weak_airflow", "odor", "drain", "dusty", "never_deep"].filter(has);
+    const premiumSymptoms = ["heavy_use", "pets", "allergy", "odor", "dusty"].filter(has);
+    const severeAccumulation = has("heavy_dirt") || has("never_deep");
+    const catalogIntent = (verdict) => ({ kind: "clean", acType: "wall", variant: VERDICT_META[verdict].variant });
+
+    if (monthsBand === "over12") {
+      if (severeAccumulation) {
+        return result("big_wash", "high", [
+          "เว้นระยะล้างเกินหนึ่งปี",
+          has("heavy_dirt") ? "มีคราบหรือความสกปรกสะสมหนัก" : "ยังไม่เคยล้างลึก",
+        ], { alternative: "hanging_coil", catalogIntent: catalogIntent("big_wash"), action: "catalog" });
+      }
+      return result("hanging_coil", "assessment", [
+        "เว้นระยะล้างเกินหนึ่งปี",
+        "ยังไม่มีข้อมูลสภาพสะสมมากพอที่จะฟันธงงานตัดล้าง",
+      ], { alternative: "big_wash", catalogIntent: catalogIntent("hanging_coil"), action: "catalog_or_contact" });
+    }
+
+    if (monthsBand === "m9_12") {
+      if (accumulationSymptoms.length || has("heavy_dirt")) {
+        return result("hanging_coil", "high", [
+          "เว้นระยะล้างประมาณ 9–12 เดือน",
+          "มีอาการที่สอดคล้องกับความสกปรกสะสมภายใน",
+        ], { alternative: has("heavy_dirt") ? "big_wash" : "premium_clean", catalogIntent: catalogIntent("hanging_coil"), action: "catalog" });
+      }
+      return result("premium_clean", "medium", [
+        "เว้นระยะล้างประมาณ 9–12 เดือน",
+        "ยังไม่พบอาการสะสมที่ชี้ว่าต้องล้างลึกทันที",
+      ], { alternative: "hanging_coil", catalogIntent: catalogIntent("premium_clean"), action: "catalog" });
+    }
+
+    if (monthsBand === "m6_8") {
+      if (has("heavy_dirt")) {
+        return result("hanging_coil", "medium", [
+          "มีความสกปรกสะสมหนักกว่าการล้างตามรอบทั่วไป",
+          "ควรให้ทีมยืนยันสภาพก่อนเริ่มงาน",
+        ], { alternative: "premium_clean", catalogIntent: catalogIntent("hanging_coil"), action: "catalog_or_contact" });
+      }
+      return result("premium_clean", premiumSymptoms.length ? "high" : "medium", [
+        "เว้นระยะล้างประมาณ 6–8 เดือน",
+        premiumSymptoms.length ? "มีปัจจัยใช้งานหรือสภาพแวดล้อมที่เหมาะกับการดูแลละเอียดขึ้น" : "เหมาะกับการล้างที่ละเอียดกว่ารอบทั่วไป",
+      ], { alternative: "standard_clean", catalogIntent: catalogIntent("premium_clean"), action: "catalog" });
+    }
+
+    if (monthsBand === "m4_5") {
+      if (premiumSymptoms.length || accumulationSymptoms.length || has("heavy_dirt")) {
+        return result("premium_clean", "medium", [
+          "ถึงรอบดูแลทั่วไปแล้ว",
+          "มีอาการหรือสภาพแวดล้อมที่ควรเพิ่มความละเอียดในการล้าง",
+        ], { alternative: "standard_clean", catalogIntent: catalogIntent("premium_clean"), action: "catalog" });
+      }
+      return result("standard_clean", "high", [
+        "เว้นระยะล้างประมาณ 4–5 เดือน",
+        "ไม่พบอาการรุนแรงหรือความสกปรกสะสมหนัก",
+      ], { alternative: "premium_clean", catalogIntent: catalogIntent("standard_clean"), action: "catalog" });
+    }
+
+    if (premiumSymptoms.length || accumulationSymptoms.length || has("heavy_dirt")) {
+      return result("premium_clean", "assessment", [
+        "เพิ่งล้างไม่นาน แต่อาการที่เลือกควรได้รับการประเมินเพิ่มเติม",
+        "ไม่ควรเร่งสรุปงานล้างใหญ่จากระยะเวลาเพียงอย่างเดียว",
+      ], { alternative: "standard_clean", catalogIntent: catalogIntent("premium_clean"), action: "catalog_or_contact" });
+    }
+    return result("standard_clean", "medium", [
+      "เพิ่งล้างมาไม่นานและไม่มีอาการรุนแรง",
+      "อาจยังไม่จำเป็นต้องรีบล้าง เว้นแต่สภาพใช้งานจริงเปลี่ยนไป",
+    ], { catalogIntent: catalogIntent("standard_clean"), action: "catalog" });
+  }
+
+  function normalize(value) {
+    return String(value || "").trim().toLowerCase();
+  }
+
+  function canonicalAcType(item) {
+    const authoritative = normalize(item && item.booking_ac_type);
+    const exact = { "ผนัง": "wall", "สี่ทิศทาง": "fourway", "แขวน": "hanging", "เปลือยใต้ฝ้า": "ceiling" };
+    if (authoritative) return exact[authoritative] || null;
+    const text = normalize(item && item.item_name);
+    if (/สี่ทิศทาง|four.?way|cassette/.test(text)) return "fourway";
+    if (/เปลือยใต้ฝ้า|ใต้ฝ้า|ceiling/.test(text)) return "ceiling";
+    if (/แอร์แขวน|แขวนเพดาน|hanging/.test(text)) return "hanging";
+    if (/แอร์ผนัง|wall/.test(text)) return "wall";
+    return null;
+  }
+
+  function canonicalJobCategory(item) {
+    const authoritative = normalize(item && item.job_category);
+    if (authoritative) {
+      if (/^(ล้าง|ล้างแอร์|wash|clean)$/.test(authoritative)) return "wash";
+      if (/^(ซ่อม|ซ่อมแอร์|repair)$/.test(authoritative)) return "repair";
+      if (/^(ตรวจเช็ค|ตรวจเช็คแอร์|ตรวจสอบ|inspection|inspect)$/.test(authoritative)) return "inspection";
+      return null;
+    }
+    const text = normalize(item && item.item_name);
+    if (/ซ่อม|repair/.test(text)) return "repair";
+    if (/ตรวจเช็ค|ตรวจสอบ|inspect/.test(text)) return "inspection";
+    if (/ล้าง|wash|clean/.test(text)) return "wash";
+    return null;
+  }
+
+  function canonicalWashVariant(item) {
+    const authoritative = normalize(item && item.booking_wash_variant);
+    const exact = {
+      "ล้างธรรมดา": "normal",
+      "ล้างปกติ": "normal",
+      "ล้างพรีเมียม": "premium",
+      "ล้างแขวนคอยล์": "coil",
+      "ล้างแบบตัดล้าง": "overhaul",
+    };
+    if (authoritative) return exact[authoritative] || null;
+    const text = normalize(item && item.item_name);
+    if (/ตัดล้าง|ล้างใหญ่|overhaul/.test(text)) return "overhaul";
+    if (/แขวนคอยล์|coil/.test(text)) return "coil";
+    if (/พรีเมียม|premium/.test(text)) return "premium";
+    if (/ล้างธรรมดา|ล้างปกติ|ธรรมดา|ปกติ|normal/.test(text)) return "normal";
+    return null;
+  }
+
+  function eligibleCatalogItems(items) {
+    const seen = new Set();
+    return (Array.isArray(items) ? items : []).filter((item) => {
+      const id = String(item && item.item_id || "").trim();
+      if (!id || item.is_active === false || item.is_customer_visible === false || seen.has(id)) return false;
+      seen.add(id);
+      return true;
+    });
+  }
+
+  function mapCatalogItems(recommendation, items, options = {}) {
+    const intent = recommendation && recommendation.catalogIntent;
+    if (!intent) return [];
+    const adapter = typeof options.adapter === "function" ? options.adapter : null;
+    return eligibleCatalogItems(items).map((item, index) => {
+      const job = canonicalJobCategory(item);
+      const acType = canonicalAcType(item);
+      const variant = canonicalWashVariant(item);
+      let rank = 99;
+      let exact = false;
+      if (intent.kind === "repair") {
+        if (job === "repair") { rank = 0; exact = true; }
+        else if (job === "inspection") { rank = 1; exact = true; }
+      } else if (intent.kind === "clean" && job === "wash") {
+        if (acType === intent.acType && (!intent.variant || variant === intent.variant)) { rank = 0; exact = true; }
+        else if (acType === intent.acType) rank = 2;
+        else rank = 5;
+      }
+      if (rank === 99) return null;
+      const draft = intent.kind === "clean" && item.booking_mode === "bookable" && adapter ? adapter(item) : null;
+      return { item, exact, directBook: Boolean(draft), rank: rank + (draft ? 0 : 0.5), index };
+    }).filter(Boolean).sort((a, b) => a.rank - b.rank || a.index - b.index).slice(0, 3);
+  }
+
+  function initialState() {
+    return { step: 0, acType: "", monthsBand: "", symptoms: [], repairSignals: [], recommendation: null };
+  }
+
+  function esc(value) {
+    return root.utils.escapeHtml(value == null ? "" : String(value));
+  }
+
+  function icon(name, size) {
+    return typeof root.utils.icon === "function" ? root.utils.icon(name, size) : "";
+  }
+
+  function choiceButtons(items, selected, attribute) {
+    return `<div class="advisor-choice-grid">${items.map((item) => `
+      <button class="advisor-choice ${selected === item.value ? "is-selected" : ""}" type="button"
+        ${attribute}="${esc(item.value)}" aria-pressed="${selected === item.value ? "true" : "false"}">
+        <span>${esc(item.label)}</span>
+      </button>
+    `).join("")}</div>`;
+  }
+
+  function chipButtons(items, selected, attribute) {
+    const values = new Set(selected || []);
+    return `<div class="advisor-chip-grid">${items.map((item) => `
+      <button class="advisor-chip ${values.has(item.value) ? "is-selected" : ""}" type="button"
+        ${attribute}="${esc(item.value)}" aria-pressed="${values.has(item.value) ? "true" : "false"}">
+        <span class="advisor-chip-check" aria-hidden="true">${values.has(item.value) ? "✓" : "+"}</span>
+        <span>${esc(item.label)}</span>
+      </button>
+    `).join("")}</div>`;
+  }
+
+  function priceText(item) {
+    const value = item.display_price ?? item.active_price ?? item.base_price;
+    const numeric = Number(value);
+    return Number.isFinite(numeric) && numeric > 0 ? root.utils.formatBaht(numeric) : "สอบถามราคา";
+  }
+
+  function firstImage(item) {
+    const images = Array.isArray(item.images) ? item.images : [];
+    const primary = images.find((image) => image && image.is_primary) || images[0];
+    return String(primary && primary.image_url || item.image_url || "").trim();
+  }
+
+  function renderCatalogResults(recommendation, catalogState) {
+    if (catalogState.status === "loading" || catalogState.status === "idle") {
+      return `<div class="advisor-catalog-loading" role="status"><span></span><span></span><p>กำลังค้นหาบริการที่ตรงจาก Catalog</p></div>`;
+    }
+    const matches = mapCatalogItems(recommendation, catalogState.items, {
+      adapter: (item) => root.services.catalogItemToCommerceDraft(item),
+    });
+    if (!matches.length) {
+      return `
+        <div class="advisor-catalog-empty">
+          <strong>ยังไม่มีรายการที่ตรงสำหรับจองอัตโนมัติ</strong>
+          <p>ให้ทีม CWF ตรวจชนิดเครื่องและอาการก่อนเลือกบริการ</p>
+          <button class="primary-btn" type="button" data-advisor-contact>${icon("chat", 18)} ติดต่อให้ทีมประเมิน</button>
+        </div>
+      `;
+    }
+    return `
+      <div class="advisor-catalog-head">
+        <strong>บริการที่เกี่ยวข้องจาก Catalog</strong>
+        <span>เลือกดูรายละเอียดหรือดำเนินการต่อ</span>
+      </div>
+      <div class="advisor-result-products">
+        ${matches.map(({ item, directBook, exact }) => {
+          const image = firstImage(item);
+          return `
+            <article class="advisor-product ${exact ? "is-exact" : ""}" data-advisor-product="${esc(item.item_id)}">
+              <div class="advisor-product-image">${image ? `<img src="${esc(image)}" alt="" loading="lazy">` : icon("sparkle", 24)}</div>
+              <div class="advisor-product-body">
+                <span>${exact ? "ตรงกับผลประเมิน" : "ตัวเลือกที่เกี่ยวข้อง"}</span>
+                <h4>${esc(item.item_name)}</h4>
+                <p>${esc(priceText(item))}${item.unit_label ? ` / ${esc(item.unit_label)}` : ""}</p>
+                <div class="advisor-product-actions">
+                  <button class="secondary-btn" type="button" data-advisor-detail="${esc(item.item_id)}">ดูรายละเอียด</button>
+                  <button class="primary-btn" type="button" data-advisor-item-action="${esc(item.item_id)}">
+                    ${directBook ? "จองบริการนี้" : "ติดต่อประเมิน"}
+                  </button>
+                </div>
+              </div>
+            </article>
+          `;
+        }).join("")}
+      </div>
+    `;
+  }
+
+  function renderResult(state, catalogState) {
+    const recommendation = state.recommendation || evaluateRecommendation(state);
+    const meta = VERDICT_META[recommendation.verdict];
+    const alternative = recommendation.alternative ? VERDICT_META[recommendation.alternative] : null;
+    return `
+      <div class="advisor-result tone-${esc(meta.tone)}" data-advisor-result tabindex="-1" role="status" aria-live="polite">
+        <div class="advisor-result-hero">
+          <div class="advisor-result-mark" aria-hidden="true">${icon(recommendation.verdict === "repair_check" ? "wrench" : "sparkle", 28)}</div>
+          <div>
+            <span>ผลประเมินเบื้องต้น</span>
+            <h3>แนะนำ: ${esc(meta.label)}</h3>
+            <p>${esc(meta.short)}</p>
+          </div>
+          <span class="advisor-confidence">ความมั่นใจ ${esc(CONFIDENCE_LABELS[recommendation.confidence])}</span>
+        </div>
+        <div class="advisor-reason-list">
+          ${recommendation.reasons.map((reason) => `<div>${icon("shield", 17)}<span>${esc(reason)}</span></div>`).join("")}
+        </div>
+        ${alternative ? `<div class="advisor-alternative"><span>ทางเลือกสำรอง</span><strong>${esc(alternative.label)}</strong></div>` : ""}
+        <p class="advisor-note">${esc(recommendation.note)}</p>
+        <div class="advisor-catalog" data-advisor-catalog>${renderCatalogResults(recommendation, catalogState)}</div>
+        <div class="advisor-result-footer">
+          <button class="secondary-btn" type="button" data-advisor-back>ย้อนกลับแก้อาการ</button>
+          <button class="advisor-reset-btn" type="button" data-advisor-reset>เริ่มประเมินใหม่</button>
+        </div>
+      </div>
+    `;
+  }
+
+  function stepContent(state, catalogState) {
+    if (state.step === 4) return renderResult(state, catalogState);
+    const steps = [
+      { title: "แอร์ของคุณเป็นแบบไหน", copy: "เลือกชนิดเครื่องก่อน เพื่อไม่แนะนำวิธีล้างผิดประเภท" },
+      { title: "ล้างครั้งก่อนเมื่อไร", copy: "ใช้ช่วงเวลาโดยประมาณได้ ไม่จำเป็นต้องจำวันที่แน่นอน" },
+      { title: "ตอนนี้มีอาการอะไรบ้าง", copy: "เลือกได้หลายข้อ ระบบจะใช้ร่วมกับรอบล้าง" },
+      { title: "มีอาการที่ควรตรวจซ่อมก่อนไหม", copy: "อาการกลุ่มนี้จะถูกส่งไปตรวจเช็คก่อนงานล้าง" },
+    ];
+    const current = steps[state.step];
+    let controls = "";
+    if (state.step === 0) controls = choiceButtons(AC_TYPES, state.acType, "data-advisor-ac");
+    if (state.step === 1) controls = choiceButtons(MONTH_BANDS, state.monthsBand, "data-advisor-months");
+    if (state.step === 2) controls = chipButtons(SYMPTOMS, state.symptoms, "data-advisor-symptom");
+    if (state.step === 3) controls = chipButtons(REPAIR_SIGNALS, state.repairSignals, "data-advisor-repair");
+    const valid = (state.step === 0 && state.acType)
+      || (state.step === 1 && state.monthsBand)
+      || (state.step === 2 && state.symptoms.length)
+      || (state.step === 3 && state.repairSignals.length);
+    return `
+      <div class="advisor-step" data-advisor-step="${state.step + 1}">
+        <div class="advisor-step-copy">
+          <span>ขั้นที่ ${state.step + 1} จาก 4</span>
+          <h3>${esc(current.title)}</h3>
+          <p>${esc(current.copy)}</p>
+        </div>
+        ${controls}
+        <div class="advisor-step-actions">
+          ${state.step ? `<button class="secondary-btn" type="button" data-advisor-back>ย้อนกลับ</button>` : `<span></span>`}
+          <button class="primary-btn" type="button" data-advisor-next ${valid ? "" : "disabled"}>
+            ${state.step === 3 ? "ดูผลประเมิน" : "ขั้นต่อไป"}
+          </button>
+        </div>
+      </div>
+    `;
+  }
+
+  function renderSection(catalogState = { status: "idle", items: [] }) {
+    const state = initialState();
+    return `
+      <section class="smart-advisor-section homepage-section" data-smart-advisor data-home-reveal>
+        <div class="advisor-aura" aria-hidden="true"><span></span><span></span><span></span></div>
+        <div class="advisor-heading">
+          <div class="advisor-brand-mark">${icon("sparkle", 23)}</div>
+          <div>
+            <span class="section-kicker">CWF Smart Advisor</span>
+            <h2>ช่วยเลือกแบบล้างหรือซ่อมให้เหมาะกับอาการ</h2>
+            <p>ตอบคำถามสั้น ๆ แล้วดูบริการจริงที่เหมาะกับเครื่องของคุณ</p>
+          </div>
+        </div>
+        <div class="advisor-progress" aria-label="ความคืบหน้าการประเมิน">
+          ${[0, 1, 2, 3].map((index) => `<span class="${index === 0 ? "is-active" : ""}" data-advisor-progress="${index}"></span>`).join("")}
+        </div>
+        <div class="advisor-body" data-advisor-body>${stepContent(state, catalogState)}</div>
+      </section>
+    `;
+  }
+
+  function bind(container) {
+    const mount = container && container.querySelector ? container.querySelector("[data-smart-advisor]") : null;
+    if (!mount) return null;
+    const existing = controllers.get(mount);
+    if (existing) return existing;
+    let state = initialState();
+    let destroyed = false;
+    const reducedMotion = Boolean(window.matchMedia?.("(prefers-reduced-motion: reduce)")?.matches);
+    mount.classList?.toggle?.("is-reduced-motion", reducedMotion);
+    const catalogState = () => root.state.catalog || { status: "idle", items: [] };
+
+    const updateProgress = () => {
+      mount.querySelectorAll("[data-advisor-progress]").forEach((node, index) => {
+        const active = state.step === 4 ? true : index <= state.step;
+        node.classList.toggle("is-active", active);
+        if (index === Math.min(state.step, 3)) node.setAttribute("aria-current", "step");
+        else node.removeAttribute("aria-current");
+      });
+    };
+    const render = (focusResult = false) => {
+      if (destroyed || !mount.isConnected) return;
+      const body = mount.querySelector("[data-advisor-body]");
+      if (!body) return;
+      body.innerHTML = stepContent(state, catalogState());
+      updateProgress();
+      if (focusResult) requestAnimationFrame(() => mount.querySelector("[data-advisor-result]")?.focus({ preventScroll: true }));
+    };
+    const toggleExclusive = (values, value, exclusive) => {
+      const selected = new Set(values);
+      if (value === exclusive) return selected.has(value) ? [] : [value];
+      selected.delete(exclusive);
+      if (selected.has(value)) selected.delete(value);
+      else selected.add(value);
+      return Array.from(selected);
+    };
+    const contact = (title) => root.ui.openContactSheet(container, { title: title || "ให้ทีม CWF ช่วยประเมินบริการ" });
+    const onClick = (event) => {
+      const button = event.target.closest("button");
+      if (!button || destroyed) return;
+      if (button.hasAttribute("data-advisor-ac")) {
+        state.acType = button.getAttribute("data-advisor-ac");
+        render();
+      } else if (button.hasAttribute("data-advisor-months")) {
+        state.monthsBand = button.getAttribute("data-advisor-months");
+        render();
+      } else if (button.hasAttribute("data-advisor-symptom")) {
+        state.symptoms = toggleExclusive(state.symptoms, button.getAttribute("data-advisor-symptom"), "routine");
+        render();
+      } else if (button.hasAttribute("data-advisor-repair")) {
+        state.repairSignals = toggleExclusive(state.repairSignals, button.getAttribute("data-advisor-repair"), "none");
+        render();
+      } else if (button.hasAttribute("data-advisor-next")) {
+        if (state.step < 3) state.step += 1;
+        else {
+          state.recommendation = evaluateRecommendation(state);
+          state.step = 4;
+        }
+        render(state.step === 4);
+      } else if (button.hasAttribute("data-advisor-back")) {
+        state.step = state.step === 4 ? 3 : Math.max(0, state.step - 1);
+        state.recommendation = null;
+        render();
+      } else if (button.hasAttribute("data-advisor-reset")) {
+        state = initialState();
+        render();
+        mount.querySelector("[data-advisor-ac]")?.focus();
+      } else if (button.hasAttribute("data-advisor-detail")) {
+        root.utils.routeTo(`storeItem-${button.getAttribute("data-advisor-detail")}`);
+      } else if (button.hasAttribute("data-advisor-item-action")) {
+        const id = button.getAttribute("data-advisor-item-action");
+        const item = (catalogState().items || []).find((row) => String(row.item_id) === String(id));
+        if (state.recommendation?.verdict === "repair_check") {
+          contact(item && item.item_name);
+          return;
+        }
+        const draft = item ? root.services.catalogItemToCommerceDraft(item) : null;
+        if (draft && root.services.applyCommerceDraft("scheduled", draft)) {
+          root.utils.routeTo("scheduled");
+        } else {
+          contact(item && item.item_name);
+        }
+      } else if (button.hasAttribute("data-advisor-contact")) {
+        contact();
+      }
+    };
+    mount.addEventListener("click", onClick);
+    updateProgress();
+    const controller = {
+      refreshCatalog() {
+        if (!destroyed && state.step === 4) render();
+      },
+      state() {
+        return { ...state, symptoms: [...state.symptoms], repairSignals: [...state.repairSignals] };
+      },
+      reducedMotion,
+      cleanup() {
+        if (destroyed) return;
+        destroyed = true;
+        mount.removeEventListener("click", onClick);
+        controllers.delete(mount);
+      },
+    };
+    controllers.set(mount, controller);
+    return controller;
+  }
+
+  function controllerFor(container) {
+    const mount = container && container.querySelector ? container.querySelector("[data-smart-advisor]") : null;
+    return mount ? controllers.get(mount) : null;
+  }
+
+  function refreshCatalog(container) {
+    controllerFor(container)?.refreshCatalog();
+  }
+
+  function cleanup(container) {
+    controllerFor(container)?.cleanup();
+  }
+
+  root.advisor = {
+    renderSection,
+    bind,
+    refreshCatalog,
+    cleanup,
+    _test: {
+      AC_TYPES,
+      MONTH_BANDS,
+      SYMPTOMS,
+      REPAIR_SIGNALS,
+      VERDICT_META,
+      evaluateRecommendation,
+      canonicalAcType,
+      canonicalJobCategory,
+      canonicalWashVariant,
+      eligibleCatalogItems,
+      mapCatalogItems,
+      initialState,
+      renderSection,
+      stepContent,
+    },
+  };
+})();

--- a/customer-app/modules/tracking.js
+++ b/customer-app/modules/tracking.js
@@ -480,6 +480,15 @@
     `;
   }
 
+  function trackingAcType(unit) {
+    const value = clean(unit && unit.ac_type).toLowerCase();
+    if (/ผนัง|wall/.test(value)) return "wall";
+    if (/สี่ทิศ|four.?way|cassette/.test(value)) return "fourway";
+    if (/เปลือยใต้ฝ้า|ใต้ฝ้า|ceiling|concealed|duct/.test(value)) return "ceiling";
+    if (/แขวน|hanging/.test(value)) return "hanging";
+    return "unknown";
+  }
+
   function nextServiceGuidance(data, unit, profile, cleanliness) {
     const inspection = unitInspection(data, unit || { checklist_summary: {} });
     const issueKeys = inspection.metrics.filter((metric) => metric.status === "issue").map((metric) => metric.key);
@@ -511,14 +520,62 @@
         reason: "มีรายการที่ควรติดตามแต่ยังระบุประเภทไม่ได้ จึงไม่ควรฟันธงรูปแบบบริการ",
       };
     }
-    const profileLabel = profile && profile.kind !== "general" ? profile.label : "บริการที่เหมาะกับอาการ";
-    const cycleText = cleanliness && cleanliness.cycleText ? cleanliness.cycleText : profile && profile.nextText;
+    const elapsedDays = cleanliness && Number.isFinite(cleanliness.elapsedDays) ? cleanliness.elapsedDays : null;
+    if (elapsedDays == null) {
+      return {
+        tone: "neutral",
+        label: "ครั้งถัดไปแนะนำ: ยังประเมินรอบบริการไม่ได้",
+        reason: "ยังไม่มีวันที่จบงานนี้สำหรับประเมินรอบบริการครั้งถัดไป",
+      };
+    }
+    if (trackingAcType(unit) !== "wall") {
+      let timing = "ยังไม่ถึงรอบล้าง";
+      let tone = "good";
+      if (elapsedDays >= 120 && elapsedDays <= 255) {
+        timing = "เริ่มเข้าใกล้รอบบริการ";
+        tone = "watch";
+      } else if (elapsedDays > 255) {
+        timing = "ควรตรวจสภาพเพื่อวางแผนบริการ";
+        tone = "due";
+      }
+      return {
+        tone,
+        label: `ครั้งถัดไปแนะนำ: ${timing}`,
+        reason: "แนะนำล้างให้ตรงชนิดเครื่องและให้ทีมประเมินรูปแบบหน้างาน",
+      };
+    }
+    if (elapsedDays < 120) {
+      return {
+        tone: "good",
+        label: "ครั้งถัดไปแนะนำ: ยังไม่ถึงรอบล้าง",
+        reason: "แนะนำติดตามสภาพและวางแผนล้างธรรมดาเมื่อครบประมาณ 4–5 เดือน",
+      };
+    }
+    if (elapsedDays <= 165) {
+      return {
+        tone: "good",
+        label: "ครั้งถัดไปแนะนำ: ล้างธรรมดา",
+        reason: "ระยะจากงานนี้อยู่ในรอบดูแลทั่วไปประมาณ 4–5 เดือน",
+      };
+    }
+    if (elapsedDays <= 255) {
+      return {
+        tone: "watch",
+        label: "ครั้งถัดไปแนะนำ: ล้างพรีเมียม",
+        reason: "ระยะจากงานนี้ประมาณ 6–8 เดือน เหมาะกับการดูแลที่ละเอียดขึ้น",
+      };
+    }
+    if (elapsedDays <= 365) {
+      return {
+        tone: "watch",
+        label: "ครั้งถัดไปแนะนำ: ประเมินล้างแขวนคอยล์",
+        reason: "ระยะจากงานนี้ประมาณ 9–12 เดือน ควรตรวจสภาพจริงก่อนเลือกรูปแบบล้าง",
+      };
+    }
     return {
-      tone: cleanliness && cleanliness.tone === "due" ? "due" : "good",
-      label: `ครั้งถัดไปแนะนำ: ${profileLabel}`,
-      reason: cycleText
-        ? `วางแผนตามรอบประมาณ ${cycleText} และติดตามอาการจริงระหว่างใช้งาน`
-        : "ติดตามสภาพการใช้งานและเลือกบริการตามอาการจริง",
+      tone: "due",
+      label: "ครั้งถัดไปแนะนำ: ประเมินล้างแขวนคอยล์หรือตัดล้าง",
+      reason: "เกินหนึ่งปีจากงานนี้ ควรให้ทีมเลือกวิธีตามสภาพจริง ไม่ฟันธงจากเวลาเพียงอย่างเดียว",
     };
   }
 

--- a/customer-app/modules/tracking.js
+++ b/customer-app/modules/tracking.js
@@ -469,7 +469,7 @@
 
   function metricStatusCard(metric) {
     return `
-      <div class="unit-inspection-item is-${metric.tone}" data-metric="${esc(metric.key)}">
+      <div class="unit-inspection-item is-${metric.tone}" data-metric="${esc(metric.key)}" data-health-reveal>
         <span class="unit-inspection-icon" aria-hidden="true"></span>
         <div>
           <b>${esc(metric.label)}</b>
@@ -480,7 +480,61 @@
     `;
   }
 
-  function renderCleanlinessHighlight(model) {
+  function nextServiceGuidance(data, unit, profile, cleanliness) {
+    const inspection = unitInspection(data, unit || { checklist_summary: {} });
+    const issueKeys = inspection.metrics.filter((metric) => metric.status === "issue").map((metric) => metric.key);
+    if (issueKeys.includes("refrigerant") || issueKeys.includes("cooling")) {
+      return {
+        tone: "repair",
+        label: "ครั้งถัดไปแนะนำ: ตรวจเช็คระบบก่อน",
+        reason: "พบผลตรวจด้านความเย็นหรือระบบน้ำยา ควรตรวจหาสาเหตุก่อนเลือกวิธีล้าง",
+      };
+    }
+    if (issueKeys.includes("drain")) {
+      return {
+        tone: "watch",
+        label: "ครั้งถัดไปแนะนำ: ประเมินระบบน้ำทิ้ง",
+        reason: "ควรตรวจการระบายน้ำและสภาพหน้างานก่อนเลือกรอบล้างครั้งถัดไป",
+      };
+    }
+    if (issueKeys.includes("airflow")) {
+      return {
+        tone: "watch",
+        label: "ครั้งถัดไปแนะนำ: ตรวจสภาพก่อนเลือกล้าง",
+        reason: "ผลตรวจแรงลมควรใช้ร่วมกับสภาพคอยล์และอาการจริงก่อนเลือกระดับการล้าง",
+      };
+    }
+    if (inspection.postIssueCount > 0) {
+      return {
+        tone: "neutral",
+        label: "ครั้งถัดไปแนะนำ: ให้ทีมประเมินอาการ",
+        reason: "มีรายการที่ควรติดตามแต่ยังระบุประเภทไม่ได้ จึงไม่ควรฟันธงรูปแบบบริการ",
+      };
+    }
+    const profileLabel = profile && profile.kind !== "general" ? profile.label : "บริการที่เหมาะกับอาการ";
+    const cycleText = cleanliness && cleanliness.cycleText ? cleanliness.cycleText : profile && profile.nextText;
+    return {
+      tone: cleanliness && cleanliness.tone === "due" ? "due" : "good",
+      label: `ครั้งถัดไปแนะนำ: ${profileLabel}`,
+      reason: cycleText
+        ? `วางแผนตามรอบประมาณ ${cycleText} และติดตามอาการจริงระหว่างใช้งาน`
+        : "ติดตามสภาพการใช้งานและเลือกบริการตามอาการจริง",
+    };
+  }
+
+  function renderNextServiceGuidance(guidance) {
+    if (!guidance) return "";
+    return `
+      <div class="next-service-guidance tone-${esc(guidance.tone)}" data-next-service-guidance data-health-reveal>
+        <span>คำแนะนำบริการครั้งถัดไป</span>
+        <strong>${esc(guidance.label)}</strong>
+        <p>${esc(guidance.reason)}</p>
+        <small>คำแนะนำเบื้องต้น ควรพิจารณาอาการจริงร่วมด้วย</small>
+      </div>
+    `;
+  }
+
+  function renderCleanlinessHighlight(model, guidance) {
     if (!model) return "";
     const hasScore = Number.isFinite(model.score);
     const score = hasScore ? Math.max(0, Math.min(100, Math.round(model.score))) : 0;
@@ -489,7 +543,7 @@
       ? `คะแนนสภาพความสะอาดโดยประมาณ ${score} เปอร์เซ็นต์`
       : "ยังไม่มีคะแนนสภาพความสะอาด";
     return `
-      <section class="unit-cleanliness-card tone-${esc(model.tone)}" data-unit-cleanliness>
+      <section class="unit-cleanliness-card tone-${esc(model.tone)}" data-unit-cleanliness data-health-motion>
         <div class="unit-cleanliness-head">
           <div>
             <span>ความสะอาดและรอบล้าง</span>
@@ -516,6 +570,7 @@
             </div>
           </div>
         </div>
+        ${renderNextServiceGuidance(guidance)}
         ${model.elapsedDays == null ? "" : `<small class="cleanliness-basis">อ้างอิงจากวันที่จบงานนี้และประเภทบริการ</small>`}
       </section>
     `;
@@ -580,6 +635,7 @@
             const preview = photos.slice(0, 4);
             const meta = [unit.service_type, unit.ac_type, unit.btu ? `${unit.btu} BTU` : ""].filter(Boolean).join(" · ") || "เครื่องปรับอากาศ";
             const measurements = structuredMeasurements(unit);
+            const nextGuidance = nextServiceGuidance(data, unit, context.profile, context.cleanliness);
             const measurementPhotoCount = phaseCount(photos, "pressure") + phaseCount(photos, "current") + phaseCount(photos, "temp");
             return `
               <section
@@ -600,7 +656,7 @@
                     <p>${esc(inspection.overall.detail)}</p>
                   </div>
                   ${inspection.hasMetricData ? `<div class="unit-inspection-grid">${inspection.metrics.map(metricStatusCard).join("")}</div>` : ""}
-                  ${renderCleanlinessHighlight(context.cleanliness)}
+                  ${renderCleanlinessHighlight(context.cleanliness, nextGuidance)}
                   ${measurements.length ? `
                     <section class="unit-measurements" data-unit-measurements>
                       <h4>ค่าตรวจวัดเพิ่มเติม</h4>
@@ -745,7 +801,7 @@
     const estimateBasis = usesAppointmentEstimate ? "วันนัดหมาย" : "วันที่จบงานนี้";
 
     return `
-      <section class="passport-shell">
+      <section class="passport-shell has-health-motion">
         <div class="passport-hero">
           <span class="passport-kicker">สุขภาพแอร์</span>
           <h2>รายงานสุขภาพแอร์ CWF</h2>
@@ -767,7 +823,7 @@
             ${done && clean(data.technician_note) ? `<div class="passport-note"><b>หมายเหตุจากช่าง</b><p>${esc(data.technician_note)}</p></div>` : ""}
           </article>
 
-          ${renderUnitPassportCards(data, units, { cleanliness })}
+          ${renderUnitPassportCards(data, units, { cleanliness, profile })}
 
           <article class="passport-card passport-warranty-card">
             <div class="passport-card-head">
@@ -1699,6 +1755,8 @@
       renderTimeline,
       cleanlinessRecommendation,
       renderCleanlinessHighlight,
+      nextServiceGuidance,
+      renderNextServiceGuidance,
       serviceProfile,
       structuredMeasurements,
       unitInspection,

--- a/customer-app/modules/ui.js
+++ b/customer-app/modules/ui.js
@@ -782,6 +782,18 @@
     return "";
   }
 
+  function renderHomepageSectionsWithAdvisor() {
+    const sections = homepageSections();
+    const rendered = sections.map((section) => ({ section, html: renderHomepageSection(section) })).filter((entry) => entry.html);
+    if (!root.advisor || typeof root.advisor.renderSection !== "function") return rendered.map((entry) => entry.html).join("");
+    const quickIndex = rendered.findIndex((entry) => entry.section.type === "quick");
+    const heroIndex = rendered.findIndex((entry) => entry.section.type === "hero");
+    const insertAfter = quickIndex >= 0 ? quickIndex : heroIndex >= 0 ? heroIndex : -1;
+    const advisorHtml = root.advisor.renderSection(root.state.catalog || { status: "idle", items: [] });
+    if (insertAfter < 0) return `${advisorHtml}${rendered.map((entry) => entry.html).join("")}`;
+    return rendered.map((entry, index) => `${entry.html}${index === insertAfter ? advisorHtml : ""}`).join("");
+  }
+
   function renderAccountShortcut() {
     const customer = root.state.customer;
     if (root.state.authStatus === "loading" && !customer) {
@@ -1062,6 +1074,7 @@
   function bindHomepage(container) {
     bindCommerceHome(container);
     bindHomepageReveal(container);
+    root.advisor?.bind?.(container);
     bindHomepageHeroSliders(container);
     bindHomepagePromoBannerSlider(container);
     bindHomepageFeaturedRotators(container);
@@ -1503,6 +1516,7 @@
       if (card) mount.innerHTML = renderQuickPrice(card);
     });
     bindHomepage(container);
+    root.advisor?.refreshCatalog?.(container);
     // Re-hide any CTA pointing at a disabled route that this refresh re-rendered.
     root.pageAvailability?.applyToDom?.(container);
   }
@@ -1544,7 +1558,8 @@
 
     renderHome(container) {
       cleanupHomepageFeaturedRotators(container);
-      const sectionsHtml = homepageSections().map(renderHomepageSection).filter(Boolean).join("");
+      root.advisor?.cleanup?.(container);
+      const sectionsHtml = renderHomepageSectionsWithAdvisor();
       container.innerHTML = `
         <section class="screen commerce-home homepage-screen">
           ${sectionsHtml}
@@ -1633,6 +1648,7 @@
       featuredCatalogPool,
       buildFeaturedPages,
       renderHomepageHero,
+      renderHomepageSectionsWithAdvisor,
       renderHomepageFeaturedServices,
       openFeaturedContactSheet,
       bindHomepageFeaturedRotators,
@@ -1640,6 +1656,10 @@
     },
   };
 
-  ui.renderHome.onLeave = () => cleanupHomepageFeaturedRotators(document.getElementById("app"));
+  ui.renderHome.onLeave = () => {
+    const container = document.getElementById("app");
+    cleanupHomepageFeaturedRotators(container);
+    root.advisor?.cleanup?.(container);
+  };
   root.ui = ui;
 })();

--- a/customer-app/sw.js
+++ b/customer-app/sw.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const BUILD_ID = "20260714_tracking_cleanliness_donut_v1";
+const BUILD_ID = "20260714_customer_smart_advisor_motion_v1";
 const CACHE_NAME = `cwf-customer-app-v2-${BUILD_ID}`;
 const APP_SHELL = [
   `./index.html?v=${BUILD_ID}`,
@@ -14,6 +14,7 @@ const APP_SHELL = [
   `./modules/api.js?v=${BUILD_ID}`,
   `./modules/pageAvailability.js?v=${BUILD_ID}`,
   `./modules/services.js?v=${BUILD_ID}`,
+  `./modules/advisor.js?v=${BUILD_ID}`,
   `./modules/ui.js?v=${BUILD_ID}`,
   `./modules/store.js?v=${BUILD_ID}`,
   `./modules/auth.js?v=${BUILD_ID}`,

--- a/test/customerAppPageAvailability.test.js
+++ b/test/customerAppPageAvailability.test.js
@@ -281,7 +281,7 @@ test("api exposes loadCustomerAppConfig as a no-store GET to /public/customer-ap
 });
 
 test("build wiring: pageAvailability.js is registered in the HTML shell and the SW cache, with the new build id", () => {
-  const build = "20260714_tracking_cleanliness_donut_v1";
+  const build = "20260714_customer_smart_advisor_motion_v1";
   assert.match(indexHtml, new RegExp(`modules/pageAvailability\\.js\\?v=${build}`));
   assert.match(swSrc, new RegExp(`BUILD_ID = "${build}"`));
   assert.match(swSrc, /modules\/pageAvailability\.js\?v=\$\{BUILD_ID\}/);
@@ -294,7 +294,7 @@ test("build wiring: pageAvailability.js is registered in the HTML shell and the 
    RUNTIME tests (execute the real code in a VM — not regex assertions).
    ========================================================================== */
 
-const BUILD = "20260714_tracking_cleanliness_donut_v1";
+const BUILD = "20260714_customer_smart_advisor_motion_v1";
 const adminSrc = read("admin-homepage-cms.js");
 
 function reqUrlOf(req) {

--- a/test/customerAppRecovery.test.js
+++ b/test/customerAppRecovery.test.js
@@ -236,7 +236,7 @@ test("Customer App build id is consistent across shell and service worker", () =
   const sw = read("customer-app/sw.js");
   const app = read("customer-app/assets/customer-app.js");
   const manifest = read("customer-app/manifest.webmanifest");
-  const build = "20260714_tracking_cleanliness_donut_v1";
+  const build = "20260714_customer_smart_advisor_motion_v1";
 
   assert.match(index, new RegExp(`customer-app\\.css\\?v=${build}`));
   assert.match(index, new RegExp(`modules\\/api\\.js\\?v=${build}`));
@@ -254,7 +254,7 @@ test("Customer App build id is consistent across shell and service worker", () =
 test("store module is loaded in index.html and precached in the service worker app shell", () => {
   const index = read("customer-app/index.html");
   const sw = read("customer-app/sw.js");
-  const build = "20260714_tracking_cleanliness_donut_v1";
+  const build = "20260714_customer_smart_advisor_motion_v1";
 
   assert.match(index, new RegExp(`modules/store\\.js\\?v=${build}`));
   assert.match(sw, /`\.\/modules\/store\.js\?v=\$\{BUILD_ID\}`/);

--- a/test/customerAppStorePayment.test.js
+++ b/test/customerAppStorePayment.test.js
@@ -58,7 +58,7 @@ test("store falls back to the LINE hand-off when payment is unconfigured or the 
 test("payment step styles exist and the Customer App payment build id is bumped", () => {
   assert.match(cssSrc, /\.pay-method-btn/);
   assert.match(cssSrc, /\.pay-qr-img/);
-  assert.match(read("customer-app/index.html"), /modules\/store\.js\?v=20260714_tracking_cleanliness_donut_v1/);
-  assert.match(read("customer-app/sw.js"), /BUILD_ID = "20260714_tracking_cleanliness_donut_v1"/);
+  assert.match(read("customer-app/index.html"), /modules\/store\.js\?v=20260714_customer_smart_advisor_motion_v1/);
+  assert.match(read("customer-app/sw.js"), /BUILD_ID = "20260714_customer_smart_advisor_motion_v1"/);
   assert.match(storeSrc, /payment-security 20260705 loaded/);
 });

--- a/test/customerBookingAdminNotifications.test.js
+++ b/test/customerBookingAdminNotifications.test.js
@@ -311,10 +311,10 @@ test("admin/customer frontend cache versions are bumped for booking notification
   assert.doesNotMatch(adminReviewHtml, /admin-review-v2\.js\?v=20260707_customer_booking_notify_v2/);
   assert.match(adminReviewHtml, /admin-review-ai-intake\.js\?v=ai-booking-intake-customer-cards-v11-admin-alert-gate/);
   assert.doesNotMatch(adminReviewHtml, /admin-review-ai-intake\.js\?v=ai-booking-intake-customer-cards-v10/);
-  assert.match(customerIndex, /bookingScheduled\.js\?v=20260714_tracking_cleanliness_donut_v1/);
-  assert.match(customerIndex, /state\.js\?v=20260714_tracking_cleanliness_donut_v1/);
-  assert.match(customerSw, /const BUILD_ID = "20260714_tracking_cleanliness_donut_v1"/);
-  assert.match(customerManifest, /20260714_tracking_cleanliness_donut_v1/);
+  assert.match(customerIndex, /bookingScheduled\.js\?v=20260714_customer_smart_advisor_motion_v1/);
+  assert.match(customerIndex, /state\.js\?v=20260714_customer_smart_advisor_motion_v1/);
+  assert.match(customerSw, /const BUILD_ID = "20260714_customer_smart_advisor_motion_v1"/);
+  assert.match(customerManifest, /20260714_customer_smart_advisor_motion_v1/);
 });
 
 test("behavior: review queue only includes customer urgent waiting rows while preserving review statuses", () => {

--- a/test/customerHistoryClaim.test.js
+++ b/test/customerHistoryClaim.test.js
@@ -544,7 +544,7 @@ test("Customer App profile opens history detail with opaque job_ref and clears c
 });
 
 test("Customer App cache version is bumped consistently", () => {
-  const expected = "20260714_tracking_cleanliness_donut_v1";
+  const expected = "20260714_customer_smart_advisor_motion_v1";
   for (const file of [
     "customer-app/index.html",
     "customer-app/sw.js",

--- a/test/customerHomepageFeaturedRotation.test.js
+++ b/test/customerHomepageFeaturedRotation.test.js
@@ -414,6 +414,6 @@ test("compact CSS and cache build remain consistent with six-card rotation", () 
   assert.match(css, /\.homepage-featured-page\s*\{[^}]*grid-area:\s*1\s*\/\s*1/s);
   assert.match(css, /transition:\s*opacity 350ms/);
   assert.match(css, /prefers-reduced-motion:\s*reduce/);
-  const build = "20260714_tracking_cleanliness_donut_v1";
+  const build = "20260714_customer_smart_advisor_motion_v1";
   for (const source of [html, sw, boot, manifest]) assert.match(source, new RegExp(build));
 });

--- a/test/customerSameDayTiming.test.js
+++ b/test/customerSameDayTiming.test.js
@@ -160,7 +160,7 @@ test("customer app disables availability HTTP cache and refreshes same-day slots
 });
 
 test("customer app build and service worker cache IDs changed", () => {
-  const id = "20260714_tracking_cleanliness_donut_v1";
+  const id = "20260714_customer_smart_advisor_motion_v1";
   for (const file of [
     "customer-app/index.html",
     "customer-app/sw.js",

--- a/test/customerSmartAdvisor.test.js
+++ b/test/customerSmartAdvisor.test.js
@@ -1,0 +1,337 @@
+"use strict";
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const vm = require("node:vm");
+
+const ROOT = path.resolve(__dirname, "..");
+const SOURCE = fs.readFileSync(path.join(ROOT, "customer-app/modules/advisor.js"), "utf8");
+const UI_SOURCE = fs.readFileSync(path.join(ROOT, "customer-app/modules/ui.js"), "utf8");
+const CSS_SOURCE = fs.readFileSync(path.join(ROOT, "customer-app/assets/customer-app.css"), "utf8");
+const INDEX_SOURCE = fs.readFileSync(path.join(ROOT, "customer-app/index.html"), "utf8");
+const SW_SOURCE = fs.readFileSync(path.join(ROOT, "customer-app/sw.js"), "utf8");
+
+function escapeHtml(value) {
+  return String(value == null ? "" : value)
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#039;");
+}
+
+function catalogItem(id, overrides = {}) {
+  return {
+    item_id: id,
+    item_name: `บริการ ${id}`,
+    item_category: "ล้างแอร์",
+    job_category: "ล้าง",
+    booking_mode: "bookable",
+    booking_ac_type: "ผนัง",
+    booking_btu: 12000,
+    booking_wash_variant: "ล้างธรรมดา",
+    is_active: true,
+    is_customer_visible: true,
+    display_price: 750,
+    unit_label: "เครื่อง",
+    images: [],
+    ...overrides,
+  };
+}
+
+class FakeClassList {
+  constructor() { this.values = new Set(); }
+  toggle(value, force) { if (force) this.values.add(value); else this.values.delete(value); }
+}
+
+class FakeProgress {
+  constructor() { this.classList = new FakeClassList(); this.attributes = new Map(); }
+  setAttribute(name, value) { this.attributes.set(name, String(value)); }
+  removeAttribute(name) { this.attributes.delete(name); }
+}
+
+class FakeMount {
+  constructor() {
+    this.isConnected = true;
+    this.listeners = new Map();
+    this.body = { innerHTML: "" };
+    this.progress = [new FakeProgress(), new FakeProgress(), new FakeProgress(), new FakeProgress()];
+    this.resultFocuses = 0;
+    this.firstFocuses = 0;
+  }
+  addEventListener(type, handler) { this.listeners.set(type, handler); }
+  removeEventListener(type, handler) { if (this.listeners.get(type) === handler) this.listeners.delete(type); }
+  querySelector(selector) {
+    if (selector === "[data-advisor-body]") return this.body;
+    if (selector === "[data-advisor-result]") return { focus: () => { this.resultFocuses += 1; } };
+    if (selector === "[data-advisor-ac]") return { focus: () => { this.firstFocuses += 1; } };
+    return null;
+  }
+  querySelectorAll(selector) { return selector === "[data-advisor-progress]" ? this.progress : []; }
+  click(attributes) {
+    const button = {
+      hasAttribute: (name) => Object.hasOwn(attributes, name),
+      getAttribute: (name) => attributes[name] ?? null,
+    };
+    this.listeners.get("click")?.({ target: { closest: () => button } });
+  }
+}
+
+function loadAdvisor(options = {}) {
+  const routes = [];
+  const contacts = [];
+  const applied = [];
+  const catalog = options.catalog || { status: "success", items: [] };
+  const app = {
+    state: { catalog },
+    utils: {
+      escapeHtml,
+      formatBaht: (value) => `${value} บาท`,
+      icon: (name) => `<i data-icon="${name}"></i>`,
+      routeTo: (route) => routes.push(route),
+    },
+    services: {
+      catalogItemToCommerceDraft: options.adapter || ((item) => item.booking_mode === "bookable" && item.booking_btu ? { id: item.item_id, draft: {} } : null),
+      applyCommerceDraft: options.apply || ((scope, draft) => { applied.push({ scope, draft }); return true; }),
+    },
+    ui: { openContactSheet: (_container, item) => contacts.push(item) },
+  };
+  vm.runInNewContext(SOURCE, {
+    window: { CWFCustomerAppV2: app, matchMedia: () => ({ matches: options.reducedMotion === true }) },
+    Set,
+    WeakMap,
+    requestAnimationFrame: (fn) => fn(),
+  }, { filename: "advisor.js" });
+  return { app, routes, contacts, applied };
+}
+
+function plain(value) {
+  return JSON.parse(JSON.stringify(value));
+}
+
+test("wall recommendation engine covers standard premium coil overhaul and uncertain overdue cases", () => {
+  const { app } = loadAdvisor();
+  const evaluate = app.advisor._test.evaluateRecommendation;
+  assert.equal(evaluate({ acType: "wall", monthsBand: "m4_5", symptoms: ["routine"], repairSignals: ["none"] }).verdict, "standard_clean");
+  assert.equal(evaluate({ acType: "wall", monthsBand: "m6_8", symptoms: ["heavy_use"], repairSignals: ["none"] }).verdict, "premium_clean");
+  assert.equal(evaluate({ acType: "wall", monthsBand: "m9_12", symptoms: ["weak_airflow", "odor"], repairSignals: ["none"] }).verdict, "hanging_coil");
+  assert.equal(evaluate({ acType: "wall", monthsBand: "over12", symptoms: ["heavy_dirt"], repairSignals: ["none"] }).verdict, "big_wash");
+  const uncertain = evaluate({ acType: "wall", monthsBand: "over12", symptoms: ["routine"], repairSignals: ["none"] });
+  assert.equal(uncertain.verdict, "hanging_coil");
+  assert.equal(uncertain.alternative, "big_wash");
+  assert.equal(uncertain.confidence, "assessment");
+});
+
+test("repair signals override cleaning while reduced cooling alone does not", () => {
+  const { app } = loadAdvisor();
+  const evaluate = app.advisor._test.evaluateRecommendation;
+  for (const signal of ["error_code", "outdoor_not_running", "indoor_not_running", "breaker_trip", "ac_not_running", "burning_smell"]) {
+    const result = evaluate({ acType: "wall", monthsBand: "m4_5", symptoms: ["routine"], repairSignals: [signal] });
+    assert.equal(result.verdict, "repair_check", signal);
+    assert.equal(result.action, "contact");
+  }
+  assert.notEqual(evaluate({ acType: "wall", monthsBand: "m6_8", symptoms: ["reduced_cooling"], repairSignals: ["none"] }).verdict, "repair_check");
+});
+
+test("unknown and non-wall AC types fail closed without a wall wash variant", () => {
+  const { app } = loadAdvisor();
+  const evaluate = app.advisor._test.evaluateRecommendation;
+  const unknown = evaluate({ acType: "unknown", monthsBand: "m6_8", symptoms: ["routine"], repairSignals: ["none"] });
+  assert.equal(unknown.verdict, "needs_assessment");
+  assert.equal(unknown.catalogIntent, null);
+  for (const acType of ["fourway", "hanging", "ceiling"]) {
+    const result = evaluate({ acType, monthsBand: "m6_8", symptoms: ["routine"], repairSignals: ["none"] });
+    assert.equal(result.verdict, "needs_assessment");
+    assert.equal(result.catalogIntent.acType, acType);
+    assert.equal(result.catalogIntent.variant, undefined);
+  }
+});
+
+test("catalog mapping uses exact authoritative metadata for all wash variants and repair", () => {
+  const { app } = loadAdvisor();
+  const { evaluateRecommendation, mapCatalogItems } = app.advisor._test;
+  const items = [
+    catalogItem(1),
+    catalogItem(2, { booking_wash_variant: "ล้างพรีเมียม" }),
+    catalogItem(3, { booking_wash_variant: "ล้างแขวนคอยล์" }),
+    catalogItem(4, { booking_wash_variant: "ล้างแบบตัดล้าง" }),
+    catalogItem(5, { item_name: "ตรวจเช็คแอร์", item_category: "ตรวจเช็ค", job_category: "ตรวจเช็ค", booking_mode: "contact_admin", booking_ac_type: null, booking_btu: null, booking_wash_variant: null }),
+  ];
+  const cases = [
+    [{ acType: "wall", monthsBand: "m4_5", symptoms: ["routine"], repairSignals: ["none"] }, 1],
+    [{ acType: "wall", monthsBand: "m6_8", symptoms: ["heavy_use"], repairSignals: ["none"] }, 2],
+    [{ acType: "wall", monthsBand: "m9_12", symptoms: ["odor"], repairSignals: ["none"] }, 3],
+    [{ acType: "wall", monthsBand: "over12", symptoms: ["heavy_dirt"], repairSignals: ["none"] }, 4],
+    [{ acType: "wall", monthsBand: "m4_5", symptoms: ["routine"], repairSignals: ["error_code"] }, 5],
+  ];
+  for (const [input, expectedId] of cases) {
+    const matches = mapCatalogItems(evaluateRecommendation(input), items, { adapter: (item) => item.booking_mode === "bookable" ? { draft: {} } : null });
+    assert.equal(matches[0].item.item_id, expectedId);
+    assert.equal(matches[0].exact, true);
+    if (expectedId === 5) assert.equal(matches[0].directBook, false);
+  }
+});
+
+test("catalog mapping filters inactive hidden duplicate rows and never treats incomplete metadata as direct-book", () => {
+  const { app } = loadAdvisor();
+  const recommendation = app.advisor._test.evaluateRecommendation({ acType: "wall", monthsBand: "m4_5", symptoms: ["routine"], repairSignals: ["none"] });
+  const items = [
+    catalogItem(1),
+    catalogItem(1, { item_name: "duplicate" }),
+    catalogItem(2, { is_active: false }),
+    catalogItem(3, { is_customer_visible: false }),
+    catalogItem(4, { booking_btu: null }),
+  ];
+  const matches = app.advisor._test.mapCatalogItems(recommendation, items, {
+    adapter: (item) => item.booking_btu ? { draft: {} } : null,
+  });
+  assert.deepEqual(plain(matches.map((match) => match.item.item_id)), [1, 4]);
+  assert.equal(matches[0].directBook, true);
+  assert.equal(matches[1].directBook, false);
+});
+
+test("non-wall catalog matching requires the exact AC type", () => {
+  const { app } = loadAdvisor();
+  const recommendation = app.advisor._test.evaluateRecommendation({ acType: "fourway", monthsBand: "m6_8", symptoms: ["routine"], repairSignals: ["none"] });
+  const matches = app.advisor._test.mapCatalogItems(recommendation, [
+    catalogItem(1),
+    catalogItem(2, { booking_ac_type: "สี่ทิศทาง", booking_wash_variant: null, item_name: "ล้างแอร์สี่ทิศทาง" }),
+  ], { adapter: () => ({ draft: {} }) });
+  assert.equal(matches[0].item.item_id, 2);
+  assert.equal(matches[0].exact, true);
+});
+
+test("wizard advances, supports multi-select, refreshes Catalog, resets, and binds once", () => {
+  const { app } = loadAdvisor({ catalog: { status: "loading", items: [] } });
+  const mount = new FakeMount();
+  const container = { querySelector: (selector) => selector === "[data-smart-advisor]" ? mount : null };
+  const first = app.advisor.bind(container);
+  const second = app.advisor.bind(container);
+  assert.equal(first, second);
+  assert.equal(mount.listeners.size, 1);
+
+  mount.click({ "data-advisor-ac": "wall" });
+  mount.click({ "data-advisor-next": "" });
+  mount.click({ "data-advisor-months": "m6_8" });
+  mount.click({ "data-advisor-next": "" });
+  mount.click({ "data-advisor-symptom": "heavy_use" });
+  mount.click({ "data-advisor-symptom": "pets" });
+  mount.click({ "data-advisor-next": "" });
+  mount.click({ "data-advisor-repair": "none" });
+  mount.click({ "data-advisor-next": "" });
+  assert.equal(first.state().recommendation.verdict, "premium_clean");
+  assert.match(mount.body.innerHTML, /กำลังค้นหาบริการที่ตรงจาก Catalog/);
+  assert.equal(mount.resultFocuses, 1);
+
+  app.state.catalog.status = "success";
+  app.state.catalog.items = [catalogItem(2, { booking_wash_variant: "ล้างพรีเมียม", item_name: "ล้างแอร์พรีเมียม" })];
+  app.advisor.refreshCatalog(container);
+  assert.match(mount.body.innerHTML, /ล้างแอร์พรีเมียม/);
+  mount.click({ "data-advisor-back": "" });
+  assert.equal(first.state().step, 3);
+  mount.click({ "data-advisor-reset": "" });
+  assert.equal(first.state().step, 0);
+  assert.equal(mount.firstFocuses, 1);
+  first.cleanup();
+  assert.equal(mount.listeners.size, 0);
+});
+
+test("booking handoff routes only after both existing adapters succeed and otherwise contacts", () => {
+  const item = catalogItem(8);
+  const success = loadAdvisor({ catalog: { status: "success", items: [item] } });
+  const mount = new FakeMount();
+  const container = { querySelector: (selector) => selector === "[data-smart-advisor]" ? mount : null };
+  success.app.advisor.bind(container);
+  mount.click({ "data-advisor-item-action": "8" });
+  assert.deepEqual(success.routes, ["scheduled"]);
+  assert.equal(success.applied.length, 1);
+  assert.equal(success.contacts.length, 0);
+
+  const denied = loadAdvisor({ catalog: { status: "success", items: [item] }, adapter: () => null });
+  const deniedMount = new FakeMount();
+  denied.app.advisor.bind({ querySelector: () => deniedMount });
+  deniedMount.click({ "data-advisor-item-action": "8" });
+  assert.equal(denied.routes.length, 0);
+  assert.equal(denied.contacts.length, 1);
+
+  const applyDenied = loadAdvisor({ catalog: { status: "success", items: [item] }, apply: () => false });
+  const applyMount = new FakeMount();
+  applyDenied.app.advisor.bind({ querySelector: () => applyMount });
+  applyMount.click({ "data-advisor-item-action": "8" });
+  assert.equal(applyDenied.routes.length, 0);
+  assert.equal(applyDenied.contacts.length, 1);
+});
+
+test("repair result always opens Contact Sheet even when a repair item has adapter-compatible metadata", () => {
+  const repairItem = catalogItem(9, { item_name: "ตรวจเช็คแอร์", job_category: "ตรวจเช็ค" });
+  const runtime = loadAdvisor({ catalog: { status: "success", items: [repairItem] } });
+  const mount = new FakeMount();
+  const container = { querySelector: () => mount };
+  const controller = runtime.app.advisor.bind(container);
+  mount.click({ "data-advisor-ac": "wall" });
+  mount.click({ "data-advisor-next": "" });
+  mount.click({ "data-advisor-months": "m4_5" });
+  mount.click({ "data-advisor-next": "" });
+  mount.click({ "data-advisor-symptom": "routine" });
+  mount.click({ "data-advisor-next": "" });
+  mount.click({ "data-advisor-repair": "error_code" });
+  mount.click({ "data-advisor-next": "" });
+  assert.equal(controller.state().recommendation.verdict, "repair_check");
+  mount.click({ "data-advisor-item-action": "9" });
+  assert.equal(runtime.routes.length, 0);
+  assert.equal(runtime.applied.length, 0);
+  assert.equal(runtime.contacts.length, 1);
+});
+
+test("advisor render contract is accessible, compact, motion-safe, and has no autoplay timer", () => {
+  const { app } = loadAdvisor();
+  const html = app.advisor.renderSection({ status: "success", items: [] });
+  assert.match(html, /data-smart-advisor/);
+  assert.match(html, /แอร์ของคุณเป็นแบบไหน/);
+  assert.match(html, /aria-label="ความคืบหน้าการประเมิน"/);
+  assert.match(CSS_SOURCE, /@media \(prefers-reduced-motion: reduce\)/);
+  assert.match(CSS_SOURCE, /\.advisor-choice,[\s\S]*?min-height: 44px/);
+  assert.match(CSS_SOURCE, /@keyframes advisor-step-in/);
+  assert.match(CSS_SOURCE, /@keyframes health-ring-sweep/);
+  assert.doesNotMatch(SOURCE, /setInterval\s*\(/);
+  assert.match(SOURCE, /matchMedia\?\.\("\(prefers-reduced-motion: reduce\)"\)/);
+  const reduced = loadAdvisor({ reducedMotion: true });
+  const mount = new FakeMount();
+  assert.equal(reduced.app.advisor.bind({ querySelector: () => mount }).reducedMotion, true);
+});
+
+test("Home places built-in advisor after Quick Actions and before Featured Services", () => {
+  const app = {
+    state: {
+      homepage: { config: { sections: [
+        { id: "hero", type: "hero", enabled: true, sort_order: 10, title: "Hero", items: [] },
+        { id: "quick", type: "quick", enabled: true, sort_order: 20, items: [] },
+        { id: "featured", type: "featured_services", enabled: true, sort_order: 30, title: "Featured", items: [] },
+      ] } },
+      catalog: { status: "success", items: [] },
+    },
+    advisor: { renderSection: () => `<section data-smart-advisor>Advisor</section>` },
+    utils: { escapeHtml, icon: () => "", formatBaht: () => "-", stateBox: () => "" },
+    services: { quickServices: [], WALL_AC: "ผนัง" },
+  };
+  vm.runInNewContext(UI_SOURCE, {
+    window: { CWFCustomerAppV2: app },
+    document: { body: { classList: { add() {}, remove() {} } }, getElementById: () => null },
+    URL,
+    WeakMap,
+    Set,
+    console,
+  });
+  const html = app.ui._test.renderHomepageSectionsWithAdvisor();
+  assert.ok(html.indexOf("data-home-section=\"quick\"") < html.indexOf("data-smart-advisor"));
+  assert.ok(html.indexOf("data-smart-advisor") < html.indexOf("data-home-featured-section"));
+});
+
+test("advisor module is loaded before ui.js and precached under the shared build id", () => {
+  const build = "20260714_customer_smart_advisor_motion_v1";
+  assert.ok(INDEX_SOURCE.indexOf(`modules/advisor.js?v=${build}`) < INDEX_SOURCE.indexOf(`modules/ui.js?v=${build}`));
+  assert.match(SW_SOURCE, new RegExp(`BUILD_ID = "${build}"`));
+  assert.match(SW_SOURCE, /modules\/advisor\.js\?v=\$\{BUILD_ID\}/);
+});

--- a/test/customerSmartAdvisor.test.js
+++ b/test/customerSmartAdvisor.test.js
@@ -111,6 +111,17 @@ function plain(value) {
   return JSON.parse(JSON.stringify(value));
 }
 
+function completeWallStandardAdvisor(mount) {
+  mount.click({ "data-advisor-ac": "wall" });
+  mount.click({ "data-advisor-next": "" });
+  mount.click({ "data-advisor-months": "m4_5" });
+  mount.click({ "data-advisor-next": "" });
+  mount.click({ "data-advisor-symptom": "routine" });
+  mount.click({ "data-advisor-next": "" });
+  mount.click({ "data-advisor-repair": "none" });
+  mount.click({ "data-advisor-next": "" });
+}
+
 test("wall recommendation engine covers standard premium coil overhaul and uncertain overdue cases", () => {
   const { app } = loadAdvisor();
   const evaluate = app.advisor._test.evaluateRecommendation;
@@ -201,6 +212,47 @@ test("non-wall catalog matching requires the exact AC type", () => {
   ], { adapter: () => ({ draft: {} }) });
   assert.equal(matches[0].item.item_id, 2);
   assert.equal(matches[0].exact, true);
+  assert.equal(matches.length, 1);
+});
+
+test("catalog mapping excludes cross-AC and limits wrong wall variants to explicit alternatives", () => {
+  const { app } = loadAdvisor();
+  const standard = app.advisor._test.evaluateRecommendation({ acType: "wall", monthsBand: "m4_5", symptoms: ["routine"], repairSignals: ["none"] });
+  const premium = catalogItem(2, { booking_wash_variant: "ล้างพรีเมียม", item_name: "ล้างพรีเมียม" });
+  const fourway = catalogItem(3, { booking_ac_type: "สี่ทิศทาง", booking_wash_variant: null, item_name: "ล้างแอร์สี่ทิศทาง" });
+  const matches = app.advisor._test.mapCatalogItems(standard, [premium, fourway], { adapter: () => ({ draft: {} }) });
+  assert.equal(matches.length, 1);
+  assert.equal(matches[0].item.item_id, 2);
+  assert.equal(matches[0].matchType, "alternative");
+  assert.equal(matches[0].directBook, false);
+
+  const html = app.advisor._test.stepContent({
+    step: 4,
+    acType: "wall",
+    monthsBand: "m4_5",
+    symptoms: ["routine"],
+    repairSignals: ["none"],
+    recommendation: standard,
+  }, { status: "success", items: [premium, fourway] });
+  assert.match(html, /ทางเลือกสำรอง/);
+  assert.doesNotMatch(html, /ล้างแอร์สี่ทิศทาง/);
+  assert.doesNotMatch(html, /จองบริการนี้/);
+});
+
+test("no exact Catalog match renders assessment CTA instead of a wrong direct-book action", () => {
+  const { app } = loadAdvisor();
+  const recommendation = app.advisor._test.evaluateRecommendation({ acType: "wall", monthsBand: "m4_5", symptoms: ["routine"], repairSignals: ["none"] });
+  recommendation.alternative = null;
+  const html = app.advisor._test.stepContent({
+    step: 4,
+    acType: "wall",
+    monthsBand: "m4_5",
+    symptoms: ["routine"],
+    repairSignals: ["none"],
+    recommendation,
+  }, { status: "success", items: [catalogItem(9, { booking_ac_type: "สี่ทิศทาง" })] });
+  assert.match(html, /ให้ทีมช่วยประเมิน/);
+  assert.doesNotMatch(html, /จองบริการนี้/);
 });
 
 test("wizard advances, supports multi-select, refreshes Catalog, resets, and binds once", () => {
@@ -244,6 +296,7 @@ test("booking handoff routes only after both existing adapters succeed and other
   const mount = new FakeMount();
   const container = { querySelector: (selector) => selector === "[data-smart-advisor]" ? mount : null };
   success.app.advisor.bind(container);
+  completeWallStandardAdvisor(mount);
   mount.click({ "data-advisor-item-action": "8" });
   assert.deepEqual(success.routes, ["scheduled"]);
   assert.equal(success.applied.length, 1);
@@ -252,6 +305,7 @@ test("booking handoff routes only after both existing adapters succeed and other
   const denied = loadAdvisor({ catalog: { status: "success", items: [item] }, adapter: () => null });
   const deniedMount = new FakeMount();
   denied.app.advisor.bind({ querySelector: () => deniedMount });
+  completeWallStandardAdvisor(deniedMount);
   deniedMount.click({ "data-advisor-item-action": "8" });
   assert.equal(denied.routes.length, 0);
   assert.equal(denied.contacts.length, 1);
@@ -259,9 +313,29 @@ test("booking handoff routes only after both existing adapters succeed and other
   const applyDenied = loadAdvisor({ catalog: { status: "success", items: [item] }, apply: () => false });
   const applyMount = new FakeMount();
   applyDenied.app.advisor.bind({ querySelector: () => applyMount });
+  completeWallStandardAdvisor(applyMount);
   applyMount.click({ "data-advisor-item-action": "8" });
   assert.equal(applyDenied.routes.length, 0);
   assert.equal(applyDenied.contacts.length, 1);
+});
+
+test("manipulated unrelated Catalog item id is rejected before booking adapters run", () => {
+  let adapterCalls = 0;
+  let applyCalls = 0;
+  const unrelated = catalogItem(9, { booking_ac_type: "สี่ทิศทาง", booking_wash_variant: null });
+  const runtime = loadAdvisor({
+    catalog: { status: "success", items: [unrelated] },
+    adapter: () => { adapterCalls += 1; return { draft: {} }; },
+    apply: () => { applyCalls += 1; return true; },
+  });
+  const mount = new FakeMount();
+  runtime.app.advisor.bind({ querySelector: () => mount });
+  completeWallStandardAdvisor(mount);
+  mount.click({ "data-advisor-item-action": "9" });
+  assert.equal(adapterCalls, 0);
+  assert.equal(applyCalls, 0);
+  assert.equal(runtime.routes.length, 0);
+  assert.equal(runtime.contacts.length, 1);
 });
 
 test("repair result always opens Contact Sheet even when a repair item has adapter-compatible metadata", () => {

--- a/test/customerTrackingFullReadUi.test.js
+++ b/test/customerTrackingFullReadUi.test.js
@@ -153,16 +153,41 @@ test("completed normal checklist renders one compact green inspection grid witho
   assert.ok(html.indexOf("passport-units-card") < html.indexOf("passport-warranty-card"));
 });
 
-test("normal metrics keep profile-based next-service guidance", () => {
+test("wall next-service guidance follows deterministic elapsed-day bands", () => {
   const app = loadTrackingRuntime();
   const data = completedHealthPayload();
   const profile = app.tracking._test.serviceProfile(data);
-  const cleanliness = app.tracking._test.cleanlinessRecommendation(data.finished_at, 90, profile, new Date("2026-08-15T00:00:00Z").getTime());
-  const guidance = app.tracking._test.nextServiceGuidance(data, data.units[0], profile, cleanliness);
-  assert.equal(guidance.tone, "good");
-  assert.match(guidance.label, /ล้างปกติ/);
-  const html = app.tracking._test.renderNextServiceGuidance(guidance);
+  const cases = [
+    [60, /ยังไม่ถึงรอบล้าง/, /ล้างธรรมดา.*4–5 เดือน/],
+    [150, /ล้างธรรมดา/, /4–5 เดือน/],
+    [210, /ล้างพรีเมียม/, /6–8 เดือน/],
+    [300, /ประเมินล้างแขวนคอยล์/, /9–12 เดือน/],
+    [390, /ประเมินล้างแขวนคอยล์หรือตัดล้าง/, /ไม่ฟันธงจากเวลา/],
+  ];
+  for (const [elapsedDays, label, reason] of cases) {
+    const guidance = app.tracking._test.nextServiceGuidance(data, data.units[0], profile, { elapsedDays });
+    assert.match(guidance.label, label, `${elapsedDays} days`);
+    assert.match(guidance.reason, reason, `${elapsedDays} days`);
+  }
+  const html = app.tracking._test.renderNextServiceGuidance(
+    app.tracking._test.nextServiceGuidance(data, data.units[0], profile, { elapsedDays: 150 }),
+  );
   assert.match(html, /คำแนะนำเบื้องต้น ควรพิจารณาอาการจริงร่วมด้วย/);
+});
+
+test("non-wall and missing-date next-service guidance fail closed", () => {
+  const app = loadTrackingRuntime();
+  const data = completedHealthPayload();
+  const profile = app.tracking._test.serviceProfile(data);
+  for (const acType of ["สี่ทิศทาง", "แขวน", "เปลือยใต้ฝ้า", "ไม่ทราบ"] ) {
+    const unit = { ...data.units[0], ac_type: acType };
+    const guidance = app.tracking._test.nextServiceGuidance(data, unit, profile, { elapsedDays: 300 });
+    assert.match(guidance.reason, /ล้างให้ตรงชนิดเครื่องและให้ทีมประเมินรูปแบบหน้างาน/);
+    assert.doesNotMatch(`${guidance.label} ${guidance.reason}`, /ล้างพรีเมียม|แขวนคอยล์|ตัดล้าง/);
+  }
+  const missing = app.tracking._test.nextServiceGuidance(data, data.units[0], profile, { elapsedDays: null });
+  assert.equal(missing.tone, "neutral");
+  assert.match(missing.reason, /ยังไม่มีวันที่จบงานนี้สำหรับประเมินรอบบริการครั้งถัดไป/);
 });
 
 test("cooling and refrigerant issues recommend repair-first without using raw notes", () => {
@@ -173,9 +198,10 @@ test("cooling and refrigerant issues recommend repair-first without using raw no
     data.units[0].checklist_summary.post_issue_count = 1;
     data.units[0].checklist_summary.metric_statuses = { refrigerant: null, cooling: null, airflow: null, drain: null, [key]: "issue" };
     const profile = app.tracking._test.serviceProfile(data);
-    const guidance = app.tracking._test.nextServiceGuidance(data, data.units[0], profile, null);
+    const guidance = app.tracking._test.nextServiceGuidance(data, data.units[0], profile, { elapsedDays: 150 });
     assert.equal(guidance.tone, "repair");
     assert.match(guidance.label, /ตรวจเช็คระบบก่อน/);
+    assert.doesNotMatch(guidance.label, /ล้างธรรมดา/);
     assert.doesNotMatch(JSON.stringify(guidance), /ข้อความภายใน/);
   }
 });
@@ -190,9 +216,10 @@ test("drain airflow and unclassified issues use cautious customer-safe guidance"
     const data = completedHealthPayload();
     data.units[0].checklist_summary.post_issue_count = 1;
     data.units[0].checklist_summary.metric_statuses = { refrigerant: null, cooling: null, airflow: null, drain: null, [key]: "issue" };
-    const guidance = app.tracking._test.nextServiceGuidance(data, data.units[0], app.tracking._test.serviceProfile(data), null);
+    const guidance = app.tracking._test.nextServiceGuidance(data, data.units[0], app.tracking._test.serviceProfile(data), { elapsedDays: 300 });
     assert.equal(guidance.tone, "watch");
     assert.match(`${guidance.label} ${guidance.reason}`, expected);
+    if (key === "drain") assert.doesNotMatch(guidance.label, /แขวนคอยล์/);
   }
   const unknown = completedHealthPayload();
   unknown.units[0].checklist_summary.post_issue_count = 1;

--- a/test/customerTrackingFullReadUi.test.js
+++ b/test/customerTrackingFullReadUi.test.js
@@ -8,6 +8,7 @@ const vm = require("node:vm");
 
 const ROOT = path.resolve(__dirname, "..");
 const TRACKING_SOURCE = fs.readFileSync(path.join(ROOT, "customer-app/modules/tracking.js"), "utf8");
+const CSS_SOURCE = fs.readFileSync(path.join(ROOT, "customer-app/assets/customer-app.css"), "utf8");
 
 function escapeHtml(value) {
   return String(value == null ? "" : value)
@@ -150,6 +151,69 @@ test("completed normal checklist renders one compact green inspection grid witho
   assert.doesNotMatch(html, /passport-muted-card/);
   for (const copy of FORBIDDEN_HEALTH_COPY) assert.doesNotMatch(html, new RegExp(copy));
   assert.ok(html.indexOf("passport-units-card") < html.indexOf("passport-warranty-card"));
+});
+
+test("normal metrics keep profile-based next-service guidance", () => {
+  const app = loadTrackingRuntime();
+  const data = completedHealthPayload();
+  const profile = app.tracking._test.serviceProfile(data);
+  const cleanliness = app.tracking._test.cleanlinessRecommendation(data.finished_at, 90, profile, new Date("2026-08-15T00:00:00Z").getTime());
+  const guidance = app.tracking._test.nextServiceGuidance(data, data.units[0], profile, cleanliness);
+  assert.equal(guidance.tone, "good");
+  assert.match(guidance.label, /ล้างปกติ/);
+  const html = app.tracking._test.renderNextServiceGuidance(guidance);
+  assert.match(html, /คำแนะนำเบื้องต้น ควรพิจารณาอาการจริงร่วมด้วย/);
+});
+
+test("cooling and refrigerant issues recommend repair-first without using raw notes", () => {
+  const app = loadTrackingRuntime();
+  for (const key of ["cooling", "refrigerant"]) {
+    const data = completedHealthPayload();
+    data.technician_note = "ข้อความภายในที่ต้องไม่ใช้วินิจฉัย";
+    data.units[0].checklist_summary.post_issue_count = 1;
+    data.units[0].checklist_summary.metric_statuses = { refrigerant: null, cooling: null, airflow: null, drain: null, [key]: "issue" };
+    const profile = app.tracking._test.serviceProfile(data);
+    const guidance = app.tracking._test.nextServiceGuidance(data, data.units[0], profile, null);
+    assert.equal(guidance.tone, "repair");
+    assert.match(guidance.label, /ตรวจเช็คระบบก่อน/);
+    assert.doesNotMatch(JSON.stringify(guidance), /ข้อความภายใน/);
+  }
+});
+
+test("drain airflow and unclassified issues use cautious customer-safe guidance", () => {
+  const app = loadTrackingRuntime();
+  const cases = [
+    ["drain", /ระบบน้ำทิ้ง/],
+    ["airflow", /ตรวจสภาพก่อนเลือกล้าง/],
+  ];
+  for (const [key, expected] of cases) {
+    const data = completedHealthPayload();
+    data.units[0].checklist_summary.post_issue_count = 1;
+    data.units[0].checklist_summary.metric_statuses = { refrigerant: null, cooling: null, airflow: null, drain: null, [key]: "issue" };
+    const guidance = app.tracking._test.nextServiceGuidance(data, data.units[0], app.tracking._test.serviceProfile(data), null);
+    assert.equal(guidance.tone, "watch");
+    assert.match(`${guidance.label} ${guidance.reason}`, expected);
+  }
+  const unknown = completedHealthPayload();
+  unknown.units[0].checklist_summary.post_issue_count = 1;
+  unknown.units[0].checklist_summary.metric_statuses = { refrigerant: null, cooling: null, airflow: null, drain: null };
+  const guidance = app.tracking._test.nextServiceGuidance(unknown, unknown.units[0], app.tracking._test.serviceProfile(unknown), null);
+  assert.equal(guidance.tone, "neutral");
+  assert.match(guidance.label, /ให้ทีมประเมินอาการ/);
+});
+
+test("Health Passport renders finite motion hooks while warranty and capability gates remain intact", () => {
+  const app = loadTrackingRuntime();
+  const html = app.tracking._test.renderPassport(completedHealthPayload());
+  assert.match(html, /passport-shell has-health-motion/);
+  assert.match(html, /data-health-motion/);
+  assert.match(html, /data-health-reveal/);
+  assert.match(html, /data-next-service-guidance/);
+  assert.match(html, /passport-warranty-card/);
+  assert.match(CSS_SOURCE, /@keyframes health-ring-sweep/);
+  assert.match(CSS_SOURCE, /@keyframes health-item-in/);
+  assert.match(CSS_SOURCE, /prefers-reduced-motion: reduce/);
+  assert.doesNotMatch(TRACKING_SOURCE, /setInterval\s*\(/);
 });
 
 test("cleanliness recommendation is deterministic from last-cleaned date and score", () => {
@@ -679,7 +743,7 @@ test("tracking UI exposes loading, not-found, rate-limit and offline states", ()
 });
 
 test("tracking assets share the full-read cache build id", () => {
-  const build = "20260714_tracking_cleanliness_donut_v1";
+  const build = "20260714_customer_smart_advisor_motion_v1";
   for (const file of [
     "customer-app/index.html",
     "customer-app/sw.js",

--- a/test/homepageCms.test.js
+++ b/test/homepageCms.test.js
@@ -296,7 +296,7 @@ test("customer homepage has no admin control, bottom nav is fixed five-tab, and 
   const sw = read("customer-app/sw.js");
   const app = read("customer-app/assets/customer-app.js");
   const manifest = read("customer-app/manifest.webmanifest");
-  const build = "20260714_tracking_cleanliness_donut_v1";
+  const build = "20260714_customer_smart_advisor_motion_v1";
 
   assert.doesNotMatch(index + ui, /โหมดแอดมิน|openCms|localStorage\.getItem\('cwfHomeCmsDemo'/);
   assert.match(index, /data-route="store"[\s\S]*ร้านค้า/);


### PR DESCRIPTION
## Summary
- add a built-in five-state Customer Smart Advisor on Home with AC-type selection, deterministic cleaning/repair recommendations, real Catalog matching, and fail-closed booking/contact handoff
- add customer-safe next-service guidance to Tracking Health Passport using service profile, elapsed time, unit AC type, completed state, and structured metric statuses
- add finite entrance/ring/status motion with reduced-motion handling

## Review fixes
- cleaning Catalog results now exclude cross-AC rows and include only exact primary variants plus explicitly declared alternatives
- explicit alternatives are labeled `ทางเลือกสำรอง` and remain contact/detail only
- direct scheduled booking requires a current exact primary match, active/customer-visible item, accepted adapter draft, and successful `applyCommerceDraft()`
- item actions recompute allowed matches before using an item ID; manipulated or stale IDs fail closed to Contact Sheet
- assessment/contact recommendations retain a visible `ให้ทีมช่วยประเมิน` CTA
- Tracking now uses deterministic wall-AC bands: <120, 120-165, 166-255, 256-365, and >365 days
- non-wall units receive type-specific assessment copy without wall wash variants; metric issues still override elapsed-time guidance

## Safety
- no backend, database, migration, production-data, auth, payment, pricing, booking-security, or Tracking capability/token/document/review gate changes
- repair recommendations always use Contact Sheet
- no BUILD_ID change in this review round

## Validation
- node --check for changed JavaScript: passed
- focused Advisor + Tracking: 52 passed, 0 failed
- focused Home/booking/privacy/document/review/cache regressions: 517 passed, 0 failed
- full branch: 1242 tests, 1180 passed, 28 failed, 34 skipped
- exact main: 1222 tests, 1160 passed, 28 failed, 34 skipped
- additional failures versus main: 0
- the shared 28 failures remain unrelated admin Catalog UI and customer-history migration checksum failures

## Visual verification
This environment still exposes no browser backend. Manual smoke remains required at 360/390/412px for long Thai copy, bottom navigation overlap, Contact Sheet, keyboard focus, Catalog cards, and multi-unit Tracking.