### PR TITLE
Redesign Smart Advisor as compact bottom sheet

### DIFF
--- a/customer-app/assets/customer-app.css
+++ b/customer-app/assets/customer-app.css
@@ -6600,8 +6600,8 @@ body.has-advisor-sheet { overflow: hidden; }
   background: rgba(5, 24, 44, 0.54);
   -webkit-backdrop-filter: blur(7px);
   backdrop-filter: blur(7px);
-  animation: advisor-backdrop-in 220ms ease both;
 }
+.advisor-sheet-layer.is-opening { animation: advisor-backdrop-in 220ms ease both; }
 .advisor-sheet-layer.is-closing { animation: advisor-backdrop-out 220ms ease both; }
 .advisor-sheet {
   display: grid;
@@ -6615,8 +6615,8 @@ body.has-advisor-sheet { overflow: hidden; }
   border-radius: 22px 22px 0 0;
   background: #f8fbfd;
   box-shadow: 0 -22px 55px -32px rgba(1, 24, 48, 0.9);
-  animation: advisor-sheet-up 280ms cubic-bezier(0.22, 0.61, 0.36, 1) both;
 }
+.advisor-sheet-layer.is-opening .advisor-sheet { animation: advisor-sheet-up 280ms cubic-bezier(0.22, 0.61, 0.36, 1) both; }
 .advisor-sheet-layer.is-closing .advisor-sheet { animation: advisor-sheet-down 220ms ease both; }
 .advisor-sheet-header {
   position: sticky;
@@ -6683,11 +6683,11 @@ body.has-advisor-sheet { overflow: hidden; }
   scrollbar-gutter: stable;
 }
 .advisor-sheet-body { min-width: 0; padding: 18px 16px 22px; }
-.advisor-sheet .advisor-step,
-.advisor-sheet .advisor-result { animation: advisor-question-forward 280ms cubic-bezier(0.22, 0.61, 0.36, 1) both; }
-.advisor-sheet-layer.direction-back .advisor-step,
-.advisor-sheet-layer.direction-back .advisor-result { animation-name: advisor-question-back; }
-.advisor-sheet-layer.direction-refresh .advisor-result { animation: none; }
+.advisor-sheet-body.is-step-forward > .advisor-step,
+.advisor-sheet-body.is-step-forward > .advisor-result { animation: advisor-question-forward 280ms cubic-bezier(0.22, 0.61, 0.36, 1) both; }
+.advisor-sheet-body.is-step-back > .advisor-step,
+.advisor-sheet-body.is-step-back > .advisor-result { animation: advisor-question-back 280ms cubic-bezier(0.22, 0.61, 0.36, 1) both; }
+.advisor-sheet-body.is-refresh > .advisor-result { animation: none; }
 .advisor-sheet .advisor-step-copy h3 { margin-top: 0; font-size: 19px; }
 .advisor-sheet .advisor-step-copy p { font-size: 12px; }
 .advisor-sheet .advisor-choice-grid {
@@ -6755,7 +6755,7 @@ body.has-advisor-sheet { overflow: hidden; }
 }
 .advisor-sheet-actions button { min-height: 46px; }
 .advisor-sheet-actions .primary-btn:disabled { opacity: 0.48; cursor: not-allowed; transform: none; }
-.advisor-sheet .advisor-result { animation-name: advisor-result-reveal; }
+.advisor-sheet-body.is-step-forward > .advisor-result { animation-name: advisor-result-reveal; }
 .advisor-sheet .advisor-reason-list > div { animation: advisor-reason-in 260ms ease both; }
 .advisor-sheet .advisor-reason-list > div:nth-child(2) { animation-delay: 45ms; }
 .advisor-sheet .advisor-reason-list > div:nth-child(3) { animation-delay: 90ms; }

--- a/customer-app/assets/customer-app.css
+++ b/customer-app/assets/customer-app.css
@@ -6509,6 +6509,305 @@ textarea.purchase-input { min-height: 66px; resize: vertical; }
   .advisor-chip,
   .advisor-progress span { transition: none !important; }
 }
+
+/* Compact Smart Advisor launcher and focused sheet */
+body.has-advisor-sheet { overflow: hidden; }
+.smart-advisor-section {
+  display: grid;
+  grid-template-columns: 56px minmax(0, 1fr);
+  gap: 13px;
+  align-items: start;
+  min-height: 0;
+  padding: 16px;
+  overflow: hidden;
+  border-radius: 15px;
+  background: linear-gradient(140deg, #eef8ff 0%, #fff 62%, #fff8d8 100%);
+}
+.advisor-launcher-orb {
+  position: relative;
+  display: grid;
+  place-items: center;
+  width: 54px;
+  height: 54px;
+  margin-top: 2px;
+  border-radius: 50%;
+  background: #0b62ad;
+  color: #fff;
+  box-shadow: 0 10px 24px -15px rgba(7, 69, 128, 0.9), 0 0 0 7px rgba(255, 205, 43, 0.14);
+}
+.advisor-launcher-orb::after {
+  position: absolute;
+  inset: -7px;
+  border: 1px solid rgba(21, 112, 187, 0.38);
+  border-top-color: #f2c328;
+  border-radius: 50%;
+  content: "";
+  animation: advisor-orbit 5s linear infinite;
+}
+.is-sheet-open .advisor-launcher-orb::after { animation-play-state: paused; }
+.smart-advisor-section.is-sheet-open { isolation: auto; overflow: visible; }
+.advisor-launcher-content,
+.advisor-launcher-copy { min-width: 0; }
+.advisor-launcher-copy h2 {
+  margin: 3px 0 0;
+  color: #092d58;
+  font-size: 18px;
+  line-height: 1.28;
+  overflow-wrap: anywhere;
+}
+.advisor-launcher-copy p {
+  display: -webkit-box;
+  margin: 5px 0 0;
+  overflow: hidden;
+  color: #526b82;
+  font-size: 12px;
+  line-height: 1.45;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+}
+.advisor-launcher-status {
+  display: flex;
+  gap: 5px;
+  align-items: center;
+  min-width: 0;
+  margin-top: 7px;
+  color: #315d85;
+  font-size: 10.5px;
+  line-height: 1.35;
+  overflow-wrap: anywhere;
+}
+.advisor-launcher-actions {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+  margin-top: 11px;
+}
+.advisor-launcher-actions .primary-btn {
+  min-height: 44px;
+  padding-inline: 16px;
+}
+.advisor-launcher-actions small { color: #6b7d8f; font-size: 10px; }
+.advisor-launcher-actions .advisor-reset-btn { min-height: 44px; }
+
+.advisor-sheet-layer {
+  position: fixed;
+  inset: 0;
+  z-index: 100;
+  display: flex;
+  align-items: flex-end;
+  justify-content: center;
+  padding-top: max(20px, env(safe-area-inset-top, 0px));
+  background: rgba(5, 24, 44, 0.54);
+  -webkit-backdrop-filter: blur(7px);
+  backdrop-filter: blur(7px);
+  animation: advisor-backdrop-in 220ms ease both;
+}
+.advisor-sheet-layer.is-closing { animation: advisor-backdrop-out 220ms ease both; }
+.advisor-sheet {
+  display: grid;
+  grid-template-rows: auto minmax(0, 1fr) auto;
+  width: min(100%, 480px);
+  max-height: 90vh;
+  max-height: 90dvh;
+  overflow: hidden;
+  border: 1px solid rgba(188, 214, 235, 0.8);
+  border-bottom: 0;
+  border-radius: 22px 22px 0 0;
+  background: #f8fbfd;
+  box-shadow: 0 -22px 55px -32px rgba(1, 24, 48, 0.9);
+  animation: advisor-sheet-up 280ms cubic-bezier(0.22, 0.61, 0.36, 1) both;
+}
+.advisor-sheet-layer.is-closing .advisor-sheet { animation: advisor-sheet-down 220ms ease both; }
+.advisor-sheet-header {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  display: grid;
+  grid-template-columns: 34px minmax(0, 1fr) 44px;
+  gap: 9px;
+  align-items: center;
+  padding: 12px 14px 9px;
+  border-bottom: 1px solid #dbe7f0;
+  background: rgba(255, 255, 255, 0.94);
+  -webkit-backdrop-filter: blur(10px);
+  backdrop-filter: blur(10px);
+}
+.advisor-sheet-brand {
+  display: grid;
+  place-items: center;
+  width: 34px;
+  height: 34px;
+  border-radius: 10px;
+  background: #0b62ad;
+  color: #fff;
+}
+.advisor-sheet-header h2 { margin: 0; color: #092d58; font-size: 15px; line-height: 1.25; }
+.advisor-sheet-header span { color: #62788c; font-size: 10.5px; font-weight: 750; }
+.advisor-sheet-close {
+  display: grid;
+  place-items: center;
+  width: 44px;
+  height: 44px;
+  border: 0;
+  border-radius: 50%;
+  background: transparent;
+  color: #294b6e;
+  font: inherit;
+  font-size: 25px;
+  cursor: pointer;
+}
+.advisor-sheet-close:focus-visible,
+.advisor-launcher-actions button:focus-visible,
+.advisor-sheet-actions button:focus-visible {
+  outline: 3px solid rgba(240, 190, 34, 0.58);
+  outline-offset: 2px;
+}
+.advisor-sheet-progress {
+  grid-column: 1 / -1;
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 5px;
+}
+.advisor-sheet-progress span {
+  height: 3px;
+  border-radius: 99px;
+  background: #dbe7f1;
+  transition: background 220ms ease, transform 220ms ease;
+}
+.advisor-sheet-progress span.is-active { background: #e9b91e; transform: scaleY(1.2); }
+.advisor-sheet-scroll {
+  min-height: 0;
+  overflow-x: hidden;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  scrollbar-gutter: stable;
+}
+.advisor-sheet-body { min-width: 0; padding: 18px 16px 22px; }
+.advisor-sheet .advisor-step,
+.advisor-sheet .advisor-result { animation: advisor-question-forward 280ms cubic-bezier(0.22, 0.61, 0.36, 1) both; }
+.advisor-sheet-layer.direction-back .advisor-step,
+.advisor-sheet-layer.direction-back .advisor-result { animation-name: advisor-question-back; }
+.advisor-sheet-layer.direction-refresh .advisor-result { animation: none; }
+.advisor-sheet .advisor-step-copy h3 { margin-top: 0; font-size: 19px; }
+.advisor-sheet .advisor-step-copy p { font-size: 12px; }
+.advisor-sheet .advisor-choice-grid {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 9px;
+  margin-top: 15px;
+}
+.advisor-sheet .advisor-chip-grid {
+  grid-template-columns: minmax(0, 1fr);
+  gap: 9px;
+  margin-top: 15px;
+}
+.advisor-sheet .advisor-choice,
+.advisor-sheet .advisor-chip {
+  display: grid;
+  grid-template-columns: 28px minmax(0, 1fr) 24px;
+  gap: 9px;
+  align-items: center;
+  min-height: 54px;
+  padding: 9px 11px;
+  text-align: left;
+  font-size: 12px;
+  transition: transform 160ms ease, border-color 190ms ease, background 190ms ease, box-shadow 190ms ease;
+}
+.advisor-choice-icon {
+  display: grid;
+  place-items: center;
+  width: 28px;
+  height: 28px;
+  border-radius: 9px;
+  background: #edf4f9;
+  color: #1768ac;
+}
+.advisor-choice-label { min-width: 0; overflow-wrap: anywhere; }
+.advisor-choice-check {
+  display: grid;
+  place-items: center;
+  width: 22px;
+  height: 22px;
+  border: 1px solid #c7d7e4;
+  border-radius: 50%;
+  background: #fff;
+  color: #fff;
+  transform: scale(0.82);
+  transition: transform 180ms ease, background 180ms ease, border-color 180ms ease, opacity 180ms ease;
+}
+.advisor-sheet .is-selected .advisor-choice-check {
+  border-color: #1670bd;
+  background: #1670bd;
+  transform: scale(1);
+}
+.advisor-sheet .is-selected .advisor-choice-icon { background: #dcefff; color: #075899; }
+.advisor-sheet-actions {
+  position: sticky;
+  bottom: 0;
+  z-index: 3;
+  display: grid;
+  grid-template-columns: minmax(0, 0.8fr) minmax(0, 1.2fr);
+  gap: 9px;
+  padding: 10px 14px calc(10px + env(safe-area-inset-bottom, 0px));
+  border-top: 1px solid #dbe7f0;
+  background: rgba(255, 255, 255, 0.96);
+  -webkit-backdrop-filter: blur(10px);
+  backdrop-filter: blur(10px);
+}
+.advisor-sheet-actions button { min-height: 46px; }
+.advisor-sheet-actions .primary-btn:disabled { opacity: 0.48; cursor: not-allowed; transform: none; }
+.advisor-sheet .advisor-result { animation-name: advisor-result-reveal; }
+.advisor-sheet .advisor-reason-list > div { animation: advisor-reason-in 260ms ease both; }
+.advisor-sheet .advisor-reason-list > div:nth-child(2) { animation-delay: 45ms; }
+.advisor-sheet .advisor-reason-list > div:nth-child(3) { animation-delay: 90ms; }
+.advisor-sheet .advisor-reason-list > div:nth-child(4) { animation-delay: 135ms; }
+.advisor-sheet .advisor-result .advisor-product { animation-name: advisor-product-in; }
+.advisor-sheet .advisor-result .primary-btn { animation: advisor-cta-glow 650ms ease 1 260ms both; }
+
+@keyframes advisor-orbit { to { transform: rotate(360deg); } }
+@keyframes advisor-backdrop-in { from { opacity: 0; } to { opacity: 1; } }
+@keyframes advisor-backdrop-out { from { opacity: 1; } to { opacity: 0; } }
+@keyframes advisor-sheet-up { from { opacity: 0; transform: translateY(24px); } to { opacity: 1; transform: translateY(0); } }
+@keyframes advisor-sheet-down { from { opacity: 1; transform: translateY(0); } to { opacity: 0; transform: translateY(24px); } }
+@keyframes advisor-question-forward { from { opacity: 0; transform: translateX(10px); } to { opacity: 1; transform: translateX(0); } }
+@keyframes advisor-question-back { from { opacity: 0; transform: translateX(-10px); } to { opacity: 1; transform: translateX(0); } }
+@keyframes advisor-result-reveal { from { opacity: 0; transform: scale(0.985); } to { opacity: 1; transform: scale(1); } }
+@keyframes advisor-reason-in { from { opacity: 0; transform: translateY(4px); } to { opacity: 1; transform: translateY(0); } }
+@keyframes advisor-cta-glow { 50% { box-shadow: 0 0 0 5px rgba(240, 190, 34, 0.2); } }
+
+@media (max-width: 380px) {
+  .smart-advisor-section { grid-template-columns: 48px minmax(0, 1fr); gap: 10px; padding: 14px; }
+  .advisor-launcher-orb { width: 46px; height: 46px; }
+  .advisor-launcher-copy h2 { font-size: 16px; }
+  .advisor-launcher-actions { align-items: stretch; flex-direction: column; gap: 4px; }
+  .advisor-launcher-actions .primary-btn { width: 100%; }
+  .advisor-sheet .advisor-choice-grid { grid-template-columns: minmax(0, 1fr); }
+  .advisor-sheet-body { padding-inline: 13px; }
+  .advisor-product-actions { grid-template-columns: 1fr; }
+}
+
+@media (max-height: 620px) {
+  .advisor-sheet { max-height: 92dvh; }
+  .advisor-sheet-body { padding-top: 13px; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .advisor-launcher-orb::after,
+  .advisor-sheet-layer,
+  .advisor-sheet,
+  .advisor-sheet .advisor-step,
+  .advisor-sheet .advisor-result,
+  .advisor-sheet .advisor-reason-list > div,
+  .advisor-sheet .advisor-product,
+  .advisor-sheet .advisor-result .primary-btn {
+    animation: none !important;
+    transition: none !important;
+    transform: none !important;
+  }
+  .advisor-sheet .advisor-choice,
+  .advisor-sheet .advisor-chip,
+  .advisor-choice-check,
+  .advisor-sheet-progress span { transition: none !important; }
+}
 /* Readable overlay on top of the blurred shell. */
 .maintenance-overlay {
   position: absolute;

--- a/customer-app/assets/customer-app.js
+++ b/customer-app/assets/customer-app.js
@@ -3,7 +3,7 @@
 
   const App = window.CWFCustomerAppV2;
   const BOOT_TIMEOUT_MS = 3500;
-  const BUILD_ID = "20260714_customer_smart_advisor_motion_v1";
+  const BUILD_ID = "20260714_smart_advisor_compact_sheet_v1";
 
   function withTimeout(promise, timeoutMs) {
     return Promise.race([

--- a/customer-app/index.html
+++ b/customer-app/index.html
@@ -21,10 +21,10 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Noto+Sans+Thai:wght@400;500;600;700;800;900&display=swap" media="print" onload="this.media='all'">
   <noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Noto+Sans+Thai:wght@400;500;600;700;800;900&display=swap"></noscript>
-  <link rel="manifest" href="./manifest.webmanifest?v=20260714_customer_smart_advisor_motion_v1">
+  <link rel="manifest" href="./manifest.webmanifest?v=20260714_smart_advisor_compact_sheet_v1">
   <link rel="icon" type="image/png" sizes="192x192" href="./assets/icons/cwf-customer-192.png">
   <link rel="apple-touch-icon" sizes="180x180" href="./assets/icons/cwf-customer-180.png">
-  <link rel="stylesheet" href="./assets/customer-app.css?v=20260714_customer_smart_advisor_motion_v1">
+  <link rel="stylesheet" href="./assets/customer-app.css?v=20260714_smart_advisor_compact_sheet_v1">
 </head>
 <body class="is-app-booting">
   <div class="app-shell" data-app-shell>
@@ -62,23 +62,23 @@
     </nav>
   </div>
 
-  <script src="./modules/state.js?v=20260714_customer_smart_advisor_motion_v1"></script>
-  <script src="./modules/utils.js?v=20260714_customer_smart_advisor_motion_v1"></script>
-  <script src="./modules/analytics.js?v=20260714_customer_smart_advisor_motion_v1"></script>
-  <script src="./modules/api.js?v=20260714_customer_smart_advisor_motion_v1"></script>
-  <script src="./modules/pageAvailability.js?v=20260714_customer_smart_advisor_motion_v1"></script>
-  <script src="./modules/services.js?v=20260714_customer_smart_advisor_motion_v1"></script>
-  <script src="./modules/advisor.js?v=20260714_customer_smart_advisor_motion_v1"></script>
-  <script src="./modules/ui.js?v=20260714_customer_smart_advisor_motion_v1"></script>
-  <script src="./modules/store.js?v=20260714_customer_smart_advisor_motion_v1"></script>
-  <script src="./modules/auth.js?v=20260714_customer_smart_advisor_motion_v1"></script>
-  <script src="./modules/pricing.js?v=20260714_customer_smart_advisor_motion_v1"></script>
-  <script src="./modules/availability.js?v=20260714_customer_smart_advisor_motion_v1"></script>
-  <script src="./modules/bookingScheduled.js?v=20260714_customer_smart_advisor_motion_v1"></script>
-  <script src="./modules/bookingUrgent.js?v=20260714_customer_smart_advisor_motion_v1"></script>
-  <script src="./modules/tracking.js?v=20260714_customer_smart_advisor_motion_v1"></script>
-  <script src="./modules/profile.js?v=20260714_customer_smart_advisor_motion_v1"></script>
-  <script src="./modules/router.js?v=20260714_customer_smart_advisor_motion_v1"></script>
-  <script src="./assets/customer-app.js?v=20260714_customer_smart_advisor_motion_v1"></script>
+  <script src="./modules/state.js?v=20260714_smart_advisor_compact_sheet_v1"></script>
+  <script src="./modules/utils.js?v=20260714_smart_advisor_compact_sheet_v1"></script>
+  <script src="./modules/analytics.js?v=20260714_smart_advisor_compact_sheet_v1"></script>
+  <script src="./modules/api.js?v=20260714_smart_advisor_compact_sheet_v1"></script>
+  <script src="./modules/pageAvailability.js?v=20260714_smart_advisor_compact_sheet_v1"></script>
+  <script src="./modules/services.js?v=20260714_smart_advisor_compact_sheet_v1"></script>
+  <script src="./modules/advisor.js?v=20260714_smart_advisor_compact_sheet_v1"></script>
+  <script src="./modules/ui.js?v=20260714_smart_advisor_compact_sheet_v1"></script>
+  <script src="./modules/store.js?v=20260714_smart_advisor_compact_sheet_v1"></script>
+  <script src="./modules/auth.js?v=20260714_smart_advisor_compact_sheet_v1"></script>
+  <script src="./modules/pricing.js?v=20260714_smart_advisor_compact_sheet_v1"></script>
+  <script src="./modules/availability.js?v=20260714_smart_advisor_compact_sheet_v1"></script>
+  <script src="./modules/bookingScheduled.js?v=20260714_smart_advisor_compact_sheet_v1"></script>
+  <script src="./modules/bookingUrgent.js?v=20260714_smart_advisor_compact_sheet_v1"></script>
+  <script src="./modules/tracking.js?v=20260714_smart_advisor_compact_sheet_v1"></script>
+  <script src="./modules/profile.js?v=20260714_smart_advisor_compact_sheet_v1"></script>
+  <script src="./modules/router.js?v=20260714_smart_advisor_compact_sheet_v1"></script>
+  <script src="./assets/customer-app.js?v=20260714_smart_advisor_compact_sheet_v1"></script>
 </body>
 </html>

--- a/customer-app/manifest.webmanifest
+++ b/customer-app/manifest.webmanifest
@@ -2,7 +2,7 @@
   "name": "CWF Customer Service",
   "short_name": "CWF Service",
   "description": "แอปลูกค้า Coldwindflow สำหรับเลือกบริการ จองคิว และติดตามงาน",
-  "start_url": "/customer-app/index.html?v=20260714_customer_smart_advisor_motion_v1#home",
+  "start_url": "/customer-app/index.html?v=20260714_smart_advisor_compact_sheet_v1#home",
   "scope": "/customer-app/",
   "id": "/customer-app/",
   "display": "standalone",

--- a/customer-app/modules/advisor.js
+++ b/customer-app/modules/advisor.js
@@ -495,27 +495,27 @@
     `;
   }
 
-  function sheetHtml(state, catalogState, direction = "forward") {
-    const result = state.step === 4;
-    const stepNumber = result ? 4 : state.step + 1;
+  function sheetProgressHtml(stepNumber) {
+    return [0, 1, 2, 3].map((index) => `<span class="${index < stepNumber ? "is-active" : ""}" ${index === Math.min(stepNumber - 1, 3) ? `aria-current="step"` : ""}></span>`).join("");
+  }
+
+  function sheetHtml() {
     return `
-      <div class="advisor-sheet-layer direction-${esc(direction)}" data-advisor-backdrop>
-        <section class="advisor-sheet" id="advisor-sheet-dialog" data-advisor-dialog data-step="${stepNumber}" role="dialog" aria-modal="true" aria-labelledby="advisor-sheet-title">
+      <div class="advisor-sheet-layer is-opening" data-advisor-backdrop>
+        <section class="advisor-sheet" id="advisor-sheet-dialog" data-advisor-dialog role="dialog" aria-modal="true" aria-labelledby="advisor-sheet-title">
           <header class="advisor-sheet-header">
             <div class="advisor-sheet-brand" aria-hidden="true">${icon("sparkle", 18)}</div>
             <div>
               <h2 id="advisor-sheet-title">ผู้ช่วยเลือกบริการ</h2>
-              <span>${result ? "ผลประเมิน" : `ขั้นที่ ${stepNumber} จาก 4`}</span>
+              <span data-advisor-step-label></span>
             </div>
             <button class="advisor-sheet-close" type="button" data-advisor-close aria-label="ปิดผู้ช่วยเลือกบริการ">×</button>
-            <div class="advisor-sheet-progress" aria-label="ความคืบหน้าการประเมิน">
-              ${[0, 1, 2, 3].map((index) => `<span class="${index < stepNumber ? "is-active" : ""}" ${index === Math.min(stepNumber - 1, 3) ? `aria-current="step"` : ""}></span>`).join("")}
-            </div>
+            <div class="advisor-sheet-progress" data-advisor-progress aria-label="ความคืบหน้าการประเมิน"></div>
           </header>
           <div class="advisor-sheet-scroll" data-advisor-scroll>
-            <div class="advisor-sheet-body" data-advisor-body>${stepContent(state, catalogState)}</div>
+            <div class="advisor-sheet-body" data-advisor-body></div>
           </div>
-          <footer class="advisor-sheet-actions" data-advisor-actions>${sheetActions(state)}</footer>
+          <footer class="advisor-sheet-actions" data-advisor-actions></footer>
         </section>
       </div>
     `;
@@ -555,15 +555,41 @@
         || mount.querySelector("[data-advisor-close]");
       target?.focus?.({ preventScroll: true });
     });
-    const renderSheet = (direction = "forward", focus = true) => {
+    const renderSheet = (direction = "forward", options = {}) => {
       if (destroyed || !isOpen || !mount.isConnected) return;
       const host = sheetHost();
       if (!host) return;
-      host.innerHTML = sheetHtml(state, catalogState(), direction);
+      let dialog = mount.querySelector("[data-advisor-dialog]");
+      const opening = !dialog;
+      if (opening) {
+        host.innerHTML = sheetHtml();
+        dialog = mount.querySelector("[data-advisor-dialog]");
+      }
+      if (!dialog) return;
       mount.classList?.toggle?.("is-sheet-open", true);
+      const result = state.step === 4;
+      const stepNumber = result ? 4 : state.step + 1;
+      const layer = mount.querySelector("[data-advisor-backdrop]");
+      const body = mount.querySelector("[data-advisor-body]");
+      const actions = mount.querySelector("[data-advisor-actions]");
+      const stepLabel = mount.querySelector("[data-advisor-step-label]");
+      const progress = mount.querySelector("[data-advisor-progress]");
+      dialog.setAttribute("data-step", stepNumber);
+      if (stepLabel) stepLabel.textContent = result ? "ผลประเมิน" : `ขั้นที่ ${stepNumber} จาก 4`;
+      if (progress) progress.innerHTML = sheetProgressHtml(stepNumber);
+      if (actions) actions.innerHTML = sheetActions(state);
+      if (body) {
+        body.classList.remove("is-step-forward");
+        body.classList.remove("is-step-back");
+        body.classList.remove("is-refresh");
+        body.classList.add(direction === "back" ? "is-step-back" : direction === "refresh" ? "is-refresh" : "is-step-forward");
+        body.innerHTML = stepContent(state, catalogState());
+      }
+      if (opening) layer?.classList?.add?.("is-opening");
+      else layer?.classList?.remove?.("is-opening");
       const scroll = mount.querySelector("[data-advisor-scroll]");
-      if (scroll) scroll.scrollTop = 0;
-      if (focus) focusCurrent();
+      if (scroll && options.resetScroll !== false) scroll.scrollTop = 0;
+      if (options.focus !== false) focusCurrent();
     };
     const toggleExclusive = (values, value, exclusive) => {
       const selected = new Set(values);
@@ -617,13 +643,15 @@
       if (closeTimer) {
         clearTimeout(closeTimer);
         closeTimer = null;
+        const host = sheetHost();
+        if (host) host.innerHTML = "";
       }
       state.started = true;
       isOpen = true;
       document.body.classList.add("has-advisor-sheet");
       document.addEventListener("keydown", onDocumentKeydown);
       renderLauncher();
-      renderSheet("open");
+      renderSheet("forward");
     };
     const closeSheet = (options = {}) => {
       if (!isOpen && !options.immediate) return;
@@ -643,7 +671,9 @@
         finish();
       } else {
         layer.classList?.add?.("is-closing");
-        closeTimer = setTimeout(finish, 220);
+        closeTimer = true;
+        const timerId = setTimeout(finish, 220);
+        if (closeTimer !== null) closeTimer = timerId;
       }
     };
     const contact = (title) => {
@@ -725,7 +755,9 @@
     renderLauncher();
     const controller = {
       refreshCatalog() {
-        if (!destroyed && isOpen && state.step === 4) renderSheet("refresh", false);
+        if (destroyed || !isOpen || state.step !== 4) return;
+        const catalog = mount.querySelector("[data-advisor-catalog]");
+        if (catalog) catalog.innerHTML = renderCatalogResults(state.recommendation, catalogState());
       },
       state() {
         return { ...state, isOpen, symptoms: [...state.symptoms], repairSignals: [...state.repairSignals] };

--- a/customer-app/modules/advisor.js
+++ b/customer-app/modules/advisor.js
@@ -300,7 +300,7 @@
   }
 
   function initialState() {
-    return { step: 0, acType: "", monthsBand: "", symptoms: [], repairSignals: [], recommendation: null };
+    return { step: 0, acType: "", monthsBand: "", symptoms: [], repairSignals: [], recommendation: null, started: false };
   }
 
   function esc(value) {
@@ -315,18 +315,21 @@
     return `<div class="advisor-choice-grid">${items.map((item) => `
       <button class="advisor-choice ${selected === item.value ? "is-selected" : ""}" type="button"
         ${attribute}="${esc(item.value)}" aria-pressed="${selected === item.value ? "true" : "false"}">
-        <span>${esc(item.label)}</span>
+        <span class="advisor-choice-icon">${icon(attribute === "data-advisor-months" ? "calendar" : "sparkle", 17)}</span>
+        <span class="advisor-choice-label">${esc(item.label)}</span>
+        <span class="advisor-choice-check" aria-hidden="true">${selected === item.value ? "✓" : ""}</span>
       </button>
     `).join("")}</div>`;
   }
 
   function chipButtons(items, selected, attribute) {
     const values = new Set(selected || []);
-    return `<div class="advisor-chip-grid">${items.map((item) => `
+    return `<div class="advisor-chip-grid ${attribute === "data-advisor-repair" ? "is-repair-list" : ""}">${items.map((item) => `
       <button class="advisor-chip ${values.has(item.value) ? "is-selected" : ""}" type="button"
         ${attribute}="${esc(item.value)}" aria-pressed="${values.has(item.value) ? "true" : "false"}">
-        <span class="advisor-chip-check" aria-hidden="true">${values.has(item.value) ? "✓" : "+"}</span>
-        <span>${esc(item.label)}</span>
+        <span class="advisor-choice-icon">${icon(attribute === "data-advisor-repair" ? "bolt" : "sparkle", 17)}</span>
+        <span class="advisor-choice-label">${esc(item.label)}</span>
+        <span class="advisor-choice-check" aria-hidden="true">${values.has(item.value) ? "✓" : ""}</span>
       </button>
     `).join("")}</div>`;
   }
@@ -414,46 +417,106 @@
         ${alternative ? `<div class="advisor-alternative"><span>ทางเลือกสำรอง</span><strong>${esc(alternative.label)}</strong></div>` : ""}
         <p class="advisor-note">${esc(recommendation.note)}</p>
         <div class="advisor-catalog" data-advisor-catalog>${renderCatalogResults(recommendation, catalogState)}</div>
-        <div class="advisor-result-footer">
-          <button class="secondary-btn" type="button" data-advisor-back>ย้อนกลับแก้อาการ</button>
-          <button class="advisor-reset-btn" type="button" data-advisor-reset>เริ่มประเมินใหม่</button>
-        </div>
       </div>
     `;
   }
 
+  const STEP_COPY = Object.freeze([
+    { title: "แอร์ของคุณเป็นแบบไหน", copy: "เลือกชนิดเครื่องก่อน เพื่อไม่แนะนำวิธีล้างผิดประเภท" },
+    { title: "ล้างครั้งก่อนเมื่อไร", copy: "ใช้ช่วงเวลาโดยประมาณได้ ไม่จำเป็นต้องจำวันที่แน่นอน" },
+    { title: "ตอนนี้มีอาการอะไรบ้าง", copy: "เลือกได้หลายข้อ ระบบจะใช้ร่วมกับรอบล้าง" },
+    { title: "มีอาการที่ควรตรวจซ่อมก่อนไหม", copy: "อาการกลุ่มนี้จะถูกส่งไปตรวจเช็คก่อนงานล้าง" },
+  ]);
+
+  function stepIsValid(state) {
+    return Boolean((state.step === 0 && state.acType)
+      || (state.step === 1 && state.monthsBand)
+      || (state.step === 2 && state.symptoms.length)
+      || (state.step === 3 && state.repairSignals.length));
+  }
+
   function stepContent(state, catalogState) {
     if (state.step === 4) return renderResult(state, catalogState);
-    const steps = [
-      { title: "แอร์ของคุณเป็นแบบไหน", copy: "เลือกชนิดเครื่องก่อน เพื่อไม่แนะนำวิธีล้างผิดประเภท" },
-      { title: "ล้างครั้งก่อนเมื่อไร", copy: "ใช้ช่วงเวลาโดยประมาณได้ ไม่จำเป็นต้องจำวันที่แน่นอน" },
-      { title: "ตอนนี้มีอาการอะไรบ้าง", copy: "เลือกได้หลายข้อ ระบบจะใช้ร่วมกับรอบล้าง" },
-      { title: "มีอาการที่ควรตรวจซ่อมก่อนไหม", copy: "อาการกลุ่มนี้จะถูกส่งไปตรวจเช็คก่อนงานล้าง" },
-    ];
-    const current = steps[state.step];
+    const current = STEP_COPY[state.step];
     let controls = "";
     if (state.step === 0) controls = choiceButtons(AC_TYPES, state.acType, "data-advisor-ac");
     if (state.step === 1) controls = choiceButtons(MONTH_BANDS, state.monthsBand, "data-advisor-months");
     if (state.step === 2) controls = chipButtons(SYMPTOMS, state.symptoms, "data-advisor-symptom");
     if (state.step === 3) controls = chipButtons(REPAIR_SIGNALS, state.repairSignals, "data-advisor-repair");
-    const valid = (state.step === 0 && state.acType)
-      || (state.step === 1 && state.monthsBand)
-      || (state.step === 2 && state.symptoms.length)
-      || (state.step === 3 && state.repairSignals.length);
     return `
-      <div class="advisor-step" data-advisor-step="${state.step + 1}">
+      <div class="advisor-step advisor-step-${state.step + 1}" data-advisor-step="${state.step + 1}">
         <div class="advisor-step-copy">
-          <span>ขั้นที่ ${state.step + 1} จาก 4</span>
-          <h3>${esc(current.title)}</h3>
+          <h3 data-advisor-question-title tabindex="-1">${esc(current.title)}</h3>
           <p>${esc(current.copy)}</p>
         </div>
         ${controls}
-        <div class="advisor-step-actions">
-          ${state.step ? `<button class="secondary-btn" type="button" data-advisor-back>ย้อนกลับ</button>` : `<span></span>`}
-          <button class="primary-btn" type="button" data-advisor-next ${valid ? "" : "disabled"}>
-            ${state.step === 3 ? "ดูผลประเมิน" : "ขั้นต่อไป"}
-          </button>
-        </div>
+      </div>
+    `;
+  }
+
+  function launcherContent(state, isOpen) {
+    const hasResult = Boolean(state.recommendation);
+    const started = Boolean(state.started);
+    const meta = hasResult ? VERDICT_META[state.recommendation.verdict] : null;
+    const cta = hasResult ? "ดูผลประเมิน" : started ? "ทำแบบประเมินต่อ" : "เริ่มประเมิน";
+    const status = hasResult
+      ? `<span class="advisor-launcher-status">ผลล่าสุด: <strong>${esc(meta.label)}</strong></span>`
+      : started
+        ? `<span class="advisor-launcher-status">ทำถึงขั้นที่ ${Math.min(state.step + 1, 4)} จาก 4</span>`
+        : `<span class="advisor-launcher-status">${icon("clock", 15)} ใช้เวลาประมาณ 1 นาที</span>`;
+    return `
+      <div class="advisor-launcher-copy">
+        <span class="section-kicker">CWF SMART ADVISOR</span>
+        <h2>${hasResult ? esc(meta.label) : "ไม่แน่ใจว่าควรล้างหรือซ่อม?"}</h2>
+        <p>${hasResult ? "เปิดดูเหตุผลและบริการจริงที่ระบบแนะนำ" : "ตอบคำถามสั้น ๆ แล้วให้ระบบช่วยเลือกบริการที่เหมาะ"}</p>
+        ${status}
+      </div>
+      <div class="advisor-launcher-actions">
+        <button class="primary-btn" type="button" data-advisor-launch aria-expanded="${isOpen ? "true" : "false"}" aria-controls="advisor-sheet-dialog">
+          ${icon(hasResult ? "sparkle" : "play", 18)} ${cta}
+        </button>
+        ${hasResult ? `<button class="advisor-reset-btn" type="button" data-advisor-reset-launcher>ประเมินใหม่</button>` : `<small>ดูบริการจริงจาก Catalog</small>`}
+      </div>
+    `;
+  }
+
+  function sheetActions(state) {
+    if (state.step === 4) {
+      return `
+        <button class="secondary-btn" type="button" data-advisor-back>ย้อนกลับแก้อาการ</button>
+        <button class="primary-btn" type="button" data-advisor-reset>เริ่มประเมินใหม่</button>
+      `;
+    }
+    return `
+      ${state.step > 0 ? `<button class="secondary-btn" type="button" data-advisor-back>ย้อนกลับ</button>` : `<span aria-hidden="true"></span>`}
+      <button class="primary-btn" type="button" data-advisor-next ${stepIsValid(state) ? "" : "disabled"}>
+        ${state.step === 3 ? "ดูผลประเมิน" : "ขั้นต่อไป"}
+      </button>
+    `;
+  }
+
+  function sheetHtml(state, catalogState, direction = "forward") {
+    const result = state.step === 4;
+    const stepNumber = result ? 4 : state.step + 1;
+    return `
+      <div class="advisor-sheet-layer direction-${esc(direction)}" data-advisor-backdrop>
+        <section class="advisor-sheet" id="advisor-sheet-dialog" data-advisor-dialog data-step="${stepNumber}" role="dialog" aria-modal="true" aria-labelledby="advisor-sheet-title">
+          <header class="advisor-sheet-header">
+            <div class="advisor-sheet-brand" aria-hidden="true">${icon("sparkle", 18)}</div>
+            <div>
+              <h2 id="advisor-sheet-title">ผู้ช่วยเลือกบริการ</h2>
+              <span>${result ? "ผลประเมิน" : `ขั้นที่ ${stepNumber} จาก 4`}</span>
+            </div>
+            <button class="advisor-sheet-close" type="button" data-advisor-close aria-label="ปิดผู้ช่วยเลือกบริการ">×</button>
+            <div class="advisor-sheet-progress" aria-label="ความคืบหน้าการประเมิน">
+              ${[0, 1, 2, 3].map((index) => `<span class="${index < stepNumber ? "is-active" : ""}" ${index === Math.min(stepNumber - 1, 3) ? `aria-current="step"` : ""}></span>`).join("")}
+            </div>
+          </header>
+          <div class="advisor-sheet-scroll" data-advisor-scroll>
+            <div class="advisor-sheet-body" data-advisor-body>${stepContent(state, catalogState)}</div>
+          </div>
+          <footer class="advisor-sheet-actions" data-advisor-actions>${sheetActions(state)}</footer>
+        </section>
       </div>
     `;
   }
@@ -462,19 +525,9 @@
     const state = initialState();
     return `
       <section class="smart-advisor-section homepage-section" data-smart-advisor data-home-reveal>
-        <div class="advisor-aura" aria-hidden="true"><span></span><span></span><span></span></div>
-        <div class="advisor-heading">
-          <div class="advisor-brand-mark">${icon("sparkle", 23)}</div>
-          <div>
-            <span class="section-kicker">CWF Smart Advisor</span>
-            <h2>ช่วยเลือกแบบล้างหรือซ่อมให้เหมาะกับอาการ</h2>
-            <p>ตอบคำถามสั้น ๆ แล้วดูบริการจริงที่เหมาะกับเครื่องของคุณ</p>
-          </div>
-        </div>
-        <div class="advisor-progress" aria-label="ความคืบหน้าการประเมิน">
-          ${[0, 1, 2, 3].map((index) => `<span class="${index === 0 ? "is-active" : ""}" data-advisor-progress="${index}"></span>`).join("")}
-        </div>
-        <div class="advisor-body" data-advisor-body>${stepContent(state, catalogState)}</div>
+        <div class="advisor-launcher-orb" aria-hidden="true"><span>${icon("sparkle", 24)}</span></div>
+        <div class="advisor-launcher-content" data-advisor-launcher-content>${launcherContent(state, false)}</div>
+        <div data-advisor-sheet-host></div>
       </section>
     `;
   }
@@ -486,25 +539,31 @@
     if (existing) return existing;
     let state = initialState();
     let destroyed = false;
+    let isOpen = false;
+    let closeTimer = null;
     const reducedMotion = Boolean(window.matchMedia?.("(prefers-reduced-motion: reduce)")?.matches);
     mount.classList?.toggle?.("is-reduced-motion", reducedMotion);
     const catalogState = () => root.state.catalog || { status: "idle", items: [] };
-
-    const updateProgress = () => {
-      mount.querySelectorAll("[data-advisor-progress]").forEach((node, index) => {
-        const active = state.step === 4 ? true : index <= state.step;
-        node.classList.toggle("is-active", active);
-        if (index === Math.min(state.step, 3)) node.setAttribute("aria-current", "step");
-        else node.removeAttribute("aria-current");
-      });
+    const sheetHost = () => mount.querySelector("[data-advisor-sheet-host]");
+    const renderLauncher = () => {
+      const launcher = mount.querySelector("[data-advisor-launcher-content]");
+      if (launcher) launcher.innerHTML = launcherContent(state, isOpen);
     };
-    const render = (focusResult = false) => {
-      if (destroyed || !mount.isConnected) return;
-      const body = mount.querySelector("[data-advisor-body]");
-      if (!body) return;
-      body.innerHTML = stepContent(state, catalogState());
-      updateProgress();
-      if (focusResult) requestAnimationFrame(() => mount.querySelector("[data-advisor-result]")?.focus({ preventScroll: true }));
+    const focusCurrent = () => requestAnimationFrame(() => {
+      if (destroyed || !isOpen) return;
+      const target = mount.querySelector(state.step === 4 ? "[data-advisor-result]" : "[data-advisor-question-title]")
+        || mount.querySelector("[data-advisor-close]");
+      target?.focus?.({ preventScroll: true });
+    });
+    const renderSheet = (direction = "forward", focus = true) => {
+      if (destroyed || !isOpen || !mount.isConnected) return;
+      const host = sheetHost();
+      if (!host) return;
+      host.innerHTML = sheetHtml(state, catalogState(), direction);
+      mount.classList?.toggle?.("is-sheet-open", true);
+      const scroll = mount.querySelector("[data-advisor-scroll]");
+      if (scroll) scroll.scrollTop = 0;
+      if (focus) focusCurrent();
     };
     const toggleExclusive = (values, value, exclusive) => {
       const selected = new Set(values);
@@ -514,38 +573,130 @@
       else selected.add(value);
       return Array.from(selected);
     };
-    const contact = (title) => root.ui.openContactSheet(container, { title: title || "ให้ทีม CWF ช่วยประเมินบริการ" });
+    const syncChoices = (attribute, selectedValues) => {
+      const selected = new Set(Array.isArray(selectedValues) ? selectedValues : [selectedValues]);
+      mount.querySelectorAll(`[${attribute}]`).forEach((button) => {
+        const active = selected.has(button.getAttribute(attribute));
+        button.classList.toggle("is-selected", active);
+        button.setAttribute("aria-pressed", active ? "true" : "false");
+        const check = button.querySelector?.(".advisor-choice-check");
+        if (check) check.textContent = active ? "✓" : "";
+      });
+      const next = mount.querySelector("[data-advisor-next]");
+      if (next) next.disabled = !stepIsValid(state);
+    };
+    const focusableNodes = () => {
+      const dialog = mount.querySelector("[data-advisor-dialog]");
+      if (!dialog) return [];
+      return Array.from(dialog.querySelectorAll("button:not([disabled]), a[href], [tabindex]:not([tabindex='-1'])"))
+        .filter((node) => !node.hidden);
+    };
+    const onDocumentKeydown = (event) => {
+      if (!isOpen || destroyed) return;
+      if (event.key === "Escape") {
+        event.preventDefault?.();
+        closeSheet();
+        return;
+      }
+      if (event.key !== "Tab") return;
+      const nodes = focusableNodes();
+      if (!nodes.length) return;
+      const first = nodes[0];
+      const last = nodes[nodes.length - 1];
+      if (event.shiftKey && document.activeElement === first) {
+        event.preventDefault?.();
+        last.focus();
+      } else if (!event.shiftKey && document.activeElement === last) {
+        event.preventDefault?.();
+        first.focus();
+      }
+    };
+    const removeOpenListeners = () => document.removeEventListener("keydown", onDocumentKeydown);
+    const openSheet = () => {
+      if (destroyed || isOpen) return;
+      if (closeTimer) {
+        clearTimeout(closeTimer);
+        closeTimer = null;
+      }
+      state.started = true;
+      isOpen = true;
+      document.body.classList.add("has-advisor-sheet");
+      document.addEventListener("keydown", onDocumentKeydown);
+      renderLauncher();
+      renderSheet("open");
+    };
+    const closeSheet = (options = {}) => {
+      if (!isOpen && !options.immediate) return;
+      isOpen = false;
+      removeOpenListeners();
+      document.body.classList.remove("has-advisor-sheet");
+      renderLauncher();
+      const host = sheetHost();
+      const layer = mount.querySelector("[data-advisor-backdrop]");
+      const finish = () => {
+        closeTimer = null;
+        if (host && !isOpen) host.innerHTML = "";
+        mount.classList?.toggle?.("is-sheet-open", false);
+        if (options.restoreFocus !== false && !destroyed) mount.querySelector("[data-advisor-launch]")?.focus?.({ preventScroll: true });
+      };
+      if (options.immediate || reducedMotion || !layer) {
+        finish();
+      } else {
+        layer.classList?.add?.("is-closing");
+        closeTimer = setTimeout(finish, 220);
+      }
+    };
+    const contact = (title) => {
+      closeSheet({ immediate: true, restoreFocus: false });
+      root.ui.openContactSheet(container, { title: title || "ให้ทีม CWF ช่วยประเมินบริการ" });
+    };
     const onClick = (event) => {
       const button = event.target.closest("button");
-      if (!button || destroyed) return;
-      if (button.hasAttribute("data-advisor-ac")) {
+      if (destroyed) return;
+      if (!button) {
+        const backdrop = event.target.closest?.("[data-advisor-backdrop]");
+        const dialog = event.target.closest?.("[data-advisor-dialog]");
+        if (backdrop && !dialog) closeSheet();
+        return;
+      }
+      if (button.hasAttribute("data-advisor-launch")) {
+        openSheet();
+      } else if (button.hasAttribute("data-advisor-close")) {
+        closeSheet();
+      } else if (button.hasAttribute("data-advisor-reset-launcher")) {
+        state = initialState();
+        renderLauncher();
+        openSheet();
+      } else if (button.hasAttribute("data-advisor-ac")) {
         state.acType = button.getAttribute("data-advisor-ac");
-        render();
+        syncChoices("data-advisor-ac", state.acType);
       } else if (button.hasAttribute("data-advisor-months")) {
         state.monthsBand = button.getAttribute("data-advisor-months");
-        render();
+        syncChoices("data-advisor-months", state.monthsBand);
       } else if (button.hasAttribute("data-advisor-symptom")) {
         state.symptoms = toggleExclusive(state.symptoms, button.getAttribute("data-advisor-symptom"), "routine");
-        render();
+        syncChoices("data-advisor-symptom", state.symptoms);
       } else if (button.hasAttribute("data-advisor-repair")) {
         state.repairSignals = toggleExclusive(state.repairSignals, button.getAttribute("data-advisor-repair"), "none");
-        render();
+        syncChoices("data-advisor-repair", state.repairSignals);
       } else if (button.hasAttribute("data-advisor-next")) {
         if (state.step < 3) state.step += 1;
         else {
           state.recommendation = evaluateRecommendation(state);
           state.step = 4;
         }
-        render(state.step === 4);
+        renderSheet("forward");
       } else if (button.hasAttribute("data-advisor-back")) {
         state.step = state.step === 4 ? 3 : Math.max(0, state.step - 1);
         state.recommendation = null;
-        render();
+        renderSheet("back");
       } else if (button.hasAttribute("data-advisor-reset")) {
         state = initialState();
-        render();
-        mount.querySelector("[data-advisor-ac]")?.focus();
+        state.started = true;
+        renderLauncher();
+        renderSheet("back");
       } else if (button.hasAttribute("data-advisor-detail")) {
+        closeSheet({ immediate: true, restoreFocus: false });
         root.utils.routeTo(`storeItem-${button.getAttribute("data-advisor-detail")}`);
       } else if (button.hasAttribute("data-advisor-item-action")) {
         const id = button.getAttribute("data-advisor-item-action");
@@ -571,18 +722,25 @@
       }
     };
     mount.addEventListener("click", onClick);
-    updateProgress();
+    renderLauncher();
     const controller = {
       refreshCatalog() {
-        if (!destroyed && state.step === 4) render();
+        if (!destroyed && isOpen && state.step === 4) renderSheet("refresh", false);
       },
       state() {
-        return { ...state, symptoms: [...state.symptoms], repairSignals: [...state.repairSignals] };
+        return { ...state, isOpen, symptoms: [...state.symptoms], repairSignals: [...state.repairSignals] };
       },
+      open: openSheet,
+      close: closeSheet,
       reducedMotion,
       cleanup() {
         if (destroyed) return;
+        closeSheet({ immediate: true, restoreFocus: false });
         destroyed = true;
+        if (closeTimer) clearTimeout(closeTimer);
+        closeTimer = null;
+        removeOpenListeners();
+        document.body.classList.remove("has-advisor-sheet");
         mount.removeEventListener("click", onClick);
         controllers.delete(mount);
       },
@@ -624,6 +782,9 @@
       initialState,
       renderSection,
       stepContent,
+      launcherContent,
+      sheetHtml,
+      stepIsValid,
     },
   };
 })();

--- a/customer-app/sw.js
+++ b/customer-app/sw.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const BUILD_ID = "20260714_customer_smart_advisor_motion_v1";
+const BUILD_ID = "20260714_smart_advisor_compact_sheet_v1";
 const CACHE_NAME = `cwf-customer-app-v2-${BUILD_ID}`;
 const APP_SHELL = [
   `./index.html?v=${BUILD_ID}`,

--- a/test/customerAppPageAvailability.test.js
+++ b/test/customerAppPageAvailability.test.js
@@ -281,7 +281,7 @@ test("api exposes loadCustomerAppConfig as a no-store GET to /public/customer-ap
 });
 
 test("build wiring: pageAvailability.js is registered in the HTML shell and the SW cache, with the new build id", () => {
-  const build = "20260714_customer_smart_advisor_motion_v1";
+  const build = "20260714_smart_advisor_compact_sheet_v1";
   assert.match(indexHtml, new RegExp(`modules/pageAvailability\\.js\\?v=${build}`));
   assert.match(swSrc, new RegExp(`BUILD_ID = "${build}"`));
   assert.match(swSrc, /modules\/pageAvailability\.js\?v=\$\{BUILD_ID\}/);
@@ -294,7 +294,7 @@ test("build wiring: pageAvailability.js is registered in the HTML shell and the 
    RUNTIME tests (execute the real code in a VM — not regex assertions).
    ========================================================================== */
 
-const BUILD = "20260714_customer_smart_advisor_motion_v1";
+const BUILD = "20260714_smart_advisor_compact_sheet_v1";
 const adminSrc = read("admin-homepage-cms.js");
 
 function reqUrlOf(req) {

--- a/test/customerAppRecovery.test.js
+++ b/test/customerAppRecovery.test.js
@@ -236,7 +236,7 @@ test("Customer App build id is consistent across shell and service worker", () =
   const sw = read("customer-app/sw.js");
   const app = read("customer-app/assets/customer-app.js");
   const manifest = read("customer-app/manifest.webmanifest");
-  const build = "20260714_customer_smart_advisor_motion_v1";
+  const build = "20260714_smart_advisor_compact_sheet_v1";
 
   assert.match(index, new RegExp(`customer-app\\.css\\?v=${build}`));
   assert.match(index, new RegExp(`modules\\/api\\.js\\?v=${build}`));
@@ -254,7 +254,7 @@ test("Customer App build id is consistent across shell and service worker", () =
 test("store module is loaded in index.html and precached in the service worker app shell", () => {
   const index = read("customer-app/index.html");
   const sw = read("customer-app/sw.js");
-  const build = "20260714_customer_smart_advisor_motion_v1";
+  const build = "20260714_smart_advisor_compact_sheet_v1";
 
   assert.match(index, new RegExp(`modules/store\\.js\\?v=${build}`));
   assert.match(sw, /`\.\/modules\/store\.js\?v=\$\{BUILD_ID\}`/);

--- a/test/customerAppStorePayment.test.js
+++ b/test/customerAppStorePayment.test.js
@@ -58,7 +58,7 @@ test("store falls back to the LINE hand-off when payment is unconfigured or the 
 test("payment step styles exist and the Customer App payment build id is bumped", () => {
   assert.match(cssSrc, /\.pay-method-btn/);
   assert.match(cssSrc, /\.pay-qr-img/);
-  assert.match(read("customer-app/index.html"), /modules\/store\.js\?v=20260714_customer_smart_advisor_motion_v1/);
-  assert.match(read("customer-app/sw.js"), /BUILD_ID = "20260714_customer_smart_advisor_motion_v1"/);
+  assert.match(read("customer-app/index.html"), /modules\/store\.js\?v=20260714_smart_advisor_compact_sheet_v1/);
+  assert.match(read("customer-app/sw.js"), /BUILD_ID = "20260714_smart_advisor_compact_sheet_v1"/);
   assert.match(storeSrc, /payment-security 20260705 loaded/);
 });

--- a/test/customerBookingAdminNotifications.test.js
+++ b/test/customerBookingAdminNotifications.test.js
@@ -311,10 +311,10 @@ test("admin/customer frontend cache versions are bumped for booking notification
   assert.doesNotMatch(adminReviewHtml, /admin-review-v2\.js\?v=20260707_customer_booking_notify_v2/);
   assert.match(adminReviewHtml, /admin-review-ai-intake\.js\?v=ai-booking-intake-customer-cards-v11-admin-alert-gate/);
   assert.doesNotMatch(adminReviewHtml, /admin-review-ai-intake\.js\?v=ai-booking-intake-customer-cards-v10/);
-  assert.match(customerIndex, /bookingScheduled\.js\?v=20260714_customer_smart_advisor_motion_v1/);
-  assert.match(customerIndex, /state\.js\?v=20260714_customer_smart_advisor_motion_v1/);
-  assert.match(customerSw, /const BUILD_ID = "20260714_customer_smart_advisor_motion_v1"/);
-  assert.match(customerManifest, /20260714_customer_smart_advisor_motion_v1/);
+  assert.match(customerIndex, /bookingScheduled\.js\?v=20260714_smart_advisor_compact_sheet_v1/);
+  assert.match(customerIndex, /state\.js\?v=20260714_smart_advisor_compact_sheet_v1/);
+  assert.match(customerSw, /const BUILD_ID = "20260714_smart_advisor_compact_sheet_v1"/);
+  assert.match(customerManifest, /20260714_smart_advisor_compact_sheet_v1/);
 });
 
 test("behavior: review queue only includes customer urgent waiting rows while preserving review statuses", () => {

--- a/test/customerHistoryClaim.test.js
+++ b/test/customerHistoryClaim.test.js
@@ -544,7 +544,7 @@ test("Customer App profile opens history detail with opaque job_ref and clears c
 });
 
 test("Customer App cache version is bumped consistently", () => {
-  const expected = "20260714_customer_smart_advisor_motion_v1";
+  const expected = "20260714_smart_advisor_compact_sheet_v1";
   for (const file of [
     "customer-app/index.html",
     "customer-app/sw.js",

--- a/test/customerHomepageFeaturedRotation.test.js
+++ b/test/customerHomepageFeaturedRotation.test.js
@@ -414,6 +414,6 @@ test("compact CSS and cache build remain consistent with six-card rotation", () 
   assert.match(css, /\.homepage-featured-page\s*\{[^}]*grid-area:\s*1\s*\/\s*1/s);
   assert.match(css, /transition:\s*opacity 350ms/);
   assert.match(css, /prefers-reduced-motion:\s*reduce/);
-  const build = "20260714_customer_smart_advisor_motion_v1";
+  const build = "20260714_smart_advisor_compact_sheet_v1";
   for (const source of [html, sw, boot, manifest]) assert.match(source, new RegExp(build));
 });

--- a/test/customerSameDayTiming.test.js
+++ b/test/customerSameDayTiming.test.js
@@ -160,7 +160,7 @@ test("customer app disables availability HTTP cache and refreshes same-day slots
 });
 
 test("customer app build and service worker cache IDs changed", () => {
-  const id = "20260714_customer_smart_advisor_motion_v1";
+  const id = "20260714_smart_advisor_compact_sheet_v1";
   for (const file of [
     "customer-app/index.html",
     "customer-app/sw.js",

--- a/test/customerSmartAdvisor.test.js
+++ b/test/customerSmartAdvisor.test.js
@@ -50,16 +50,19 @@ class FakeClassList {
 }
 
 class FakeElement {
-  constructor(onFocus) {
+  constructor(onFocus, onHtmlChange) {
     this.classList = new FakeClassList();
     this.attributes = new Map();
-    this.innerHTML = "";
+    this._innerHTML = "";
     this.textContent = "";
     this.scrollTop = 99;
     this.hidden = false;
     this.disabled = false;
     this.onFocus = onFocus;
+    this.onHtmlChange = onHtmlChange;
   }
+  get innerHTML() { return this._innerHTML; }
+  set innerHTML(value) { this._innerHTML = String(value); this.onHtmlChange?.(this._innerHTML); }
   setAttribute(name, value) { this.attributes.set(name, String(value)); }
   getAttribute(name) { return this.attributes.get(name) ?? null; }
   removeAttribute(name) { this.attributes.delete(name); }
@@ -74,8 +77,15 @@ class FakeMount {
     this.listeners = new Map();
     this.classList = new FakeClassList();
     this.document = fakeDocument;
+    this.shellWrites = 0;
     this.launcher = new FakeElement((node) => { this.launcherFocuses += 1; if (this.document) this.document.activeElement = node; });
-    this.host = new FakeElement();
+    this.host = new FakeElement(null, () => { this.shellWrites += 1; });
+    this.layer = new FakeElement();
+    this.body = new FakeElement();
+    this.actions = new FakeElement();
+    this.stepLabel = new FakeElement();
+    this.progress = new FakeElement();
+    this.catalog = new FakeElement();
     this.closeButton = new FakeElement((node) => { if (this.document) this.document.activeElement = node; });
     this.nextButton = new FakeElement((node) => { if (this.document) this.document.activeElement = node; });
     this.question = new FakeElement((node) => { this.questionFocuses += 1; if (this.document) this.document.activeElement = node; });
@@ -89,18 +99,24 @@ class FakeMount {
   }
   addEventListener(type, handler) { this.listeners.set(type, handler); }
   removeEventListener(type, handler) { if (this.listeners.get(type) === handler) this.listeners.delete(type); }
+  html() { return [this.host.innerHTML, this.body.innerHTML, this.catalog.innerHTML, this.actions.innerHTML].join(""); }
   querySelector(selector) {
     const open = this.host.innerHTML.includes("data-advisor-dialog");
     if (selector === "[data-advisor-launcher-content]") return this.launcher;
     if (selector === "[data-advisor-sheet-host]") return this.host;
     if (selector === "[data-advisor-launch]") return this.launcher;
-    if (selector === "[data-advisor-backdrop]") return open ? new FakeElement() : null;
+    if (selector === "[data-advisor-backdrop]") return open ? this.layer : null;
     if (selector === "[data-advisor-dialog]") return open ? this.dialog : null;
     if (selector === "[data-advisor-close]") return open ? this.closeButton : null;
     if (selector === "[data-advisor-next]") return open ? this.nextButton : null;
     if (selector === "[data-advisor-scroll]") return open ? this.scroll : null;
-    if (selector === "[data-advisor-question-title]") return open && !this.host.innerHTML.includes("data-advisor-result") ? this.question : null;
-    if (selector === "[data-advisor-result]") return open && this.host.innerHTML.includes("data-advisor-result") ? this.result : null;
+    if (selector === "[data-advisor-body]") return open ? this.body : null;
+    if (selector === "[data-advisor-actions]") return open ? this.actions : null;
+    if (selector === "[data-advisor-step-label]") return open ? this.stepLabel : null;
+    if (selector === "[data-advisor-progress]") return open ? this.progress : null;
+    if (selector === "[data-advisor-catalog]") return open && this.body.innerHTML.includes("data-advisor-catalog") ? this.catalog : null;
+    if (selector === "[data-advisor-question-title]") return open && !this.body.innerHTML.includes("data-advisor-result") ? this.question : null;
+    if (selector === "[data-advisor-result]") return open && this.body.innerHTML.includes("data-advisor-result") ? this.result : null;
     return null;
   }
   querySelectorAll() { return []; }
@@ -334,19 +350,19 @@ test("wizard advances, supports multi-select, refreshes Catalog, resets, and bin
   mount.click({ "data-advisor-repair": "none" });
   mount.click({ "data-advisor-next": "" });
   assert.equal(first.state().recommendation.verdict, "premium_clean");
-  assert.match(mount.host.innerHTML, /กำลังค้นหาบริการที่ตรงจาก Catalog/);
+  assert.match(mount.html(), /กำลังค้นหาบริการที่ตรงจาก Catalog/);
   assert.equal(mount.resultFocuses, 1);
 
   app.state.catalog.status = "success";
   app.state.catalog.items = [catalogItem(2, { booking_wash_variant: "ล้างพรีเมียม", item_name: "ล้างแอร์พรีเมียม" })];
   app.advisor.refreshCatalog(container);
-  assert.match(mount.host.innerHTML, /ล้างแอร์พรีเมียม/);
+  assert.match(mount.html(), /ล้างแอร์พรีเมียม/);
   mount.click({ "data-advisor-back": "" });
   assert.equal(first.state().step, 3);
   mount.click({ "data-advisor-reset": "" });
   assert.equal(first.state().step, 0);
   assert.equal(first.state().recommendation, null);
-  assert.match(mount.host.innerHTML, /แอร์ของคุณเป็นแบบไหน/);
+  assert.match(mount.html(), /แอร์ของคุณเป็นแบบไหน/);
   first.cleanup();
   assert.equal(mount.listeners.size, 0);
 });
@@ -363,7 +379,7 @@ test("launcher opens an accessible sheet and close resumes the saved step", () =
   assert.match(mount.launcher.innerHTML, /aria-expanded="true"/);
   assert.match(mount.host.innerHTML, /role="dialog"/);
   assert.match(mount.host.innerHTML, /aria-modal="true"/);
-  assert.match(mount.host.innerHTML, /data-advisor-ac/);
+  assert.match(mount.html(), /data-advisor-ac/);
   assert.ok(runtime.document.body.classList.contains("has-advisor-sheet"));
   assert.equal(mount.questionFocuses, 1);
 
@@ -383,8 +399,62 @@ test("launcher opens an accessible sheet and close resumes the saved step", () =
 
   mount.click({ "data-advisor-launch": "" });
   assert.equal(controller.state().step, 1);
-  assert.match(mount.host.innerHTML, /data-advisor-months/);
-  assert.doesNotMatch(mount.host.innerHTML, /data-advisor-ac=/);
+  assert.match(mount.html(), /data-advisor-months/);
+  assert.doesNotMatch(mount.html(), /data-advisor-ac=/);
+});
+
+test("sheet shell opens once while steps and Catalog refresh update in place", () => {
+  const runtime = loadAdvisor({ catalog: { status: "loading", items: [] } });
+  const mount = new FakeMount(runtime.document);
+  const container = { querySelector: () => mount };
+  const controller = runtime.app.advisor.bind(container);
+
+  mount.click({ "data-advisor-launch": "" });
+  const openingShell = mount.host.innerHTML;
+  assert.equal(mount.shellWrites, 1);
+  assert.match(openingShell, /advisor-sheet-layer is-opening/);
+  assert.ok(mount.layer.classList.contains("is-opening"));
+
+  mount.click({ "data-advisor-ac": "wall" });
+  mount.click({ "data-advisor-next": "" });
+  assert.equal(mount.shellWrites, 1);
+  assert.equal(mount.host.innerHTML, openingShell);
+  assert.ok(!mount.layer.classList.contains("is-opening"));
+  assert.ok(mount.body.classList.contains("is-step-forward"));
+
+  mount.click({ "data-advisor-back": "" });
+  assert.equal(mount.shellWrites, 1);
+  assert.ok(mount.body.classList.contains("is-step-back"));
+
+  mount.click({ "data-advisor-next": "" });
+  mount.click({ "data-advisor-months": "m4_5" });
+  mount.click({ "data-advisor-next": "" });
+  mount.click({ "data-advisor-symptom": "routine" });
+  mount.click({ "data-advisor-next": "" });
+  mount.click({ "data-advisor-repair": "none" });
+  mount.click({ "data-advisor-next": "" });
+  assert.equal(controller.state().step, 4);
+  assert.equal(mount.shellWrites, 1);
+
+  const focusedBeforeRefresh = new FakeElement();
+  runtime.document.activeElement = focusedBeforeRefresh;
+  mount.scroll.scrollTop = 173;
+  const resultFocuses = mount.resultFocuses;
+  runtime.app.state.catalog.status = "success";
+  runtime.app.state.catalog.items = [catalogItem(1)];
+  runtime.app.advisor.refreshCatalog(container);
+  assert.equal(mount.shellWrites, 1);
+  assert.equal(mount.host.innerHTML, openingShell);
+  assert.equal(mount.scroll.scrollTop, 173);
+  assert.equal(runtime.document.activeElement, focusedBeforeRefresh);
+  assert.equal(mount.resultFocuses, resultFocuses);
+  assert.match(mount.catalog.innerHTML, /data-advisor-product="1"/);
+
+  mount.click({ "data-advisor-close": "" });
+  assert.equal(mount.host.innerHTML, "");
+  mount.click({ "data-advisor-launch": "" });
+  assert.equal(mount.shellWrites, 3);
+  assert.ok(mount.layer.classList.contains("is-opening"));
 });
 
 test("multi-select exclusive choices and Back preserve the existing answers", () => {
@@ -438,7 +508,7 @@ test("closed result stays compact and never exposes Catalog cards on Home", () =
   const controller = runtime.app.advisor.bind({ querySelector: () => mount });
   completeWallStandardAdvisor(mount);
   assert.equal(controller.state().recommendation.verdict, "standard_clean");
-  assert.match(mount.host.innerHTML, /advisor-result-products/);
+  assert.match(mount.html(), /advisor-result-products/);
   mount.click({ "data-advisor-close": "" });
   assert.match(mount.launcher.innerHTML, /ผลล่าสุด/);
   assert.match(mount.launcher.innerHTML, /ดูผลประเมิน/);
@@ -448,7 +518,7 @@ test("closed result stays compact and never exposes Catalog cards on Home", () =
   assert.equal(controller.state().recommendation, null);
   assert.equal(controller.state().step, 0);
   assert.equal(controller.state().isOpen, true);
-  assert.match(mount.host.innerHTML, /data-advisor-ac=/);
+  assert.match(mount.html(), /data-advisor-ac=/);
 });
 
 test("booking handoff routes only after both existing adapters succeed and otherwise contacts", () => {
@@ -542,6 +612,13 @@ test("advisor render contract is accessible, compact, motion-safe, and has no au
   assert.match(CSS_SOURCE, /@keyframes advisor-sheet-up/);
   assert.match(CSS_SOURCE, /@keyframes advisor-question-forward/);
   assert.match(CSS_SOURCE, /@keyframes advisor-result-reveal/);
+  assert.match(CSS_SOURCE, /\.advisor-sheet-layer\.is-opening \{ animation: advisor-backdrop-in/);
+  assert.match(CSS_SOURCE, /\.advisor-sheet-layer\.is-opening \.advisor-sheet \{ animation: advisor-sheet-up/);
+  assert.doesNotMatch(CSS_SOURCE.match(/\.advisor-sheet-layer \{[\s\S]*?\}/)?.[0] || "", /animation:/);
+  assert.doesNotMatch(CSS_SOURCE.match(/\.advisor-sheet \{[\s\S]*?\}/)?.[0] || "", /animation:/);
+  assert.match(CSS_SOURCE, /\.advisor-sheet-body\.is-step-forward > \.advisor-step/);
+  assert.match(CSS_SOURCE, /\.advisor-sheet-body\.is-step-back > \.advisor-step/);
+  assert.match(CSS_SOURCE, /@media \(prefers-reduced-motion: reduce\)[\s\S]*?\.advisor-sheet-layer[\s\S]*?animation: none !important/);
   assert.doesNotMatch(SOURCE, /setInterval\s*\(/);
   assert.match(SOURCE, /matchMedia\?\.\("\(prefers-reduced-motion: reduce\)"\)/);
   const reduced = loadAdvisor({ reducedMotion: true });

--- a/test/customerSmartAdvisor.test.js
+++ b/test/customerSmartAdvisor.test.js
@@ -44,32 +44,66 @@ function catalogItem(id, overrides = {}) {
 class FakeClassList {
   constructor() { this.values = new Set(); }
   toggle(value, force) { if (force) this.values.add(value); else this.values.delete(value); }
+  add(value) { this.values.add(value); }
+  remove(value) { this.values.delete(value); }
+  contains(value) { return this.values.has(value); }
 }
 
-class FakeProgress {
-  constructor() { this.classList = new FakeClassList(); this.attributes = new Map(); }
+class FakeElement {
+  constructor(onFocus) {
+    this.classList = new FakeClassList();
+    this.attributes = new Map();
+    this.innerHTML = "";
+    this.textContent = "";
+    this.scrollTop = 99;
+    this.hidden = false;
+    this.disabled = false;
+    this.onFocus = onFocus;
+  }
   setAttribute(name, value) { this.attributes.set(name, String(value)); }
+  getAttribute(name) { return this.attributes.get(name) ?? null; }
   removeAttribute(name) { this.attributes.delete(name); }
+  focus() { this.onFocus?.(this); }
+  querySelector() { return null; }
+  querySelectorAll() { return []; }
 }
 
 class FakeMount {
-  constructor() {
+  constructor(fakeDocument = null) {
     this.isConnected = true;
     this.listeners = new Map();
-    this.body = { innerHTML: "" };
-    this.progress = [new FakeProgress(), new FakeProgress(), new FakeProgress(), new FakeProgress()];
+    this.classList = new FakeClassList();
+    this.document = fakeDocument;
+    this.launcher = new FakeElement((node) => { this.launcherFocuses += 1; if (this.document) this.document.activeElement = node; });
+    this.host = new FakeElement();
+    this.closeButton = new FakeElement((node) => { if (this.document) this.document.activeElement = node; });
+    this.nextButton = new FakeElement((node) => { if (this.document) this.document.activeElement = node; });
+    this.question = new FakeElement((node) => { this.questionFocuses += 1; if (this.document) this.document.activeElement = node; });
+    this.result = new FakeElement((node) => { this.resultFocuses += 1; if (this.document) this.document.activeElement = node; });
+    this.scroll = new FakeElement();
+    this.dialog = new FakeElement();
+    this.dialog.querySelectorAll = () => [this.closeButton, this.nextButton];
     this.resultFocuses = 0;
-    this.firstFocuses = 0;
+    this.questionFocuses = 0;
+    this.launcherFocuses = 0;
   }
   addEventListener(type, handler) { this.listeners.set(type, handler); }
   removeEventListener(type, handler) { if (this.listeners.get(type) === handler) this.listeners.delete(type); }
   querySelector(selector) {
-    if (selector === "[data-advisor-body]") return this.body;
-    if (selector === "[data-advisor-result]") return { focus: () => { this.resultFocuses += 1; } };
-    if (selector === "[data-advisor-ac]") return { focus: () => { this.firstFocuses += 1; } };
+    const open = this.host.innerHTML.includes("data-advisor-dialog");
+    if (selector === "[data-advisor-launcher-content]") return this.launcher;
+    if (selector === "[data-advisor-sheet-host]") return this.host;
+    if (selector === "[data-advisor-launch]") return this.launcher;
+    if (selector === "[data-advisor-backdrop]") return open ? new FakeElement() : null;
+    if (selector === "[data-advisor-dialog]") return open ? this.dialog : null;
+    if (selector === "[data-advisor-close]") return open ? this.closeButton : null;
+    if (selector === "[data-advisor-next]") return open ? this.nextButton : null;
+    if (selector === "[data-advisor-scroll]") return open ? this.scroll : null;
+    if (selector === "[data-advisor-question-title]") return open && !this.host.innerHTML.includes("data-advisor-result") ? this.question : null;
+    if (selector === "[data-advisor-result]") return open && this.host.innerHTML.includes("data-advisor-result") ? this.result : null;
     return null;
   }
-  querySelectorAll(selector) { return selector === "[data-advisor-progress]" ? this.progress : []; }
+  querySelectorAll() { return []; }
   click(attributes) {
     const button = {
       hasAttribute: (name) => Object.hasOwn(attributes, name),
@@ -77,12 +111,33 @@ class FakeMount {
     };
     this.listeners.get("click")?.({ target: { closest: () => button } });
   }
+  clickBackdrop() {
+    const backdrop = new FakeElement();
+    this.listeners.get("click")?.({ target: { closest: (selector) => selector === "[data-advisor-backdrop]" ? backdrop : null } });
+  }
+}
+
+function fakeDocument() {
+  const listeners = new Map();
+  return {
+    activeElement: null,
+    body: { classList: new FakeClassList() },
+    listeners,
+    addEventListener(type, handler) { listeners.set(type, handler); },
+    removeEventListener(type, handler) { if (listeners.get(type) === handler) listeners.delete(type); },
+    keydown(key, options = {}) {
+      let prevented = false;
+      listeners.get("keydown")?.({ key, shiftKey: options.shiftKey === true, preventDefault: () => { prevented = true; } });
+      return prevented;
+    },
+  };
 }
 
 function loadAdvisor(options = {}) {
   const routes = [];
   const contacts = [];
   const applied = [];
+  const document = fakeDocument();
   const catalog = options.catalog || { status: "success", items: [] };
   const app = {
     state: { catalog },
@@ -100,11 +155,14 @@ function loadAdvisor(options = {}) {
   };
   vm.runInNewContext(SOURCE, {
     window: { CWFCustomerAppV2: app, matchMedia: () => ({ matches: options.reducedMotion === true }) },
+    document,
     Set,
     WeakMap,
     requestAnimationFrame: (fn) => fn(),
+    setTimeout: (fn) => { fn(); return 1; },
+    clearTimeout() {},
   }, { filename: "advisor.js" });
-  return { app, routes, contacts, applied };
+  return { app, routes, contacts, applied, document };
 }
 
 function plain(value) {
@@ -112,6 +170,7 @@ function plain(value) {
 }
 
 function completeWallStandardAdvisor(mount) {
+  mount.click({ "data-advisor-launch": "" });
   mount.click({ "data-advisor-ac": "wall" });
   mount.click({ "data-advisor-next": "" });
   mount.click({ "data-advisor-months": "m4_5" });
@@ -256,14 +315,15 @@ test("no exact Catalog match renders assessment CTA instead of a wrong direct-bo
 });
 
 test("wizard advances, supports multi-select, refreshes Catalog, resets, and binds once", () => {
-  const { app } = loadAdvisor({ catalog: { status: "loading", items: [] } });
-  const mount = new FakeMount();
+  const { app, document } = loadAdvisor({ catalog: { status: "loading", items: [] } });
+  const mount = new FakeMount(document);
   const container = { querySelector: (selector) => selector === "[data-smart-advisor]" ? mount : null };
   const first = app.advisor.bind(container);
   const second = app.advisor.bind(container);
   assert.equal(first, second);
   assert.equal(mount.listeners.size, 1);
 
+  mount.click({ "data-advisor-launch": "" });
   mount.click({ "data-advisor-ac": "wall" });
   mount.click({ "data-advisor-next": "" });
   mount.click({ "data-advisor-months": "m6_8" });
@@ -274,20 +334,121 @@ test("wizard advances, supports multi-select, refreshes Catalog, resets, and bin
   mount.click({ "data-advisor-repair": "none" });
   mount.click({ "data-advisor-next": "" });
   assert.equal(first.state().recommendation.verdict, "premium_clean");
-  assert.match(mount.body.innerHTML, /กำลังค้นหาบริการที่ตรงจาก Catalog/);
+  assert.match(mount.host.innerHTML, /กำลังค้นหาบริการที่ตรงจาก Catalog/);
   assert.equal(mount.resultFocuses, 1);
 
   app.state.catalog.status = "success";
   app.state.catalog.items = [catalogItem(2, { booking_wash_variant: "ล้างพรีเมียม", item_name: "ล้างแอร์พรีเมียม" })];
   app.advisor.refreshCatalog(container);
-  assert.match(mount.body.innerHTML, /ล้างแอร์พรีเมียม/);
+  assert.match(mount.host.innerHTML, /ล้างแอร์พรีเมียม/);
   mount.click({ "data-advisor-back": "" });
   assert.equal(first.state().step, 3);
   mount.click({ "data-advisor-reset": "" });
   assert.equal(first.state().step, 0);
-  assert.equal(mount.firstFocuses, 1);
+  assert.equal(first.state().recommendation, null);
+  assert.match(mount.host.innerHTML, /แอร์ของคุณเป็นแบบไหน/);
   first.cleanup();
   assert.equal(mount.listeners.size, 0);
+});
+
+test("launcher opens an accessible sheet and close resumes the saved step", () => {
+  const runtime = loadAdvisor();
+  const mount = new FakeMount(runtime.document);
+  const controller = runtime.app.advisor.bind({ querySelector: () => mount });
+  assert.equal(mount.host.innerHTML, "");
+  assert.doesNotMatch(mount.launcher.innerHTML, /data-advisor-ac/);
+
+  mount.click({ "data-advisor-launch": "" });
+  assert.equal(controller.state().isOpen, true);
+  assert.match(mount.launcher.innerHTML, /aria-expanded="true"/);
+  assert.match(mount.host.innerHTML, /role="dialog"/);
+  assert.match(mount.host.innerHTML, /aria-modal="true"/);
+  assert.match(mount.host.innerHTML, /data-advisor-ac/);
+  assert.ok(runtime.document.body.classList.contains("has-advisor-sheet"));
+  assert.equal(mount.questionFocuses, 1);
+
+  mount.click({ "data-advisor-ac": "wall" });
+  mount.click({ "data-advisor-next": "" });
+  assert.equal(controller.state().step, 1);
+  assert.equal(mount.scroll.scrollTop, 0);
+  mount.click({ "data-advisor-close": "" });
+  assert.equal(controller.state().isOpen, false);
+  assert.equal(controller.state().acType, "wall");
+  assert.equal(mount.host.innerHTML, "");
+  assert.match(mount.launcher.innerHTML, /ทำแบบประเมินต่อ/);
+  assert.match(mount.launcher.innerHTML, /ทำถึงขั้นที่ 2 จาก 4/);
+  assert.ok(!runtime.document.body.classList.contains("has-advisor-sheet"));
+  assert.equal(mount.launcherFocuses, 1);
+  assert.match(mount.launcher.innerHTML, /aria-expanded="false"/);
+
+  mount.click({ "data-advisor-launch": "" });
+  assert.equal(controller.state().step, 1);
+  assert.match(mount.host.innerHTML, /data-advisor-months/);
+  assert.doesNotMatch(mount.host.innerHTML, /data-advisor-ac=/);
+});
+
+test("multi-select exclusive choices and Back preserve the existing answers", () => {
+  const runtime = loadAdvisor();
+  const mount = new FakeMount(runtime.document);
+  const controller = runtime.app.advisor.bind({ querySelector: () => mount });
+  mount.click({ "data-advisor-launch": "" });
+  mount.click({ "data-advisor-ac": "wall" });
+  mount.click({ "data-advisor-next": "" });
+  mount.click({ "data-advisor-months": "m6_8" });
+  mount.click({ "data-advisor-next": "" });
+  mount.click({ "data-advisor-symptom": "routine" });
+  mount.click({ "data-advisor-symptom": "heavy_use" });
+  assert.deepEqual(Array.from(controller.state().symptoms), ["heavy_use"]);
+  mount.click({ "data-advisor-next": "" });
+  mount.click({ "data-advisor-repair": "none" });
+  mount.click({ "data-advisor-repair": "error_code" });
+  assert.deepEqual(Array.from(controller.state().repairSignals), ["error_code"]);
+  mount.click({ "data-advisor-back": "" });
+  assert.equal(controller.state().step, 2);
+  assert.deepEqual(Array.from(controller.state().symptoms), ["heavy_use"]);
+  assert.equal(mount.scroll.scrollTop, 0);
+});
+
+test("Escape, backdrop, focus trap and cleanup close the sheet without leaking listeners", () => {
+  const runtime = loadAdvisor();
+  const mount = new FakeMount(runtime.document);
+  const controller = runtime.app.advisor.bind({ querySelector: () => mount });
+  mount.click({ "data-advisor-launch": "" });
+  assert.equal(runtime.document.listeners.size, 1);
+  runtime.document.activeElement = mount.nextButton;
+  assert.equal(runtime.document.keydown("Tab"), true);
+  assert.equal(runtime.document.activeElement, mount.closeButton);
+  assert.equal(runtime.document.keydown("Escape"), true);
+  assert.equal(controller.state().isOpen, false);
+  assert.equal(runtime.document.listeners.size, 0);
+
+  mount.click({ "data-advisor-launch": "" });
+  mount.clickBackdrop();
+  assert.equal(controller.state().isOpen, false);
+  mount.click({ "data-advisor-launch": "" });
+  controller.cleanup();
+  assert.equal(runtime.document.listeners.size, 0);
+  assert.ok(!runtime.document.body.classList.contains("has-advisor-sheet"));
+  assert.equal(mount.listeners.size, 0);
+});
+
+test("closed result stays compact and never exposes Catalog cards on Home", () => {
+  const runtime = loadAdvisor({ catalog: { status: "success", items: [catalogItem(1)] } });
+  const mount = new FakeMount(runtime.document);
+  const controller = runtime.app.advisor.bind({ querySelector: () => mount });
+  completeWallStandardAdvisor(mount);
+  assert.equal(controller.state().recommendation.verdict, "standard_clean");
+  assert.match(mount.host.innerHTML, /advisor-result-products/);
+  mount.click({ "data-advisor-close": "" });
+  assert.match(mount.launcher.innerHTML, /ผลล่าสุด/);
+  assert.match(mount.launcher.innerHTML, /ดูผลประเมิน/);
+  assert.doesNotMatch(mount.launcher.innerHTML, /advisor-product|data-advisor-item-action/);
+  assert.equal(mount.host.innerHTML, "");
+  mount.click({ "data-advisor-reset-launcher": "" });
+  assert.equal(controller.state().recommendation, null);
+  assert.equal(controller.state().step, 0);
+  assert.equal(controller.state().isOpen, true);
+  assert.match(mount.host.innerHTML, /data-advisor-ac=/);
 });
 
 test("booking handoff routes only after both existing adapters succeed and otherwise contacts", () => {
@@ -344,6 +505,7 @@ test("repair result always opens Contact Sheet even when a repair item has adapt
   const mount = new FakeMount();
   const container = { querySelector: () => mount };
   const controller = runtime.app.advisor.bind(container);
+  mount.click({ "data-advisor-launch": "" });
   mount.click({ "data-advisor-ac": "wall" });
   mount.click({ "data-advisor-next": "" });
   mount.click({ "data-advisor-months": "m4_5" });
@@ -363,16 +525,27 @@ test("advisor render contract is accessible, compact, motion-safe, and has no au
   const { app } = loadAdvisor();
   const html = app.advisor.renderSection({ status: "success", items: [] });
   assert.match(html, /data-smart-advisor/);
-  assert.match(html, /แอร์ของคุณเป็นแบบไหน/);
-  assert.match(html, /aria-label="ความคืบหน้าการประเมิน"/);
+  assert.match(html, /ไม่แน่ใจว่าควรล้างหรือซ่อม/);
+  assert.match(html, /data-advisor-launch/);
+  assert.match(html, /aria-expanded="false"/);
+  assert.doesNotMatch(html, /data-advisor-ac|data-advisor-months|data-advisor-symptom|data-advisor-repair/);
+  assert.doesNotMatch(html, /ความคืบหน้าการประเมิน|ขั้นที่ 1 จาก 4/);
   assert.match(CSS_SOURCE, /@media \(prefers-reduced-motion: reduce\)/);
-  assert.match(CSS_SOURCE, /\.advisor-choice,[\s\S]*?min-height: 44px/);
-  assert.match(CSS_SOURCE, /@keyframes advisor-step-in/);
-  assert.match(CSS_SOURCE, /@keyframes health-ring-sweep/);
+  assert.match(CSS_SOURCE, /\.advisor-sheet[\s\S]*?max-height: 90dvh/);
+  assert.match(CSS_SOURCE, /\.advisor-sheet-actions[\s\S]*?safe-area-inset-bottom/);
+  assert.match(CSS_SOURCE, /\.advisor-sheet-layer[\s\S]*?z-index: 100/);
+  assert.match(CSS_SOURCE, /\.advisor-sheet \.advisor-chip-grid[\s\S]*?grid-template-columns: minmax\(0, 1fr\)/);
+  assert.match(CSS_SOURCE, /@media \(max-width: 380px\)[\s\S]*?\.advisor-sheet \.advisor-choice-grid \{ grid-template-columns: minmax\(0, 1fr\)/);
+  assert.match(CSS_SOURCE, /@media \(max-height: 620px\)[\s\S]*?max-height: 92dvh/);
+  assert.match(CSS_SOURCE, /body\.has-advisor-sheet \{ overflow: hidden/);
+  assert.match(CSS_SOURCE, /@keyframes advisor-orbit/);
+  assert.match(CSS_SOURCE, /@keyframes advisor-sheet-up/);
+  assert.match(CSS_SOURCE, /@keyframes advisor-question-forward/);
+  assert.match(CSS_SOURCE, /@keyframes advisor-result-reveal/);
   assert.doesNotMatch(SOURCE, /setInterval\s*\(/);
   assert.match(SOURCE, /matchMedia\?\.\("\(prefers-reduced-motion: reduce\)"\)/);
   const reduced = loadAdvisor({ reducedMotion: true });
-  const mount = new FakeMount();
+  const mount = new FakeMount(reduced.document);
   assert.equal(reduced.app.advisor.bind({ querySelector: () => mount }).reducedMotion, true);
 });
 
@@ -404,7 +577,7 @@ test("Home places built-in advisor after Quick Actions and before Featured Servi
 });
 
 test("advisor module is loaded before ui.js and precached under the shared build id", () => {
-  const build = "20260714_customer_smart_advisor_motion_v1";
+  const build = "20260714_smart_advisor_compact_sheet_v1";
   assert.ok(INDEX_SOURCE.indexOf(`modules/advisor.js?v=${build}`) < INDEX_SOURCE.indexOf(`modules/ui.js?v=${build}`));
   assert.match(SW_SOURCE, new RegExp(`BUILD_ID = "${build}"`));
   assert.match(SW_SOURCE, /modules\/advisor\.js\?v=\$\{BUILD_ID\}/);

--- a/test/customerTrackingFullReadUi.test.js
+++ b/test/customerTrackingFullReadUi.test.js
@@ -770,7 +770,7 @@ test("tracking UI exposes loading, not-found, rate-limit and offline states", ()
 });
 
 test("tracking assets share the full-read cache build id", () => {
-  const build = "20260714_customer_smart_advisor_motion_v1";
+  const build = "20260714_smart_advisor_compact_sheet_v1";
   for (const file of [
     "customer-app/index.html",
     "customer-app/sw.js",

--- a/test/homepageCms.test.js
+++ b/test/homepageCms.test.js
@@ -296,7 +296,7 @@ test("customer homepage has no admin control, bottom nav is fixed five-tab, and 
   const sw = read("customer-app/sw.js");
   const app = read("customer-app/assets/customer-app.js");
   const manifest = read("customer-app/manifest.webmanifest");
-  const build = "20260714_customer_smart_advisor_motion_v1";
+  const build = "20260714_smart_advisor_compact_sheet_v1";
 
   assert.doesNotMatch(index + ui, /โหมดแอดมิน|openCms|localStorage\.getItem\('cwfHomeCmsDemo'/);
   assert.match(index, /data-route="store"[\s\S]*ร้านค้า/);


### PR DESCRIPTION
## Summary
- replace the always-expanded Home advisor form with a compact launcher
- open the existing advisor flow in an accessible bottom sheet with one question per step
- preserve answers across close/reopen and show a compact completed-result summary
- add focus trapping, Escape/backdrop close, scroll locking, sticky actions, responsive one-column repair choices, interaction motion, and reduced-motion handling
- preserve recommendation, Catalog matching, booking revalidation, and Contact Sheet fallback logic
- bump Customer App BUILD_ID to `20260714_smart_advisor_compact_sheet_v1`

## Review blocker follow-up
- create the backdrop/dialog/header/scroll/footer shell once per open
- update only progress text, question/result body, and footer controls on Next/Back
- scope forward/back animation hooks to the body; backdrop and sheet opening animations now require `is-opening`
- refresh only `[data-advisor-catalog]`, preserving sheet shell, scroll position, and focus
- closing and reopening creates a fresh shell and replays the opening hook

## Validation
- syntax checks for changed JavaScript
- focused Advisor/Home/build/booking/Tracking suite: 360/360 passed
- full branch suite: 1,185 passed, 28 failed, 34 skipped (1,247 total)
- exact main suite at `8a58f740ae7fe8a9821f6841bbcd84609f93798d`: 1,180 passed, 28 failed, 34 skipped (1,242 total)
- failing test names are identical between branch and main; additional failures: 0

## Visual verification
The execution environment has no browser backend, so screenshots could not be attached. Responsive DOM/CSS contracts cover 360/390/412 widths, safe-area spacing, low viewport height, bottom-nav stacking, reduced motion, stable sheet-shell lifecycle, and scroll/focus preservation.

```powershell
npx --yes http-server . -p 4173 -a 127.0.0.1 -c-1
```

Open `http://127.0.0.1:4173/customer-app/index.html#home`.

No backend, security, recommendation, Catalog mapping, booking validation, migration, production data, merge, or deploy changes are included.