### PR TITLE
Polish Smart Advisor mobile experience

### DIFF
--- a/customer-app/assets/customer-app.css
+++ b/customer-app/assets/customer-app.css
@@ -6513,31 +6513,44 @@ textarea.purchase-input { min-height: 66px; resize: vertical; }
 /* Compact Smart Advisor launcher and focused sheet */
 body.has-advisor-sheet { overflow: hidden; }
 .smart-advisor-section {
+  position: relative;
   display: grid;
-  grid-template-columns: 56px minmax(0, 1fr);
-  gap: 13px;
-  align-items: start;
-  min-height: 0;
-  padding: 16px;
+  grid-template-columns: 42px minmax(0, 1fr);
+  gap: 10px;
+  align-items: center;
+  min-height: 112px;
+  padding: 12px;
   overflow: hidden;
-  border-radius: 15px;
+  border: 1px solid rgba(142, 194, 232, 0.55);
+  border-radius: 13px;
   background: linear-gradient(140deg, #eef8ff 0%, #fff 62%, #fff8d8 100%);
 }
+.smart-advisor-section::before {
+  position: absolute;
+  inset: -40% auto -40% -45%;
+  width: 34%;
+  background: linear-gradient(100deg, transparent, rgba(255, 255, 255, 0.72), transparent);
+  content: "";
+  pointer-events: none;
+  transform: skewX(-18deg);
+  animation: advisor-launcher-sheen 7s ease-in-out infinite;
+}
+.smart-advisor-section > * { position: relative; z-index: 1; }
 .advisor-launcher-orb {
   position: relative;
   display: grid;
   place-items: center;
-  width: 54px;
-  height: 54px;
-  margin-top: 2px;
+  width: 40px;
+  height: 40px;
   border-radius: 50%;
   background: #0b62ad;
   color: #fff;
-  box-shadow: 0 10px 24px -15px rgba(7, 69, 128, 0.9), 0 0 0 7px rgba(255, 205, 43, 0.14);
+  box-shadow: 0 8px 20px -14px rgba(7, 69, 128, 0.9), 0 0 0 5px rgba(255, 205, 43, 0.14);
+  animation: advisor-orb-breathe 4.8s ease-in-out infinite;
 }
 .advisor-launcher-orb::after {
   position: absolute;
-  inset: -7px;
+  inset: -5px;
   border: 1px solid rgba(21, 112, 187, 0.38);
   border-top-color: #f2c328;
   border-radius: 50%;
@@ -6548,46 +6561,76 @@ body.has-advisor-sheet { overflow: hidden; }
 .smart-advisor-section.is-sheet-open { isolation: auto; overflow: visible; }
 .advisor-launcher-content,
 .advisor-launcher-copy { min-width: 0; }
-.advisor-launcher-copy h2 {
-  margin: 3px 0 0;
-  color: #092d58;
-  font-size: 18px;
-  line-height: 1.28;
-  overflow-wrap: anywhere;
+.advisor-launcher-content {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 9px;
+  align-items: end;
 }
-.advisor-launcher-copy p {
+.advisor-launcher-copy h2 {
   display: -webkit-box;
-  margin: 5px 0 0;
+  margin: 2px 0 0;
   overflow: hidden;
-  color: #526b82;
-  font-size: 12px;
-  line-height: 1.45;
+  color: #092d58;
+  font-size: 16px;
+  line-height: 1.22;
+  overflow-wrap: anywhere;
   -webkit-box-orient: vertical;
   -webkit-line-clamp: 2;
 }
+.advisor-launcher-copy p {
+  margin: 3px 0 0;
+  overflow: hidden;
+  color: #526b82;
+  font-size: 10.5px;
+  line-height: 1.35;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
 .advisor-launcher-status {
-  display: flex;
+  display: inline-flex;
   gap: 5px;
   align-items: center;
   min-width: 0;
-  margin-top: 7px;
+  max-width: 100%;
+  margin-top: 5px;
+  padding: 3px 7px;
+  border-radius: 99px;
+  background: rgba(224, 240, 252, 0.9);
   color: #315d85;
   font-size: 10.5px;
   line-height: 1.35;
-  overflow-wrap: anywhere;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 .advisor-launcher-actions {
   display: flex;
-  gap: 10px;
+  gap: 3px;
   align-items: center;
-  margin-top: 11px;
+  flex-direction: column;
+  margin: 0;
 }
 .advisor-launcher-actions .primary-btn {
-  min-height: 44px;
-  padding-inline: 16px;
+  position: relative;
+  min-height: 42px;
+  padding: 8px 13px;
+  overflow: hidden;
+  white-space: nowrap;
+  transition: transform 160ms ease, box-shadow 180ms ease;
 }
-.advisor-launcher-actions small { color: #6b7d8f; font-size: 10px; }
-.advisor-launcher-actions .advisor-reset-btn { min-height: 44px; }
+.advisor-launcher-actions .primary-btn::after {
+  position: absolute;
+  inset: 0 auto 0 -55%;
+  width: 42%;
+  background: linear-gradient(100deg, transparent, rgba(255, 255, 255, 0.55), transparent);
+  content: "";
+  pointer-events: none;
+  transform: skewX(-18deg);
+  animation: advisor-cta-sheen 750ms ease 1 420ms both;
+}
+.advisor-launcher-actions .primary-btn:active { transform: scale(0.98); }
+.advisor-launcher-actions .advisor-reset-btn { min-height: 28px; font-size: 10px; }
 
 .advisor-sheet-layer {
   position: fixed;
@@ -6641,6 +6684,7 @@ body.has-advisor-sheet { overflow: hidden; }
   background: #0b62ad;
   color: #fff;
 }
+.advisor-sheet-layer.is-opening .advisor-sheet-brand { animation: advisor-brand-activate 520ms cubic-bezier(0.22, 1.3, 0.36, 1) both 100ms; }
 .advisor-sheet-header h2 { margin: 0; color: #092d58; font-size: 15px; line-height: 1.25; }
 .advisor-sheet-header span { color: #62788c; font-size: 10.5px; font-weight: 750; }
 .advisor-sheet-close {
@@ -6672,17 +6716,22 @@ body.has-advisor-sheet { overflow: hidden; }
   height: 3px;
   border-radius: 99px;
   background: #dbe7f1;
-  transition: background 220ms ease, transform 220ms ease;
+  transform: scaleX(0.12);
+  transform-origin: left center;
+  transition: background 280ms ease, transform 300ms cubic-bezier(0.22, 0.61, 0.36, 1);
 }
-.advisor-sheet-progress span.is-active { background: #e9b91e; transform: scaleY(1.2); }
+.advisor-sheet-progress span.is-active { background: #e9b91e; transform: scaleX(1) scaleY(1.15); }
 .advisor-sheet-scroll {
   min-height: 0;
   overflow-x: hidden;
   overflow-y: auto;
   overscroll-behavior: contain;
+  scroll-padding-block: 16px 88px;
   scrollbar-gutter: stable;
+  -webkit-overflow-scrolling: touch;
+  touch-action: pan-y;
 }
-.advisor-sheet-body { min-width: 0; padding: 18px 16px 22px; }
+.advisor-sheet-body { min-width: 0; padding: 15px 14px 20px; }
 .advisor-sheet-body.is-step-forward > .advisor-step,
 .advisor-sheet-body.is-step-forward > .advisor-result { animation: advisor-question-forward 280ms cubic-bezier(0.22, 0.61, 0.36, 1) both; }
 .advisor-sheet-body.is-step-back > .advisor-step,
@@ -6692,32 +6741,51 @@ body.has-advisor-sheet { overflow: hidden; }
 .advisor-sheet .advisor-step-copy p { font-size: 12px; }
 .advisor-sheet .advisor-choice-grid {
   grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 9px;
-  margin-top: 15px;
+  gap: 8px;
+  margin-top: 12px;
 }
 .advisor-sheet .advisor-chip-grid {
   grid-template-columns: minmax(0, 1fr);
-  gap: 9px;
-  margin-top: 15px;
+  gap: 7px;
+  margin-top: 12px;
 }
 .advisor-sheet .advisor-choice,
 .advisor-sheet .advisor-chip {
+  position: relative;
   display: grid;
-  grid-template-columns: 28px minmax(0, 1fr) 24px;
-  gap: 9px;
+  grid-template-columns: 26px minmax(0, 1fr) 20px;
+  gap: 8px;
   align-items: center;
-  min-height: 54px;
-  padding: 9px 11px;
+  min-height: 48px;
+  padding: 8px 9px;
+  overflow: hidden;
   text-align: left;
-  font-size: 12px;
+  font-size: 12.5px;
+  box-shadow: 0 3px 10px -9px rgba(15, 62, 105, 0.65);
   transition: transform 160ms ease, border-color 190ms ease, background 190ms ease, box-shadow 190ms ease;
 }
+.advisor-sheet .advisor-choice::before,
+.advisor-sheet .advisor-chip::before {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(100deg, transparent 5%, rgba(209, 235, 255, 0.78) 50%, transparent 95%);
+  content: "";
+  opacity: 0;
+  pointer-events: none;
+  transform: translateX(-100%);
+}
+.advisor-sheet .advisor-choice > *,
+.advisor-sheet .advisor-chip > * { position: relative; z-index: 1; }
+.advisor-sheet .advisor-choice:active,
+.advisor-sheet .advisor-chip:active { transform: scale(0.985); }
+.advisor-sheet .advisor-choice.is-selected::before,
+.advisor-sheet .advisor-chip.is-selected::before { animation: advisor-choice-sweep 380ms ease 1; }
 .advisor-choice-icon {
   display: grid;
   place-items: center;
-  width: 28px;
-  height: 28px;
-  border-radius: 9px;
+  width: 26px;
+  height: 26px;
+  border-radius: 8px;
   background: #edf4f9;
   color: #1768ac;
 }
@@ -6725,8 +6793,8 @@ body.has-advisor-sheet { overflow: hidden; }
 .advisor-choice-check {
   display: grid;
   place-items: center;
-  width: 22px;
-  height: 22px;
+  width: 20px;
+  height: 20px;
   border: 1px solid #c7d7e4;
   border-radius: 50%;
   background: #fff;
@@ -6738,8 +6806,13 @@ body.has-advisor-sheet { overflow: hidden; }
   border-color: #1670bd;
   background: #1670bd;
   transform: scale(1);
+  animation: advisor-check-spring 300ms cubic-bezier(0.2, 1.45, 0.4, 1) both;
 }
-.advisor-sheet .is-selected .advisor-choice-icon { background: #dcefff; color: #075899; }
+.advisor-sheet .is-selected .advisor-choice-icon {
+  background: #dcefff;
+  color: #075899;
+  animation: advisor-icon-pop 260ms cubic-bezier(0.2, 1.35, 0.4, 1) both;
+}
 .advisor-sheet-actions {
   position: sticky;
   bottom: 0;
@@ -6753,10 +6826,12 @@ body.has-advisor-sheet { overflow: hidden; }
   -webkit-backdrop-filter: blur(10px);
   backdrop-filter: blur(10px);
 }
-.advisor-sheet-actions button { min-height: 46px; }
+.advisor-sheet-actions button { min-height: 44px; }
+.advisor-sheet-actions .secondary-btn { color: #587086; font-size: 11px; }
 .advisor-sheet-actions .primary-btn:disabled { opacity: 0.48; cursor: not-allowed; transform: none; }
 .advisor-sheet-body.is-step-forward > .advisor-result { animation-name: advisor-result-reveal; }
-.advisor-sheet .advisor-reason-list > div { animation: advisor-reason-in 260ms ease both; }
+.advisor-sheet .advisor-confidence { animation: advisor-confidence-pop 340ms cubic-bezier(0.2, 1.35, 0.4, 1) both 90ms; }
+.advisor-sheet .advisor-reason-list > div { animation: advisor-reason-in 280ms ease both; }
 .advisor-sheet .advisor-reason-list > div:nth-child(2) { animation-delay: 45ms; }
 .advisor-sheet .advisor-reason-list > div:nth-child(3) { animation-delay: 90ms; }
 .advisor-sheet .advisor-reason-list > div:nth-child(4) { animation-delay: 135ms; }
@@ -6764,6 +6839,9 @@ body.has-advisor-sheet { overflow: hidden; }
 .advisor-sheet .advisor-result .primary-btn { animation: advisor-cta-glow 650ms ease 1 260ms both; }
 
 @keyframes advisor-orbit { to { transform: rotate(360deg); } }
+@keyframes advisor-orb-breathe { 0%, 100% { transform: scale(1); } 50% { transform: scale(1.035); } }
+@keyframes advisor-launcher-sheen { 0%, 70% { left: -45%; opacity: 0; } 76% { opacity: 0.8; } 94%, 100% { left: 120%; opacity: 0; } }
+@keyframes advisor-cta-sheen { from { left: -55%; opacity: 0; } 30% { opacity: 1; } to { left: 120%; opacity: 0; } }
 @keyframes advisor-backdrop-in { from { opacity: 0; } to { opacity: 1; } }
 @keyframes advisor-backdrop-out { from { opacity: 1; } to { opacity: 0; } }
 @keyframes advisor-sheet-up { from { opacity: 0; transform: translateY(24px); } to { opacity: 1; transform: translateY(0); } }
@@ -6773,32 +6851,111 @@ body.has-advisor-sheet { overflow: hidden; }
 @keyframes advisor-result-reveal { from { opacity: 0; transform: scale(0.985); } to { opacity: 1; transform: scale(1); } }
 @keyframes advisor-reason-in { from { opacity: 0; transform: translateY(4px); } to { opacity: 1; transform: translateY(0); } }
 @keyframes advisor-cta-glow { 50% { box-shadow: 0 0 0 5px rgba(240, 190, 34, 0.2); } }
+@keyframes advisor-brand-activate { from { opacity: 0.5; transform: scale(0.82); } to { opacity: 1; transform: scale(1); } }
+@keyframes advisor-choice-sweep { from { opacity: 0; transform: translateX(-100%); } 45% { opacity: 1; } to { opacity: 0; transform: translateX(100%); } }
+@keyframes advisor-icon-pop { from { transform: scale(0.82); } to { transform: scale(1); } }
+@keyframes advisor-check-spring { from { opacity: 0; transform: scale(0.65); } to { opacity: 1; transform: scale(1); } }
+@keyframes advisor-confidence-pop { from { opacity: 0; transform: scale(0.85); } to { opacity: 1; transform: scale(1); } }
+
+.advisor-sheet .advisor-result-hero {
+  grid-template-columns: 38px minmax(0, 1fr) auto;
+  gap: 8px;
+}
+.advisor-sheet .advisor-result-mark { width: 38px; height: 38px; border-radius: 10px; }
+.advisor-sheet .advisor-result-hero h3 { font-size: 17px; }
+.advisor-sheet .advisor-result-hero p { font-size: 11px; }
+.advisor-sheet .advisor-confidence {
+  grid-column: 3;
+  grid-row: 1;
+  align-self: start;
+  max-width: 112px;
+  padding: 4px 7px;
+  text-align: center;
+  font-size: 9.5px;
+}
+.advisor-sheet .advisor-reason-list { gap: 5px; margin-top: 10px; }
+.advisor-sheet .advisor-reason-list > div { gap: 6px; font-size: 11.5px; line-height: 1.35; }
+.advisor-sheet .advisor-alternative { margin-top: 9px; padding: 7px 9px; }
+.advisor-sheet .advisor-note { margin-top: 8px; font-size: 10.5px; }
+.advisor-sheet .advisor-catalog { margin-top: 11px; padding-top: 10px; }
+.advisor-sheet .advisor-product {
+  grid-template-columns: 62px minmax(0, 1fr);
+  gap: 8px;
+  padding: 7px;
+}
+.advisor-sheet .advisor-product-image { width: 62px; border-radius: 7px; }
+.advisor-sheet .advisor-product-actions { gap: 5px; margin-top: 6px; }
+.advisor-sheet .advisor-product-actions button { min-height: 42px; padding: 6px; font-size: 10.5px; }
+
+@media (max-width: 600px) {
+  .smart-advisor-section {
+    grid-template-columns: 42px minmax(0, 1fr);
+    min-height: 112px;
+    padding: 12px;
+  }
+  .advisor-launcher-copy p { display: none; }
+  .advisor-sheet-layer {
+    inset: var(--advisor-viewport-top, 0px) 0 auto;
+    width: 100%;
+    height: var(--advisor-viewport-height, 100dvh);
+    min-height: 0;
+    padding: 0;
+    align-items: stretch;
+  }
+  .advisor-sheet {
+    width: 100%;
+    height: 100%;
+    max-height: none;
+    border: 0;
+    border-radius: 0;
+  }
+  .advisor-sheet-header {
+    padding-top: max(10px, env(safe-area-inset-top, 0px));
+  }
+  .advisor-sheet-scroll {
+    scroll-padding-top: 14px;
+    scroll-padding-bottom: calc(82px + env(safe-area-inset-bottom, 0px));
+  }
+  .advisor-sheet-actions {
+    padding-bottom: calc(9px + env(safe-area-inset-bottom, 0px));
+  }
+  .advisor-sheet .advisor-chip-grid { grid-template-columns: minmax(0, 1fr); }
+}
 
 @media (max-width: 380px) {
-  .smart-advisor-section { grid-template-columns: 48px minmax(0, 1fr); gap: 10px; padding: 14px; }
-  .advisor-launcher-orb { width: 46px; height: 46px; }
-  .advisor-launcher-copy h2 { font-size: 16px; }
-  .advisor-launcher-actions { align-items: stretch; flex-direction: column; gap: 4px; }
-  .advisor-launcher-actions .primary-btn { width: 100%; }
+  .smart-advisor-section { grid-template-columns: 40px minmax(0, 1fr); gap: 8px; min-height: 108px; padding: 11px; }
+  .advisor-launcher-orb { width: 38px; height: 38px; }
+  .advisor-launcher-copy h2 { font-size: 15px; }
+  .advisor-launcher-content { gap: 6px; }
+  .advisor-launcher-actions .primary-btn { min-height: 40px; padding-inline: 10px; font-size: 11px; }
   .advisor-sheet .advisor-choice-grid { grid-template-columns: minmax(0, 1fr); }
-  .advisor-sheet-body { padding-inline: 13px; }
+  .advisor-sheet-body { padding-inline: 12px; }
   .advisor-product-actions { grid-template-columns: 1fr; }
+  .advisor-sheet .advisor-confidence { grid-column: 2; grid-row: auto; justify-self: start; }
 }
 
 @media (max-height: 620px) {
-  .advisor-sheet { max-height: 92dvh; }
   .advisor-sheet-body { padding-top: 13px; }
 }
 
 @media (prefers-reduced-motion: reduce) {
   .advisor-launcher-orb::after,
+  .advisor-launcher-orb,
+  .smart-advisor-section::before,
+  .advisor-launcher-actions .primary-btn::after,
   .advisor-sheet-layer,
   .advisor-sheet,
+  .advisor-sheet-brand,
   .advisor-sheet .advisor-step,
   .advisor-sheet .advisor-result,
+  .advisor-sheet .advisor-confidence,
   .advisor-sheet .advisor-reason-list > div,
   .advisor-sheet .advisor-product,
-  .advisor-sheet .advisor-result .primary-btn {
+  .advisor-sheet .advisor-result .primary-btn,
+  .advisor-sheet .advisor-choice::before,
+  .advisor-sheet .advisor-chip::before,
+  .advisor-sheet .is-selected .advisor-choice-icon,
+  .advisor-sheet .is-selected .advisor-choice-check {
     animation: none !important;
     transition: none !important;
     transform: none !important;

--- a/customer-app/assets/customer-app.css
+++ b/customer-app/assets/customer-app.css
@@ -6828,6 +6828,18 @@ body.has-advisor-sheet { overflow: hidden; }
 }
 .advisor-sheet-actions button { min-height: 44px; }
 .advisor-sheet-actions .secondary-btn { color: #587086; font-size: 11px; }
+.advisor-sheet-actions .advisor-result-edit-btn,
+.advisor-sheet-actions .advisor-result-reset-btn {
+  min-height: 40px;
+  font-size: 11px;
+}
+.advisor-sheet-actions .advisor-result-reset-btn {
+  border: 0;
+  background: transparent;
+  box-shadow: none;
+  color: #6a7f91;
+}
+.advisor-sheet-actions .advisor-result-reset-btn:hover { background: #f2f6f9; color: #294a64; }
 .advisor-sheet-actions .primary-btn:disabled { opacity: 0.48; cursor: not-allowed; transform: none; }
 .advisor-sheet-body.is-step-forward > .advisor-result { animation-name: advisor-result-reveal; }
 .advisor-sheet .advisor-confidence { animation: advisor-confidence-pop 340ms cubic-bezier(0.2, 1.35, 0.4, 1) both 90ms; }

--- a/customer-app/assets/customer-app.js
+++ b/customer-app/assets/customer-app.js
@@ -3,7 +3,7 @@
 
   const App = window.CWFCustomerAppV2;
   const BOOT_TIMEOUT_MS = 3500;
-  const BUILD_ID = "20260714_smart_advisor_compact_sheet_v1";
+  const BUILD_ID = "20260715_smart_advisor_mobile_polish_v2";
 
   function withTimeout(promise, timeoutMs) {
     return Promise.race([

--- a/customer-app/index.html
+++ b/customer-app/index.html
@@ -21,10 +21,10 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Noto+Sans+Thai:wght@400;500;600;700;800;900&display=swap" media="print" onload="this.media='all'">
   <noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Noto+Sans+Thai:wght@400;500;600;700;800;900&display=swap"></noscript>
-  <link rel="manifest" href="./manifest.webmanifest?v=20260714_smart_advisor_compact_sheet_v1">
+  <link rel="manifest" href="./manifest.webmanifest?v=20260715_smart_advisor_mobile_polish_v2">
   <link rel="icon" type="image/png" sizes="192x192" href="./assets/icons/cwf-customer-192.png">
   <link rel="apple-touch-icon" sizes="180x180" href="./assets/icons/cwf-customer-180.png">
-  <link rel="stylesheet" href="./assets/customer-app.css?v=20260714_smart_advisor_compact_sheet_v1">
+  <link rel="stylesheet" href="./assets/customer-app.css?v=20260715_smart_advisor_mobile_polish_v2">
 </head>
 <body class="is-app-booting">
   <div class="app-shell" data-app-shell>
@@ -62,23 +62,23 @@
     </nav>
   </div>
 
-  <script src="./modules/state.js?v=20260714_smart_advisor_compact_sheet_v1"></script>
-  <script src="./modules/utils.js?v=20260714_smart_advisor_compact_sheet_v1"></script>
-  <script src="./modules/analytics.js?v=20260714_smart_advisor_compact_sheet_v1"></script>
-  <script src="./modules/api.js?v=20260714_smart_advisor_compact_sheet_v1"></script>
-  <script src="./modules/pageAvailability.js?v=20260714_smart_advisor_compact_sheet_v1"></script>
-  <script src="./modules/services.js?v=20260714_smart_advisor_compact_sheet_v1"></script>
-  <script src="./modules/advisor.js?v=20260714_smart_advisor_compact_sheet_v1"></script>
-  <script src="./modules/ui.js?v=20260714_smart_advisor_compact_sheet_v1"></script>
-  <script src="./modules/store.js?v=20260714_smart_advisor_compact_sheet_v1"></script>
-  <script src="./modules/auth.js?v=20260714_smart_advisor_compact_sheet_v1"></script>
-  <script src="./modules/pricing.js?v=20260714_smart_advisor_compact_sheet_v1"></script>
-  <script src="./modules/availability.js?v=20260714_smart_advisor_compact_sheet_v1"></script>
-  <script src="./modules/bookingScheduled.js?v=20260714_smart_advisor_compact_sheet_v1"></script>
-  <script src="./modules/bookingUrgent.js?v=20260714_smart_advisor_compact_sheet_v1"></script>
-  <script src="./modules/tracking.js?v=20260714_smart_advisor_compact_sheet_v1"></script>
-  <script src="./modules/profile.js?v=20260714_smart_advisor_compact_sheet_v1"></script>
-  <script src="./modules/router.js?v=20260714_smart_advisor_compact_sheet_v1"></script>
-  <script src="./assets/customer-app.js?v=20260714_smart_advisor_compact_sheet_v1"></script>
+  <script src="./modules/state.js?v=20260715_smart_advisor_mobile_polish_v2"></script>
+  <script src="./modules/utils.js?v=20260715_smart_advisor_mobile_polish_v2"></script>
+  <script src="./modules/analytics.js?v=20260715_smart_advisor_mobile_polish_v2"></script>
+  <script src="./modules/api.js?v=20260715_smart_advisor_mobile_polish_v2"></script>
+  <script src="./modules/pageAvailability.js?v=20260715_smart_advisor_mobile_polish_v2"></script>
+  <script src="./modules/services.js?v=20260715_smart_advisor_mobile_polish_v2"></script>
+  <script src="./modules/advisor.js?v=20260715_smart_advisor_mobile_polish_v2"></script>
+  <script src="./modules/ui.js?v=20260715_smart_advisor_mobile_polish_v2"></script>
+  <script src="./modules/store.js?v=20260715_smart_advisor_mobile_polish_v2"></script>
+  <script src="./modules/auth.js?v=20260715_smart_advisor_mobile_polish_v2"></script>
+  <script src="./modules/pricing.js?v=20260715_smart_advisor_mobile_polish_v2"></script>
+  <script src="./modules/availability.js?v=20260715_smart_advisor_mobile_polish_v2"></script>
+  <script src="./modules/bookingScheduled.js?v=20260715_smart_advisor_mobile_polish_v2"></script>
+  <script src="./modules/bookingUrgent.js?v=20260715_smart_advisor_mobile_polish_v2"></script>
+  <script src="./modules/tracking.js?v=20260715_smart_advisor_mobile_polish_v2"></script>
+  <script src="./modules/profile.js?v=20260715_smart_advisor_mobile_polish_v2"></script>
+  <script src="./modules/router.js?v=20260715_smart_advisor_mobile_polish_v2"></script>
+  <script src="./assets/customer-app.js?v=20260715_smart_advisor_mobile_polish_v2"></script>
 </body>
 </html>

--- a/customer-app/manifest.webmanifest
+++ b/customer-app/manifest.webmanifest
@@ -2,7 +2,7 @@
   "name": "CWF Customer Service",
   "short_name": "CWF Service",
   "description": "แอปลูกค้า Coldwindflow สำหรับเลือกบริการ จองคิว และติดตามงาน",
-  "start_url": "/customer-app/index.html?v=20260714_smart_advisor_compact_sheet_v1#home",
+  "start_url": "/customer-app/index.html?v=20260715_smart_advisor_mobile_polish_v2#home",
   "scope": "/customer-app/",
   "id": "/customer-app/",
   "display": "standalone",

--- a/customer-app/modules/advisor.js
+++ b/customer-app/modules/advisor.js
@@ -519,8 +519,8 @@
   function sheetActions(state) {
     if (state.step === 4) {
       return `
-        <button class="secondary-btn" type="button" data-advisor-back>ย้อนกลับแก้อาการ</button>
-        <button class="primary-btn" type="button" data-advisor-reset>เริ่มประเมินใหม่</button>
+        <button class="secondary-btn advisor-result-edit-btn" type="button" data-advisor-back>แก้คำตอบ</button>
+        <button class="advisor-reset-btn advisor-result-reset-btn" type="button" data-advisor-reset>ประเมินใหม่</button>
       `;
     }
     return `
@@ -598,11 +598,13 @@
       if (window.visualViewport) viewportTarget.addEventListener?.("scroll", updateViewport);
       updateViewport();
     };
-    const unbindViewport = () => {
+    const stopViewportListeners = () => {
       if (!viewportListenersBound) return;
       viewportListenersBound = false;
       viewportTarget.removeEventListener?.("resize", updateViewport);
       if (window.visualViewport) viewportTarget.removeEventListener?.("scroll", updateViewport);
+    };
+    const clearViewportVariables = () => {
       mount.style?.removeProperty?.("--advisor-viewport-height");
       mount.style?.removeProperty?.("--advisor-viewport-top");
     };
@@ -717,9 +719,13 @@
     };
     const closeSheet = (options = {}) => {
       if (!isOpen && !options.immediate) return;
+      if (options.immediate && closeTimer) {
+        clearTimeout(closeTimer);
+        closeTimer = null;
+      }
       isOpen = false;
       removeOpenListeners();
-      unbindViewport();
+      stopViewportListeners();
       document.body.classList.remove("has-advisor-sheet");
       renderLauncher();
       const host = sheetHost();
@@ -728,6 +734,7 @@
         closeTimer = null;
         if (host && !isOpen) host.innerHTML = "";
         mount.classList?.toggle?.("is-sheet-open", false);
+        clearViewportVariables();
         if (options.restoreFocus !== false && !destroyed) mount.querySelector("[data-advisor-launch]")?.focus?.({ preventScroll: true });
       };
       if (options.immediate || reducedMotion || !layer) {
@@ -835,7 +842,8 @@
         if (closeTimer) clearTimeout(closeTimer);
         closeTimer = null;
         removeOpenListeners();
-        unbindViewport();
+        stopViewportListeners();
+        clearViewportVariables();
         document.body.classList.remove("has-advisor-sheet");
         mount.removeEventListener("click", onClick);
         controllers.delete(mount);
@@ -880,6 +888,7 @@
       stepContent,
       launcherContent,
       sheetHtml,
+      sheetActions,
       stepIsValid,
     },
   };

--- a/customer-app/modules/advisor.js
+++ b/customer-app/modules/advisor.js
@@ -5,45 +5,45 @@
   const controllers = new WeakMap();
 
   const AC_TYPES = Object.freeze([
-    { value: "wall", label: "แอร์ผนัง", bookingValue: "ผนัง" },
-    { value: "fourway", label: "แอร์สี่ทิศทาง", bookingValue: "สี่ทิศทาง" },
-    { value: "hanging", label: "แอร์แขวน", bookingValue: "แขวน" },
-    { value: "ceiling", label: "แอร์เปลือยใต้ฝ้า", bookingValue: "เปลือยใต้ฝ้า" },
-    { value: "unknown", label: "ไม่แน่ใจ", bookingValue: null },
+    { value: "wall", label: "แอร์ผนัง", bookingValue: "ผนัง", icon: "wall-ac" },
+    { value: "fourway", label: "แอร์สี่ทิศทาง", bookingValue: "สี่ทิศทาง", icon: "fourway" },
+    { value: "hanging", label: "แอร์แขวน", bookingValue: "แขวน", icon: "hanging-ac" },
+    { value: "ceiling", label: "แอร์เปลือยใต้ฝ้า", bookingValue: "เปลือยใต้ฝ้า", icon: "ceiling-ac" },
+    { value: "unknown", label: "ไม่แน่ใจ", bookingValue: null, icon: "question" },
   ]);
 
   const MONTH_BANDS = Object.freeze([
-    { value: "recent", label: "ไม่เกิน 3 เดือน" },
-    { value: "m4_5", label: "4–5 เดือน" },
-    { value: "m6_8", label: "6–8 เดือน" },
-    { value: "m9_12", label: "9–12 เดือน" },
-    { value: "over12", label: "เกิน 1 ปี" },
-    { value: "unknown", label: "จำไม่ได้ / ไม่แน่ใจ" },
+    { value: "recent", label: "ไม่เกิน 3 เดือน", icon: "calendar-check" },
+    { value: "m4_5", label: "4–5 เดือน", icon: "calendar" },
+    { value: "m6_8", label: "6–8 เดือน", icon: "clock" },
+    { value: "m9_12", label: "9–12 เดือน", icon: "history" },
+    { value: "over12", label: "เกิน 1 ปี", icon: "calendar-alert" },
+    { value: "unknown", label: "จำไม่ได้ / ไม่แน่ใจ", icon: "question" },
   ]);
 
   const SYMPTOMS = Object.freeze([
-    { value: "routine", label: "ไม่มีอาการ แค่ถึงรอบล้าง" },
-    { value: "reduced_cooling", label: "เย็นน้อยลง" },
-    { value: "weak_airflow", label: "ลมอ่อน" },
-    { value: "odor", label: "มีกลิ่น" },
-    { value: "drain", label: "น้ำหยด / ระบายน้ำไม่ดี" },
-    { value: "dusty", label: "มีฝุ่นหรือคราบมาก" },
-    { value: "heavy_dirt", label: "สกปรกหนัก / หมักหมม" },
-    { value: "noise", label: "เสียงดัง" },
-    { value: "heavy_use", label: "ใช้งานหนักทุกวัน" },
-    { value: "pets", label: "มีสัตว์เลี้ยง" },
-    { value: "allergy", label: "มีผู้แพ้ง่ายหรือเด็กเล็ก" },
-    { value: "never_deep", label: "ไม่เคยล้างลึก" },
+    { value: "routine", label: "ไม่มีอาการ แค่ถึงรอบล้าง", icon: "check-circle" },
+    { value: "reduced_cooling", label: "เย็นน้อยลง", icon: "thermometer" },
+    { value: "weak_airflow", label: "ลมอ่อน", icon: "wind" },
+    { value: "odor", label: "มีกลิ่น", icon: "air-wave" },
+    { value: "drain", label: "น้ำหยด / ระบายน้ำไม่ดี", icon: "droplet" },
+    { value: "dusty", label: "มีฝุ่นหรือคราบมาก", icon: "filter" },
+    { value: "heavy_dirt", label: "สกปรกหนัก / หมักหมม", icon: "warning" },
+    { value: "noise", label: "เสียงดัง", icon: "sound" },
+    { value: "heavy_use", label: "ใช้งานหนักทุกวัน", icon: "activity" },
+    { value: "pets", label: "มีสัตว์เลี้ยง", icon: "paw" },
+    { value: "allergy", label: "มีผู้แพ้ง่ายหรือเด็กเล็ก", icon: "health-shield" },
+    { value: "never_deep", label: "ไม่เคยล้างลึก", icon: "layers" },
   ]);
 
   const REPAIR_SIGNALS = Object.freeze([
-    { value: "error_code", label: "มี Error Code" },
-    { value: "ac_not_running", label: "แอร์ไม่ทำงาน" },
-    { value: "outdoor_not_running", label: "คอยร้อนไม่ทำงาน" },
-    { value: "indoor_not_running", label: "คอยล์เย็นไม่ทำงาน" },
-    { value: "breaker_trip", label: "เบรกเกอร์ตัด" },
-    { value: "burning_smell", label: "มีเสียงหรือกลิ่นไหม้" },
-    { value: "none", label: "ไม่มีอาการเหล่านี้" },
+    { value: "error_code", label: "มี Error Code", icon: "code-alert" },
+    { value: "ac_not_running", label: "แอร์ไม่ทำงาน", icon: "power-off" },
+    { value: "outdoor_not_running", label: "คอยร้อนไม่ทำงาน", icon: "fan" },
+    { value: "indoor_not_running", label: "คอยล์เย็นไม่ทำงาน", icon: "snow-vent" },
+    { value: "breaker_trip", label: "เบรกเกอร์ตัด", icon: "breaker" },
+    { value: "burning_smell", label: "มีเสียงหรือกลิ่นไหม้", icon: "flame-alert" },
+    { value: "none", label: "ไม่มีอาการเหล่านี้", icon: "check-circle" },
   ]);
 
   const VERDICT_META = Object.freeze({
@@ -311,11 +311,47 @@
     return typeof root.utils.icon === "function" ? root.utils.icon(name, size) : "";
   }
 
+  const ADVISOR_ICON_PATHS = Object.freeze({
+    "wall-ac": '<rect x="3" y="5" width="18" height="8" rx="2"/><path d="M7 9h10M8 16c1.2 1.2 2.5 1.8 4 1.8s2.8-.6 4-1.8"/>',
+    fourway: '<rect x="6" y="6" width="12" height="12" rx="2"/><path d="M12 2v4M12 18v4M2 12h4M18 12h4M9 9h6v6H9z"/>',
+    "hanging-ac": '<path d="M6 3v3M18 3v3"/><rect x="3" y="6" width="18" height="8" rx="2"/><path d="M7 18h10M9 14v4M15 14v4"/>',
+    "ceiling-ac": '<path d="M3 5h18M6 5v8h12V5M9 16h6M8 20c1.1-1.2 2.4-1.8 4-1.8s2.9.6 4 1.8"/>',
+    question: '<circle cx="12" cy="12" r="9"/><path d="M9.8 9a2.4 2.4 0 1 1 3.6 2.1c-.9.5-1.4 1-1.4 2M12 17h.01"/>',
+    "calendar-check": '<rect x="3" y="4" width="18" height="17" rx="3"/><path d="M8 2v4M16 2v4M3 9h18M8 15l2 2 5-5"/>',
+    calendar: '<rect x="3" y="4" width="18" height="17" rx="3"/><path d="M8 2v4M16 2v4M3 9h18M8 13h2M14 13h2M8 17h2"/>',
+    clock: '<circle cx="12" cy="12" r="9"/><path d="M12 7v5l3.5 2"/>',
+    history: '<path d="M4 5v5h5M5.5 18A9 9 0 1 0 4 10"/><path d="M12 7v5l3 2"/>',
+    "calendar-alert": '<rect x="3" y="4" width="18" height="17" rx="3"/><path d="M8 2v4M16 2v4M3 9h18M12 12v4M12 18h.01"/>',
+    "check-circle": '<circle cx="12" cy="12" r="9"/><path d="m8 12 2.5 2.5L16 9"/>',
+    thermometer: '<path d="M10 5a2 2 0 0 1 4 0v8.2a4 4 0 1 1-4 0V5zM12 9v7"/><path d="M17 6h3M18 10h2"/>',
+    wind: '<path d="M3 8h11a2 2 0 1 0-2-2M3 12h16a2 2 0 1 1-2 2M3 16h9"/>',
+    "air-wave": '<path d="M3 8c3-3 6 3 9 0s6 3 9 0M3 13c3-3 6 3 9 0s6 3 9 0M5 18c2-2 4 2 6 0"/>',
+    droplet: '<path d="M12 3s6 6.2 6 11a6 6 0 0 1-12 0c0-4.8 6-11 6-11z"/><path d="M9 15c.5 1.2 1.5 1.8 3 1.8"/>',
+    filter: '<path d="M4 5h16l-6 7v6l-4 2v-8L4 5z"/><path d="M7 8h10"/>',
+    warning: '<path d="M12 3 2.8 20h18.4L12 3z"/><path d="M12 9v5M12 17h.01"/>',
+    sound: '<path d="M4 10v4h4l5 4V6L8 10H4zM17 9c1.5 1.5 1.5 4.5 0 6M19.5 6.5c3 3 3 8 0 11"/>',
+    activity: '<path d="M3 12h4l2-6 4 12 2-6h6"/>',
+    paw: '<circle cx="8" cy="8" r="1.8"/><circle cx="16" cy="8" r="1.8"/><circle cx="5.5" cy="12" r="1.6"/><circle cx="18.5" cy="12" r="1.6"/><path d="M8 17c0-2.2 1.8-4 4-4s4 1.8 4 4c0 2-1.5 3-4 3s-4-1-4-3z"/>',
+    "health-shield": '<path d="M12 3l7 3v6c0 4.5-3 7.5-7 9-4-1.5-7-4.5-7-9V6l7-3z"/><path d="M12 8v8M8 12h8"/>',
+    layers: '<path d="m12 3 9 5-9 5-9-5 9-5zM3 12l9 5 9-5M3 16l9 5 9-5"/>',
+    "code-alert": '<path d="m8 8-4 4 4 4M16 8l4 4-4 4M13 6l-2 12"/><circle cx="19" cy="5" r="3"/><path d="M19 3.8v1.4M19 6.2h.01"/>',
+    "power-off": '<path d="M12 3v8M6.3 5.8A8 8 0 1 0 18.5 6M3 3l18 18"/>',
+    fan: '<circle cx="12" cy="12" r="2"/><path d="M12 10c-1-4 1-7 4-7 2 3 1 6-2 8M14 12c4-1 7 1 7 4-3 2-6 1-8-2M12 14c1 4-1 7-4 7-2-3-1-6 2-8M10 12c-4 1-7-1-7-4 3-2 6-1 8 2"/>',
+    "snow-vent": '<path d="M12 3v18M5 7l14 10M19 7 5 17M8 4l4 3 4-3M8 20l4-3 4 3"/>',
+    breaker: '<path d="M13 2 5 13h6l-1 9 9-12h-6l0-8z"/><path d="M3 3l18 18"/>',
+    "flame-alert": '<path d="M13 3c1 4-2 5-2 8 0 1.5 1 2.5 2 3.5 1.5-1 2.5-2.5 2-5 3 2 4 4.5 3 7a6.5 6.5 0 0 1-12 0c-1-3 1-6 4-8-.5 3 1 4 1 4"/><path d="M20 4v3M20 9h.01"/>',
+  });
+
+  function semanticIcon(name, size = 20) {
+    const key = ADVISOR_ICON_PATHS[name] ? name : "question";
+    return `<span class="advisor-semantic-icon" data-advisor-icon="${esc(key)}" aria-hidden="true"><svg viewBox="0 0 24 24" width="${size}" height="${size}" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">${ADVISOR_ICON_PATHS[key]}</svg></span>`;
+  }
+
   function choiceButtons(items, selected, attribute) {
     return `<div class="advisor-choice-grid">${items.map((item) => `
       <button class="advisor-choice ${selected === item.value ? "is-selected" : ""}" type="button"
         ${attribute}="${esc(item.value)}" aria-pressed="${selected === item.value ? "true" : "false"}">
-        <span class="advisor-choice-icon">${icon(attribute === "data-advisor-months" ? "calendar" : "sparkle", 17)}</span>
+        <span class="advisor-choice-icon">${semanticIcon(item.icon, 20)}</span>
         <span class="advisor-choice-label">${esc(item.label)}</span>
         <span class="advisor-choice-check" aria-hidden="true">${selected === item.value ? "✓" : ""}</span>
       </button>
@@ -327,7 +363,7 @@
     return `<div class="advisor-chip-grid ${attribute === "data-advisor-repair" ? "is-repair-list" : ""}">${items.map((item) => `
       <button class="advisor-chip ${values.has(item.value) ? "is-selected" : ""}" type="button"
         ${attribute}="${esc(item.value)}" aria-pressed="${values.has(item.value) ? "true" : "false"}">
-        <span class="advisor-choice-icon">${icon(attribute === "data-advisor-repair" ? "bolt" : "sparkle", 17)}</span>
+        <span class="advisor-choice-icon">${semanticIcon(item.icon, 20)}</span>
         <span class="advisor-choice-label">${esc(item.label)}</span>
         <span class="advisor-choice-check" aria-hidden="true">${values.has(item.value) ? "✓" : ""}</span>
       </button>
@@ -475,7 +511,7 @@
         <button class="primary-btn" type="button" data-advisor-launch aria-expanded="${isOpen ? "true" : "false"}" aria-controls="advisor-sheet-dialog">
           ${icon(hasResult ? "sparkle" : "play", 18)} ${cta}
         </button>
-        ${hasResult ? `<button class="advisor-reset-btn" type="button" data-advisor-reset-launcher>ประเมินใหม่</button>` : `<small>ดูบริการจริงจาก Catalog</small>`}
+        ${hasResult ? `<button class="advisor-reset-btn" type="button" data-advisor-reset-launcher>ประเมินใหม่</button>` : ""}
       </div>
     `;
   }
@@ -542,9 +578,34 @@
     let isOpen = false;
     let closeTimer = null;
     const reducedMotion = Boolean(window.matchMedia?.("(prefers-reduced-motion: reduce)")?.matches);
+    const viewportTarget = window.visualViewport || window;
+    let viewportListenersBound = false;
     mount.classList?.toggle?.("is-reduced-motion", reducedMotion);
     const catalogState = () => root.state.catalog || { status: "idle", items: [] };
     const sheetHost = () => mount.querySelector("[data-advisor-sheet-host]");
+    const updateViewport = () => {
+      if (destroyed || !isOpen) return;
+      const viewport = window.visualViewport;
+      const height = Number(viewport?.height || window.innerHeight || document.documentElement?.clientHeight || 0);
+      const offsetTop = Number(viewport?.offsetTop || 0);
+      if (height > 0) mount.style?.setProperty?.("--advisor-viewport-height", `${Math.round(height)}px`);
+      mount.style?.setProperty?.("--advisor-viewport-top", `${Math.max(0, Math.round(offsetTop))}px`);
+    };
+    const bindViewport = () => {
+      if (viewportListenersBound) return;
+      viewportListenersBound = true;
+      viewportTarget.addEventListener?.("resize", updateViewport);
+      if (window.visualViewport) viewportTarget.addEventListener?.("scroll", updateViewport);
+      updateViewport();
+    };
+    const unbindViewport = () => {
+      if (!viewportListenersBound) return;
+      viewportListenersBound = false;
+      viewportTarget.removeEventListener?.("resize", updateViewport);
+      if (window.visualViewport) viewportTarget.removeEventListener?.("scroll", updateViewport);
+      mount.style?.removeProperty?.("--advisor-viewport-height");
+      mount.style?.removeProperty?.("--advisor-viewport-top");
+    };
     const renderLauncher = () => {
       const launcher = mount.querySelector("[data-advisor-launcher-content]");
       if (launcher) launcher.innerHTML = launcherContent(state, isOpen);
@@ -650,6 +711,7 @@
       isOpen = true;
       document.body.classList.add("has-advisor-sheet");
       document.addEventListener("keydown", onDocumentKeydown);
+      bindViewport();
       renderLauncher();
       renderSheet("forward");
     };
@@ -657,6 +719,7 @@
       if (!isOpen && !options.immediate) return;
       isOpen = false;
       removeOpenListeners();
+      unbindViewport();
       document.body.classList.remove("has-advisor-sheet");
       renderLauncher();
       const host = sheetHost();
@@ -772,6 +835,7 @@
         if (closeTimer) clearTimeout(closeTimer);
         closeTimer = null;
         removeOpenListeners();
+        unbindViewport();
         document.body.classList.remove("has-advisor-sheet");
         mount.removeEventListener("click", onClick);
         controllers.delete(mount);

--- a/customer-app/sw.js
+++ b/customer-app/sw.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const BUILD_ID = "20260714_smart_advisor_compact_sheet_v1";
+const BUILD_ID = "20260715_smart_advisor_mobile_polish_v2";
 const CACHE_NAME = `cwf-customer-app-v2-${BUILD_ID}`;
 const APP_SHELL = [
   `./index.html?v=${BUILD_ID}`,

--- a/test/customerAppPageAvailability.test.js
+++ b/test/customerAppPageAvailability.test.js
@@ -281,7 +281,7 @@ test("api exposes loadCustomerAppConfig as a no-store GET to /public/customer-ap
 });
 
 test("build wiring: pageAvailability.js is registered in the HTML shell and the SW cache, with the new build id", () => {
-  const build = "20260714_smart_advisor_compact_sheet_v1";
+  const build = "20260715_smart_advisor_mobile_polish_v2";
   assert.match(indexHtml, new RegExp(`modules/pageAvailability\\.js\\?v=${build}`));
   assert.match(swSrc, new RegExp(`BUILD_ID = "${build}"`));
   assert.match(swSrc, /modules\/pageAvailability\.js\?v=\$\{BUILD_ID\}/);
@@ -294,7 +294,7 @@ test("build wiring: pageAvailability.js is registered in the HTML shell and the 
    RUNTIME tests (execute the real code in a VM — not regex assertions).
    ========================================================================== */
 
-const BUILD = "20260714_smart_advisor_compact_sheet_v1";
+const BUILD = "20260715_smart_advisor_mobile_polish_v2";
 const adminSrc = read("admin-homepage-cms.js");
 
 function reqUrlOf(req) {

--- a/test/customerAppRecovery.test.js
+++ b/test/customerAppRecovery.test.js
@@ -236,7 +236,7 @@ test("Customer App build id is consistent across shell and service worker", () =
   const sw = read("customer-app/sw.js");
   const app = read("customer-app/assets/customer-app.js");
   const manifest = read("customer-app/manifest.webmanifest");
-  const build = "20260714_smart_advisor_compact_sheet_v1";
+  const build = "20260715_smart_advisor_mobile_polish_v2";
 
   assert.match(index, new RegExp(`customer-app\\.css\\?v=${build}`));
   assert.match(index, new RegExp(`modules\\/api\\.js\\?v=${build}`));
@@ -254,7 +254,7 @@ test("Customer App build id is consistent across shell and service worker", () =
 test("store module is loaded in index.html and precached in the service worker app shell", () => {
   const index = read("customer-app/index.html");
   const sw = read("customer-app/sw.js");
-  const build = "20260714_smart_advisor_compact_sheet_v1";
+  const build = "20260715_smart_advisor_mobile_polish_v2";
 
   assert.match(index, new RegExp(`modules/store\\.js\\?v=${build}`));
   assert.match(sw, /`\.\/modules\/store\.js\?v=\$\{BUILD_ID\}`/);

--- a/test/customerAppStorePayment.test.js
+++ b/test/customerAppStorePayment.test.js
@@ -58,7 +58,7 @@ test("store falls back to the LINE hand-off when payment is unconfigured or the 
 test("payment step styles exist and the Customer App payment build id is bumped", () => {
   assert.match(cssSrc, /\.pay-method-btn/);
   assert.match(cssSrc, /\.pay-qr-img/);
-  assert.match(read("customer-app/index.html"), /modules\/store\.js\?v=20260714_smart_advisor_compact_sheet_v1/);
-  assert.match(read("customer-app/sw.js"), /BUILD_ID = "20260714_smart_advisor_compact_sheet_v1"/);
+  assert.match(read("customer-app/index.html"), /modules\/store\.js\?v=20260715_smart_advisor_mobile_polish_v2/);
+  assert.match(read("customer-app/sw.js"), /BUILD_ID = "20260715_smart_advisor_mobile_polish_v2"/);
   assert.match(storeSrc, /payment-security 20260705 loaded/);
 });

--- a/test/customerBookingAdminNotifications.test.js
+++ b/test/customerBookingAdminNotifications.test.js
@@ -311,10 +311,10 @@ test("admin/customer frontend cache versions are bumped for booking notification
   assert.doesNotMatch(adminReviewHtml, /admin-review-v2\.js\?v=20260707_customer_booking_notify_v2/);
   assert.match(adminReviewHtml, /admin-review-ai-intake\.js\?v=ai-booking-intake-customer-cards-v11-admin-alert-gate/);
   assert.doesNotMatch(adminReviewHtml, /admin-review-ai-intake\.js\?v=ai-booking-intake-customer-cards-v10/);
-  assert.match(customerIndex, /bookingScheduled\.js\?v=20260714_smart_advisor_compact_sheet_v1/);
-  assert.match(customerIndex, /state\.js\?v=20260714_smart_advisor_compact_sheet_v1/);
-  assert.match(customerSw, /const BUILD_ID = "20260714_smart_advisor_compact_sheet_v1"/);
-  assert.match(customerManifest, /20260714_smart_advisor_compact_sheet_v1/);
+  assert.match(customerIndex, /bookingScheduled\.js\?v=20260715_smart_advisor_mobile_polish_v2/);
+  assert.match(customerIndex, /state\.js\?v=20260715_smart_advisor_mobile_polish_v2/);
+  assert.match(customerSw, /const BUILD_ID = "20260715_smart_advisor_mobile_polish_v2"/);
+  assert.match(customerManifest, /20260715_smart_advisor_mobile_polish_v2/);
 });
 
 test("behavior: review queue only includes customer urgent waiting rows while preserving review statuses", () => {

--- a/test/customerHistoryClaim.test.js
+++ b/test/customerHistoryClaim.test.js
@@ -544,7 +544,7 @@ test("Customer App profile opens history detail with opaque job_ref and clears c
 });
 
 test("Customer App cache version is bumped consistently", () => {
-  const expected = "20260714_smart_advisor_compact_sheet_v1";
+  const expected = "20260715_smart_advisor_mobile_polish_v2";
   for (const file of [
     "customer-app/index.html",
     "customer-app/sw.js",

--- a/test/customerHomepageFeaturedRotation.test.js
+++ b/test/customerHomepageFeaturedRotation.test.js
@@ -414,6 +414,6 @@ test("compact CSS and cache build remain consistent with six-card rotation", () 
   assert.match(css, /\.homepage-featured-page\s*\{[^}]*grid-area:\s*1\s*\/\s*1/s);
   assert.match(css, /transition:\s*opacity 350ms/);
   assert.match(css, /prefers-reduced-motion:\s*reduce/);
-  const build = "20260714_smart_advisor_compact_sheet_v1";
+  const build = "20260715_smart_advisor_mobile_polish_v2";
   for (const source of [html, sw, boot, manifest]) assert.match(source, new RegExp(build));
 });

--- a/test/customerSameDayTiming.test.js
+++ b/test/customerSameDayTiming.test.js
@@ -160,7 +160,7 @@ test("customer app disables availability HTTP cache and refreshes same-day slots
 });
 
 test("customer app build and service worker cache IDs changed", () => {
-  const id = "20260714_smart_advisor_compact_sheet_v1";
+  const id = "20260715_smart_advisor_mobile_polish_v2";
   for (const file of [
     "customer-app/index.html",
     "customer-app/sw.js",

--- a/test/customerSmartAdvisor.test.js
+++ b/test/customerSmartAdvisor.test.js
@@ -49,6 +49,24 @@ class FakeClassList {
   contains(value) { return this.values.has(value); }
 }
 
+class FakeStyle {
+  constructor() { this.values = new Map(); }
+  setProperty(name, value) { this.values.set(name, String(value)); }
+  removeProperty(name) { this.values.delete(name); }
+  getPropertyValue(name) { return this.values.get(name) || ""; }
+}
+
+function fakeEventTarget(properties = {}) {
+  const listeners = new Map();
+  return {
+    ...properties,
+    listeners,
+    addEventListener(type, handler) { listeners.set(type, handler); },
+    removeEventListener(type, handler) { if (listeners.get(type) === handler) listeners.delete(type); },
+    emit(type) { listeners.get(type)?.(); },
+  };
+}
+
 class FakeElement {
   constructor(onFocus, onHtmlChange) {
     this.classList = new FakeClassList();
@@ -76,6 +94,7 @@ class FakeMount {
     this.isConnected = true;
     this.listeners = new Map();
     this.classList = new FakeClassList();
+    this.style = new FakeStyle();
     this.document = fakeDocument;
     this.shellWrites = 0;
     this.launcher = new FakeElement((node) => { this.launcherFocuses += 1; if (this.document) this.document.activeElement = node; });
@@ -138,6 +157,7 @@ function fakeDocument() {
   return {
     activeElement: null,
     body: { classList: new FakeClassList() },
+    documentElement: { clientHeight: 760 },
     listeners,
     addEventListener(type, handler) { listeners.set(type, handler); },
     removeEventListener(type, handler) { if (listeners.get(type) === handler) listeners.delete(type); },
@@ -169,8 +189,18 @@ function loadAdvisor(options = {}) {
     },
     ui: { openContactSheet: (_container, item) => contacts.push(item) },
   };
+  const visualViewport = options.visualViewport ? fakeEventTarget({
+    height: options.visualViewport.height,
+    offsetTop: options.visualViewport.offsetTop || 0,
+  }) : null;
+  const fakeWindow = fakeEventTarget({
+    CWFCustomerAppV2: app,
+    innerHeight: options.innerHeight || 760,
+    visualViewport,
+    matchMedia: () => ({ matches: options.reducedMotion === true }),
+  });
   vm.runInNewContext(SOURCE, {
-    window: { CWFCustomerAppV2: app, matchMedia: () => ({ matches: options.reducedMotion === true }) },
+    window: fakeWindow,
     document,
     Set,
     WeakMap,
@@ -178,7 +208,7 @@ function loadAdvisor(options = {}) {
     setTimeout: (fn) => { fn(); return 1; },
     clearTimeout() {},
   }, { filename: "advisor.js" });
-  return { app, routes, contacts, applied, document };
+  return { app, routes, contacts, applied, document, window: fakeWindow, visualViewport };
 }
 
 function plain(value) {
@@ -403,6 +433,71 @@ test("launcher opens an accessible sheet and close resumes the saved step", () =
   assert.doesNotMatch(mount.html(), /data-advisor-ac=/);
 });
 
+test("semantic choice icons are deterministic, distinct, and emoji-free", () => {
+  const { app } = loadAdvisor();
+  const renderIcons = (step) => Array.from(app.advisor._test.stepContent({
+    step,
+    acType: "",
+    monthsBand: "",
+    symptoms: [],
+    repairSignals: [],
+    recommendation: null,
+  }, { status: "success", items: [] }).matchAll(/data-advisor-icon="([^"]+)"/g), (match) => match[1]);
+  const acIcons = renderIcons(0);
+  const monthIcons = renderIcons(1);
+  const symptomIcons = renderIcons(2);
+  const repairIcons = renderIcons(3);
+  assert.equal(acIcons.length, 5);
+  assert.equal(new Set(acIcons).size, 5);
+  assert.equal(monthIcons.length, 6);
+  assert.ok(new Set(monthIcons).size > 3);
+  assert.equal(symptomIcons.length, 12);
+  assert.equal(new Set(symptomIcons).size, 12);
+  assert.equal(repairIcons.length, 7);
+  assert.equal(new Set(repairIcons).size, 7);
+  assert.doesNotMatch([acIcons, monthIcons, symptomIcons, repairIcons].flat().join(""), /[\u{1F300}-\u{1FAFF}]/u);
+});
+
+test("visualViewport drives the mobile panel and listeners clean up on close and route leave", () => {
+  const runtime = loadAdvisor({ visualViewport: { height: 612.4, offsetTop: 48.6 } });
+  const mount = new FakeMount(runtime.document);
+  const controller = runtime.app.advisor.bind({ querySelector: () => mount });
+  mount.click({ "data-advisor-launch": "" });
+  assert.equal(mount.style.getPropertyValue("--advisor-viewport-height"), "612px");
+  assert.equal(mount.style.getPropertyValue("--advisor-viewport-top"), "49px");
+  assert.deepEqual(Array.from(runtime.visualViewport.listeners.keys()).sort(), ["resize", "scroll"]);
+
+  runtime.visualViewport.height = 488.2;
+  runtime.visualViewport.offsetTop = 72.1;
+  runtime.visualViewport.emit("resize");
+  assert.equal(mount.style.getPropertyValue("--advisor-viewport-height"), "488px");
+  assert.equal(mount.style.getPropertyValue("--advisor-viewport-top"), "72px");
+  runtime.visualViewport.offsetTop = 16;
+  runtime.visualViewport.emit("scroll");
+  assert.equal(mount.style.getPropertyValue("--advisor-viewport-top"), "16px");
+
+  mount.click({ "data-advisor-close": "" });
+  assert.equal(runtime.visualViewport.listeners.size, 0);
+  assert.equal(mount.style.getPropertyValue("--advisor-viewport-height"), "");
+  mount.click({ "data-advisor-launch": "" });
+  controller.cleanup();
+  assert.equal(runtime.visualViewport.listeners.size, 0);
+});
+
+test("visualViewport fallback uses window height and removes its resize listener", () => {
+  const runtime = loadAdvisor({ innerHeight: 701 });
+  const mount = new FakeMount(runtime.document);
+  const controller = runtime.app.advisor.bind({ querySelector: () => mount });
+  mount.click({ "data-advisor-launch": "" });
+  assert.equal(mount.style.getPropertyValue("--advisor-viewport-height"), "701px");
+  assert.deepEqual(Array.from(runtime.window.listeners.keys()), ["resize"]);
+  runtime.window.innerHeight = 640;
+  runtime.window.emit("resize");
+  assert.equal(mount.style.getPropertyValue("--advisor-viewport-height"), "640px");
+  controller.cleanup();
+  assert.equal(runtime.window.listeners.size, 0);
+});
+
 test("sheet shell opens once while steps and Catalog refresh update in place", () => {
   const runtime = loadAdvisor({ catalog: { status: "loading", items: [] } });
   const mount = new FakeMount(runtime.document);
@@ -600,15 +695,28 @@ test("advisor render contract is accessible, compact, motion-safe, and has no au
   assert.match(html, /aria-expanded="false"/);
   assert.doesNotMatch(html, /data-advisor-ac|data-advisor-months|data-advisor-symptom|data-advisor-repair/);
   assert.doesNotMatch(html, /ความคืบหน้าการประเมิน|ขั้นที่ 1 จาก 4/);
+  assert.doesNotMatch(html, /ดูบริการจริงจาก Catalog/);
   assert.match(CSS_SOURCE, /@media \(prefers-reduced-motion: reduce\)/);
   assert.match(CSS_SOURCE, /\.advisor-sheet[\s\S]*?max-height: 90dvh/);
   assert.match(CSS_SOURCE, /\.advisor-sheet-actions[\s\S]*?safe-area-inset-bottom/);
   assert.match(CSS_SOURCE, /\.advisor-sheet-layer[\s\S]*?z-index: 100/);
   assert.match(CSS_SOURCE, /\.advisor-sheet \.advisor-chip-grid[\s\S]*?grid-template-columns: minmax\(0, 1fr\)/);
   assert.match(CSS_SOURCE, /@media \(max-width: 380px\)[\s\S]*?\.advisor-sheet \.advisor-choice-grid \{ grid-template-columns: minmax\(0, 1fr\)/);
-  assert.match(CSS_SOURCE, /@media \(max-height: 620px\)[\s\S]*?max-height: 92dvh/);
+  assert.match(CSS_SOURCE, /@media \(max-width: 600px\)[\s\S]*?height: var\(--advisor-viewport-height, 100dvh\)/);
+  assert.match(CSS_SOURCE, /@media \(max-width: 600px\)[\s\S]*?max-height: none[\s\S]*?border-radius: 0/);
   assert.match(CSS_SOURCE, /body\.has-advisor-sheet \{ overflow: hidden/);
+  assert.match(CSS_SOURCE, /\.smart-advisor-section \{[\s\S]*?min-height: 112px[\s\S]*?padding: 12px/);
+  assert.match(CSS_SOURCE, /\.advisor-launcher-orb \{[\s\S]*?width: 40px[\s\S]*?height: 40px/);
+  assert.match(CSS_SOURCE, /\.advisor-launcher-actions \.primary-btn \{[\s\S]*?min-height: 42px/);
+  assert.match(CSS_SOURCE, /@media \(max-width: 600px\)[\s\S]*?\.advisor-launcher-copy p \{ display: none; \}/);
+  assert.match(CSS_SOURCE, /\.advisor-sheet-scroll \{[\s\S]*?overflow-y: auto[\s\S]*?overscroll-behavior: contain/);
+  assert.match(CSS_SOURCE, /\.advisor-sheet-actions \{[\s\S]*?safe-area-inset-bottom/);
   assert.match(CSS_SOURCE, /@keyframes advisor-orbit/);
+  assert.match(CSS_SOURCE, /@keyframes advisor-orb-breathe/);
+  assert.match(CSS_SOURCE, /@keyframes advisor-launcher-sheen/);
+  assert.match(CSS_SOURCE, /@keyframes advisor-choice-sweep/);
+  assert.match(CSS_SOURCE, /@keyframes advisor-check-spring/);
+  assert.match(CSS_SOURCE, /@keyframes advisor-confidence-pop/);
   assert.match(CSS_SOURCE, /@keyframes advisor-sheet-up/);
   assert.match(CSS_SOURCE, /@keyframes advisor-question-forward/);
   assert.match(CSS_SOURCE, /@keyframes advisor-result-reveal/);
@@ -621,6 +729,7 @@ test("advisor render contract is accessible, compact, motion-safe, and has no au
   assert.match(CSS_SOURCE, /@media \(prefers-reduced-motion: reduce\)[\s\S]*?\.advisor-sheet-layer[\s\S]*?animation: none !important/);
   assert.doesNotMatch(SOURCE, /setInterval\s*\(/);
   assert.match(SOURCE, /matchMedia\?\.\("\(prefers-reduced-motion: reduce\)"\)/);
+  assert.match(SOURCE, /window\.visualViewport/);
   const reduced = loadAdvisor({ reducedMotion: true });
   const mount = new FakeMount(reduced.document);
   assert.equal(reduced.app.advisor.bind({ querySelector: () => mount }).reducedMotion, true);
@@ -654,7 +763,7 @@ test("Home places built-in advisor after Quick Actions and before Featured Servi
 });
 
 test("advisor module is loaded before ui.js and precached under the shared build id", () => {
-  const build = "20260714_smart_advisor_compact_sheet_v1";
+  const build = "20260715_smart_advisor_mobile_polish_v2";
   assert.ok(INDEX_SOURCE.indexOf(`modules/advisor.js?v=${build}`) < INDEX_SOURCE.indexOf(`modules/ui.js?v=${build}`));
   assert.match(SW_SOURCE, new RegExp(`BUILD_ID = "${build}"`));
   assert.match(SW_SOURCE, /modules\/advisor\.js\?v=\$\{BUILD_ID\}/);

--- a/test/customerSmartAdvisor.test.js
+++ b/test/customerSmartAdvisor.test.js
@@ -199,16 +199,34 @@ function loadAdvisor(options = {}) {
     visualViewport,
     matchMedia: () => ({ matches: options.reducedMotion === true }),
   });
+  const timers = new Map();
+  let nextTimerId = 1;
+  const setTimer = options.deferTimers
+    ? (callback) => {
+      const id = nextTimerId++;
+      timers.set(id, callback);
+      return id;
+    }
+    : (callback) => {
+      callback();
+      return nextTimerId++;
+    };
+  const clearTimer = (id) => timers.delete(id);
+  const runTimers = () => {
+    const callbacks = Array.from(timers.values());
+    timers.clear();
+    callbacks.forEach((callback) => callback());
+  };
   vm.runInNewContext(SOURCE, {
     window: fakeWindow,
     document,
     Set,
     WeakMap,
     requestAnimationFrame: (fn) => fn(),
-    setTimeout: (fn) => { fn(); return 1; },
-    clearTimeout() {},
+    setTimeout: setTimer,
+    clearTimeout: clearTimer,
   }, { filename: "advisor.js" });
-  return { app, routes, contacts, applied, document, window: fakeWindow, visualViewport };
+  return { app, routes, contacts, applied, document, window: fakeWindow, visualViewport, timers, runTimers };
 }
 
 function plain(value) {
@@ -357,7 +375,47 @@ test("no exact Catalog match renders assessment CTA instead of a wrong direct-bo
     recommendation,
   }, { status: "success", items: [catalogItem(9, { booking_ac_type: "สี่ทิศทาง" })] });
   assert.match(html, /ให้ทีมช่วยประเมิน/);
+  assert.match(html, /class="primary-btn"[^>]*data-advisor-contact/);
   assert.doesNotMatch(html, /จองบริการนี้/);
+});
+
+test("result footer keeps reset secondary while business actions remain primary", () => {
+  const { app } = loadAdvisor();
+  const resultState = {
+    ...app.advisor._test.initialState(),
+    step: 4,
+    recommendation: app.advisor._test.evaluateRecommendation({
+      acType: "wall",
+      monthsBand: "m4_5",
+      symptoms: ["routine"],
+      repairSignals: ["none"],
+    }),
+  };
+  const footer = app.advisor._test.sheetActions(resultState);
+  assert.match(footer, /data-advisor-back/);
+  assert.match(footer, /data-advisor-reset/);
+  assert.doesNotMatch(footer, /primary-btn/);
+
+  const exactHtml = app.advisor._test.stepContent(resultState, {
+    status: "success",
+    items: [catalogItem(1)],
+  });
+  assert.match(exactHtml, /class="primary-btn"[^>]*data-advisor-item-action/);
+
+  const repairState = {
+    ...resultState,
+    recommendation: app.advisor._test.evaluateRecommendation({
+      acType: "wall",
+      monthsBand: "m4_5",
+      symptoms: ["routine"],
+      repairSignals: ["error_code"],
+    }),
+  };
+  const repairHtml = app.advisor._test.stepContent(repairState, {
+    status: "success",
+    items: [],
+  });
+  assert.match(repairHtml, /class="primary-btn"[^>]*data-advisor-contact/);
 });
 
 test("wizard advances, supports multi-select, refreshes Catalog, resets, and binds once", () => {
@@ -482,6 +540,67 @@ test("visualViewport drives the mobile panel and listeners clean up on close and
   mount.click({ "data-advisor-launch": "" });
   controller.cleanup();
   assert.equal(runtime.visualViewport.listeners.size, 0);
+});
+
+test("animated close preserves viewport geometry until the panel is removed", () => {
+  const runtime = loadAdvisor({
+    deferTimers: true,
+    visualViewport: { height: 486.2, offsetTop: 71.7 },
+  });
+  const mount = new FakeMount(runtime.document);
+  runtime.app.advisor.bind({ querySelector: () => mount });
+  mount.click({ "data-advisor-launch": "" });
+  assert.equal(mount.style.getPropertyValue("--advisor-viewport-height"), "486px");
+  assert.equal(mount.style.getPropertyValue("--advisor-viewport-top"), "72px");
+
+  mount.click({ "data-advisor-close": "" });
+  assert.equal(runtime.visualViewport.listeners.size, 0);
+  assert.equal(mount.style.getPropertyValue("--advisor-viewport-height"), "486px");
+  assert.equal(mount.style.getPropertyValue("--advisor-viewport-top"), "72px");
+  assert.match(mount.host.innerHTML, /data-advisor-dialog/);
+  assert.ok(mount.layer.classList.contains("is-closing"));
+
+  runtime.visualViewport.height = 760;
+  runtime.visualViewport.offsetTop = 0;
+  runtime.visualViewport.emit("resize");
+  assert.equal(mount.style.getPropertyValue("--advisor-viewport-height"), "486px");
+  assert.equal(mount.style.getPropertyValue("--advisor-viewport-top"), "72px");
+
+  runtime.runTimers();
+  assert.equal(mount.host.innerHTML, "");
+  assert.equal(mount.style.getPropertyValue("--advisor-viewport-height"), "");
+  assert.equal(mount.style.getPropertyValue("--advisor-viewport-top"), "");
+});
+
+test("immediate close and cleanup remove viewport listeners and variables without delay", () => {
+  const immediateRuntime = loadAdvisor({
+    deferTimers: true,
+    visualViewport: { height: 520, offsetTop: 36 },
+  });
+  const immediateMount = new FakeMount(immediateRuntime.document);
+  const immediateController = immediateRuntime.app.advisor.bind({ querySelector: () => immediateMount });
+  immediateMount.click({ "data-advisor-launch": "" });
+  immediateController.close({ immediate: true });
+  assert.equal(immediateRuntime.visualViewport.listeners.size, 0);
+  assert.equal(immediateMount.style.getPropertyValue("--advisor-viewport-height"), "");
+  assert.equal(immediateMount.style.getPropertyValue("--advisor-viewport-top"), "");
+  assert.equal(immediateMount.host.innerHTML, "");
+
+  const cleanupRuntime = loadAdvisor({
+    deferTimers: true,
+    visualViewport: { height: 440, offsetTop: 84 },
+  });
+  const cleanupMount = new FakeMount(cleanupRuntime.document);
+  const cleanupController = cleanupRuntime.app.advisor.bind({ querySelector: () => cleanupMount });
+  cleanupMount.click({ "data-advisor-launch": "" });
+  cleanupMount.click({ "data-advisor-close": "" });
+  assert.equal(cleanupRuntime.timers.size, 1);
+  cleanupController.cleanup();
+  assert.equal(cleanupRuntime.timers.size, 0);
+  assert.equal(cleanupRuntime.visualViewport.listeners.size, 0);
+  assert.equal(cleanupMount.style.getPropertyValue("--advisor-viewport-height"), "");
+  assert.equal(cleanupMount.style.getPropertyValue("--advisor-viewport-top"), "");
+  assert.ok(!cleanupRuntime.document.body.classList.contains("has-advisor-sheet"));
 });
 
 test("visualViewport fallback uses window height and removes its resize listener", () => {
@@ -666,8 +785,11 @@ test("manipulated unrelated Catalog item id is rejected before booking adapters 
 
 test("repair result always opens Contact Sheet even when a repair item has adapter-compatible metadata", () => {
   const repairItem = catalogItem(9, { item_name: "ตรวจเช็คแอร์", job_category: "ตรวจเช็ค" });
-  const runtime = loadAdvisor({ catalog: { status: "success", items: [repairItem] } });
-  const mount = new FakeMount();
+  const runtime = loadAdvisor({
+    catalog: { status: "success", items: [repairItem] },
+    visualViewport: { height: 520, offsetTop: 32 },
+  });
+  const mount = new FakeMount(runtime.document);
   const container = { querySelector: () => mount };
   const controller = runtime.app.advisor.bind(container);
   mount.click({ "data-advisor-launch": "" });
@@ -684,6 +806,9 @@ test("repair result always opens Contact Sheet even when a repair item has adapt
   assert.equal(runtime.routes.length, 0);
   assert.equal(runtime.applied.length, 0);
   assert.equal(runtime.contacts.length, 1);
+  assert.equal(runtime.visualViewport.listeners.size, 0);
+  assert.equal(mount.style.getPropertyValue("--advisor-viewport-height"), "");
+  assert.equal(mount.style.getPropertyValue("--advisor-viewport-top"), "");
 });
 
 test("advisor render contract is accessible, compact, motion-safe, and has no autoplay timer", () => {

--- a/test/customerTrackingFullReadUi.test.js
+++ b/test/customerTrackingFullReadUi.test.js
@@ -770,7 +770,7 @@ test("tracking UI exposes loading, not-found, rate-limit and offline states", ()
 });
 
 test("tracking assets share the full-read cache build id", () => {
-  const build = "20260714_smart_advisor_compact_sheet_v1";
+  const build = "20260715_smart_advisor_mobile_polish_v2";
   for (const file of [
     "customer-app/index.html",
     "customer-app/sw.js",

--- a/test/homepageCms.test.js
+++ b/test/homepageCms.test.js
@@ -296,7 +296,7 @@ test("customer homepage has no admin control, bottom nav is fixed five-tab, and 
   const sw = read("customer-app/sw.js");
   const app = read("customer-app/assets/customer-app.js");
   const manifest = read("customer-app/manifest.webmanifest");
-  const build = "20260714_smart_advisor_compact_sheet_v1";
+  const build = "20260715_smart_advisor_mobile_polish_v2";
 
   assert.doesNotMatch(index + ui, /โหมดแอดมิน|openCms|localStorage\.getItem\('cwfHomeCmsDemo'/);
   assert.match(index, /data-route="store"[\s\S]*ร้านค้า/);


### PR DESCRIPTION
## Summary
- compact the collapsed Smart Advisor launcher to a 108–112px mobile contract with a 38–40px assistant mark and 40–42px CTA
- make the Advisor a visual-viewport-aware full-screen panel at widths up to 600px while preserving the desktop bottom sheet
- update panel height/top on VisualViewport resize and scroll, including keyboard/browser-chrome changes, with complete close/route cleanup and a window-height fallback
- add deterministic stroke SVG icons for every AC type, month band, symptom, and repair signal
- compact choices, results, reasons, Catalog cards, and footer controls
- add visible pulse/orbit/sheen, progress, selection, step, confidence, reason, and Catalog motion hooks with comprehensive reduced-motion overrides
- preserve recommendation, Catalog mapping, booking revalidation, and Contact Sheet fallback logic
- bump Customer App BUILD_ID to `20260715_smart_advisor_mobile_polish_v2`

## Review fixes
- make result footer controls secondary/tertiary and compact, leaving exact Catalog booking or Contact Sheet as the only primary result action
- split viewport teardown so resize/scroll listeners stop immediately while height/top variables remain stable through the 220ms close animation
- clear viewport variables after animated removal and immediately for Contact Sheet, cleanup, route leave, and other immediate closes
- add deferred-timer coverage for address-bar offset, keyboard-height geometry, immediate cleanup, and Contact Sheet cleanup

## Validation
- changed JavaScript syntax checks passed
- focused Advisor/Home/build/booking/Tracking suite: 366/366 passed
- full branch suite: 1,191 passed, 28 failed, 34 skipped (1,253 total)
- exact main suite at `3c549597bd1a24f7f218bd938a5e944bd6831bdb`: 1,185 passed, 28 failed, 34 skipped (1,247 total)
- failing test names are identical between branch and main; additional failures: 0
- BUILD_ID was not changed in the review fix

## Visual verification
The execution environment has no browser backend, so Android Chrome screenshots could not be attached. Deferred-timer VisualViewport tests verify that address-bar offset and keyboard-height geometry remain unchanged until close animation completion. Physical Android Chrome smoke remains the non-code visual gate.

Local preview:
```powershell
npx --yes http-server . -p 4174 -a 127.0.0.1 -c-1
```

Open `http://127.0.0.1:4174/customer-app/index.html#home`.

No backend, security, recommendation, Catalog mapping, booking adapter, Tracking, migration, production data, merge, or deploy changes are included.