### PR TITLE
Fix Customer History migration runner DB env compatibility

### DIFF
--- a/docs/CUSTOMER_HISTORY_CLAIM_METHODS_PRODUCTION_RUNBOOK.md
+++ b/docs/CUSTOMER_HISTORY_CLAIM_METHODS_PRODUCTION_RUNBOOK.md
@@ -7,8 +7,10 @@ phone-only or Booking-Code-only product flow.
 ## Preconditions
 
 - Run from the reviewed and deployed schema-capability release commit.
-- Use only the `DATABASE_URL` injected by the Production service.
-- Do not print, copy, or store the database URL or any secret.
+- Use only database credentials injected by the Production service. The runner
+  prefers `DATABASE_URL` when present; otherwise it uses `DB_HOST`, `DB_PORT`
+  (default `5432`), `DB_USER`, `DB_PASSWORD`, and `DB_NAME`.
+- Do not print, copy, or store connection settings or any secret.
 - Do not apply until the owner gives a separate explicit Production approval.
 
 ## 1. Read-only preflight

--- a/scripts/run-customer-history-claim-methods-migration.js
+++ b/scripts/run-customer-history-claim-methods-migration.js
@@ -25,8 +25,16 @@ function clean(value) {
   return String(value == null ? "" : value).trim();
 }
 
-function safeErrorMessage(error) {
-  const msg = clean(error && error.message ? error.message : error) || "unknown error";
+function safeErrorMessage(error, env = process.env) {
+  let msg = clean(error && error.message ? error.message : error) || "unknown error";
+  for (const [value, replacement] of [
+    [env.DATABASE_URL, "[REDACTED_DATABASE_URL]"],
+    [env.DB_PASSWORD, "[REDACTED_PASSWORD]"],
+    [env.DB_HOST, "[REDACTED_HOST]"],
+  ]) {
+    const sensitiveValue = String(value == null ? "" : value);
+    if (sensitiveValue) msg = msg.split(sensitiveValue).join(replacement);
+  }
   return msg
     .replace(/postgres(?:ql)?:\/\/[^\s"'<>]+/gi, "[REDACTED_DATABASE_URL]")
     .replace(/(password|passwd|pwd|secret|token)=([^&\s]+)/gi, "$1=[REDACTED]")
@@ -69,8 +77,23 @@ function verifyChecksum(repoRoot) {
 
 function createClientConfig(env = process.env) {
   const databaseUrl = clean(env.DATABASE_URL);
-  if (!databaseUrl) throw new Error("DATABASE_URL is required");
-  return { connectionString: databaseUrl, options: "-c timezone=Asia/Bangkok", ssl: { rejectUnauthorized: false } };
+  const shared = { options: "-c timezone=Asia/Bangkok", ssl: { rejectUnauthorized: false } };
+  if (databaseUrl) return { connectionString: databaseUrl, ...shared };
+
+  const required = ["DB_HOST", "DB_USER", "DB_PASSWORD", "DB_NAME"];
+  const missing = required.filter((name) => !clean(env[name]));
+  if (missing.length) {
+    throw new Error(`database configuration missing required env: ${missing.join(", ")}`);
+  }
+
+  return {
+    host: clean(env.DB_HOST),
+    port: Number(clean(env.DB_PORT) || 5432),
+    user: clean(env.DB_USER),
+    password: String(env.DB_PASSWORD),
+    database: clean(env.DB_NAME),
+    ...shared,
+  };
 }
 
 function mapRows(rows, key) {
@@ -354,7 +377,7 @@ async function runCli(options = {}) {
   } catch (error) {
     const status = error?.migrationStatus || STATUS.FAILED;
     logger.error(`${PREFIX}_STATUS=${status}`);
-    logger.error(`${PREFIX}_FAILED: ${safeErrorMessage(error)}`);
+    logger.error(`${PREFIX}_FAILED: ${safeErrorMessage(error, options.env || process.env)}`);
     return status === STATUS.PREREQUISITE_MISSING ? EXIT_CODE.PREREQUISITE_MISSING
       : status === STATUS.SCHEMA_DRIFT ? EXIT_CODE.SCHEMA_DRIFT : EXIT_CODE.FAILED;
   }

--- a/test/customerHistoryClaimMethodsMigration.test.js
+++ b/test/customerHistoryClaimMethodsMigration.test.js
@@ -171,6 +171,98 @@ async function expectPreflightBlocked(client, expectedCode = runner.EXIT_CODE.SC
   return result;
 }
 
+test("database config prefers DATABASE_URL and preserves connection settings", () => {
+  const config = runner.createClientConfig({
+    DATABASE_URL: "postgres://url-user:url-password@url-db.example.test/cwf",
+    DB_HOST: "ignored-host",
+  });
+  assert.deepEqual(config, {
+    connectionString: "postgres://url-user:url-password@url-db.example.test/cwf",
+    options: "-c timezone=Asia/Bangkok",
+    ssl: { rejectUnauthorized: false },
+  });
+});
+
+test("database config supports split DB env and defaults DB_PORT to 5432", () => {
+  const env = {
+    DB_HOST: "production-db.internal",
+    DB_USER: "cwf_backend",
+    DB_PASSWORD: "split-password",
+    DB_NAME: "cwf_production",
+  };
+  assert.deepEqual(runner.createClientConfig(env), {
+    host: "production-db.internal",
+    port: 5432,
+    user: "cwf_backend",
+    password: "split-password",
+    database: "cwf_production",
+    options: "-c timezone=Asia/Bangkok",
+    ssl: { rejectUnauthorized: false },
+  });
+  assert.equal(runner.createClientConfig({ ...env, DB_PORT: "6432" }).port, 6432);
+});
+
+test("missing required split DB env fails before client creation", async () => {
+  const completeEnv = {
+    DB_HOST: "production-db.internal",
+    DB_USER: "cwf_backend",
+    DB_PASSWORD: "split-password",
+    DB_NAME: "cwf_production",
+  };
+  for (const missingName of ["DB_HOST", "DB_USER", "DB_PASSWORD", "DB_NAME"]) {
+    const env = { ...completeEnv };
+    delete env[missingName];
+    const logger = captureLogger();
+    let clientCreated = false;
+    const code = await runner.runCli({
+      env,
+      argv: [],
+      logger,
+      clientFactory() {
+        clientCreated = true;
+        return new FakeClient();
+      },
+    });
+    assert.equal(code, runner.EXIT_CODE.FAILED);
+    assert.equal(clientCreated, false);
+    assert.match(logger.lines.join("\n"), new RegExp(`missing required env: ${missingName}`));
+  }
+});
+
+test("connection failures do not log URL, host, or password secrets", async () => {
+  const cases = [
+    {
+      env: { DATABASE_URL: "postgres://private-user:private-pass@private-db.example.test/cwf" },
+      message: "connection failed: postgres://private-user:private-pass@private-db.example.test/cwf",
+      secrets: ["private-user", "private-pass", "private-db.example.test"],
+    },
+    {
+      env: {
+        DB_HOST: "private-db.internal",
+        DB_USER: "private-user",
+        DB_PASSWORD: "private-pass",
+        DB_NAME: "cwf_production",
+      },
+      message: "connection to private-db.internal failed password=private-pass",
+      secrets: ["private-db.internal", "private-pass"],
+    },
+  ];
+  for (const testCase of cases) {
+    const logger = captureLogger();
+    const client = new FakeClient();
+    client.connect = async () => { throw new Error(testCase.message); };
+    const code = await runner.runCli({
+      env: testCase.env,
+      argv: [],
+      logger,
+      clientFactory: () => client,
+    });
+    assert.equal(code, runner.EXIT_CODE.FAILED);
+    const output = logger.lines.join("\n");
+    for (const secret of testCase.secrets) assert.doesNotMatch(output, new RegExp(secret.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
+  }
+});
+
 test("legacy constraint is READY_TO_APPLY and preflight is read-only", async () => {
   const client = new FakeClient();
   const result = await runWith(client);


### PR DESCRIPTION
Closes #179

## Base / head
- Base SHA: `bab99da2e8b46248144998c6add9919caa4e3746`
- Head SHA: `978b7d583cc3d10a988d99c7c99799adccb04e8a`

## Root cause
`scripts/run-customer-history-claim-methods-migration.js#createClientConfig()` required `DATABASE_URL` and failed before client creation. Production backend credentials are injected as split `DB_HOST`, `DB_PORT`, `DB_USER`, `DB_PASSWORD`, and `DB_NAME`, so the owner-operated runner could not reach its read-only schema preflight from Render Web Shell.

## Changed files
- `scripts/run-customer-history-claim-methods-migration.js`
- `test/customerHistoryClaimMethodsMigration.test.js`
- `docs/CUSTOMER_HISTORY_CLAIM_METHODS_PRODUCTION_RUNBOOK.md`

## Implementation
- Prefer a non-empty `DATABASE_URL` exactly as before.
- Otherwise validate `DB_HOST`, `DB_USER`, `DB_PASSWORD`, and `DB_NAME` before client creation; use `DB_PORT` or default `5432`.
- Preserve `-c timezone=Asia/Bangkok` and `ssl.rejectUnauthorized=false` on both paths.
- Redact the active URL, host, and password from safe diagnostics.
- Update the owner runbook to document both injected Production env shapes.

Checksum, read-only preflight, confirmation token, schema fail-closed inspection, and migration SQL are unchanged.

## Security / production considerations
- Missing split credentials fail before `clientFactory`/connect.
- Logs do not expose connection URL, DB host, or DB password.
- No migration SQL, schema, route, UI, auth, payment, pricing, booking, or dispatch changes.
- No Production migration/data action, deploy, or merge was performed.

## Validation
- `node --check scripts/run-customer-history-claim-methods-migration.js` — pass
- `node --check test/customerHistoryClaimMethodsMigration.test.js` — pass
- `node --test test/customerHistoryClaimMethodsMigration.test.js` — pass, 19/19
- `npm test` on branch — 1305 tests, 1251 pass, 20 fail
- `npm test` on untouched base `bab99da2e8b46248144998c6add9919caa4e3746` with the same environment and dependency installation — 1301 tests, 1247 pass, 20 fail
- Exact failed-test-name set comparison — identical 20/20; branch-only failures = 0
- All baseline failures are in `test/adminStoreCatalogUi.test.js` and are unrelated to this change.
- `git diff --check` — pass
- Working tree after commit — clean

## Remaining risks
- The runner has not been executed against Production, per scope. Owner must review/deploy and separately authorize any Production preflight or apply action.
- Invalid non-empty `DB_PORT` values remain delegated to the PostgreSQL client, matching the backend-style env contract; missing/empty port defaults to 5432.