### PR TITLE
feat: prepare Customer History claim-method schema capability

### DIFF
--- a/docs/CUSTOMER_HISTORY_CLAIM_METHODS_PRODUCTION_RUNBOOK.md
+++ b/docs/CUSTOMER_HISTORY_CLAIM_METHODS_PRODUCTION_RUNBOOK.md
@@ -22,7 +22,7 @@ npm run migrate:customer-history-claim-methods:check
 | `READY_TO_APPLY` | 0 | Exact one-method legacy constraint and all other expected schema are present. Stop for owner apply approval. |
 | `ALREADY_APPLIED` | 0 | Exact approved three-method constraint is present. Do not apply again; continue to verification. |
 | `PREREQUISITE_MISSING` | 2 | `customer_history_claims` is missing. Stop. |
-| `SCHEMA_DRIFT` | 3 | Constraint name/shape, columns, default, FKs, checks, indexes, or migration checksum differ. Stop. |
+| `SCHEMA_DRIFT` | 3 | Exact columns/defaults, primary key, named CHECKs, FKs/delete actions, critical indexes, or migration checksum differ. Stop. |
 | `FAILED` | 1 | Connection, timeout, lock, or unexpected failure. Stop and investigate without exposing secrets. |
 
 Only these method capabilities are accepted:

--- a/docs/CUSTOMER_HISTORY_CLAIM_METHODS_PRODUCTION_RUNBOOK.md
+++ b/docs/CUSTOMER_HISTORY_CLAIM_METHODS_PRODUCTION_RUNBOOK.md
@@ -1,0 +1,78 @@
+# Customer History claim methods production runbook
+
+This schema-capability migration is owner-operated. It only widens the
+`customer_history_claims_method_check` constraint; it does not enable the
+phone-only or Booking-Code-only product flow.
+
+## Preconditions
+
+- Run from the reviewed and deployed schema-capability release commit.
+- Use only the `DATABASE_URL` injected by the Production service.
+- Do not print, copy, or store the database URL or any secret.
+- Do not apply until the owner gives a separate explicit Production approval.
+
+## 1. Read-only preflight
+
+```sh
+npm run migrate:customer-history-claim-methods:check
+```
+
+| Status | Exit | Action |
+| --- | ---: | --- |
+| `READY_TO_APPLY` | 0 | Exact one-method legacy constraint and all other expected schema are present. Stop for owner apply approval. |
+| `ALREADY_APPLIED` | 0 | Exact approved three-method constraint is present. Do not apply again; continue to verification. |
+| `PREREQUISITE_MISSING` | 2 | `customer_history_claims` is missing. Stop. |
+| `SCHEMA_DRIFT` | 3 | Constraint name/shape, columns, default, FKs, checks, indexes, or migration checksum differ. Stop. |
+| `FAILED` | 1 | Connection, timeout, lock, or unexpected failure. Stop and investigate without exposing secrets. |
+
+Only these method capabilities are accepted:
+
+- legacy: `booking_code_phone`
+- widened: `phone`, `booking_code`, `booking_code_phone`
+
+Every other method set or constraint shape fails closed.
+
+## 2. Apply after separate owner approval
+
+The confirmation token and `--apply` argument are both required:
+
+```sh
+CONFIRM_CUSTOMER_HISTORY_CLAIM_METHODS_MIGRATION=APPLY_20260717_CUSTOMER_HISTORY_CLAIM_METHODS npm run migrate:customer-history-claim-methods -- --apply
+```
+
+PowerShell:
+
+```powershell
+$env:CONFIRM_CUSTOMER_HISTORY_CLAIM_METHODS_MIGRATION='APPLY_20260717_CUSTOMER_HISTORY_CLAIM_METHODS'
+npm run migrate:customer-history-claim-methods -- --apply
+Remove-Item Env:CONFIRM_CUSTOMER_HISTORY_CLAIM_METHODS_MIGRATION
+```
+
+The SQL uses `lock_timeout = '5s'`, `statement_timeout = '30s'`, and the
+transaction-scoped advisory lock `202607170177`. It snapshots row count and a
+server-side fingerprint before the ALTER statements and rolls back if data
+changes or validation fails.
+
+## 3. Read-only verification
+
+Run the same check again:
+
+```sh
+npm run migrate:customer-history-claim-methods:check
+```
+
+It must return `ALREADY_APPLIED` with exit 0. The current application must still
+create only `booking_code_phone` claims; this release does not change the claim
+route or Customer App UI.
+
+## Rollback limitations
+
+The migration does not rewrite rows and retains the existing
+`booking_code_phone` default. Application rollback is safe while leaving the
+widened constraint in place.
+
+Before any `phone` or `booking_code` rows exist, a separately reviewed migration
+may restore the legacy one-method constraint. After new-method rows exist,
+narrowing the constraint would require deleting valid claims or falsely
+relabeling audit data; do not do either. Retain the widened constraint and roll
+back only the application unless the owner approves a separate data plan.

--- a/migrations/20260717_customer_history_claim_methods.sql
+++ b/migrations/20260717_customer_history_claim_methods.sql
@@ -1,0 +1,94 @@
+-- Widen Customer History claim audit methods without changing existing rows.
+-- Owner-operated only. The application never runs this migration at startup.
+
+BEGIN;
+
+SET LOCAL lock_timeout = '5s';
+SET LOCAL statement_timeout = '30s';
+
+-- Transaction-scoped and distinct from the original Customer History migration.
+SELECT pg_advisory_xact_lock(202607170177);
+
+DO $$
+DECLARE
+  current_definition TEXT;
+BEGIN
+  SELECT pg_get_constraintdef(con.oid)
+    INTO current_definition
+    FROM pg_constraint con
+   WHERE con.conrelid = 'public.customer_history_claims'::regclass
+     AND con.conname = 'customer_history_claims_method_check'
+     AND con.contype = 'c';
+
+  IF current_definition IS NULL THEN
+    RAISE EXCEPTION 'customer_history_claims_method_check is missing';
+  END IF;
+
+  IF regexp_replace(lower(current_definition), '[[:space:]]+', '', 'g')
+       <> 'check((claim_method=''booking_code_phone''::text))' THEN
+    RAISE EXCEPTION 'customer_history_claims_method_check is not the approved legacy shape';
+  END IF;
+END
+$$;
+
+CREATE TEMP TABLE cwf_customer_history_claim_methods_snapshot
+ON COMMIT DROP
+AS
+SELECT COUNT(*)::BIGINT AS row_count,
+       md5(COALESCE(string_agg(md5(to_jsonb(c)::TEXT), '' ORDER BY c.claim_id), '')) AS row_fingerprint
+  FROM public.customer_history_claims c;
+
+ALTER TABLE public.customer_history_claims
+  DROP CONSTRAINT customer_history_claims_method_check;
+
+ALTER TABLE public.customer_history_claims
+  ADD CONSTRAINT customer_history_claims_method_check
+  CHECK (
+    claim_method IN (
+      'phone',
+      'booking_code',
+      'booking_code_phone'
+    )
+  )
+  NOT VALID;
+
+ALTER TABLE public.customer_history_claims
+  VALIDATE CONSTRAINT customer_history_claims_method_check;
+
+DO $$
+DECLARE
+  before_count BIGINT;
+  before_fingerprint TEXT;
+  after_count BIGINT;
+  after_fingerprint TEXT;
+  widened_definition TEXT;
+BEGIN
+  SELECT pg_get_constraintdef(con.oid)
+    INTO widened_definition
+    FROM pg_constraint con
+   WHERE con.conrelid = 'public.customer_history_claims'::regclass
+     AND con.conname = 'customer_history_claims_method_check'
+     AND con.contype = 'c';
+
+  IF regexp_replace(lower(COALESCE(widened_definition, '')), '[[:space:]]+', '', 'g')
+       <> 'check((claim_method=any(array[''phone''::text,''booking_code''::text,''booking_code_phone''::text])))' THEN
+    RAISE EXCEPTION 'customer_history_claims_method_check did not reach the approved widened shape';
+  END IF;
+
+  SELECT row_count, row_fingerprint
+    INTO before_count, before_fingerprint
+    FROM cwf_customer_history_claim_methods_snapshot;
+
+  SELECT COUNT(*)::BIGINT,
+         md5(COALESCE(string_agg(md5(to_jsonb(c)::TEXT), '' ORDER BY c.claim_id), ''))
+    INTO after_count, after_fingerprint
+    FROM public.customer_history_claims c;
+
+  IF before_count IS DISTINCT FROM after_count
+     OR before_fingerprint IS DISTINCT FROM after_fingerprint THEN
+    RAISE EXCEPTION 'customer_history_claims data changed during method migration';
+  END IF;
+END
+$$;
+
+COMMIT;

--- a/package.json
+++ b/package.json
@@ -7,6 +7,8 @@
     "migrate:customer-auth": "node scripts/run-customer-auth-migration.js",
     "migrate:customer-history-claims:check": "node scripts/run-customer-history-claims-migration.js",
     "migrate:customer-history-claims": "node scripts/run-customer-history-claims-migration.js",
+    "migrate:customer-history-claim-methods:check": "node scripts/run-customer-history-claim-methods-migration.js",
+    "migrate:customer-history-claim-methods": "node scripts/run-customer-history-claim-methods-migration.js",
     "migrate:catalog-store-media-pricing": "node scripts/run-catalog-store-media-pricing-migration.js",
     "migrate:catalog-marketplace-v2": "node scripts/run-catalog-marketplace-v2-migration.js",
     "migrate:catalog-autoplay": "node scripts/run-catalog-autoplay-migration.js",

--- a/scripts/run-customer-history-claim-methods-migration.js
+++ b/scripts/run-customer-history-claim-methods-migration.js
@@ -1,0 +1,274 @@
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+const crypto = require("crypto");
+const { Client } = require("pg");
+const history = require("../server/services/public/customerHistory");
+
+const MIGRATION_RELATIVE_PATH = "migrations/20260717_customer_history_claim_methods.sql";
+const EXPECTED_SHA256 = "4ca57cb0d49f318fc4d80bb4b75b4d0d3af64da5728f92379885f261c7b1d0c7";
+const CONFIRM_ENV = "CONFIRM_CUSTOMER_HISTORY_CLAIM_METHODS_MIGRATION";
+const CONFIRM_VALUE = "APPLY_20260717_CUSTOMER_HISTORY_CLAIM_METHODS";
+const ADVISORY_LOCK_KEY = "202607170177";
+const STATUS = Object.freeze({
+  READY_TO_APPLY: "READY_TO_APPLY",
+  ALREADY_APPLIED: "ALREADY_APPLIED",
+  PREREQUISITE_MISSING: "PREREQUISITE_MISSING",
+  SCHEMA_DRIFT: "SCHEMA_DRIFT",
+  FAILED: "FAILED",
+});
+const EXIT_CODE = Object.freeze({ FAILED: 1, PREREQUISITE_MISSING: 2, SCHEMA_DRIFT: 3 });
+const PREFIX = "CUSTOMER_HISTORY_CLAIM_METHODS_MIGRATION";
+
+function clean(value) {
+  return String(value == null ? "" : value).trim();
+}
+
+function safeErrorMessage(error) {
+  const msg = clean(error && error.message ? error.message : error) || "unknown error";
+  return msg
+    .replace(/postgres(?:ql)?:\/\/[^\s"'<>]+/gi, "[REDACTED_DATABASE_URL]")
+    .replace(/(password|passwd|pwd|secret|token)=([^&\s]+)/gi, "$1=[REDACTED]")
+    .replace(/password authentication failed for user\s+"[^"]+"/gi, 'password authentication failed for user "[REDACTED]"')
+    .replace(/user\s+"[^"]+"/gi, 'user "[REDACTED]"')
+    .replace(/host\s+"[^"]+"/gi, 'host "[REDACTED]"')
+    .replace(/\b(?:[a-z0-9-]+\.)+[a-z]{2,}\b/gi, "[REDACTED_HOST]")
+    .replace(/\b(?:\d{1,3}\.){3}\d{1,3}(?::\d+)?\b/g, "[REDACTED_HOST]")
+    .replace(/\blocalhost(?::\d+)?\b/gi, "[REDACTED_HOST]");
+}
+
+function migrationError(status, message) {
+  const error = new Error(message);
+  error.migrationStatus = status;
+  return error;
+}
+
+function resolveMigrationPath(repoRoot = path.resolve(__dirname, "..")) {
+  const root = path.resolve(repoRoot);
+  const migrationPath = path.resolve(root, MIGRATION_RELATIVE_PATH);
+  const expected = path.resolve(root, "migrations", "20260717_customer_history_claim_methods.sql");
+  if (migrationPath !== expected || !migrationPath.startsWith(root + path.sep)) throw new Error("migration path rejected");
+  return migrationPath;
+}
+
+function readMigrationSql(repoRoot) {
+  return fs.readFileSync(resolveMigrationPath(repoRoot), "utf8");
+}
+
+function migrationChecksum(repoRoot) {
+  const sql = readMigrationSql(repoRoot).replace(/\r\n/g, "\n");
+  return crypto.createHash("sha256").update(sql, "utf8").digest("hex");
+}
+
+function verifyChecksum(repoRoot) {
+  const actual = migrationChecksum(repoRoot);
+  if (actual !== EXPECTED_SHA256) throw migrationError(STATUS.SCHEMA_DRIFT, "migration checksum mismatch");
+  return actual;
+}
+
+function createClientConfig(env = process.env) {
+  const databaseUrl = clean(env.DATABASE_URL);
+  if (!databaseUrl) throw new Error("DATABASE_URL is required");
+  return { connectionString: databaseUrl, options: "-c timezone=Asia/Bangkok", ssl: { rejectUnauthorized: false } };
+}
+
+function mapRows(rows, key) {
+  return new Map((rows || []).map((row) => [String(row[key]), row]));
+}
+
+async function dataSnapshot(client) {
+  const result = await client.query(`
+    SELECT COUNT(*)::bigint AS row_count,
+           md5(COALESCE(string_agg(md5(to_jsonb(c)::text), '' ORDER BY c.claim_id), '')) AS row_fingerprint
+      FROM public.customer_history_claims c
+  `);
+  return {
+    rowCount: String(result.rows?.[0]?.row_count || "0"),
+    rowFingerprint: String(result.rows?.[0]?.row_fingerprint || ""),
+  };
+}
+
+async function inspectSchema(client) {
+  const table = await client.query("SELECT to_regclass('public.customer_history_claims') AS table_name");
+  if (!table.rows?.[0]?.table_name) {
+    throw migrationError(STATUS.PREREQUISITE_MISSING, "customer_history_claims prerequisite missing");
+  }
+
+  const columns = await client.query(`
+    SELECT column_name, data_type, is_nullable, column_default
+      FROM information_schema.columns
+     WHERE table_schema='public' AND table_name='customer_history_claims'
+     ORDER BY column_name
+  `);
+  const cols = mapRows(columns.rows, "column_name");
+  const expectedColumns = {
+    claim_id: ["bigint", "NO"], customer_sub: ["text", "NO"], phone_norm: ["text", "NO"],
+    phone_last4: ["text", "NO"], proof_job_id: ["bigint", "NO"], claim_method: ["text", "NO"],
+    claimed_at: ["timestamp with time zone", "NO"], last_verified_at: ["timestamp with time zone", "NO"],
+    revoked_at: ["timestamp with time zone", "YES"], revoke_reason: ["text", "YES"],
+  };
+  for (const [name, [type, nullable]] of Object.entries(expectedColumns)) {
+    const row = cols.get(name);
+    if (!row || row.data_type !== type || row.is_nullable !== nullable) {
+      throw migrationError(STATUS.SCHEMA_DRIFT, `customer_history_claims column drift: ${name}`);
+    }
+  }
+  if (clean(cols.get("claim_method")?.column_default).replace(/\s+/g, "") !== "'booking_code_phone'::text") {
+    throw migrationError(STATUS.SCHEMA_DRIFT, "claim_method default drift");
+  }
+
+  const fks = await client.query(`
+    SELECT con.conname, confrel.relname AS foreign_table,
+           array_agg(att.attname ORDER BY cols.ordinality) AS column_names,
+           array_agg(fatt.attname ORDER BY cols.ordinality) AS foreign_column_names
+      FROM pg_constraint con
+      JOIN pg_class rel ON rel.oid=con.conrelid
+      JOIN pg_namespace nsp ON nsp.oid=rel.relnamespace
+      JOIN pg_class confrel ON confrel.oid=con.confrelid
+      JOIN unnest(con.conkey) WITH ORDINALITY AS cols(attnum, ordinality) ON TRUE
+      JOIN unnest(con.confkey) WITH ORDINALITY AS fcols(attnum, ordinality) ON fcols.ordinality=cols.ordinality
+      JOIN pg_attribute att ON att.attrelid=rel.oid AND att.attnum=cols.attnum
+      JOIN pg_attribute fatt ON fatt.attrelid=confrel.oid AND fatt.attnum=fcols.attnum
+     WHERE nsp.nspname='public' AND rel.relname='customer_history_claims' AND con.contype='f'
+     GROUP BY con.conname, confrel.relname
+  `);
+  const hasCustomerFk = (fks.rows || []).some((row) => row.foreign_table === "customer_profiles"
+    && (row.column_names || []).join(",") === "customer_sub" && (row.foreign_column_names || []).join(",") === "sub");
+  const hasJobFk = (fks.rows || []).some((row) => row.foreign_table === "jobs"
+    && (row.column_names || []).join(",") === "proof_job_id" && (row.foreign_column_names || []).join(",") === "job_id");
+  if (!hasCustomerFk || !hasJobFk) throw migrationError(STATUS.SCHEMA_DRIFT, "customer_history_claims FK drift");
+
+  const checks = await client.query(`
+    SELECT conname, pg_get_constraintdef(oid) AS definition
+      FROM pg_constraint
+     WHERE conrelid='public.customer_history_claims'::regclass AND contype='c'
+  `);
+  const methodChecks = (checks.rows || []).filter((row) => /claim_method/i.test(String(row.definition || "")));
+  if (methodChecks.length !== 1 || methodChecks[0].conname !== "customer_history_claims_method_check") {
+    throw migrationError(STATUS.SCHEMA_DRIFT, "claim_method CHECK name or count drift");
+  }
+  const methodCapability = history.classifyClaimMethodConstraint(methodChecks[0].definition);
+  if (!methodCapability) throw migrationError(STATUS.SCHEMA_DRIFT, "claim_method CHECK shape drift");
+  const checkText = (checks.rows || []).map((row) => `${row.conname} ${row.definition}`).join("\n");
+  if (!/phone_norm/.test(checkText) || !/\^0\[0-9\]\{8,9\}\$/.test(checkText)) {
+    throw migrationError(STATUS.SCHEMA_DRIFT, "canonical phone_norm CHECK missing");
+  }
+  if (!/phone_last4/.test(checkText) || !/(?:right|"right")\(phone_norm,\s*4\)/i.test(checkText)) {
+    throw migrationError(STATUS.SCHEMA_DRIFT, "phone_last4 CHECK missing");
+  }
+
+  const indexes = await client.query(`
+    SELECT indexname, indexdef FROM pg_indexes
+     WHERE schemaname='public' AND tablename='customer_history_claims'
+  `);
+  const indexDefs = mapRows(indexes.rows, "indexname");
+  const activePhone = indexDefs.get("ux_customer_history_claims_active_phone")?.indexdef || "";
+  const activeProof = indexDefs.get("ux_customer_history_claims_active_proof_job")?.indexdef || "";
+  const activeSub = indexDefs.get("idx_customer_history_claims_customer_sub")?.indexdef || "";
+  if (!/UNIQUE/i.test(activePhone) || !/phone_norm/.test(activePhone) || !/revoked_at IS NULL/i.test(activePhone)) {
+    throw migrationError(STATUS.SCHEMA_DRIFT, "active phone index drift");
+  }
+  if (!/UNIQUE/i.test(activeProof) || !/proof_job_id/.test(activeProof) || !/revoked_at IS NULL/i.test(activeProof)) {
+    throw migrationError(STATUS.SCHEMA_DRIFT, "active proof index drift");
+  }
+  if (!/customer_sub/.test(activeSub) || !/revoked_at IS NULL/i.test(activeSub)) {
+    throw migrationError(STATUS.SCHEMA_DRIFT, "active customer index drift");
+  }
+
+  return { methodCapability, snapshot: await dataSnapshot(client) };
+}
+
+async function preflight(client) {
+  const schema = await inspectSchema(client);
+  return {
+    status: schema.methodCapability === history.CLAIM_METHOD_CAPABILITY.WIDENED
+      ? STATUS.ALREADY_APPLIED
+      : STATUS.READY_TO_APPLY,
+    snapshot: schema.snapshot,
+  };
+}
+
+function applyIntent(argv = [], env = process.env) {
+  const hasApply = argv.includes("--apply");
+  const hasConfirm = clean(env[CONFIRM_ENV]) === CONFIRM_VALUE;
+  if (hasApply && !hasConfirm) throw new Error("confirmation env missing");
+  if (!hasApply && hasConfirm) throw new Error("--apply argument missing");
+  return hasApply && hasConfirm;
+}
+
+async function runMigration(options = {}) {
+  const env = options.env || process.env;
+  const argv = options.argv || process.argv.slice(2);
+  const logger = options.logger || console;
+  const repoRoot = options.repoRoot || path.resolve(__dirname, "..");
+  const clientFactory = options.clientFactory || ((config) => new Client(config));
+  verifyChecksum(repoRoot);
+  const shouldApply = applyIntent(argv, env);
+  const client = clientFactory(createClientConfig(env));
+  let originalError = null;
+  try {
+    await client.connect();
+    const before = await preflight(client);
+    if (before.status === STATUS.ALREADY_APPLIED) {
+      logger.log(`${PREFIX}_STATUS=${STATUS.ALREADY_APPLIED}`);
+      return { status: STATUS.ALREADY_APPLIED };
+    }
+    if (!shouldApply) {
+      logger.log(`${PREFIX}_STATUS=${STATUS.READY_TO_APPLY}`);
+      return { status: STATUS.READY_TO_APPLY };
+    }
+
+    logger.log(`${PREFIX}_APPLY_START`);
+    try {
+      await client.query(readMigrationSql(repoRoot));
+    } catch (error) {
+      try { await client.query("ROLLBACK"); } catch (_) {}
+      throw error;
+    }
+    const after = await inspectSchema(client);
+    if (after.methodCapability !== history.CLAIM_METHOD_CAPABILITY.WIDENED) {
+      throw migrationError(STATUS.SCHEMA_DRIFT, "widened claim_method CHECK verification failed");
+    }
+    if (after.snapshot.rowCount !== before.snapshot.rowCount
+      || after.snapshot.rowFingerprint !== before.snapshot.rowFingerprint) {
+      throw migrationError(STATUS.SCHEMA_DRIFT, "customer_history_claims data verification failed");
+    }
+    logger.log(`${PREFIX}_OK`);
+    return { status: "APPLIED" };
+  } catch (error) {
+    originalError = error;
+    throw error;
+  } finally {
+    try {
+      await client.end();
+    } catch (error) {
+      if (!originalError) throw error;
+    }
+  }
+}
+
+async function runCli(options = {}) {
+  const logger = options.logger || console;
+  try {
+    await runMigration(options);
+    return 0;
+  } catch (error) {
+    const status = error?.migrationStatus || STATUS.FAILED;
+    logger.error(`${PREFIX}_STATUS=${status}`);
+    logger.error(`${PREFIX}_FAILED: ${safeErrorMessage(error)}`);
+    return status === STATUS.PREREQUISITE_MISSING ? EXIT_CODE.PREREQUISITE_MISSING
+      : status === STATUS.SCHEMA_DRIFT ? EXIT_CODE.SCHEMA_DRIFT : EXIT_CODE.FAILED;
+  }
+}
+
+if (require.main === module) {
+  runCli().then((code) => { process.exitCode = code; });
+}
+
+module.exports = {
+  ADVISORY_LOCK_KEY, CONFIRM_ENV, CONFIRM_VALUE, EXPECTED_SHA256, EXIT_CODE,
+  MIGRATION_RELATIVE_PATH, STATUS, applyIntent, createClientConfig, dataSnapshot,
+  inspectSchema, migrationChecksum, preflight, readMigrationSql, resolveMigrationPath,
+  runCli, runMigration, safeErrorMessage, verifyChecksum,
+};

--- a/scripts/run-customer-history-claim-methods-migration.js
+++ b/scripts/run-customer-history-claim-methods-migration.js
@@ -77,6 +77,33 @@ function mapRows(rows, key) {
   return new Map((rows || []).map((row) => [String(row[key]), row]));
 }
 
+function compactSql(value) {
+  return clean(value).toLowerCase().replace(/\s+/g, "");
+}
+
+function columnDefaultMatches(name, value) {
+  const actual = compactSql(value);
+  if (name === "claim_id") {
+    return /^nextval\('(?:public\.)?customer_history_claims_claim_id_seq'::regclass\)$/.test(actual);
+  }
+  if (name === "claim_method") return actual === "'booking_code_phone'::text";
+  if (name === "claimed_at" || name === "last_verified_at") return actual === "now()";
+  return actual === "";
+}
+
+function compactCheck(value) {
+  return compactSql(value).replace(/"right"/g, "right").replace(/[()]/g, "");
+}
+
+function sameColumns(row, expected) {
+  return Array.isArray(row?.column_names) && row.column_names.length === expected.length
+    && row.column_names.every((name, index) => name === expected[index]);
+}
+
+function normalizedPredicate(value) {
+  return compactSql(value).replace(/[()]/g, "");
+}
+
 async function dataSnapshot(client) {
   const result = await client.query(`
     SELECT COUNT(*)::bigint AS row_count,
@@ -101,79 +128,148 @@ async function inspectSchema(client) {
      WHERE table_schema='public' AND table_name='customer_history_claims'
      ORDER BY column_name
   `);
-  const cols = mapRows(columns.rows, "column_name");
+  const columnRows = columns.rows || [];
+  const cols = mapRows(columnRows, "column_name");
   const expectedColumns = {
     claim_id: ["bigint", "NO"], customer_sub: ["text", "NO"], phone_norm: ["text", "NO"],
     phone_last4: ["text", "NO"], proof_job_id: ["bigint", "NO"], claim_method: ["text", "NO"],
     claimed_at: ["timestamp with time zone", "NO"], last_verified_at: ["timestamp with time zone", "NO"],
     revoked_at: ["timestamp with time zone", "YES"], revoke_reason: ["text", "YES"],
   };
+  if (columnRows.length !== 10 || cols.size !== 10) {
+    throw migrationError(STATUS.SCHEMA_DRIFT, "customer_history_claims column count drift");
+  }
   for (const [name, [type, nullable]] of Object.entries(expectedColumns)) {
     const row = cols.get(name);
-    if (!row || row.data_type !== type || row.is_nullable !== nullable) {
+    if (!row || row.data_type !== type || row.is_nullable !== nullable || !columnDefaultMatches(name, row.column_default)) {
       throw migrationError(STATUS.SCHEMA_DRIFT, `customer_history_claims column drift: ${name}`);
     }
   }
-  if (clean(cols.get("claim_method")?.column_default).replace(/\s+/g, "") !== "'booking_code_phone'::text") {
-    throw migrationError(STATUS.SCHEMA_DRIFT, "claim_method default drift");
+
+  const primaryKeys = await client.query(`
+    SELECT con.conname, idx.relname AS index_name, ind.indisprimary, ind.indisunique,
+           array_agg(att.attname ORDER BY keys.ordinality) AS column_names
+      FROM pg_constraint con
+      JOIN pg_class rel ON rel.oid=con.conrelid
+      JOIN pg_namespace nsp ON nsp.oid=rel.relnamespace
+      JOIN pg_class idx ON idx.oid=con.conindid
+      JOIN pg_index ind ON ind.indexrelid=con.conindid
+      JOIN unnest(con.conkey) WITH ORDINALITY AS keys(attnum, ordinality) ON TRUE
+      JOIN pg_attribute att ON att.attrelid=rel.oid AND att.attnum=keys.attnum
+     WHERE nsp.nspname='public' AND rel.relname='customer_history_claims' AND con.contype='p'
+     GROUP BY con.conname, idx.relname, ind.indisprimary, ind.indisunique
+  `);
+  const pkRows = primaryKeys.rows || [];
+  const primaryKey = pkRows[0];
+  if (pkRows.length !== 1 || primaryKey.conname !== "customer_history_claims_pkey"
+    || primaryKey.index_name !== "customer_history_claims_pkey"
+    || primaryKey.indisprimary !== true || primaryKey.indisunique !== true
+    || !sameColumns(primaryKey, ["claim_id"])) {
+    throw migrationError(STATUS.SCHEMA_DRIFT, "customer_history_claims primary key drift");
   }
 
   const fks = await client.query(`
-    SELECT con.conname, confrel.relname AS foreign_table,
+    SELECT con.conname, confnsp.nspname AS foreign_schema, confrel.relname AS foreign_table,
+           con.confdeltype AS delete_action,
            array_agg(att.attname ORDER BY cols.ordinality) AS column_names,
            array_agg(fatt.attname ORDER BY cols.ordinality) AS foreign_column_names
       FROM pg_constraint con
       JOIN pg_class rel ON rel.oid=con.conrelid
       JOIN pg_namespace nsp ON nsp.oid=rel.relnamespace
       JOIN pg_class confrel ON confrel.oid=con.confrelid
+      JOIN pg_namespace confnsp ON confnsp.oid=confrel.relnamespace
       JOIN unnest(con.conkey) WITH ORDINALITY AS cols(attnum, ordinality) ON TRUE
       JOIN unnest(con.confkey) WITH ORDINALITY AS fcols(attnum, ordinality) ON fcols.ordinality=cols.ordinality
       JOIN pg_attribute att ON att.attrelid=rel.oid AND att.attnum=cols.attnum
       JOIN pg_attribute fatt ON fatt.attrelid=confrel.oid AND fatt.attnum=fcols.attnum
      WHERE nsp.nspname='public' AND rel.relname='customer_history_claims' AND con.contype='f'
-     GROUP BY con.conname, confrel.relname
+     GROUP BY con.conname, confnsp.nspname, confrel.relname, con.confdeltype
   `);
-  const hasCustomerFk = (fks.rows || []).some((row) => row.foreign_table === "customer_profiles"
-    && (row.column_names || []).join(",") === "customer_sub" && (row.foreign_column_names || []).join(",") === "sub");
-  const hasJobFk = (fks.rows || []).some((row) => row.foreign_table === "jobs"
-    && (row.column_names || []).join(",") === "proof_job_id" && (row.foreign_column_names || []).join(",") === "job_id");
-  if (!hasCustomerFk || !hasJobFk) throw migrationError(STATUS.SCHEMA_DRIFT, "customer_history_claims FK drift");
+  const fkRows = fks.rows || [];
+  const fkByName = mapRows(fkRows, "conname");
+  const expectedFks = {
+    customer_history_claims_customer_sub_fkey: { columns: ["customer_sub"], table: "customer_profiles", foreignColumns: ["sub"], deleteAction: "c" },
+    customer_history_claims_proof_job_id_fkey: { columns: ["proof_job_id"], table: "jobs", foreignColumns: ["job_id"], deleteAction: "r" },
+  };
+  if (fkRows.length !== 2 || fkByName.size !== 2) {
+    throw migrationError(STATUS.SCHEMA_DRIFT, "customer_history_claims FK count drift");
+  }
+  for (const [name, expected] of Object.entries(expectedFks)) {
+    const row = fkByName.get(name);
+    if (!row || row.foreign_schema !== "public" || row.foreign_table !== expected.table
+      || row.delete_action !== expected.deleteAction || !sameColumns(row, expected.columns)
+      || !Array.isArray(row.foreign_column_names)
+      || row.foreign_column_names.join(",") !== expected.foreignColumns.join(",")) {
+      throw migrationError(STATUS.SCHEMA_DRIFT, `customer_history_claims FK drift: ${name}`);
+    }
+  }
 
   const checks = await client.query(`
     SELECT conname, pg_get_constraintdef(oid) AS definition
       FROM pg_constraint
      WHERE conrelid='public.customer_history_claims'::regclass AND contype='c'
   `);
-  const methodChecks = (checks.rows || []).filter((row) => /claim_method/i.test(String(row.definition || "")));
-  if (methodChecks.length !== 1 || methodChecks[0].conname !== "customer_history_claims_method_check") {
-    throw migrationError(STATUS.SCHEMA_DRIFT, "claim_method CHECK name or count drift");
+  const checkRows = checks.rows || [];
+  const checksByName = mapRows(checkRows, "conname");
+  const requiredCheckNames = [
+    "customer_history_claims_method_check",
+    "customer_history_claims_phone_norm_not_blank",
+    "customer_history_claims_phone_norm_canonical_check",
+    "customer_history_claims_phone_last4_check",
+  ];
+  if (checkRows.length !== requiredCheckNames.length || checksByName.size !== requiredCheckNames.length
+    || requiredCheckNames.some((name) => !checksByName.has(name))) {
+    throw migrationError(STATUS.SCHEMA_DRIFT, "customer_history_claims CHECK name or count drift");
   }
-  const methodCapability = history.classifyClaimMethodConstraint(methodChecks[0].definition);
+  const methodCapability = history.classifyClaimMethodConstraint(checksByName.get("customer_history_claims_method_check").definition);
   if (!methodCapability) throw migrationError(STATUS.SCHEMA_DRIFT, "claim_method CHECK shape drift");
-  const checkText = (checks.rows || []).map((row) => `${row.conname} ${row.definition}`).join("\n");
-  if (!/phone_norm/.test(checkText) || !/\^0\[0-9\]\{8,9\}\$/.test(checkText)) {
-    throw migrationError(STATUS.SCHEMA_DRIFT, "canonical phone_norm CHECK missing");
+  if (compactCheck(checksByName.get("customer_history_claims_phone_norm_not_blank").definition)
+      !== "checklengthbtrimphone_norm>0") {
+    throw migrationError(STATUS.SCHEMA_DRIFT, "phone_norm not-blank CHECK shape drift");
   }
-  if (!/phone_last4/.test(checkText) || !/(?:right|"right")\(phone_norm,\s*4\)/i.test(checkText)) {
-    throw migrationError(STATUS.SCHEMA_DRIFT, "phone_last4 CHECK missing");
+  if (compactCheck(checksByName.get("customer_history_claims_phone_norm_canonical_check").definition)
+      !== "checkphone_norm~'^0[0-9]{8,9}$'::text") {
+    throw migrationError(STATUS.SCHEMA_DRIFT, "phone_norm canonical CHECK shape drift");
+  }
+  if (compactCheck(checksByName.get("customer_history_claims_phone_last4_check").definition)
+      !== "checkphone_last4~'^[0-9]{4}$'::textandphone_last4=rightphone_norm,4") {
+    throw migrationError(STATUS.SCHEMA_DRIFT, "phone_last4 CHECK shape drift");
   }
 
   const indexes = await client.query(`
-    SELECT indexname, indexdef FROM pg_indexes
-     WHERE schemaname='public' AND tablename='customer_history_claims'
+    SELECT idx.relname AS indexname, ind.indisunique AS is_unique, ind.indisprimary AS is_primary,
+           array_agg(att.attname ORDER BY keys.ordinality)
+             FILTER (WHERE keys.ordinality <= ind.indnkeyatts) AS column_names,
+           pg_get_expr(ind.indpred, ind.indrelid) AS predicate
+      FROM pg_index ind
+      JOIN pg_class rel ON rel.oid=ind.indrelid
+      JOIN pg_namespace nsp ON nsp.oid=rel.relnamespace
+      JOIN pg_class idx ON idx.oid=ind.indexrelid
+      JOIN unnest(ind.indkey) WITH ORDINALITY AS keys(attnum, ordinality) ON TRUE
+      LEFT JOIN pg_attribute att ON att.attrelid=rel.oid AND att.attnum=keys.attnum
+     WHERE nsp.nspname='public' AND rel.relname='customer_history_claims'
+     GROUP BY idx.relname, ind.indisunique, ind.indisprimary, ind.indpred, ind.indrelid
   `);
-  const indexDefs = mapRows(indexes.rows, "indexname");
-  const activePhone = indexDefs.get("ux_customer_history_claims_active_phone")?.indexdef || "";
-  const activeProof = indexDefs.get("ux_customer_history_claims_active_proof_job")?.indexdef || "";
-  const activeSub = indexDefs.get("idx_customer_history_claims_customer_sub")?.indexdef || "";
-  if (!/UNIQUE/i.test(activePhone) || !/phone_norm/.test(activePhone) || !/revoked_at IS NULL/i.test(activePhone)) {
-    throw migrationError(STATUS.SCHEMA_DRIFT, "active phone index drift");
+  const indexRows = indexes.rows || [];
+  const indexesByName = mapRows(indexRows, "indexname");
+  const expectedIndexes = {
+    customer_history_claims_pkey: { unique: true, primary: true, columns: ["claim_id"], predicate: "" },
+    ux_customer_history_claims_active_phone: { unique: true, primary: false, columns: ["phone_norm"], predicate: "revoked_atisnull" },
+    ux_customer_history_claims_active_proof_job: { unique: true, primary: false, columns: ["proof_job_id"], predicate: "revoked_atisnull" },
+    idx_customer_history_claims_customer_sub: { unique: false, primary: false, columns: ["customer_sub"], predicate: "revoked_atisnull" },
+  };
+  for (const [name, expected] of Object.entries(expectedIndexes)) {
+    const row = indexesByName.get(name);
+    if (!row || row.is_unique !== expected.unique || row.is_primary !== expected.primary
+      || !sameColumns(row, expected.columns) || normalizedPredicate(row.predicate) !== expected.predicate) {
+      throw migrationError(STATUS.SCHEMA_DRIFT, `customer_history_claims index drift: ${name}`);
+    }
   }
-  if (!/UNIQUE/i.test(activeProof) || !/proof_job_id/.test(activeProof) || !/revoked_at IS NULL/i.test(activeProof)) {
-    throw migrationError(STATUS.SCHEMA_DRIFT, "active proof index drift");
-  }
-  if (!/customer_sub/.test(activeSub) || !/revoked_at IS NULL/i.test(activeSub)) {
-    throw migrationError(STATUS.SCHEMA_DRIFT, "active customer index drift");
+  const criticalColumnKeys = new Set(Object.values(expectedIndexes).map((expected) => expected.columns.join(",")));
+  const conflictingIndexes = indexRows.filter((row) => !Object.prototype.hasOwnProperty.call(expectedIndexes, row.indexname)
+    && criticalColumnKeys.has(Array.isArray(row.column_names) ? row.column_names.join(",") : ""));
+  if (indexesByName.size !== indexRows.length || conflictingIndexes.length) {
+    throw migrationError(STATUS.SCHEMA_DRIFT, "customer_history_claims duplicate or conflicting index");
   }
 
   return { methodCapability, snapshot: await dataSnapshot(client) };
@@ -203,13 +299,15 @@ async function runMigration(options = {}) {
   const logger = options.logger || console;
   const repoRoot = options.repoRoot || path.resolve(__dirname, "..");
   const clientFactory = options.clientFactory || ((config) => new Client(config));
-  verifyChecksum(repoRoot);
+  const verifyMigration = options.verifyMigration || (() => verifyChecksum(repoRoot));
+  const migrationReader = options.migrationReader || (() => readMigrationSql(repoRoot));
   const shouldApply = applyIntent(argv, env);
   const client = clientFactory(createClientConfig(env));
   let originalError = null;
   try {
     await client.connect();
     const before = await preflight(client);
+    verifyMigration();
     if (before.status === STATUS.ALREADY_APPLIED) {
       logger.log(`${PREFIX}_STATUS=${STATUS.ALREADY_APPLIED}`);
       return { status: STATUS.ALREADY_APPLIED };
@@ -221,7 +319,7 @@ async function runMigration(options = {}) {
 
     logger.log(`${PREFIX}_APPLY_START`);
     try {
-      await client.query(readMigrationSql(repoRoot));
+      await client.query(migrationReader());
     } catch (error) {
       try { await client.query("ROLLBACK"); } catch (_) {}
       throw error;

--- a/server/services/public/customerHistory.js
+++ b/server/services/public/customerHistory.js
@@ -4,6 +4,7 @@ const crypto = require("crypto");
 
 const REF_VERSION = "v1";
 const CLAIM_METHOD = "booking_code_phone";
+const CLAIM_METHOD_CAPABILITY = Object.freeze({ LEGACY: "legacy", WIDENED: "widened" });
 const GENERIC_CLAIM_ERROR = "CLAIM_FAILED";
 
 function clean(value) {
@@ -95,6 +96,19 @@ function normalizeJobPhoneDigits(value) {
   const digits = clean(value).replace(/\D/g, "");
   const parsed = normalizeClaimPhone(digits);
   return parsed ? parsed.phone_norm : "";
+}
+
+function classifyClaimMethodConstraint(value) {
+  const definition = clean(value).toLowerCase().replace(/\s+/g, "");
+  const textCast = "(?:::text)?";
+  const legacy = new RegExp(`^check\\(\\(+claim_method='booking_code_phone'${textCast}\\)+\\)$`, "i");
+  const widened = new RegExp(
+    `^check\\(\\(+claim_method=any\\(array\\['phone'${textCast},'booking_code'${textCast},'booking_code_phone'${textCast}\\](?:::text\\[\\])?\\)\\)+\\)$`,
+    "i"
+  );
+  if (legacy.test(definition)) return CLAIM_METHOD_CAPABILITY.LEGACY;
+  if (widened.test(definition)) return CLAIM_METHOD_CAPABILITY.WIDENED;
+  return null;
 }
 
 function publicStatus(value) {
@@ -232,14 +246,22 @@ async function schemaReady(db) {
            AND con.contype='f'
            AND pg_get_constraintdef(con.oid) ILIKE '%FOREIGN KEY (proof_job_id) REFERENCES jobs(job_id)%'
       ) AS has_job_fk,
-      EXISTS (
-        SELECT 1
+      (
+        SELECT pg_get_constraintdef(con.oid)
           FROM pg_constraint con
           JOIN pg_class rel ON rel.oid=con.conrelid
           JOIN pg_namespace nsp ON nsp.oid=rel.relnamespace
          WHERE nsp.nspname='public' AND rel.relname='customer_history_claims'
-           AND con.contype='c' AND pg_get_constraintdef(con.oid) ILIKE '%booking_code_phone%'
-      ) AS has_method_check,
+           AND con.contype='c' AND con.conname='customer_history_claims_method_check'
+      ) AS method_check_definition,
+      (
+        SELECT COUNT(*)::integer
+          FROM pg_constraint con
+          JOIN pg_class rel ON rel.oid=con.conrelid
+          JOIN pg_namespace nsp ON nsp.oid=rel.relnamespace
+         WHERE nsp.nspname='public' AND rel.relname='customer_history_claims'
+           AND con.contype='c' AND pg_get_constraintdef(con.oid) ILIKE '%claim_method%'
+      ) AS method_check_count,
       EXISTS (
         SELECT 1
           FROM pg_constraint con
@@ -278,13 +300,18 @@ async function schemaReady(db) {
       ) AS has_active_sub_index
   `);
   const s = shape.rows?.[0] || {};
+  const methodCapability = Number(s.method_check_count) === 1
+    ? classifyClaimMethodConstraint(s.method_check_definition)
+    : null;
   const shapeValid = !!s.has_customer_fk && !!s.has_job_fk
-    && !!s.has_method_check && !!s.has_phone_norm_check && !!s.has_phone_last4_check
+    && !!methodCapability && !!s.has_phone_norm_check && !!s.has_phone_last4_check
     && !!s.has_active_phone_index && !!s.has_active_proof_index && !!s.has_active_sub_index;
   return {
     has_claims: columnsValid && shapeValid,
     has_customer_sub: hasCustomerSub,
     claims_table_exists: true,
+    claim_method_capability: methodCapability,
+    supports_simple_claim: methodCapability === CLAIM_METHOD_CAPABILITY.WIDENED,
     diagnostic_code: columnsValid && shapeValid ? "READY" : "SCHEMA_DRIFT",
   };
 }
@@ -326,9 +353,11 @@ function buildAuthorizedWhere({ customerSub, hasCustomerSub, phoneDigits, startP
 
 module.exports = {
   CLAIM_METHOD,
+  CLAIM_METHOD_CAPABILITY,
   GENERIC_CLAIM_ERROR,
   buildAuthorizedWhere,
   clean,
+  classifyClaimMethodConstraint,
   detailRow,
   groupLocations,
   hmacHex,

--- a/test/customerHistoryClaim.test.js
+++ b/test/customerHistoryClaim.test.js
@@ -13,7 +13,7 @@ const history = require("../server/services/public/customerHistory");
 
 const REPO_ROOT = path.resolve(__dirname, "..");
 
-function makePool({ jobs = [], claims = [], hasClaims = true, hasCustomerSub = true, schemaDrift = false, phoneLast4Check = true, schemaReadyError = null, failInsert = false, uniqueConflictClaim = null } = {}) {
+function makePool({ jobs = [], claims = [], hasClaims = true, hasCustomerSub = true, schemaDrift = false, phoneLast4Check = true, methodDefinition = "CHECK ((claim_method = 'booking_code_phone'::text))", methodCheckCount = 1, schemaReadyError = null, failInsert = false, uniqueConflictClaim = null } = {}) {
   const state = {
     jobs: jobs.map((x) => ({ ...x })),
     claims: claims.map((x) => ({ ...x })),
@@ -22,6 +22,8 @@ function makePool({ jobs = [], claims = [], hasClaims = true, hasCustomerSub = t
     hasCustomerSub,
     schemaDrift,
     phoneLast4Check,
+    methodDefinition,
+    methodCheckCount,
     schemaReadyError,
     failInsert,
     uniqueConflictClaim,
@@ -49,7 +51,8 @@ function makePool({ jobs = [], claims = [], hasClaims = true, hasCustomerSub = t
       return { rows: [{
         has_customer_fk: true,
         has_job_fk: true,
-        has_method_check: true,
+        method_check_definition: state.methodDefinition,
+        method_check_count: state.methodCheckCount,
         has_phone_norm_check: true,
         has_phone_last4_check: state.phoneLast4Check,
         has_active_phone_index: true,
@@ -193,6 +196,8 @@ test("schema readiness accepts quoted and unquoted right() deparse while phone_l
   const pool = makePool();
   const status = await history.schemaReady(pool);
   assert.equal(status.has_claims, true);
+  assert.equal(status.claim_method_capability, "legacy");
+  assert.equal(status.supports_simple_claim, false);
 
   const shapeQuery = pool.state.queries.find(({ sql }) => /AS has_phone_last4_check/.test(sql));
   assert.ok(shapeQuery, "schema readiness must query the phone_last4 constraint shape");
@@ -220,6 +225,26 @@ test("schema readiness accepts quoted and unquoted right() deparse while phone_l
   const driftedStatus = await history.schemaReady(makePool({ phoneLast4Check: false }));
   assert.equal(driftedStatus.has_claims, false);
   assert.equal(driftedStatus.diagnostic_code, "SCHEMA_DRIFT");
+});
+
+test("schema readiness reports widened claim methods without changing legacy claim behavior", async () => {
+  const widened = "CHECK ((claim_method = ANY (ARRAY['phone'::text, 'booking_code'::text, 'booking_code_phone'::text])))";
+  const status = await history.schemaReady(makePool({ methodDefinition: widened }));
+  assert.equal(status.has_claims, true);
+  assert.equal(status.claim_method_capability, "widened");
+  assert.equal(status.supports_simple_claim, true);
+  assert.equal(history.CLAIM_METHOD, "booking_code_phone");
+
+  for (const methodDefinition of [
+    "CHECK ((claim_method = ANY (ARRAY['phone'::text, 'booking_code_phone'::text])))",
+    "CHECK ((claim_method = ANY (ARRAY['phone'::text, 'booking_code'::text, 'booking_code_phone'::text, 'email'::text])))",
+  ]) {
+    const drifted = await history.schemaReady(makePool({ methodDefinition }));
+    assert.equal(drifted.has_claims, false);
+    assert.equal(drifted.diagnostic_code, "SCHEMA_DRIFT");
+  }
+  const duplicate = await history.schemaReady(makePool({ methodDefinition: widened, methodCheckCount: 2 }));
+  assert.equal(duplicate.has_claims, false);
 });
 
 test("unauthenticated claim returns 401", async () => {
@@ -321,6 +346,22 @@ test("claim succeeds, retries by same account are idempotent, and other accounts
     assert.equal(res.status, 400);
     assert.equal((await json(res)).error, "CLAIM_FAILED");
   });
+});
+
+test("current phone plus Booking Code claim remains compatible with widened schema", async () => {
+  const methodDefinition = "CHECK ((claim_method = ANY (ARRAY['phone'::text, 'booking_code'::text, 'booking_code_phone'::text])))";
+  const pool = makePool({ jobs: [LEGACY_JOB], methodDefinition });
+  await withServer({ pool }, async (base) => {
+    const response = await fetch(`${base}/public/customer-history/claim`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ phone: "0812345678", booking_code: "CWFABC123" }),
+    });
+    assert.equal(response.status, 200);
+    assert.equal((await json(response)).claimed, true);
+  });
+  assert.equal(pool.state.claims.length, 1);
+  assert.equal(pool.state.claims[0].claim_method, "booking_code_phone");
 });
 
 test("successful claim immediately authorizes history and location prefill data", async () => {

--- a/test/customerHistoryClaimMethodsMigration.test.js
+++ b/test/customerHistoryClaimMethodsMigration.test.js
@@ -1,0 +1,214 @@
+"use strict";
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+
+const runner = require("../scripts/run-customer-history-claim-methods-migration");
+
+const REPO_ROOT = path.resolve(__dirname, "..");
+const LEGACY = "CHECK ((claim_method = 'booking_code_phone'::text))";
+const WIDENED = "CHECK ((claim_method = ANY (ARRAY['phone'::text, 'booking_code'::text, 'booking_code_phone'::text])))";
+
+function expectedColumns() {
+  return [
+    ["claim_id", "bigint", "NO", "nextval('customer_history_claims_claim_id_seq'::regclass)"],
+    ["customer_sub", "text", "NO", null], ["phone_norm", "text", "NO", null],
+    ["phone_last4", "text", "NO", null], ["proof_job_id", "bigint", "NO", null],
+    ["claim_method", "text", "NO", "'booking_code_phone'::text"],
+    ["claimed_at", "timestamp with time zone", "NO", "now()"],
+    ["last_verified_at", "timestamp with time zone", "NO", "now()"],
+    ["revoked_at", "timestamp with time zone", "YES", null], ["revoke_reason", "text", "YES", null],
+  ].map(([column_name, data_type, is_nullable, column_default]) => ({ column_name, data_type, is_nullable, column_default }));
+}
+
+function methodRow(shape) {
+  if (shape === "missing") return null;
+  if (shape === "unknown") {
+    return { conname: "customer_history_claims_method_check", definition: "CHECK ((claim_method = ANY (ARRAY['phone'::text, 'booking_code'::text, 'booking_code_phone'::text, 'email'::text])))" };
+  }
+  if (shape === "missing-approved") {
+    return { conname: "customer_history_claims_method_check", definition: "CHECK ((claim_method = ANY (ARRAY['phone'::text, 'booking_code_phone'::text])))" };
+  }
+  return {
+    conname: shape === "renamed" ? "customer_history_claims_method_check_v2" : "customer_history_claims_method_check",
+    definition: shape === "widened" ? WIDENED : LEGACY,
+  };
+}
+
+class FakeClient {
+  constructor(options = {}) {
+    this.options = options;
+    this.queries = [];
+    this.connected = false;
+    this.ended = false;
+    this.applied = options.methodShape === "widened";
+  }
+
+  async connect() { this.connected = true; }
+  async end() { this.ended = true; }
+
+  async query(sql) {
+    const text = String(sql);
+    this.queries.push(text);
+    if (text === "ROLLBACK") {
+      this.rolledBack = true;
+      return { rows: [] };
+    }
+    if (text.includes("SELECT pg_advisory_xact_lock(202607170177)")) {
+      if (this.options.alterError) throw new Error(this.options.alterError);
+      this.applied = true;
+      return { rows: [] };
+    }
+    if (text.includes("SELECT to_regclass('public.customer_history_claims') AS table_name")) {
+      return { rows: [{ table_name: this.options.hasTable === false ? null : "customer_history_claims" }] };
+    }
+    if (text.includes("information_schema.columns")) {
+      const rows = expectedColumns();
+      if (this.options.schemaDrift === "default") rows.find((row) => row.column_name === "claim_method").column_default = null;
+      return { rows };
+    }
+    if (text.includes("con.contype='f'")) {
+      return { rows: [
+        { conname: "fk_customer", foreign_table: "customer_profiles", column_names: ["customer_sub"], foreign_column_names: ["sub"] },
+        { conname: "fk_job", foreign_table: "jobs", column_names: ["proof_job_id"], foreign_column_names: ["job_id"] },
+      ] };
+    }
+    if (text.includes("pg_get_constraintdef(oid)")) {
+      const shape = this.applied ? "widened" : (this.options.methodShape || "legacy");
+      const method = methodRow(shape);
+      return { rows: [
+        ...(method ? [method] : []),
+        { conname: "customer_history_claims_phone_norm_canonical_check", definition: "CHECK ((phone_norm ~ '^0[0-9]{8,9}$'::text))" },
+        { conname: "customer_history_claims_phone_last4_check", definition: "CHECK (((phone_last4 ~ '^[0-9]{4}$'::text) AND (phone_last4 = \"right\"(phone_norm, 4))))" },
+      ] };
+    }
+    if (text.includes("FROM pg_indexes")) {
+      return { rows: [
+        { indexname: "ux_customer_history_claims_active_phone", indexdef: "CREATE UNIQUE INDEX ux_customer_history_claims_active_phone ON public.customer_history_claims (phone_norm) WHERE revoked_at IS NULL" },
+        { indexname: "ux_customer_history_claims_active_proof_job", indexdef: "CREATE UNIQUE INDEX ux_customer_history_claims_active_proof_job ON public.customer_history_claims (proof_job_id) WHERE revoked_at IS NULL" },
+        { indexname: "idx_customer_history_claims_customer_sub", indexdef: "CREATE INDEX idx_customer_history_claims_customer_sub ON public.customer_history_claims (customer_sub) WHERE revoked_at IS NULL" },
+      ] };
+    }
+    if (text.includes("row_fingerprint")) {
+      return { rows: [{ row_count: String(this.options.rowCount || 2), row_fingerprint: this.options.fingerprint || "stable-fingerprint" }] };
+    }
+    return { rows: [] };
+  }
+}
+
+function captureLogger() {
+  const lines = [];
+  return { lines, log(value) { lines.push(String(value)); }, error(value) { lines.push(String(value)); } };
+}
+
+async function runWith(client, options = {}) {
+  const logger = captureLogger();
+  const code = await runner.runCli({
+    repoRoot: options.repoRoot || REPO_ROOT,
+    argv: options.argv || [],
+    env: { DATABASE_URL: "postgres://user:password@db.example.test/cwf", ...options.env },
+    logger,
+    clientFactory: () => client,
+  });
+  return { code, logger };
+}
+
+test("legacy constraint is READY_TO_APPLY and preflight is read-only", async () => {
+  const client = new FakeClient();
+  const result = await runWith(client);
+  assert.equal(result.code, 0);
+  assert.deepEqual(result.logger.lines, ["CUSTOMER_HISTORY_CLAIM_METHODS_MIGRATION_STATUS=READY_TO_APPLY"]);
+  assert.equal(client.queries.some((sql) => sql.includes("ALTER TABLE")), false);
+});
+
+test("exact widened constraint is ALREADY_APPLIED without running migration SQL", async () => {
+  const client = new FakeClient({ methodShape: "widened" });
+  const result = await runWith(client);
+  assert.equal(result.code, 0);
+  assert.deepEqual(result.logger.lines, ["CUSTOMER_HISTORY_CLAIM_METHODS_MIGRATION_STATUS=ALREADY_APPLIED"]);
+  assert.equal(client.queries.some((sql) => sql.includes("ALTER TABLE")), false);
+});
+
+test("a successful apply followed by a second apply does not alter schema twice", async () => {
+  const client = new FakeClient();
+  const options = { argv: ["--apply"], env: { [runner.CONFIRM_ENV]: runner.CONFIRM_VALUE } };
+  const first = await runWith(client, options);
+  const second = await runWith(client, options);
+  assert.equal(first.code, 0);
+  assert.equal(second.code, 0);
+  assert.deepEqual(second.logger.lines, ["CUSTOMER_HISTORY_CLAIM_METHODS_MIGRATION_STATUS=ALREADY_APPLIED"]);
+  assert.equal(client.queries.filter((sql) => sql.includes("ALTER TABLE")).length, 1);
+});
+
+test("missing claims table is PREREQUISITE_MISSING", async () => {
+  const result = await runWith(new FakeClient({ hasTable: false }));
+  assert.equal(result.code, runner.EXIT_CODE.PREREQUISITE_MISSING);
+  assert.match(result.logger.lines.join("\n"), /STATUS=PREREQUISITE_MISSING/);
+});
+
+test("missing, renamed, unknown-extra, and incomplete method constraints fail closed", async () => {
+  for (const methodShape of ["missing", "renamed", "unknown", "missing-approved"]) {
+    const result = await runWith(new FakeClient({ methodShape }));
+    assert.equal(result.code, runner.EXIT_CODE.SCHEMA_DRIFT, methodShape);
+    assert.match(result.logger.lines.join("\n"), /STATUS=SCHEMA_DRIFT/);
+  }
+});
+
+test("wrong or missing confirmation token is rejected before connecting", async () => {
+  for (const env of [{}, { [runner.CONFIRM_ENV]: "WRONG" }]) {
+    const client = new FakeClient();
+    const result = await runWith(client, { argv: ["--apply"], env });
+    assert.equal(result.code, runner.EXIT_CODE.FAILED);
+    assert.equal(client.connected, false);
+  }
+});
+
+test("migration is transactional, locked, preserves existing rows, and verifies widened shape", async () => {
+  const client = new FakeClient({ rowCount: 7, fingerprint: "same-seven-rows" });
+  const result = await runWith(client, { argv: ["--apply"], env: { [runner.CONFIRM_ENV]: runner.CONFIRM_VALUE } });
+  assert.equal(result.code, 0);
+  assert.equal(client.applied, true);
+  assert.deepEqual(result.logger.lines, [
+    "CUSTOMER_HISTORY_CLAIM_METHODS_MIGRATION_APPLY_START",
+    "CUSTOMER_HISTORY_CLAIM_METHODS_MIGRATION_OK",
+  ]);
+  const sql = runner.readMigrationSql(REPO_ROOT);
+  assert.match(sql, /^--[\s\S]*\nBEGIN;/);
+  assert.match(sql, /SET LOCAL lock_timeout = '5s'/);
+  assert.match(sql, /SET LOCAL statement_timeout = '30s'/);
+  assert.match(sql, new RegExp(`pg_advisory_xact_lock\\(${runner.ADVISORY_LOCK_KEY}\\)`));
+  assert.match(sql, /NOT VALID[\s\S]*VALIDATE CONSTRAINT customer_history_claims_method_check/);
+  assert.match(sql, /row_fingerprint/);
+  assert.doesNotMatch(sql, /\b(?:INSERT|UPDATE|DELETE|TRUNCATE)\b/i);
+});
+
+test("ALTER or VALIDATE failure rolls back the migration transaction", async () => {
+  const client = new FakeClient({ alterError: "validate failed" });
+  const result = await runWith(client, { argv: ["--apply"], env: { [runner.CONFIRM_ENV]: runner.CONFIRM_VALUE } });
+  assert.equal(result.code, runner.EXIT_CODE.FAILED);
+  assert.equal(client.rolledBack, true);
+  assert.equal(client.ended, true);
+});
+
+test("migration checksum rejects tampering and is stable across CRLF", async () => {
+  assert.equal(runner.migrationChecksum(REPO_ROOT), runner.EXPECTED_SHA256);
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "cwf-history-methods-"));
+  fs.mkdirSync(path.join(tmp, "migrations"), { recursive: true });
+  const sql = runner.readMigrationSql(REPO_ROOT);
+  fs.writeFileSync(path.join(tmp, runner.MIGRATION_RELATIVE_PATH), sql.replace(/\r?\n/g, "\r\n"), "utf8");
+  assert.equal(runner.migrationChecksum(tmp), runner.EXPECTED_SHA256);
+  fs.writeFileSync(path.join(tmp, runner.MIGRATION_RELATIVE_PATH), `${sql}\n-- tampered\n`, "utf8");
+  const client = new FakeClient();
+  const result = await runWith(client, { repoRoot: tmp });
+  assert.equal(result.code, runner.EXIT_CODE.SCHEMA_DRIFT);
+  assert.equal(client.connected, false);
+});
+
+test("package exposes explicit claim-method check and apply commands", () => {
+  const pkg = JSON.parse(fs.readFileSync(path.join(REPO_ROOT, "package.json"), "utf8"));
+  assert.equal(pkg.scripts["migrate:customer-history-claim-methods:check"], "node scripts/run-customer-history-claim-methods-migration.js");
+  assert.equal(pkg.scripts["migrate:customer-history-claim-methods"], "node scripts/run-customer-history-claim-methods-migration.js");
+});

--- a/test/customerHistoryClaimMethodsMigration.test.js
+++ b/test/customerHistoryClaimMethodsMigration.test.js
@@ -38,6 +38,42 @@ function methodRow(shape) {
   };
 }
 
+function expectedPrimaryKeys(shape) {
+  if (shape === "missing") return [];
+  return [{
+    conname: "customer_history_claims_pkey",
+    index_name: shape === "wrong-index" ? "unexpected_pkey_index" : "customer_history_claims_pkey",
+    indisprimary: true,
+    indisunique: true,
+    column_names: [shape === "wrong-column" ? "proof_job_id" : "claim_id"],
+  }];
+}
+
+function expectedForeignKeys(shape) {
+  const rows = [
+    { conname: "customer_history_claims_customer_sub_fkey", foreign_schema: "public", foreign_table: "customer_profiles", delete_action: shape === "wrong-delete" ? "a" : "c", column_names: ["customer_sub"], foreign_column_names: ["sub"] },
+    { conname: "customer_history_claims_proof_job_id_fkey", foreign_schema: "public", foreign_table: shape === "wrong-target" ? "customer_profiles" : "jobs", delete_action: "r", column_names: ["proof_job_id"], foreign_column_names: ["job_id"] },
+  ];
+  if (shape === "duplicate") rows.push({ ...rows[0], conname: "duplicate_customer_sub_fkey" });
+  return rows;
+}
+
+function expectedIndexes(shape) {
+  const rows = [
+    { indexname: "customer_history_claims_pkey", is_unique: true, is_primary: true, column_names: ["claim_id"], predicate: null },
+    { indexname: "ux_customer_history_claims_active_phone", is_unique: true, is_primary: false, column_names: ["phone_norm"], predicate: "(revoked_at IS NULL)" },
+    { indexname: "ux_customer_history_claims_active_proof_job", is_unique: true, is_primary: false, column_names: ["proof_job_id"], predicate: "(revoked_at IS NULL)" },
+    { indexname: "idx_customer_history_claims_customer_sub", is_unique: false, is_primary: false, column_names: ["customer_sub"], predicate: "(revoked_at IS NULL)" },
+  ];
+  const phone = rows[1];
+  if (shape === "wrong-unique") phone.is_unique = false;
+  if (shape === "wrong-column") phone.column_names = ["customer_sub"];
+  if (shape === "wrong-predicate") phone.predicate = null;
+  if (shape === "wrong-pk-index") rows[0].column_names = ["proof_job_id"];
+  if (shape === "duplicate") rows.push({ ...phone, indexname: "duplicate_active_phone" });
+  return rows;
+}
+
 class FakeClient {
   constructor(options = {}) {
     this.options = options;
@@ -67,31 +103,34 @@ class FakeClient {
     }
     if (text.includes("information_schema.columns")) {
       const rows = expectedColumns();
-      if (this.options.schemaDrift === "default") rows.find((row) => row.column_name === "claim_method").column_default = null;
+      if (this.options.columnShape === "extra") rows.push({ column_name: "unexpected", data_type: "text", is_nullable: "YES", column_default: null });
+      if (this.options.columnShape === "missing") rows.splice(rows.findIndex((row) => row.column_name === "phone_norm"), 1);
+      if (this.options.columnShape === "type") rows.find((row) => row.column_name === "phone_norm").data_type = "character varying";
+      if (this.options.columnShape === "nullability") rows.find((row) => row.column_name === "phone_norm").is_nullable = "YES";
+      if (this.options.columnShape === "default") rows.find((row) => row.column_name === "phone_norm").column_default = "'unexpected'::text";
       return { rows };
     }
+    if (text.includes("con.contype='p'")) return { rows: expectedPrimaryKeys(this.options.pkShape) };
     if (text.includes("con.contype='f'")) {
-      return { rows: [
-        { conname: "fk_customer", foreign_table: "customer_profiles", column_names: ["customer_sub"], foreign_column_names: ["sub"] },
-        { conname: "fk_job", foreign_table: "jobs", column_names: ["proof_job_id"], foreign_column_names: ["job_id"] },
-      ] };
+      return { rows: expectedForeignKeys(this.options.fkShape) };
     }
     if (text.includes("pg_get_constraintdef(oid)")) {
       const shape = this.applied ? "widened" : (this.options.methodShape || "legacy");
       const method = methodRow(shape);
-      return { rows: [
+      const rows = [
         ...(method ? [method] : []),
+        { conname: "customer_history_claims_phone_norm_not_blank", definition: "CHECK ((length(btrim(phone_norm)) > 0))" },
         { conname: "customer_history_claims_phone_norm_canonical_check", definition: "CHECK ((phone_norm ~ '^0[0-9]{8,9}$'::text))" },
         { conname: "customer_history_claims_phone_last4_check", definition: "CHECK (((phone_last4 ~ '^[0-9]{4}$'::text) AND (phone_last4 = \"right\"(phone_norm, 4))))" },
-      ] };
+      ];
+      if (this.options.checkShape === "missing-not-blank") rows.splice(rows.findIndex((row) => row.conname === "customer_history_claims_phone_norm_not_blank"), 1);
+      if (this.options.checkShape === "duplicate-method" && method) rows.push({ ...method, conname: "duplicate_method_check" });
+      if (this.options.checkShape === "conflicting-phone") {
+        rows.find((row) => row.conname === "customer_history_claims_phone_norm_canonical_check").definition = "CHECK ((phone_norm ~ '^0[0-9]{7,9}$'::text))";
+      }
+      return { rows };
     }
-    if (text.includes("FROM pg_indexes")) {
-      return { rows: [
-        { indexname: "ux_customer_history_claims_active_phone", indexdef: "CREATE UNIQUE INDEX ux_customer_history_claims_active_phone ON public.customer_history_claims (phone_norm) WHERE revoked_at IS NULL" },
-        { indexname: "ux_customer_history_claims_active_proof_job", indexdef: "CREATE UNIQUE INDEX ux_customer_history_claims_active_proof_job ON public.customer_history_claims (proof_job_id) WHERE revoked_at IS NULL" },
-        { indexname: "idx_customer_history_claims_customer_sub", indexdef: "CREATE INDEX idx_customer_history_claims_customer_sub ON public.customer_history_claims (customer_sub) WHERE revoked_at IS NULL" },
-      ] };
-    }
+    if (text.includes("FROM pg_index ind")) return { rows: expectedIndexes(this.options.indexShape) };
     if (text.includes("row_fingerprint")) {
       return { rows: [{ row_count: String(this.options.rowCount || 2), row_fingerprint: this.options.fingerprint || "stable-fingerprint" }] };
     }
@@ -112,8 +151,24 @@ async function runWith(client, options = {}) {
     env: { DATABASE_URL: "postgres://user:password@db.example.test/cwf", ...options.env },
     logger,
     clientFactory: () => client,
+    verifyMigration: options.verifyMigration,
+    migrationReader: options.migrationReader,
   });
   return { code, logger };
+}
+
+async function expectPreflightBlocked(client, expectedCode = runner.EXIT_CODE.SCHEMA_DRIFT) {
+  let migrationRead = false;
+  const result = await runWith(client, {
+    argv: ["--apply"],
+    env: { [runner.CONFIRM_ENV]: runner.CONFIRM_VALUE },
+    verifyMigration() { migrationRead = true; },
+    migrationReader() { migrationRead = true; return runner.readMigrationSql(REPO_ROOT); },
+  });
+  assert.equal(result.code, expectedCode);
+  assert.equal(migrationRead, false, "schema drift must stop before reading migration SQL");
+  assert.equal(client.queries.some((sql) => /ALTER TABLE/i.test(sql)), false, "schema drift must not execute ALTER");
+  return result;
 }
 
 test("legacy constraint is READY_TO_APPLY and preflight is read-only", async () => {
@@ -144,16 +199,45 @@ test("a successful apply followed by a second apply does not alter schema twice"
 });
 
 test("missing claims table is PREREQUISITE_MISSING", async () => {
-  const result = await runWith(new FakeClient({ hasTable: false }));
-  assert.equal(result.code, runner.EXIT_CODE.PREREQUISITE_MISSING);
+  const result = await expectPreflightBlocked(new FakeClient({ hasTable: false }), runner.EXIT_CODE.PREREQUISITE_MISSING);
   assert.match(result.logger.lines.join("\n"), /STATUS=PREREQUISITE_MISSING/);
 });
 
 test("missing, renamed, unknown-extra, and incomplete method constraints fail closed", async () => {
   for (const methodShape of ["missing", "renamed", "unknown", "missing-approved"]) {
-    const result = await runWith(new FakeClient({ methodShape }));
-    assert.equal(result.code, runner.EXIT_CODE.SCHEMA_DRIFT, methodShape);
+    const result = await expectPreflightBlocked(new FakeClient({ methodShape }));
     assert.match(result.logger.lines.join("\n"), /STATUS=SCHEMA_DRIFT/);
+  }
+});
+
+test("extra, missing, type, nullability, and default column drift fail before ALTER", async () => {
+  for (const columnShape of ["extra", "missing", "type", "nullability", "default"]) {
+    await expectPreflightBlocked(new FakeClient({ columnShape }));
+  }
+});
+
+test("missing, wrong-column, and inconsistent-index primary keys fail before ALTER", async () => {
+  for (const pkShape of ["missing", "wrong-column", "wrong-index"]) {
+    await expectPreflightBlocked(new FakeClient({ pkShape }));
+  }
+  await expectPreflightBlocked(new FakeClient({ indexShape: "wrong-pk-index" }));
+});
+
+test("required CHECK constraints reject missing, duplicate, and conflicting shapes before ALTER", async () => {
+  for (const checkShape of ["missing-not-blank", "duplicate-method", "conflicting-phone"]) {
+    await expectPreflightBlocked(new FakeClient({ checkShape }));
+  }
+});
+
+test("critical FKs reject wrong delete action, target, and duplicates before ALTER", async () => {
+  for (const fkShape of ["wrong-delete", "wrong-target", "duplicate"]) {
+    await expectPreflightBlocked(new FakeClient({ fkShape }));
+  }
+});
+
+test("critical indexes reject wrong uniqueness, column, predicate, and duplicates before ALTER", async () => {
+  for (const indexShape of ["wrong-unique", "wrong-column", "wrong-predicate", "duplicate"]) {
+    await expectPreflightBlocked(new FakeClient({ indexShape }));
   }
 });
 
@@ -204,7 +288,7 @@ test("migration checksum rejects tampering and is stable across CRLF", async () 
   const client = new FakeClient();
   const result = await runWith(client, { repoRoot: tmp });
   assert.equal(result.code, runner.EXIT_CODE.SCHEMA_DRIFT);
-  assert.equal(client.connected, false);
+  assert.equal(client.connected, true);
 });
 
 test("package exposes explicit claim-method check and apply commands", () => {


### PR DESCRIPTION
Relates to #177

## Phase scope

This PR prepares only the Customer History schema capability for `phone`, `booking_code`, and `booking_code_phone`. It does **not** change the claim route, Customer App UI, authentication, or current proof behavior. The running application continues to create only `booking_code_phone` claims.

## Base / head

- Base SHA: `bd2f91652edb859a1bdf6ecb283fd0d0283fd690`
- Head SHA: `1d26d02240b3fd24a0cf0a995de2c22ba3405b96`

## Root cause / schema capability

The applied schema accepts only `booking_code_phone`. Future phone-only and Booking-Code-only claims cannot be recorded truthfully until the named CHECK constraint is widened. The original applied migration remains unchanged.

## Changed files

- `migrations/20260717_customer_history_claim_methods.sql`
- `scripts/run-customer-history-claim-methods-migration.js`
- `docs/CUSTOMER_HISTORY_CLAIM_METHODS_PRODUCTION_RUNBOOK.md`
- `server/services/public/customerHistory.js`
- `test/customerHistoryClaimMethodsMigration.test.js`
- `test/customerHistoryClaim.test.js`
- `package.json`

## Review blocker resolution

The preflight now fails closed before checksum/migration-SQL reads and before ALTER when any catalog contract drifts:

- Exactly 10 expected columns; extra/missing/name/type/nullability/default drift is rejected.
- Exactly one `customer_history_claims_pkey` on `claim_id`; its unique primary index must match.
- Exactly the four named CHECK constraints from the original schema; method, not-blank, canonical phone, and last-four semantics are verified.
- Exactly the two named critical FKs, including local/foreign columns, `public` target schema, and `CASCADE`/`RESTRICT` delete actions.
- Named PK and three critical indexes verify primary/unique flags, exact key columns, and partial predicates.
- Duplicate or conflicting critical FK/CHECK/index catalog rows are rejected.
- Every drift regression asserts that migration verification/reading and ALTER never occur.

## Migration implementation (unchanged by blocker fix)

- Transactional widening to exactly the three approved values.
- `SET LOCAL lock_timeout = '5s'`, `SET LOCAL statement_timeout = '30s'`.
- Transaction advisory lock `202607170177`.
- Exact in-transaction legacy and widened constraint guards.
- Server-side row-count/fingerprint preservation check.
- `NOT VALID` then `VALIDATE CONSTRAINT`; failures roll back.
- SHA-256 tamper protection with LF/CRLF normalization.

## Commands

Read-only preflight:

```sh
npm run migrate:customer-history-claim-methods:check
```

Owner-confirmed apply (not authorized or run by this PR):

```sh
CONFIRM_CUSTOMER_HISTORY_CLAIM_METHODS_MIGRATION=APPLY_20260717_CUSTOMER_HISTORY_CLAIM_METHODS npm run migrate:customer-history-claim-methods -- --apply
```

Verification: run the read-only preflight command again; it must return `ALREADY_APPLIED`.

Statuses: `READY_TO_APPLY` (0), `ALREADY_APPLIED` (0), `PREREQUISITE_MISSING` (2), `SCHEMA_DRIFT` (3), `FAILED` (1).

## Runtime readiness

`schemaReady()` classifies exact legacy and widened method constraints. Both remain valid for the current app, while `supports_simple_claim` is available for a future phase. Current route behavior and `CLAIM_METHOD = 'booking_code_phone'` are unchanged.

## Validation

- `node --check` for every JavaScript file changed by the PR — pass
- Focused Customer History/migration/schema tests — 51/51 pass
- `git diff --check` — pass
- Migration checksum — unchanged and verified
- `npm test` branch — 1,301 total; 1,247 pass; 20 fail; 34 skipped
- `npm test` untouched base `bd2f91652edb859a1bdf6ecb283fd0d0283fd690`, same Node/dependencies — 1,284 total; 1,230 pass; 20 fail; 34 skipped
- Exact failure-name comparison — branch-only failures: **0**, base-only failures: **0**

The 20 baseline failures are the pre-existing `adminStoreCatalogUi.test.js` failures and are outside this PR.

## Production / rollback

- No Production migration or data action was performed.
- Production apply requires separate explicit owner approval after review, merge, and deployment.
- Existing rows and the `booking_code_phone` default remain unchanged.
- Current application behavior works on legacy and widened schemas.
- Application rollback can retain the widened constraint.
- After future `phone` or `booking_code` rows exist, narrowing is unsafe without deleting or falsely relabeling audit data.

## Remaining risks

- ALTER/VALIDATE requires a table lock bounded by the 5s/30s timeouts.
- The row fingerprint aggregates claims in PostgreSQL; an unexpectedly large table fails closed on timeout.
- Catalog checks intentionally reject unknown but potentially equivalent schema shapes as `SCHEMA_DRIFT`.