### PR TITLE
Fix Customer History runner false PK schema drift

### DIFF
--- a/scripts/run-customer-history-claim-methods-migration.js
+++ b/scripts/run-customer-history-claim-methods-migration.js
@@ -118,9 +118,10 @@ function compactCheck(value) {
   return compactSql(value).replace(/"right"/g, "right").replace(/[()]/g, "");
 }
 
-function sameColumns(row, expected) {
-  return Array.isArray(row?.column_names) && row.column_names.length === expected.length
-    && row.column_names.every((name, index) => name === expected[index]);
+function sameColumns(row, expected, key = "column_names") {
+  const actual = row?.[key];
+  return Array.isArray(actual) && actual.length === expected.length
+    && actual.every((name, index) => typeof name === "string" && name === expected[index]);
 }
 
 function normalizedPredicate(value) {
@@ -171,7 +172,7 @@ async function inspectSchema(client) {
 
   const primaryKeys = await client.query(`
     SELECT con.conname, idx.relname AS index_name, ind.indisprimary, ind.indisunique,
-           array_agg(att.attname ORDER BY keys.ordinality) AS column_names
+           array_agg(att.attname::text ORDER BY keys.ordinality) AS column_names
       FROM pg_constraint con
       JOIN pg_class rel ON rel.oid=con.conrelid
       JOIN pg_namespace nsp ON nsp.oid=rel.relnamespace
@@ -194,8 +195,8 @@ async function inspectSchema(client) {
   const fks = await client.query(`
     SELECT con.conname, confnsp.nspname AS foreign_schema, confrel.relname AS foreign_table,
            con.confdeltype AS delete_action,
-           array_agg(att.attname ORDER BY cols.ordinality) AS column_names,
-           array_agg(fatt.attname ORDER BY cols.ordinality) AS foreign_column_names
+           array_agg(att.attname::text ORDER BY cols.ordinality) AS column_names,
+           array_agg(fatt.attname::text ORDER BY cols.ordinality) AS foreign_column_names
       FROM pg_constraint con
       JOIN pg_class rel ON rel.oid=con.conrelid
       JOIN pg_namespace nsp ON nsp.oid=rel.relnamespace
@@ -221,8 +222,7 @@ async function inspectSchema(client) {
     const row = fkByName.get(name);
     if (!row || row.foreign_schema !== "public" || row.foreign_table !== expected.table
       || row.delete_action !== expected.deleteAction || !sameColumns(row, expected.columns)
-      || !Array.isArray(row.foreign_column_names)
-      || row.foreign_column_names.join(",") !== expected.foreignColumns.join(",")) {
+      || !sameColumns(row, expected.foreignColumns, "foreign_column_names")) {
       throw migrationError(STATUS.SCHEMA_DRIFT, `customer_history_claims FK drift: ${name}`);
     }
   }
@@ -261,7 +261,7 @@ async function inspectSchema(client) {
 
   const indexes = await client.query(`
     SELECT idx.relname AS indexname, ind.indisunique AS is_unique, ind.indisprimary AS is_primary,
-           array_agg(att.attname ORDER BY keys.ordinality)
+           array_agg(att.attname::text ORDER BY keys.ordinality)
              FILTER (WHERE keys.ordinality <= ind.indnkeyatts) AS column_names,
            pg_get_expr(ind.indpred, ind.indrelid) AS predicate
       FROM pg_index ind

--- a/test/customerHistoryClaimMethodsMigration.test.js
+++ b/test/customerHistoryClaimMethodsMigration.test.js
@@ -38,6 +38,16 @@ function methodRow(shape) {
   };
 }
 
+function shapedColumnNames(expected, shape) {
+  if (shape === "array-text") return `{${expected.join(",")}}`;
+  if (shape === "wrong-array-text") return "{other_id}";
+  if (shape === "multi-array-text") return `{${expected.join(",")},other_id}`;
+  if (shape === "reordered") return ["other_id", ...expected];
+  if (shape === "malformed") return "{claim_id";
+  if (shape === "null") return null;
+  return [...expected];
+}
+
 function expectedPrimaryKeys(shape) {
   if (shape === "missing") return [];
   return [{
@@ -45,7 +55,7 @@ function expectedPrimaryKeys(shape) {
     index_name: shape === "wrong-index" ? "unexpected_pkey_index" : "customer_history_claims_pkey",
     indisprimary: true,
     indisunique: true,
-    column_names: [shape === "wrong-column" ? "proof_job_id" : "claim_id"],
+    column_names: shape === "wrong-column" ? ["proof_job_id"] : shapedColumnNames(["claim_id"], shape),
   }];
 }
 
@@ -54,6 +64,8 @@ function expectedForeignKeys(shape) {
     { conname: "customer_history_claims_customer_sub_fkey", foreign_schema: "public", foreign_table: "customer_profiles", delete_action: shape === "wrong-delete" ? "a" : "c", column_names: ["customer_sub"], foreign_column_names: ["sub"] },
     { conname: "customer_history_claims_proof_job_id_fkey", foreign_schema: "public", foreign_table: shape === "wrong-target" ? "customer_profiles" : "jobs", delete_action: "r", column_names: ["proof_job_id"], foreign_column_names: ["job_id"] },
   ];
+  if (shape?.startsWith("local-")) rows[0].column_names = shapedColumnNames(["customer_sub"], shape.slice(6));
+  if (shape?.startsWith("foreign-")) rows[0].foreign_column_names = shapedColumnNames(["sub"], shape.slice(8));
   if (shape === "duplicate") rows.push({ ...rows[0], conname: "duplicate_customer_sub_fkey" });
   return rows;
 }
@@ -70,6 +82,7 @@ function expectedIndexes(shape) {
   if (shape === "wrong-column") phone.column_names = ["customer_sub"];
   if (shape === "wrong-predicate") phone.predicate = null;
   if (shape === "wrong-pk-index") rows[0].column_names = ["proof_job_id"];
+  if (shape?.startsWith("columns-")) phone.column_names = shapedColumnNames(["phone_norm"], shape.slice(8));
   if (shape === "duplicate") rows.push({ ...phone, indexname: "duplicate_active_phone" });
   return rows;
 }
@@ -271,6 +284,19 @@ test("legacy constraint is READY_TO_APPLY and preflight is read-only", async () 
   assert.equal(client.queries.some((sql) => sql.includes("ALTER TABLE")), false);
 });
 
+test("PK, FK, and index inspection casts PostgreSQL name values to deterministic text arrays", async () => {
+  const client = new FakeClient();
+  const result = await runWith(client);
+  assert.equal(result.code, 0, "JavaScript text arrays from node-postgres must be accepted");
+  const primaryKeyQuery = client.queries.find((sql) => sql.includes("con.contype='p'"));
+  const foreignKeyQuery = client.queries.find((sql) => sql.includes("con.contype='f'"));
+  const indexQuery = client.queries.find((sql) => sql.includes("FROM pg_index ind"));
+  assert.match(primaryKeyQuery, /array_agg\(att\.attname::text ORDER BY keys\.ordinality\)/);
+  assert.match(foreignKeyQuery, /array_agg\(att\.attname::text ORDER BY cols\.ordinality\)/);
+  assert.match(foreignKeyQuery, /array_agg\(fatt\.attname::text ORDER BY cols\.ordinality\)/);
+  assert.match(indexQuery, /array_agg\(att\.attname::text ORDER BY keys\.ordinality\)/);
+});
+
 test("exact widened constraint is ALREADY_APPLIED without running migration SQL", async () => {
   const client = new FakeClient({ methodShape: "widened" });
   const result = await runWith(client);
@@ -315,6 +341,12 @@ test("missing, wrong-column, and inconsistent-index primary keys fail before ALT
   await expectPreflightBlocked(new FakeClient({ indexShape: "wrong-pk-index" }));
 });
 
+test("PK column inspection rejects array-text, wrong, extra/reordered, malformed, and null values", async () => {
+  for (const pkShape of ["array-text", "wrong-array-text", "multi-array-text", "reordered", "malformed", "null"]) {
+    await expectPreflightBlocked(new FakeClient({ pkShape }));
+  }
+});
+
 test("required CHECK constraints reject missing, duplicate, and conflicting shapes before ALTER", async () => {
   for (const checkShape of ["missing-not-blank", "duplicate-method", "conflicting-phone"]) {
     await expectPreflightBlocked(new FakeClient({ checkShape }));
@@ -327,9 +359,23 @@ test("critical FKs reject wrong delete action, target, and duplicates before ALT
   }
 });
 
+test("critical FK local and foreign column lists remain exact and fail closed", async () => {
+  for (const side of ["local", "foreign"]) {
+    for (const shape of ["array-text", "wrong-array-text", "multi-array-text", "reordered", "malformed", "null"]) {
+      await expectPreflightBlocked(new FakeClient({ fkShape: `${side}-${shape}` }));
+    }
+  }
+});
+
 test("critical indexes reject wrong uniqueness, column, predicate, and duplicates before ALTER", async () => {
   for (const indexShape of ["wrong-unique", "wrong-column", "wrong-predicate", "duplicate"]) {
     await expectPreflightBlocked(new FakeClient({ indexShape }));
+  }
+});
+
+test("critical index column lists reject array-text, wrong, extra/reordered, malformed, and null values", async () => {
+  for (const shape of ["array-text", "wrong-array-text", "multi-array-text", "reordered", "malformed", "null"]) {
+    await expectPreflightBlocked(new FakeClient({ indexShape: `columns-${shape}` }));
   }
 });
 


### PR DESCRIPTION
## Base / head
- Base SHA: `e58df154dd4d746f5c41fd563d2bf27418920695`
- Head SHA: `769ef6b0edb6d7f47d27657368051277ad8e0e1f`

## Root cause
The PK, FK, and index inspection queries aggregate `pg_attribute.attname`, whose PostgreSQL type is `name`. Therefore `array_agg(att.attname)` returns `name[]` (OID 1003). With the repository's current `pg` dependency, the OID 1003 parser returns the literal string `"{claim_id}"`, while the OID 1009 `text[]` parser returns the JavaScript array `["claim_id"]`. `sameColumns()` intentionally accepts only exact JavaScript arrays, so valid Production PK metadata was reported as schema drift.

Local parser proof with the installed dependency:
- `name[]` OID 1003 + `{claim_id}` => `"{claim_id}"`
- `text[]` OID 1009 + `{claim_id}` => `["claim_id"]`

## Changed files
- `scripts/run-customer-history-claim-methods-migration.js`
- `test/customerHistoryClaimMethodsMigration.test.js`

## Implementation
- Cast PK local column names to `text` inside `array_agg`.
- Cast FK local and referenced column names to `text` inside `array_agg`.
- Cast index column names to `text` inside `array_agg`.
- Reuse one strict exact-list comparator for local and foreign column lists; it accepts only JavaScript arrays of exact string values, length, and order.

The SQL-side cast was chosen instead of parsing PostgreSQL array-text in JavaScript. This makes the database result type deterministic for node-postgres without broadening accepted schema shapes or implementing a second array grammar.

## Fail-closed behavior
- Exact PK name/index/flags/`["claim_id"]` remains required.
- Exact FK local/referenced columns and delete actions remain required.
- Exact critical index uniqueness/columns/predicates remain required.
- Array-text strings (including `{claim_id}`), wrong values, extra/multi-column values, reordered values, malformed strings, and null are rejected.
- Every new drift regression asserts migration SQL is not read and no ALTER is executed.

## Unchanged safety contracts
- Migration SQL and checksum: unchanged.
- Confirmation token and apply intent: unchanged.
- Schema readiness/checksum/preflight order: unchanged.
- No Production DB/schema/data action, migration run, deploy, or merge.
- No route/UI/simple-claim/auth/payment/pricing/booking/dispatch change.

## Validation
- `node --check scripts/run-customer-history-claim-methods-migration.js` — pass
- `node --check test/customerHistoryClaimMethodsMigration.test.js` — pass
- `node --test test/customerHistoryClaimMethodsMigration.test.js` — pass, 23/23
- `npm test` branch — 1309 tests, 1255 pass, 20 fail
- `npm test` untouched base `e58df154dd4d746f5c41fd563d2bf27418920695`, same environment/dependency installation — 1305 tests, 1251 pass, 20 fail
- Exact failure-name comparison — identical 20/20; branch-only failures = 0
- Baseline failures remain confined to the unrelated `test/adminStoreCatalogUi.test.js` assertions.
- `git diff --check` — pass
- Working tree — clean

## Remaining risk / owner action
- This hotfix has not been executed against Production. After review/merge/deploy, the owner may rerun only the separately authorized read-only preflight. This PR does not authorize or perform `--apply`.