### PR TITLE
Issue #183: phone tracking and direct completed-job reviews

### DIFF
--- a/customer-app/assets/customer-app.css
+++ b/customer-app/assets/customer-app.css
@@ -2138,6 +2138,30 @@ p { margin: 0; }
 .field-help { display: block; margin-top: 7px; color: var(--muted); font-size: 12.5px; line-height: 1.5; }
 .tracking-search-btn { min-height: 48px; width: 100%; }
 .tracking-result-shell { min-height: 148px; overflow: hidden; }
+.tracking-choice-shell,
+.tracking-choice-list,
+.tracking-choice { min-width: 0; }
+.tracking-choice-list { display: grid; grid-template-columns: 1fr; gap: 10px; }
+.tracking-choice {
+  width: 100%;
+  min-height: 64px;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 4px;
+  padding: 13px 14px;
+  border: 1px solid rgba(11, 75, 179, 0.18);
+  border-radius: 16px;
+  background: #fff;
+  color: var(--ink);
+  text-align: left;
+  cursor: pointer;
+  overflow-wrap: anywhere;
+}
+.tracking-choice:hover,
+.tracking-choice:focus-visible { border-color: var(--primary); box-shadow: 0 0 0 3px rgba(11, 75, 179, 0.12); }
+.tracking-choice span,
+.tracking-choice small { color: var(--muted); line-height: 1.45; }
 .tracking-empty-state,
 .tracking-error-state {
   min-height: 132px;

--- a/customer-app/assets/customer-app.js
+++ b/customer-app/assets/customer-app.js
@@ -3,7 +3,7 @@
 
   const App = window.CWFCustomerAppV2;
   const BOOT_TIMEOUT_MS = 3500;
-  const BUILD_ID = "20260717_customer_history_simple_link_v1";
+  const BUILD_ID = "20260718_tracking_phone_review_direct_v1";
 
   function withTimeout(promise, timeoutMs) {
     return Promise.race([

--- a/customer-app/index.html
+++ b/customer-app/index.html
@@ -21,10 +21,10 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Noto+Sans+Thai:wght@400;500;600;700;800;900&display=swap" media="print" onload="this.media='all'">
   <noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Noto+Sans+Thai:wght@400;500;600;700;800;900&display=swap"></noscript>
-  <link rel="manifest" href="./manifest.webmanifest?v=20260717_customer_history_simple_link_v1">
+  <link rel="manifest" href="./manifest.webmanifest?v=20260718_tracking_phone_review_direct_v1">
   <link rel="icon" type="image/png" sizes="192x192" href="./assets/icons/cwf-customer-192.png">
   <link rel="apple-touch-icon" sizes="180x180" href="./assets/icons/cwf-customer-180.png">
-  <link rel="stylesheet" href="./assets/customer-app.css?v=20260717_customer_history_simple_link_v1">
+  <link rel="stylesheet" href="./assets/customer-app.css?v=20260718_tracking_phone_review_direct_v1">
 </head>
 <body class="is-app-booting">
   <div class="app-shell" data-app-shell>
@@ -62,24 +62,24 @@
     </nav>
   </div>
 
-  <script src="./modules/iconRegistry.js?v=20260717_customer_history_simple_link_v1"></script>
-  <script src="./modules/state.js?v=20260717_customer_history_simple_link_v1"></script>
-  <script src="./modules/utils.js?v=20260717_customer_history_simple_link_v1"></script>
-  <script src="./modules/analytics.js?v=20260717_customer_history_simple_link_v1"></script>
-  <script src="./modules/api.js?v=20260717_customer_history_simple_link_v1"></script>
-  <script src="./modules/pageAvailability.js?v=20260717_customer_history_simple_link_v1"></script>
-  <script src="./modules/services.js?v=20260717_customer_history_simple_link_v1"></script>
-  <script src="./modules/advisor.js?v=20260717_customer_history_simple_link_v1"></script>
-  <script src="./modules/ui.js?v=20260717_customer_history_simple_link_v1"></script>
-  <script src="./modules/store.js?v=20260717_customer_history_simple_link_v1"></script>
-  <script src="./modules/auth.js?v=20260717_customer_history_simple_link_v1"></script>
-  <script src="./modules/pricing.js?v=20260717_customer_history_simple_link_v1"></script>
-  <script src="./modules/availability.js?v=20260717_customer_history_simple_link_v1"></script>
-  <script src="./modules/bookingScheduled.js?v=20260717_customer_history_simple_link_v1"></script>
-  <script src="./modules/bookingUrgent.js?v=20260717_customer_history_simple_link_v1"></script>
-  <script src="./modules/tracking.js?v=20260717_customer_history_simple_link_v1"></script>
-  <script src="./modules/profile.js?v=20260717_customer_history_simple_link_v1"></script>
-  <script src="./modules/router.js?v=20260717_customer_history_simple_link_v1"></script>
-  <script src="./assets/customer-app.js?v=20260717_customer_history_simple_link_v1"></script>
+  <script src="./modules/iconRegistry.js?v=20260718_tracking_phone_review_direct_v1"></script>
+  <script src="./modules/state.js?v=20260718_tracking_phone_review_direct_v1"></script>
+  <script src="./modules/utils.js?v=20260718_tracking_phone_review_direct_v1"></script>
+  <script src="./modules/analytics.js?v=20260718_tracking_phone_review_direct_v1"></script>
+  <script src="./modules/api.js?v=20260718_tracking_phone_review_direct_v1"></script>
+  <script src="./modules/pageAvailability.js?v=20260718_tracking_phone_review_direct_v1"></script>
+  <script src="./modules/services.js?v=20260718_tracking_phone_review_direct_v1"></script>
+  <script src="./modules/advisor.js?v=20260718_tracking_phone_review_direct_v1"></script>
+  <script src="./modules/ui.js?v=20260718_tracking_phone_review_direct_v1"></script>
+  <script src="./modules/store.js?v=20260718_tracking_phone_review_direct_v1"></script>
+  <script src="./modules/auth.js?v=20260718_tracking_phone_review_direct_v1"></script>
+  <script src="./modules/pricing.js?v=20260718_tracking_phone_review_direct_v1"></script>
+  <script src="./modules/availability.js?v=20260718_tracking_phone_review_direct_v1"></script>
+  <script src="./modules/bookingScheduled.js?v=20260718_tracking_phone_review_direct_v1"></script>
+  <script src="./modules/bookingUrgent.js?v=20260718_tracking_phone_review_direct_v1"></script>
+  <script src="./modules/tracking.js?v=20260718_tracking_phone_review_direct_v1"></script>
+  <script src="./modules/profile.js?v=20260718_tracking_phone_review_direct_v1"></script>
+  <script src="./modules/router.js?v=20260718_tracking_phone_review_direct_v1"></script>
+  <script src="./assets/customer-app.js?v=20260718_tracking_phone_review_direct_v1"></script>
 </body>
 </html>

--- a/customer-app/manifest.webmanifest
+++ b/customer-app/manifest.webmanifest
@@ -2,7 +2,7 @@
   "name": "CWF Customer Service",
   "short_name": "CWF Service",
   "description": "แอปลูกค้า Coldwindflow สำหรับเลือกบริการ จองคิว และติดตามงาน",
-  "start_url": "/customer-app/index.html?v=20260717_customer_history_simple_link_v1#home",
+  "start_url": "/customer-app/index.html?v=20260718_tracking_phone_review_direct_v1#home",
   "scope": "/customer-app/",
   "id": "/customer-app/",
   "display": "standalone",

--- a/customer-app/modules/api.js
+++ b/customer-app/modules/api.js
@@ -120,6 +120,22 @@
       return requestJson("/public/track", { query: { q }, cache: "no-store" });
     },
 
+    async lookupTracking(identifier) {
+      return requestJson("/public/track/lookup", {
+        method: "POST",
+        body: { identifier: String(identifier || "").trim() },
+        cache: "no-store",
+      });
+    },
+
+    async selectTracking(selectionRef) {
+      return requestJson("/public/track/select", {
+        method: "POST",
+        body: { selection_ref: String(selectionRef || "").trim() },
+        cache: "no-store",
+      });
+    },
+
     async loadUrgentStatus(q) {
       return requestJson("/public/urgent-status", { query: { q }, cache: "no-store" });
     },

--- a/customer-app/modules/tracking.js
+++ b/customer-app/modules/tracking.js
@@ -6,8 +6,9 @@
   const LINE_URL = "https://lin.ee/fG1Oq7y";
   const WARRANTY_COPY = "รับประกันงานล้าง 30 วัน เฉพาะอาการที่เกี่ยวข้องกับการบริการ ไม่รวมอะไหล่เสีย ระบบรั่ว บอร์ด คอมเพรสเซอร์ ไฟตก หรือปัญหาจากตัวเครื่องเดิม";
 
-  // Private, in-memory lookup credential. It may be the long secret
-  // booking_token (from the ?q=/?token= deep link) or a customer-typed code.
+  // Private, in-memory lookup credential for a long booking_token from a
+  // ?q=/?token= deep link. Customer-typed phone/code lookups receive a separate
+  // short-lived selection reference in tracking state.
   // It is NEVER written into the draft, the visible input, or rendered HTML.
   // Refresh and post-review reloads reuse THIS value so a token session is not
   // silently downgraded to code-only access. A manual "ตรวจสอบสถานะ" replaces it
@@ -1028,43 +1029,21 @@
 
   function renderTechnicianReviewForm(data) {
     if (!isDone(data) || data.review?.already_reviewed) return "";
-    // Reviewing is a WRITE. Two authorised shapes, mirroring the server policy:
-    //  - token lookup (access_level "token"): the exact booking_token authorises
-    //    and is injected from in-memory state only at submit time. No PII entry needed.
-    //  - LEGACY job with no booking_token: a booking_code lookup exposes a
-    //    minimal `legacy_review_eligible` flag; the customer proves ownership by
-    //    typing their FULL phone, posted as booking_code + customer_phone.
-    // A tokened job accessed by code is NOT legacy-eligible, so it never shows
-    // the legacy form (the server would reject a downgrade anyway).
+    // Reviewing is authorised by the exact booking token or the short-lived,
+    // job-bound selection reference returned by the server. Both credentials
+    // stay in memory and are injected only when the request is submitted.
     const reviewToken = canUseTokenActions(data) ? (data.booking_token || "") : "";
-    const legacyEligible = !reviewToken
-      && data.legacy_review_eligible === true
-      && !!clean(data.booking_code);
-    if (!reviewToken && !legacyEligible) return "";
-    // For token access the booking_token is NOT written into the form (it would
-    // leak into rendered HTML). The form is marked data-review-token and the
-    // handler injects the token from state at submit time. The legacy path only
-    // ever uses the public booking_code + the customer's phone.
-    const credentialFields = reviewToken
-      ? ""
-      : `<input type="hidden" name="booking_code" value="${esc(data.booking_code || "")}">
-          <label class="field">
-            <span>เบอร์โทรที่ใช้จอง (ยืนยันตัวตน)</span>
-            <input class="input" type="tel" name="customer_phone" inputmode="numeric"
-                   autocomplete="tel" placeholder="เช่น 0812345678" required>
-          </label>`;
-    const legacyHint = legacyEligible
-      ? `<p class="muted">กรอกเบอร์โทรที่ใช้จองงานนี้เพื่อยืนยันตัวตนก่อนรีวิว</p>`
+    const selectionReference = data.capabilities?.can_submit_review === true
+      ? clean(data.selection_ref)
       : "";
+    if (!reviewToken && !selectionReference) return "";
     return `
       <section class="tracking-extra-card review-form-card">
         <div class="section-head compact">
           <span class="section-kicker">Review</span>
           <h2>ให้คะแนนงานนี้</h2>
         </div>
-        ${legacyHint}
-        <form data-review-form${reviewToken ? " data-review-token" : ""}>
-          ${credentialFields}
+        <form data-review-form>
           ${renderStarRatingField("technician", "คะแนนทีมช่าง")}
           <label class="field">
             <span>รีวิว</span>
@@ -1170,8 +1149,9 @@
 
     const hasExactToken = canUseTokenActions(data) && !!clean(data.booking_token);
     if (hasExactToken && data.catalog_review?.eligible === true) return "catalog";
-    const hasLegacyPhoneProofPath = data.legacy_review_eligible === true && !!clean(data.booking_code);
-    if (hasExactToken || hasLegacyPhoneProofPath) return "technician";
+    const hasSelectionReference = data.capabilities?.can_submit_review === true
+      && !!clean(data.selection_ref);
+    if (hasExactToken || hasSelectionReference) return "technician";
     return "";
   }
 
@@ -1186,7 +1166,7 @@
           <span class="section-kicker">Review</span>
           <h2>การให้คะแนนเป็นแบบอ่านอย่างเดียว</h2>
         </div>
-        <p class="muted">การค้นด้วย Booking Code ใช้ดูสถานะได้ แต่บันทึกคะแนนไม่ได้ กรุณาเปิดลิงก์ติดตามงานแบบปลอดภัยที่ได้รับจาก CWF หรือติดต่อแอดมิน</p>
+        <p class="muted">งานนี้ยังไม่อยู่ในสถานะที่ส่งรีวิวได้</p>
       </section>`;
   }
 
@@ -1360,9 +1340,30 @@
     }
   }
 
+  function renderTrackingChoices(jobs) {
+    const list = Array.isArray(jobs) ? jobs : [];
+    if (!list.length) return "";
+    return `
+      <div class="tracking-choice-shell">
+        <div class="section-head compact">
+          <span class="section-kicker">Tracking</span>
+          <h2>เลือกงานที่ต้องการติดตาม</h2>
+        </div>
+        <div class="tracking-choice-list">
+          ${list.map((job, index) => `
+            <button class="tracking-choice" type="button" data-tracking-choice="${index}">
+              <strong>${esc(job.booking_code || "งาน CWF")}</strong>
+              <span>${esc(job.appointment_datetime ? root.utils.formatDateTime(job.appointment_datetime) : "ไม่ระบุวันนัดหมาย")}</span>
+              <span>${esc(job.service_summary || "บริการ CWF")} · ${esc(job.job_status || "รอตรวจสอบสถานะ")}</span>
+              ${job.location_summary ? `<small>${esc(job.location_summary)}</small>` : ""}
+            </button>`).join("")}
+        </div>
+      </div>`;
+  }
+
   function renderTrackingResult() {
     const state = root.state.tracking;
-    if (state.status === "idle") return `<div class="tracking-empty-state"><strong>ค้นหางานของคุณ</strong><span>กรอกเลขติดตามที่อยู่ในข้อความยืนยันนัดหมาย</span></div>`;
+    if (state.status === "idle") return `<div class="tracking-empty-state"><strong>ค้นหางานของคุณ</strong><span>กรอกเบอร์โทรที่ใช้จอง หรือ Booking Code</span></div>`;
     if (state.status === "loading") return `
       <div class="tracking-skeleton" role="status" aria-live="polite" aria-label="กำลังค้นหางาน">
         <span class="skeleton-line is-title"></span>
@@ -1370,6 +1371,7 @@
         <span class="skeleton-line is-short"></span>
         <div class="skeleton-grid"><span></span><span></span></div>
       </div>`;
+    if (state.status === "choices") return renderTrackingChoices(state.data?.jobs);
     if (state.status === "error") {
       const rateLimited = state.errorKind === "rate";
       const offline = state.errorKind === "network";
@@ -1565,46 +1567,23 @@
     })));
   }
 
-  // lookup(container, opts)
-  //   opts.credential : an explicit PRIVATE credential (deep-link token, or the
-  //                     preserved active credential for refresh / review reload).
-  //                     When provided it is used for the request and is NEVER
-  //                     written to the draft or the visible input.
-  //   (no opts)       : manual "ตรวจสอบสถานะ" — use whatever the customer typed
-  //                     in the visible input and make it the new active credential.
-  async function lookup(container, opts) {
-    opts = opts || {};
-    const input = container.querySelector("#tracking-code");
-    const usingPrivate = opts.credential != null;
-    const qRaw = usingPrivate
-      ? String(opts.credential || "").trim()
-      : String((input && input.value) || "").trim();
-    const q = !usingPrivate && /^CWF[A-Z0-9]{7}$/i.test(qRaw) ? qRaw.toUpperCase() : qRaw;
-    // The active credential future refreshes/reviews reuse is always the one
-    // actually used for THIS request. A private credential (token) is preserved;
-    // a manual read replaces it with the typed value.
-    setActiveCredential(q);
-    // Only the visible typed value is persisted to the draft — a private
-    // credential must never enter the draft (it would re-render into the input).
-    if (!usingPrivate) {
-      root.state.updateDraft("tracking", { trackingCode: q });
-    }
-    if (!q) {
-      root.state.setTracking({ status: "error", data: null, error: "กรุณากรอกเลขงานหรือรหัสติดตาม" });
-      container.querySelector("[data-tracking-result]").innerHTML = renderTrackingResult();
-      return;
-    }
-    // Store order codes look like "CWF-XXXX" — route them to the order lookup
-    // instead of the job/booking tracker.
-    if (/^CWF-/i.test(q)) { await lookupOrder(container, q); return; }
-    root.state.setTracking({ status: "loading", data: null, error: "", errorKind: "", retryAfter: 0 });
+  function finishTrackingRender(container) {
     container.querySelector("[data-tracking-result]").innerHTML = renderTrackingResult();
+    const timeline = container.querySelector("[data-tracking-timeline]");
+    if (timeline) timeline.innerHTML = renderTimeline();
+    bindResultActions(container);
+    root.utils.decorateActionIcons?.(container);
+  }
+
+  async function openSelection(container, selectionReference) {
+    const reference = clean(selectionReference);
+    if (!reference) return;
+    root.state.setTracking({ status: "loading", data: null, error: "", errorKind: "", retryAfter: 0 });
+    finishTrackingRender(container);
     try {
-      const data = await root.api.trackBooking(q);
+      const data = await root.api.selectTracking(reference);
       root.state.setTracking({ status: "success", data, error: "", errorKind: "", retryAfter: 0 });
-      // Privacy: the request may have used the private booking_token. Only ever
-      // put the human-facing booking_code into the visible input/draft — the
-      // token stays solely in activeCredential + state as the request credential.
+      const input = container.querySelector("#tracking-code");
       if (data && data.booking_code) {
         root.state.updateDraft("tracking", { trackingCode: String(data.booking_code) });
         if (input) input.value = String(data.booking_code);
@@ -1618,20 +1597,71 @@
         errorKind: status === 429 ? "rate" : status === 404 ? "not-found" : "network",
         retryAfter: Number(error?.data?.retry_after_s || 0),
       });
+    }
+    finishTrackingRender(container);
+  }
+
+  // Deep-link tokens retain the existing GET contract. Customer-typed phone
+  // numbers and Booking Codes use a body-only lookup and then a signed selection
+  // reference, so the typed identifier is never copied into a request URL.
+  async function lookup(container, opts) {
+    opts = opts || {};
+    const input = container.querySelector("#tracking-code");
+    const usingPrivate = opts.credential != null;
+    const qRaw = usingPrivate
+      ? String(opts.credential || "").trim()
+      : String((input && input.value) || "").trim();
+    const q = !usingPrivate && /^CWF[A-Z0-9]{7}$/i.test(qRaw) ? qRaw.toUpperCase() : qRaw;
+    if (usingPrivate) setActiveCredential(q);
+    else setActiveCredential("");
+    if (!usingPrivate) {
+      root.state.updateDraft("tracking", { trackingCode: q });
+    }
+    if (!q) {
+      root.state.setTracking({ status: "error", data: null, error: "กรุณากรอกเบอร์โทรหรือ Booking Code" });
+      finishTrackingRender(container);
+      return;
+    }
+    // Store order codes look like "CWF-XXXX" — route them to the order lookup
+    // instead of the job/booking tracker.
+    if (/^CWF-/i.test(q)) { await lookupOrder(container, q); return; }
+    root.state.setTracking({ status: "loading", data: null, error: "", errorKind: "", retryAfter: 0 });
+    finishTrackingRender(container);
+    try {
+      if (usingPrivate) {
+        const data = await root.api.trackBooking(q);
+        root.state.setTracking({ status: "success", data, error: "", errorKind: "", retryAfter: 0 });
+        if (data && data.booking_code) {
+          root.state.updateDraft("tracking", { trackingCode: String(data.booking_code) });
+          if (input) input.value = String(data.booking_code);
+        }
+      } else {
+        const result = await root.api.lookupTracking(q);
+        const jobs = Array.isArray(result?.jobs) ? result.jobs : [];
+        if (jobs.length === 1) return openSelection(container, jobs[0].selection_ref);
+        root.state.setTracking({ status: "choices", data: { jobs }, error: "", errorKind: "", retryAfter: 0 });
+      }
+    } catch (error) {
+      const status = Number(error && error.status);
+      root.state.setTracking({
+        status: "error",
+        data: null,
+        error: error && error.message,
+        errorKind: status === 429 ? "rate" : status === 404 ? "not-found" : "network",
+        retryAfter: Number(error?.data?.retry_after_s || 0),
+      });
       // A failed private lookup must not leave the token anywhere visible — it
       // was never written to the input/draft, so nothing to clear here.
     }
-    container.querySelector("[data-tracking-result]").innerHTML = renderTrackingResult();
-    const timeline = container.querySelector("[data-tracking-timeline]");
-    if (timeline) timeline.innerHTML = renderTimeline();
-    bindResultActions(container);
-    root.utils.decorateActionIcons?.(container);
+    finishTrackingRender(container);
   }
 
   // Refresh / post-review reloads reuse the private active credential so a
   // token session keeps full access instead of silently downgrading to the
   // visible booking_code.
   function reloadCurrent(container) {
+    const selectionReference = clean(root.state.tracking.data?.selection_ref);
+    if (selectionReference) return openSelection(container, selectionReference);
     if (activeCredential) return lookup(container, { credential: activeCredential });
     return lookup(container);
   }
@@ -1675,6 +1705,18 @@
       });
     }
 
+    if (result && !result.dataset.trackingChoicesBound) {
+      result.dataset.trackingChoicesBound = "1";
+      result.addEventListener("click", (event) => {
+        const choice = event.target.closest("[data-tracking-choice]");
+        if (!choice) return;
+        const index = Number(choice.getAttribute("data-tracking-choice"));
+        const jobs = root.state.tracking.data?.jobs;
+        const reference = Array.isArray(jobs) ? jobs[index]?.selection_ref : "";
+        if (reference) openSelection(container, reference);
+      });
+    }
+
     const refresh = container.querySelector("[data-action='track-refresh']");
     if (refresh) refresh.addEventListener("click", () => reloadCurrent(container), { once: true });
 
@@ -1711,11 +1753,13 @@
         const status = form.querySelector("[data-review-status]");
         const submit = form.querySelector("button[type='submit']");
         const payload = Object.fromEntries(new FormData(form).entries());
-        // Token credential is injected from state, never read from the DOM.
-        if (form.hasAttribute("data-review-token")) {
-          const token = (root.state.tracking.data || {}).booking_token || "";
-          if (token) payload.booking_token = token;
-        }
+        // The credential is injected from in-memory state, never read from or
+        // rendered into the DOM.
+        const trackingData = root.state.tracking.data || {};
+        const token = canUseTokenActions(trackingData) ? clean(trackingData.booking_token) : "";
+        const selectionReference = clean(trackingData.selection_ref);
+        if (token) payload.booking_token = token;
+        else if (selectionReference) payload.selection_ref = selectionReference;
         payload.rating = Number(payload.rating || 5);
         if (status) status.textContent = "กำลังส่งรีวิว...";
         if (submit) submit.disabled = true;
@@ -1787,10 +1831,10 @@
           <section class="card lookup-card" aria-labelledby="tracking-search-title">
             <h2 id="tracking-search-title" class="tracking-search-title">ค้นหางาน</h2>
             <div class="field">
-              <label for="tracking-code">เลขติดตามงาน</label>
-              <input id="tracking-code" class="input tracking-code-input" placeholder="CWFXXXXXXX" value="${esc(code)}"
+              <label for="tracking-code">เบอร์โทร หรือ Booking Code</label>
+              <input id="tracking-code" class="input tracking-code-input" placeholder="กรอกเบอร์โทรหรือรหัสงาน" value="${esc(code)}"
                 inputmode="text" autocomplete="off" autocapitalize="characters" spellcheck="false" maxlength="32">
-              <span class="field-help">เลขติดตามอยู่ในข้อความยืนยันนัดหมายจาก CWF</span>
+              <span class="field-help">ค้นหาด้วยเบอร์ที่ใช้จอง หรือรหัสงานจาก CWF</span>
             </div>
             <div class="button-row">
               <button class="primary-btn tracking-search-btn" type="button" data-action="track-read">ค้นหางาน</button>
@@ -1858,5 +1902,5 @@
       unitInspection,
     },
   };
-  console.info("[customer-tracking] review restore v1 loaded");
+  console.info("[customer-tracking] phone lookup review direct v1 loaded");
 })();

--- a/customer-app/sw.js
+++ b/customer-app/sw.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const BUILD_ID = "20260717_customer_history_simple_link_v1";
+const BUILD_ID = "20260718_tracking_phone_review_direct_v1";
 const CACHE_NAME = `cwf-customer-app-v2-${BUILD_ID}`;
 const APP_SHELL = [
   `./index.html?v=${BUILD_ID}`,

--- a/index.js
+++ b/index.js
@@ -26762,7 +26762,7 @@ app.post("/public/review", async (req, res) => {
   // already-verified job identity instead. Token/code behavior stays unchanged.
   const identifierKey = selection
     ? trackingPrivacy.selectionReviewLimiterKey(selection.job_id)
-    : crypto.createHash("sha256").update(token || code).digest("hex");
+    : trackingPrivacy.publicReviewLimiterKey(token ? "token" : "code", token || code);
   if (!publicReviewKeyRateLimiter.check(identifierKey).allowed) {
     return res.status(429).json({ error: "ส่งรีวิวถี่เกินไป กรุณารอสักครู่", code: "RATE_LIMITED" });
   }

--- a/index.js
+++ b/index.js
@@ -26554,9 +26554,14 @@ if (FLAG_SHOW_TECH_TEAM_ON_TRACKING && canShowPublicTechnician) {
     // human-readable booking_code = masked PII only (it leaks too easily to
     // act as a full credential) — see server/services/public/trackingPrivacy.js.
     const fullAccess = !selection && trackingPrivacy.isFullAccessQuery(q, row);
+    // A selection capability has one absolute 15-minute lifetime. Returning the
+    // verified reference prevents select/refresh/post-review reload from rolling
+    // that deadline forward. A fresh capability is issued only by a fresh lookup.
     const issuedSelectionReference = fullAccess
       ? ""
-      : trackingPrivacy.createTrackingSelectionReference(row.job_id, getJwtSecret());
+      : selection
+        ? selectionReference
+        : trackingPrivacy.createTrackingSelectionReference(row.job_id, getJwtSecret());
     // Minimal, non-sensitive eligibility signal so a LEGACY customer (a job with
     // no booking_token) can still see the review form on a booking_code lookup
     // and submit code + full phone. It reveals only that a review is possible —
@@ -26752,9 +26757,12 @@ app.post("/public/review", async (req, res) => {
   if ((selectionReference && !selection) || (!token && !selection && !code)) {
     return res.status(400).json({ error: GENERIC_REVIEW_ERROR });
   }
-  // Per-identifier budget (defends one job's code against many-IP hammering).
-  const identifierValue = token || selectionReference || code;
-  const identifierKey = crypto.createHash("sha256").update(identifierValue).digest("hex");
+  // Per-identifier budget (defends one job's credential against many-IP
+  // hammering). Selection ciphertext is randomized, so bind its bucket to the
+  // already-verified job identity instead. Token/code behavior stays unchanged.
+  const identifierKey = selection
+    ? trackingPrivacy.selectionReviewLimiterKey(selection.job_id)
+    : crypto.createHash("sha256").update(token || code).digest("hex");
   if (!publicReviewKeyRateLimiter.check(identifierKey).allowed) {
     return res.status(429).json({ error: "ส่งรีวิวถี่เกินไป กรุณารอสักครู่", code: "RATE_LIMITED" });
   }

--- a/index.js
+++ b/index.js
@@ -26225,7 +26225,10 @@ app.get("/public/urgent-status", async (req, res) => {
   }
 });
 
-app.get("/public/track", async (req, res) => {
+app.get("/public/track", publicTrackHandler);
+app.post("/public/track/select", publicTrackHandler);
+
+async function publicTrackHandler(req, res) {
   res.set("Cache-Control", "no-store, no-cache, must-revalidate, max-age=0");
   res.set("Pragma", "no-cache");
   res.set("Expires", "0");
@@ -26239,11 +26242,17 @@ app.get("/public/track", async (req, res) => {
       retry_after_s: trackRate.retry_after_s,
     });
   }
+  const selectionReference = String(req.body?.selection_ref || "").trim();
+  const selection = selectionReference
+    ? trackingPrivacy.verifyTrackingSelectionReference(selectionReference, getJwtSecret())
+    : null;
+  if (selectionReference && !selection) return res.status(404).json({ error: "ไม่พบงาน" });
   const rawQuery = (req.query.q || req.query.token || req.query.booking_code || "").toString().trim();
   // Booking codes are case-insensitive for customer input. Token casing is
   // private and significant, so only normalize a value with the exact code shape.
-  const q = /^CWF[A-Z0-9]{7}$/i.test(rawQuery) ? rawQuery.toUpperCase() : rawQuery;
-  if (!q) return res.status(400).json({ error: "ต้องส่ง q (token หรือ booking_code)" });
+  const isBookingCodeQuery = /^CWF[A-Z0-9]{7}$/i.test(rawQuery);
+  const q = isBookingCodeQuery ? rawQuery.toUpperCase() : rawQuery;
+  if (!q && !selection) return res.status(400).json({ error: "ต้องระบุข้อมูลค้นหา" });
 
   try {
     const r = await pool.query(
@@ -26261,13 +26270,15 @@ app.get("/public/track", async (req, res) => {
         tp.full_name AS tech_name, tp.photo_path AS tech_photo, tp.rank_level AS tech_rank_level, tp.rank_key AS tech_rank_key, tp.rating, tp.grade, tp.phone AS tech_phone
       FROM public.jobs j
       LEFT JOIN public.technician_profiles tp ON tp.username = j.technician_username
-      WHERE (j.booking_token=$1 OR j.booking_code=$1)
-      LIMIT 1
+      WHERE ${selection ? "j.job_id=$1" : isBookingCodeQuery ? "j.booking_code=$1" : "j.booking_token=$1"}
+      LIMIT 2
       `,
-      [q]
+      [selection ? selection.job_id : q]
     );
 
-    if (r.rows.length === 0) return res.status(404).json({ error: "ไม่พบงาน" });
+    if (r.rows.length === 0 || (isBookingCodeQuery && r.rows.length !== 1)) {
+      return res.status(404).json({ error: "ไม่พบงาน" });
+    }
 
     const row = r.rows[0];
     const origin = `${req.protocol}://${req.get("host")}`;
@@ -26542,7 +26553,10 @@ if (FLAG_SHOW_TECH_TEAM_ON_TRACKING && canShowPublicTechnician) {
     // Access level: the long random booking_token = full detail. The short
     // human-readable booking_code = masked PII only (it leaks too easily to
     // act as a full credential) — see server/services/public/trackingPrivacy.js.
-    const fullAccess = trackingPrivacy.isFullAccessQuery(q, row);
+    const fullAccess = !selection && trackingPrivacy.isFullAccessQuery(q, row);
+    const issuedSelectionReference = fullAccess
+      ? ""
+      : trackingPrivacy.createTrackingSelectionReference(row.job_id, getJwtSecret());
     // Minimal, non-sensitive eligibility signal so a LEGACY customer (a job with
     // no booking_token) can still see the review form on a booking_code lookup
     // and submit code + full phone. It reveals only that a review is possible —
@@ -26640,10 +26654,60 @@ if (FLAG_SHOW_TECH_TEAM_ON_TRACKING && canShowPublicTechnician) {
       // ✅ รายชื่อทีมช่างทั้งหมด (ถ้าเปิด flag) — ใช้ในหน้า Tracking
       technician_team,
     };
-    res.json(fullAccess ? trackPayload : trackingPrivacy.redactPublicTrackPayload(trackPayload));
+    res.json(fullAccess
+      ? trackPayload
+      : trackingPrivacy.selectionPublicTrackPayload(
+          trackPayload,
+          issuedSelectionReference,
+          isDone && !row.canceled_at && !row.customer_rating && !!row.technician_username,
+        ));
   } catch (e) {
-    console.error(e);
+    console.error("[public/track] failed", { code: String(e?.code || "TRACK_FAILED") });
     res.status(500).json({ error: "ติดตามงานไม่สำเร็จ" });
+  }
+}
+
+app.post("/public/track/lookup", async (req, res) => {
+  res.set("Cache-Control", "no-store, no-cache, must-revalidate, max-age=0");
+  res.set("Referrer-Policy", "no-referrer");
+  const trackRate = publicTrackRateLimiter.check(trackingPrivacy.clientIpKey(req));
+  if (!trackRate.allowed) {
+    return res.status(429).json({ error: "ค้นหาบ่อยเกินไป กรุณารอสักครู่", code: "RATE_LIMITED", retry_after_s: trackRate.retry_after_s });
+  }
+  const identifier = String(req.body?.identifier || "").trim();
+  const phone = trackingPrivacy.normalizeTrackingPhone(identifier);
+  const bookingCode = /^CWF[A-Z0-9]{7}$/i.test(identifier) ? identifier.toUpperCase() : "";
+  if (!phone && !bookingCode) return res.status(400).json({ error: "ไม่พบงาน" });
+  const secret = getJwtSecret();
+  if (!secret) return res.status(503).json({ error: "ระบบติดตามงานยังไม่พร้อมใช้งาน" });
+  try {
+    const result = phone
+      ? await pool.query(
+          `SELECT job_id, booking_code, appointment_datetime, job_type, job_status, job_zone, address_text
+             FROM public.jobs
+            WHERE regexp_replace(COALESCE(customer_phone, ''), '[^0-9]', '', 'g') = ANY($1::text[])
+            ORDER BY COALESCE(appointment_datetime, created_at) DESC NULLS LAST, job_id DESC
+            LIMIT 50`,
+          [phone.match_digits],
+        )
+      : await pool.query(
+          `SELECT job_id, booking_code, appointment_datetime, job_type, job_status, job_zone, address_text
+             FROM public.jobs
+            WHERE booking_code=$1
+            ORDER BY job_id DESC
+            LIMIT 2`,
+          [bookingCode],
+        );
+    const rows = result.rows || [];
+    if (!rows.length || (bookingCode && rows.length !== 1)) return res.status(404).json({ error: "ไม่พบงาน" });
+    return res.json(trackingPrivacy.buildSafeTrackingLookupResponse(
+      rows,
+      phone ? "phone" : "booking_code",
+      secret,
+    ));
+  } catch (error) {
+    console.error("[public/track/lookup] failed", { code: String(error?.code || "LOOKUP_FAILED") });
+    return res.status(500).json({ error: "ค้นหางานไม่สำเร็จ" });
   }
 });
 
@@ -26669,6 +26733,10 @@ app.post("/public/review", async (req, res) => {
   const GENERIC_REVIEW_ERROR = "ไม่สามารถส่งรีวิวได้ กรุณาตรวจสอบเลข/สถานะงานและข้อมูลยืนยันอีกครั้ง";
   const body = req.body || {};
   const token = String(body.token || body.booking_token || "").trim();
+  const selectionReference = String(body.selection_ref || "").trim();
+  const selection = selectionReference
+    ? trackingPrivacy.verifyTrackingSelectionReference(selectionReference, getJwtSecret())
+    : null;
   const code = String(body.booking_code || body.q || "").trim();
   const phoneDigits = String(body.customer_phone || "").replace(/\D/g, "");
   const star = Number(body.rating);
@@ -26681,11 +26749,12 @@ app.post("/public/review", async (req, res) => {
   if (!Number.isFinite(star) || star < 1 || star > 5) {
     return res.status(400).json({ error: "rating ต้องอยู่ระหว่าง 1-5" });
   }
-  if (!token && !code) {
+  if ((selectionReference && !selection) || (!token && !selection && !code)) {
     return res.status(400).json({ error: GENERIC_REVIEW_ERROR });
   }
   // Per-identifier budget (defends one job's code against many-IP hammering).
-  const identifierKey = token ? `t:${token}` : `c:${code}`;
+  const identifierValue = token || selectionReference || code;
+  const identifierKey = crypto.createHash("sha256").update(identifierValue).digest("hex");
   if (!publicReviewKeyRateLimiter.check(identifierKey).allowed) {
     return res.status(429).json({ error: "ส่งรีวิวถี่เกินไป กรุณารอสักครู่", code: "RATE_LIMITED" });
   }
@@ -26699,13 +26768,19 @@ app.post("/public/review", async (req, res) => {
     let jr;
     if (token) {
       jr = await client.query(
-        `SELECT job_id, job_status, technician_username, customer_rating, booking_token, customer_phone
+        `SELECT job_id, job_status, technician_username, customer_rating, booking_token, customer_phone, canceled_at
            FROM public.jobs WHERE booking_token=$1 LIMIT 1 FOR UPDATE`,
         [token]
       );
+    } else if (selection) {
+      jr = await client.query(
+        `SELECT job_id, job_status, technician_username, customer_rating, booking_token, customer_phone, canceled_at
+           FROM public.jobs WHERE job_id=$1 LIMIT 1 FOR UPDATE`,
+        [selection.job_id]
+      );
     } else {
       jr = await client.query(
-        `SELECT job_id, job_status, technician_username, customer_rating, booking_token, customer_phone
+        `SELECT job_id, job_status, technician_username, customer_rating, booking_token, customer_phone, canceled_at
            FROM public.jobs WHERE booking_code=$1 LIMIT 1 FOR UPDATE`,
         [code]
       );
@@ -26717,8 +26792,8 @@ app.post("/public/review", async (req, res) => {
     if (!job) deny();
 
     const jobHasToken = Boolean(String(job.booking_token || "").trim());
-    if (token) {
-      // Token path already authorised by the exact-token WHERE clause.
+    if (token || selection) {
+      // Exact-token and verified job-bound selection paths are already authorised.
     } else {
       // Legacy code path: only for jobs that genuinely have no token, and only
       // with the full phone matching exactly.
@@ -26728,6 +26803,7 @@ app.post("/public/review", async (req, res) => {
     }
 
     if (String(job.job_status || "").trim() !== "เสร็จแล้ว") deny();
+    if (job.canceled_at) deny();
     if (job.customer_rating) deny();
     if (!job.technician_username) deny();
 
@@ -26772,7 +26848,7 @@ app.post("/public/review", async (req, res) => {
     // Generic authorisation/eligibility failures never reveal the mismatch;
     // only a genuine unexpected server error is a 500.
     if (e && e.generic) return res.status(400).json({ error: e.message });
-    console.error("[public/review] failed", e && e.message);
+    console.error("[public/review] failed", { code: String(e?.code || "REVIEW_FAILED") });
     return res.status(400).json({ error: "ไม่สามารถส่งรีวิวได้ กรุณาตรวจสอบเลข/สถานะงานและข้อมูลยืนยันอีกครั้ง" });
   } finally {
     client.release();

--- a/server/services/public/trackingPrivacy.js
+++ b/server/services/public/trackingPrivacy.js
@@ -16,6 +16,9 @@
 
 const crypto = require("crypto");
 
+const TRACKING_SELECTION_PURPOSE = "customer_tracking_selection";
+const TRACKING_SELECTION_MAX_AGE_SEC = 15 * 60;
+
 const TRACKING_METRIC_KEYS = Object.freeze(["refrigerant", "cooling", "airflow", "drain"]);
 const TRACKING_METRIC_PATTERNS = Object.freeze({
   refrigerant: [/น้ำยา/u, /แรงดัน/u, /\bpressure\b/i, /\bpsi\b/i, /\brefrigerant\b/i, /\bgas\b/i],
@@ -108,6 +111,112 @@ function timingSafeEqualStr(a, b) {
   const bufB = Buffer.from(String(b == null ? "" : b));
   if (bufA.length !== bufB.length) return false;
   return crypto.timingSafeEqual(bufA, bufB);
+}
+
+function base64urlEncode(value) {
+  return Buffer.from(value).toString("base64url");
+}
+
+function base64urlDecode(value) {
+  return Buffer.from(String(value || ""), "base64url");
+}
+
+function trackingSelectionKey(secret) {
+  const value = String(secret || "").trim();
+  if (!value) return null;
+  return crypto.createHmac("sha256", value).update("cwf:tracking-selection:v1").digest();
+}
+
+function createTrackingSelectionReference(jobId, secret, options = {}) {
+  const id = Number(jobId);
+  const key = trackingSelectionKey(secret);
+  if (!Number.isSafeInteger(id) || id <= 0 || !key) return "";
+  const now = Math.floor(Number(options.now == null ? Date.now() : options.now) / 1000);
+  const ttl = Math.min(
+    TRACKING_SELECTION_MAX_AGE_SEC,
+    Math.max(1, Math.floor(Number(options.ttlSec || TRACKING_SELECTION_MAX_AGE_SEC))),
+  );
+  const payload = Buffer.from(JSON.stringify({
+    v: 1,
+    purpose: TRACKING_SELECTION_PURPOSE,
+    job_id: id,
+    iat: now,
+    exp: now + ttl,
+  }));
+  const iv = crypto.randomBytes(12);
+  const cipher = crypto.createCipheriv("aes-256-gcm", key, iv);
+  cipher.setAAD(Buffer.from(TRACKING_SELECTION_PURPOSE));
+  const ciphertext = Buffer.concat([cipher.update(payload), cipher.final()]);
+  const tag = cipher.getAuthTag();
+  return `${base64urlEncode(iv)}.${base64urlEncode(ciphertext)}.${base64urlEncode(tag)}`;
+}
+
+function verifyTrackingSelectionReference(reference, secret, options = {}) {
+  const key = trackingSelectionKey(secret);
+  const parts = String(reference || "").trim().split(".");
+  if (!key || parts.length !== 3 || parts.some((part) => !part)) return null;
+  let payload;
+  try {
+    const iv = base64urlDecode(parts[0]);
+    const ciphertext = base64urlDecode(parts[1]);
+    const tag = base64urlDecode(parts[2]);
+    if (iv.length !== 12 || !ciphertext.length || tag.length !== 16) return null;
+    const decipher = crypto.createDecipheriv("aes-256-gcm", key, iv);
+    decipher.setAAD(Buffer.from(TRACKING_SELECTION_PURPOSE));
+    decipher.setAuthTag(tag);
+    payload = JSON.parse(Buffer.concat([decipher.update(ciphertext), decipher.final()]).toString("utf8"));
+  } catch (_) {
+    return null;
+  }
+  const now = Math.floor(Number(options.now == null ? Date.now() : options.now) / 1000);
+  const jobId = Number(payload && payload.job_id);
+  const issuedAt = Number(payload && payload.iat);
+  const expiresAt = Number(payload && payload.exp);
+  if (!payload
+    || payload.v !== 1
+    || payload.purpose !== TRACKING_SELECTION_PURPOSE
+    || !Number.isSafeInteger(jobId)
+    || jobId <= 0
+    || !Number.isSafeInteger(issuedAt)
+    || !Number.isSafeInteger(expiresAt)
+    || issuedAt > now + 30
+    || expiresAt <= now
+    || expiresAt <= issuedAt
+    || expiresAt - issuedAt > TRACKING_SELECTION_MAX_AGE_SEC) return null;
+  return { job_id: jobId, expires_at: expiresAt };
+}
+
+function safeTrackingResult(row, selectionReference) {
+  const source = row && typeof row === "object" ? row : {};
+  const hasLocation = Boolean(String(source.address_text || "").trim());
+  return {
+    booking_code: source.booking_code || null,
+    appointment_datetime: source.appointment_datetime || null,
+    service_summary: source.job_type || null,
+    job_status: source.job_status || null,
+    location_summary: source.job_zone || (hasLocation ? "สถานที่จากงานเดิม" : null),
+    selection_ref: String(selectionReference || ""),
+  };
+}
+
+function normalizeTrackingPhone(value) {
+  const digits = String(value || "").replace(/\D/g, "");
+  let local = "";
+  if (/^0[0-9]{8,9}$/.test(digits)) local = digits;
+  else if (/^66[1-9][0-9]{7,8}$/.test(digits)) local = `0${digits.slice(2)}`;
+  else if (/^0066[1-9][0-9]{7,8}$/.test(digits)) local = `0${digits.slice(4)}`;
+  if (!/^0[0-9]{8,9}$/.test(local)) return null;
+  const international = `66${local.slice(1)}`;
+  return { phone_norm: local, match_digits: [local, international, `00${international}`] };
+}
+
+function buildSafeTrackingLookupResponse(rows, lookupType, secret, options = {}) {
+  const type = lookupType === "phone" ? "phone" : "booking_code";
+  const jobs = (Array.isArray(rows) ? rows : []).map((row) => safeTrackingResult(
+    row,
+    createTrackingSelectionReference(row && row.job_id, secret, options),
+  )).filter((job) => job.selection_ref);
+  return { lookup_type: type, jobs };
 }
 
 // Privileged/token action access only when the query equals booking_token.
@@ -278,6 +387,20 @@ function redactPublicTrackPayload(payload) {
   };
 }
 
+function selectionPublicTrackPayload(payload, selectionReference, canSubmitReview = false) {
+  const projected = redactPublicTrackPayload(payload);
+  return {
+    ...projected,
+    access_level: "selection",
+    capabilities: {
+      ...projected.capabilities,
+      can_submit_review: canSubmitReview === true,
+    },
+    selection_ref: String(selectionReference || ""),
+    legacy_review_eligible: false,
+  };
+}
+
 // Fixed-window in-memory rate limiter with an LRU cap so the map can never
 // grow without bound. One instance per endpoint (budgets differ).
 function createPublicLookupRateLimiter(options = {}) {
@@ -333,12 +456,18 @@ function clientIpKey(req) {
 }
 
 module.exports = {
+  buildSafeTrackingLookupResponse,
   clientIpKey,
+  createTrackingSelectionReference,
   createPublicLookupRateLimiter,
   isFullAccessQuery,
   maskPhone,
+  normalizeTrackingPhone,
   redactPublicTrackPayload,
+  safeTrackingResult,
+  selectionPublicTrackPayload,
   shortenAddress,
   summarizeUnitChecklists,
   timingSafeEqualStr,
+  verifyTrackingSelectionReference,
 };

--- a/server/services/public/trackingPrivacy.js
+++ b/server/services/public/trackingPrivacy.js
@@ -186,6 +186,12 @@ function verifyTrackingSelectionReference(reference, secret, options = {}) {
   return { job_id: jobId, expires_at: expiresAt };
 }
 
+function selectionReviewLimiterKey(jobId) {
+  const id = Number(jobId);
+  if (!Number.isSafeInteger(id) || id <= 0) return "";
+  return crypto.createHash("sha256").update(`cwf:public-review:selection-job:${id}`).digest("hex");
+}
+
 function safeTrackingResult(row, selectionReference) {
   const source = row && typeof row === "object" ? row : {};
   const hasLocation = Boolean(String(source.address_text || "").trim());
@@ -465,6 +471,7 @@ module.exports = {
   normalizeTrackingPhone,
   redactPublicTrackPayload,
   safeTrackingResult,
+  selectionReviewLimiterKey,
   selectionPublicTrackPayload,
   shortenAddress,
   summarizeUnitChecklists,

--- a/server/services/public/trackingPrivacy.js
+++ b/server/services/public/trackingPrivacy.js
@@ -189,7 +189,14 @@ function verifyTrackingSelectionReference(reference, secret, options = {}) {
 function selectionReviewLimiterKey(jobId) {
   const id = Number(jobId);
   if (!Number.isSafeInteger(id) || id <= 0) return "";
-  return crypto.createHash("sha256").update(`cwf:public-review:selection-job:${id}`).digest("hex");
+  return publicReviewLimiterKey("selection-job", String(id));
+}
+
+function publicReviewLimiterKey(kind, value) {
+  const domain = String(kind || "").trim();
+  const identifier = String(value || "");
+  if (!new Set(["token", "code", "selection-job"]).has(domain) || !identifier) return "";
+  return crypto.createHash("sha256").update(`cwf:public-review:${domain}:${identifier}`).digest("hex");
 }
 
 function safeTrackingResult(row, selectionReference) {
@@ -394,16 +401,49 @@ function redactPublicTrackPayload(payload) {
 }
 
 function selectionPublicTrackPayload(payload, selectionReference, canSubmitReview = false) {
-  const projected = redactPublicTrackPayload(payload);
+  const source = payload && typeof payload === "object" ? payload : {};
   return {
-    ...projected,
     access_level: "selection",
     capabilities: {
-      ...projected.capabilities,
+      can_view_full_tracking: true,
+      can_use_token_actions: false,
+      can_view_documents: false,
       can_submit_review: canSubmitReview === true,
     },
+    can_view_full_tracking: true,
+    can_use_token_actions: false,
     selection_ref: String(selectionReference || ""),
     legacy_review_eligible: false,
+    booking_code: source.booking_code || null,
+    job_type: source.job_type || null,
+    job_status: source.job_status || null,
+    booking_mode: source.booking_mode || null,
+    dispatch_mode: source.dispatch_mode || null,
+    appointment_datetime: source.appointment_datetime || null,
+    duration_min: source.duration_min == null ? null : source.duration_min,
+    job_zone: source.job_zone || null,
+    created_at: source.created_at || null,
+    travel_started_at: source.travel_started_at || null,
+    checkin_at: source.checkin_at || null,
+    started_at: source.started_at || null,
+    finished_at: source.finished_at || null,
+    canceled_at: source.canceled_at || null,
+    cancel_reason: source.cancel_reason || null,
+    technician_note: source.technician_note || null,
+    service_items: Array.isArray(source.service_items)
+      ? source.service_items.map((item) => ({
+          item_name: item && item.item_name ? item.item_name : null,
+          qty: item && item.qty != null ? item.qty : null,
+        }))
+      : [],
+    photos: Array.isArray(source.photos) ? source.photos.map(publicPhoto).filter(Boolean) : [],
+    units: Array.isArray(source.units) ? source.units.map(publicUnit).filter(Boolean) : [],
+    technician: publicTechnician(source.technician),
+    technician_team: Array.isArray(source.technician_team)
+      ? source.technician_team.map(publicTechnician).filter(Boolean)
+      : [],
+    review: publicReview(source.review),
+    catalog_review: publicCatalogReview(source.catalog_review),
   };
 }
 
@@ -469,6 +509,7 @@ module.exports = {
   isFullAccessQuery,
   maskPhone,
   normalizeTrackingPhone,
+  publicReviewLimiterKey,
   redactPublicTrackPayload,
   safeTrackingResult,
   selectionReviewLimiterKey,

--- a/test/customerAppPageAvailability.test.js
+++ b/test/customerAppPageAvailability.test.js
@@ -281,7 +281,7 @@ test("api exposes loadCustomerAppConfig as a no-store GET to /public/customer-ap
 });
 
 test("build wiring: pageAvailability.js is registered in the HTML shell and the SW cache, with the new build id", () => {
-  const build = "20260717_customer_history_simple_link_v1";
+  const build = "20260718_tracking_phone_review_direct_v1";
   assert.match(indexHtml, new RegExp(`modules/pageAvailability\\.js\\?v=${build}`));
   assert.match(swSrc, new RegExp(`BUILD_ID = "${build}"`));
   assert.match(swSrc, /modules\/pageAvailability\.js\?v=\$\{BUILD_ID\}/);
@@ -294,7 +294,7 @@ test("build wiring: pageAvailability.js is registered in the HTML shell and the 
    RUNTIME tests (execute the real code in a VM — not regex assertions).
    ========================================================================== */
 
-const BUILD = "20260717_customer_history_simple_link_v1";
+const BUILD = "20260718_tracking_phone_review_direct_v1";
 const adminSrc = read("admin-homepage-cms.js");
 
 function reqUrlOf(req) {

--- a/test/customerAppRecovery.test.js
+++ b/test/customerAppRecovery.test.js
@@ -236,7 +236,7 @@ test("Customer App build id is consistent across shell and service worker", () =
   const sw = read("customer-app/sw.js");
   const app = read("customer-app/assets/customer-app.js");
   const manifest = read("customer-app/manifest.webmanifest");
-  const build = "20260717_customer_history_simple_link_v1";
+  const build = "20260718_tracking_phone_review_direct_v1";
 
   assert.match(index, new RegExp(`customer-app\\.css\\?v=${build}`));
   assert.match(index, new RegExp(`modules\\/api\\.js\\?v=${build}`));
@@ -254,7 +254,7 @@ test("Customer App build id is consistent across shell and service worker", () =
 test("store module is loaded in index.html and precached in the service worker app shell", () => {
   const index = read("customer-app/index.html");
   const sw = read("customer-app/sw.js");
-  const build = "20260717_customer_history_simple_link_v1";
+  const build = "20260718_tracking_phone_review_direct_v1";
 
   assert.match(index, new RegExp(`modules/store\\.js\\?v=${build}`));
   assert.match(sw, /`\.\/modules\/store\.js\?v=\$\{BUILD_ID\}`/);

--- a/test/customerAppStorePayment.test.js
+++ b/test/customerAppStorePayment.test.js
@@ -58,7 +58,7 @@ test("store falls back to the LINE hand-off when payment is unconfigured or the 
 test("payment step styles exist and the Customer App payment build id is bumped", () => {
   assert.match(cssSrc, /\.pay-method-btn/);
   assert.match(cssSrc, /\.pay-qr-img/);
-  assert.match(read("customer-app/index.html"), /modules\/store\.js\?v=20260717_customer_history_simple_link_v1/);
-  assert.match(read("customer-app/sw.js"), /BUILD_ID = "20260717_customer_history_simple_link_v1"/);
+  assert.match(read("customer-app/index.html"), /modules\/store\.js\?v=20260718_tracking_phone_review_direct_v1/);
+  assert.match(read("customer-app/sw.js"), /BUILD_ID = "20260718_tracking_phone_review_direct_v1"/);
   assert.match(storeSrc, /payment-security 20260705 loaded/);
 });

--- a/test/customerBookingAdminNotifications.test.js
+++ b/test/customerBookingAdminNotifications.test.js
@@ -311,10 +311,10 @@ test("admin/customer frontend cache versions are bumped for booking notification
   assert.doesNotMatch(adminReviewHtml, /admin-review-v2\.js\?v=20260707_customer_booking_notify_v2/);
   assert.match(adminReviewHtml, /admin-review-ai-intake\.js\?v=ai-booking-intake-customer-cards-v11-admin-alert-gate/);
   assert.doesNotMatch(adminReviewHtml, /admin-review-ai-intake\.js\?v=ai-booking-intake-customer-cards-v10/);
-  assert.match(customerIndex, /bookingScheduled\.js\?v=20260717_customer_history_simple_link_v1/);
-  assert.match(customerIndex, /state\.js\?v=20260717_customer_history_simple_link_v1/);
-  assert.match(customerSw, /const BUILD_ID = "20260717_customer_history_simple_link_v1"/);
-  assert.match(customerManifest, /20260717_customer_history_simple_link_v1/);
+  assert.match(customerIndex, /bookingScheduled\.js\?v=20260718_tracking_phone_review_direct_v1/);
+  assert.match(customerIndex, /state\.js\?v=20260718_tracking_phone_review_direct_v1/);
+  assert.match(customerSw, /const BUILD_ID = "20260718_tracking_phone_review_direct_v1"/);
+  assert.match(customerManifest, /20260718_tracking_phone_review_direct_v1/);
 });
 
 test("behavior: review queue only includes customer urgent waiting rows while preserving review statuses", () => {

--- a/test/customerHistoryClaim.test.js
+++ b/test/customerHistoryClaim.test.js
@@ -845,7 +845,7 @@ test("Customer History search and preview keep 360px and 390px width contracts",
 });
 
 test("Customer App cache version is bumped consistently", () => {
-  const expected = "20260717_customer_history_simple_link_v1";
+  const expected = "20260718_tracking_phone_review_direct_v1";
   for (const file of [
     "customer-app/index.html",
     "customer-app/sw.js",

--- a/test/customerHomepageFeaturedRotation.test.js
+++ b/test/customerHomepageFeaturedRotation.test.js
@@ -414,6 +414,6 @@ test("compact CSS and cache build remain consistent with six-card rotation", () 
   assert.match(css, /\.homepage-featured-page\s*\{[^}]*grid-area:\s*1\s*\/\s*1/s);
   assert.match(css, /transition:\s*opacity 350ms/);
   assert.match(css, /prefers-reduced-motion:\s*reduce/);
-  const build = "20260717_customer_history_simple_link_v1";
+  const build = "20260718_tracking_phone_review_direct_v1";
   for (const source of [html, sw, boot, manifest]) assert.match(source, new RegExp(build));
 });

--- a/test/customerSameDayTiming.test.js
+++ b/test/customerSameDayTiming.test.js
@@ -160,7 +160,7 @@ test("customer app disables availability HTTP cache and refreshes same-day slots
 });
 
 test("customer app build and service worker cache IDs changed", () => {
-  const id = "20260717_customer_history_simple_link_v1";
+  const id = "20260718_tracking_phone_review_direct_v1";
   for (const file of [
     "customer-app/index.html",
     "customer-app/sw.js",

--- a/test/customerSmartAdvisor.test.js
+++ b/test/customerSmartAdvisor.test.js
@@ -1174,7 +1174,7 @@ test("Home places built-in advisor after Quick Actions and before Featured Servi
 });
 
 test("advisor module is loaded before ui.js and precached under the shared build id", () => {
-  const build = "20260717_customer_history_simple_link_v1";
+  const build = "20260718_tracking_phone_review_direct_v1";
   assert.ok(INDEX_SOURCE.indexOf(`modules/advisor.js?v=${build}`) < INDEX_SOURCE.indexOf(`modules/ui.js?v=${build}`));
   assert.match(SW_SOURCE, new RegExp(`BUILD_ID = "${build}"`));
   assert.match(SW_SOURCE, /modules\/advisor\.js\?v=\$\{BUILD_ID\}/);

--- a/test/customerTrackingFullReadUi.test.js
+++ b/test/customerTrackingFullReadUi.test.js
@@ -534,7 +534,7 @@ test("exact-token capability retains document and review behavior", () => {
     catalog_review: null,
   };
   assert.match(app.tracking._test.receiptUrl(data), /\/docs\/receipt\/88\?key=private-token/);
-  assert.match(app.tracking._test.renderReview(data), /data-review-token/);
+  assert.match(app.tracking._test.renderReview(data), /data-review-form/);
 });
 
 test("canceled jobs render a terminal canceled hero and timeline", () => {
@@ -606,7 +606,6 @@ test("completed copy follows read versus privileged-action capability", () => {
 function assertNoPrivilegedAftercare(html) {
   assert.doesNotMatch(html, /booking_token|\/docs\/receipt|\/docs\/quote|\/docs\/eslip/);
   assert.doesNotMatch(html, /data-review-form|data-catalog-review-form|open-eslip/);
-  assert.doesNotMatch(html, /ให้คะแนนงานนี้|ส่งรีวิว/);
 }
 
 test("code-only completed shows existing technician review and warranty read-only", () => {
@@ -684,7 +683,7 @@ test("code-only completed preserves both existing review summaries", () => {
   assertNoPrivilegedAftercare(html);
 });
 
-test("code-only completed with no review still shows warranty without review invitation", () => {
+test("completed job without a server-issued write capability stays read-only", () => {
   const app = loadTrackingRuntime();
   const data = {
     ...codeReadPayload(),
@@ -696,6 +695,7 @@ test("code-only completed with no review still shows warranty without review inv
   assert.match(html, />หลังบริการ</);
   assert.match(html, /เงื่อนไขรับประกัน/);
   assertNoPrivilegedAftercare(html);
+  assert.match(html, /งานนี้ยังไม่อยู่ในสถานะที่ส่งรีวิวได้/);
 });
 
 test("token completed retains documents and one eligible write-review flow", () => {
@@ -731,7 +731,7 @@ test("token completed falls back to technician review when catalog review is ine
     catalog_review: { eligible: false, already_reviewed: false, review: null },
   };
   const html = app.tracking._test.renderAftercare(data);
-  assert.match(html, /data-review-form data-review-token/);
+  assert.match(html, /data-review-form/);
   assert.doesNotMatch(html, /data-catalog-review-form/);
   assert.doesNotMatch(html, /private-token/);
 });
@@ -747,30 +747,62 @@ test("token completed falls back to technician review when catalog review is nul
     catalog_review: null,
   };
   const html = app.tracking._test.renderAftercare(data);
-  assert.match(html, /data-review-form data-review-token/);
+  assert.match(html, /data-review-form/);
   assert.doesNotMatch(html, /data-catalog-review-form|private-token/);
 });
 
-test("legacy completed job shows phone-proof technician form without granting token actions", () => {
+test("selected completed job shows technician review without phone re-verification", () => {
   const app = loadTrackingRuntime();
   const data = {
     ...completedHealthPayload(),
-    legacy_review_eligible: true,
+    access_level: "selection",
+    selection_ref: "opaque-selection-reference",
+    capabilities: { can_view_full_tracking: true, can_use_token_actions: false, can_submit_review: true },
     catalog_review: { eligible: false, already_reviewed: false, review: null },
   };
   const html = app.tracking._test.renderAftercare(data);
   assert.match(html, /data-review-form/);
-  assert.match(html, /name="booking_code" value="CWFABC1234"/);
-  assert.match(html, /name="customer_phone"/);
-  assert.doesNotMatch(html, /data-review-token|data-catalog-review-form|booking_token/);
+  assert.doesNotMatch(html, /name="booking_code"|name="customer_phone"|ยืนยันตัวตน|opaque-selection-reference/);
+  assert.doesNotMatch(html, /data-catalog-review-form|booking_token/);
 });
 
-test("ordinary code-only completed job is read-only with an explicit explanation", () => {
+test("phone multi-result list renders safe fields and never renders the signed selection reference", () => {
+  const app = loadTrackingRuntime();
+  app.state.tracking = {
+    status: "choices",
+    data: {
+      jobs: [
+        { booking_code: "CWFABC1234", appointment_datetime: "2026-07-18T09:00:00+07:00", service_summary: "ล้างแอร์", job_status: "เสร็จแล้ว", location_summary: "บางนา", selection_ref: "opaque-one" },
+        { booking_code: "CWFABC5678", appointment_datetime: "2026-07-19T10:00:00+07:00", service_summary: "ซ่อมแอร์", job_status: "รอดำเนินการ", location_summary: "พระโขนง", selection_ref: "opaque-two" },
+      ],
+    },
+    error: "",
+  };
+  const html = app.tracking._test.renderTrackingResult();
+  assert.match(html, /เลือกงานที่ต้องการติดตาม/);
+  assert.match(html, /CWFABC1234/);
+  assert.match(html, /CWFABC5678/);
+  assert.equal((html.match(/data-tracking-choice=/g) || []).length, 2);
+  assert.doesNotMatch(html, /opaque-one|opaque-two|selection_ref|job_id|customer_phone|address_text/);
+});
+
+test("tracking UI uses one phone-or-code field and removes the old phone-proof flow", () => {
+  const source = fs.readFileSync(path.join(ROOT, "customer-app", "modules", "tracking.js"), "utf8");
+  assert.match(source, /เบอร์โทร หรือ Booking Code/);
+  assert.match(source, /placeholder="กรอกเบอร์โทรหรือรหัสงาน"/);
+  assert.match(source, /lookupTracking\(q\)/);
+  assert.match(source, /selectTracking\(reference\)/);
+  assert.match(source, /if \(jobs\.length === 1\) return openSelection/);
+  assert.match(source, /status: "choices"/);
+  assert.doesNotMatch(source, /name="customer_phone"|เบอร์โทรที่ใช้จอง \(ยืนยันตัวตน\)|กรอกเบอร์โทรที่ใช้จองงานนี้เพื่อยืนยันตัวตนก่อนรีวิว/);
+});
+
+test("completed job without a write capability has a generic unavailable explanation", () => {
   const app = loadTrackingRuntime();
   const data = completedHealthPayload({ legacy_review_eligible: false });
   const html = app.tracking._test.renderAftercare(data);
-  assert.match(html, /การให้คะแนนเป็นแบบอ่านอย่างเดียว/);
-  assert.match(html, /Booking Code/);
+  assert.match(html, /งานนี้ยังไม่อยู่ในสถานะที่ส่งรีวิวได้/);
+  assert.doesNotMatch(html, /Booking Code.*บันทึกคะแนนไม่ได้/);
   assert.doesNotMatch(html, /data-review-form|data-catalog-review-form/);
 });
 
@@ -798,6 +830,7 @@ test("tracking review forms use five accessible 44px star choices and never rend
 
 test("failed technician review request re-enables submit and exposes the error", async () => {
   let submitHandler;
+  let requestBody;
   const status = { textContent: "" };
   const submit = { disabled: false };
   const busy = new Set();
@@ -817,9 +850,15 @@ test("failed technician review request re-enables submit and exposes the error",
   }
   const app = loadTrackingRuntime({
     FormData: ReviewFormData,
-    fetch: async () => ({ ok: false, json: async () => ({ error: "ส่งไม่สำเร็จ" }) }),
+    fetch: async (_url, options) => {
+      requestBody = JSON.parse(options.body);
+      return { ok: false, json: async () => ({ error: "ส่งไม่สำเร็จ" }) };
+    },
   });
-  app.state.tracking.data = { booking_token: "private-token" };
+  app.state.tracking.data = {
+    selection_ref: "opaque-selection-reference",
+    capabilities: { can_submit_review: true },
+  };
   const container = {
     querySelector(selector) { return selector === "[data-review-form]" ? form : null; },
   };
@@ -828,6 +867,16 @@ test("failed technician review request re-enables submit and exposes the error",
   assert.equal(submit.disabled, false);
   assert.equal(status.textContent, "ส่งไม่สำเร็จ");
   assert.equal(busy.has("aria-busy"), false);
+  assert.equal(requestBody.selection_ref, "opaque-selection-reference");
+  assert.equal(requestBody.customer_phone, undefined);
+  assert.equal(requestBody.booking_code, undefined);
+});
+
+test("tracking choice and review controls remain width-safe at 360px and 390px", () => {
+  assert.match(CSS_SOURCE, /\.tracking-choice-shell,[\s\S]*?\.tracking-choice\s*\{\s*min-width:\s*0;/);
+  assert.match(CSS_SOURCE, /\.tracking-choice\s*\{[\s\S]*?width:\s*100%;[\s\S]*?min-height:\s*64px;/);
+  assert.match(CSS_SOURCE, /\.tracking-choice\s*\{[\s\S]*?overflow-wrap:\s*anywhere;/);
+  assert.match(CSS_SOURCE, /grid-template-columns:\s*repeat\(5,\s*minmax\(44px,\s*1fr\)\)/);
 });
 
 test("failed catalog review request re-enables submit and exposes the error", async () => {
@@ -920,7 +969,7 @@ test("tracking UI exposes loading, not-found, rate-limit and offline states", ()
 });
 
 test("tracking assets share the full-read cache build id", () => {
-  const build = "20260717_customer_history_simple_link_v1";
+  const build = "20260718_tracking_phone_review_direct_v1";
   for (const file of [
     "customer-app/index.html",
     "customer-app/sw.js",

--- a/test/customerTrackingPrivacy.test.js
+++ b/test/customerTrackingPrivacy.test.js
@@ -241,6 +241,51 @@ test("tracking selection references are job-bound, short-lived, and fail closed"
   assert.equal(trackingPrivacy.verifyTrackingSelectionReference("malformed", secret, { now: issuedAt }), null);
 });
 
+test("tracking selection references keep one absolute expiry across select and refresh", () => {
+  const secret = "absolute-expiry-test-secret";
+  const issuedAt = 1_720_000_000_000;
+  const reference = trackingPrivacy.createTrackingSelectionReference(42, secret, { now: issuedAt });
+  const initial = trackingPrivacy.verifyTrackingSelectionReference(reference, secret, { now: issuedAt });
+  assert.ok(initial.expires_at <= Math.floor(issuedAt / 1000) + (15 * 60));
+
+  // /public/track/select and subsequent refreshes return this same reference.
+  const afterSelect = trackingPrivacy.verifyTrackingSelectionReference(reference, secret, { now: issuedAt + 5 * 60_000 });
+  const afterRefresh = trackingPrivacy.verifyTrackingSelectionReference(reference, secret, { now: issuedAt + 14 * 60_000 });
+  assert.equal(afterSelect.expires_at, initial.expires_at);
+  assert.equal(afterRefresh.expires_at, initial.expires_at);
+  assert.equal(trackingPrivacy.verifyTrackingSelectionReference(reference, secret, { now: issuedAt + 15 * 60_000 }), null);
+
+  const modified = `${reference.slice(0, -1)}${reference.endsWith("A") ? "B" : "A"}`;
+  assert.equal(trackingPrivacy.verifyTrackingSelectionReference(modified, secret, { now: issuedAt }), null);
+});
+
+test("selection review limiter is stable per verified job and distinct across jobs", () => {
+  const secret = "stable-review-limiter-test-secret";
+  const now = 1_720_000_000_000;
+  const first = trackingPrivacy.verifyTrackingSelectionReference(
+    trackingPrivacy.createTrackingSelectionReference(42, secret, { now }), secret, { now },
+  );
+  const second = trackingPrivacy.verifyTrackingSelectionReference(
+    trackingPrivacy.createTrackingSelectionReference(42, secret, { now: now + 1_000 }), secret, { now: now + 1_000 },
+  );
+  const other = trackingPrivacy.verifyTrackingSelectionReference(
+    trackingPrivacy.createTrackingSelectionReference(43, secret, { now }), secret, { now },
+  );
+  const firstKey = trackingPrivacy.selectionReviewLimiterKey(first.job_id);
+  const secondKey = trackingPrivacy.selectionReviewLimiterKey(second.job_id);
+  const otherKey = trackingPrivacy.selectionReviewLimiterKey(other.job_id);
+  assert.match(firstKey, /^[a-f0-9]{64}$/);
+  assert.equal(secondKey, firstKey);
+  assert.notEqual(otherKey, firstKey);
+  assert.equal(trackingPrivacy.selectionReviewLimiterKey(null), "");
+
+  // A fresh lookup/reference for the same job cannot reset the shared budget.
+  const limiter = trackingPrivacy.createPublicLookupRateLimiter({ windowMs: 60_000, max: 1 });
+  assert.equal(limiter.check(firstKey).allowed, true);
+  assert.equal(limiter.check(secondKey).allowed, false);
+  assert.equal(limiter.check(otherKey).allowed, true);
+});
+
 test("phone lookup list projection exposes only safe fields plus the opaque selection reference", () => {
   const projected = trackingPrivacy.safeTrackingResult({
     job_id: 99,
@@ -379,6 +424,7 @@ test("/public/track is rate-limited and issues a signed selection projection for
   assert.match(indexSrc, /trackingPrivacy\.selectionPublicTrackPayload\(/);
   assert.match(indexSrc, /app\.post\("\/public\/track\/lookup"/);
   assert.match(indexSrc, /app\.post\("\/public\/track\/select", publicTrackHandler\)/);
+  assert.match(indexSrc, /selection\s*\? selectionReference\s*:\s*trackingPrivacy\.createTrackingSelectionReference/);
   assert.match(indexSrc, /trackingPrivacy\.summarizeUnitChecklists\(checksByUnit\.get\(String\(unit\.unit_id\)\) \|\| \[\]\)/);
 });
 
@@ -398,6 +444,9 @@ test("technician review accepts only verified token/selection credentials and re
   const route = indexSrc.match(/app\.post\("\/public\/review"[\s\S]*?\n}\);/);
   assert.ok(route, "public review route not found");
   assert.match(route[0], /verifyTrackingSelectionReference\(selectionReference, getJwtSecret\(\)\)/);
+  assert.match(route[0], /trackingPrivacy\.selectionReviewLimiterKey\(selection\.job_id\)/);
+  assert.match(route[0], /createHash\("sha256"\)\.update\(token \|\| code\)/);
+  assert.doesNotMatch(route[0], /update\(token \|\| selectionReference \|\| code\)/);
   assert.match(route[0], /FROM public\.jobs WHERE job_id=\$1 LIMIT 1 FOR UPDATE/);
   assert.match(route[0], /if \(job\.canceled_at\) deny\(\)/);
   assert.match(route[0], /if \(job\.customer_rating\) deny\(\)/);
@@ -405,6 +454,7 @@ test("technician review accepts only verified token/selection credentials and re
   assert.match(route[0], /ON CONFLICT \(job_id\) DO NOTHING/);
   assert.match(route[0], /console\.error\("\[public\/review\] failed", \{ code: String\(e\?\.code \|\| "REVIEW_FAILED"\) \}\)/);
   assert.doesNotMatch(route[0], /console\.(?:log|warn|error)\([^\n]*identifierValue/);
+  assert.doesNotMatch(route[0], /console\.(?:log|warn|error)\([^\n]*(?:selectionReference|token|booking_code|selection\.job_id|job\.job_id)/);
 });
 
 test("/public/urgent-status is rate-limited", () => {

--- a/test/customerTrackingPrivacy.test.js
+++ b/test/customerTrackingPrivacy.test.js
@@ -41,6 +41,7 @@ function richPayload() {
     gps_latitude: 13.75,
     gps_longitude: 100.5,
     receipt_url: "https://host/docs/receipt/42?key=a1b2c3d4e5f6",
+    job_type: "ล้างแอร์",
     job_status: "รอดำเนินการ",
     booking_mode: "scheduled",
     dispatch_mode: "normal",
@@ -48,6 +49,7 @@ function richPayload() {
     duration_min: 90,
     finished_at: null,
     technician_note: "ลูกค้าไม่อยู่บ้าน",
+    service_items: [{ item_name: "ล้างแอร์", qty: 2, unit_price: 500, line_total: 1000 }],
     technician: { username: "tech1", full_name: "ช่าง หนึ่ง", phone: "0899999999" },
     technician_team: [{ username: "tech1", phone: "0899999999" }],
     photos: [{ photo_id: 900, public_url: "https://x/y.jpg", phase: "after" }],
@@ -134,6 +136,30 @@ test("booking-code read model exposes only legacy full-phone-proof eligibility a
   assert.equal(eligible.capabilities.can_submit_review, false);
   assert.equal(eligible.catalog_review.eligible, false);
   assert.equal(eligible.booking_token, undefined);
+});
+
+test("selected job detail uses a minimal allowlist and omits precise customer PII", () => {
+  const selected = trackingPrivacy.selectionPublicTrackPayload(richPayload(), "opaque-selection", true);
+  for (const gone of [
+    "customer_name", "customer_phone", "address_text", "maps_url", "gps_latitude",
+    "gps_longitude", "booking_token", "job_id", "receipt_url", "job_price",
+    "payment_status", "paid_at",
+  ]) {
+    assert.equal(selected[gone], undefined, `${gone} must not be present for selection access`);
+  }
+  assert.equal(selected.access_level, "selection");
+  assert.equal(selected.booking_code, richPayload().booking_code);
+  assert.equal(selected.appointment_datetime, richPayload().appointment_datetime);
+  assert.equal(selected.job_type, richPayload().job_type);
+  assert.equal(selected.job_status, richPayload().job_status);
+  assert.equal(selected.finished_at, richPayload().finished_at);
+  assert.equal(selected.selection_ref, "opaque-selection");
+  assert.equal(selected.capabilities.can_submit_review, true);
+  assert.equal(selected.capabilities.can_view_documents, false);
+  assert.deepEqual(selected.service_items, [{ item_name: richPayload().service_items[0].item_name, qty: 2 }]);
+  assert.equal(selected.photos[0].photo_id, undefined);
+  assert.equal(selected.units[0].unit_id, undefined);
+  assert.equal(selected.catalog_review.eligible, false);
 });
 
 function checklist(type, completed, rows) {
@@ -255,7 +281,7 @@ test("tracking selection references keep one absolute expiry across select and r
   assert.equal(afterRefresh.expires_at, initial.expires_at);
   assert.equal(trackingPrivacy.verifyTrackingSelectionReference(reference, secret, { now: issuedAt + 15 * 60_000 }), null);
 
-  const modified = `${reference.slice(0, -1)}${reference.endsWith("A") ? "B" : "A"}`;
+  const modified = `${reference[0] === "A" ? "B" : "A"}${reference.slice(1)}`;
   assert.equal(trackingPrivacy.verifyTrackingSelectionReference(modified, secret, { now: issuedAt }), null);
 });
 
@@ -284,6 +310,20 @@ test("selection review limiter is stable per verified job and distinct across jo
   assert.equal(limiter.check(firstKey).allowed, true);
   assert.equal(limiter.check(secondKey).allowed, false);
   assert.equal(limiter.check(otherKey).allowed, true);
+});
+
+test("review limiter keys are stable and domain-separated for token and Booking Code", () => {
+  const sharedText = "same-visible-value";
+  const tokenKey = trackingPrivacy.publicReviewLimiterKey("token", sharedText);
+  const repeatedTokenKey = trackingPrivacy.publicReviewLimiterKey("token", sharedText);
+  const codeKey = trackingPrivacy.publicReviewLimiterKey("code", sharedText);
+  const repeatedCodeKey = trackingPrivacy.publicReviewLimiterKey("code", sharedText);
+  assert.match(tokenKey, /^[a-f0-9]{64}$/);
+  assert.equal(repeatedTokenKey, tokenKey);
+  assert.equal(repeatedCodeKey, codeKey);
+  assert.notEqual(tokenKey, codeKey);
+  assert.equal(trackingPrivacy.publicReviewLimiterKey("unknown", sharedText), "");
+  assert.equal(trackingPrivacy.publicReviewLimiterKey("token", ""), "");
 });
 
 test("phone lookup list projection exposes only safe fields plus the opaque selection reference", () => {
@@ -421,6 +461,7 @@ test("job documents open for an authenticated admin without any key", async () =
 test("/public/track is rate-limited and issues a signed selection projection for non-token lookups", () => {
   assert.match(indexSrc, /publicTrackRateLimiter\.check\(trackingPrivacy\.clientIpKey\(req\)\)/);
   assert.match(indexSrc, /const fullAccess = !selection && trackingPrivacy\.isFullAccessQuery\(q, row\);/);
+  assert.match(indexSrc, /res\.json\(fullAccess\s*\? trackPayload\s*:\s*trackingPrivacy\.selectionPublicTrackPayload/);
   assert.match(indexSrc, /trackingPrivacy\.selectionPublicTrackPayload\(/);
   assert.match(indexSrc, /app\.post\("\/public\/track\/lookup"/);
   assert.match(indexSrc, /app\.post\("\/public\/track\/select", publicTrackHandler\)/);
@@ -445,7 +486,7 @@ test("technician review accepts only verified token/selection credentials and re
   assert.ok(route, "public review route not found");
   assert.match(route[0], /verifyTrackingSelectionReference\(selectionReference, getJwtSecret\(\)\)/);
   assert.match(route[0], /trackingPrivacy\.selectionReviewLimiterKey\(selection\.job_id\)/);
-  assert.match(route[0], /createHash\("sha256"\)\.update\(token \|\| code\)/);
+  assert.match(route[0], /publicReviewLimiterKey\(token \? "token" : "code", token \|\| code\)/);
   assert.doesNotMatch(route[0], /update\(token \|\| selectionReference \|\| code\)/);
   assert.match(route[0], /FROM public\.jobs WHERE job_id=\$1 LIMIT 1 FOR UPDATE/);
   assert.match(route[0], /if \(job\.canceled_at\) deny\(\)/);

--- a/test/customerTrackingPrivacy.test.js
+++ b/test/customerTrackingPrivacy.test.js
@@ -212,6 +212,77 @@ test("maskPhone handles empty/short values safely", () => {
   assert.equal(trackingPrivacy.maskPhone("08-1234-5678"), "•••• 5678");
 });
 
+test("tracking phone normalization accepts local, dashed, +66, and 0066 formats", () => {
+  for (const value of ["0812345678", "081-234-5678", "+66812345678", "0066812345678"]) {
+    assert.deepEqual(trackingPrivacy.normalizeTrackingPhone(value), {
+      phone_norm: "0812345678",
+      match_digits: ["0812345678", "66812345678", "0066812345678"],
+    });
+  }
+  assert.equal(trackingPrivacy.normalizeTrackingPhone("not-a-phone"), null);
+  assert.equal(trackingPrivacy.normalizeTrackingPhone("12345"), null);
+});
+
+test("tracking selection references are job-bound, short-lived, and fail closed", () => {
+  const secret = "test-secret-not-production";
+  const issuedAt = 1_720_000_000_000;
+  const reference = trackingPrivacy.createTrackingSelectionReference(42, secret, { now: issuedAt, ttlSec: 300 });
+  assert.match(reference, /^[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+$/);
+  const visibleReferenceBytes = Buffer.concat(reference.split(".").map((part) => Buffer.from(part, "base64url")));
+  assert.equal(visibleReferenceBytes.includes(Buffer.from('"job_id":42')), false);
+  assert.deepEqual(trackingPrivacy.verifyTrackingSelectionReference(reference, secret, { now: issuedAt + 60_000 }), {
+    job_id: 42,
+    expires_at: Math.floor(issuedAt / 1000) + 300,
+  });
+  const modified = `${reference[0] === "A" ? "B" : "A"}${reference.slice(1)}`;
+  assert.equal(trackingPrivacy.verifyTrackingSelectionReference(modified, secret, { now: issuedAt }), null);
+  assert.equal(trackingPrivacy.verifyTrackingSelectionReference(reference, "wrong-secret", { now: issuedAt }), null);
+  assert.equal(trackingPrivacy.verifyTrackingSelectionReference(reference, secret, { now: issuedAt + 301_000 }), null);
+  assert.equal(trackingPrivacy.verifyTrackingSelectionReference("malformed", secret, { now: issuedAt }), null);
+});
+
+test("phone lookup list projection exposes only safe fields plus the opaque selection reference", () => {
+  const projected = trackingPrivacy.safeTrackingResult({
+    job_id: 99,
+    booking_code: "CWFABC1234",
+    booking_token: "private-token",
+    customer_phone: "0812345678",
+    appointment_datetime: "2026-07-18T09:00:00+07:00",
+    job_type: "ล้างแอร์",
+    job_status: "เสร็จแล้ว",
+    job_zone: "บางนา",
+    address_text: "99/1 precise private address",
+    maps_url: "https://maps.example/private",
+  }, "opaque-reference");
+  assert.deepEqual(Object.keys(projected).sort(), [
+    "appointment_datetime", "booking_code", "job_status", "location_summary",
+    "selection_ref", "service_summary",
+  ]);
+  assert.equal(projected.location_summary, "บางนา");
+  assert.equal(projected.selection_ref, "opaque-reference");
+  for (const forbidden of ["job_id", "booking_token", "customer_phone", "address_text", "maps_url"]) {
+    assert.equal(projected[forbidden], undefined);
+  }
+});
+
+test("safe lookup response supports one or many jobs with independently job-bound references", () => {
+  const rows = [
+    { job_id: 11, booking_code: "CWFJOB0001", appointment_datetime: "2026-07-18", job_type: "ล้างแอร์", job_status: "เสร็จแล้ว", job_zone: "บางนา" },
+    { job_id: 12, booking_code: "CWFJOB0002", appointment_datetime: "2026-07-19", job_type: "ซ่อมแอร์", job_status: "รอดำเนินการ", job_zone: "พระโขนง" },
+  ];
+  const secret = "lookup-test-secret";
+  const now = 1_720_000_000_000;
+  const single = trackingPrivacy.buildSafeTrackingLookupResponse(rows.slice(0, 1), "booking_code", secret, { now });
+  const multiple = trackingPrivacy.buildSafeTrackingLookupResponse(rows, "phone", secret, { now });
+  assert.equal(single.lookup_type, "booking_code");
+  assert.equal(single.jobs.length, 1);
+  assert.equal(multiple.lookup_type, "phone");
+  assert.equal(multiple.jobs.length, 2);
+  assert.notEqual(multiple.jobs[0].selection_ref, multiple.jobs[1].selection_ref);
+  assert.equal(trackingPrivacy.verifyTrackingSelectionReference(multiple.jobs[0].selection_ref, secret, { now }).job_id, 11);
+  assert.equal(trackingPrivacy.verifyTrackingSelectionReference(multiple.jobs[1].selection_ref, secret, { now }).job_id, 12);
+});
+
 // ---------- rate limiter ----------
 
 test("rate limiter allows up to max per window, then 429 with retry_after, then resets", () => {
@@ -302,11 +373,38 @@ test("job documents open for an authenticated admin without any key", async () =
 
 // ---------- wiring contracts ----------
 
-test("/public/track is rate-limited and redacts code lookups via the allowlist", () => {
+test("/public/track is rate-limited and issues a signed selection projection for non-token lookups", () => {
   assert.match(indexSrc, /publicTrackRateLimiter\.check\(trackingPrivacy\.clientIpKey\(req\)\)/);
-  assert.match(indexSrc, /const fullAccess = trackingPrivacy\.isFullAccessQuery\(q, row\);/);
-  assert.match(indexSrc, /res\.json\(fullAccess \? trackPayload : trackingPrivacy\.redactPublicTrackPayload\(trackPayload\)\);/);
+  assert.match(indexSrc, /const fullAccess = !selection && trackingPrivacy\.isFullAccessQuery\(q, row\);/);
+  assert.match(indexSrc, /trackingPrivacy\.selectionPublicTrackPayload\(/);
+  assert.match(indexSrc, /app\.post\("\/public\/track\/lookup"/);
+  assert.match(indexSrc, /app\.post\("\/public\/track\/select", publicTrackHandler\)/);
   assert.match(indexSrc, /trackingPrivacy\.summarizeUnitChecklists\(checksByUnit\.get\(String\(unit\.unit_id\)\) \|\| \[\]\)/);
+});
+
+test("phone and Booking Code lookup wiring uses safe rows and never accepts a client job_id", () => {
+  const route = indexSrc.match(/app\.post\("\/public\/track\/lookup"[\s\S]*?\n}\);/);
+  assert.ok(route, "tracking lookup route not found");
+  assert.match(route[0], /normalizeTrackingPhone\(identifier\)/);
+  assert.match(route[0], /regexp_replace\(COALESCE\(customer_phone/);
+  assert.match(route[0], /= ANY\(\$1::text\[\]\)/);
+  assert.match(route[0], /WHERE booking_code=\$1/);
+  assert.match(route[0], /LIMIT 2/);
+  assert.match(route[0], /buildSafeTrackingLookupResponse/);
+  assert.doesNotMatch(route[0], /req\.body\?\.job_id|req\.body\.job_id/);
+});
+
+test("technician review accepts only verified token/selection credentials and rechecks eligibility under lock", () => {
+  const route = indexSrc.match(/app\.post\("\/public\/review"[\s\S]*?\n}\);/);
+  assert.ok(route, "public review route not found");
+  assert.match(route[0], /verifyTrackingSelectionReference\(selectionReference, getJwtSecret\(\)\)/);
+  assert.match(route[0], /FROM public\.jobs WHERE job_id=\$1 LIMIT 1 FOR UPDATE/);
+  assert.match(route[0], /if \(job\.canceled_at\) deny\(\)/);
+  assert.match(route[0], /if \(job\.customer_rating\) deny\(\)/);
+  assert.match(route[0], /if \(!job\.technician_username\) deny\(\)/);
+  assert.match(route[0], /ON CONFLICT \(job_id\) DO NOTHING/);
+  assert.match(route[0], /console\.error\("\[public\/review\] failed", \{ code: String\(e\?\.code \|\| "REVIEW_FAILED"\) \}\)/);
+  assert.doesNotMatch(route[0], /console\.(?:log|warn|error)\([^\n]*identifierValue/);
 });
 
 test("/public/urgent-status is rate-limited", () => {
@@ -336,21 +434,19 @@ test("all three job-doc routes share one gate helper + sensitive headers", () =>
   }
 });
 
-test("the customer app only builds receipt links + review form on full (token) access", () => {
+test("the customer app keeps document access token-only and injects review credentials from memory", () => {
   // The receipt URL still carries the booking_token as ?key=, but it is now
   // constructed at click time from state (receiptUrl(data)) instead of being
   // interpolated into rendered HTML — see Blocker 1.
   assert.match(trackingClientSrc, /`\/docs\/receipt\/\$\{encodeURIComponent\(data\.job_id\)\}\?key=\$\{encodeURIComponent\(data\.booking_token\)\}`/);
-  // Read and write capabilities are separate; code-only reads cannot create
-  // document links or review forms.
+  // Documents remain token-only; selected jobs may use an opaque review reference.
   assert.match(trackingClientSrc, /if \(!canUseTokenActions\(data\)\) return "";/);
   assert.match(trackingClientSrc, /const reviewToken = canUseTokenActions\(data\)/);
   assert.match(trackingClientSrc, /if \(!catalogReview\.eligible \|\| !canUseTokenActions\(data\)\) return "";/);
-  // Blocker 1: the booking_token must NOT be embedded in rendered HTML as a
-  // hidden input. It is injected from state at submit time and the form is only
-  // flagged with data-review-token.
+  // Neither credential may be embedded in rendered HTML or hidden inputs.
   assert.doesNotMatch(trackingClientSrc, /name="booking_token"/);
-  assert.match(trackingClientSrc, /data-review-token/);
   assert.match(trackingClientSrc, /payload\.booking_token = token/);
+  assert.match(trackingClientSrc, /payload\.selection_ref = selectionReference/);
   assert.doesNotMatch(trackingClientSrc, /<input type="hidden" name="q"/);
+  assert.doesNotMatch(trackingClientSrc, /name="customer_phone"|เบอร์โทรที่ใช้จอง \(ยืนยันตัวตน\)/);
 });

--- a/test/homepageCms.test.js
+++ b/test/homepageCms.test.js
@@ -305,7 +305,7 @@ test("customer homepage has no admin control, bottom nav is fixed five-tab, and 
   const sw = read("customer-app/sw.js");
   const app = read("customer-app/assets/customer-app.js");
   const manifest = read("customer-app/manifest.webmanifest");
-  const build = "20260717_customer_history_simple_link_v1";
+  const build = "20260718_tracking_phone_review_direct_v1";
 
   assert.doesNotMatch(index + ui, /โหมดแอดมิน|openCms|localStorage\.getItem\('cwfHomeCmsDemo'/);
   assert.match(index, /data-route="store"[\s\S]*ร้านค้า/);


### PR DESCRIPTION
Closes #183

## Base and head
- Base: `5b3fe3ba063ec53583d67162476359204df198fa`
- Head: `ba5b8e7e5f4c67248b324deabfaa59bc86b2c16c`

## Root cause
The Customer App presented one tracking field, but the backend only resolved an exact booking token or Booking Code. Phone lookup and safe multi-job selection did not exist. Technician-review submission also required the legacy Booking Code + full-phone proof, so customers entering through a Booking Code could not review without typing their phone again.

The first implementation also issued a fresh randomized selection capability on each select/refresh and used its raw ciphertext as the review limiter identity. That allowed rolling expiry renewal and separate limiter buckets for the same job.

## Implementation
- Added normalized phone lookup for local, dashed, `+66`, and `0066` formats.
- Added safe single/multi-job lookup projections with no internal job ID, full phone, precise address, or credentials.
- Added 15-minute authenticated-encrypted selection references bound to one job.
- Added POST selection flow; the frontend never sends a raw job ID.
- Preserved existing secure booking-token links and Catalog Review behavior.
- Allowed eligible completed jobs opened by Booking Code, phone selection, or secure token to submit Technician Review without phone re-entry.
- Preserved completed/non-canceled/technician/duplicate-review checks under the review transaction.
- Removed the legacy phone-verification field/copy from the Customer App.
- Added accessible mobile result cards and refreshed the PWA build/cache version.

## Review blocker resolution
- `/public/track/select`, refresh, and post-review reload now return the already-verified selection reference instead of minting a new 15-minute capability.
- Absolute expiry therefore never moves beyond the initial reference expiry; an expired reference fails closed and requires a new phone/Booking Code lookup.
- Selection review throttling now derives a stable SHA-256 key from the verified, domain-separated `selection-job:<job_id>` identity.
- Independently issued references for the same job share one limiter bucket; different jobs use different buckets.
- Token and Booking Code limiter behavior is unchanged.
- No raw selection reference, token, Booking Code, or internal job ID is logged by the review route or exposed to the client.

## Latest review blocker resolution
- Replaced the inherited code-read projection with an explicit selection-access allowlist.
- Selection detail omits full phone, customer name, precise address, map URL, GPS, booking token, job/internal IDs, receipt/document URLs, payment/pricing data, private credentials, and unknown upstream fields.
- Selection detail retains only Booking Code, service summary, appointment/status/timeline, broad job zone, completed-work photos/checklists, customer-facing technician output, review summary, and the opaque selection reference.
- Secure booking-token access still returns the original full `trackPayload`; document and Catalog Review behavior is unchanged.
- Review limiter inputs are now domain-separated before SHA-256: `token:<value>`, `code:<value>`, and `selection-job:<verified job_id>`.
- Equal token/code text therefore uses separate buckets while repeated credentials and references remain stable.

## Changed files
- Backend: `index.js`, `server/services/public/trackingPrivacy.js`
- Customer App: `customer-app/modules/api.js`, `customer-app/modules/tracking.js`, `customer-app/assets/customer-app.css`
- PWA/build: `customer-app/assets/customer-app.js`, `customer-app/index.html`, `customer-app/manifest.webmanifest`, `customer-app/sw.js`
- Focused and active build-contract tests under `test/`
- Latest review fix touches only `index.js`, `server/services/public/trackingPrivacy.js`, and `test/customerTrackingPrivacy.test.js`.

## Security considerations
- Manual identifiers are sent in POST bodies, never visible URLs.
- Selection references are AES-256-GCM capabilities derived with domain separation from the existing server secret.
- Initial lifetime is at most 15 minutes and cannot be renewed by select or refresh.
- Raw phone, Booking Code, booking token, selection reference, and internal job ID are not logged by the affected review flow.
- Selection lists expose only the approved summary fields.
- Modified, expired, wrong-secret, and wrong-job references fail closed.
- Existing IP limiter remains active; stable per-job throttling prevents fresh selection ciphertext from resetting review budget.
- No auth-contract, database-schema, migration, payment, pricing, booking-creation, dispatch, or technician-assignment changes.

## Validation
- Latest review-fix `node --check` on all 3 changed JavaScript files: PASS
- Focused tracking/privacy/review/recovery suite: **253/253 PASS**
- `npm test` on branch: 1327 total, 1273 pass, 20 fail
- `npm test` on untouched base with the same environment/dependencies: 1314 total, 1260 pass, 20 fail
- Exact failed-test-name comparison: identical 20-name sets; **branch-only failures = 0**
- The 20 shared failures are the existing `adminStoreCatalogUi` baseline failures.
- `git diff --check`: PASS
- Working tree after commit: clean

## Production / migration actions
None. This PR does not include or require a database migration and does not touch Production data.

## Remaining risks
- Phone lookup intentionally grants the holder of a phone number access to a minimized list of matching jobs per the approved product decision; rate limiting and minimal projection reduce, but do not eliminate, phone-number knowledge risk.
- Selection references expire after 15 minutes; users must repeat lookup after expiry.
- Rate limiting retains the application's existing per-process behavior in multi-instance deployments.
