### PR TITLE
Make customer history claims production ready

### DIFF
--- a/customer-app/assets/customer-app.js
+++ b/customer-app/assets/customer-app.js
@@ -3,7 +3,7 @@
 
   const App = window.CWFCustomerAppV2;
   const BOOT_TIMEOUT_MS = 3500;
-  const BUILD_ID = "20260715_smart_advisor_portal_autoflow_v3";
+  const BUILD_ID = "20260716_customer_history_production_ready_v1";
 
   function withTimeout(promise, timeoutMs) {
     return Promise.race([

--- a/customer-app/index.html
+++ b/customer-app/index.html
@@ -21,10 +21,10 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Noto+Sans+Thai:wght@400;500;600;700;800;900&display=swap" media="print" onload="this.media='all'">
   <noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Noto+Sans+Thai:wght@400;500;600;700;800;900&display=swap"></noscript>
-  <link rel="manifest" href="./manifest.webmanifest?v=20260715_smart_advisor_portal_autoflow_v3">
+  <link rel="manifest" href="./manifest.webmanifest?v=20260716_customer_history_production_ready_v1">
   <link rel="icon" type="image/png" sizes="192x192" href="./assets/icons/cwf-customer-192.png">
   <link rel="apple-touch-icon" sizes="180x180" href="./assets/icons/cwf-customer-180.png">
-  <link rel="stylesheet" href="./assets/customer-app.css?v=20260715_smart_advisor_portal_autoflow_v3">
+  <link rel="stylesheet" href="./assets/customer-app.css?v=20260716_customer_history_production_ready_v1">
 </head>
 <body class="is-app-booting">
   <div class="app-shell" data-app-shell>
@@ -62,23 +62,23 @@
     </nav>
   </div>
 
-  <script src="./modules/state.js?v=20260715_smart_advisor_portal_autoflow_v3"></script>
-  <script src="./modules/utils.js?v=20260715_smart_advisor_portal_autoflow_v3"></script>
-  <script src="./modules/analytics.js?v=20260715_smart_advisor_portal_autoflow_v3"></script>
-  <script src="./modules/api.js?v=20260715_smart_advisor_portal_autoflow_v3"></script>
-  <script src="./modules/pageAvailability.js?v=20260715_smart_advisor_portal_autoflow_v3"></script>
-  <script src="./modules/services.js?v=20260715_smart_advisor_portal_autoflow_v3"></script>
-  <script src="./modules/advisor.js?v=20260715_smart_advisor_portal_autoflow_v3"></script>
-  <script src="./modules/ui.js?v=20260715_smart_advisor_portal_autoflow_v3"></script>
-  <script src="./modules/store.js?v=20260715_smart_advisor_portal_autoflow_v3"></script>
-  <script src="./modules/auth.js?v=20260715_smart_advisor_portal_autoflow_v3"></script>
-  <script src="./modules/pricing.js?v=20260715_smart_advisor_portal_autoflow_v3"></script>
-  <script src="./modules/availability.js?v=20260715_smart_advisor_portal_autoflow_v3"></script>
-  <script src="./modules/bookingScheduled.js?v=20260715_smart_advisor_portal_autoflow_v3"></script>
-  <script src="./modules/bookingUrgent.js?v=20260715_smart_advisor_portal_autoflow_v3"></script>
-  <script src="./modules/tracking.js?v=20260715_smart_advisor_portal_autoflow_v3"></script>
-  <script src="./modules/profile.js?v=20260715_smart_advisor_portal_autoflow_v3"></script>
-  <script src="./modules/router.js?v=20260715_smart_advisor_portal_autoflow_v3"></script>
-  <script src="./assets/customer-app.js?v=20260715_smart_advisor_portal_autoflow_v3"></script>
+  <script src="./modules/state.js?v=20260716_customer_history_production_ready_v1"></script>
+  <script src="./modules/utils.js?v=20260716_customer_history_production_ready_v1"></script>
+  <script src="./modules/analytics.js?v=20260716_customer_history_production_ready_v1"></script>
+  <script src="./modules/api.js?v=20260716_customer_history_production_ready_v1"></script>
+  <script src="./modules/pageAvailability.js?v=20260716_customer_history_production_ready_v1"></script>
+  <script src="./modules/services.js?v=20260716_customer_history_production_ready_v1"></script>
+  <script src="./modules/advisor.js?v=20260716_customer_history_production_ready_v1"></script>
+  <script src="./modules/ui.js?v=20260716_customer_history_production_ready_v1"></script>
+  <script src="./modules/store.js?v=20260716_customer_history_production_ready_v1"></script>
+  <script src="./modules/auth.js?v=20260716_customer_history_production_ready_v1"></script>
+  <script src="./modules/pricing.js?v=20260716_customer_history_production_ready_v1"></script>
+  <script src="./modules/availability.js?v=20260716_customer_history_production_ready_v1"></script>
+  <script src="./modules/bookingScheduled.js?v=20260716_customer_history_production_ready_v1"></script>
+  <script src="./modules/bookingUrgent.js?v=20260716_customer_history_production_ready_v1"></script>
+  <script src="./modules/tracking.js?v=20260716_customer_history_production_ready_v1"></script>
+  <script src="./modules/profile.js?v=20260716_customer_history_production_ready_v1"></script>
+  <script src="./modules/router.js?v=20260716_customer_history_production_ready_v1"></script>
+  <script src="./assets/customer-app.js?v=20260716_customer_history_production_ready_v1"></script>
 </body>
 </html>

--- a/customer-app/manifest.webmanifest
+++ b/customer-app/manifest.webmanifest
@@ -2,7 +2,7 @@
   "name": "CWF Customer Service",
   "short_name": "CWF Service",
   "description": "แอปลูกค้า Coldwindflow สำหรับเลือกบริการ จองคิว และติดตามงาน",
-  "start_url": "/customer-app/index.html?v=20260715_smart_advisor_portal_autoflow_v3#home",
+  "start_url": "/customer-app/index.html?v=20260716_customer_history_production_ready_v1#home",
   "scope": "/customer-app/",
   "id": "/customer-app/",
   "display": "standalone",

--- a/customer-app/modules/profile.js
+++ b/customer-app/modules/profile.js
@@ -112,7 +112,8 @@
             <button class="primary-btn" type="submit" ${h.claimStatus === "saving" ? "disabled" : ""}>
               ${h.claimStatus === "saving" ? "กำลังตรวจสอบ..." : "เชื่อมประวัติ"}
             </button>
-            <button class="secondary-btn" type="button" data-history-refresh ${loading ? "disabled" : ""}>โหลดประวัติ</button>
+            <button class="secondary-btn" type="button" data-history-refresh ${loading ? "disabled" : ""}>${h.schemaUnavailable ? "ลองใหม่" : "โหลดประวัติ"}</button>
+            ${h.schemaUnavailable ? `<a class="secondary-btn" href="https://lin.ee/fG1Oq7y" target="_blank" rel="noopener noreferrer">ติดต่อแอดมิน</a>` : ""}
           </div>
         </form>
         ${renderHistorySummary({ claimed, items, locations, loading, error: h.error || h.locationsError, detail: h.detail, detailStatus: h.detailStatus, detailError: h.detailError })}
@@ -197,12 +198,19 @@
         locations: Array.isArray(locationsData?.locations) ? locationsData.locations : [],
         error: "",
         locationsError: "",
+        schemaUnavailable: false,
       });
     } catch (error) {
       const message = error?.status === 503
-        ? "ระบบประวัติลูกค้ายังไม่พร้อมใช้งาน"
+        ? "ระบบเชื่อมประวัติอยู่ระหว่างเตรียมความพร้อม กรุณาลองใหม่หรือติดต่อแอดมิน"
         : (error?.message || "โหลดประวัติไม่สำเร็จ");
-      root.state.setCustomerHistory({ status: "error", locationsStatus: "error", error: message, locationsError: message });
+      root.state.setCustomerHistory({
+        status: "error",
+        locationsStatus: "error",
+        error: message,
+        locationsError: message,
+        schemaUnavailable: error?.status === 503,
+      });
     }
     paintHistory(container);
   }
@@ -245,13 +253,18 @@
             claimSuccess: "เชื่อมประวัติสำเร็จ",
             claimBookingCode: "",
             claimed: true,
+            schemaUnavailable: false,
           });
           await loadHistoryData(container);
-        } catch (_) {
+        } catch (error) {
+          const schemaUnavailable = error?.status === 503;
           root.state.setCustomerHistory({
             claimStatus: "error",
-            claimError: "ไม่สามารถยืนยันประวัติงานได้ กรุณาตรวจสอบข้อมูลอีกครั้ง",
+            claimError: schemaUnavailable
+              ? "ระบบเชื่อมประวัติอยู่ระหว่างเตรียมความพร้อม กรุณาลองใหม่หรือติดต่อแอดมิน"
+              : "ไม่สามารถยืนยันประวัติงานได้ กรุณาตรวจสอบข้อมูลอีกครั้ง",
             claimSuccess: "",
+            schemaUnavailable,
           });
           paintHistory(container);
         }
@@ -445,4 +458,5 @@
       else renderLoggedOut(container);
     },
   };
+  console.info("[customer-profile] customer history production ready v1 loaded");
 })();

--- a/customer-app/sw.js
+++ b/customer-app/sw.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const BUILD_ID = "20260715_smart_advisor_portal_autoflow_v3";
+const BUILD_ID = "20260716_customer_history_production_ready_v1";
 const CACHE_NAME = `cwf-customer-app-v2-${BUILD_ID}`;
 const APP_SHELL = [
   `./index.html?v=${BUILD_ID}`,

--- a/docs/CUSTOMER_HISTORY_CLAIMS_PRODUCTION_RUNBOOK.md
+++ b/docs/CUSTOMER_HISTORY_CLAIMS_PRODUCTION_RUNBOOK.md
@@ -1,0 +1,63 @@
+# Customer History Claims production runbook
+
+This migration is owner-operated. The application never applies it during server startup.
+
+## 1. Preflight (read-only)
+
+Run from the reviewed release commit with the production `DATABASE_URL` supplied through the deployment secret store:
+
+```sh
+npm run migrate:customer-history-claims:check
+```
+
+Expected status and exit codes:
+
+| Status | Exit | Meaning / action |
+| --- | ---: | --- |
+| `READY_TO_APPLY` | 0 | Prerequisites match and the claims table is absent. Continue only after owner approval. |
+| `ALREADY_APPLIED` | 0 | The exact expected schema is present. Do not apply again. Continue to verification. |
+| `PREREQUISITE_MISSING` | 2 | `customer_profiles.sub` or `jobs.job_id` is unsuitable. Stop; fix the prerequisite in a separately reviewed change. |
+| `SCHEMA_DRIFT` | 3 | The checked-in SQL checksum or an existing claims schema differs. Stop; inspect the drift. Do not overwrite it. |
+| `FAILED` | 1 | Connection, lock, or unexpected database failure. Stop and investigate without printing secrets. |
+
+The runner redacts database URLs, hosts, users, passwords, and tokens from surfaced errors. Do not paste the raw `DATABASE_URL` into a terminal transcript or ticket.
+
+## 2. Apply (owner approval required)
+
+Only when preflight returned `READY_TO_APPLY`, set the one-use confirmation value and apply from the same reviewed commit:
+
+```sh
+CONFIRM_CUSTOMER_HISTORY_CLAIMS_MIGRATION=APPLY_20260710_CUSTOMER_HISTORY_CLAIMS npm run migrate:customer-history-claims -- --apply
+```
+
+On PowerShell:
+
+```powershell
+$env:CONFIRM_CUSTOMER_HISTORY_CLAIMS_MIGRATION='APPLY_20260710_CUSTOMER_HISTORY_CLAIMS'
+npm run migrate:customer-history-claims -- --apply
+Remove-Item Env:CONFIRM_CUSTOMER_HISTORY_CLAIMS_MIGRATION
+```
+
+The apply path uses an advisory lock plus lock and statement timeouts. Any non-zero exit is a stop condition; do not retry blindly.
+
+## 3. Verify
+
+Run the read-only check again:
+
+```sh
+npm run migrate:customer-history-claims:check
+```
+
+It must return `ALREADY_APPLIED` with exit 0. Then verify through a non-production test account (or an owner-approved production smoke test) that:
+
+1. Wrong phone/code combinations return the same generic public failure.
+2. A valid full legacy phone plus Booking Code creates one claim.
+3. Repeating the same proof on the same account succeeds without a duplicate row.
+4. History and locations load, and a selected location prefills scheduled and urgent booking drafts.
+5. Server logs contain diagnostic codes only and no phone or Booking Code.
+
+## Rollback / stop conditions
+
+Stop immediately on `PREREQUISITE_MISSING`, `SCHEMA_DRIFT`, any non-zero apply result, unexpected row creation, or public PII disclosure. Do not edit production data to recover.
+
+The migration is additive. If rollback is approved before any claims exist, the reviewed outline is at the end of `migrations/20260710_customer_history_claims.sql`. Once claims exist, dropping the table destroys ownership records; take a backup and require an explicit owner/database review before any rollback. Application rollback can be performed independently by reverting the release commit; the server will fail closed with `CUSTOMER_HISTORY_SCHEMA_NOT_READY` when the expected schema is unavailable.

--- a/scripts/run-customer-history-claims-migration.js
+++ b/scripts/run-customer-history-claims-migration.js
@@ -10,6 +10,17 @@ const EXPECTED_SHA256 = "745446126557ec50d726bdd73a6d4ba8a6c67ba5f9239895186d075
 const CONFIRM_ENV = "CONFIRM_CUSTOMER_HISTORY_CLAIMS_MIGRATION";
 const CONFIRM_VALUE = "APPLY_20260710_CUSTOMER_HISTORY_CLAIMS";
 const ADVISORY_LOCK_KEY = "202607100152";
+const STATUS = Object.freeze({
+  READY_TO_APPLY: "READY_TO_APPLY",
+  ALREADY_APPLIED: "ALREADY_APPLIED",
+  PREREQUISITE_MISSING: "PREREQUISITE_MISSING",
+  SCHEMA_DRIFT: "SCHEMA_DRIFT",
+});
+const EXIT_CODE = Object.freeze({
+  FAILED: 1,
+  PREREQUISITE_MISSING: 2,
+  SCHEMA_DRIFT: 3,
+});
 
 function clean(value) {
   return String(value == null ? "" : value).trim();
@@ -28,6 +39,12 @@ function safeErrorMessage(error) {
     .replace(/\blocalhost(?::\d+)?\b/gi, "[REDACTED_HOST]");
 }
 
+function migrationError(status, message) {
+  const error = new Error(message);
+  error.migrationStatus = status;
+  return error;
+}
+
 function resolveMigrationPath(repoRoot = path.resolve(__dirname, "..")) {
   const root = path.resolve(repoRoot);
   const migrationPath = path.resolve(root, MIGRATION_RELATIVE_PATH);
@@ -43,13 +60,16 @@ function readMigrationSql(repoRoot) {
 }
 
 function migrationChecksum(repoRoot) {
-  return crypto.createHash("sha256").update(readMigrationSql(repoRoot), "utf8").digest("hex");
+  // Git may materialize the checked-in SQL with CRLF on Windows. Hash the
+  // canonical repository content so the immutable checksum is cross-platform.
+  const canonicalSql = readMigrationSql(repoRoot).replace(/\r\n/g, "\n");
+  return crypto.createHash("sha256").update(canonicalSql, "utf8").digest("hex");
 }
 
 function verifyChecksum(repoRoot) {
   const actual = migrationChecksum(repoRoot);
   if (actual !== EXPECTED_SHA256) {
-    throw new Error("migration checksum mismatch");
+    throw migrationError(STATUS.SCHEMA_DRIFT, "migration checksum mismatch");
   }
   return actual;
 }
@@ -76,8 +96,8 @@ async function inspectPreflight(client) {
       to_regclass('public.customer_history_claims') IS NOT NULL AS has_claims
   `);
   const t = tables.rows?.[0] || {};
-  if (!t.has_customer_profiles) throw new Error("customer_profiles prerequisite missing");
-  if (!t.has_jobs) throw new Error("jobs prerequisite missing");
+  if (!t.has_customer_profiles) throw migrationError(STATUS.PREREQUISITE_MISSING, "customer_profiles prerequisite missing");
+  if (!t.has_jobs) throw migrationError(STATUS.PREREQUISITE_MISSING, "jobs prerequisite missing");
 
   const columns = await client.query(`
     SELECT table_name, column_name, data_type, is_nullable
@@ -87,8 +107,12 @@ async function inspectPreflight(client) {
          OR (table_name='customer_profiles' AND column_name='sub'))
   `);
   const byTableColumn = new Map((columns.rows || []).map((row) => [`${row.table_name}.${row.column_name}`, row]));
-  if (byTableColumn.get("jobs.job_id")?.data_type !== "bigint") throw new Error("jobs.job_id must be bigint");
-  if (!byTableColumn.has("customer_profiles.sub")) throw new Error("customer_profiles.sub missing");
+  if (byTableColumn.get("jobs.job_id")?.data_type !== "bigint") {
+    throw migrationError(STATUS.PREREQUISITE_MISSING, "jobs.job_id must be bigint");
+  }
+  if (!byTableColumn.has("customer_profiles.sub")) {
+    throw migrationError(STATUS.PREREQUISITE_MISSING, "customer_profiles.sub missing");
+  }
 
   const subKey = await client.query(`
     SELECT con.conname,
@@ -107,14 +131,14 @@ async function inspectPreflight(client) {
     const names = Array.isArray(row.column_names) ? row.column_names : [];
     return names.length === 1 && names[0] === "sub";
   });
-  if (!supportsSubFk) throw new Error("customer_profiles.sub does not support FK");
+  if (!supportsSubFk) throw migrationError(STATUS.PREREQUISITE_MISSING, "customer_profiles.sub does not support FK");
 
   return { claimsExists: !!t.has_claims };
 }
 
 async function verifyAppliedSchema(client, options = {}) {
   const table = await client.query("SELECT to_regclass('public.customer_history_claims') AS table_name");
-  if (!table.rows?.[0]?.table_name) throw new Error("customer_history_claims table missing");
+  if (!table.rows?.[0]?.table_name) throw migrationError(STATUS.SCHEMA_DRIFT, "customer_history_claims table missing");
 
   const columns = await client.query(`
     SELECT column_name, data_type, is_nullable
@@ -139,7 +163,7 @@ async function verifyAppliedSchema(client, options = {}) {
   for (const [name, [type, nullable]] of Object.entries(expectedColumns)) {
     const row = cols.get(name);
     if (!row || row.data_type !== type || row.is_nullable !== nullable) {
-      throw new Error(`customer_history_claims column drift: ${name}`);
+      throw migrationError(STATUS.SCHEMA_DRIFT, `customer_history_claims column drift: ${name}`);
     }
   }
 
@@ -167,8 +191,8 @@ async function verifyAppliedSchema(client, options = {}) {
   const hasJobFk = (fks.rows || []).some((row) => row.foreign_table === "jobs"
     && (row.column_names || []).join(",") === "proof_job_id"
     && (row.foreign_column_names || []).join(",") === "job_id");
-  if (!hasCustomerFk) throw new Error("customer_sub FK missing");
-  if (!hasJobFk) throw new Error("proof_job_id FK missing");
+  if (!hasCustomerFk) throw migrationError(STATUS.SCHEMA_DRIFT, "customer_sub FK missing");
+  if (!hasJobFk) throw migrationError(STATUS.SCHEMA_DRIFT, "proof_job_id FK missing");
 
   const checks = await client.query(`
     SELECT conname, pg_get_constraintdef(oid) AS definition
@@ -177,9 +201,13 @@ async function verifyAppliedSchema(client, options = {}) {
        AND contype='c'
   `);
   const checkText = (checks.rows || []).map((row) => `${row.conname} ${row.definition}`).join("\n");
-  if (!/booking_code_phone/.test(checkText)) throw new Error("claim_method CHECK missing");
-  if (!/phone_norm/.test(checkText) || !/\^0\[0-9\]\{8,9\}\$/.test(checkText)) throw new Error("canonical phone_norm CHECK missing");
-  if (!/phone_last4/.test(checkText) || !/right\(phone_norm,\s*4\)/i.test(checkText)) throw new Error("phone_last4 CHECK missing");
+  if (!/booking_code_phone/.test(checkText)) throw migrationError(STATUS.SCHEMA_DRIFT, "claim_method CHECK missing");
+  if (!/phone_norm/.test(checkText) || !/\^0\[0-9\]\{8,9\}\$/.test(checkText)) {
+    throw migrationError(STATUS.SCHEMA_DRIFT, "canonical phone_norm CHECK missing");
+  }
+  if (!/phone_last4/.test(checkText) || !/right\(phone_norm,\s*4\)/i.test(checkText)) {
+    throw migrationError(STATUS.SCHEMA_DRIFT, "phone_last4 CHECK missing");
+  }
 
   const indexes = await client.query(`
     SELECT indexname, indexdef
@@ -192,18 +220,20 @@ async function verifyAppliedSchema(client, options = {}) {
   const activeProof = indexDefs.get("ux_customer_history_claims_active_proof_job") || "";
   const activeSub = indexDefs.get("idx_customer_history_claims_customer_sub") || "";
   if (!/UNIQUE/i.test(activePhone) || !/phone_norm/.test(activePhone) || !/revoked_at IS NULL/i.test(activePhone)) {
-    throw new Error("active phone partial unique index missing");
+    throw migrationError(STATUS.SCHEMA_DRIFT, "active phone partial unique index missing");
   }
   if (!/UNIQUE/i.test(activeProof) || !/proof_job_id/.test(activeProof) || !/revoked_at IS NULL/i.test(activeProof)) {
-    throw new Error("active proof job partial unique index missing");
+    throw migrationError(STATUS.SCHEMA_DRIFT, "active proof job partial unique index missing");
   }
   if (!/customer_sub/.test(activeSub) || !/revoked_at IS NULL/i.test(activeSub)) {
-    throw new Error("active customer_sub index missing");
+    throw migrationError(STATUS.SCHEMA_DRIFT, "active customer_sub index missing");
   }
 
   const count = await client.query("SELECT COUNT(*)::bigint AS count FROM public.customer_history_claims");
   const rowCount = Number(count.rows?.[0]?.count || 0);
-  if (options.expectEmpty && rowCount !== 0) throw new Error("customer_history_claims row count must be zero after first apply");
+  if (options.expectEmpty && rowCount !== 0) {
+    throw migrationError(STATUS.SCHEMA_DRIFT, "customer_history_claims row count must be zero after first apply");
+  }
   return { rowCount };
 }
 
@@ -211,9 +241,9 @@ async function preflight(client) {
   const info = await inspectPreflight(client);
   if (info.claimsExists) {
     await verifyAppliedSchema(client);
-    return { status: "ALREADY_APPLIED" };
+    return { status: STATUS.ALREADY_APPLIED };
   }
-  return { status: "READY_TO_APPLY" };
+  return { status: STATUS.READY_TO_APPLY };
 }
 
 function applyIntent(argv = [], env = process.env) {
@@ -241,13 +271,15 @@ async function runMigration(options = {}) {
   try {
     await client.connect();
     const preflightResult = await preflight(client);
-    if (preflightResult.status === "ALREADY_APPLIED") {
+    if (preflightResult.status === STATUS.ALREADY_APPLIED) {
+      logger.log(`CUSTOMER_HISTORY_CLAIMS_MIGRATION_STATUS=${STATUS.ALREADY_APPLIED}`);
       logger.log("CUSTOMER_HISTORY_CLAIMS_MIGRATION_ALREADY_APPLIED");
-      return { status: "ALREADY_APPLIED" };
+      return { status: STATUS.ALREADY_APPLIED };
     }
     if (!shouldApply) {
+      logger.log(`CUSTOMER_HISTORY_CLAIMS_MIGRATION_STATUS=${STATUS.READY_TO_APPLY}`);
       logger.log("CUSTOMER_HISTORY_CLAIMS_MIGRATION_PREFLIGHT_OK");
-      return { status: "READY_TO_APPLY" };
+      return { status: STATUS.READY_TO_APPLY };
     }
 
     const lock = await client.query("SELECT pg_try_advisory_lock($1::bigint) AS locked", [ADVISORY_LOCK_KEY]);
@@ -294,8 +326,16 @@ async function runCli(options = {}) {
     await runMigration(options);
     return 0;
   } catch (error) {
+    const status = error?.migrationStatus;
+    if (status === STATUS.PREREQUISITE_MISSING || status === STATUS.SCHEMA_DRIFT) {
+      logger.error(`CUSTOMER_HISTORY_CLAIMS_MIGRATION_STATUS=${status}`);
+    }
     logger.error(`CUSTOMER_HISTORY_CLAIMS_MIGRATION_FAILED: ${safeErrorMessage(error)}`);
-    return 1;
+    return status === STATUS.PREREQUISITE_MISSING
+      ? EXIT_CODE.PREREQUISITE_MISSING
+      : status === STATUS.SCHEMA_DRIFT
+        ? EXIT_CODE.SCHEMA_DRIFT
+        : EXIT_CODE.FAILED;
   }
 }
 
@@ -310,7 +350,9 @@ module.exports = {
   CONFIRM_ENV,
   CONFIRM_VALUE,
   EXPECTED_SHA256,
+  EXIT_CODE,
   MIGRATION_RELATIVE_PATH,
+  STATUS,
   applyIntent,
   createClientConfig,
   inspectPreflight,

--- a/server/routes/public/customerHistory.js
+++ b/server/routes/public/customerHistory.js
@@ -45,6 +45,16 @@ function createCustomerHistoryRoutes(deps = {}) {
     });
   }
 
+  function logUnavailable(route, ready, error) {
+    const dbCode = /^[A-Z0-9_]{2,16}$/.test(String(error?.code || "")) ? String(error.code) : undefined;
+    logger.warn?.("[customer_history] unavailable", {
+      diagnostic_code: "CUSTOMER_HISTORY_SCHEMA_NOT_READY",
+      schema_state: ready?.diagnostic_code || "CHECK_FAILED",
+      route,
+      ...(dbCode ? { db_code: dbCode } : {}),
+    });
+  }
+
   async function resolveClaimUniqueRace(customerSub, phone, proofJobId) {
     const r = await pool.query(
       `SELECT claim_id, customer_sub, phone_norm, phone_last4, proof_job_id
@@ -61,9 +71,18 @@ function createCustomerHistoryRoutes(deps = {}) {
     return { replayed: true, failed: false, phone_last4: row.phone_last4 || phone.phone_last4 };
   }
 
-  async function authorizedContext(db, customerSub) {
-    const ready = await history.schemaReady(db);
+  async function authorizedContext(db, customerSub, route) {
+    let ready;
+    try {
+      ready = await history.schemaReady(db);
+    } catch (error) {
+      logUnavailable(route, null, error);
+      const unavailable = new Error("CUSTOMER_HISTORY_SCHEMA_NOT_READY");
+      unavailable.status = 503;
+      throw unavailable;
+    }
     if (!ready.has_claims) {
+      logUnavailable(route, ready);
       const err = new Error("CUSTOMER_HISTORY_SCHEMA_NOT_READY");
       err.status = 503;
       throw err;
@@ -90,6 +109,7 @@ function createCustomerHistoryRoutes(deps = {}) {
       await client.query("BEGIN");
       const ready = await history.schemaReady(client);
       if (!ready.has_claims) {
+        logUnavailable("claim", ready);
         await client.query("ROLLBACK");
         return res.status(503).json({ error: "CUSTOMER_HISTORY_SCHEMA_NOT_READY" });
       }
@@ -169,7 +189,11 @@ function createCustomerHistoryRoutes(deps = {}) {
         } catch (_) {}
         return genericClaimFailure(res);
       }
-      logger.warn?.("[customer_history_claim] failed", { code: error.code || error.message || "error" });
+      if (error?.status === 503) logUnavailable("claim", null, error);
+      else logger.warn?.("[customer_history_claim] failed", {
+        diagnostic_code: "CUSTOMER_HISTORY_CLAIM_FAILED",
+        db_code: /^[A-Z0-9_]{2,16}$/.test(String(error?.code || "")) ? String(error.code) : undefined,
+      });
       return res.status(error.status || 500).json({ error: error.status === 503 ? "CUSTOMER_HISTORY_SCHEMA_NOT_READY" : "CLAIM_FAILED" });
     } finally {
       client.release();
@@ -183,7 +207,7 @@ function createCustomerHistoryRoutes(deps = {}) {
       return res.status(400).json({ error: "PHONE_QUERY_NOT_ALLOWED" });
     }
     try {
-      const ctx = await authorizedContext(pool, customerSub);
+      const ctx = await authorizedContext(pool, customerSub, "history");
       const auth = history.buildAuthorizedWhere({
         customerSub,
         hasCustomerSub: ctx.ready.has_customer_sub,
@@ -216,7 +240,7 @@ function createCustomerHistoryRoutes(deps = {}) {
       return res.status(400).json({ error: "PHONE_QUERY_NOT_ALLOWED" });
     }
     try {
-      const ctx = await authorizedContext(pool, customerSub);
+      const ctx = await authorizedContext(pool, customerSub, "locations");
       const auth = history.buildAuthorizedWhere({
         customerSub,
         hasCustomerSub: ctx.ready.has_customer_sub,
@@ -251,7 +275,7 @@ function createCustomerHistoryRoutes(deps = {}) {
     const parsed = history.parseJobRef({ secret: secret(), customerSub, jobRef: req.params.job_ref });
     if (!parsed) return res.status(404).json({ error: "NOT_FOUND" });
     try {
-      const ctx = await authorizedContext(pool, customerSub);
+      const ctx = await authorizedContext(pool, customerSub, "detail");
       const auth = history.buildAuthorizedWhere({
         customerSub,
         hasCustomerSub: ctx.ready.has_customer_sub,

--- a/server/routes/public/customerHistory.js
+++ b/server/routes/public/customerHistory.js
@@ -107,7 +107,14 @@ function createCustomerHistoryRoutes(deps = {}) {
     let proofJobId = null;
     try {
       await client.query("BEGIN");
-      const ready = await history.schemaReady(client);
+      let ready;
+      try {
+        ready = await history.schemaReady(client);
+      } catch (error) {
+        logUnavailable("claim", null, error);
+        try { await client.query("ROLLBACK"); } catch (_) {}
+        return res.status(503).json({ error: "CUSTOMER_HISTORY_SCHEMA_NOT_READY" });
+      }
       if (!ready.has_claims) {
         logUnavailable("claim", ready);
         await client.query("ROLLBACK");

--- a/server/services/public/customerHistory.js
+++ b/server/services/public/customerHistory.js
@@ -177,9 +177,115 @@ async function schemaReady(db) {
         WHERE table_schema='public' AND table_name='jobs' AND column_name='customer_sub'
       ) AS has_customer_sub
   `);
+  const tableExists = !!r.rows?.[0]?.has_claims;
+  const hasCustomerSub = !!r.rows?.[0]?.has_customer_sub;
+  if (!tableExists) {
+    return {
+      has_claims: false,
+      has_customer_sub: hasCustomerSub,
+      claims_table_exists: false,
+      diagnostic_code: "TABLE_MISSING",
+    };
+  }
+
+  const columns = await db.query(`
+    SELECT column_name, data_type, is_nullable
+      FROM information_schema.columns
+     WHERE table_schema='public'
+       AND table_name='customer_history_claims'
+  `);
+  const actual = new Map((columns.rows || []).map((row) => [row.column_name, row]));
+  const expected = {
+    claim_id: ["bigint", "NO"],
+    customer_sub: ["text", "NO"],
+    phone_norm: ["text", "NO"],
+    phone_last4: ["text", "NO"],
+    proof_job_id: ["bigint", "NO"],
+    claim_method: ["text", "NO"],
+    claimed_at: ["timestamp with time zone", "NO"],
+    last_verified_at: ["timestamp with time zone", "NO"],
+    revoked_at: ["timestamp with time zone", "YES"],
+    revoke_reason: ["text", "YES"],
+  };
+  const columnsValid = Object.entries(expected).every(([name, [type, nullable]]) => {
+    const row = actual.get(name);
+    return row && row.data_type === type && row.is_nullable === nullable;
+  });
+
+  const shape = await db.query(`
+    SELECT
+      EXISTS (
+        SELECT 1
+          FROM pg_constraint con
+          JOIN pg_class rel ON rel.oid=con.conrelid
+          JOIN pg_namespace nsp ON nsp.oid=rel.relnamespace
+         WHERE nsp.nspname='public' AND rel.relname='customer_history_claims'
+           AND con.contype='f'
+           AND pg_get_constraintdef(con.oid) ILIKE '%FOREIGN KEY (customer_sub) REFERENCES customer_profiles(sub)%'
+      ) AS has_customer_fk,
+      EXISTS (
+        SELECT 1
+          FROM pg_constraint con
+          JOIN pg_class rel ON rel.oid=con.conrelid
+          JOIN pg_namespace nsp ON nsp.oid=rel.relnamespace
+         WHERE nsp.nspname='public' AND rel.relname='customer_history_claims'
+           AND con.contype='f'
+           AND pg_get_constraintdef(con.oid) ILIKE '%FOREIGN KEY (proof_job_id) REFERENCES jobs(job_id)%'
+      ) AS has_job_fk,
+      EXISTS (
+        SELECT 1
+          FROM pg_constraint con
+          JOIN pg_class rel ON rel.oid=con.conrelid
+          JOIN pg_namespace nsp ON nsp.oid=rel.relnamespace
+         WHERE nsp.nspname='public' AND rel.relname='customer_history_claims'
+           AND con.contype='c' AND pg_get_constraintdef(con.oid) ILIKE '%booking_code_phone%'
+      ) AS has_method_check,
+      EXISTS (
+        SELECT 1
+          FROM pg_constraint con
+          JOIN pg_class rel ON rel.oid=con.conrelid
+          JOIN pg_namespace nsp ON nsp.oid=rel.relnamespace
+         WHERE nsp.nspname='public' AND rel.relname='customer_history_claims'
+           AND con.contype='c' AND pg_get_constraintdef(con.oid) LIKE '%phone_norm%'
+           AND pg_get_constraintdef(con.oid) LIKE '%^0[0-9]{8,9}$%'
+      ) AS has_phone_norm_check,
+      EXISTS (
+        SELECT 1
+          FROM pg_constraint con
+          JOIN pg_class rel ON rel.oid=con.conrelid
+          JOIN pg_namespace nsp ON nsp.oid=rel.relnamespace
+         WHERE nsp.nspname='public' AND rel.relname='customer_history_claims'
+           AND con.contype='c' AND pg_get_constraintdef(con.oid) LIKE '%phone_last4%'
+           AND pg_get_constraintdef(con.oid) ILIKE '%right(phone_norm, 4)%'
+      ) AS has_phone_last4_check,
+      EXISTS (
+        SELECT 1 FROM pg_indexes
+         WHERE schemaname='public' AND tablename='customer_history_claims'
+           AND indexname='ux_customer_history_claims_active_phone'
+           AND indexdef ILIKE '%UNIQUE%' AND indexdef ILIKE '%revoked_at IS NULL%'
+      ) AS has_active_phone_index,
+      EXISTS (
+        SELECT 1 FROM pg_indexes
+         WHERE schemaname='public' AND tablename='customer_history_claims'
+           AND indexname='ux_customer_history_claims_active_proof_job'
+           AND indexdef ILIKE '%UNIQUE%' AND indexdef ILIKE '%revoked_at IS NULL%'
+      ) AS has_active_proof_index,
+      EXISTS (
+        SELECT 1 FROM pg_indexes
+         WHERE schemaname='public' AND tablename='customer_history_claims'
+           AND indexname='idx_customer_history_claims_customer_sub'
+           AND indexdef ILIKE '%customer_sub%' AND indexdef ILIKE '%revoked_at IS NULL%'
+      ) AS has_active_sub_index
+  `);
+  const s = shape.rows?.[0] || {};
+  const shapeValid = !!s.has_customer_fk && !!s.has_job_fk
+    && !!s.has_method_check && !!s.has_phone_norm_check && !!s.has_phone_last4_check
+    && !!s.has_active_phone_index && !!s.has_active_proof_index && !!s.has_active_sub_index;
   return {
-    has_claims: !!r.rows?.[0]?.has_claims,
-    has_customer_sub: !!r.rows?.[0]?.has_customer_sub,
+    has_claims: columnsValid && shapeValid,
+    has_customer_sub: hasCustomerSub,
+    claims_table_exists: true,
+    diagnostic_code: columnsValid && shapeValid ? "READY" : "SCHEMA_DRIFT",
   };
 }
 

--- a/test/customerAppPageAvailability.test.js
+++ b/test/customerAppPageAvailability.test.js
@@ -281,7 +281,7 @@ test("api exposes loadCustomerAppConfig as a no-store GET to /public/customer-ap
 });
 
 test("build wiring: pageAvailability.js is registered in the HTML shell and the SW cache, with the new build id", () => {
-  const build = "20260715_smart_advisor_portal_autoflow_v3";
+  const build = "20260716_customer_history_production_ready_v1";
   assert.match(indexHtml, new RegExp(`modules/pageAvailability\\.js\\?v=${build}`));
   assert.match(swSrc, new RegExp(`BUILD_ID = "${build}"`));
   assert.match(swSrc, /modules\/pageAvailability\.js\?v=\$\{BUILD_ID\}/);
@@ -294,7 +294,7 @@ test("build wiring: pageAvailability.js is registered in the HTML shell and the 
    RUNTIME tests (execute the real code in a VM — not regex assertions).
    ========================================================================== */
 
-const BUILD = "20260715_smart_advisor_portal_autoflow_v3";
+const BUILD = "20260716_customer_history_production_ready_v1";
 const adminSrc = read("admin-homepage-cms.js");
 
 function reqUrlOf(req) {

--- a/test/customerAppRecovery.test.js
+++ b/test/customerAppRecovery.test.js
@@ -236,7 +236,7 @@ test("Customer App build id is consistent across shell and service worker", () =
   const sw = read("customer-app/sw.js");
   const app = read("customer-app/assets/customer-app.js");
   const manifest = read("customer-app/manifest.webmanifest");
-  const build = "20260715_smart_advisor_portal_autoflow_v3";
+  const build = "20260716_customer_history_production_ready_v1";
 
   assert.match(index, new RegExp(`customer-app\\.css\\?v=${build}`));
   assert.match(index, new RegExp(`modules\\/api\\.js\\?v=${build}`));
@@ -254,7 +254,7 @@ test("Customer App build id is consistent across shell and service worker", () =
 test("store module is loaded in index.html and precached in the service worker app shell", () => {
   const index = read("customer-app/index.html");
   const sw = read("customer-app/sw.js");
-  const build = "20260715_smart_advisor_portal_autoflow_v3";
+  const build = "20260716_customer_history_production_ready_v1";
 
   assert.match(index, new RegExp(`modules/store\\.js\\?v=${build}`));
   assert.match(sw, /`\.\/modules\/store\.js\?v=\$\{BUILD_ID\}`/);

--- a/test/customerAppStorePayment.test.js
+++ b/test/customerAppStorePayment.test.js
@@ -58,7 +58,7 @@ test("store falls back to the LINE hand-off when payment is unconfigured or the 
 test("payment step styles exist and the Customer App payment build id is bumped", () => {
   assert.match(cssSrc, /\.pay-method-btn/);
   assert.match(cssSrc, /\.pay-qr-img/);
-  assert.match(read("customer-app/index.html"), /modules\/store\.js\?v=20260715_smart_advisor_portal_autoflow_v3/);
-  assert.match(read("customer-app/sw.js"), /BUILD_ID = "20260715_smart_advisor_portal_autoflow_v3"/);
+  assert.match(read("customer-app/index.html"), /modules\/store\.js\?v=20260716_customer_history_production_ready_v1/);
+  assert.match(read("customer-app/sw.js"), /BUILD_ID = "20260716_customer_history_production_ready_v1"/);
   assert.match(storeSrc, /payment-security 20260705 loaded/);
 });

--- a/test/customerBookingAdminNotifications.test.js
+++ b/test/customerBookingAdminNotifications.test.js
@@ -311,10 +311,10 @@ test("admin/customer frontend cache versions are bumped for booking notification
   assert.doesNotMatch(adminReviewHtml, /admin-review-v2\.js\?v=20260707_customer_booking_notify_v2/);
   assert.match(adminReviewHtml, /admin-review-ai-intake\.js\?v=ai-booking-intake-customer-cards-v11-admin-alert-gate/);
   assert.doesNotMatch(adminReviewHtml, /admin-review-ai-intake\.js\?v=ai-booking-intake-customer-cards-v10/);
-  assert.match(customerIndex, /bookingScheduled\.js\?v=20260715_smart_advisor_portal_autoflow_v3/);
-  assert.match(customerIndex, /state\.js\?v=20260715_smart_advisor_portal_autoflow_v3/);
-  assert.match(customerSw, /const BUILD_ID = "20260715_smart_advisor_portal_autoflow_v3"/);
-  assert.match(customerManifest, /20260715_smart_advisor_portal_autoflow_v3/);
+  assert.match(customerIndex, /bookingScheduled\.js\?v=20260716_customer_history_production_ready_v1/);
+  assert.match(customerIndex, /state\.js\?v=20260716_customer_history_production_ready_v1/);
+  assert.match(customerSw, /const BUILD_ID = "20260716_customer_history_production_ready_v1"/);
+  assert.match(customerManifest, /20260716_customer_history_production_ready_v1/);
 });
 
 test("behavior: review queue only includes customer urgent waiting rows while preserving review statuses", () => {

--- a/test/customerHistoryClaim.test.js
+++ b/test/customerHistoryClaim.test.js
@@ -13,7 +13,7 @@ const history = require("../server/services/public/customerHistory");
 
 const REPO_ROOT = path.resolve(__dirname, "..");
 
-function makePool({ jobs = [], claims = [], hasClaims = true, hasCustomerSub = true, schemaDrift = false, failInsert = false, uniqueConflictClaim = null } = {}) {
+function makePool({ jobs = [], claims = [], hasClaims = true, hasCustomerSub = true, schemaDrift = false, schemaReadyError = null, failInsert = false, uniqueConflictClaim = null } = {}) {
   const state = {
     jobs: jobs.map((x) => ({ ...x })),
     claims: claims.map((x) => ({ ...x })),
@@ -21,6 +21,7 @@ function makePool({ jobs = [], claims = [], hasClaims = true, hasCustomerSub = t
     hasClaims,
     hasCustomerSub,
     schemaDrift,
+    schemaReadyError,
     failInsert,
     uniqueConflictClaim,
   };
@@ -29,6 +30,7 @@ function makePool({ jobs = [], claims = [], hasClaims = true, hasCustomerSub = t
     state.queries.push({ sql: s, params });
     if (/BEGIN|COMMIT|ROLLBACK/.test(s)) return { rows: [] };
     if (/to_regclass\('public\.customer_history_claims'\)/.test(s)) {
+      if (state.schemaReadyError) throw state.schemaReadyError;
       return { rows: [{ has_claims: state.hasClaims, has_customer_sub: state.hasCustomerSub }] };
     }
     if (/information_schema\.columns/.test(s) && /table_name='customer_history_claims'/.test(s)) {
@@ -210,6 +212,30 @@ test("missing or drifted claim schema returns 503 with safe diagnostics and no p
     assert.match(output, /CUSTOMER_HISTORY_SCHEMA_NOT_READY/);
     assert.doesNotMatch(output, /0812345678|CWFABC123/);
   }
+});
+
+test("claim schema readiness query exceptions roll back and return safe 503 without proof PII", async () => {
+  const phone = "0812345678";
+  const bookingCode = "CWFABC123";
+  const logs = [];
+  const schemaReadyError = Object.assign(new Error(`catalog failed for ${phone} ${bookingCode}`), { code: "42501" });
+  const pool = makePool({ jobs: [LEGACY_JOB], schemaReadyError });
+
+  await withServer({ pool, logger: { warn: (...args) => logs.push(args) } }, async (base) => {
+    const res = await fetch(`${base}/public/customer-history/claim`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ phone, booking_code: bookingCode }),
+    });
+    assert.equal(res.status, 503);
+    assert.deepEqual(await json(res), { error: "CUSTOMER_HISTORY_SCHEMA_NOT_READY" });
+  });
+
+  assert.ok(pool.state.queries.some(({ sql }) => /ROLLBACK/.test(sql)));
+  const output = JSON.stringify(logs);
+  assert.match(output, /CUSTOMER_HISTORY_SCHEMA_NOT_READY/);
+  assert.match(output, /42501/);
+  assert.doesNotMatch(output, new RegExp(`${phone}|${bookingCode}`));
 });
 
 test("wrong phone/code cases use generic CLAIM_FAILED and never fallback to partial phone sources", async () => {

--- a/test/customerHistoryClaim.test.js
+++ b/test/customerHistoryClaim.test.js
@@ -13,13 +13,14 @@ const history = require("../server/services/public/customerHistory");
 
 const REPO_ROOT = path.resolve(__dirname, "..");
 
-function makePool({ jobs = [], claims = [], hasClaims = true, hasCustomerSub = true, failInsert = false, uniqueConflictClaim = null } = {}) {
+function makePool({ jobs = [], claims = [], hasClaims = true, hasCustomerSub = true, schemaDrift = false, failInsert = false, uniqueConflictClaim = null } = {}) {
   const state = {
     jobs: jobs.map((x) => ({ ...x })),
     claims: claims.map((x) => ({ ...x })),
     queries: [],
     hasClaims,
     hasCustomerSub,
+    schemaDrift,
     failInsert,
     uniqueConflictClaim,
   };
@@ -29,6 +30,29 @@ function makePool({ jobs = [], claims = [], hasClaims = true, hasCustomerSub = t
     if (/BEGIN|COMMIT|ROLLBACK/.test(s)) return { rows: [] };
     if (/to_regclass\('public\.customer_history_claims'\)/.test(s)) {
       return { rows: [{ has_claims: state.hasClaims, has_customer_sub: state.hasCustomerSub }] };
+    }
+    if (/information_schema\.columns/.test(s) && /table_name='customer_history_claims'/.test(s)) {
+      const rows = [
+        ["claim_id", "bigint", "NO"], ["customer_sub", "text", "NO"],
+        ["phone_norm", "text", "NO"], ["phone_last4", "text", "NO"],
+        ["proof_job_id", "bigint", "NO"], ["claim_method", "text", "NO"],
+        ["claimed_at", "timestamp with time zone", "NO"],
+        ["last_verified_at", "timestamp with time zone", "NO"],
+        ["revoked_at", "timestamp with time zone", "YES"], ["revoke_reason", "text", "YES"],
+      ].map(([column_name, data_type, is_nullable]) => ({ column_name, data_type, is_nullable }));
+      return { rows: state.schemaDrift ? rows.filter((row) => row.column_name !== "phone_norm") : rows };
+    }
+    if (/AS has_customer_fk/.test(s)) {
+      return { rows: [{
+        has_customer_fk: true,
+        has_job_fk: true,
+        has_method_check: true,
+        has_phone_norm_check: true,
+        has_phone_last4_check: true,
+        has_active_phone_index: true,
+        has_active_proof_index: true,
+        has_active_sub_index: true,
+      }] };
     }
     if (/FROM public\.jobs\s+WHERE upper\(btrim/.test(s)) {
       const code = String(params[0] || "").toUpperCase();
@@ -169,6 +193,25 @@ test("unauthenticated claim returns 401", async () => {
   });
 });
 
+test("missing or drifted claim schema returns 503 with safe diagnostics and no proof PII", async () => {
+  for (const options of [{ hasClaims: false }, { hasClaims: true, schemaDrift: true }]) {
+    const logs = [];
+    const pool = makePool({ jobs: [LEGACY_JOB], ...options });
+    await withServer({ pool, logger: { warn: (...args) => logs.push(args) } }, async (base) => {
+      const res = await fetch(`${base}/public/customer-history/claim`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ phone: "0812345678", booking_code: "CWFABC123" }),
+      });
+      assert.equal(res.status, 503);
+      assert.equal((await json(res)).error, "CUSTOMER_HISTORY_SCHEMA_NOT_READY");
+    });
+    const output = JSON.stringify(logs);
+    assert.match(output, /CUSTOMER_HISTORY_SCHEMA_NOT_READY/);
+    assert.doesNotMatch(output, /0812345678|CWFABC123/);
+  }
+});
+
 test("wrong phone/code cases use generic CLAIM_FAILED and never fallback to partial phone sources", async () => {
   const pool = makePool({ jobs: [{ ...LEGACY_JOB, customer_note: "0812345678", address_text: "phone 0812345678 but not customer_phone", customer_phone: "0899999999" }] });
   await withServer({ pool }, async (base) => {
@@ -217,6 +260,36 @@ test("claim succeeds, retries by same account are idempotent, and other accounts
     });
     assert.equal(res.status, 400);
     assert.equal((await json(res)).error, "CLAIM_FAILED");
+  });
+});
+
+test("successful claim immediately authorizes history and location prefill data", async () => {
+  const pool = makePool({ jobs: [LEGACY_JOB] });
+  await withServer({ pool, sub: "line:u1" }, async (base) => {
+    const claim = await fetch(`${base}/public/customer-history/claim`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ phone: "0812345678", booking_code: "CWFABC123" }),
+    });
+    assert.equal(claim.status, 200);
+
+    const [historyRes, locationsRes] = await Promise.all([
+      fetch(`${base}/public/customer-history`),
+      fetch(`${base}/public/customer-history/locations`),
+    ]);
+    assert.equal(historyRes.status, 200);
+    assert.equal(locationsRes.status, 200);
+    const historyBody = await json(historyRes);
+    const locationsBody = await json(locationsRes);
+    assert.equal(historyBody.claimed, true);
+    assert.equal(historyBody.items.length, 1);
+    assert.equal(locationsBody.claimed, true);
+    assert.equal(locationsBody.locations[0].address_text, LEGACY_JOB.address_text);
+
+    const stateContext = makeBrowserContext();
+    const stateRoot = loadModule(stateContext, "customer-app/modules/state.js");
+    assert.equal(stateRoot.state.applyHistoryLocation("scheduled", locationsBody.locations[0]), true);
+    assert.equal(stateRoot.state.draft.scheduled.address_text, LEGACY_JOB.address_text);
   });
 });
 
@@ -543,8 +616,17 @@ test("Customer App profile opens history detail with opaque job_ref and clears c
   assert.equal(submitState.claimBookingCode, "");
 });
 
+test("Customer App schema-not-ready state offers retry and admin contact without weakening generic proof failure", () => {
+  const src = fs.readFileSync(path.join(REPO_ROOT, "customer-app/modules/profile.js"), "utf8");
+  assert.match(src, /schemaUnavailable \? "ลองใหม่" : "โหลดประวัติ"/);
+  assert.match(src, /ติดต่อแอดมิน/);
+  assert.match(src, /error\?\.status === 503/);
+  assert.match(src, /ไม่สามารถยืนยันประวัติงานได้ กรุณาตรวจสอบข้อมูลอีกครั้ง/);
+  assert.doesNotMatch(src, /เบอร์โทรไม่ถูก|Booking Code ไม่ถูก/);
+});
+
 test("Customer App cache version is bumped consistently", () => {
-  const expected = "20260715_smart_advisor_portal_autoflow_v3";
+  const expected = "20260716_customer_history_production_ready_v1";
   for (const file of [
     "customer-app/index.html",
     "customer-app/sw.js",

--- a/test/customerHistoryClaimsMigration.test.js
+++ b/test/customerHistoryClaimsMigration.test.js
@@ -148,7 +148,10 @@ test("default mode is read-only preflight and does not write", async () => {
   const client = new FakeClient({ hasClaims: false });
   const result = await runWithClient(client);
   assert.equal(result.code, 0);
-  assert.deepEqual(result.log.lines, ["CUSTOMER_HISTORY_CLAIMS_MIGRATION_PREFLIGHT_OK"]);
+  assert.deepEqual(result.log.lines, [
+    "CUSTOMER_HISTORY_CLAIMS_MIGRATION_STATUS=READY_TO_APPLY",
+    "CUSTOMER_HISTORY_CLAIMS_MIGRATION_PREFLIGHT_OK",
+  ]);
   assert.equal(client.queries.some((q) => q.sql.includes("pg_try_advisory_lock")), false);
   assert.equal(client.queries.some((q) => q.sql.includes("CREATE TABLE IF NOT EXISTS public.customer_history_claims")), false);
   assert.equal(client.ended, true);
@@ -179,37 +182,41 @@ test("checksum mismatch fails before DB write", async () => {
     logger: log,
     clientFactory: () => client,
   });
-  assert.equal(code, 1);
+  assert.equal(code, runner.EXIT_CODE.SCHEMA_DRIFT);
   assert.equal(client.connected, false);
   assert.match(log.lines.join("\n"), /CUSTOMER_HISTORY_CLAIMS_MIGRATION_FAILED/);
 });
 
 test("missing prerequisite schema and incorrect jobs.job_id type fail closed", async () => {
   const missing = await runWithClient(new FakeClient({ hasCustomerProfiles: false }));
-  assert.equal(missing.code, 1);
+  assert.equal(missing.code, runner.EXIT_CODE.PREREQUISITE_MISSING);
+  assert.match(missing.log.lines.join("\n"), /STATUS=PREREQUISITE_MISSING/);
 
   const wrongType = await runWithClient(new FakeClient({ jobIdType: "integer" }));
-  assert.equal(wrongType.code, 1);
+  assert.equal(wrongType.code, runner.EXIT_CODE.PREREQUISITE_MISSING);
 });
 
 test("already-applied exact schema exits successfully without running migration", async () => {
   const client = new FakeClient({ hasClaims: true });
   const result = await runWithClient(client);
   assert.equal(result.code, 0);
-  assert.deepEqual(result.log.lines, ["CUSTOMER_HISTORY_CLAIMS_MIGRATION_ALREADY_APPLIED"]);
+  assert.deepEqual(result.log.lines, [
+    "CUSTOMER_HISTORY_CLAIMS_MIGRATION_STATUS=ALREADY_APPLIED",
+    "CUSTOMER_HISTORY_CLAIMS_MIGRATION_ALREADY_APPLIED",
+  ]);
   assert.equal(client.queries.some((q) => q.sql.includes("CREATE TABLE IF NOT EXISTS public.customer_history_claims")), false);
 });
 
 test("schema drift fails closed", async () => {
   const result = await runWithClient(new FakeClient({ hasClaims: true, schemaDrift: "missing_index" }));
-  assert.equal(result.code, 1);
-  assert.match(result.log.lines.join("\n"), /CUSTOMER_HISTORY_CLAIMS_MIGRATION_FAILED/);
+  assert.equal(result.code, runner.EXIT_CODE.SCHEMA_DRIFT);
+  assert.match(result.log.lines.join("\n"), /STATUS=SCHEMA_DRIFT/);
 });
 
 test("advisory lock unavailable fails before migration SQL", async () => {
   const client = new FakeClient({ locked: false });
   const result = await runWithClient(client, { argv: ["--apply"], env: { [runner.CONFIRM_ENV]: runner.CONFIRM_VALUE } });
-  assert.equal(result.code, 1);
+  assert.equal(result.code, runner.EXIT_CODE.FAILED);
   assert.equal(client.queries.some((q) => q.sql.includes("CREATE TABLE IF NOT EXISTS public.customer_history_claims")), false);
   assert.equal(client.ended, true);
 });
@@ -246,7 +253,7 @@ test("migration SQL failure rolls back, unlocks, and closes", async () => {
 test("post-apply verification failure exits non-zero and still unlocks", async () => {
   const client = new FakeClient({ schemaDrift: "missing_check" });
   const result = await runWithClient(client, { argv: ["--apply"], env: { [runner.CONFIRM_ENV]: runner.CONFIRM_VALUE } });
-  assert.equal(result.code, 1);
+  assert.equal(result.code, runner.EXIT_CODE.SCHEMA_DRIFT);
   assert.ok(client.queries.some((q) => q.sql.includes("pg_advisory_unlock")));
   assert.equal(client.ended, true);
 });
@@ -273,4 +280,13 @@ test("package exposes explicit check and apply commands", () => {
   const pkg = JSON.parse(fs.readFileSync(path.join(REPO_ROOT, "package.json"), "utf8"));
   assert.equal(pkg.scripts["migrate:customer-history-claims:check"], "node scripts/run-customer-history-claims-migration.js");
   assert.equal(pkg.scripts["migrate:customer-history-claims"], "node scripts/run-customer-history-claims-migration.js");
+});
+
+test("migration checksum is stable across LF and CRLF checkouts", () => {
+  assert.equal(runner.migrationChecksum(REPO_ROOT), runner.EXPECTED_SHA256);
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "cwf-history-claims-eol-"));
+  fs.mkdirSync(path.join(tmp, "migrations"), { recursive: true });
+  const sql = fs.readFileSync(path.join(REPO_ROOT, runner.MIGRATION_RELATIVE_PATH), "utf8").replace(/\r?\n/g, "\r\n");
+  fs.writeFileSync(path.join(tmp, runner.MIGRATION_RELATIVE_PATH), sql, "utf8");
+  assert.equal(runner.migrationChecksum(tmp), runner.EXPECTED_SHA256);
 });

--- a/test/customerHomepageFeaturedRotation.test.js
+++ b/test/customerHomepageFeaturedRotation.test.js
@@ -414,6 +414,6 @@ test("compact CSS and cache build remain consistent with six-card rotation", () 
   assert.match(css, /\.homepage-featured-page\s*\{[^}]*grid-area:\s*1\s*\/\s*1/s);
   assert.match(css, /transition:\s*opacity 350ms/);
   assert.match(css, /prefers-reduced-motion:\s*reduce/);
-  const build = "20260715_smart_advisor_portal_autoflow_v3";
+  const build = "20260716_customer_history_production_ready_v1";
   for (const source of [html, sw, boot, manifest]) assert.match(source, new RegExp(build));
 });

--- a/test/customerSameDayTiming.test.js
+++ b/test/customerSameDayTiming.test.js
@@ -160,7 +160,7 @@ test("customer app disables availability HTTP cache and refreshes same-day slots
 });
 
 test("customer app build and service worker cache IDs changed", () => {
-  const id = "20260715_smart_advisor_portal_autoflow_v3";
+  const id = "20260716_customer_history_production_ready_v1";
   for (const file of [
     "customer-app/index.html",
     "customer-app/sw.js",

--- a/test/customerSmartAdvisor.test.js
+++ b/test/customerSmartAdvisor.test.js
@@ -1174,7 +1174,7 @@ test("Home places built-in advisor after Quick Actions and before Featured Servi
 });
 
 test("advisor module is loaded before ui.js and precached under the shared build id", () => {
-  const build = "20260715_smart_advisor_portal_autoflow_v3";
+  const build = "20260716_customer_history_production_ready_v1";
   assert.ok(INDEX_SOURCE.indexOf(`modules/advisor.js?v=${build}`) < INDEX_SOURCE.indexOf(`modules/ui.js?v=${build}`));
   assert.match(SW_SOURCE, new RegExp(`BUILD_ID = "${build}"`));
   assert.match(SW_SOURCE, /modules\/advisor\.js\?v=\$\{BUILD_ID\}/);

--- a/test/customerTrackingFullReadUi.test.js
+++ b/test/customerTrackingFullReadUi.test.js
@@ -770,7 +770,7 @@ test("tracking UI exposes loading, not-found, rate-limit and offline states", ()
 });
 
 test("tracking assets share the full-read cache build id", () => {
-  const build = "20260715_smart_advisor_portal_autoflow_v3";
+  const build = "20260716_customer_history_production_ready_v1";
   for (const file of [
     "customer-app/index.html",
     "customer-app/sw.js",

--- a/test/homepageCms.test.js
+++ b/test/homepageCms.test.js
@@ -296,7 +296,7 @@ test("customer homepage has no admin control, bottom nav is fixed five-tab, and 
   const sw = read("customer-app/sw.js");
   const app = read("customer-app/assets/customer-app.js");
   const manifest = read("customer-app/manifest.webmanifest");
-  const build = "20260715_smart_advisor_portal_autoflow_v3";
+  const build = "20260716_customer_history_production_ready_v1";
 
   assert.doesNotMatch(index + ui, /โหมดแอดมิน|openCms|localStorage\.getItem\('cwfHomeCmsDemo'/);
   assert.match(index, /data-route="store"[\s\S]*ร้านค้า/);


### PR DESCRIPTION
Closes #167

## Base / head

- Base `main`: `12de376557759d8e5825440c8a02b105f6886a3f`
- Head: `35eef46513b23a3b83b826b48c5e27254f2a3916`

## Root cause

- The production route was mounted correctly; route mounting was not the failure.
- Runtime readiness treated any existing `customer_history_claims` table as ready, so partial/drifted schema could pass the check and fail later.
- The migration runner detected several faults but surfaced prerequisite, drift, and checksum failures as one generic failure. Its raw checksum also changed on Windows CRLF checkouts.
- Customer App collapsed schema 503 into a dead-end message, and the claim handler hid the distinction needed to offer retry/support actions.
- Safe server diagnostics were incomplete across claim/history/location/detail schema failures.

## Changed files

Runtime and migration:
- `server/services/public/customerHistory.js`
- `server/routes/public/customerHistory.js`
- `scripts/run-customer-history-claims-migration.js`
- `docs/CUSTOMER_HISTORY_CLAIMS_PRODUCTION_RUNBOOK.md`

Customer UI/cache:
- `customer-app/modules/profile.js`
- `customer-app/index.html`
- `customer-app/sw.js`
- `customer-app/assets/customer-app.js`
- `customer-app/manifest.webmanifest`

Tests:
- `test/customerHistoryClaim.test.js`
- `test/customerHistoryClaimsMigration.test.js`
- nine existing Customer App build-ID contract tests updated only for the required cache bump.

## Implementation summary

- Runtime readiness now verifies the exact required columns/types/nullability, FKs, checks, and active partial indexes before serving claim/history/location/detail.
- Schema failures return 503 and log `CUSTOMER_HISTORY_SCHEMA_NOT_READY` with an allowlisted schema state/DB code only.
- Claim readiness query exceptions are caught inside the transaction, rolled back, safely diagnosed, and returned as `503 CUSTOMER_HISTORY_SCHEMA_NOT_READY` so the Customer App enters retry/contact state.
- Claim proof remains full normalized legacy phone + normalized Booking Code. Same-account replay remains idempotent; different-account and wrong-proof cases retain the same generic public failure.
- Successful claim refreshes history and locations immediately; integration coverage verifies location data can prefill the scheduled draft.
- UI now offers explicit retry and admin-contact actions for schema 503 instead of a dead state.
- Migration preflight exposes:
  - `READY_TO_APPLY` exit 0
  - `ALREADY_APPLIED` exit 0
  - `PREREQUISITE_MISSING` exit 2
  - `SCHEMA_DRIFT` exit 3
  - unexpected failure exit 1
- Migration checksum canonicalizes CRLF to LF without changing or applying the SQL.

## Security considerations

- No Customer JWT/auth contract changes.
- No rate-limit reductions.
- Wrong phone, wrong Booking Code, already-claimed-by-another-account, and unique-race failures remain indistinguishable publicly.
- Logs contain no full phone or Booking Code and redact database URL/host/user/password/token errors.
- Existing `private, no-store` response behavior remains.
- No payment, pricing, dispatch, technician assignment, production data, merge, or deploy changes.

## Exact validation

- `node --check` on all 17 changed JavaScript files: **PASS**
- `node --test test/customerHistoryClaim.test.js test/customerHistoryClaimsMigration.test.js`: **33/33 PASS**, including readiness-query throw → rollback + safe 503 + no proof PII
- Focused + affected cache contract run (11 test files): **364/364 PASS**
- `npm test` on PR head: **1,266 tests; 1,212 pass; 20 fail; 0 cancelled; 34 skipped**. All 20 remaining failures are exact-name matches from the untouched base; there are no failures introduced by this branch.
- `git diff --check`: **PASS**
- Final worktree after push: **clean**

## Baseline full-suite proof

Environment/dependency parity:
- Untouched detached worktree at base SHA `12de376557759d8e5825440c8a02b105f6886a3f`
- Node `v25.9.0`; npm `11.12.1`
- Both worktrees installed with `npm ci`
- Identical `package-lock.json` SHA-256: `B91DE7900F01B31D45E296C9AF014A7C99F9CD465CD3D8EA815D6709B43EFB03`

Comparison:
- Base: **1,261 tests; 1,199 pass; 28 fail; 0 cancelled; 34 skipped**
- PR head: **1,266 tests; 1,212 pass; 20 fail; 0 cancelled; 34 skipped**
- New failure names on PR head: **0**
- Shared exact failure names: **20/20**
- Base-only failures fixed by this PR: **8**, all customer-history migration-runner tests affected by the CRLF-sensitive checksum behavior corrected in this PR.

Exact shared baseline failure names (all in unchanged `test/adminStoreCatalogUi.test.js`):
1. `a single failed upload can be retried without touching files that already succeeded, and can be dismissed without retrying`
2. `bindGalleryActions wires retry/remove buttons (data-qact) in addition to the existing image actions (data-gact)`
3. `booking section shows only booking_mode/ac_type/btu/wash_variant prominently; service_key is tucked into a collapsed Advanced subsection`
4. `closeCatalogModal refuses to close while a gallery upload is in flight instead of silently discarding it`
5. `confirmDeleteCatalogItem calls the real DELETE endpoint and surfaces a Cloudinary cleanup warning distinctly from plain success`
6. `delete confirmation modal warns extra when the item is currently active and visible to customers`
7. `gallery delete/set-primary/reorder actions guard against double-clicks while a gallery action is in flight`
8. `hidden/collapsed fields (price-rule-matching accordion, booking advanced subsection) are populated on edit just like visible fields, so collapsing them never clears stored values`
9. `image upload only happens after the item is saved and an itemId exists`
10. `loadReviews sends status/source as server-side query params (so unassigned/approved_unassigned filter the full table, not just the latest fetched page)`
11. `onGalleryImagePicked builds a per-file status queue, blocks picking while already uploading, and clearly reports over-limit truncation instead of staying silent`
12. `openCatalogModalForEdit never assigns blank/empty values when raw pricing data exists (no data loss on open+save)`
13. `review action buttons never expose customer phone/email/internal IDs beyond completed_job_id and a display identity`
14. `review action buttons support approve/reject/hide/restore-to-pending depending on current status`
15. `runGalleryUploadQueue uploads sequentially with per-file status transitions, reloads the gallery, keeps failed items for retry, and never re-uploads a succeeded file`
16. `setReviewModerationStatus confirms before acting, PATCHes the review, and updates state without a full reload`
17. `the 7-section reorganization does not change which element id backs each field: every id read in catalogModalPayload is also written in openCatalogModalForEdit, so reordering sections never drops a value on open+save`
18. `the catalog modal's HTML template is a fully-balanced tag tree (catches stray/missing closing tags that text-window regexes can miss), and sections 5/6/7 plus the error box stay direct children of .cwf-modal-body`
19. `the gallery manager shows a save-first message instead of upload controls when there is no editingItemId yet`
20. `the gallery upload queue shows a per-file pending/uploading/done/error status with a retry/remove action on failure, and a live in-progress count`

Base-only failure names corrected by the PR's migration checksum/preflight implementation:
- `advisory lock unavailable fails before migration SQL`
- `already-applied exact schema exits successfully without running migration`
- `default mode is read-only preflight and does not write`
- `migration SQL failure rolls back, unlocks, and closes`
- `migration success uses lock, timeouts, verifies schema, and unlocks`
- `post-apply verification failure exits non-zero and still unlocks`
- `secrets are redacted from failure logs`
- `unlock and client.end run after lock-protected errors`

## 360px / 390px UI screenshots

Responsive schema-not-ready state was rendered with production Customer App CSS and captured successfully:
- 360px: `issue-167-ui-360.jpg` (local delivery artifact)
- 390px: `issue-167-ui-390.jpg` (local delivery artifact)

The GitHub connector cannot upload binary attachments, so the local files must be attached to this Draft PR manually if inline PR images are required.

## Production migration action (owner only)

Do not apply automatically or during server startup. Follow `docs/CUSTOMER_HISTORY_CLAIMS_PRODUCTION_RUNBOOK.md`:

1. Run `npm run migrate:customer-history-claims:check`.
2. Continue only on `READY_TO_APPLY` after owner approval, or stop on `PREREQUISITE_MISSING` / `SCHEMA_DRIFT`.
3. Owner apply command:
   `CONFIRM_CUSTOMER_HISTORY_CLAIMS_MIGRATION=APPLY_20260710_CUSTOMER_HISTORY_CLAIMS npm run migrate:customer-history-claims -- --apply`
4. Run preflight again and require `ALREADY_APPLIED`.

No production migration or production data action was performed by Codex.

## Remaining risks

- Production schema state has not been queried and migration has not been applied; the owner must run the preflight/runbook.
- Full-suite green remains blocked by the 20 exact-name baseline failures in unchanged `test/adminStoreCatalogUi.test.js`; the branch introduces no new failure names.
- Screenshot binaries require manual attachment because the connector has no binary-upload operation.
