### PR TITLE
fix: support quoted right() in customer history schema readiness

### DIFF
--- a/server/services/public/customerHistory.js
+++ b/server/services/public/customerHistory.js
@@ -255,8 +255,8 @@ async function schemaReady(db) {
           JOIN pg_class rel ON rel.oid=con.conrelid
           JOIN pg_namespace nsp ON nsp.oid=rel.relnamespace
          WHERE nsp.nspname='public' AND rel.relname='customer_history_claims'
-           AND con.contype='c' AND pg_get_constraintdef(con.oid) LIKE '%phone_last4%'
-           AND pg_get_constraintdef(con.oid) ILIKE '%right(phone_norm, 4)%'
+           AND con.contype='c'
+           AND pg_get_constraintdef(con.oid) ~* 'phone_last4[[:space:]]*=[[:space:]]*(right|"right")[[:space:]]*\\([[:space:]]*phone_norm[[:space:]]*,[[:space:]]*4[[:space:]]*\\)'
       ) AS has_phone_last4_check,
       EXISTS (
         SELECT 1 FROM pg_indexes

--- a/test/customerHistoryClaim.test.js
+++ b/test/customerHistoryClaim.test.js
@@ -13,7 +13,7 @@ const history = require("../server/services/public/customerHistory");
 
 const REPO_ROOT = path.resolve(__dirname, "..");
 
-function makePool({ jobs = [], claims = [], hasClaims = true, hasCustomerSub = true, schemaDrift = false, schemaReadyError = null, failInsert = false, uniqueConflictClaim = null } = {}) {
+function makePool({ jobs = [], claims = [], hasClaims = true, hasCustomerSub = true, schemaDrift = false, phoneLast4Check = true, schemaReadyError = null, failInsert = false, uniqueConflictClaim = null } = {}) {
   const state = {
     jobs: jobs.map((x) => ({ ...x })),
     claims: claims.map((x) => ({ ...x })),
@@ -21,6 +21,7 @@ function makePool({ jobs = [], claims = [], hasClaims = true, hasCustomerSub = t
     hasClaims,
     hasCustomerSub,
     schemaDrift,
+    phoneLast4Check,
     schemaReadyError,
     failInsert,
     uniqueConflictClaim,
@@ -50,7 +51,7 @@ function makePool({ jobs = [], claims = [], hasClaims = true, hasCustomerSub = t
         has_job_fk: true,
         has_method_check: true,
         has_phone_norm_check: true,
-        has_phone_last4_check: true,
+        has_phone_last4_check: state.phoneLast4Check,
         has_active_phone_index: true,
         has_active_proof_index: true,
         has_active_sub_index: true,
@@ -186,6 +187,39 @@ test("claim phone normalizer supports exact local, dashed, +66, and 0066 only", 
   }
   assert.equal(history.normalizeClaimPhone("812345678"), null);
   assert.equal(history.normalizeClaimPhone("12345678"), null);
+});
+
+test("schema readiness accepts quoted and unquoted right() deparse while phone_last4 drift fails closed", async () => {
+  const pool = makePool();
+  const status = await history.schemaReady(pool);
+  assert.equal(status.has_claims, true);
+
+  const shapeQuery = pool.state.queries.find(({ sql }) => /AS has_phone_last4_check/.test(sql));
+  assert.ok(shapeQuery, "schema readiness must query the phone_last4 constraint shape");
+  const patternMatch = shapeQuery.sql.match(/pg_get_constraintdef\(con\.oid\) ~\* '([^']+)'/);
+  assert.ok(patternMatch, "phone_last4 readiness must use a constraint-definition matcher");
+  const matcher = new RegExp(patternMatch[1].replaceAll("[[:space:]]", "\\s"), "i");
+
+  assert.match(
+    `CHECK (((phone_last4 ~ '^[0-9]{4}$'::text) AND (phone_last4 = "right"(phone_norm, 4))))`,
+    matcher
+  );
+  assert.match(
+    `CHECK (((phone_last4 ~ '^[0-9]{4}$'::text) AND (phone_last4 = right(phone_norm, 4))))`,
+    matcher
+  );
+  for (const drifted of [
+    "CHECK (phone_last4 = left(phone_norm, 4))",
+    `CHECK ("right"(phone_norm, 4) = '1234')`,
+    `CHECK (phone_last4 <> "right"(phone_norm, 4))`,
+    `CHECK (phone_last4 = "right"(other_phone, 4))`,
+  ]) {
+    assert.doesNotMatch(drifted, matcher);
+  }
+
+  const driftedStatus = await history.schemaReady(makePool({ phoneLast4Check: false }));
+  assert.equal(driftedStatus.has_claims, false);
+  assert.equal(driftedStatus.diagnostic_code, "SCHEMA_DRIFT");
 });
 
 test("unauthenticated claim returns 401", async () => {


### PR DESCRIPTION
Closes #175

## Base / head

- Base SHA: `ad4d7dc8cd000aa916dfdeab1091c5e317b5a5cb`
- Head SHA: `b6de408f7387b5df8db8c60ed05b79e694358bce`

## Root cause

`schemaReady()` matched the literal substring `right(phone_norm, 4)`. PostgreSQL can deparse the same valid built-in call as `"right"(phone_norm, 4)`, causing the production-valid `phone_last4` constraint to be reported as schema drift.

## Changed files

- `server/services/public/customerHistory.js`
- `test/customerHistoryClaim.test.js`

## Implementation

- Replaced the literal `ILIKE` check with a case-insensitive PostgreSQL regex accepting both `right` and `"right"`.
- The matcher still requires `phone_last4 = right-or-quoted-right(phone_norm, 4)`.
- Missing or drifted constraint results remain fail closed with `SCHEMA_DRIFT`.
- Added regression coverage using the actual quoted PostgreSQL deparse shape, the unquoted shape, and multiple drift shapes.

## Security / data considerations

- No auth, payment, pricing, booking, or dispatch behavior changed.
- No migration SQL changed.
- No database or Production data action is required.
- Schema readiness remains fail closed.

## Validation

- `node --check server/services/public/customerHistory.js` — pass
- `node --check test/customerHistoryClaim.test.js` — pass
- `node --test test/customerHistoryClaim.test.js test/customerHistoryClaimsMigration.test.js` — pass, 34/34
- `git diff --check` — pass
- `npm test` on branch — 1,284 tests; 1,230 pass; 20 fail; 34 skipped
- `npm test` on untouched base `ad4d7dc8cd000aa916dfdeab1091c5e317b5a5cb`, using the same Node environment and dependency installation — the same 20 test names fail
- Exact failure-name set comparison — branch-only failures: **0**, base-only failures: **0**

The 20 baseline failures are confined to the pre-existing `adminStoreCatalogUi.test.js` expectations and are unrelated to this Customer History change.

## Remaining risks

- This validates the exact quoted/unquoted deparse forms specified in #175. Other materially different PostgreSQL expression shapes remain rejected intentionally.