### PR TITLE
Remove decorative Customer App route heading icons

### DIFF
--- a/customer-app/assets/customer-app.css
+++ b/customer-app/assets/customer-app.css
@@ -3433,7 +3433,7 @@ img.account-avatar {
 .booking-wizard-page {
   display: grid;
   gap: 14px;
-  padding-bottom: 20px;
+  padding: 12px 16px 20px;
 }
 
 .page-toolbar {
@@ -7233,18 +7233,25 @@ body.has-advisor-sheet { overflow: hidden; }
 }
 .cwf-icon-slot img { display: block; width: 100%; height: 100%; object-fit: contain; border-radius: 7px; }
 .cwf-icon-slot.is-image { width: 1.5em; height: 1.5em; }
-.page-icon-heading {
-  display: flex;
-  align-items: center;
-  gap: 9px;
-  min-width: 0;
-  margin: 0 0 10px;
-  padding: 8px 12px;
+.route-page-heading {
+  width: 100%;
+  margin: 0;
+  padding: 0;
   color: var(--navy);
-  font-size: 14px;
-  font-weight: 800;
 }
-.page-icon-heading > span:last-child { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.route-page-heading__title {
+  max-width: 100%;
+  overflow-wrap: anywhere;
+  color: inherit;
+  font-size: clamp(18px, 5vw, 21px);
+  font-weight: 800;
+  line-height: 1.3;
+}
+.booking-wizard-page > .route-page-heading {
+  margin: 0;
+}
+.route-page-heading ~ .page-header-mount:empty { display: none; }
+.route-page-heading ~ .page-header-mount .page-header-banner { margin-bottom: 0; }
 .profile-slot-icon { display: inline-flex; margin: 0 0 8px; color: var(--blue); }
 [data-cwf-action-icon] { display: inline-flex; margin-right: 6px; vertical-align: middle; }
 
@@ -7263,5 +7270,4 @@ body.has-advisor-sheet { overflow: hidden; }
   .bottom-nav { grid-template-columns: repeat(5, minmax(0, 1fr)); }
   .bottom-nav .nav-item { min-width: 0; padding-inline: 1px; }
   .bottom-nav .nav-item [data-nav-label] { font-size: 9px !important; }
-  .page-icon-heading { padding-inline: 8px; }
 }

--- a/customer-app/assets/customer-app.js
+++ b/customer-app/assets/customer-app.js
@@ -3,7 +3,7 @@
 
   const App = window.CWFCustomerAppV2;
   const BOOT_TIMEOUT_MS = 3500;
-  const BUILD_ID = "20260718_tracking_phone_review_direct_v1";
+  const BUILD_ID = "20260718_remove_route_header_icons_v1";
 
   function withTimeout(promise, timeoutMs) {
     return Promise.race([

--- a/customer-app/index.html
+++ b/customer-app/index.html
@@ -21,10 +21,10 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Noto+Sans+Thai:wght@400;500;600;700;800;900&display=swap" media="print" onload="this.media='all'">
   <noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Noto+Sans+Thai:wght@400;500;600;700;800;900&display=swap"></noscript>
-  <link rel="manifest" href="./manifest.webmanifest?v=20260718_tracking_phone_review_direct_v1">
+  <link rel="manifest" href="./manifest.webmanifest?v=20260718_remove_route_header_icons_v1">
   <link rel="icon" type="image/png" sizes="192x192" href="./assets/icons/cwf-customer-192.png">
   <link rel="apple-touch-icon" sizes="180x180" href="./assets/icons/cwf-customer-180.png">
-  <link rel="stylesheet" href="./assets/customer-app.css?v=20260718_tracking_phone_review_direct_v1">
+  <link rel="stylesheet" href="./assets/customer-app.css?v=20260718_remove_route_header_icons_v1">
 </head>
 <body class="is-app-booting">
   <div class="app-shell" data-app-shell>
@@ -62,24 +62,24 @@
     </nav>
   </div>
 
-  <script src="./modules/iconRegistry.js?v=20260718_tracking_phone_review_direct_v1"></script>
-  <script src="./modules/state.js?v=20260718_tracking_phone_review_direct_v1"></script>
-  <script src="./modules/utils.js?v=20260718_tracking_phone_review_direct_v1"></script>
-  <script src="./modules/analytics.js?v=20260718_tracking_phone_review_direct_v1"></script>
-  <script src="./modules/api.js?v=20260718_tracking_phone_review_direct_v1"></script>
-  <script src="./modules/pageAvailability.js?v=20260718_tracking_phone_review_direct_v1"></script>
-  <script src="./modules/services.js?v=20260718_tracking_phone_review_direct_v1"></script>
-  <script src="./modules/advisor.js?v=20260718_tracking_phone_review_direct_v1"></script>
-  <script src="./modules/ui.js?v=20260718_tracking_phone_review_direct_v1"></script>
-  <script src="./modules/store.js?v=20260718_tracking_phone_review_direct_v1"></script>
-  <script src="./modules/auth.js?v=20260718_tracking_phone_review_direct_v1"></script>
-  <script src="./modules/pricing.js?v=20260718_tracking_phone_review_direct_v1"></script>
-  <script src="./modules/availability.js?v=20260718_tracking_phone_review_direct_v1"></script>
-  <script src="./modules/bookingScheduled.js?v=20260718_tracking_phone_review_direct_v1"></script>
-  <script src="./modules/bookingUrgent.js?v=20260718_tracking_phone_review_direct_v1"></script>
-  <script src="./modules/tracking.js?v=20260718_tracking_phone_review_direct_v1"></script>
-  <script src="./modules/profile.js?v=20260718_tracking_phone_review_direct_v1"></script>
-  <script src="./modules/router.js?v=20260718_tracking_phone_review_direct_v1"></script>
-  <script src="./assets/customer-app.js?v=20260718_tracking_phone_review_direct_v1"></script>
+  <script src="./modules/iconRegistry.js?v=20260718_remove_route_header_icons_v1"></script>
+  <script src="./modules/state.js?v=20260718_remove_route_header_icons_v1"></script>
+  <script src="./modules/utils.js?v=20260718_remove_route_header_icons_v1"></script>
+  <script src="./modules/analytics.js?v=20260718_remove_route_header_icons_v1"></script>
+  <script src="./modules/api.js?v=20260718_remove_route_header_icons_v1"></script>
+  <script src="./modules/pageAvailability.js?v=20260718_remove_route_header_icons_v1"></script>
+  <script src="./modules/services.js?v=20260718_remove_route_header_icons_v1"></script>
+  <script src="./modules/advisor.js?v=20260718_remove_route_header_icons_v1"></script>
+  <script src="./modules/ui.js?v=20260718_remove_route_header_icons_v1"></script>
+  <script src="./modules/store.js?v=20260718_remove_route_header_icons_v1"></script>
+  <script src="./modules/auth.js?v=20260718_remove_route_header_icons_v1"></script>
+  <script src="./modules/pricing.js?v=20260718_remove_route_header_icons_v1"></script>
+  <script src="./modules/availability.js?v=20260718_remove_route_header_icons_v1"></script>
+  <script src="./modules/bookingScheduled.js?v=20260718_remove_route_header_icons_v1"></script>
+  <script src="./modules/bookingUrgent.js?v=20260718_remove_route_header_icons_v1"></script>
+  <script src="./modules/tracking.js?v=20260718_remove_route_header_icons_v1"></script>
+  <script src="./modules/profile.js?v=20260718_remove_route_header_icons_v1"></script>
+  <script src="./modules/router.js?v=20260718_remove_route_header_icons_v1"></script>
+  <script src="./assets/customer-app.js?v=20260718_remove_route_header_icons_v1"></script>
 </body>
 </html>

--- a/customer-app/manifest.webmanifest
+++ b/customer-app/manifest.webmanifest
@@ -2,7 +2,7 @@
   "name": "CWF Customer Service",
   "short_name": "CWF Service",
   "description": "แอปลูกค้า Coldwindflow สำหรับเลือกบริการ จองคิว และติดตามงาน",
-  "start_url": "/customer-app/index.html?v=20260718_tracking_phone_review_direct_v1#home",
+  "start_url": "/customer-app/index.html?v=20260718_remove_route_header_icons_v1#home",
   "scope": "/customer-app/",
   "id": "/customer-app/",
   "display": "standalone",

--- a/customer-app/modules/ui.js
+++ b/customer-app/modules/ui.js
@@ -5,6 +5,8 @@
   let homeLoadPromise = null;
   const FEATURED_ROTATION_INTERVAL_MS = 6000;
   const featuredRotatorControllers = new WeakMap();
+  const routeHeadingObservers = new WeakMap();
+  console.info("[customer-ui] text-only route headings v1 loaded");
 
   function collectionState(name, emptyText, renderItems) {
     const bucket = root.state[name] || { status: "idle", items: [], error: "" };
@@ -1550,25 +1552,43 @@
   }
 
   function routeIconPage(route) {
-    if (route === "storeItem") return "store";
+    if (route === "storeItem" || /^storeItem-\d+$/.test(String(route || ""))) return "store";
     if (route === "scheduled" || route === "urgent") return "booking";
     return ["home", "store", "booking", "tracking", "profile"].includes(route) ? route : "home";
   }
 
-  function applyRouteIcons(container, route) {
-    if (!container) return;
+  function ensureRouteHeading(container, route) {
     const page = routeIconPage(route);
-    const screen = container.querySelector?.(".screen");
+    const screen = container.querySelector?.(".screen, .booking-wizard-page");
     if (screen && !screen.querySelector("[data-page-icon-heading]")) {
       const registry = window.CWFIconRegistry;
       const item = registry?.navigationItem?.(homepageConfig(), page) || { label: page };
       screen.insertAdjacentHTML("afterbegin", `
-        <div class="page-icon-heading" data-page-icon-heading="${root.utils.escapeHtml(page)}">
-          ${root.utils.iconSlot(`page.${page}.header`, 26)}
-          <span>${root.utils.escapeHtml(item.label)}</span>
-        </div>
+        <header class="route-page-heading" data-page-icon-heading="${root.utils.escapeHtml(page)}">
+          <h2 class="route-page-heading__title">${root.utils.escapeHtml(item.label)}</h2>
+        </header>
       `);
     }
+  }
+
+  function bindRouteHeading(container, route) {
+    ensureRouteHeading(container, route);
+    if (typeof MutationObserver !== "function") return;
+    let binding = routeHeadingObservers.get(container);
+    if (!binding) {
+      binding = { route: "", observer: null };
+      binding.observer = new MutationObserver(() => {
+        if (root.state.currentRoute === binding.route) ensureRouteHeading(container, binding.route);
+      });
+      binding.observer.observe(container, { childList: true, subtree: true });
+      routeHeadingObservers.set(container, binding);
+    }
+    binding.route = route;
+  }
+
+  function applyRouteIcons(container, route) {
+    if (!container) return;
+    bindRouteHeading(container, route);
     [
       ["[data-profile-address]", "profile.address"],
       ["[data-profile-history]", "profile.history"],

--- a/customer-app/modules/ui.js
+++ b/customer-app/modules/ui.js
@@ -6,7 +6,6 @@
   const FEATURED_ROTATION_INTERVAL_MS = 6000;
   const featuredRotatorControllers = new WeakMap();
   const routeHeadingObservers = new WeakMap();
-  console.info("[customer-ui] text-only route headings v1 loaded");
 
   function collectionState(name, emptyText, renderItems) {
     const bucket = root.state[name] || { status: "idle", items: [], error: "" };

--- a/customer-app/sw.js
+++ b/customer-app/sw.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const BUILD_ID = "20260718_tracking_phone_review_direct_v1";
+const BUILD_ID = "20260718_remove_route_header_icons_v1";
 const CACHE_NAME = `cwf-customer-app-v2-${BUILD_ID}`;
 const APP_SHELL = [
   `./index.html?v=${BUILD_ID}`,

--- a/test/customerAppPageAvailability.test.js
+++ b/test/customerAppPageAvailability.test.js
@@ -281,7 +281,7 @@ test("api exposes loadCustomerAppConfig as a no-store GET to /public/customer-ap
 });
 
 test("build wiring: pageAvailability.js is registered in the HTML shell and the SW cache, with the new build id", () => {
-  const build = "20260718_tracking_phone_review_direct_v1";
+  const build = "20260718_remove_route_header_icons_v1";
   assert.match(indexHtml, new RegExp(`modules/pageAvailability\\.js\\?v=${build}`));
   assert.match(swSrc, new RegExp(`BUILD_ID = "${build}"`));
   assert.match(swSrc, /modules\/pageAvailability\.js\?v=\$\{BUILD_ID\}/);
@@ -294,7 +294,7 @@ test("build wiring: pageAvailability.js is registered in the HTML shell and the 
    RUNTIME tests (execute the real code in a VM — not regex assertions).
    ========================================================================== */
 
-const BUILD = "20260718_tracking_phone_review_direct_v1";
+const BUILD = "20260718_remove_route_header_icons_v1";
 const adminSrc = read("admin-homepage-cms.js");
 
 function reqUrlOf(req) {

--- a/test/customerAppRecovery.test.js
+++ b/test/customerAppRecovery.test.js
@@ -236,7 +236,7 @@ test("Customer App build id is consistent across shell and service worker", () =
   const sw = read("customer-app/sw.js");
   const app = read("customer-app/assets/customer-app.js");
   const manifest = read("customer-app/manifest.webmanifest");
-  const build = "20260718_tracking_phone_review_direct_v1";
+  const build = "20260718_remove_route_header_icons_v1";
 
   assert.match(index, new RegExp(`customer-app\\.css\\?v=${build}`));
   assert.match(index, new RegExp(`modules\\/api\\.js\\?v=${build}`));
@@ -254,7 +254,7 @@ test("Customer App build id is consistent across shell and service worker", () =
 test("store module is loaded in index.html and precached in the service worker app shell", () => {
   const index = read("customer-app/index.html");
   const sw = read("customer-app/sw.js");
-  const build = "20260718_tracking_phone_review_direct_v1";
+  const build = "20260718_remove_route_header_icons_v1";
 
   assert.match(index, new RegExp(`modules/store\\.js\\?v=${build}`));
   assert.match(sw, /`\.\/modules\/store\.js\?v=\$\{BUILD_ID\}`/);

--- a/test/customerAppStorePayment.test.js
+++ b/test/customerAppStorePayment.test.js
@@ -58,7 +58,7 @@ test("store falls back to the LINE hand-off when payment is unconfigured or the 
 test("payment step styles exist and the Customer App payment build id is bumped", () => {
   assert.match(cssSrc, /\.pay-method-btn/);
   assert.match(cssSrc, /\.pay-qr-img/);
-  assert.match(read("customer-app/index.html"), /modules\/store\.js\?v=20260718_tracking_phone_review_direct_v1/);
-  assert.match(read("customer-app/sw.js"), /BUILD_ID = "20260718_tracking_phone_review_direct_v1"/);
+  assert.match(read("customer-app/index.html"), /modules\/store\.js\?v=20260718_remove_route_header_icons_v1/);
+  assert.match(read("customer-app/sw.js"), /BUILD_ID = "20260718_remove_route_header_icons_v1"/);
   assert.match(storeSrc, /payment-security 20260705 loaded/);
 });

--- a/test/customerBookingAdminNotifications.test.js
+++ b/test/customerBookingAdminNotifications.test.js
@@ -311,10 +311,10 @@ test("admin/customer frontend cache versions are bumped for booking notification
   assert.doesNotMatch(adminReviewHtml, /admin-review-v2\.js\?v=20260707_customer_booking_notify_v2/);
   assert.match(adminReviewHtml, /admin-review-ai-intake\.js\?v=ai-booking-intake-customer-cards-v11-admin-alert-gate/);
   assert.doesNotMatch(adminReviewHtml, /admin-review-ai-intake\.js\?v=ai-booking-intake-customer-cards-v10/);
-  assert.match(customerIndex, /bookingScheduled\.js\?v=20260718_tracking_phone_review_direct_v1/);
-  assert.match(customerIndex, /state\.js\?v=20260718_tracking_phone_review_direct_v1/);
-  assert.match(customerSw, /const BUILD_ID = "20260718_tracking_phone_review_direct_v1"/);
-  assert.match(customerManifest, /20260718_tracking_phone_review_direct_v1/);
+  assert.match(customerIndex, /bookingScheduled\.js\?v=20260718_remove_route_header_icons_v1/);
+  assert.match(customerIndex, /state\.js\?v=20260718_remove_route_header_icons_v1/);
+  assert.match(customerSw, /const BUILD_ID = "20260718_remove_route_header_icons_v1"/);
+  assert.match(customerManifest, /20260718_remove_route_header_icons_v1/);
 });
 
 test("behavior: review queue only includes customer urgent waiting rows while preserving review statuses", () => {

--- a/test/customerHistoryClaim.test.js
+++ b/test/customerHistoryClaim.test.js
@@ -845,7 +845,7 @@ test("Customer History search and preview keep 360px and 390px width contracts",
 });
 
 test("Customer App cache version is bumped consistently", () => {
-  const expected = "20260718_tracking_phone_review_direct_v1";
+  const expected = "20260718_remove_route_header_icons_v1";
   for (const file of [
     "customer-app/index.html",
     "customer-app/sw.js",

--- a/test/customerHomepageFeaturedRotation.test.js
+++ b/test/customerHomepageFeaturedRotation.test.js
@@ -414,6 +414,6 @@ test("compact CSS and cache build remain consistent with six-card rotation", () 
   assert.match(css, /\.homepage-featured-page\s*\{[^}]*grid-area:\s*1\s*\/\s*1/s);
   assert.match(css, /transition:\s*opacity 350ms/);
   assert.match(css, /prefers-reduced-motion:\s*reduce/);
-  const build = "20260718_tracking_phone_review_direct_v1";
+  const build = "20260718_remove_route_header_icons_v1";
   for (const source of [html, sw, boot, manifest]) assert.match(source, new RegExp(build));
 });

--- a/test/customerRouteHeadings.test.js
+++ b/test/customerRouteHeadings.test.js
@@ -1,0 +1,177 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const vm = require("node:vm");
+
+const ROOT = path.resolve(__dirname, "..");
+const UI_SOURCE = fs.readFileSync(path.join(ROOT, "customer-app/modules/ui.js"), "utf8");
+
+function escapeHtml(value) {
+  return String(value == null ? "" : value)
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#039;");
+}
+
+function loadUi(overrides = {}) {
+  const labels = {
+    home: "หน้าแรก",
+    store: "ร้านค้า",
+    booking: "จองบริการ",
+    tracking: "ติดตามงาน",
+    profile: "บัญชี",
+  };
+  const calls = { actionDecorations: 0, iconSlots: [], pageHeaderQueries: 0 };
+  const app = {
+    state: { homepage: { status: "success", config: {} } },
+    utils: {
+      escapeHtml,
+      iconSlot(slot) {
+        calls.iconSlots.push(slot);
+        return `<span data-cwf-icon-slot="${escapeHtml(slot)}"></span>`;
+      },
+      decorateActionIcons() { calls.actionDecorations += 1; },
+      ...(overrides.utils || {}),
+    },
+  };
+  const document = {
+    body: { classList: { add() {}, remove() {} } },
+    getElementById() { return null; },
+    querySelector() { return null; },
+  };
+  const window = {
+    CWFCustomerAppV2: app,
+    CWFIconRegistry: {
+      navigationItem(_config, page) { return { label: labels[page] }; },
+    },
+  };
+  vm.runInNewContext(UI_SOURCE, { window, document, URL, WeakMap, Set, console, MutationObserver: overrides.MutationObserver }, { filename: "ui.js" });
+  return { app, calls };
+}
+
+function routeContainer() {
+  const insertions = [];
+  const headingTarget = {
+    querySelector(selector) {
+      return selector === "[data-page-icon-heading]" && insertions.length ? {} : null;
+    },
+    insertAdjacentHTML(position, html) {
+      assert.equal(position, "afterbegin");
+      insertions.push(String(html));
+    },
+  };
+  return {
+    insertions,
+    querySelector(selector) {
+      if (selector === ".screen, .booking-wizard-page") return headingTarget;
+      return null;
+    },
+    querySelectorAll(selector) {
+      if (selector === "[data-page-header]") return [];
+      return [];
+    },
+  };
+}
+
+test("all Customer App routes render one semantic text-only page heading", () => {
+  const { app } = loadUi({
+    utils: {
+      iconSlot() { throw new Error("page heading must not request an icon slot"); },
+    },
+  });
+  const routes = [
+    ["home", "home", "หน้าแรก"],
+    ["store", "store", "ร้านค้า"],
+    ["storeItem", "store", "ร้านค้า"],
+    ["storeItem-42", "store", "ร้านค้า"],
+    ["booking", "booking", "จองบริการ"],
+    ["scheduled", "booking", "จองบริการ"],
+    ["urgent", "booking", "จองบริการ"],
+    ["tracking", "tracking", "ติดตามงาน"],
+    ["profile", "profile", "บัญชี"],
+  ];
+
+  for (const [route, page, label] of routes) {
+    const container = routeContainer();
+    app.ui.applyRouteIcons(container, route);
+    app.ui.applyRouteIcons(container, route);
+
+    assert.equal(container.insertions.length, 1, `${route} heading should not be injected twice`);
+    const html = container.insertions[0];
+    assert.match(html, /<header class="route-page-heading"/);
+    assert.match(html, new RegExp(`data-page-icon-heading="${page}"`));
+    assert.match(html, new RegExp(`<h2 class="route-page-heading__title">${label}</h2>`));
+    assert.doesNotMatch(html, /<svg\b|<img\b|cwf-icon-slot|data-(?:cwf-)?icon-slot/i);
+  }
+});
+
+test("applyRouteIcons keeps profile slots, action decoration, and page-header binding", () => {
+  const { app, calls } = loadUi();
+  const makeProfileMount = () => ({
+    insertions: [],
+    querySelector() { return null; },
+    insertAdjacentHTML(_position, html) { this.insertions.push(String(html)); },
+  });
+  const address = makeProfileMount();
+  const history = makeProfileMount();
+  const container = {
+    querySelector(selector) {
+      if (selector === ".screen, .booking-wizard-page") return null;
+      if (selector === "[data-profile-address]") return address;
+      if (selector === "[data-profile-history]") return history;
+      return null;
+    },
+    querySelectorAll(selector) {
+      if (selector === "[data-page-header]") calls.pageHeaderQueries += 1;
+      return [];
+    },
+  };
+
+  app.ui.applyRouteIcons(container, "profile");
+
+  assert.deepEqual(calls.iconSlots, ["profile.address", "profile.history"]);
+  assert.match(address.insertions[0], /data-profile-slot-icon/);
+  assert.match(history.insertions[0], /data-profile-slot-icon/);
+  assert.equal(calls.actionDecorations, 1);
+  assert.equal(calls.pageHeaderQueries, 1);
+});
+
+test("async route repaint restores one heading only for the still-current route", () => {
+  let observerCallback = null;
+  class FakeMutationObserver {
+    constructor(callback) { observerCallback = callback; }
+    observe() {}
+  }
+  const { app } = loadUi({ MutationObserver: FakeMutationObserver });
+  const container = routeContainer();
+  app.state.currentRoute = "scheduled";
+
+  app.ui.applyRouteIcons(container, "scheduled");
+  assert.equal(container.insertions.length, 1);
+
+  container.insertions.length = 0;
+  observerCallback();
+  observerCallback();
+  assert.equal(container.insertions.length, 1, "repaint should restore exactly one heading");
+
+  app.state.currentRoute = "tracking";
+  container.insertions.length = 0;
+  observerCallback();
+  assert.equal(container.insertions.length, 0, "stale route observer must not decorate a different route");
+});
+
+test("route heading layout stays aligned and mobile overflow guards remain active", () => {
+  const css = fs.readFileSync(path.join(ROOT, "customer-app/assets/customer-app.css"), "utf8");
+
+  assert.match(css, /\.route-page-heading\s*\{[^}]*width:\s*100%;[^}]*margin:\s*0;[^}]*padding:\s*0;/s);
+  assert.match(css, /\.route-page-heading__title\s*\{[^}]*max-width:\s*100%;[^}]*overflow-wrap:\s*anywhere;/s);
+  assert.match(css, /\.booking-wizard-page\s*\{[^}]*padding:\s*12px 16px 20px;/s);
+  assert.match(css, /\.booking-wizard-page > \.route-page-heading\s*\{[^}]*margin:\s*0;/s);
+  assert.match(css, /\.route-page-heading ~ \.page-header-mount:empty\s*\{\s*display:\s*none;/);
+  assert.match(css, /html\s*\{[^}]*overflow-x:\s*hidden;/s);
+  assert.match(css, /body\s*\{[^}]*overflow-x:\s*hidden;/s);
+  assert.doesNotMatch(css, /\.page-icon-heading/);
+});

--- a/test/customerRouteHeadings.test.js
+++ b/test/customerRouteHeadings.test.js
@@ -76,6 +76,10 @@ function routeContainer() {
   };
 }
 
+test("Customer App UI module has no startup debug logging", () => {
+  assert.doesNotMatch(UI_SOURCE, /\bconsole\.(?:debug|info|log)\s*\(/);
+});
+
 test("all Customer App routes render one semantic text-only page heading", () => {
   const { app } = loadUi({
     utils: {

--- a/test/customerSameDayTiming.test.js
+++ b/test/customerSameDayTiming.test.js
@@ -160,7 +160,7 @@ test("customer app disables availability HTTP cache and refreshes same-day slots
 });
 
 test("customer app build and service worker cache IDs changed", () => {
-  const id = "20260718_tracking_phone_review_direct_v1";
+  const id = "20260718_remove_route_header_icons_v1";
   for (const file of [
     "customer-app/index.html",
     "customer-app/sw.js",

--- a/test/customerSmartAdvisor.test.js
+++ b/test/customerSmartAdvisor.test.js
@@ -1174,7 +1174,7 @@ test("Home places built-in advisor after Quick Actions and before Featured Servi
 });
 
 test("advisor module is loaded before ui.js and precached under the shared build id", () => {
-  const build = "20260718_tracking_phone_review_direct_v1";
+  const build = "20260718_remove_route_header_icons_v1";
   assert.ok(INDEX_SOURCE.indexOf(`modules/advisor.js?v=${build}`) < INDEX_SOURCE.indexOf(`modules/ui.js?v=${build}`));
   assert.match(SW_SOURCE, new RegExp(`BUILD_ID = "${build}"`));
   assert.match(SW_SOURCE, /modules\/advisor\.js\?v=\$\{BUILD_ID\}/);

--- a/test/customerTrackingFullReadUi.test.js
+++ b/test/customerTrackingFullReadUi.test.js
@@ -969,7 +969,7 @@ test("tracking UI exposes loading, not-found, rate-limit and offline states", ()
 });
 
 test("tracking assets share the full-read cache build id", () => {
-  const build = "20260718_tracking_phone_review_direct_v1";
+  const build = "20260718_remove_route_header_icons_v1";
   for (const file of [
     "customer-app/index.html",
     "customer-app/sw.js",

--- a/test/homepageCms.test.js
+++ b/test/homepageCms.test.js
@@ -305,7 +305,7 @@ test("customer homepage has no admin control, bottom nav is fixed five-tab, and 
   const sw = read("customer-app/sw.js");
   const app = read("customer-app/assets/customer-app.js");
   const manifest = read("customer-app/manifest.webmanifest");
-  const build = "20260718_tracking_phone_review_direct_v1";
+  const build = "20260718_remove_route_header_icons_v1";
 
   assert.doesNotMatch(index + ui, /โหมดแอดมิน|openCms|localStorage\.getItem\('cwfHomeCmsDemo'/);
   assert.match(index, /data-route="store"[\s\S]*ร้านค้า/);


### PR DESCRIPTION
## Summary

- replace the decorative icon-and-label row beneath the global CWF header with a compact semantic text-only route heading
- keep the existing `data-page-icon-heading` hook for deduplication while removing SVG/image/icon-slot markup from the heading
- align headings with the main content column, including the scheduled booking wizard, and remove empty CMS mount spacing
- preserve profile address/history icons, action decoration, page-header binding, bottom navigation, quick-menu icons, Smart Advisor, and all route/business behavior
- bump the Customer App PWA/cache build ID to `20260718_remove_route_header_icons_v1`

## Root cause

`applyRouteIcons()` injected `.page-icon-heading` with `iconSlot(`page.${page}.header`)` on every route render. The old row added inner padding, icon width, gap, and bottom margin, so route titles did not align with the content column and used excess vertical space. Scheduled/urgent flows can repaint their route container asynchronously, so the heading also needs guarded reinjection without duplication.

## Before / after

Before:

`[decorative route icon] หน้าแรก / ร้านค้า / จองบริการ / ติดตามงาน / บัญชี`

After:

`หน้าแรก / ร้านค้า / จองบริการ / ติดตามงาน / บัญชี`

The structure is now `<header class="route-page-heading"><h2>…</h2></header>`. The existing data hook remains; the old `.page-icon-heading` selector contract is removed.

## Validation

- `node --check`: all 14 changed JavaScript files passed
- manifest JSON parse: passed
- focused review-blocker tests (route headings, console cleanliness, router/page availability, recovery/deep-link, build/cache): 158/158 passed
- local browser validation at 360px and 390px across home, store, storeItem, booking, scheduled, urgent, tracking, and profile:
  - no horizontal overflow
  - exactly one heading per route
  - no heading SVG, image, or icon slot
  - heading/content columns aligned
  - top gap 12–16px; heading-to-content gap 14–16px
  - five bottom-navigation icons intact
  - four homepage quick-menu icons and Smart Advisor intact
  - homepage heading geometry stable after async data load
- `git diff --check`: passed
- full branch suite: 1,332 tests; 1,277 passed; 21 failed; 34 skipped
- untouched base `3d74d17e009a83f6ade830445ef8a3b7d9731bb8`: 1,327 tests; 1,272 passed; 21 failed; 34 skipped
- exact failure-name sets: identical
- branch-only failures: 0

The 21 shared failures are pre-existing tests in Admin catalog/review and tracking cleanliness areas outside this PR's diff.

Closes #185