### PR TITLE
Restore completed-job Customer App reviews

### DIFF
--- a/customer-app/assets/customer-app.css
+++ b/customer-app/assets/customer-app.css
@@ -2011,6 +2011,77 @@ p { margin: 0; }
   flex-direction: column;
   gap: 12px;
 }
+.review-form-card,
+.catalog-review-form-card,
+.review-readonly-card,
+.review-form-card form,
+.catalog-review-form-card form { min-width: 0; }
+.review-star-field {
+  min-width: 0;
+  margin: 0;
+  padding: 0;
+  border: 0;
+}
+.review-star-field legend {
+  margin-bottom: 8px;
+  color: var(--ink);
+  font-size: 14px;
+  font-weight: 800;
+}
+.review-star-options {
+  display: grid;
+  grid-template-columns: repeat(5, minmax(44px, 1fr));
+  gap: 6px;
+  width: 100%;
+  max-width: 360px;
+  min-width: 0;
+}
+.review-star-radio {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  clip-path: inset(50%);
+  white-space: nowrap;
+}
+.review-star-choice {
+  display: inline-flex;
+  min-width: 44px;
+  min-height: 44px;
+  align-items: center;
+  justify-content: center;
+  gap: 3px;
+  padding: 6px 4px;
+  border: 1px solid var(--line);
+  border-radius: 12px;
+  background: #fff;
+  color: #9aa5b1;
+  cursor: pointer;
+  font-size: 25px;
+  line-height: 1;
+  touch-action: manipulation;
+}
+.review-star-choice small {
+  color: currentColor;
+  font-size: 11px;
+  font-weight: 900;
+}
+.review-star-radio:checked + .review-star-choice {
+  border-color: #e2a600;
+  background: var(--soft-yellow);
+  color: #d99a00;
+  box-shadow: 0 0 0 2px rgba(255, 196, 0, 0.14);
+}
+.review-star-radio:focus-visible + .review-star-choice {
+  outline: 3px solid var(--blue);
+  outline-offset: 2px;
+}
+.review-star-choice:hover { border-color: #e2a600; color: #d99a00; }
+.review-submit-status { min-height: 22px; overflow-wrap: anywhere; }
+.review-form-card button[type="submit"],
+.catalog-review-form-card button[type="submit"] { min-height: 44px; }
 .review-summary-card p,
 .warranty-card p { line-height: 1.65; }
 .preserve-lines { white-space: pre-wrap; }
@@ -2101,6 +2172,8 @@ p { margin: 0; }
   .tracking-service-lines span { text-align: left; }
   .support-strip { display: grid; grid-template-columns: 1fr 1fr; }
   .support-strip .secondary-btn { width: 100%; }
+  .review-star-options { gap: 4px; }
+  .review-star-choice { padding-inline: 2px; font-size: 23px; }
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/customer-app/assets/customer-app.js
+++ b/customer-app/assets/customer-app.js
@@ -3,7 +3,7 @@
 
   const App = window.CWFCustomerAppV2;
   const BOOT_TIMEOUT_MS = 3500;
-  const BUILD_ID = "20260717_customer_history_line_hotfix_v1";
+  const BUILD_ID = "20260717_customer_review_restore_v1";
 
   function withTimeout(promise, timeoutMs) {
     return Promise.race([

--- a/customer-app/index.html
+++ b/customer-app/index.html
@@ -21,10 +21,10 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Noto+Sans+Thai:wght@400;500;600;700;800;900&display=swap" media="print" onload="this.media='all'">
   <noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Noto+Sans+Thai:wght@400;500;600;700;800;900&display=swap"></noscript>
-  <link rel="manifest" href="./manifest.webmanifest?v=20260717_customer_history_line_hotfix_v1">
+  <link rel="manifest" href="./manifest.webmanifest?v=20260717_customer_review_restore_v1">
   <link rel="icon" type="image/png" sizes="192x192" href="./assets/icons/cwf-customer-192.png">
   <link rel="apple-touch-icon" sizes="180x180" href="./assets/icons/cwf-customer-180.png">
-  <link rel="stylesheet" href="./assets/customer-app.css?v=20260717_customer_history_line_hotfix_v1">
+  <link rel="stylesheet" href="./assets/customer-app.css?v=20260717_customer_review_restore_v1">
 </head>
 <body class="is-app-booting">
   <div class="app-shell" data-app-shell>
@@ -62,24 +62,24 @@
     </nav>
   </div>
 
-  <script src="./modules/iconRegistry.js?v=20260717_customer_history_line_hotfix_v1"></script>
-  <script src="./modules/state.js?v=20260717_customer_history_line_hotfix_v1"></script>
-  <script src="./modules/utils.js?v=20260717_customer_history_line_hotfix_v1"></script>
-  <script src="./modules/analytics.js?v=20260717_customer_history_line_hotfix_v1"></script>
-  <script src="./modules/api.js?v=20260717_customer_history_line_hotfix_v1"></script>
-  <script src="./modules/pageAvailability.js?v=20260717_customer_history_line_hotfix_v1"></script>
-  <script src="./modules/services.js?v=20260717_customer_history_line_hotfix_v1"></script>
-  <script src="./modules/advisor.js?v=20260717_customer_history_line_hotfix_v1"></script>
-  <script src="./modules/ui.js?v=20260717_customer_history_line_hotfix_v1"></script>
-  <script src="./modules/store.js?v=20260717_customer_history_line_hotfix_v1"></script>
-  <script src="./modules/auth.js?v=20260717_customer_history_line_hotfix_v1"></script>
-  <script src="./modules/pricing.js?v=20260717_customer_history_line_hotfix_v1"></script>
-  <script src="./modules/availability.js?v=20260717_customer_history_line_hotfix_v1"></script>
-  <script src="./modules/bookingScheduled.js?v=20260717_customer_history_line_hotfix_v1"></script>
-  <script src="./modules/bookingUrgent.js?v=20260717_customer_history_line_hotfix_v1"></script>
-  <script src="./modules/tracking.js?v=20260717_customer_history_line_hotfix_v1"></script>
-  <script src="./modules/profile.js?v=20260717_customer_history_line_hotfix_v1"></script>
-  <script src="./modules/router.js?v=20260717_customer_history_line_hotfix_v1"></script>
-  <script src="./assets/customer-app.js?v=20260717_customer_history_line_hotfix_v1"></script>
+  <script src="./modules/iconRegistry.js?v=20260717_customer_review_restore_v1"></script>
+  <script src="./modules/state.js?v=20260717_customer_review_restore_v1"></script>
+  <script src="./modules/utils.js?v=20260717_customer_review_restore_v1"></script>
+  <script src="./modules/analytics.js?v=20260717_customer_review_restore_v1"></script>
+  <script src="./modules/api.js?v=20260717_customer_review_restore_v1"></script>
+  <script src="./modules/pageAvailability.js?v=20260717_customer_review_restore_v1"></script>
+  <script src="./modules/services.js?v=20260717_customer_review_restore_v1"></script>
+  <script src="./modules/advisor.js?v=20260717_customer_review_restore_v1"></script>
+  <script src="./modules/ui.js?v=20260717_customer_review_restore_v1"></script>
+  <script src="./modules/store.js?v=20260717_customer_review_restore_v1"></script>
+  <script src="./modules/auth.js?v=20260717_customer_review_restore_v1"></script>
+  <script src="./modules/pricing.js?v=20260717_customer_review_restore_v1"></script>
+  <script src="./modules/availability.js?v=20260717_customer_review_restore_v1"></script>
+  <script src="./modules/bookingScheduled.js?v=20260717_customer_review_restore_v1"></script>
+  <script src="./modules/bookingUrgent.js?v=20260717_customer_review_restore_v1"></script>
+  <script src="./modules/tracking.js?v=20260717_customer_review_restore_v1"></script>
+  <script src="./modules/profile.js?v=20260717_customer_review_restore_v1"></script>
+  <script src="./modules/router.js?v=20260717_customer_review_restore_v1"></script>
+  <script src="./assets/customer-app.js?v=20260717_customer_review_restore_v1"></script>
 </body>
 </html>

--- a/customer-app/manifest.webmanifest
+++ b/customer-app/manifest.webmanifest
@@ -2,7 +2,7 @@
   "name": "CWF Customer Service",
   "short_name": "CWF Service",
   "description": "แอปลูกค้า Coldwindflow สำหรับเลือกบริการ จองคิว และติดตามงาน",
-  "start_url": "/customer-app/index.html?v=20260717_customer_history_line_hotfix_v1#home",
+  "start_url": "/customer-app/index.html?v=20260717_customer_review_restore_v1#home",
   "scope": "/customer-app/",
   "id": "/customer-app/",
   "display": "standalone",

--- a/customer-app/modules/tracking.js
+++ b/customer-app/modules/tracking.js
@@ -1029,15 +1029,17 @@
   function renderTechnicianReviewForm(data) {
     if (!isDone(data) || data.review?.already_reviewed) return "";
     // Reviewing is a WRITE. Two authorised shapes, mirroring the server policy:
-    //  - token lookup (access_level "token"): the exact booking_token authorises,
-    //    posted as a hidden field. No PII entry needed.
+    //  - token lookup (access_level "token"): the exact booking_token authorises
+    //    and is injected from in-memory state only at submit time. No PII entry needed.
     //  - LEGACY job with no booking_token: a booking_code lookup exposes a
     //    minimal `legacy_review_eligible` flag; the customer proves ownership by
     //    typing their FULL phone, posted as booking_code + customer_phone.
     // A tokened job accessed by code is NOT legacy-eligible, so it never shows
     // the legacy form (the server would reject a downgrade anyway).
     const reviewToken = canUseTokenActions(data) ? (data.booking_token || "") : "";
-    const legacyEligible = !reviewToken && canUseTokenActions(data) && data.legacy_review_eligible === true;
+    const legacyEligible = !reviewToken
+      && data.legacy_review_eligible === true
+      && !!clean(data.booking_code);
     if (!reviewToken && !legacyEligible) return "";
     // For token access the booking_token is NOT written into the form (it would
     // leak into rendered HTML). The form is marked data-review-token and the
@@ -1063,16 +1065,7 @@
         ${legacyHint}
         <form data-review-form${reviewToken ? " data-review-token" : ""}>
           ${credentialFields}
-          <label class="field">
-            <span>คะแนน</span>
-            <select class="input" name="rating">
-              <option value="5">5 - ดีมาก</option>
-              <option value="4">4 - ดี</option>
-              <option value="3">3 - พอใช้</option>
-              <option value="2">2 - ควรปรับปรุง</option>
-              <option value="1">1 - ไม่พอใจ</option>
-            </select>
-          </label>
+          ${renderStarRatingField("technician", "คะแนนทีมช่าง")}
           <label class="field">
             <span>รีวิว</span>
             <textarea class="input" name="review_text" rows="3" placeholder="เขียนรีวิว (ถ้ามี)"></textarea>
@@ -1082,7 +1075,7 @@
             <textarea class="input" name="complaint_text" rows="2" placeholder="ส่งถึงทีม CWF (ถ้ามี)"></textarea>
           </label>
           <button class="primary-btn" type="submit">ส่งรีวิว</button>
-          <p class="muted" data-review-status></p>
+          <p class="muted review-submit-status" data-review-status role="status" aria-live="polite"></p>
         </form>
       </section>
     `;
@@ -1090,6 +1083,22 @@
 
   function renderReview(data) {
     return renderExistingTechnicianReviewSummary(data) || renderTechnicianReviewForm(data);
+  }
+
+  function renderStarRatingField(prefix, label) {
+    const choices = [1, 2, 3, 4, 5].map((rating) => {
+      const id = `${prefix}-review-rating-${rating}`;
+      return `
+        <input class="review-star-radio" type="radio" name="rating" id="${id}" value="${rating}"${rating === 5 ? " checked" : ""} required>
+        <label class="review-star-choice" for="${id}" aria-label="${rating} ดาว">
+          <span aria-hidden="true">★</span><small>${rating}</small>
+        </label>`;
+    }).join("");
+    return `
+      <fieldset class="review-star-field">
+        <legend>${esc(label)}</legend>
+        <div class="review-star-options">${choices}</div>
+      </fieldset>`;
   }
 
   // Separate, additional section from renderReview() above (which rates the
@@ -1139,22 +1148,13 @@
           <h2>รีวิวบริการนี้</h2>
         </div>
         <form data-catalog-review-form>
-          <label class="field">
-            <span>คะแนนบริการ</span>
-            <select class="input" name="rating">
-              <option value="5">5 - ดีมาก</option>
-              <option value="4">4 - ดี</option>
-              <option value="3">3 - พอใช้</option>
-              <option value="2">2 - ควรปรับปรุง</option>
-              <option value="1">1 - ไม่พอใจ</option>
-            </select>
-          </label>
+          ${renderStarRatingField("catalog", "คะแนนบริการ")}
           <label class="field">
             <span>ความเห็น</span>
             <textarea class="input" name="comment" rows="3" placeholder="เขียนรีวิวบริการ (ถ้ามี)"></textarea>
           </label>
           <button class="primary-btn" type="submit">ส่งรีวิว</button>
-          <p class="muted" data-catalog-review-status></p>
+          <p class="muted review-submit-status" data-catalog-review-status role="status" aria-live="polite"></p>
         </form>
       </section>
     `;
@@ -1162,6 +1162,32 @@
 
   function renderCatalogReview(data) {
     return renderExistingCatalogReviewSummary(data) || renderCatalogReviewForm(data);
+  }
+
+  function reviewFormKind(data) {
+    if (!isDone(data)) return "";
+    if (data.review?.already_reviewed || data.catalog_review?.already_reviewed) return "";
+
+    const hasExactToken = canUseTokenActions(data) && !!clean(data.booking_token);
+    if (hasExactToken && data.catalog_review?.eligible === true) return "catalog";
+    const hasLegacyPhoneProofPath = data.legacy_review_eligible === true && !!clean(data.booking_code);
+    if (hasExactToken || hasLegacyPhoneProofPath) return "technician";
+    return "";
+  }
+
+  function renderReviewUnavailableNotice(data) {
+    if (!isDone(data)
+      || data.review?.already_reviewed
+      || data.catalog_review?.already_reviewed
+      || reviewFormKind(data)) return "";
+    return `
+      <section class="tracking-extra-card review-readonly-card" role="note">
+        <div class="section-head compact">
+          <span class="section-kicker">Review</span>
+          <h2>การให้คะแนนเป็นแบบอ่านอย่างเดียว</h2>
+        </div>
+        <p class="muted">การค้นด้วย Booking Code ใช้ดูสถานะได้ แต่บันทึกคะแนนไม่ได้ กรุณาเปิดลิงก์ติดตามงานแบบปลอดภัยที่ได้รับจาก CWF หรือติดต่อแอดมิน</p>
+      </section>`;
   }
 
   function renderWarranty(data) {
@@ -1210,17 +1236,18 @@
       renderWarranty(data),
     ];
 
-    // Documents and new-review forms remain exact-token actions. Keep the
-    // existing single-form rule: catalog review is primary when its API shape
-    // exists; technician review is the legacy fallback only when absent.
-    const catalogReviewAvailable = data.catalog_review != null;
-    const privilegedContent = canUseTokenActions(data)
-      ? [
-          renderReceipt(data),
-          catalogReviewAvailable ? renderCatalogReviewForm(data) : renderTechnicianReviewForm(data),
-        ]
-      : [];
-    const content = [...readOnlyContent, ...privilegedContent].filter(Boolean).join("");
+    // Choose exactly one write surface. Catalog is primary only when it is
+    // genuinely eligible with an exact token. Ineligible/null Catalog data
+    // falls back to Technician review. A legacy no-token job may use the
+    // existing booking-code + full-phone proof contract.
+    const formKind = reviewFormKind(data);
+    const actionContent = [
+      canUseTokenActions(data) ? renderReceipt(data) : "",
+      formKind === "catalog" ? renderCatalogReviewForm(data) : "",
+      formKind === "technician" ? renderTechnicianReviewForm(data) : "",
+      renderReviewUnavailableNotice(data),
+    ];
+    const content = [...readOnlyContent, ...actionContent].filter(Boolean).join("");
     return content || root.utils.stateBox("", "รายละเอียดหลังบริการจะแสดงหลังงานเสร็จ");
   }
 
@@ -1692,10 +1719,13 @@
         payload.rating = Number(payload.rating || 5);
         if (status) status.textContent = "กำลังส่งรีวิว...";
         if (submit) submit.disabled = true;
+        form.setAttribute("aria-busy", "true");
         try {
           const response = await fetch(`${root.api.getApiBase()}/public/review`, {
             method: "POST",
             headers: { "Content-Type": "application/json" },
+            cache: "no-store",
+            referrerPolicy: "no-referrer",
             body: JSON.stringify(payload),
           });
           const data = await response.json().catch(() => ({}));
@@ -1705,6 +1735,7 @@
         } catch (error) {
           if (status) status.textContent = error.message || "ส่งรีวิวไม่สำเร็จ";
           if (submit) submit.disabled = false;
+          form.removeAttribute("aria-busy");
         }
       });
     }
@@ -1718,10 +1749,14 @@
         const formData = Object.fromEntries(new FormData(catalogForm).entries());
         // Credential from state, not the DOM.
         const d = root.state.tracking.data || {};
-        if (!canUseTokenActions(d) || !d.booking_token) return;
+        if (!canUseTokenActions(d) || !d.booking_token) {
+          if (status) status.textContent = "สิทธิ์รีวิวหมดอายุ กรุณาเปิดลิงก์ติดตามงานอีกครั้ง";
+          return;
+        }
         const token = d.booking_token;
         if (status) status.textContent = "กำลังส่งรีวิว...";
         if (submit) submit.disabled = true;
+        catalogForm.setAttribute("aria-busy", "true");
         try {
           await root.api.submitTrackingReview(token, {
             rating: Number(formData.rating || 5),
@@ -1732,6 +1767,7 @@
         } catch (error) {
           if (status) status.textContent = (error && error.message) || "ส่งรีวิวไม่สำเร็จ";
           if (submit) submit.disabled = false;
+          catalogForm.removeAttribute("aria-busy");
         }
       });
     }
@@ -1806,11 +1842,13 @@
       receiptUrl,
       renderReview,
       renderCatalogReview,
+      reviewFormKind,
       renderAftercare,
       renderPassport,
       renderUnitPassportCards,
       renderTrackingResult,
       renderTimeline,
+      bindResultActions,
       cleanlinessRecommendation,
       renderCleanlinessHighlight,
       nextServiceGuidance,
@@ -1820,4 +1858,5 @@
       unitInspection,
     },
   };
+  console.info("[customer-tracking] review restore v1 loaded");
 })();

--- a/customer-app/sw.js
+++ b/customer-app/sw.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const BUILD_ID = "20260717_customer_history_line_hotfix_v1";
+const BUILD_ID = "20260717_customer_review_restore_v1";
 const CACHE_NAME = `cwf-customer-app-v2-${BUILD_ID}`;
 const APP_SHELL = [
   `./index.html?v=${BUILD_ID}`,

--- a/server/services/public/trackingPrivacy.js
+++ b/server/services/public/trackingPrivacy.js
@@ -229,7 +229,11 @@ function redactPublicTrackPayload(payload) {
     },
     can_view_full_tracking: true,
     can_use_token_actions: false,
-    legacy_review_eligible: false,
+    // A true value is emitted only for a completed legacy job that has no
+    // booking token. It is not a write credential: /public/review still
+    // requires the booking code plus an exact full-phone proof. Tokened jobs
+    // always arrive here with false, so code-only access cannot downgrade.
+    legacy_review_eligible: source.legacy_review_eligible === true,
     booking_code: source.booking_code || null,
     customer_name: source.customer_name || null,
     customer_phone: source.customer_phone || null,

--- a/test/customerAppPageAvailability.test.js
+++ b/test/customerAppPageAvailability.test.js
@@ -281,7 +281,7 @@ test("api exposes loadCustomerAppConfig as a no-store GET to /public/customer-ap
 });
 
 test("build wiring: pageAvailability.js is registered in the HTML shell and the SW cache, with the new build id", () => {
-  const build = "20260717_customer_history_line_hotfix_v1";
+  const build = "20260717_customer_review_restore_v1";
   assert.match(indexHtml, new RegExp(`modules/pageAvailability\\.js\\?v=${build}`));
   assert.match(swSrc, new RegExp(`BUILD_ID = "${build}"`));
   assert.match(swSrc, /modules\/pageAvailability\.js\?v=\$\{BUILD_ID\}/);
@@ -294,7 +294,7 @@ test("build wiring: pageAvailability.js is registered in the HTML shell and the 
    RUNTIME tests (execute the real code in a VM — not regex assertions).
    ========================================================================== */
 
-const BUILD = "20260717_customer_history_line_hotfix_v1";
+const BUILD = "20260717_customer_review_restore_v1";
 const adminSrc = read("admin-homepage-cms.js");
 
 function reqUrlOf(req) {

--- a/test/customerAppRecovery.test.js
+++ b/test/customerAppRecovery.test.js
@@ -236,7 +236,7 @@ test("Customer App build id is consistent across shell and service worker", () =
   const sw = read("customer-app/sw.js");
   const app = read("customer-app/assets/customer-app.js");
   const manifest = read("customer-app/manifest.webmanifest");
-  const build = "20260717_customer_history_line_hotfix_v1";
+  const build = "20260717_customer_review_restore_v1";
 
   assert.match(index, new RegExp(`customer-app\\.css\\?v=${build}`));
   assert.match(index, new RegExp(`modules\\/api\\.js\\?v=${build}`));
@@ -254,7 +254,7 @@ test("Customer App build id is consistent across shell and service worker", () =
 test("store module is loaded in index.html and precached in the service worker app shell", () => {
   const index = read("customer-app/index.html");
   const sw = read("customer-app/sw.js");
-  const build = "20260717_customer_history_line_hotfix_v1";
+  const build = "20260717_customer_review_restore_v1";
 
   assert.match(index, new RegExp(`modules/store\\.js\\?v=${build}`));
   assert.match(sw, /`\.\/modules\/store\.js\?v=\$\{BUILD_ID\}`/);

--- a/test/customerAppStorePayment.test.js
+++ b/test/customerAppStorePayment.test.js
@@ -58,7 +58,7 @@ test("store falls back to the LINE hand-off when payment is unconfigured or the 
 test("payment step styles exist and the Customer App payment build id is bumped", () => {
   assert.match(cssSrc, /\.pay-method-btn/);
   assert.match(cssSrc, /\.pay-qr-img/);
-  assert.match(read("customer-app/index.html"), /modules\/store\.js\?v=20260717_customer_history_line_hotfix_v1/);
-  assert.match(read("customer-app/sw.js"), /BUILD_ID = "20260717_customer_history_line_hotfix_v1"/);
+  assert.match(read("customer-app/index.html"), /modules\/store\.js\?v=20260717_customer_review_restore_v1/);
+  assert.match(read("customer-app/sw.js"), /BUILD_ID = "20260717_customer_review_restore_v1"/);
   assert.match(storeSrc, /payment-security 20260705 loaded/);
 });

--- a/test/customerBookingAdminNotifications.test.js
+++ b/test/customerBookingAdminNotifications.test.js
@@ -311,10 +311,10 @@ test("admin/customer frontend cache versions are bumped for booking notification
   assert.doesNotMatch(adminReviewHtml, /admin-review-v2\.js\?v=20260707_customer_booking_notify_v2/);
   assert.match(adminReviewHtml, /admin-review-ai-intake\.js\?v=ai-booking-intake-customer-cards-v11-admin-alert-gate/);
   assert.doesNotMatch(adminReviewHtml, /admin-review-ai-intake\.js\?v=ai-booking-intake-customer-cards-v10/);
-  assert.match(customerIndex, /bookingScheduled\.js\?v=20260717_customer_history_line_hotfix_v1/);
-  assert.match(customerIndex, /state\.js\?v=20260717_customer_history_line_hotfix_v1/);
-  assert.match(customerSw, /const BUILD_ID = "20260717_customer_history_line_hotfix_v1"/);
-  assert.match(customerManifest, /20260717_customer_history_line_hotfix_v1/);
+  assert.match(customerIndex, /bookingScheduled\.js\?v=20260717_customer_review_restore_v1/);
+  assert.match(customerIndex, /state\.js\?v=20260717_customer_review_restore_v1/);
+  assert.match(customerSw, /const BUILD_ID = "20260717_customer_review_restore_v1"/);
+  assert.match(customerManifest, /20260717_customer_review_restore_v1/);
 });
 
 test("behavior: review queue only includes customer urgent waiting rows while preserving review statuses", () => {

--- a/test/customerHistoryClaim.test.js
+++ b/test/customerHistoryClaim.test.js
@@ -656,7 +656,7 @@ test("Customer App schema-not-ready state offers retry and admin contact without
 });
 
 test("Customer App cache version is bumped consistently", () => {
-  const expected = "20260717_customer_history_line_hotfix_v1";
+  const expected = "20260717_customer_review_restore_v1";
   for (const file of [
     "customer-app/index.html",
     "customer-app/sw.js",

--- a/test/customerHomepageFeaturedRotation.test.js
+++ b/test/customerHomepageFeaturedRotation.test.js
@@ -414,6 +414,6 @@ test("compact CSS and cache build remain consistent with six-card rotation", () 
   assert.match(css, /\.homepage-featured-page\s*\{[^}]*grid-area:\s*1\s*\/\s*1/s);
   assert.match(css, /transition:\s*opacity 350ms/);
   assert.match(css, /prefers-reduced-motion:\s*reduce/);
-  const build = "20260717_customer_history_line_hotfix_v1";
+  const build = "20260717_customer_review_restore_v1";
   for (const source of [html, sw, boot, manifest]) assert.match(source, new RegExp(build));
 });

--- a/test/customerSameDayTiming.test.js
+++ b/test/customerSameDayTiming.test.js
@@ -160,7 +160,7 @@ test("customer app disables availability HTTP cache and refreshes same-day slots
 });
 
 test("customer app build and service worker cache IDs changed", () => {
-  const id = "20260717_customer_history_line_hotfix_v1";
+  const id = "20260717_customer_review_restore_v1";
   for (const file of [
     "customer-app/index.html",
     "customer-app/sw.js",

--- a/test/customerSmartAdvisor.test.js
+++ b/test/customerSmartAdvisor.test.js
@@ -1174,7 +1174,7 @@ test("Home places built-in advisor after Quick Actions and before Featured Servi
 });
 
 test("advisor module is loaded before ui.js and precached under the shared build id", () => {
-  const build = "20260717_customer_history_line_hotfix_v1";
+  const build = "20260717_customer_review_restore_v1";
   assert.ok(INDEX_SOURCE.indexOf(`modules/advisor.js?v=${build}`) < INDEX_SOURCE.indexOf(`modules/ui.js?v=${build}`));
   assert.match(SW_SOURCE, new RegExp(`BUILD_ID = "${build}"`));
   assert.match(SW_SOURCE, /modules\/advisor\.js\?v=\$\{BUILD_ID\}/);

--- a/test/customerTrackingFullReadUi.test.js
+++ b/test/customerTrackingFullReadUi.test.js
@@ -19,7 +19,7 @@ function escapeHtml(value) {
     .replace(/'/g, "&#039;");
 }
 
-function loadTrackingRuntime() {
+function loadTrackingRuntime(options = {}) {
   const app = {
     state: {
       tracking: { status: "idle", data: null, error: "" },
@@ -34,7 +34,10 @@ function loadTrackingRuntime() {
       stateBox: (status, message) => `<div class="${escapeHtml(status)}">${escapeHtml(message)}</div>`,
       timeline: (items) => items.map((item) => `<div>${escapeHtml(item.title)}:${escapeHtml(item.copy)}</div>`).join(""),
     },
-    api: { getApiBase: () => "https://example.test" },
+    api: {
+      getApiBase: () => "https://example.test",
+      ...(options.api || {}),
+    },
   };
   const sandbox = {
     window: {
@@ -45,8 +48,8 @@ function loadTrackingRuntime() {
     navigator: { clipboard: { writeText: async () => {} } },
     URL,
     console: { info() {}, warn() {}, error() {} },
-    FormData,
-    fetch: async () => { throw new Error("unexpected fetch"); },
+    FormData: options.FormData || FormData,
+    fetch: options.fetch || (async () => { throw new Error("unexpected fetch"); }),
     setTimeout,
     clearTimeout,
     Date,
@@ -717,6 +720,153 @@ test("token completed retains documents and one eligible write-review flow", () 
   assert.match(html, /เงื่อนไขรับประกัน/);
 });
 
+test("token completed falls back to technician review when catalog review is ineligible", () => {
+  const app = loadTrackingRuntime();
+  const data = {
+    ...completedHealthPayload(),
+    access_level: "token",
+    can_use_token_actions: true,
+    capabilities: { can_view_full_tracking: true, can_use_token_actions: true },
+    booking_token: "private-token",
+    catalog_review: { eligible: false, already_reviewed: false, review: null },
+  };
+  const html = app.tracking._test.renderAftercare(data);
+  assert.match(html, /data-review-form data-review-token/);
+  assert.doesNotMatch(html, /data-catalog-review-form/);
+  assert.doesNotMatch(html, /private-token/);
+});
+
+test("token completed falls back to technician review when catalog review is null", () => {
+  const app = loadTrackingRuntime();
+  const data = {
+    ...completedHealthPayload(),
+    access_level: "token",
+    can_use_token_actions: true,
+    capabilities: { can_view_full_tracking: true, can_use_token_actions: true },
+    booking_token: "private-token",
+    catalog_review: null,
+  };
+  const html = app.tracking._test.renderAftercare(data);
+  assert.match(html, /data-review-form data-review-token/);
+  assert.doesNotMatch(html, /data-catalog-review-form|private-token/);
+});
+
+test("legacy completed job shows phone-proof technician form without granting token actions", () => {
+  const app = loadTrackingRuntime();
+  const data = {
+    ...completedHealthPayload(),
+    legacy_review_eligible: true,
+    catalog_review: { eligible: false, already_reviewed: false, review: null },
+  };
+  const html = app.tracking._test.renderAftercare(data);
+  assert.match(html, /data-review-form/);
+  assert.match(html, /name="booking_code" value="CWFABC1234"/);
+  assert.match(html, /name="customer_phone"/);
+  assert.doesNotMatch(html, /data-review-token|data-catalog-review-form|booking_token/);
+});
+
+test("ordinary code-only completed job is read-only with an explicit explanation", () => {
+  const app = loadTrackingRuntime();
+  const data = completedHealthPayload({ legacy_review_eligible: false });
+  const html = app.tracking._test.renderAftercare(data);
+  assert.match(html, /การให้คะแนนเป็นแบบอ่านอย่างเดียว/);
+  assert.match(html, /Booking Code/);
+  assert.doesNotMatch(html, /data-review-form|data-catalog-review-form/);
+});
+
+test("tracking review forms use five accessible 44px star choices and never render the token", () => {
+  const app = loadTrackingRuntime();
+  const data = {
+    ...completedHealthPayload(),
+    access_level: "token",
+    can_use_token_actions: true,
+    capabilities: { can_view_full_tracking: true, can_use_token_actions: true },
+    booking_token: "private-token",
+    catalog_review: { eligible: true, already_reviewed: false, review: null },
+  };
+  const catalogHtml = app.tracking._test.renderAftercare(data);
+  assert.equal((catalogHtml.match(/class="review-star-radio"/g) || []).length, 5);
+  assert.equal((catalogHtml.match(/class="review-star-choice"/g) || []).length, 5);
+  assert.match(catalogHtml, /aria-label="1 ดาว"/);
+  assert.match(catalogHtml, /aria-label="5 ดาว"/);
+  assert.match(catalogHtml, /role="status" aria-live="polite"/);
+  assert.doesNotMatch(catalogHtml, /<select|private-token|booking_token/);
+  assert.match(CSS_SOURCE, /\.review-star-choice\s*\{[\s\S]*?min-width:\s*44px;[\s\S]*?min-height:\s*44px;/);
+  assert.match(CSS_SOURCE, /grid-template-columns:\s*repeat\(5,\s*minmax\(44px,\s*1fr\)\)/);
+  assert.match(CSS_SOURCE, /\.review-star-radio:focus-visible \+ \.review-star-choice/);
+});
+
+test("failed technician review request re-enables submit and exposes the error", async () => {
+  let submitHandler;
+  const status = { textContent: "" };
+  const submit = { disabled: false };
+  const busy = new Set();
+  const form = {
+    addEventListener(type, handler) { if (type === "submit") submitHandler = handler; },
+    querySelector(selector) {
+      if (selector === "[data-review-status]") return status;
+      if (selector === "button[type='submit']") return submit;
+      return null;
+    },
+    hasAttribute(name) { return name === "data-review-token"; },
+    setAttribute(name) { busy.add(name); },
+    removeAttribute(name) { busy.delete(name); },
+  };
+  class ReviewFormData {
+    entries() { return [["rating", "4"], ["review_text", "ทดสอบ"]][Symbol.iterator](); }
+  }
+  const app = loadTrackingRuntime({
+    FormData: ReviewFormData,
+    fetch: async () => ({ ok: false, json: async () => ({ error: "ส่งไม่สำเร็จ" }) }),
+  });
+  app.state.tracking.data = { booking_token: "private-token" };
+  const container = {
+    querySelector(selector) { return selector === "[data-review-form]" ? form : null; },
+  };
+  app.tracking._test.bindResultActions(container);
+  await submitHandler({ preventDefault() {} });
+  assert.equal(submit.disabled, false);
+  assert.equal(status.textContent, "ส่งไม่สำเร็จ");
+  assert.equal(busy.has("aria-busy"), false);
+});
+
+test("failed catalog review request re-enables submit and exposes the error", async () => {
+  let submitHandler;
+  const status = { textContent: "" };
+  const submit = { disabled: false };
+  const busy = new Set();
+  const form = {
+    addEventListener(type, handler) { if (type === "submit") submitHandler = handler; },
+    querySelector(selector) {
+      if (selector === "[data-catalog-review-status]") return status;
+      if (selector === "button[type='submit']") return submit;
+      return null;
+    },
+    setAttribute(name) { busy.add(name); },
+    removeAttribute(name) { busy.delete(name); },
+  };
+  class ReviewFormData {
+    entries() { return [["rating", "3"], ["comment", "ทดสอบ"]][Symbol.iterator](); }
+  }
+  const app = loadTrackingRuntime({
+    FormData: ReviewFormData,
+    api: { submitTrackingReview: async () => { throw new Error("ส่งไม่สำเร็จ"); } },
+  });
+  app.state.tracking.data = {
+    access_level: "token",
+    can_use_token_actions: true,
+    booking_token: "private-token",
+  };
+  const container = {
+    querySelector(selector) { return selector === "[data-catalog-review-form]" ? form : null; },
+  };
+  app.tracking._test.bindResultActions(container);
+  await submitHandler({ preventDefault() {} });
+  assert.equal(submit.disabled, false);
+  assert.equal(status.textContent, "ส่งไม่สำเร็จ");
+  assert.equal(busy.has("aria-busy"), false);
+});
+
 test("token completed with existing reviews shows both summaries and no duplicate form", () => {
   const app = loadTrackingRuntime();
   const data = {
@@ -770,7 +920,7 @@ test("tracking UI exposes loading, not-found, rate-limit and offline states", ()
 });
 
 test("tracking assets share the full-read cache build id", () => {
-  const build = "20260717_customer_history_line_hotfix_v1";
+  const build = "20260717_customer_review_restore_v1";
   for (const file of [
     "customer-app/index.html",
     "customer-app/sw.js",

--- a/test/customerTrackingPrivacy.test.js
+++ b/test/customerTrackingPrivacy.test.js
@@ -127,10 +127,12 @@ test("a brand-new sensitive field added upstream does NOT leak through code reda
   assert.equal(redacted.some_future_pii_field, undefined);
 });
 
-test("booking-code read model never advertises legacy or catalog write eligibility", () => {
+test("booking-code read model exposes only legacy full-phone-proof eligibility and never catalog/token write eligibility", () => {
   assert.equal(trackingPrivacy.redactPublicTrackPayload(richPayload()).legacy_review_eligible, false);
   const eligible = trackingPrivacy.redactPublicTrackPayload({ ...richPayload(), legacy_review_eligible: true });
-  assert.equal(eligible.legacy_review_eligible, false);
+  assert.equal(eligible.legacy_review_eligible, true);
+  assert.equal(eligible.capabilities.can_submit_review, false);
+  assert.equal(eligible.catalog_review.eligible, false);
   assert.equal(eligible.booking_token, undefined);
 });
 

--- a/test/homepageCms.test.js
+++ b/test/homepageCms.test.js
@@ -305,7 +305,7 @@ test("customer homepage has no admin control, bottom nav is fixed five-tab, and 
   const sw = read("customer-app/sw.js");
   const app = read("customer-app/assets/customer-app.js");
   const manifest = read("customer-app/manifest.webmanifest");
-  const build = "20260717_customer_history_line_hotfix_v1";
+  const build = "20260717_customer_review_restore_v1";
 
   assert.doesNotMatch(index + ui, /โหมดแอดมิน|openCms|localStorage\.getItem\('cwfHomeCmsDemo'/);
   assert.match(index, /data-route="store"[\s\S]*ร้านค้า/);


### PR DESCRIPTION
Closes #168

## Base / head

- Base: `c5e874c38955245b61d17073a2e772b94fe482d4`
- Head: `8c518612bbe75eca91c75ac5ab2cd70d739a3c33`
- Branch: `codex/customer-review-restore`

## Confirmed root cause

1. `renderAftercare()` treated any non-null `catalog_review` object as the primary write surface. When the object was present but `eligible=false`, `renderCatalogReviewForm()` returned an empty string and Technician review never received the fallback.
2. The existing server contract supports a completed legacy job with no booking token through booking code + exact full-phone proof, but the booking-code privacy projector forced `legacy_review_eligible=false` and the UI additionally gated that flag behind token actions, making the legacy path unreachable.
3. Tracking review forms used a native select instead of touch-friendly, keyboard-accessible 1–5 star controls.
4. Code-only completed jobs had no explicit explanation for why review writing was unavailable.

## Review decision table

| State | Customer App result |
| --- | --- |
| Existing Technician or Catalog review | Render the persisted summary; render no duplicate form |
| Completed + exact token + Catalog eligible | Render one Catalog review form |
| Completed + exact token + Catalog ineligible | Fall back to one Technician review form |
| Completed + exact token + Catalog null/unavailable | Fall back to one Technician review form |
| Completed legacy no-token job + server-projected eligibility | Render Technician review with booking code + exact full-phone proof |
| Ordinary Booking Code lookup | Read-only summary/warranty plus an explicit secure-link/contact explanation; no write form |
| Wrong/near-miss token | Existing server routes deny the write |
| Failed request | Show the error, clear busy state, and re-enable submit |

## Implementation

- Added one deterministic review-surface decision so Catalog is primary only when genuinely eligible.
- Restored Technician fallback for ineligible/null Catalog data.
- Restored the existing legacy full-phone-proof UI path without granting token actions to ordinary booking-code access.
- Replaced both rating selects with five native radio controls, 44px minimum targets, selected/focus-visible states, accessible labels, and live status text.
- Added explicit loading, error, success, read-only, and expired-credential copy.
- Kept success reload behavior so persisted review summaries replace the form.
- Bumped the Customer App build/cache ID to `20260717_customer_review_restore_v1`.

## Changed files

Core:

- `customer-app/modules/tracking.js`
- `customer-app/assets/customer-app.css`
- `server/services/public/trackingPrivacy.js`
- `customer-app/index.html`
- `customer-app/sw.js`
- `customer-app/assets/customer-app.js`
- `customer-app/manifest.webmanifest`

Tests:

- `test/customerTrackingFullReadUi.test.js`
- `test/customerTrackingPrivacy.test.js`
- Active Customer App build/cache assertions in:
  - `test/customerAppPageAvailability.test.js`
  - `test/customerAppRecovery.test.js`
  - `test/customerAppStorePayment.test.js`
  - `test/customerBookingAdminNotifications.test.js`
  - `test/customerHistoryClaim.test.js`
  - `test/customerHomepageFeaturedRotation.test.js`
  - `test/customerSameDayTiming.test.js`
  - `test/customerSmartAdvisor.test.js`
  - `test/homepageCms.test.js`

## Security considerations

- Exact booking token remains the write credential for tokened jobs.
- Booking Code alone remains read-only and `capabilities.can_submit_review` remains false.
- Legacy write requires an actual no-token job plus exact full-phone proof under the existing `POST /public/review` contract.
- No token is rendered into HTML, hidden inputs, visible URL, local/session storage, or console logs.
- Technician POST uses `cache: no-store` and `referrerPolicy: no-referrer`.
- Catalog POST continues to resolve the job and target server-side from the exact token, hash the token for audit, rate-limit by hash/IP, lock the job, and reject duplicates.
- No rate-limit, no-store, no-referrer, Customer JWT, auth/session, payment, pricing, booking, dispatch, or technician-assignment contract was weakened.

## Exact validation

- `node --check` on all 15 changed JavaScript files — PASS
- Focused command covering review routes/privacy/UI plus all affected build assertions — PASS, 433/433
- Review-focused subset — PASS, 119/119
- `npm test` on PR branch — 1,283 tests; 1,229 pass; 20 pre-existing failures
- `npm test` on untouched base `c5e874c38955245b61d17073a2e772b94fe482d4` using the same environment/dependencies — 1,276 tests; 1,222 pass; the same 20 failures
- Normalized failure-name comparison — branch-only: 0; base-only: 0
- Customer and root manifest JSON parse — PASS
- `git diff --check` — PASS
- Working tree after commit — clean

## Responsive / interaction QA

Local browser QA using the production Customer App CSS and actual tracking renderer:

| Viewport | Horizontal overflow | Stars | Submit | Credential exposure |
| --- | --- | --- | --- | --- |
| 320px | none | 5 targets, each >=44px | 54px | none |
| 360px | none | 5 targets, each >=44px | 54px | none |
| 390px | none | 5 targets, each >=44px | 54px | none |
| 430px | none | 5 targets, each >=44px | 54px | none |

Tap selection, native radio semantics, keyboard focus-visible contract, loading/error status, and failed-request re-enable were verified. Screenshot files were generated at 320/360/390/430px; the available GitHub connector does not support binary attachment upload and the browser session is read-only, so the local files are included in the delivery handoff rather than falsely claiming an attachment.

## Migration / Production action

None. This PR adds no migration and requires no Production data action. Do not deploy or merge as part of this task.

## Remaining risks

- The full suite has 20 pre-existing `adminStoreCatalogUi` failures on both base and branch; no branch-only failures were introduced.
- Browser QA uses a local deterministic completed-job fixture. Production smoke testing should use a non-sensitive test booking after owner-approved deployment.
