### PR TITLE
Fix Smart Advisor portal and autoflow

### DIFF
--- a/customer-app/assets/customer-app.css
+++ b/customer-app/assets/customer-app.css
@@ -6652,6 +6652,7 @@ body.has-advisor-sheet { overflow: hidden; }
   pointer-events: none;
 }
 .advisor-portal-root.is-open { pointer-events: auto; }
+.advisor-portal-root.is-closing { pointer-events: none; }
 .advisor-sheet-layer {
   position: absolute;
   inset: 0;

--- a/customer-app/assets/customer-app.css
+++ b/customer-app/assets/customer-app.css
@@ -6515,11 +6515,11 @@ body.has-advisor-sheet { overflow: hidden; }
 .smart-advisor-section {
   position: relative;
   display: grid;
-  grid-template-columns: 42px minmax(0, 1fr);
-  gap: 10px;
+  grid-template-columns: 36px minmax(0, 1fr);
+  gap: 8px;
   align-items: center;
-  min-height: 112px;
-  padding: 12px;
+  min-height: 96px;
+  padding: 10px;
   overflow: hidden;
   border: 1px solid rgba(142, 194, 232, 0.55);
   border-radius: 13px;
@@ -6540,8 +6540,8 @@ body.has-advisor-sheet { overflow: hidden; }
   position: relative;
   display: grid;
   place-items: center;
-  width: 40px;
-  height: 40px;
+  width: 34px;
+  height: 34px;
   border-radius: 50%;
   background: #0b62ad;
   color: #fff;
@@ -6558,25 +6558,26 @@ body.has-advisor-sheet { overflow: hidden; }
   animation: advisor-orbit 5s linear infinite;
 }
 .is-sheet-open .advisor-launcher-orb::after { animation-play-state: paused; }
-.smart-advisor-section.is-sheet-open { isolation: auto; overflow: visible; }
 .advisor-launcher-content,
 .advisor-launcher-copy { min-width: 0; }
 .advisor-launcher-content {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) auto;
-  gap: 9px;
-  align-items: end;
+  gap: 5px;
+}
+.smart-advisor-section .section-kicker {
+  padding: 1px 6px;
+  font-size: 8.5px;
+  line-height: 1.25;
+  letter-spacing: 0.04em;
 }
 .advisor-launcher-copy h2 {
-  display: -webkit-box;
-  margin: 2px 0 0;
+  margin: 1px 0 0;
   overflow: hidden;
   color: #092d58;
-  font-size: 16px;
-  line-height: 1.22;
-  overflow-wrap: anywhere;
-  -webkit-box-orient: vertical;
-  -webkit-line-clamp: 2;
+  font-size: 14px;
+  line-height: 1.2;
+  text-overflow: clip;
+  white-space: nowrap;
 }
 .advisor-launcher-copy p {
   margin: 3px 0 0;
@@ -6593,32 +6594,43 @@ body.has-advisor-sheet { overflow: hidden; }
   align-items: center;
   min-width: 0;
   max-width: 100%;
-  margin-top: 5px;
-  padding: 3px 7px;
+  margin: 0;
+  padding: 2px 6px;
   border-radius: 99px;
   background: rgba(224, 240, 252, 0.9);
   color: #315d85;
-  font-size: 10.5px;
+  font-size: 9.5px;
   line-height: 1.35;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
+.advisor-launcher-footer {
+  display: flex;
+  gap: 7px;
+  align-items: center;
+  justify-content: space-between;
+  min-width: 0;
+}
 .advisor-launcher-actions {
   display: flex;
   gap: 3px;
   align-items: center;
-  flex-direction: column;
+  flex-direction: row;
   margin: 0;
 }
 .advisor-launcher-actions .primary-btn {
   position: relative;
-  min-height: 42px;
-  padding: 8px 13px;
+  display: inline-flex;
+  justify-content: center;
+  min-width: 96px;
+  min-height: 38px;
+  padding: 7px 12px;
   overflow: hidden;
   white-space: nowrap;
   transition: transform 160ms ease, box-shadow 180ms ease;
 }
+.advisor-launcher-actions .primary-btn > span { position: relative; z-index: 1; width: 100%; text-align: center; }
 .advisor-launcher-actions .primary-btn::after {
   position: absolute;
   inset: 0 auto 0 -55%;
@@ -6632,10 +6644,17 @@ body.has-advisor-sheet { overflow: hidden; }
 .advisor-launcher-actions .primary-btn:active { transform: scale(0.98); }
 .advisor-launcher-actions .advisor-reset-btn { min-height: 28px; font-size: 10px; }
 
-.advisor-sheet-layer {
+.advisor-portal-root {
   position: fixed;
   inset: 0;
-  z-index: 100;
+  z-index: 10000;
+  isolation: isolate;
+  pointer-events: none;
+}
+.advisor-portal-root.is-open { pointer-events: auto; }
+.advisor-sheet-layer {
+  position: absolute;
+  inset: 0;
   display: flex;
   align-items: flex-end;
   justify-content: center;
@@ -6666,15 +6685,17 @@ body.has-advisor-sheet { overflow: hidden; }
   top: 0;
   z-index: 2;
   display: grid;
-  grid-template-columns: 34px minmax(0, 1fr) 44px;
-  gap: 9px;
+  grid-template-columns: 44px minmax(0, 1fr) 44px;
+  gap: 6px;
   align-items: center;
-  padding: 12px 14px 9px;
+  min-height: 68px;
+  padding: 8px 10px 7px;
   border-bottom: 1px solid #dbe7f0;
   background: rgba(255, 255, 255, 0.94);
   -webkit-backdrop-filter: blur(10px);
   backdrop-filter: blur(10px);
 }
+.advisor-sheet-leading { display: grid; place-items: center; width: 44px; height: 44px; }
 .advisor-sheet-brand {
   display: grid;
   place-items: center;
@@ -6683,6 +6704,17 @@ body.has-advisor-sheet { overflow: hidden; }
   border-radius: 10px;
   background: #0b62ad;
   color: #fff;
+}
+.advisor-sheet-back {
+  display: grid;
+  place-items: center;
+  width: 44px;
+  height: 44px;
+  border: 0;
+  border-radius: 50%;
+  background: transparent;
+  color: #294b6e;
+  cursor: pointer;
 }
 .advisor-sheet-layer.is-opening .advisor-sheet-brand { animation: advisor-brand-activate 520ms cubic-bezier(0.22, 1.3, 0.36, 1) both 100ms; }
 .advisor-sheet-header h2 { margin: 0; color: #092d58; font-size: 15px; line-height: 1.25; }
@@ -6701,6 +6733,7 @@ body.has-advisor-sheet { overflow: hidden; }
   cursor: pointer;
 }
 .advisor-sheet-close:focus-visible,
+.advisor-sheet-back:focus-visible,
 .advisor-launcher-actions button:focus-visible,
 .advisor-sheet-actions button:focus-visible {
   outline: 3px solid rgba(240, 190, 34, 0.58);
@@ -6826,6 +6859,9 @@ body.has-advisor-sheet { overflow: hidden; }
   -webkit-backdrop-filter: blur(10px);
   backdrop-filter: blur(10px);
 }
+.advisor-sheet-actions[hidden] { display: none; }
+.advisor-sheet-actions.is-symptom-actions { grid-template-columns: minmax(0, 1fr); }
+.advisor-sheet-actions .advisor-symptoms-done { width: min(100%, 220px); min-height: 42px; justify-self: end; }
 .advisor-sheet-actions button { min-height: 44px; }
 .advisor-sheet-actions .secondary-btn { color: #587086; font-size: 11px; }
 .advisor-sheet-actions .advisor-result-edit-btn,
@@ -6901,9 +6937,9 @@ body.has-advisor-sheet { overflow: hidden; }
 
 @media (max-width: 600px) {
   .smart-advisor-section {
-    grid-template-columns: 42px minmax(0, 1fr);
-    min-height: 112px;
-    padding: 12px;
+    grid-template-columns: 36px minmax(0, 1fr);
+    min-height: 96px;
+    padding: 10px;
   }
   .advisor-launcher-copy p { display: none; }
   .advisor-sheet-layer {
@@ -6935,11 +6971,12 @@ body.has-advisor-sheet { overflow: hidden; }
 }
 
 @media (max-width: 380px) {
-  .smart-advisor-section { grid-template-columns: 40px minmax(0, 1fr); gap: 8px; min-height: 108px; padding: 11px; }
-  .advisor-launcher-orb { width: 38px; height: 38px; }
-  .advisor-launcher-copy h2 { font-size: 15px; }
-  .advisor-launcher-content { gap: 6px; }
-  .advisor-launcher-actions .primary-btn { min-height: 40px; padding-inline: 10px; font-size: 11px; }
+  .smart-advisor-section { grid-template-columns: 34px minmax(0, 1fr); gap: 7px; min-height: 92px; padding: 9px; }
+  .advisor-launcher-orb { width: 32px; height: 32px; }
+  .advisor-launcher-copy h2 { font-size: 13px; }
+  .advisor-launcher-content { gap: 4px; }
+  .advisor-launcher-status { font-size: 9px; }
+  .advisor-launcher-actions .primary-btn { min-width: 92px; min-height: 36px; padding-inline: 9px; font-size: 10.5px; }
   .advisor-sheet .advisor-choice-grid { grid-template-columns: minmax(0, 1fr); }
   .advisor-sheet-body { padding-inline: 12px; }
   .advisor-product-actions { grid-template-columns: 1fr; }

--- a/customer-app/assets/customer-app.js
+++ b/customer-app/assets/customer-app.js
@@ -3,7 +3,7 @@
 
   const App = window.CWFCustomerAppV2;
   const BOOT_TIMEOUT_MS = 3500;
-  const BUILD_ID = "20260715_smart_advisor_mobile_polish_v2";
+  const BUILD_ID = "20260715_smart_advisor_portal_autoflow_v3";
 
   function withTimeout(promise, timeoutMs) {
     return Promise.race([

--- a/customer-app/index.html
+++ b/customer-app/index.html
@@ -21,10 +21,10 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Noto+Sans+Thai:wght@400;500;600;700;800;900&display=swap" media="print" onload="this.media='all'">
   <noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Noto+Sans+Thai:wght@400;500;600;700;800;900&display=swap"></noscript>
-  <link rel="manifest" href="./manifest.webmanifest?v=20260715_smart_advisor_mobile_polish_v2">
+  <link rel="manifest" href="./manifest.webmanifest?v=20260715_smart_advisor_portal_autoflow_v3">
   <link rel="icon" type="image/png" sizes="192x192" href="./assets/icons/cwf-customer-192.png">
   <link rel="apple-touch-icon" sizes="180x180" href="./assets/icons/cwf-customer-180.png">
-  <link rel="stylesheet" href="./assets/customer-app.css?v=20260715_smart_advisor_mobile_polish_v2">
+  <link rel="stylesheet" href="./assets/customer-app.css?v=20260715_smart_advisor_portal_autoflow_v3">
 </head>
 <body class="is-app-booting">
   <div class="app-shell" data-app-shell>
@@ -62,23 +62,23 @@
     </nav>
   </div>
 
-  <script src="./modules/state.js?v=20260715_smart_advisor_mobile_polish_v2"></script>
-  <script src="./modules/utils.js?v=20260715_smart_advisor_mobile_polish_v2"></script>
-  <script src="./modules/analytics.js?v=20260715_smart_advisor_mobile_polish_v2"></script>
-  <script src="./modules/api.js?v=20260715_smart_advisor_mobile_polish_v2"></script>
-  <script src="./modules/pageAvailability.js?v=20260715_smart_advisor_mobile_polish_v2"></script>
-  <script src="./modules/services.js?v=20260715_smart_advisor_mobile_polish_v2"></script>
-  <script src="./modules/advisor.js?v=20260715_smart_advisor_mobile_polish_v2"></script>
-  <script src="./modules/ui.js?v=20260715_smart_advisor_mobile_polish_v2"></script>
-  <script src="./modules/store.js?v=20260715_smart_advisor_mobile_polish_v2"></script>
-  <script src="./modules/auth.js?v=20260715_smart_advisor_mobile_polish_v2"></script>
-  <script src="./modules/pricing.js?v=20260715_smart_advisor_mobile_polish_v2"></script>
-  <script src="./modules/availability.js?v=20260715_smart_advisor_mobile_polish_v2"></script>
-  <script src="./modules/bookingScheduled.js?v=20260715_smart_advisor_mobile_polish_v2"></script>
-  <script src="./modules/bookingUrgent.js?v=20260715_smart_advisor_mobile_polish_v2"></script>
-  <script src="./modules/tracking.js?v=20260715_smart_advisor_mobile_polish_v2"></script>
-  <script src="./modules/profile.js?v=20260715_smart_advisor_mobile_polish_v2"></script>
-  <script src="./modules/router.js?v=20260715_smart_advisor_mobile_polish_v2"></script>
-  <script src="./assets/customer-app.js?v=20260715_smart_advisor_mobile_polish_v2"></script>
+  <script src="./modules/state.js?v=20260715_smart_advisor_portal_autoflow_v3"></script>
+  <script src="./modules/utils.js?v=20260715_smart_advisor_portal_autoflow_v3"></script>
+  <script src="./modules/analytics.js?v=20260715_smart_advisor_portal_autoflow_v3"></script>
+  <script src="./modules/api.js?v=20260715_smart_advisor_portal_autoflow_v3"></script>
+  <script src="./modules/pageAvailability.js?v=20260715_smart_advisor_portal_autoflow_v3"></script>
+  <script src="./modules/services.js?v=20260715_smart_advisor_portal_autoflow_v3"></script>
+  <script src="./modules/advisor.js?v=20260715_smart_advisor_portal_autoflow_v3"></script>
+  <script src="./modules/ui.js?v=20260715_smart_advisor_portal_autoflow_v3"></script>
+  <script src="./modules/store.js?v=20260715_smart_advisor_portal_autoflow_v3"></script>
+  <script src="./modules/auth.js?v=20260715_smart_advisor_portal_autoflow_v3"></script>
+  <script src="./modules/pricing.js?v=20260715_smart_advisor_portal_autoflow_v3"></script>
+  <script src="./modules/availability.js?v=20260715_smart_advisor_portal_autoflow_v3"></script>
+  <script src="./modules/bookingScheduled.js?v=20260715_smart_advisor_portal_autoflow_v3"></script>
+  <script src="./modules/bookingUrgent.js?v=20260715_smart_advisor_portal_autoflow_v3"></script>
+  <script src="./modules/tracking.js?v=20260715_smart_advisor_portal_autoflow_v3"></script>
+  <script src="./modules/profile.js?v=20260715_smart_advisor_portal_autoflow_v3"></script>
+  <script src="./modules/router.js?v=20260715_smart_advisor_portal_autoflow_v3"></script>
+  <script src="./assets/customer-app.js?v=20260715_smart_advisor_portal_autoflow_v3"></script>
 </body>
 </html>

--- a/customer-app/manifest.webmanifest
+++ b/customer-app/manifest.webmanifest
@@ -2,7 +2,7 @@
   "name": "CWF Customer Service",
   "short_name": "CWF Service",
   "description": "แอปลูกค้า Coldwindflow สำหรับเลือกบริการ จองคิว และติดตามงาน",
-  "start_url": "/customer-app/index.html?v=20260715_smart_advisor_mobile_polish_v2#home",
+  "start_url": "/customer-app/index.html?v=20260715_smart_advisor_portal_autoflow_v3#home",
   "scope": "/customer-app/",
   "id": "/customer-app/",
   "display": "standalone",

--- a/customer-app/modules/advisor.js
+++ b/customer-app/modules/advisor.js
@@ -505,13 +505,13 @@
         <span class="section-kicker">CWF SMART ADVISOR</span>
         <h2>${hasResult ? esc(meta.label) : "ไม่แน่ใจว่าควรล้างหรือซ่อม?"}</h2>
         <p>${hasResult ? "เปิดดูเหตุผลและบริการจริงที่ระบบแนะนำ" : "ตอบคำถามสั้น ๆ แล้วให้ระบบช่วยเลือกบริการที่เหมาะ"}</p>
-        ${status}
       </div>
-      <div class="advisor-launcher-actions">
-        <button class="primary-btn" type="button" data-advisor-launch aria-expanded="${isOpen ? "true" : "false"}" aria-controls="advisor-sheet-dialog">
-          ${icon(hasResult ? "sparkle" : "play", 18)} ${cta}
-        </button>
-        ${hasResult ? `<button class="advisor-reset-btn" type="button" data-advisor-reset-launcher>ประเมินใหม่</button>` : ""}
+      <div class="advisor-launcher-footer">
+        ${status}
+        <div class="advisor-launcher-actions">
+          <button class="primary-btn" type="button" data-advisor-launch aria-expanded="${isOpen ? "true" : "false"}" aria-controls="advisor-sheet-dialog"><span>${cta}</span></button>
+          ${hasResult ? `<button class="advisor-reset-btn" type="button" data-advisor-reset-launcher>ประเมินใหม่</button>` : ""}
+        </div>
       </div>
     `;
   }
@@ -523,12 +523,10 @@
         <button class="advisor-reset-btn advisor-result-reset-btn" type="button" data-advisor-reset>ประเมินใหม่</button>
       `;
     }
-    return `
-      ${state.step > 0 ? `<button class="secondary-btn" type="button" data-advisor-back>ย้อนกลับ</button>` : `<span aria-hidden="true"></span>`}
-      <button class="primary-btn" type="button" data-advisor-next ${stepIsValid(state) ? "" : "disabled"}>
-        ${state.step === 3 ? "ดูผลประเมิน" : "ขั้นต่อไป"}
-      </button>
-    `;
+    if (state.step === 2 && state.symptoms.length && !state.symptoms.includes("routine")) {
+      return `<button class="primary-btn advisor-symptoms-done" type="button" data-advisor-symptoms-done>เลือกครบแล้ว</button>`;
+    }
+    return "";
   }
 
   function sheetProgressHtml(stepNumber) {
@@ -540,7 +538,7 @@
       <div class="advisor-sheet-layer is-opening" data-advisor-backdrop>
         <section class="advisor-sheet" id="advisor-sheet-dialog" data-advisor-dialog role="dialog" aria-modal="true" aria-labelledby="advisor-sheet-title">
           <header class="advisor-sheet-header">
-            <div class="advisor-sheet-brand" aria-hidden="true">${icon("sparkle", 18)}</div>
+            <div class="advisor-sheet-leading" data-advisor-header-leading></div>
             <div>
               <h2 id="advisor-sheet-title">ผู้ช่วยเลือกบริการ</h2>
               <span data-advisor-step-label></span>
@@ -563,7 +561,6 @@
       <section class="smart-advisor-section homepage-section" data-smart-advisor data-home-reveal>
         <div class="advisor-launcher-orb" aria-hidden="true"><span>${icon("sparkle", 24)}</span></div>
         <div class="advisor-launcher-content" data-advisor-launcher-content>${launcherContent(state, false)}</div>
-        <div data-advisor-sheet-host></div>
       </section>
     `;
   }
@@ -577,19 +574,31 @@
     let destroyed = false;
     let isOpen = false;
     let closeTimer = null;
+    let transitionTimer = null;
+    let transitionLocked = false;
+    let portalRoot = null;
     const reducedMotion = Boolean(window.matchMedia?.("(prefers-reduced-motion: reduce)")?.matches);
     const viewportTarget = window.visualViewport || window;
     let viewportListenersBound = false;
     mount.classList?.toggle?.("is-reduced-motion", reducedMotion);
     const catalogState = () => root.state.catalog || { status: "idle", items: [] };
-    const sheetHost = () => mount.querySelector("[data-advisor-sheet-host]");
+    const sheetQuery = (selector) => portalRoot?.querySelector?.(selector) || null;
+    const ensurePortal = () => {
+      if (portalRoot && portalRoot.isConnected !== false) return portalRoot;
+      portalRoot = document.createElement("div");
+      portalRoot.className = "advisor-portal-root is-open";
+      portalRoot.setAttribute("data-advisor-portal", "");
+      portalRoot.addEventListener("click", onPortalClick);
+      document.body.appendChild(portalRoot);
+      return portalRoot;
+    };
     const updateViewport = () => {
-      if (destroyed || !isOpen) return;
+      if (destroyed || !isOpen || !portalRoot) return;
       const viewport = window.visualViewport;
       const height = Number(viewport?.height || window.innerHeight || document.documentElement?.clientHeight || 0);
       const offsetTop = Number(viewport?.offsetTop || 0);
-      if (height > 0) mount.style?.setProperty?.("--advisor-viewport-height", `${Math.round(height)}px`);
-      mount.style?.setProperty?.("--advisor-viewport-top", `${Math.max(0, Math.round(offsetTop))}px`);
+      if (height > 0) portalRoot.style?.setProperty?.("--advisor-viewport-height", `${Math.round(height)}px`);
+      portalRoot.style?.setProperty?.("--advisor-viewport-top", `${Math.max(0, Math.round(offsetTop))}px`);
     };
     const bindViewport = () => {
       if (viewportListenersBound) return;
@@ -605,8 +614,14 @@
       if (window.visualViewport) viewportTarget.removeEventListener?.("scroll", updateViewport);
     };
     const clearViewportVariables = () => {
-      mount.style?.removeProperty?.("--advisor-viewport-height");
-      mount.style?.removeProperty?.("--advisor-viewport-top");
+      portalRoot?.style?.removeProperty?.("--advisor-viewport-height");
+      portalRoot?.style?.removeProperty?.("--advisor-viewport-top");
+    };
+    const removePortal = () => {
+      if (!portalRoot) return;
+      portalRoot.removeEventListener("click", onPortalClick);
+      portalRoot.remove?.();
+      portalRoot = null;
     };
     const renderLauncher = () => {
       const launcher = mount.querySelector("[data-advisor-launcher-content]");
@@ -614,33 +629,41 @@
     };
     const focusCurrent = () => requestAnimationFrame(() => {
       if (destroyed || !isOpen) return;
-      const target = mount.querySelector(state.step === 4 ? "[data-advisor-result]" : "[data-advisor-question-title]")
-        || mount.querySelector("[data-advisor-close]");
+      const target = sheetQuery(state.step === 4 ? "[data-advisor-result]" : "[data-advisor-question-title]")
+        || sheetQuery("[data-advisor-close]");
       target?.focus?.({ preventScroll: true });
     });
     const renderSheet = (direction = "forward", options = {}) => {
       if (destroyed || !isOpen || !mount.isConnected) return;
-      const host = sheetHost();
-      if (!host) return;
-      let dialog = mount.querySelector("[data-advisor-dialog]");
+      const host = ensurePortal();
+      let dialog = sheetQuery("[data-advisor-dialog]");
       const opening = !dialog;
       if (opening) {
         host.innerHTML = sheetHtml();
-        dialog = mount.querySelector("[data-advisor-dialog]");
+        dialog = sheetQuery("[data-advisor-dialog]");
       }
       if (!dialog) return;
       mount.classList?.toggle?.("is-sheet-open", true);
+      portalRoot?.classList?.add?.("is-open");
       const result = state.step === 4;
       const stepNumber = result ? 4 : state.step + 1;
-      const layer = mount.querySelector("[data-advisor-backdrop]");
-      const body = mount.querySelector("[data-advisor-body]");
-      const actions = mount.querySelector("[data-advisor-actions]");
-      const stepLabel = mount.querySelector("[data-advisor-step-label]");
-      const progress = mount.querySelector("[data-advisor-progress]");
+      const layer = sheetQuery("[data-advisor-backdrop]");
+      const body = sheetQuery("[data-advisor-body]");
+      const actions = sheetQuery("[data-advisor-actions]");
+      const stepLabel = sheetQuery("[data-advisor-step-label]");
+      const progress = sheetQuery("[data-advisor-progress]");
+      const leading = sheetQuery("[data-advisor-header-leading]");
       dialog.setAttribute("data-step", stepNumber);
       if (stepLabel) stepLabel.textContent = result ? "ผลประเมิน" : `ขั้นที่ ${stepNumber} จาก 4`;
       if (progress) progress.innerHTML = sheetProgressHtml(stepNumber);
-      if (actions) actions.innerHTML = sheetActions(state);
+      if (leading) leading.innerHTML = state.step > 0
+        ? `<button class="advisor-sheet-back" type="button" data-advisor-back aria-label="ย้อนกลับ">${icon("arrow-left", 19)}</button>`
+        : `<div class="advisor-sheet-brand" aria-hidden="true">${icon("sparkle", 18)}</div>`;
+      if (actions) {
+        actions.innerHTML = sheetActions(state);
+        actions.hidden = !actions.innerHTML.trim();
+        actions.classList.toggle("is-symptom-actions", state.step === 2 && !actions.hidden);
+      }
       if (body) {
         body.classList.remove("is-step-forward");
         body.classList.remove("is-step-back");
@@ -650,7 +673,7 @@
       }
       if (opening) layer?.classList?.add?.("is-opening");
       else layer?.classList?.remove?.("is-opening");
-      const scroll = mount.querySelector("[data-advisor-scroll]");
+      const scroll = sheetQuery("[data-advisor-scroll]");
       if (scroll && options.resetScroll !== false) scroll.scrollTop = 0;
       if (options.focus !== false) focusCurrent();
     };
@@ -664,18 +687,39 @@
     };
     const syncChoices = (attribute, selectedValues) => {
       const selected = new Set(Array.isArray(selectedValues) ? selectedValues : [selectedValues]);
-      mount.querySelectorAll(`[${attribute}]`).forEach((button) => {
+      portalRoot?.querySelectorAll?.(`[${attribute}]`).forEach((button) => {
         const active = selected.has(button.getAttribute(attribute));
         button.classList.toggle("is-selected", active);
         button.setAttribute("aria-pressed", active ? "true" : "false");
         const check = button.querySelector?.(".advisor-choice-check");
         if (check) check.textContent = active ? "✓" : "";
       });
-      const next = mount.querySelector("[data-advisor-next]");
-      if (next) next.disabled = !stepIsValid(state);
+    };
+    const updateActions = () => {
+      const actions = sheetQuery("[data-advisor-actions]");
+      if (!actions) return;
+      actions.innerHTML = sheetActions(state);
+      actions.hidden = !actions.innerHTML.trim();
+      actions.classList.toggle("is-symptom-actions", state.step === 2 && !actions.hidden);
+    };
+    const clearTransition = () => {
+      if (transitionTimer) clearTimeout(transitionTimer);
+      transitionTimer = null;
+      transitionLocked = false;
+    };
+    const afterSelection = (callback) => {
+      if (transitionLocked || destroyed || !isOpen) return;
+      transitionLocked = true;
+      const finish = () => {
+        transitionTimer = null;
+        transitionLocked = false;
+        if (!destroyed && isOpen) callback();
+      };
+      if (reducedMotion) finish();
+      else transitionTimer = setTimeout(finish, 180);
     };
     const focusableNodes = () => {
-      const dialog = mount.querySelector("[data-advisor-dialog]");
+      const dialog = sheetQuery("[data-advisor-dialog]");
       if (!dialog) return [];
       return Array.from(dialog.querySelectorAll("button:not([disabled]), a[href], [tabindex]:not([tabindex='-1'])"))
         .filter((node) => !node.hidden);
@@ -706,11 +750,11 @@
       if (closeTimer) {
         clearTimeout(closeTimer);
         closeTimer = null;
-        const host = sheetHost();
-        if (host) host.innerHTML = "";
+        removePortal();
       }
       state.started = true;
       isOpen = true;
+      ensurePortal();
       document.body.classList.add("has-advisor-sheet");
       document.addEventListener("keydown", onDocumentKeydown);
       bindViewport();
@@ -724,17 +768,19 @@
         closeTimer = null;
       }
       isOpen = false;
+      clearTransition();
       removeOpenListeners();
       stopViewportListeners();
       document.body.classList.remove("has-advisor-sheet");
       renderLauncher();
-      const host = sheetHost();
-      const layer = mount.querySelector("[data-advisor-backdrop]");
+      const host = portalRoot;
+      const layer = sheetQuery("[data-advisor-backdrop]");
       const finish = () => {
         closeTimer = null;
         if (host && !isOpen) host.innerHTML = "";
         mount.classList?.toggle?.("is-sheet-open", false);
         clearViewportVariables();
+        removePortal();
         if (options.restoreFocus !== false && !destroyed) mount.querySelector("[data-advisor-launch]")?.focus?.({ preventScroll: true });
       };
       if (options.immediate || reducedMotion || !layer) {
@@ -750,8 +796,20 @@
       closeSheet({ immediate: true, restoreFocus: false });
       root.ui.openContactSheet(container, { title: title || "ให้ทีม CWF ช่วยประเมินบริการ" });
     };
-    const onClick = (event) => {
+    const onLauncherClick = (event) => {
       const button = event.target.closest("button");
+      if (destroyed) return;
+      if (!button) return;
+      if (button.hasAttribute("data-advisor-launch")) {
+        openSheet();
+      } else if (button.hasAttribute("data-advisor-reset-launcher")) {
+        state = initialState();
+        renderLauncher();
+        openSheet();
+      }
+    };
+    const onPortalClick = (event) => {
+      const button = event.target.closest?.("button");
       if (destroyed) return;
       if (!button) {
         const backdrop = event.target.closest?.("[data-advisor-backdrop]");
@@ -759,34 +817,49 @@
         if (backdrop && !dialog) closeSheet();
         return;
       }
-      if (button.hasAttribute("data-advisor-launch")) {
-        openSheet();
-      } else if (button.hasAttribute("data-advisor-close")) {
+      if (button.hasAttribute("data-advisor-close")) {
         closeSheet();
-      } else if (button.hasAttribute("data-advisor-reset-launcher")) {
-        state = initialState();
-        renderLauncher();
-        openSheet();
       } else if (button.hasAttribute("data-advisor-ac")) {
+        if (transitionLocked) return;
         state.acType = button.getAttribute("data-advisor-ac");
         syncChoices("data-advisor-ac", state.acType);
+        afterSelection(() => {
+          state.step = 1;
+          renderSheet("forward");
+        });
       } else if (button.hasAttribute("data-advisor-months")) {
+        if (transitionLocked) return;
         state.monthsBand = button.getAttribute("data-advisor-months");
         syncChoices("data-advisor-months", state.monthsBand);
+        afterSelection(() => {
+          state.step = 2;
+          renderSheet("forward");
+        });
       } else if (button.hasAttribute("data-advisor-symptom")) {
-        state.symptoms = toggleExclusive(state.symptoms, button.getAttribute("data-advisor-symptom"), "routine");
+        if (transitionLocked) return;
+        const symptom = button.getAttribute("data-advisor-symptom");
+        state.symptoms = symptom === "routine" ? ["routine"] : toggleExclusive(state.symptoms, symptom, "routine");
         syncChoices("data-advisor-symptom", state.symptoms);
+        updateActions();
+        if (state.symptoms.includes("routine")) afterSelection(() => {
+          state.step = 3;
+          renderSheet("forward");
+        });
       } else if (button.hasAttribute("data-advisor-repair")) {
-        state.repairSignals = toggleExclusive(state.repairSignals, button.getAttribute("data-advisor-repair"), "none");
+        if (transitionLocked) return;
+        state.repairSignals = [button.getAttribute("data-advisor-repair")];
         syncChoices("data-advisor-repair", state.repairSignals);
-      } else if (button.hasAttribute("data-advisor-next")) {
-        if (state.step < 3) state.step += 1;
-        else {
+        afterSelection(() => {
           state.recommendation = evaluateRecommendation(state);
           state.step = 4;
-        }
+          renderSheet("forward");
+        });
+      } else if (button.hasAttribute("data-advisor-symptoms-done")) {
+        if (!state.symptoms.length || state.symptoms.includes("routine")) return;
+        state.step = 3;
         renderSheet("forward");
       } else if (button.hasAttribute("data-advisor-back")) {
+        clearTransition();
         state.step = state.step === 4 ? 3 : Math.max(0, state.step - 1);
         state.recommendation = null;
         renderSheet("back");
@@ -821,12 +894,12 @@
         contact();
       }
     };
-    mount.addEventListener("click", onClick);
+    mount.addEventListener("click", onLauncherClick);
     renderLauncher();
     const controller = {
       refreshCatalog() {
         if (destroyed || !isOpen || state.step !== 4) return;
-        const catalog = mount.querySelector("[data-advisor-catalog]");
+        const catalog = sheetQuery("[data-advisor-catalog]");
         if (catalog) catalog.innerHTML = renderCatalogResults(state.recommendation, catalogState());
       },
       state() {
@@ -841,11 +914,13 @@
         destroyed = true;
         if (closeTimer) clearTimeout(closeTimer);
         closeTimer = null;
+        clearTransition();
         removeOpenListeners();
         stopViewportListeners();
         clearViewportVariables();
+        removePortal();
         document.body.classList.remove("has-advisor-sheet");
-        mount.removeEventListener("click", onClick);
+        mount.removeEventListener("click", onLauncherClick);
         controllers.delete(mount);
       },
     };

--- a/customer-app/modules/advisor.js
+++ b/customer-app/modules/advisor.js
@@ -312,6 +312,7 @@
   }
 
   const ADVISOR_ICON_PATHS = Object.freeze({
+    "arrow-left": '<path d="M19 12H5M11 18l-6-6 6-6"/>',
     "wall-ac": '<rect x="3" y="5" width="18" height="8" rx="2"/><path d="M7 9h10M8 16c1.2 1.2 2.5 1.8 4 1.8s2.8-.6 4-1.8"/>',
     fourway: '<rect x="6" y="6" width="12" height="12" rx="2"/><path d="M12 2v4M12 18v4M2 12h4M18 12h4M9 9h6v6H9z"/>',
     "hanging-ac": '<path d="M6 3v3M18 3v3"/><rect x="3" y="6" width="18" height="8" rx="2"/><path d="M7 18h10M9 14v4M15 14v4"/>',
@@ -657,7 +658,7 @@
       if (stepLabel) stepLabel.textContent = result ? "ผลประเมิน" : `ขั้นที่ ${stepNumber} จาก 4`;
       if (progress) progress.innerHTML = sheetProgressHtml(stepNumber);
       if (leading) leading.innerHTML = state.step > 0
-        ? `<button class="advisor-sheet-back" type="button" data-advisor-back aria-label="ย้อนกลับ">${icon("arrow-left", 19)}</button>`
+        ? `<button class="advisor-sheet-back" type="button" data-advisor-back aria-label="ย้อนกลับ">${semanticIcon("arrow-left", 19)}</button>`
         : `<div class="advisor-sheet-brand" aria-hidden="true">${icon("sparkle", 18)}</div>`;
       if (actions) {
         actions.innerHTML = sheetActions(state);
@@ -768,6 +769,8 @@
         closeTimer = null;
       }
       isOpen = false;
+      portalRoot?.classList?.remove?.("is-open");
+      portalRoot?.classList?.add?.("is-closing");
       clearTransition();
       removeOpenListeners();
       stopViewportListeners();
@@ -809,8 +812,8 @@
       }
     };
     const onPortalClick = (event) => {
+      if (destroyed || !isOpen) return;
       const button = event.target.closest?.("button");
-      if (destroyed) return;
       if (!button) {
         const backdrop = event.target.closest?.("[data-advisor-backdrop]");
         const dialog = event.target.closest?.("[data-advisor-dialog]");

--- a/customer-app/sw.js
+++ b/customer-app/sw.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const BUILD_ID = "20260715_smart_advisor_mobile_polish_v2";
+const BUILD_ID = "20260715_smart_advisor_portal_autoflow_v3";
 const CACHE_NAME = `cwf-customer-app-v2-${BUILD_ID}`;
 const APP_SHELL = [
   `./index.html?v=${BUILD_ID}`,

--- a/test/customerAppPageAvailability.test.js
+++ b/test/customerAppPageAvailability.test.js
@@ -281,7 +281,7 @@ test("api exposes loadCustomerAppConfig as a no-store GET to /public/customer-ap
 });
 
 test("build wiring: pageAvailability.js is registered in the HTML shell and the SW cache, with the new build id", () => {
-  const build = "20260715_smart_advisor_mobile_polish_v2";
+  const build = "20260715_smart_advisor_portal_autoflow_v3";
   assert.match(indexHtml, new RegExp(`modules/pageAvailability\\.js\\?v=${build}`));
   assert.match(swSrc, new RegExp(`BUILD_ID = "${build}"`));
   assert.match(swSrc, /modules\/pageAvailability\.js\?v=\$\{BUILD_ID\}/);
@@ -294,7 +294,7 @@ test("build wiring: pageAvailability.js is registered in the HTML shell and the 
    RUNTIME tests (execute the real code in a VM — not regex assertions).
    ========================================================================== */
 
-const BUILD = "20260715_smart_advisor_mobile_polish_v2";
+const BUILD = "20260715_smart_advisor_portal_autoflow_v3";
 const adminSrc = read("admin-homepage-cms.js");
 
 function reqUrlOf(req) {

--- a/test/customerAppRecovery.test.js
+++ b/test/customerAppRecovery.test.js
@@ -236,7 +236,7 @@ test("Customer App build id is consistent across shell and service worker", () =
   const sw = read("customer-app/sw.js");
   const app = read("customer-app/assets/customer-app.js");
   const manifest = read("customer-app/manifest.webmanifest");
-  const build = "20260715_smart_advisor_mobile_polish_v2";
+  const build = "20260715_smart_advisor_portal_autoflow_v3";
 
   assert.match(index, new RegExp(`customer-app\\.css\\?v=${build}`));
   assert.match(index, new RegExp(`modules\\/api\\.js\\?v=${build}`));
@@ -254,7 +254,7 @@ test("Customer App build id is consistent across shell and service worker", () =
 test("store module is loaded in index.html and precached in the service worker app shell", () => {
   const index = read("customer-app/index.html");
   const sw = read("customer-app/sw.js");
-  const build = "20260715_smart_advisor_mobile_polish_v2";
+  const build = "20260715_smart_advisor_portal_autoflow_v3";
 
   assert.match(index, new RegExp(`modules/store\\.js\\?v=${build}`));
   assert.match(sw, /`\.\/modules\/store\.js\?v=\$\{BUILD_ID\}`/);

--- a/test/customerAppStorePayment.test.js
+++ b/test/customerAppStorePayment.test.js
@@ -58,7 +58,7 @@ test("store falls back to the LINE hand-off when payment is unconfigured or the 
 test("payment step styles exist and the Customer App payment build id is bumped", () => {
   assert.match(cssSrc, /\.pay-method-btn/);
   assert.match(cssSrc, /\.pay-qr-img/);
-  assert.match(read("customer-app/index.html"), /modules\/store\.js\?v=20260715_smart_advisor_mobile_polish_v2/);
-  assert.match(read("customer-app/sw.js"), /BUILD_ID = "20260715_smart_advisor_mobile_polish_v2"/);
+  assert.match(read("customer-app/index.html"), /modules\/store\.js\?v=20260715_smart_advisor_portal_autoflow_v3/);
+  assert.match(read("customer-app/sw.js"), /BUILD_ID = "20260715_smart_advisor_portal_autoflow_v3"/);
   assert.match(storeSrc, /payment-security 20260705 loaded/);
 });

--- a/test/customerBookingAdminNotifications.test.js
+++ b/test/customerBookingAdminNotifications.test.js
@@ -311,10 +311,10 @@ test("admin/customer frontend cache versions are bumped for booking notification
   assert.doesNotMatch(adminReviewHtml, /admin-review-v2\.js\?v=20260707_customer_booking_notify_v2/);
   assert.match(adminReviewHtml, /admin-review-ai-intake\.js\?v=ai-booking-intake-customer-cards-v11-admin-alert-gate/);
   assert.doesNotMatch(adminReviewHtml, /admin-review-ai-intake\.js\?v=ai-booking-intake-customer-cards-v10/);
-  assert.match(customerIndex, /bookingScheduled\.js\?v=20260715_smart_advisor_mobile_polish_v2/);
-  assert.match(customerIndex, /state\.js\?v=20260715_smart_advisor_mobile_polish_v2/);
-  assert.match(customerSw, /const BUILD_ID = "20260715_smart_advisor_mobile_polish_v2"/);
-  assert.match(customerManifest, /20260715_smart_advisor_mobile_polish_v2/);
+  assert.match(customerIndex, /bookingScheduled\.js\?v=20260715_smart_advisor_portal_autoflow_v3/);
+  assert.match(customerIndex, /state\.js\?v=20260715_smart_advisor_portal_autoflow_v3/);
+  assert.match(customerSw, /const BUILD_ID = "20260715_smart_advisor_portal_autoflow_v3"/);
+  assert.match(customerManifest, /20260715_smart_advisor_portal_autoflow_v3/);
 });
 
 test("behavior: review queue only includes customer urgent waiting rows while preserving review statuses", () => {

--- a/test/customerHistoryClaim.test.js
+++ b/test/customerHistoryClaim.test.js
@@ -544,7 +544,7 @@ test("Customer App profile opens history detail with opaque job_ref and clears c
 });
 
 test("Customer App cache version is bumped consistently", () => {
-  const expected = "20260715_smart_advisor_mobile_polish_v2";
+  const expected = "20260715_smart_advisor_portal_autoflow_v3";
   for (const file of [
     "customer-app/index.html",
     "customer-app/sw.js",

--- a/test/customerHomepageFeaturedRotation.test.js
+++ b/test/customerHomepageFeaturedRotation.test.js
@@ -414,6 +414,6 @@ test("compact CSS and cache build remain consistent with six-card rotation", () 
   assert.match(css, /\.homepage-featured-page\s*\{[^}]*grid-area:\s*1\s*\/\s*1/s);
   assert.match(css, /transition:\s*opacity 350ms/);
   assert.match(css, /prefers-reduced-motion:\s*reduce/);
-  const build = "20260715_smart_advisor_mobile_polish_v2";
+  const build = "20260715_smart_advisor_portal_autoflow_v3";
   for (const source of [html, sw, boot, manifest]) assert.match(source, new RegExp(build));
 });

--- a/test/customerSameDayTiming.test.js
+++ b/test/customerSameDayTiming.test.js
@@ -160,7 +160,7 @@ test("customer app disables availability HTTP cache and refreshes same-day slots
 });
 
 test("customer app build and service worker cache IDs changed", () => {
-  const id = "20260715_smart_advisor_mobile_polish_v2";
+  const id = "20260715_smart_advisor_portal_autoflow_v3";
   for (const file of [
     "customer-app/index.html",
     "customer-app/sw.js",

--- a/test/customerSmartAdvisor.test.js
+++ b/test/customerSmartAdvisor.test.js
@@ -588,6 +588,9 @@ test("single choices auto-flow while symptoms remain multi-select and Back prese
   mount.click({ "data-advisor-ac": "wall" });
   assert.equal(controller.state().step, 1);
   assert.match(runtime.document.portal.leading.innerHTML, /data-advisor-back/);
+  assert.match(runtime.document.portal.leading.innerHTML, /aria-label="ย้อนกลับ"/);
+  assert.match(runtime.document.portal.leading.innerHTML, /data-advisor-icon="arrow-left"/);
+  assert.doesNotMatch(runtime.document.portal.leading.innerHTML, /data-icon="sparkle"/);
   mount.click({ "data-advisor-months": "m6_8" });
   assert.equal(controller.state().step, 2);
 
@@ -609,6 +612,16 @@ test("single choices auto-flow while symptoms remain multi-select and Back prese
   mount.click({ "data-advisor-repair": "error_code" });
   assert.equal(controller.state().step, 4);
   assert.equal(controller.state().recommendation.verdict, "repair_check");
+});
+
+test("semantic Back icon has its own arrow path instead of a utility fallback", () => {
+  assert.match(SOURCE, /"arrow-left":\s*'<path d="M19 12H5M11 18l-6-6 6-6"\/>'/);
+  assert.match(SOURCE, /data-advisor-back[^>]*aria-label="ย้อนกลับ"[^>]*>\$\{semanticIcon\("arrow-left", 19\)\}/);
+  assert.doesNotMatch(SOURCE, /data-advisor-back[^>]*>\$\{icon\("arrow-left"/);
+  assert.match(CSS_SOURCE, /\.advisor-sheet-back\s*\{[^}]*width:\s*44px[^}]*height:\s*44px/s);
+  assert.match(CSS_SOURCE, /\.advisor-portal-root\s*\{[^}]*pointer-events:\s*none/s);
+  assert.match(CSS_SOURCE, /\.advisor-portal-root\.is-open\s*\{\s*pointer-events:\s*auto;?\s*\}/);
+  assert.match(CSS_SOURCE, /\.advisor-portal-root\.is-closing\s*\{\s*pointer-events:\s*none;?\s*\}/);
 });
 
 test("routine and no-repair choices auto-flow without dropping exclusive state", () => {
@@ -749,6 +762,8 @@ test("animated close preserves viewport geometry until the panel is removed", ()
 
   mount.click({ "data-advisor-close": "" });
   assert.equal(runtime.visualViewport.listeners.size, 0);
+  assert.ok(!portal.classList.contains("is-open"));
+  assert.ok(portal.classList.contains("is-closing"));
   assert.equal(portal.style.getPropertyValue("--advisor-viewport-height"), "486px");
   assert.equal(portal.style.getPropertyValue("--advisor-viewport-top"), "72px");
   assert.match(mount.host.innerHTML, /data-advisor-dialog/);
@@ -765,6 +780,85 @@ test("animated close preserves viewport geometry until the panel is removed", ()
   assert.equal(portal.style.getPropertyValue("--advisor-viewport-height"), "");
   assert.equal(portal.style.getPropertyValue("--advisor-viewport-top"), "");
   assert.equal(runtime.document.portal, null);
+});
+
+test("animated close blocks every Portal action before the node is removed", () => {
+  let adapterCalls = 0;
+  let applyCalls = 0;
+  const runtime = loadAdvisor({
+    deferTimers: true,
+    catalog: { status: "success", items: [catalogItem(1)] },
+    adapter: (item) => { adapterCalls += 1; return { id: item.item_id, draft: {} }; },
+    apply: () => { applyCalls += 1; return true; },
+  });
+  const mount = new FakeMount(runtime.document);
+  const controller = runtime.app.advisor.bind({ querySelector: () => mount });
+  mount.click({ "data-advisor-launch": "" });
+  mount.click({ "data-advisor-ac": "wall" });
+  runtime.runTimers();
+  mount.click({ "data-advisor-months": "m4_5" });
+  runtime.runTimers();
+  mount.click({ "data-advisor-symptom": "routine" });
+  runtime.runTimers();
+  mount.click({ "data-advisor-repair": "none" });
+  runtime.runTimers();
+  assert.equal(controller.state().step, 4);
+
+  const portal = runtime.document.portal;
+  const stateBeforeClose = controller.state();
+  const adapterCallsBeforeClose = adapterCalls;
+  const applyCallsBeforeClose = applyCalls;
+  mount.click({ "data-advisor-close": "" });
+  assert.ok(!portal.classList.contains("is-open"));
+  assert.ok(portal.classList.contains("is-closing"));
+  assert.equal(portal.listeners.size, 1);
+
+  mount.click({ "data-advisor-ac": "fourway" });
+  mount.click({ "data-advisor-back": "" });
+  mount.click({ "data-advisor-repair": "error_code" });
+  mount.click({ "data-advisor-item-action": "1" });
+  mount.click({ "data-advisor-detail": "1" });
+  mount.click({ "data-advisor-contact": "" });
+  mount.click({ "data-advisor-reset": "" });
+
+  assert.deepEqual(plain(controller.state()), plain({ ...stateBeforeClose, isOpen: false }));
+  assert.equal(adapterCalls, adapterCallsBeforeClose);
+  assert.equal(applyCalls, applyCallsBeforeClose);
+  assert.deepEqual(runtime.routes, []);
+  assert.deepEqual(runtime.contacts, []);
+  assert.equal(runtime.timers.size, 1);
+
+  runtime.runTimers();
+  assert.equal(runtime.document.portal, null);
+  assert.equal(portal.listeners.size, 0);
+});
+
+test("reopening during a pending close replaces the Portal and binds one working listener", () => {
+  const runtime = loadAdvisor({ deferTimers: true });
+  const mount = new FakeMount(runtime.document);
+  const controller = runtime.app.advisor.bind({ querySelector: () => mount });
+  mount.click({ "data-advisor-launch": "" });
+  const closingPortal = runtime.document.portal;
+  mount.click({ "data-advisor-close": "" });
+  assert.equal(runtime.timers.size, 1);
+  assert.ok(closingPortal.classList.contains("is-closing"));
+
+  mount.click({ "data-advisor-launch": "" });
+  const reopenedPortal = runtime.document.portal;
+  assert.notEqual(reopenedPortal, closingPortal);
+  assert.equal(runtime.timers.size, 0);
+  assert.equal(runtime.document.body.children.length, 1);
+  assert.equal(closingPortal.listeners.size, 0);
+  assert.equal(reopenedPortal.listeners.size, 1);
+  assert.ok(reopenedPortal.classList.contains("is-open"));
+  assert.ok(!reopenedPortal.classList.contains("is-closing"));
+
+  mount.click({ "data-advisor-ac": "wall" });
+  assert.equal(runtime.timers.size, 1);
+  runtime.runTimers();
+  assert.equal(controller.state().step, 1);
+  assert.equal(controller.state().acType, "wall");
+  controller.cleanup();
 });
 
 test("immediate close and cleanup remove viewport listeners and variables without delay", () => {

--- a/test/customerSmartAdvisor.test.js
+++ b/test/customerSmartAdvisor.test.js
@@ -96,46 +96,29 @@ class FakeMount {
     this.classList = new FakeClassList();
     this.style = new FakeStyle();
     this.document = fakeDocument;
-    this.shellWrites = 0;
+    if (this.document) this.document.mount = this;
     this.launcher = new FakeElement((node) => { this.launcherFocuses += 1; if (this.document) this.document.activeElement = node; });
-    this.host = new FakeElement(null, () => { this.shellWrites += 1; });
-    this.layer = new FakeElement();
-    this.body = new FakeElement();
-    this.actions = new FakeElement();
-    this.stepLabel = new FakeElement();
-    this.progress = new FakeElement();
-    this.catalog = new FakeElement();
-    this.closeButton = new FakeElement((node) => { if (this.document) this.document.activeElement = node; });
-    this.nextButton = new FakeElement((node) => { if (this.document) this.document.activeElement = node; });
-    this.question = new FakeElement((node) => { this.questionFocuses += 1; if (this.document) this.document.activeElement = node; });
-    this.result = new FakeElement((node) => { this.resultFocuses += 1; if (this.document) this.document.activeElement = node; });
-    this.scroll = new FakeElement();
-    this.dialog = new FakeElement();
-    this.dialog.querySelectorAll = () => [this.closeButton, this.nextButton];
     this.resultFocuses = 0;
     this.questionFocuses = 0;
     this.launcherFocuses = 0;
   }
   addEventListener(type, handler) { this.listeners.set(type, handler); }
   removeEventListener(type, handler) { if (this.listeners.get(type) === handler) this.listeners.delete(type); }
-  html() { return [this.host.innerHTML, this.body.innerHTML, this.catalog.innerHTML, this.actions.innerHTML].join(""); }
+  get portal() { return this.document?.portal || null; }
+  get shellWrites() { return this.portal?.shellWrites || 0; }
+  get host() { return this.portal || new FakeElement(); }
+  get layer() { return this.portal?.layer || new FakeElement(); }
+  get body() { return this.portal?.body || new FakeElement(); }
+  get actions() { return this.portal?.actions || new FakeElement(); }
+  get catalog() { return this.portal?.catalog || new FakeElement(); }
+  get scroll() { return this.portal?.scroll || new FakeElement(); }
+  get result() { return this.portal?.result || new FakeElement(); }
+  get nextButton() { return this.portal?.nextButton || new FakeElement(); }
+  get closeButton() { return this.portal?.closeButton || new FakeElement(); }
+  html() { return [this.portal?.innerHTML, this.portal?.body.innerHTML, this.portal?.catalog.innerHTML, this.portal?.actions.innerHTML].join(""); }
   querySelector(selector) {
-    const open = this.host.innerHTML.includes("data-advisor-dialog");
     if (selector === "[data-advisor-launcher-content]") return this.launcher;
-    if (selector === "[data-advisor-sheet-host]") return this.host;
     if (selector === "[data-advisor-launch]") return this.launcher;
-    if (selector === "[data-advisor-backdrop]") return open ? this.layer : null;
-    if (selector === "[data-advisor-dialog]") return open ? this.dialog : null;
-    if (selector === "[data-advisor-close]") return open ? this.closeButton : null;
-    if (selector === "[data-advisor-next]") return open ? this.nextButton : null;
-    if (selector === "[data-advisor-scroll]") return open ? this.scroll : null;
-    if (selector === "[data-advisor-body]") return open ? this.body : null;
-    if (selector === "[data-advisor-actions]") return open ? this.actions : null;
-    if (selector === "[data-advisor-step-label]") return open ? this.stepLabel : null;
-    if (selector === "[data-advisor-progress]") return open ? this.progress : null;
-    if (selector === "[data-advisor-catalog]") return open && this.body.innerHTML.includes("data-advisor-catalog") ? this.catalog : null;
-    if (selector === "[data-advisor-question-title]") return open && !this.body.innerHTML.includes("data-advisor-result") ? this.question : null;
-    if (selector === "[data-advisor-result]") return open && this.body.innerHTML.includes("data-advisor-result") ? this.result : null;
     return null;
   }
   querySelectorAll() { return []; }
@@ -144,19 +127,80 @@ class FakeMount {
       hasAttribute: (name) => Object.hasOwn(attributes, name),
       getAttribute: (name) => attributes[name] ?? null,
     };
-    this.listeners.get("click")?.({ target: { closest: () => button } });
+    const launcherClick = Object.hasOwn(attributes, "data-advisor-launch") || Object.hasOwn(attributes, "data-advisor-reset-launcher");
+    (launcherClick ? this.listeners.get("click") : this.portal?.listeners.get("click"))?.({ target: { closest: () => button } });
   }
   clickBackdrop() {
     const backdrop = new FakeElement();
-    this.listeners.get("click")?.({ target: { closest: (selector) => selector === "[data-advisor-backdrop]" ? backdrop : null } });
+    this.portal?.listeners.get("click")?.({ target: { closest: (selector) => selector === "[data-advisor-backdrop]" ? backdrop : null } });
   }
+}
+
+class FakePortal {
+  constructor(fakeDocument) {
+    this.document = fakeDocument;
+    this.isConnected = false;
+    this.parentElement = null;
+    this.listeners = new Map();
+    this.classList = new FakeClassList();
+    this.style = new FakeStyle();
+    this.attributes = new Map();
+    this._innerHTML = "";
+    this.shellWrites = 0;
+    this.layer = new FakeElement();
+    this.body = new FakeElement();
+    this.actions = new FakeElement();
+    this.stepLabel = new FakeElement();
+    this.progress = new FakeElement();
+    this.leading = new FakeElement();
+    this.catalog = new FakeElement();
+    this.closeButton = new FakeElement((node) => { this.document.activeElement = node; });
+    this.nextButton = new FakeElement((node) => { this.document.activeElement = node; });
+    this.question = new FakeElement((node) => {
+      this.document.activeElement = node;
+      if (this.document.mount) this.document.mount.questionFocuses += 1;
+    });
+    this.result = new FakeElement((node) => {
+      this.document.activeElement = node;
+      if (this.document.mount) this.document.mount.resultFocuses += 1;
+    });
+    this.scroll = new FakeElement();
+    this.dialog = new FakeElement();
+    this.dialog.querySelectorAll = () => [this.closeButton, this.nextButton];
+  }
+  set className(value) { this.classList.values = new Set(String(value).split(/\s+/).filter(Boolean)); }
+  get className() { return Array.from(this.classList.values).join(" "); }
+  get innerHTML() { return this._innerHTML; }
+  set innerHTML(value) { this._innerHTML = String(value); this.shellWrites += 1; }
+  setAttribute(name, value) { this.attributes.set(name, String(value)); }
+  getAttribute(name) { return this.attributes.get(name) ?? null; }
+  addEventListener(type, handler) { this.listeners.set(type, handler); }
+  removeEventListener(type, handler) { if (this.listeners.get(type) === handler) this.listeners.delete(type); }
+  remove() { this.document.body.removeChild(this); }
+  querySelector(selector) {
+    const open = this.innerHTML.includes("data-advisor-dialog");
+    if (selector === "[data-advisor-backdrop]") return open ? this.layer : null;
+    if (selector === "[data-advisor-dialog]") return open ? this.dialog : null;
+    if (selector === "[data-advisor-close]") return open ? this.closeButton : null;
+    if (selector === "[data-advisor-scroll]") return open ? this.scroll : null;
+    if (selector === "[data-advisor-body]") return open ? this.body : null;
+    if (selector === "[data-advisor-actions]") return open ? this.actions : null;
+    if (selector === "[data-advisor-step-label]") return open ? this.stepLabel : null;
+    if (selector === "[data-advisor-progress]") return open ? this.progress : null;
+    if (selector === "[data-advisor-header-leading]") return open ? this.leading : null;
+    if (selector === "[data-advisor-catalog]") return open && this.body.innerHTML.includes("data-advisor-catalog") ? this.catalog : null;
+    if (selector === "[data-advisor-question-title]") return open && !this.body.innerHTML.includes("data-advisor-result") ? this.question : null;
+    if (selector === "[data-advisor-result]") return open && this.body.innerHTML.includes("data-advisor-result") ? this.result : null;
+    return null;
+  }
+  querySelectorAll() { return []; }
 }
 
 function fakeDocument() {
   const listeners = new Map();
-  return {
+  const document = {
     activeElement: null,
-    body: { classList: new FakeClassList() },
+    portal: null,
     documentElement: { clientHeight: 760 },
     listeners,
     addEventListener(type, handler) { listeners.set(type, handler); },
@@ -167,6 +211,25 @@ function fakeDocument() {
       return prevented;
     },
   };
+  document.createElement = () => new FakePortal(document);
+  document.body = {
+    classList: new FakeClassList(),
+    children: [],
+    appendChild(node) {
+      node.parentElement = this;
+      node.isConnected = true;
+      this.children.push(node);
+      document.portal = node;
+      return node;
+    },
+    removeChild(node) {
+      this.children = this.children.filter((child) => child !== node);
+      node.parentElement = null;
+      node.isConnected = false;
+      if (document.portal === node) document.portal = null;
+    },
+  };
+  return document;
 }
 
 function loadAdvisor(options = {}) {
@@ -236,13 +299,9 @@ function plain(value) {
 function completeWallStandardAdvisor(mount) {
   mount.click({ "data-advisor-launch": "" });
   mount.click({ "data-advisor-ac": "wall" });
-  mount.click({ "data-advisor-next": "" });
   mount.click({ "data-advisor-months": "m4_5" });
-  mount.click({ "data-advisor-next": "" });
   mount.click({ "data-advisor-symptom": "routine" });
-  mount.click({ "data-advisor-next": "" });
   mount.click({ "data-advisor-repair": "none" });
-  mount.click({ "data-advisor-next": "" });
 }
 
 test("wall recommendation engine covers standard premium coil overhaul and uncertain overdue cases", () => {
@@ -429,14 +488,11 @@ test("wizard advances, supports multi-select, refreshes Catalog, resets, and bin
 
   mount.click({ "data-advisor-launch": "" });
   mount.click({ "data-advisor-ac": "wall" });
-  mount.click({ "data-advisor-next": "" });
   mount.click({ "data-advisor-months": "m6_8" });
-  mount.click({ "data-advisor-next": "" });
   mount.click({ "data-advisor-symptom": "heavy_use" });
   mount.click({ "data-advisor-symptom": "pets" });
-  mount.click({ "data-advisor-next": "" });
+  mount.click({ "data-advisor-symptoms-done": "" });
   mount.click({ "data-advisor-repair": "none" });
-  mount.click({ "data-advisor-next": "" });
   assert.equal(first.state().recommendation.verdict, "premium_clean");
   assert.match(mount.html(), /กำลังค้นหาบริการที่ตรงจาก Catalog/);
   assert.equal(mount.resultFocuses, 1);
@@ -472,7 +528,6 @@ test("launcher opens an accessible sheet and close resumes the saved step", () =
   assert.equal(mount.questionFocuses, 1);
 
   mount.click({ "data-advisor-ac": "wall" });
-  mount.click({ "data-advisor-next": "" });
   assert.equal(controller.state().step, 1);
   assert.equal(mount.scroll.scrollTop, 0);
   mount.click({ "data-advisor-close": "" });
@@ -489,6 +544,143 @@ test("launcher opens an accessible sheet and close resumes the saved step", () =
   assert.equal(controller.state().step, 1);
   assert.match(mount.html(), /data-advisor-months/);
   assert.doesNotMatch(mount.html(), /data-advisor-ac=/);
+});
+
+test("sheet uses one body-level portal with separate event delegation and no orphan nodes", () => {
+  const runtime = loadAdvisor();
+  const mount = new FakeMount(runtime.document);
+  const controller = runtime.app.advisor.bind({ querySelector: () => mount });
+  assert.equal(runtime.document.body.children.length, 0);
+
+  mount.click({ "data-advisor-launch": "" });
+  const firstPortal = runtime.document.portal;
+  assert.ok(firstPortal);
+  assert.equal(firstPortal.parentElement, runtime.document.body);
+  assert.equal(firstPortal.getAttribute("data-advisor-portal"), "");
+  assert.equal(runtime.document.body.children.length, 1);
+  assert.equal(mount.listeners.size, 1);
+  assert.equal(firstPortal.listeners.size, 1);
+  assert.equal(mount.querySelector("[data-advisor-dialog]"), null);
+  assert.match(firstPortal.innerHTML, /data-advisor-dialog/);
+
+  mount.click({ "data-advisor-close": "" });
+  assert.equal(runtime.document.portal, null);
+  assert.equal(runtime.document.body.children.length, 0);
+  assert.equal(firstPortal.listeners.size, 0);
+
+  mount.click({ "data-advisor-launch": "" });
+  assert.notEqual(runtime.document.portal, firstPortal);
+  assert.equal(runtime.document.body.children.length, 1);
+  controller.cleanup();
+  assert.equal(runtime.document.portal, null);
+  assert.equal(runtime.document.body.children.length, 0);
+  assert.equal(mount.listeners.size, 0);
+});
+
+test("single choices auto-flow while symptoms remain multi-select and Back preserves answers", () => {
+  const runtime = loadAdvisor();
+  const mount = new FakeMount(runtime.document);
+  const controller = runtime.app.advisor.bind({ querySelector: () => mount });
+  mount.click({ "data-advisor-launch": "" });
+  assert.equal(controller.state().step, 0);
+  assert.equal(mount.actions.hidden, true);
+
+  mount.click({ "data-advisor-ac": "wall" });
+  assert.equal(controller.state().step, 1);
+  assert.match(runtime.document.portal.leading.innerHTML, /data-advisor-back/);
+  mount.click({ "data-advisor-months": "m6_8" });
+  assert.equal(controller.state().step, 2);
+
+  mount.click({ "data-advisor-symptom": "heavy_use" });
+  mount.click({ "data-advisor-symptom": "pets" });
+  assert.equal(controller.state().step, 2);
+  assert.deepEqual(Array.from(controller.state().symptoms), ["heavy_use", "pets"]);
+  assert.match(mount.actions.innerHTML, /data-advisor-symptoms-done/);
+  assert.doesNotMatch(mount.actions.innerHTML, /ขั้นต่อไป/);
+  mount.click({ "data-advisor-symptoms-done": "" });
+  assert.equal(controller.state().step, 3);
+  assert.equal(mount.actions.hidden, true);
+  assert.doesNotMatch(mount.actions.innerHTML, /ดูผลประเมิน/);
+
+  mount.click({ "data-advisor-back": "" });
+  assert.equal(controller.state().step, 2);
+  assert.deepEqual(Array.from(controller.state().symptoms), ["heavy_use", "pets"]);
+  mount.click({ "data-advisor-symptoms-done": "" });
+  mount.click({ "data-advisor-repair": "error_code" });
+  assert.equal(controller.state().step, 4);
+  assert.equal(controller.state().recommendation.verdict, "repair_check");
+});
+
+test("routine and no-repair choices auto-flow without dropping exclusive state", () => {
+  const runtime = loadAdvisor();
+  const mount = new FakeMount(runtime.document);
+  const controller = runtime.app.advisor.bind({ querySelector: () => mount });
+  mount.click({ "data-advisor-launch": "" });
+  mount.click({ "data-advisor-ac": "wall" });
+  mount.click({ "data-advisor-months": "m4_5" });
+  mount.click({ "data-advisor-symptom": "heavy_use" });
+  mount.click({ "data-advisor-symptom": "routine" });
+  assert.equal(controller.state().step, 3);
+  assert.deepEqual(Array.from(controller.state().symptoms), ["routine"]);
+  mount.click({ "data-advisor-repair": "none" });
+  assert.equal(controller.state().step, 4);
+  assert.equal(controller.state().recommendation.verdict, "standard_clean");
+  mount.click({ "data-advisor-back": "" });
+  assert.equal(controller.state().step, 3);
+  mount.click({ "data-advisor-back": "" });
+  assert.equal(controller.state().step, 2);
+  mount.click({ "data-advisor-symptom": "routine" });
+  assert.equal(controller.state().step, 3);
+  assert.deepEqual(Array.from(controller.state().symptoms), ["routine"]);
+});
+
+test("repair choices evaluate immediately with repair-first outcomes", () => {
+  for (const signal of ["error_code", "outdoor_not_running", "breaker_trip"]) {
+    const runtime = loadAdvisor();
+    const mount = new FakeMount(runtime.document);
+    const controller = runtime.app.advisor.bind({ querySelector: () => mount });
+    mount.click({ "data-advisor-launch": "" });
+    mount.click({ "data-advisor-ac": "wall" });
+    mount.click({ "data-advisor-months": "m4_5" });
+    mount.click({ "data-advisor-symptom": "routine" });
+    assert.equal(controller.state().step, 3, signal);
+    assert.equal(mount.actions.hidden, true, signal);
+    mount.click({ "data-advisor-repair": signal });
+    assert.equal(controller.state().step, 4, signal);
+    assert.equal(controller.state().recommendation.verdict, "repair_check", signal);
+    controller.cleanup();
+  }
+});
+
+test("selection lock prevents double advance and close cancels ghost navigation", () => {
+  const runtime = loadAdvisor({ deferTimers: true });
+  const mount = new FakeMount(runtime.document);
+  const controller = runtime.app.advisor.bind({ querySelector: () => mount });
+  mount.click({ "data-advisor-launch": "" });
+  mount.click({ "data-advisor-ac": "wall" });
+  mount.click({ "data-advisor-ac": "fourway" });
+  assert.equal(controller.state().step, 0);
+  assert.equal(controller.state().acType, "wall");
+  assert.equal(runtime.timers.size, 1);
+  runtime.runTimers();
+  assert.equal(controller.state().step, 1);
+
+  mount.click({ "data-advisor-months": "m4_5" });
+  assert.equal(runtime.timers.size, 1);
+  mount.click({ "data-advisor-close": "" });
+  assert.equal(controller.state().isOpen, false);
+  assert.equal(runtime.timers.size, 1);
+  runtime.runTimers();
+  assert.equal(controller.state().step, 1);
+  assert.equal(runtime.document.portal, null);
+
+  const reduced = loadAdvisor({ reducedMotion: true });
+  const reducedMount = new FakeMount(reduced.document);
+  const reducedController = reduced.app.advisor.bind({ querySelector: () => reducedMount });
+  reducedMount.click({ "data-advisor-launch": "" });
+  reducedMount.click({ "data-advisor-ac": "wall" });
+  assert.equal(reducedController.state().step, 1);
+  assert.equal(reduced.timers.size, 0);
 });
 
 test("semantic choice icons are deterministic, distinct, and emoji-free", () => {
@@ -521,22 +713,23 @@ test("visualViewport drives the mobile panel and listeners clean up on close and
   const mount = new FakeMount(runtime.document);
   const controller = runtime.app.advisor.bind({ querySelector: () => mount });
   mount.click({ "data-advisor-launch": "" });
-  assert.equal(mount.style.getPropertyValue("--advisor-viewport-height"), "612px");
-  assert.equal(mount.style.getPropertyValue("--advisor-viewport-top"), "49px");
+  const portal = runtime.document.portal;
+  assert.equal(portal.style.getPropertyValue("--advisor-viewport-height"), "612px");
+  assert.equal(portal.style.getPropertyValue("--advisor-viewport-top"), "49px");
   assert.deepEqual(Array.from(runtime.visualViewport.listeners.keys()).sort(), ["resize", "scroll"]);
 
   runtime.visualViewport.height = 488.2;
   runtime.visualViewport.offsetTop = 72.1;
   runtime.visualViewport.emit("resize");
-  assert.equal(mount.style.getPropertyValue("--advisor-viewport-height"), "488px");
-  assert.equal(mount.style.getPropertyValue("--advisor-viewport-top"), "72px");
+  assert.equal(portal.style.getPropertyValue("--advisor-viewport-height"), "488px");
+  assert.equal(portal.style.getPropertyValue("--advisor-viewport-top"), "72px");
   runtime.visualViewport.offsetTop = 16;
   runtime.visualViewport.emit("scroll");
-  assert.equal(mount.style.getPropertyValue("--advisor-viewport-top"), "16px");
+  assert.equal(portal.style.getPropertyValue("--advisor-viewport-top"), "16px");
 
   mount.click({ "data-advisor-close": "" });
   assert.equal(runtime.visualViewport.listeners.size, 0);
-  assert.equal(mount.style.getPropertyValue("--advisor-viewport-height"), "");
+  assert.equal(runtime.document.portal, null);
   mount.click({ "data-advisor-launch": "" });
   controller.cleanup();
   assert.equal(runtime.visualViewport.listeners.size, 0);
@@ -550,26 +743,28 @@ test("animated close preserves viewport geometry until the panel is removed", ()
   const mount = new FakeMount(runtime.document);
   runtime.app.advisor.bind({ querySelector: () => mount });
   mount.click({ "data-advisor-launch": "" });
-  assert.equal(mount.style.getPropertyValue("--advisor-viewport-height"), "486px");
-  assert.equal(mount.style.getPropertyValue("--advisor-viewport-top"), "72px");
+  const portal = runtime.document.portal;
+  assert.equal(portal.style.getPropertyValue("--advisor-viewport-height"), "486px");
+  assert.equal(portal.style.getPropertyValue("--advisor-viewport-top"), "72px");
 
   mount.click({ "data-advisor-close": "" });
   assert.equal(runtime.visualViewport.listeners.size, 0);
-  assert.equal(mount.style.getPropertyValue("--advisor-viewport-height"), "486px");
-  assert.equal(mount.style.getPropertyValue("--advisor-viewport-top"), "72px");
+  assert.equal(portal.style.getPropertyValue("--advisor-viewport-height"), "486px");
+  assert.equal(portal.style.getPropertyValue("--advisor-viewport-top"), "72px");
   assert.match(mount.host.innerHTML, /data-advisor-dialog/);
   assert.ok(mount.layer.classList.contains("is-closing"));
 
   runtime.visualViewport.height = 760;
   runtime.visualViewport.offsetTop = 0;
   runtime.visualViewport.emit("resize");
-  assert.equal(mount.style.getPropertyValue("--advisor-viewport-height"), "486px");
-  assert.equal(mount.style.getPropertyValue("--advisor-viewport-top"), "72px");
+  assert.equal(portal.style.getPropertyValue("--advisor-viewport-height"), "486px");
+  assert.equal(portal.style.getPropertyValue("--advisor-viewport-top"), "72px");
 
   runtime.runTimers();
   assert.equal(mount.host.innerHTML, "");
-  assert.equal(mount.style.getPropertyValue("--advisor-viewport-height"), "");
-  assert.equal(mount.style.getPropertyValue("--advisor-viewport-top"), "");
+  assert.equal(portal.style.getPropertyValue("--advisor-viewport-height"), "");
+  assert.equal(portal.style.getPropertyValue("--advisor-viewport-top"), "");
+  assert.equal(runtime.document.portal, null);
 });
 
 test("immediate close and cleanup remove viewport listeners and variables without delay", () => {
@@ -580,10 +775,12 @@ test("immediate close and cleanup remove viewport listeners and variables withou
   const immediateMount = new FakeMount(immediateRuntime.document);
   const immediateController = immediateRuntime.app.advisor.bind({ querySelector: () => immediateMount });
   immediateMount.click({ "data-advisor-launch": "" });
+  const immediatePortal = immediateRuntime.document.portal;
   immediateController.close({ immediate: true });
   assert.equal(immediateRuntime.visualViewport.listeners.size, 0);
-  assert.equal(immediateMount.style.getPropertyValue("--advisor-viewport-height"), "");
-  assert.equal(immediateMount.style.getPropertyValue("--advisor-viewport-top"), "");
+  assert.equal(immediatePortal.style.getPropertyValue("--advisor-viewport-height"), "");
+  assert.equal(immediatePortal.style.getPropertyValue("--advisor-viewport-top"), "");
+  assert.equal(immediateRuntime.document.portal, null);
   assert.equal(immediateMount.host.innerHTML, "");
 
   const cleanupRuntime = loadAdvisor({
@@ -598,8 +795,7 @@ test("immediate close and cleanup remove viewport listeners and variables withou
   cleanupController.cleanup();
   assert.equal(cleanupRuntime.timers.size, 0);
   assert.equal(cleanupRuntime.visualViewport.listeners.size, 0);
-  assert.equal(cleanupMount.style.getPropertyValue("--advisor-viewport-height"), "");
-  assert.equal(cleanupMount.style.getPropertyValue("--advisor-viewport-top"), "");
+  assert.equal(cleanupRuntime.document.portal, null);
   assert.ok(!cleanupRuntime.document.body.classList.contains("has-advisor-sheet"));
 });
 
@@ -608,11 +804,11 @@ test("visualViewport fallback uses window height and removes its resize listener
   const mount = new FakeMount(runtime.document);
   const controller = runtime.app.advisor.bind({ querySelector: () => mount });
   mount.click({ "data-advisor-launch": "" });
-  assert.equal(mount.style.getPropertyValue("--advisor-viewport-height"), "701px");
+  assert.equal(runtime.document.portal.style.getPropertyValue("--advisor-viewport-height"), "701px");
   assert.deepEqual(Array.from(runtime.window.listeners.keys()), ["resize"]);
   runtime.window.innerHeight = 640;
   runtime.window.emit("resize");
-  assert.equal(mount.style.getPropertyValue("--advisor-viewport-height"), "640px");
+  assert.equal(runtime.document.portal.style.getPropertyValue("--advisor-viewport-height"), "640px");
   controller.cleanup();
   assert.equal(runtime.window.listeners.size, 0);
 });
@@ -624,13 +820,13 @@ test("sheet shell opens once while steps and Catalog refresh update in place", (
   const controller = runtime.app.advisor.bind(container);
 
   mount.click({ "data-advisor-launch": "" });
+  const openingPortal = runtime.document.portal;
   const openingShell = mount.host.innerHTML;
   assert.equal(mount.shellWrites, 1);
   assert.match(openingShell, /advisor-sheet-layer is-opening/);
   assert.ok(mount.layer.classList.contains("is-opening"));
 
   mount.click({ "data-advisor-ac": "wall" });
-  mount.click({ "data-advisor-next": "" });
   assert.equal(mount.shellWrites, 1);
   assert.equal(mount.host.innerHTML, openingShell);
   assert.ok(!mount.layer.classList.contains("is-opening"));
@@ -640,13 +836,10 @@ test("sheet shell opens once while steps and Catalog refresh update in place", (
   assert.equal(mount.shellWrites, 1);
   assert.ok(mount.body.classList.contains("is-step-back"));
 
-  mount.click({ "data-advisor-next": "" });
+  mount.click({ "data-advisor-ac": "wall" });
   mount.click({ "data-advisor-months": "m4_5" });
-  mount.click({ "data-advisor-next": "" });
   mount.click({ "data-advisor-symptom": "routine" });
-  mount.click({ "data-advisor-next": "" });
   mount.click({ "data-advisor-repair": "none" });
-  mount.click({ "data-advisor-next": "" });
   assert.equal(controller.state().step, 4);
   assert.equal(mount.shellWrites, 1);
 
@@ -667,7 +860,8 @@ test("sheet shell opens once while steps and Catalog refresh update in place", (
   mount.click({ "data-advisor-close": "" });
   assert.equal(mount.host.innerHTML, "");
   mount.click({ "data-advisor-launch": "" });
-  assert.equal(mount.shellWrites, 3);
+  assert.notEqual(runtime.document.portal, openingPortal);
+  assert.equal(mount.shellWrites, 1);
   assert.ok(mount.layer.classList.contains("is-opening"));
 });
 
@@ -677,19 +871,17 @@ test("multi-select exclusive choices and Back preserve the existing answers", ()
   const controller = runtime.app.advisor.bind({ querySelector: () => mount });
   mount.click({ "data-advisor-launch": "" });
   mount.click({ "data-advisor-ac": "wall" });
-  mount.click({ "data-advisor-next": "" });
   mount.click({ "data-advisor-months": "m6_8" });
-  mount.click({ "data-advisor-next": "" });
-  mount.click({ "data-advisor-symptom": "routine" });
   mount.click({ "data-advisor-symptom": "heavy_use" });
-  assert.deepEqual(Array.from(controller.state().symptoms), ["heavy_use"]);
-  mount.click({ "data-advisor-next": "" });
-  mount.click({ "data-advisor-repair": "none" });
-  mount.click({ "data-advisor-repair": "error_code" });
-  assert.deepEqual(Array.from(controller.state().repairSignals), ["error_code"]);
+  mount.click({ "data-advisor-symptom": "pets" });
+  assert.deepEqual(Array.from(controller.state().symptoms), ["heavy_use", "pets"]);
+  assert.equal(controller.state().step, 2);
+  assert.match(mount.actions.innerHTML, /data-advisor-symptoms-done/);
+  mount.click({ "data-advisor-symptoms-done": "" });
+  assert.equal(controller.state().step, 3);
   mount.click({ "data-advisor-back": "" });
   assert.equal(controller.state().step, 2);
-  assert.deepEqual(Array.from(controller.state().symptoms), ["heavy_use"]);
+  assert.deepEqual(Array.from(controller.state().symptoms), ["heavy_use", "pets"]);
   assert.equal(mount.scroll.scrollTop, 0);
 });
 
@@ -738,7 +930,7 @@ test("closed result stays compact and never exposes Catalog cards on Home", () =
 test("booking handoff routes only after both existing adapters succeed and otherwise contacts", () => {
   const item = catalogItem(8);
   const success = loadAdvisor({ catalog: { status: "success", items: [item] } });
-  const mount = new FakeMount();
+  const mount = new FakeMount(success.document);
   const container = { querySelector: (selector) => selector === "[data-smart-advisor]" ? mount : null };
   success.app.advisor.bind(container);
   completeWallStandardAdvisor(mount);
@@ -748,7 +940,7 @@ test("booking handoff routes only after both existing adapters succeed and other
   assert.equal(success.contacts.length, 0);
 
   const denied = loadAdvisor({ catalog: { status: "success", items: [item] }, adapter: () => null });
-  const deniedMount = new FakeMount();
+  const deniedMount = new FakeMount(denied.document);
   denied.app.advisor.bind({ querySelector: () => deniedMount });
   completeWallStandardAdvisor(deniedMount);
   deniedMount.click({ "data-advisor-item-action": "8" });
@@ -756,7 +948,7 @@ test("booking handoff routes only after both existing adapters succeed and other
   assert.equal(denied.contacts.length, 1);
 
   const applyDenied = loadAdvisor({ catalog: { status: "success", items: [item] }, apply: () => false });
-  const applyMount = new FakeMount();
+  const applyMount = new FakeMount(applyDenied.document);
   applyDenied.app.advisor.bind({ querySelector: () => applyMount });
   completeWallStandardAdvisor(applyMount);
   applyMount.click({ "data-advisor-item-action": "8" });
@@ -773,7 +965,7 @@ test("manipulated unrelated Catalog item id is rejected before booking adapters 
     adapter: () => { adapterCalls += 1; return { draft: {} }; },
     apply: () => { applyCalls += 1; return true; },
   });
-  const mount = new FakeMount();
+  const mount = new FakeMount(runtime.document);
   runtime.app.advisor.bind({ querySelector: () => mount });
   completeWallStandardAdvisor(mount);
   mount.click({ "data-advisor-item-action": "9" });
@@ -794,21 +986,16 @@ test("repair result always opens Contact Sheet even when a repair item has adapt
   const controller = runtime.app.advisor.bind(container);
   mount.click({ "data-advisor-launch": "" });
   mount.click({ "data-advisor-ac": "wall" });
-  mount.click({ "data-advisor-next": "" });
   mount.click({ "data-advisor-months": "m4_5" });
-  mount.click({ "data-advisor-next": "" });
   mount.click({ "data-advisor-symptom": "routine" });
-  mount.click({ "data-advisor-next": "" });
   mount.click({ "data-advisor-repair": "error_code" });
-  mount.click({ "data-advisor-next": "" });
   assert.equal(controller.state().recommendation.verdict, "repair_check");
   mount.click({ "data-advisor-item-action": "9" });
   assert.equal(runtime.routes.length, 0);
   assert.equal(runtime.applied.length, 0);
   assert.equal(runtime.contacts.length, 1);
   assert.equal(runtime.visualViewport.listeners.size, 0);
-  assert.equal(mount.style.getPropertyValue("--advisor-viewport-height"), "");
-  assert.equal(mount.style.getPropertyValue("--advisor-viewport-top"), "");
+  assert.equal(runtime.document.portal, null);
 });
 
 test("advisor render contract is accessible, compact, motion-safe, and has no autoplay timer", () => {
@@ -818,21 +1005,25 @@ test("advisor render contract is accessible, compact, motion-safe, and has no au
   assert.match(html, /ไม่แน่ใจว่าควรล้างหรือซ่อม/);
   assert.match(html, /data-advisor-launch/);
   assert.match(html, /aria-expanded="false"/);
+  assert.doesNotMatch(html, /data-advisor-sheet-host|data-advisor-portal/);
+  assert.doesNotMatch(html, /data-icon="play"/);
+  assert.doesNotMatch(SOURCE, /data-advisor-next|>ขั้นต่อไป<|>ดูผลประเมิน</);
   assert.doesNotMatch(html, /data-advisor-ac|data-advisor-months|data-advisor-symptom|data-advisor-repair/);
   assert.doesNotMatch(html, /ความคืบหน้าการประเมิน|ขั้นที่ 1 จาก 4/);
   assert.doesNotMatch(html, /ดูบริการจริงจาก Catalog/);
   assert.match(CSS_SOURCE, /@media \(prefers-reduced-motion: reduce\)/);
   assert.match(CSS_SOURCE, /\.advisor-sheet[\s\S]*?max-height: 90dvh/);
   assert.match(CSS_SOURCE, /\.advisor-sheet-actions[\s\S]*?safe-area-inset-bottom/);
-  assert.match(CSS_SOURCE, /\.advisor-sheet-layer[\s\S]*?z-index: 100/);
+  assert.match(CSS_SOURCE, /\.advisor-portal-root \{[\s\S]*?position: fixed[\s\S]*?z-index: 10000[\s\S]*?isolation: isolate/);
   assert.match(CSS_SOURCE, /\.advisor-sheet \.advisor-chip-grid[\s\S]*?grid-template-columns: minmax\(0, 1fr\)/);
   assert.match(CSS_SOURCE, /@media \(max-width: 380px\)[\s\S]*?\.advisor-sheet \.advisor-choice-grid \{ grid-template-columns: minmax\(0, 1fr\)/);
   assert.match(CSS_SOURCE, /@media \(max-width: 600px\)[\s\S]*?height: var\(--advisor-viewport-height, 100dvh\)/);
   assert.match(CSS_SOURCE, /@media \(max-width: 600px\)[\s\S]*?max-height: none[\s\S]*?border-radius: 0/);
   assert.match(CSS_SOURCE, /body\.has-advisor-sheet \{ overflow: hidden/);
-  assert.match(CSS_SOURCE, /\.smart-advisor-section \{[\s\S]*?min-height: 112px[\s\S]*?padding: 12px/);
-  assert.match(CSS_SOURCE, /\.advisor-launcher-orb \{[\s\S]*?width: 40px[\s\S]*?height: 40px/);
-  assert.match(CSS_SOURCE, /\.advisor-launcher-actions \.primary-btn \{[\s\S]*?min-height: 42px/);
+  assert.match(CSS_SOURCE, /\.smart-advisor-section \{[\s\S]*?min-height: 96px[\s\S]*?padding: 10px/);
+  assert.match(CSS_SOURCE, /\.advisor-launcher-orb \{[\s\S]*?width: 34px[\s\S]*?height: 34px/);
+  assert.match(CSS_SOURCE, /\.advisor-launcher-copy h2 \{[\s\S]*?white-space: nowrap/);
+  assert.match(CSS_SOURCE, /\.advisor-launcher-actions \.primary-btn \{[\s\S]*?justify-content: center[\s\S]*?min-height: 38px/);
   assert.match(CSS_SOURCE, /@media \(max-width: 600px\)[\s\S]*?\.advisor-launcher-copy p \{ display: none; \}/);
   assert.match(CSS_SOURCE, /\.advisor-sheet-scroll \{[\s\S]*?overflow-y: auto[\s\S]*?overscroll-behavior: contain/);
   assert.match(CSS_SOURCE, /\.advisor-sheet-actions \{[\s\S]*?safe-area-inset-bottom/);
@@ -853,6 +1044,7 @@ test("advisor render contract is accessible, compact, motion-safe, and has no au
   assert.match(CSS_SOURCE, /\.advisor-sheet-body\.is-step-back > \.advisor-step/);
   assert.match(CSS_SOURCE, /@media \(prefers-reduced-motion: reduce\)[\s\S]*?\.advisor-sheet-layer[\s\S]*?animation: none !important/);
   assert.doesNotMatch(SOURCE, /setInterval\s*\(/);
+  assert.match(SOURCE, /document\.body\.appendChild\(portalRoot\)/);
   assert.match(SOURCE, /matchMedia\?\.\("\(prefers-reduced-motion: reduce\)"\)/);
   assert.match(SOURCE, /window\.visualViewport/);
   const reduced = loadAdvisor({ reducedMotion: true });
@@ -888,7 +1080,7 @@ test("Home places built-in advisor after Quick Actions and before Featured Servi
 });
 
 test("advisor module is loaded before ui.js and precached under the shared build id", () => {
-  const build = "20260715_smart_advisor_mobile_polish_v2";
+  const build = "20260715_smart_advisor_portal_autoflow_v3";
   assert.ok(INDEX_SOURCE.indexOf(`modules/advisor.js?v=${build}`) < INDEX_SOURCE.indexOf(`modules/ui.js?v=${build}`));
   assert.match(SW_SOURCE, new RegExp(`BUILD_ID = "${build}"`));
   assert.match(SW_SOURCE, /modules\/advisor\.js\?v=\$\{BUILD_ID\}/);

--- a/test/customerTrackingFullReadUi.test.js
+++ b/test/customerTrackingFullReadUi.test.js
@@ -770,7 +770,7 @@ test("tracking UI exposes loading, not-found, rate-limit and offline states", ()
 });
 
 test("tracking assets share the full-read cache build id", () => {
-  const build = "20260715_smart_advisor_mobile_polish_v2";
+  const build = "20260715_smart_advisor_portal_autoflow_v3";
   for (const file of [
     "customer-app/index.html",
     "customer-app/sw.js",

--- a/test/homepageCms.test.js
+++ b/test/homepageCms.test.js
@@ -296,7 +296,7 @@ test("customer homepage has no admin control, bottom nav is fixed five-tab, and 
   const sw = read("customer-app/sw.js");
   const app = read("customer-app/assets/customer-app.js");
   const manifest = read("customer-app/manifest.webmanifest");
-  const build = "20260715_smart_advisor_mobile_polish_v2";
+  const build = "20260715_smart_advisor_portal_autoflow_v3";
 
   assert.doesNotMatch(index + ui, /โหมดแอดมิน|openCms|localStorage\.getItem\('cwfHomeCmsDemo'/);
   assert.match(index, /data-route="store"[\s\S]*ร้านค้า/);


### PR DESCRIPTION
## Summary
- render the Smart Advisor dialog through a direct body-level portal so Home sections and bottom navigation cannot overlap it
- compact the mobile launcher and center its text-only CTA
- auto-advance single-choice AC/month/repair steps while preserving multi-select symptoms and explicit Back navigation
- move VisualViewport geometry and portal event lifecycle out of the Home mount
- bump the Customer App build ID to `20260715_smart_advisor_portal_autoflow_v3`

## Business behavior preserved
- recommendation outputs and repair-first rules are unchanged
- Catalog matching and AC isolation are unchanged
- booking adapter revalidation remains fail closed
- Contact Sheet fallback remains unchanged

## Validation
- `node --check customer-app/modules/advisor.js`
- Smart Advisor: 31/31 passed
- focused Home/Booking/Tracking/build suite: 371/371 passed
- full suite branch: 1258 tests, 1196 passed, 28 failed, 34 skipped
- exact main: 1253 tests, 1191 passed, 28 failed, 34 skipped
- additional failures versus exact main: 0 (failure-name sets match)

## Visual gate
The execution environment exposed no browser backend, so screenshots were not fabricated. Portal, viewport, responsive, focus, and auto-flow contracts are covered by static/runtime tests; physical Android Chrome visual smoke remains required before marking ready.

No backend, security, migration, production-data, merge, or deploy changes.