### PR TITLE
feat(booking): isolate pending customer reservations

### DIFF
--- a/admin-add-v2.html
+++ b/admin-add-v2.html
@@ -592,7 +592,7 @@
   </div>
 
   <script src="admin-v2-common.js?v=20260428_allpages_ui1"></script>
-  <script src="admin-add-v2.js?v=20260712_job_location_roundtrip_v1"></script>
+  <script src="admin-add-v2.js?v=20260719_customer_booking_pr3_v1"></script>
   <script src="admin-add-ai-intake-prefill.js?v=line-ai-prefill-real-v8"></script>
 </body>
 </html>

--- a/admin-add-v2.js
+++ b/admin-add-v2.js
@@ -1636,16 +1636,17 @@ async function loadAvailability() {
     } catch(e){}
 
     if (forced) qs.set('forced','1');
+    qs.set('aggregate','1');
 
     if (DEBUG_ENABLED) qs.set('debug','1');
     if (DEBUG_ENABLED) {
-      DBG.lastReq = maskPII({ endpoint: '/public/availability_v2', query: Object.fromEntries(qs.entries()) });
+      DBG.lastReq = maskPII({ endpoint: '/admin/availability_by_tech_v2', query: Object.fromEntries(qs.entries()) });
       DBG.conflict = null;
       DBG.intervals = null;
       DBG.lastRes = null;
       dbgRender();
     }
-    const r = await apiFetch(`/public/availability_v2?${qs.toString()}`);
+    const r = await apiFetch(`/admin/availability_by_tech_v2?${qs.toString()}`);
 
     if (DEBUG_ENABLED) {
       DBG.lastRes = r;

--- a/admin-queue-v2.html
+++ b/admin-queue-v2.html
@@ -523,6 +523,6 @@
   </div>
 
   <script src="admin-v2-common.js?v=20260428_allpages_ui1"></script>
-  <script src="admin-queue-v2.js?v=20260428_hero_actions_compact1"></script>
+  <script src="admin-queue-v2.js?v=20260719_customer_booking_pr3_v1"></script>
 </body>
 </html>

--- a/admin-queue-v2.js
+++ b/admin-queue-v2.js
@@ -291,7 +291,7 @@ function goToToday(){
 
 async function loadDayAvailability(date, tech_type){
   const duration_min = Math.max(15, Number(el('duration_min').value || state.durationMin || 30));
-  const data = await apiFetch(`/public/availability_v2?date=${encodeURIComponent(date)}&tech_type=${encodeURIComponent(tech_type)}&duration_min=${encodeURIComponent(duration_min)}&forced=1`);
+  const data = await apiFetch(`/admin/availability_by_tech_v2?date=${encodeURIComponent(date)}&tech_type=${encodeURIComponent(tech_type)}&duration_min=${encodeURIComponent(duration_min)}&forced=1&aggregate=1`);
   return {
     hasAny: (data.slots || []).some(s=>s.available),
     ranges: rangeFromSlots(data.slots || []),

--- a/admin-review-v2.html
+++ b/admin-review-v2.html
@@ -174,7 +174,7 @@
   </div>
 
   <script src="admin-v2-common.js?v=20260428_allpages_ui1"></script>
-  <script src="admin-review-v2.js?v=20260712_job_location_roundtrip_v1"></script>
+  <script src="admin-review-v2.js?v=20260719_customer_booking_pr3_v1"></script>
   <script src="admin-review-ai-intake.js?v=ai-booking-intake-customer-cards-v11-admin-alert-gate"></script>
 </body>
 </html>

--- a/admin-review-v2.js
+++ b/admin-review-v2.js
@@ -965,7 +965,13 @@ async function dispatchJob(){
 
   try{
     const payload = { technician_username, tech_type, mode, team_members };
-    const out = await apiFetch(`/jobs/${CURRENT.job_id}/dispatch_v2`, { method:"POST", body: JSON.stringify(payload) });
+    const isPendingCustomerBooking = String(CURRENT.job_source || "") === "customer"
+      && String(CURRENT.job_status || "") === "รอตรวจสอบ"
+      && ["scheduled", "urgent"].includes(String(CURRENT.booking_mode || ""));
+    const endpoint = isPendingCustomerBooking
+      ? `/admin/customer-bookings/${CURRENT.job_id}/approve`
+      : `/jobs/${CURRENT.job_id}/dispatch_v2`;
+    const out = await apiFetch(endpoint, { method:"POST", body: JSON.stringify(payload) });
     showToast("ยิงงานสำเร็จ","success");
     closeModal();
     await loadQueue();
@@ -1019,7 +1025,13 @@ async function cancelJob(){
   if (blockReadOnlyMutation()) return;
   if (!confirm("ยืนยันยกเลิกงานนี้?")) return;
   try{
-    await apiFetch(`/jobs/${CURRENT.job_id}/cancel`, { method:"POST", body: JSON.stringify({ reason: "admin_cancel" }) });
+    const isPendingCustomerBooking = String(CURRENT.job_source || "") === "customer"
+      && String(CURRENT.job_status || "") === "รอตรวจสอบ"
+      && ["scheduled", "urgent"].includes(String(CURRENT.booking_mode || ""));
+    const endpoint = isPendingCustomerBooking
+      ? `/admin/customer-bookings/${CURRENT.job_id}/reject`
+      : `/jobs/${CURRENT.job_id}/admin-cancel`;
+    await apiFetch(endpoint, { method:"POST", body: JSON.stringify({ reason: "admin_cancel" }) });
     showToast("ยกเลิกงานแล้ว","success");
     closeModal();
     await loadQueue();

--- a/index.js
+++ b/index.js
@@ -42,6 +42,9 @@ const customerAvailability = require("./server/services/public/customerAvailabil
 const { registerPublicCustomerAvailabilityRoutes } = require("./server/routes/public/customerAvailability");
 const { registerAdminAvailabilityRoutes } = require("./server/routes/admin/adminAvailability");
 const { createBookingJobService } = require("./server/services/booking/createBookingJob");
+const { pendingCustomerScheduledReservationSql } = require("./server/services/booking/bookingStatuses");
+const { createBookingApprovalService } = require("./server/services/booking/bookingApprovalService");
+const { registerBookingApprovalRoutes } = require("./server/routes/admin/bookingApprovals");
 const { registerPublicCustomerBookingRoutes } = require("./server/routes/public/customerBookings");
 const { registerAdminBookingRoutes } = require("./server/routes/admin/adminBookings");
 const { createTechnicianJobMoneyHelpers } = require("./server/technicianJobMoneySummary");
@@ -1879,7 +1882,7 @@ async function assertTechBelongsToJob(clientOrPool, job_id, username) {
      AND ja.technician_username = $2
     WHERE j.job_id = $1
       AND (
-        j.technician_username = $2
+        (j.technician_username = $2 AND NOT ${pendingCustomerScheduledReservationSql("j")})
         OR j.technician_team = $2
         OR $2 = ANY(regexp_split_to_array(COALESCE(j.technician_team,''), '\\s*,\\s*'))
         OR tm.username IS NOT NULL
@@ -14231,6 +14234,22 @@ registerAdminBookingRoutes(app, {
   requireInternalApiKeyOnly,
 });
 
+const bookingApprovalService = createBookingApprovalService({
+  pool,
+  availabilityEngine: customerAvailability,
+  getAvailabilityDependencies: publicCustomerAvailabilityDeps,
+  refreshTechnicianIncomePreviewForJob: _refreshTechnicianIncomePreviewForJob,
+  notifyDirectJobAssigned: _notifyDirectJobAssigned,
+  notifyUrgentOffer: _notifyUrgentOffer,
+  isTechReady,
+  checkTechCollision,
+  logJobUpdate,
+});
+registerBookingApprovalRoutes(app, {
+  service: bookingApprovalService,
+  requireAdminSession,
+});
+
 app.get("/admin/jobs_v2", requireAdminSoft, async (req, res) => {
   try {
     const date_from = (req.query.date_from || "").toString().trim();
@@ -14528,7 +14547,7 @@ app.get("/admin/review_queue_v2", requireAdminSoft, async (req, res) => {
     const sqlWhere = where.length ? `WHERE ${where.join(' AND ')}` : '';
     const r = await pool.query(
       `
-      SELECT job_id, booking_code, customer_name, customer_phone, job_type,
+      SELECT job_id, booking_code, customer_name, customer_phone, job_type, job_source,
              appointment_datetime, job_status, duration_min, job_price,
              address_text, maps_url, job_zone,
              technician_username, dispatch_mode, booking_mode,
@@ -16342,7 +16361,7 @@ function _techVisibilityPredicateSql(aliasParam = '$1') {
       WHERE ja.job_id = j.job_id
         AND ja.technician_username = ANY(${aliasParam}::text[])
     )
-    OR j.technician_username = ANY(${aliasParam}::text[])
+    OR (j.technician_username = ANY(${aliasParam}::text[]) AND NOT ${pendingCustomerScheduledReservationSql("j")})
     OR EXISTS (
       SELECT 1 FROM public.job_team_members tm
       WHERE tm.job_id = j.job_id
@@ -17011,7 +17030,7 @@ app.put("/jobs/:job_id/status", async (req, res) => {
   try {
     const realId = await resolveJobIdAny(pool, job_id);
     if (!realId) return res.status(400).json({ error: "job_id ไม่ถูกต้อง" });
-    if (status === 'กำลังทำ') await assertJobActionableForTechnician(pool, realId);
+    await assertJobActionableForTechnician(pool, realId);
 
     // ✅ เมื่อเริ่มงานครั้งแรก ให้บันทึก started_at
     if (status === 'กำลังทำ') {
@@ -18996,7 +19015,7 @@ app.post("/jobs/:job_id/photos/meta", async (req, res) => {
     res.json({ success: true, photo_id: r.rows[0].photo_id });
   } catch (e) {
     console.error(e);
-    res.status(500).json({ error: "สร้าง metadata รูปไม่สำเร็จ" });
+    res.status(Number(e.status || 500)).json({ error: e.message || "สร้าง metadata รูปไม่สำเร็จ", code: e.code || undefined });
   }
 });
 
@@ -19113,7 +19132,7 @@ app.post("/jobs/:job_id/photos/:photo_id/upload", upload.single("photo"), async 
     });
   } catch (e) {
     console.error(e);
-    res.status(500).json({ error: "อัปโหลดรูปไม่สำเร็จ" });
+    res.status(Number(e.status || 500)).json({ error: e.message || "อัปโหลดรูปไม่สำเร็จ", code: e.code || undefined });
   }
 });
 
@@ -19143,6 +19162,7 @@ app.get("/jobs/:job_id/units", async (req, res) => {
   try {
     const realId = await resolveJobIdAny(pool, req.params.job_id);
     if (!realId) return res.status(400).json({ error: "ไม่พบงานนี้" });
+    await assertJobActionableForTechnician(pool, realId);
     // เปิดระบบแยกเครื่องแบบปลอดภัยเมื่อช่าง/แอดมินเข้าหน้านี้
     // เพื่อให้งานเก่าหรืองานที่สร้างก่อน migration เห็นการ์ดเครื่องทันที ไม่กลับไปลงรูปรวม
     const units = await getUnitsWithEvidence(realId, pool);
@@ -19152,7 +19172,7 @@ app.get("/jobs/:job_id/units", async (req, res) => {
     return res.json({ success: true, per_unit_evidence_enabled: units.length > 0, units });
   } catch (e) {
     console.error('GET /jobs/:job_id/units', e);
-    return res.status(500).json({ error: "โหลดข้อมูลเครื่องไม่สำเร็จ" });
+    return res.status(Number(e.status || 500)).json({ error: e.message || "โหลดข้อมูลเครื่องไม่สำเร็จ", code: e.code || undefined });
   }
 });
 
@@ -19162,6 +19182,7 @@ app.put("/jobs/:job_id/units/:unit_id/checklist", requireTechnicianSession, asyn
     if (!realId) return res.status(400).json({ error: "ไม่พบงานนี้" });
     const technician = await requireTechOwnsResolvedJob(req, res, realId, pool);
     if (!technician) return;
+    await assertJobActionableForTechnician(pool, realId);
     const unitId = Number(req.params.unit_id || 0);
     const type = String(req.body?.checklist_type || '').trim();
     if (!['pre','post'].includes(type)) return res.status(400).json({ error: "ประเภทเช็คลิสไม่ถูกต้อง" });
@@ -19178,7 +19199,7 @@ app.put("/jobs/:job_id/units/:unit_id/checklist", requireTechnicianSession, asyn
     return res.json({ success: true, message: "บันทึกเช็คลิสเครื่องนี้แล้ว" });
   } catch (e) {
     console.error('PUT /jobs/:job_id/units/:unit_id/checklist', e);
-    return res.status(500).json({ error: "บันทึกเช็คลิสเครื่องนี้ไม่สำเร็จ" });
+    return res.status(Number(e.status || 500)).json({ error: e.message || "บันทึกเช็คลิสเครื่องนี้ไม่สำเร็จ", code: e.code || undefined });
   }
 });
 
@@ -19706,22 +19727,12 @@ app.post("/jobs/:job_id/assignment-done", requireTechnicianSession, async (req, 
       return res.status(400).json({ error: "job_id ไม่ถูกต้อง" });
     }
 
-    // Ensure this tech is actually part of the job
-    const ok = await client.query(
-      `
-      SELECT 1
-      FROM public.jobs j
-      LEFT JOIN public.job_team_members tm ON tm.job_id=j.job_id AND tm.username=$2
-      LEFT JOIN public.job_assignments ja ON ja.job_id=j.job_id AND ja.technician_username=$2
-      WHERE j.job_id=$1 AND (j.technician_username=$2 OR j.technician_team=$2 OR tm.username IS NOT NULL OR ja.technician_username IS NOT NULL)
-      LIMIT 1
-      `,
-      [realId, technician_username]
-    );
-    if (!ok.rows.length) {
+    const ownsJob = await assertTechBelongsToJob(client, realId, technician_username);
+    if (!ownsJob) {
       await client.query("ROLLBACK");
       return res.status(400).json({ error: "ช่างคนนี้ไม่ได้อยู่ในทีมของงานนี้" });
     }
+    await assertJobActionableForTechnician(client, realId);
 
     // Upsert to done (idempotent)
     await client.query(
@@ -19750,7 +19761,7 @@ app.post("/jobs/:job_id/assignment-done", requireTechnicianSession, async (req, 
   } catch (e) {
     await client.query("ROLLBACK");
     console.error(e);
-    return res.status(500).json({ error: e.message || "บันทึกสถานะงานไม่สำเร็จ" });
+    return res.status(Number(e.status || 500)).json({ error: e.message || "บันทึกสถานะงานไม่สำเร็จ", code: e.code || undefined });
   } finally {
     client.release();
   }

--- a/server/routes/admin/adminAvailability.js
+++ b/server/routes/admin/adminAvailability.js
@@ -8,19 +8,26 @@ function registerAdminAvailabilityRoutes(app, options = {}) {
   const isEnabled = options.isEnabled || (() => true);
   const requireAdminSession = options.requireAdminSession;
 
-  // Authorization intentionally remains byte-for-byte compatible in PR1. This
-  // route has no middleware today; the finding is tracked for a follow-up PR.
-  app.get("/admin/availability_by_tech_v2", async (req, res) => {
+  app.get("/admin/availability_by_tech_v2", requireAdminSession, async (req, res) => {
     if (!isEnabled()) return res.status(404).json({ error: "DISABLED" });
     const date = String(req.query.date || new Date().toISOString().slice(0, 10));
     const tech_type = String(req.query.tech_type || "company").trim().toLowerCase();
     const duration_min = Math.max(15, Number(req.query.duration_min || 60));
     const include_paused = String(req.query.forced || req.query.include_paused || "").trim() === "1";
+    const aggregate = String(req.query.aggregate || "").trim() === "1";
     try {
-      const data = await engine.computeAdminAvailabilityByTech(
-        getDependencies(),
-        { ...req.query, date, tech_type, duration_min, include_paused }
-      );
+      const data = aggregate
+        ? await engine.computeForcedAvailability(getDependencies(), {
+            ...req.query,
+            date,
+            tech_type,
+            duration_min,
+            include_paused,
+          })
+        : await engine.computeAdminAvailabilityByTech(
+            getDependencies(),
+            { ...req.query, date, tech_type, duration_min, include_paused }
+          );
       return res.json(data);
     } catch (error) {
       console.error(error);

--- a/server/routes/admin/bookingApprovals.js
+++ b/server/routes/admin/bookingApprovals.js
@@ -1,0 +1,13 @@
+"use strict";
+
+function registerBookingApprovalRoutes(app, options = {}) {
+  const service = options.service;
+  const requireAdminSession = options.requireAdminSession;
+  if (!service || typeof service.approve !== "function" || typeof service.reject !== "function") {
+    throw new TypeError("booking approval service is required");
+  }
+  app.post("/admin/customer-bookings/:job_id/approve", requireAdminSession, service.approve);
+  app.post("/admin/customer-bookings/:job_id/reject", requireAdminSession, service.reject);
+}
+
+module.exports = { registerBookingApprovalRoutes };

--- a/server/routes/public/customerAvailability.js
+++ b/server/routes/public/customerAvailability.js
@@ -20,6 +20,12 @@ function registerPublicCustomerAvailabilityRoutes(app, options = {}) {
     const date = String(req.query.date || new Date().toISOString().slice(0, 10));
     const tech_type = String(req.query.tech_type || "company").trim().toLowerCase();
     const forced = String(req.query.forced || "").trim() === "1";
+    if (forced) {
+      return res.status(403).json({
+        error: "FORCED_AVAILABILITY_ADMIN_ONLY",
+        code: "FORCED_AVAILABILITY_ADMIN_ONLY",
+      });
+    }
     const duration_min = Math.max(15, Number(req.query.duration_min || 60));
     const crewSizeRaw = Number(req.query.crew_size || req.query.crewSize || 1);
     const crew_size = Math.max(1, Math.min(10, Number.isFinite(crewSizeRaw) ? Math.floor(crewSizeRaw) : 1));

--- a/server/services/booking/availabilityEngine.js
+++ b/server/services/booking/availabilityEngine.js
@@ -544,16 +544,20 @@ async function reservePublicCustomerTechnician(deps, options) {
   if (typeof db.query === "function") {
     await db.query("SELECT pg_advisory_xact_lock(hashtext($1))", [lockKey]);
   }
-  const techs = await eligibleCustomerTechnicians(
+  let techs = await eligibleCustomerTechnicians(
     { ...deps, pool: db },
     { ...options, date, lock_calendar_rows: true }
   );
+  const preferredUsername = String(options.preferred_username || "").trim();
+  if (preferredUsername) {
+    techs = techs.filter((tech) => String(tech.username || "") === preferredUsername);
+  }
   const startMin = deps.toMin(start);
   const loadMap = await loadCustomerScheduledLoadMap(
     db,
     date,
     techs.map((tech) => tech.username),
-    { start_min: startMin }
+    { start_min: startMin, ignore_job_id: options.ignore_job_id || null }
   );
   const candidates = [];
   for (const tech of techs) {

--- a/server/services/booking/bookingApprovalService.js
+++ b/server/services/booking/bookingApprovalService.js
@@ -1,6 +1,7 @@
 "use strict";
 
 const { JOB_STATUS, ASSIGNMENT_STATUS, OFFER_STATUS } = require("./bookingStatuses");
+const { loadCanonicalServiceCriteria } = require("./bookingJobUnits");
 
 function createBookingApprovalService(dependencies = {}) {
   const {
@@ -42,29 +43,7 @@ function createBookingApprovalService(dependencies = {}) {
   }
 
   async function loadServiceCriteria(client, job) {
-    const units = await client.query(
-      `SELECT item_name, ac_type, wash_type, btu
-         FROM public.job_units
-        WHERE job_id=$1
-        ORDER BY unit_no`,
-      [job.job_id]
-    );
-    if (units.rows.length) {
-      return units.rows.map((unit) => ({
-        job_type: String(unit.item_name || job.job_type || ""),
-        ac_type: String(unit.ac_type || ""),
-        wash_variant: String(unit.wash_type || ""),
-        btu: Number(unit.btu || 0),
-        machine_count: 1,
-      }));
-    }
-    const items = await client.query(
-      `SELECT COALESCE(SUM(GREATEST(COALESCE(qty,0),0)),0)::int AS units
-         FROM public.job_items
-        WHERE job_id=$1`,
-      [job.job_id]
-    );
-    return [{ job_type: job.job_type, machine_count: Math.max(1, Number(items.rows[0]?.units || 1)) }];
+    return loadCanonicalServiceCriteria(client, job.job_id);
   }
 
   async function reserveScheduledTechnician(client, job) {

--- a/server/services/booking/bookingApprovalService.js
+++ b/server/services/booking/bookingApprovalService.js
@@ -1,0 +1,296 @@
+"use strict";
+
+const { JOB_STATUS, ASSIGNMENT_STATUS, OFFER_STATUS } = require("./bookingStatuses");
+
+function createBookingApprovalService(dependencies = {}) {
+  const {
+    pool,
+    availabilityEngine,
+    getAvailabilityDependencies,
+    refreshTechnicianIncomePreviewForJob,
+    notifyDirectJobAssigned,
+    notifyUrgentOffer,
+    isTechReady,
+    checkTechCollision,
+    logJobUpdate,
+  } = dependencies;
+
+  function httpError(status, code) {
+    const error = new Error(code);
+    error.status = status;
+    error.code = code;
+    return error;
+  }
+
+  function adminUsername(req) {
+    return String(req?.auth?.username || req?.actor?.username || "").trim() || null;
+  }
+
+  async function loadReservation(client, jobId) {
+    const result = await client.query(
+      `SELECT j.job_id, j.booking_code, j.job_source, j.booking_mode, j.job_status,
+              j.technician_username, j.job_type, j.appointment_datetime,
+              COALESCE(j.duration_min,60)::int AS duration_min, j.job_zone,
+              to_char(j.appointment_datetime AT TIME ZONE 'Asia/Bangkok','YYYY-MM-DD') AS booking_date,
+              to_char(j.appointment_datetime AT TIME ZONE 'Asia/Bangkok','HH24:MI') AS booking_start
+         FROM public.jobs j
+        WHERE j.job_id=$1
+        FOR UPDATE`,
+      [jobId]
+    );
+    return result.rows[0] || null;
+  }
+
+  async function loadServiceCriteria(client, job) {
+    const units = await client.query(
+      `SELECT item_name, ac_type, wash_type, btu
+         FROM public.job_units
+        WHERE job_id=$1
+        ORDER BY unit_no`,
+      [job.job_id]
+    );
+    if (units.rows.length) {
+      return units.rows.map((unit) => ({
+        job_type: String(unit.item_name || job.job_type || ""),
+        ac_type: String(unit.ac_type || ""),
+        wash_variant: String(unit.wash_type || ""),
+        btu: Number(unit.btu || 0),
+        machine_count: 1,
+      }));
+    }
+    const items = await client.query(
+      `SELECT COALESCE(SUM(GREATEST(COALESCE(qty,0),0)),0)::int AS units
+         FROM public.job_items
+        WHERE job_id=$1`,
+      [job.job_id]
+    );
+    return [{ job_type: job.job_type, machine_count: Math.max(1, Number(items.rows[0]?.units || 1)) }];
+  }
+
+  async function reserveScheduledTechnician(client, job) {
+    const services = await loadServiceCriteria(client, job);
+    const options = {
+      date: job.booking_date,
+      start: job.booking_start,
+      duration_min: job.duration_min,
+      tech_type: "all",
+      services,
+      ignore_job_id: job.job_id,
+    };
+    const deps = getAvailabilityDependencies(client);
+    const reserved = String(job.technician_username || "").trim();
+    if (reserved) {
+      try {
+        return await availabilityEngine.reservePublicCustomerTechnician(deps, {
+          ...options,
+          preferred_username: reserved,
+        });
+      } catch (error) {
+        if (![409, 400].includes(Number(error.status || 0))) throw error;
+      }
+    }
+    return availabilityEngine.reservePublicCustomerTechnician(deps, options);
+  }
+
+  async function assertPendingReservationShape(client, jobId) {
+    const state = await client.query(
+      `SELECT
+         (SELECT COUNT(*)::int FROM public.job_assignments WHERE job_id=$1) AS assignments,
+         (SELECT COUNT(*)::int FROM public.job_team_members WHERE job_id=$1) AS team_members,
+         (SELECT COUNT(*)::int FROM public.job_offers WHERE job_id=$1) AS offers`,
+      [jobId]
+    );
+    const row = state.rows[0] || {};
+    if (Number(row.assignments || 0) !== 0 || Number(row.team_members || 0) !== 0 || Number(row.offers || 0) !== 0) {
+      throw httpError(409, "PENDING_RESERVATION_STATE_DRIFT");
+    }
+  }
+
+  async function approve(req, res) {
+    const jobId = Number(req.params?.job_id || 0);
+    if (!Number.isInteger(jobId) || jobId <= 0) return res.status(400).json({ error: "INVALID_JOB_ID" });
+    const client = await pool.connect();
+    let afterCommit = null;
+    try {
+      await client.query("BEGIN");
+      const job = await loadReservation(client, jobId);
+      if (!job) throw httpError(404, "BOOKING_NOT_FOUND");
+
+      if (job.job_source !== "customer") throw httpError(409, "BOOKING_NOT_PENDING_APPROVAL");
+      if (job.job_status !== JOB_STATUS.CUSTOMER_SCHEDULED_REVIEW) {
+        if (job.booking_mode === "scheduled") {
+          const assignment = await client.query(
+            `SELECT technician_username FROM public.job_assignments
+              WHERE job_id=$1 AND status=$2 ORDER BY technician_username LIMIT 1`,
+            [jobId, ASSIGNMENT_STATUS.IN_PROGRESS]
+          );
+          if (assignment.rows[0]) {
+            await client.query("COMMIT");
+            return res.json({ success: true, replayed: true, job_id: jobId, mode: "scheduled" });
+          }
+        }
+        if (job.booking_mode === "urgent" && job.job_status === JOB_STATUS.ADMIN_URGENT_WAITING) {
+          const offer = await client.query(`SELECT 1 FROM public.job_offers WHERE job_id=$1 LIMIT 1`, [jobId]);
+          if (offer.rows[0]) {
+            await client.query("COMMIT");
+            return res.json({ success: true, replayed: true, job_id: jobId, mode: "urgent" });
+          }
+        }
+        throw httpError(409, "BOOKING_NOT_PENDING_APPROVAL");
+      }
+      await assertPendingReservationShape(client, jobId);
+
+      if (job.booking_mode === "scheduled") {
+        const selected = await reserveScheduledTechnician(client, job);
+        await client.query(
+          `UPDATE public.jobs
+              SET technician_username=$2, technician_team=$2,
+                  job_status=$3, dispatch_mode='forced',
+                  approved_by_admin=COALESCE(approved_by_admin,$4),
+                  approved_at=COALESCE(approved_at,NOW())
+            WHERE job_id=$1`,
+          [jobId, selected.username, JOB_STATUS.ADMIN_SCHEDULED_PENDING, adminUsername(req)]
+        );
+        await client.query(
+          `INSERT INTO public.job_assignments (job_id, technician_username, status)
+           VALUES ($1,$2,$3)
+           ON CONFLICT (job_id, technician_username)
+           DO UPDATE SET status=EXCLUDED.status`,
+          [jobId, selected.username, ASSIGNMENT_STATUS.IN_PROGRESS]
+        );
+        await logJobUpdate(jobId, {
+          actor_username: adminUsername(req),
+          actor_role: "admin",
+          action: "customer_booking_approved",
+          message: "Pending customer scheduled booking approved",
+          payload: { reserved_technician: job.technician_username || null, assigned_technician: selected.username },
+        }, client);
+        await client.query("COMMIT");
+        afterCommit = { mode: "scheduled", usernames: [selected.username], job };
+      } else if (job.booking_mode === "urgent") {
+        const username = String(req.body?.technician_username || "").trim();
+        if (!username) throw httpError(400, "TECHNICIAN_REQUIRED");
+        if (!(await isTechReady(username))) throw httpError(409, "TECHNICIAN_NOT_READY");
+        const conflict = await checkTechCollision(username, job.appointment_datetime, job.duration_min, jobId);
+        if (conflict) throw httpError(409, "TECHNICIAN_SLOT_CONFLICT");
+        await client.query(
+          `INSERT INTO public.job_offers (job_id, technician_username, status, expires_at)
+           VALUES ($1,$2,$3,NOW() + INTERVAL '10 minutes')`,
+          [jobId, username, OFFER_STATUS.PENDING]
+        );
+        await client.query(
+          `UPDATE public.jobs
+              SET technician_username=NULL, technician_team=NULL,
+                  job_status=$2, dispatch_mode='offer',
+                  approved_by_admin=COALESCE(approved_by_admin,$3),
+                  approved_at=COALESCE(approved_at,NOW())
+            WHERE job_id=$1`,
+          [jobId, JOB_STATUS.ADMIN_URGENT_WAITING, adminUsername(req)]
+        );
+        await logJobUpdate(jobId, {
+          actor_username: adminUsername(req),
+          actor_role: "admin",
+          action: "customer_urgent_approved",
+          message: "Pending customer urgent booking approved for offer",
+          payload: { offer_technician: username },
+        }, client);
+        await client.query("COMMIT");
+        afterCommit = { mode: "urgent", usernames: [username], job };
+      } else {
+        throw httpError(409, "BOOKING_MODE_NOT_APPROVABLE");
+      }
+
+      if (afterCommit.mode === "scheduled") {
+        let income = {};
+        try {
+          income = await refreshTechnicianIncomePreviewForJob(jobId, afterCommit.usernames, { source: "job_preview" }) || {};
+        } catch (error) {
+          console.warn("[booking_approval] scheduled income preview failed", { job_id: jobId, code: "POST_COMMIT_INCOME_FAILED" });
+        }
+        try {
+          await notifyDirectJobAssigned({
+            usernames: afterCommit.usernames,
+            job_id: jobId,
+            booking_code: job.booking_code,
+            job_type: job.job_type,
+            appointment_datetime: job.appointment_datetime,
+            job_zone: job.job_zone,
+            income_by_username: income,
+          });
+        } catch (error) {
+          console.warn("[booking_approval] scheduled notification failed", { job_id: jobId, code: "POST_COMMIT_NOTIFICATION_FAILED" });
+        }
+      } else {
+        try {
+          await notifyUrgentOffer({
+            usernames: afterCommit.usernames,
+            job_id: jobId,
+            booking_code: job.booking_code,
+            job_type: job.job_type,
+            appointment_datetime: job.appointment_datetime,
+            job_zone: job.job_zone,
+          });
+        } catch (error) {
+          console.warn("[booking_approval] urgent post_commit action failed", { job_id: jobId, code: "POST_COMMIT_ACTION_FAILED" });
+        }
+      }
+      return res.json({ success: true, replayed: false, job_id: jobId, mode: afterCommit.mode });
+    } catch (error) {
+      try { await client.query("ROLLBACK"); } catch (_) {}
+      const status = Number(error.status || 500);
+      return res.status(status >= 400 && status < 600 ? status : 500).json({
+        error: error.code || "BOOKING_APPROVAL_FAILED",
+        code: error.code || "BOOKING_APPROVAL_FAILED",
+      });
+    } finally {
+      client.release();
+    }
+  }
+
+  async function reject(req, res) {
+    const jobId = Number(req.params?.job_id || 0);
+    if (!Number.isInteger(jobId) || jobId <= 0) return res.status(400).json({ error: "INVALID_JOB_ID" });
+    const client = await pool.connect();
+    try {
+      await client.query("BEGIN");
+      const job = await loadReservation(client, jobId);
+      if (!job) throw httpError(404, "BOOKING_NOT_FOUND");
+      if (job.job_source !== "customer" || job.job_status !== JOB_STATUS.CUSTOMER_SCHEDULED_REVIEW) {
+        throw httpError(409, "BOOKING_NOT_PENDING_APPROVAL");
+      }
+      const reason = String(req.body?.reason || "admin_rejected_pending_booking").trim().slice(0, 500);
+      await client.query(
+        `UPDATE public.jobs
+            SET job_status='ยกเลิก', canceled_at=COALESCE(canceled_at,NOW()),
+                cancel_reason=$2, technician_username=NULL, technician_team=NULL
+          WHERE job_id=$1`,
+        [jobId, reason]
+      );
+      await logJobUpdate(jobId, {
+        actor_username: adminUsername(req),
+        actor_role: "admin",
+        action: "customer_booking_rejected",
+        message: reason,
+        payload: {
+          booking_mode: job.booking_mode,
+          reserved_technician: job.technician_username || null,
+        },
+      }, client);
+      await client.query("COMMIT");
+      return res.json({ success: true, job_id: jobId, status: "rejected" });
+    } catch (error) {
+      try { await client.query("ROLLBACK"); } catch (_) {}
+      const status = Number(error.status || 500);
+      return res.status(status >= 400 && status < 600 ? status : 500).json({
+        error: error.code || "BOOKING_REJECTION_FAILED",
+        code: error.code || "BOOKING_REJECTION_FAILED",
+      });
+    } finally {
+      client.release();
+    }
+  }
+
+  return { approve, reject };
+}
+
+module.exports = { createBookingApprovalService };

--- a/server/services/booking/bookingJobUnits.js
+++ b/server/services/booking/bookingJobUnits.js
@@ -1,0 +1,212 @@
+"use strict";
+
+const {
+  normalizeServiceType,
+  normalizeAcType,
+  normalizeWashVariantLabel,
+  normalizeWashKey,
+} = require("../../normalizers");
+
+const ALLOWED_JOB_TYPES = new Set(["ล้าง", "ซ่อม", "ติดตั้ง"]);
+const ALLOWED_AC_TYPES = new Set(["ผนัง", "สี่ทิศทาง", "แขวน", "เปลือยใต้ฝ้า"]);
+const INACTIVE_UNIT_STATUSES = new Set(["cancelled", "removed", "deleted", "void", "inactive"]);
+
+function httpError(status, code) {
+  const error = new Error(code);
+  error.status = status;
+  error.code = code;
+  return error;
+}
+
+function generateUnitCode(jobId, unitNo) {
+  const jid = Math.abs(Number(jobId || 0) || 0);
+  const no = Math.max(1, Math.min(99, Math.floor(Number(unitNo || 1) || 1)));
+  return `${String(jid).padStart(5, "0").slice(-5)}${String(no).padStart(2, "0")}`;
+}
+
+function unitDisplayItemName(value) {
+  let text = String(value || "").trim();
+  if (!text) return "เครื่องปรับอากาศ";
+  text = text.replace(/\s*(?:x|×)\s*\d+\s*$/i, "");
+  text = text.replace(/\s*\d+\s*เครื่อง\s*$/i, "");
+  text = text.replace(/\s{2,}/g, " ").trim();
+  return text || "เครื่องปรับอากาศ";
+}
+
+function strictJobType(value) {
+  const text = String(value || "").trim();
+  const lower = text.toLowerCase();
+  const categories = new Set();
+  if (/ล้าง/.test(text) || /\b(?:wash|clean|cleaning)\b/.test(lower)) categories.add("ล้าง");
+  if (/ซ่อม|ตรวจอาการ|ตรวจเช็ค/.test(text) || /\b(?:repair|inspect|inspection)\b/.test(lower)) categories.add("ซ่อม");
+  if (/ติดตั้ง/.test(text) || /\b(?:install|installation)\b/.test(lower)) categories.add("ติดตั้ง");
+  if (categories.size !== 1) return "";
+  const normalized = normalizeServiceType(text);
+  return ALLOWED_JOB_TYPES.has(normalized) && categories.has(normalized) ? normalized : "";
+}
+
+function parseCanonicalServiceItem(row = {}) {
+  const itemName = String(row.item_name || "").trim();
+  const parts = itemName.split("•").map((part) => part.trim()).filter(Boolean);
+  const jobType = strictJobType(parts[0] || "");
+  const acType = normalizeAcType(parts[0] || "");
+  const machineCount = Number(row.qty);
+  if (!jobType || !ALLOWED_AC_TYPES.has(acType) || !Number.isInteger(machineCount) || machineCount < 1 || machineCount > 99) {
+    throw httpError(409, "PENDING_SERVICE_CRITERIA_DRIFT");
+  }
+
+  const btuParts = parts.filter((part) => /^\d[\d,]*\s*BTU$/i.test(part));
+  if (btuParts.length !== 1) throw httpError(409, "PENDING_SERVICE_CRITERIA_DRIFT");
+  const btu = Number(btuParts[0].replace(/[^\d]/g, ""));
+  if (!Number.isFinite(btu) || btu <= 0) throw httpError(409, "PENDING_SERVICE_CRITERIA_DRIFT");
+
+  const countParts = parts.filter((part) => /^\d+\s*เครื่อง$/.test(part));
+  if (countParts.length !== 1 || Number(countParts[0].replace(/[^\d]/g, "")) !== machineCount) {
+    throw httpError(409, "PENDING_SERVICE_CRITERIA_DRIFT");
+  }
+
+  const detailParts = parts.slice(1).filter((part) => !/^\d[\d,]*\s*BTU$/i.test(part) && !/^\d+\s*เครื่อง$/.test(part));
+  let washVariant = "";
+  let repairVariant = "";
+  if (jobType === "ล้าง" && acType === "ผนัง") {
+    if (detailParts.length !== 1 || !normalizeWashKey(detailParts[0])) {
+      throw httpError(409, "PENDING_SERVICE_CRITERIA_DRIFT");
+    }
+    washVariant = normalizeWashVariantLabel(detailParts[0]);
+  } else if (jobType === "ซ่อม") {
+    if (detailParts.length !== 1) throw httpError(409, "PENDING_SERVICE_CRITERIA_DRIFT");
+    repairVariant = detailParts[0];
+  } else if (detailParts.length !== 0) {
+    throw httpError(409, "PENDING_SERVICE_CRITERIA_DRIFT");
+  }
+
+  return {
+    job_type: jobType,
+    ac_type: acType,
+    wash_variant: washVariant,
+    repair_variant: repairVariant,
+    btu,
+    machine_count: machineCount,
+  };
+}
+
+async function loadJobItems(db, jobId) {
+  const result = await db.query(
+    `SELECT job_item_id, item_name, qty, assigned_technician_username, COALESCE(is_service,FALSE) AS is_service
+       FROM public.job_items
+      WHERE job_id=$1
+      ORDER BY job_item_id ASC`,
+    [jobId]
+  );
+  return result.rows || [];
+}
+
+function expandItemTargets(items, fallbackTechnician) {
+  const targets = [];
+  for (const item of items) {
+    const rawQty = Number(item.qty);
+    if (!Number.isFinite(rawQty) || rawQty <= 0) continue;
+    if (item.is_service && !Number.isInteger(rawQty)) throw httpError(409, "PENDING_SERVICE_CRITERIA_DRIFT");
+    const quantity = Math.min(99, Math.floor(rawQty));
+    if (quantity < 1) continue;
+    const criteria = item.is_service ? parseCanonicalServiceItem(item) : null;
+    for (let index = 0; index < quantity; index += 1) {
+      targets.push({
+        item_name: unitDisplayItemName(item.item_name),
+        assigned_technician: String(item.assigned_technician_username || fallbackTechnician || "").trim() || null,
+        criteria,
+      });
+    }
+  }
+  return targets;
+}
+
+async function ensureBookingJobUnits(jobId, db) {
+  const realId = Number(jobId);
+  if (!Number.isInteger(realId) || realId <= 0 || !db || typeof db.query !== "function") {
+    throw httpError(500, "BOOKING_JOB_UNITS_UNAVAILABLE");
+  }
+  const jobResult = await db.query(`SELECT technician_username, job_source, job_type FROM public.jobs WHERE job_id=$1 LIMIT 1`, [realId]);
+  const job = jobResult.rows[0];
+  if (!job) throw httpError(404, "BOOKING_NOT_FOUND");
+  const items = await loadJobItems(db, realId);
+  const targets = expandItemTargets(items, job.technician_username);
+  if (!targets.length && job.job_source !== "customer") {
+    targets.push({ item_name: unitDisplayItemName(job.job_type), assigned_technician: job.technician_username || null, criteria: null });
+  }
+  if (!targets.length) throw httpError(409, "PENDING_SERVICE_CRITERIA_DRIFT");
+
+  for (let index = 0; index < targets.length; index += 1) {
+    const unitNo = index + 1;
+    const target = targets[index];
+    const criteria = target.criteria;
+    const variant = criteria ? (criteria.wash_variant || criteria.repair_variant || null) : null;
+    await db.query(
+      `INSERT INTO public.job_units
+         (job_id, unit_code, unit_no, item_name, ac_type, wash_type, btu, assigned_technician, status)
+       VALUES ($1,$2,$3,$4,$5,$6,$7,$8,'pending')
+       ON CONFLICT (job_id, unit_no) DO UPDATE
+         SET unit_code=EXCLUDED.unit_code,
+             item_name=EXCLUDED.item_name,
+             ac_type=EXCLUDED.ac_type,
+             wash_type=EXCLUDED.wash_type,
+             btu=EXCLUDED.btu,
+             assigned_technician=EXCLUDED.assigned_technician,
+             status=CASE
+               WHEN LOWER(COALESCE(NULLIF(public.job_units.status,''),'pending')) IN ('cancelled','removed','deleted','void','inactive') THEN 'pending'
+               ELSE COALESCE(NULLIF(public.job_units.status,''),'pending')
+             END,
+             updated_at=NOW()`,
+      [
+        realId,
+        generateUnitCode(realId, unitNo),
+        unitNo,
+        target.item_name,
+        criteria?.ac_type || null,
+        variant,
+        criteria ? String(criteria.btu) : null,
+        target.assigned_technician,
+      ]
+    );
+  }
+  return (await db.query(`SELECT * FROM public.job_units WHERE job_id=$1 ORDER BY unit_no ASC, unit_id ASC`, [realId])).rows || [];
+}
+
+async function loadCanonicalServiceCriteria(db, jobId) {
+  const items = await loadJobItems(db, jobId);
+  const serviceItems = items.filter((item) => item.is_service);
+  if (!serviceItems.length) throw httpError(409, "PENDING_SERVICE_CRITERIA_DRIFT");
+  const criteria = serviceItems.map(parseCanonicalServiceItem);
+
+  const unitsResult = await db.query(
+    `SELECT unit_no, ac_type, wash_type, btu, status
+       FROM public.job_units
+      WHERE job_id=$1
+      ORDER BY unit_no ASC, unit_id ASC`,
+    [jobId]
+  );
+  const activeUnits = (unitsResult.rows || []).filter((unit) => !INACTIVE_UNIT_STATUSES.has(String(unit.status || "pending").trim().toLowerCase()));
+  const allTargets = expandItemTargets(items, null);
+  if (activeUnits.length !== allTargets.length) throw httpError(409, "PENDING_SERVICE_CRITERIA_DRIFT");
+  for (let index = 0; index < allTargets.length; index += 1) {
+    const expected = allTargets[index].criteria;
+    if (!expected) continue;
+    const unit = activeUnits[index];
+    const expectedVariant = expected.wash_variant || expected.repair_variant || "";
+    if (
+      Number(unit.unit_no) !== index + 1
+      || String(unit.ac_type || "") !== expected.ac_type
+      || String(unit.wash_type || "") !== expectedVariant
+      || Number(unit.btu || 0) !== expected.btu
+    ) {
+      throw httpError(409, "PENDING_SERVICE_CRITERIA_DRIFT");
+    }
+  }
+  return criteria;
+}
+
+module.exports = {
+  ensureBookingJobUnits,
+  loadCanonicalServiceCriteria,
+  parseCanonicalServiceItem,
+};

--- a/server/services/booking/bookingStatuses.js
+++ b/server/services/booking/bookingStatuses.js
@@ -17,8 +17,21 @@ const OFFER_STATUS = Object.freeze({
   PENDING: "pending",
 });
 
+function isPendingCustomerScheduledReservation(job = {}) {
+  return String(job.job_source || "") === "customer"
+    && String(job.booking_mode || "") === "scheduled"
+    && String(job.job_status || "") === JOB_STATUS.CUSTOMER_SCHEDULED_REVIEW;
+}
+
+function pendingCustomerScheduledReservationSql(alias = "j") {
+  const safeAlias = /^[A-Za-z_][A-Za-z0-9_]*$/.test(String(alias || "")) ? String(alias) : "j";
+  return `(${safeAlias}.job_source='customer' AND ${safeAlias}.booking_mode='scheduled' AND ${safeAlias}.job_status='${JOB_STATUS.CUSTOMER_SCHEDULED_REVIEW}')`;
+}
+
 module.exports = {
   JOB_STATUS,
   ASSIGNMENT_STATUS,
   OFFER_STATUS,
+  isPendingCustomerScheduledReservation,
+  pendingCustomerScheduledReservationSql,
 };

--- a/server/services/booking/createBookingJob.js
+++ b/server/services/booking/createBookingJob.js
@@ -944,6 +944,7 @@ function createBookingJobService(dependencies = {}) {
     }
 
     req.cwfBookSource = "customer";
+    req.cwfPublicUrgentPrepared = true;
     req.body = {
       ...incoming,
       appointment_datetime: urgentPublicAdapter.computeCustomerUrgentAppointmentIso(),
@@ -956,7 +957,7 @@ function createBookingJobService(dependencies = {}) {
       allow_time_proposal: true,
     };
 
-    return handleAdminBookV2(req, res);
+    return handlePublicBook(req, res);
   }
 
   // ✅ Fail-safe capability check: jobs.catalog_item_id / jobs.customer_sub are
@@ -1003,6 +1004,7 @@ function createBookingJobService(dependencies = {}) {
       repair_variant,
       services,
       scheduled_request_key,
+      urgent_request_key,
       catalog_item_id, // optional: links this booking to the Store catalog item it was booked for
     } = req.body || {};
 
@@ -1038,7 +1040,7 @@ function createBookingJobService(dependencies = {}) {
     // customer-safe adapter on the CANONICAL booking_mode ALONE — never client_app,
     // which the caller can drop/forge to skip the sanitiser and reach the raw
     // urgent engine with attacker-chosen technician/assign fields.
-    if (canonicalBookingMode === "urgent") {
+    if (canonicalBookingMode === "urgent" && req.cwfPublicUrgentPrepared !== true) {
       return handlePublicCustomerUrgentBook(req, res);
     }
 
@@ -1083,17 +1085,31 @@ function createBookingJobService(dependencies = {}) {
     const scheduledRequestKey = bm === "scheduled"
       ? String(scheduled_request_key || "").trim()
       : "";
+    const urgentRequestKey = bm === "urgent"
+      ? String(urgent_request_key || "").trim()
+      : "";
     const validScheduledRequestKey = /^[A-Za-z0-9_-]{16,128}$/.test(scheduledRequestKey);
+    const validUrgentRequestKey = /^[A-Za-z0-9_-]{16,128}$/.test(urgentRequestKey);
     if (bm === "scheduled" && !validScheduledRequestKey) {
+      return res.status(400).json({ error: "MISSING_REQUEST_KEY", code: "MISSING_REQUEST_KEY" });
+    }
+    if (bm === "urgent" && !validUrgentRequestKey) {
       return res.status(400).json({ error: "MISSING_REQUEST_KEY", code: "MISSING_REQUEST_KEY" });
     }
     const scheduledDeterministicToken = scheduledRequestKey
       ? deriveCustomerScheduledBookingToken(scheduledRequestKey)
       : null;
-    if (scheduledDeterministicToken) token = scheduledDeterministicToken;
+    const urgentDeterministicToken = urgentRequestKey
+      ? urgentPublicAdapter.deriveUrgentBookingToken(urgentRequestKey)
+      : null;
+    const bookingRequestKey = scheduledRequestKey || urgentRequestKey;
+    const deterministicToken = scheduledDeterministicToken || urgentDeterministicToken;
+    if (deterministicToken) token = deterministicToken;
     const allowAdminScheduleFallback = allow_admin_schedule_fallback === true || String(allow_admin_schedule_fallback || "").trim() === "true";
     const canUseAdminScheduleFallback = bm === "scheduled" && allowAdminScheduleFallback;
-    const urgentOfferEnabled = bm === "urgent" && ENABLE_URGENT_FLOW;
+    // Customer urgent jobs wait for admin approval. The existing offer flow is
+    // entered only by the authenticated approval route after commit.
+    const urgentOfferEnabled = false;
     const allowTimeProposal = allow_time_proposal === true
       ? true
       : allow_time_proposal === false || allow_time_proposal == null
@@ -1112,6 +1128,15 @@ function createBookingJobService(dependencies = {}) {
       admin_override_duration_min: 0, // ลูกค้าห้าม override
     };
     if (Array.isArray(services) && services.length) payloadV2.services = services;
+    if (bm === "urgent") {
+      const urgentServices = Array.isArray(payloadV2.services) && payloadV2.services.length
+        ? payloadV2.services
+        : [payloadV2];
+      const cleaningOnly = urgentServices.every((service) => /(?:ล้าง|wash|clean)/i.test(String(service?.job_type || "")));
+      if (!cleaningOnly) {
+        return res.status(400).json({ error: "URGENT_CLEANING_ONLY", code: "URGENT_CLEANING_ONLY" });
+      }
+    }
     // CWF Spec: conservative duration for schedule/collision
     const duration_min_v2 = computeDurationMinMulti(payloadV2, { source: "public_book", conservative: true });
     if (duration_min_v2 <= 0) return res.status(400).json({ error: "งานประเภทนี้ต้องให้แอดมินกำหนดเวลา (duration)" });
@@ -1163,12 +1188,12 @@ function createBookingJobService(dependencies = {}) {
     // now occupies the slot — so the replay lookup cannot sit behind the "slot
     // full" check. Reusing the key with a materially different payload is rejected
     // with 409 (no mutation, no old-job data leaked).
-    if (bm === "scheduled" && scheduledRequestKey && scheduledDeterministicToken) {
+    if (bookingRequestKey && deterministicToken) {
       const idem = await pool.connect();
       let prior = null;
       try {
         await idem.query("BEGIN");
-        await idem.query("SELECT pg_advisory_xact_lock(hashtext($1))", [scheduledRequestKey]);
+        await idem.query("SELECT pg_advisory_xact_lock(hashtext($1))", [bookingRequestKey]);
         const r = await idem.query(
           `SELECT job_id, booking_code, booking_token, dispatch_mode, duration_min, job_price,
                   appointment_datetime, customer_phone, customer_name, address_text, maps_url,
@@ -1176,10 +1201,10 @@ function createBookingJobService(dependencies = {}) {
              FROM public.jobs
             WHERE booking_token=$1
               AND job_source='customer'
-              AND COALESCE(booking_mode,'scheduled')='scheduled'
+              AND booking_mode=$2
               AND canceled_at IS NULL
             LIMIT 1`,
-          [scheduledDeterministicToken]
+          [deterministicToken, bm]
         );
         await idem.query("COMMIT");
         prior = r.rows[0] || null;
@@ -1208,7 +1233,7 @@ function createBookingJobService(dependencies = {}) {
           job_id: prior.job_id,
           booking_code: prior.booking_code,
           token: prior.booking_token,
-          booking_mode: "scheduled",
+          booking_mode: bm,
           dispatch_mode: prior.dispatch_mode || "normal",
           duration_min: Number(prior.duration_min || duration_min_v2 || 0),
           effective_block_min: effectiveBlockMin(Number(prior.duration_min || duration_min_v2 || 0)),
@@ -1255,8 +1280,8 @@ function createBookingJobService(dependencies = {}) {
     try {
       await client.query("BEGIN");
 
-      if (scheduledRequestKey && scheduledDeterministicToken) {
-        await client.query("SELECT pg_advisory_xact_lock(hashtext($1))", [scheduledRequestKey]);
+      if (bookingRequestKey && deterministicToken) {
+        await client.query("SELECT pg_advisory_xact_lock(hashtext($1))", [bookingRequestKey]);
         const existing = await client.query(
           `SELECT job_id, booking_code, booking_token, booking_mode, dispatch_mode,
                   duration_min, job_price, appointment_datetime, customer_phone, customer_name,
@@ -1264,10 +1289,10 @@ function createBookingJobService(dependencies = {}) {
              FROM public.jobs
             WHERE booking_token=$1
               AND job_source='customer'
-              AND COALESCE(booking_mode,'scheduled')='scheduled'
+              AND booking_mode=$2
               AND canceled_at IS NULL
             LIMIT 1`,
-          [scheduledDeterministicToken]
+          [deterministicToken, bm]
         );
         if (existing.rows[0]) {
           // Race safety net: a concurrent request with the same key committed first.
@@ -1292,7 +1317,7 @@ function createBookingJobService(dependencies = {}) {
             job_id: row.job_id,
             booking_code: row.booking_code,
             token: row.booking_token,
-            booking_mode: "scheduled",
+            booking_mode: bm,
             dispatch_mode: row.dispatch_mode || "normal",
             duration_min: Number(row.duration_min || duration_min_v2 || 0),
             effective_block_min: effectiveBlockMin(Number(row.duration_min || duration_min_v2 || 0)),
@@ -1411,9 +1436,7 @@ function createBookingJobService(dependencies = {}) {
         (customer_note || "").toString(),
         (maps_url || "").toString(),
         (job_zone || "").toString(),
-        bm === 'urgent'
-          ? (urgentOfferEnabled ? JOB_STATUS.ADMIN_URGENT_WAITING : JOB_STATUS.URGENT_NO_TECHNICIAN)
-          : JOB_STATUS.CUSTOMER_SCHEDULED_REVIEW,
+        JOB_STATUS.CUSTOMER_SCHEDULED_REVIEW,
         duration_min_v2,
         (bm === 'urgent' ? 'urgent' : 'scheduled'),
         dispatchMode,

--- a/server/services/booking/createBookingJob.js
+++ b/server/services/booking/createBookingJob.js
@@ -2,8 +2,10 @@
 
 const crypto = require("crypto");
 const { JOB_STATUS, ASSIGNMENT_STATUS, OFFER_STATUS } = require("./bookingStatuses");
+const { ensureBookingJobUnits } = require("./bookingJobUnits");
 
 function createBookingJobService(dependencies = {}) {
+  const ensureCanonicalBookingJobUnits = dependencies.ensureBookingJobUnits || ensureBookingJobUnits;
   const {
     pool,
     urgentPublicAdapter,
@@ -25,7 +27,6 @@ function createBookingJobService(dependencies = {}) {
     technicianMatchesServiceZone,
     http409Conflict,
     generateUniqueBookingCode,
-    ensureJobUnits,
     effectiveBlockMin,
     isTechFree,
     getJwtSecret,
@@ -715,7 +716,7 @@ function createBookingJobService(dependencies = {}) {
         console.log("[admin_book_v2] urgent_offers", { job_id, booking_code, count: available.length });
       }
 
-      await ensureJobUnits(job_id, client);
+      await ensureCanonicalBookingJobUnits(job_id, client);
       await client.query(`UPDATE public.jobs SET per_unit_evidence_enabled=TRUE WHERE job_id=$1`, [job_id]);
 
       await client.query("COMMIT");
@@ -899,14 +900,16 @@ function createBookingJobService(dependencies = {}) {
 
   // Scalar material fields persisted on the jobs row (everything but the service
   // lines, which are compared via the signature above).
-  function scheduledScalarsMatch(jobRow, incoming) {
+  function scheduledScalarsMatch(jobRow, incoming, options = {}) {
     const apptTime = (v) => {
       const t = new Date(v).getTime();
       return Number.isFinite(t) ? t : NaN;
     };
-    const a = apptTime(jobRow.appointment_datetime);
-    const b = apptTime(normalizeAppointmentDatetime(incoming.appointment_datetime));
-    if (!(Number.isFinite(a) && Number.isFinite(b) && a === b)) return false;
+    if (options.serverAppointmentAuthoritative !== true) {
+      const a = apptTime(jobRow.appointment_datetime);
+      const b = apptTime(normalizeAppointmentDatetime(incoming.appointment_datetime));
+      if (!(Number.isFinite(a) && Number.isFinite(b) && a === b)) return false;
+    }
     if (normalizedBookingScalar(jobRow.customer_phone).replace(/\D/g, "") !== normalizedBookingScalar(incoming.customer_phone).replace(/\D/g, "")) return false;
     if (normalizedBookingScalar(jobRow.customer_name) !== normalizedBookingScalar(incoming.customer_name)) return false;
     if (normalizedBookingScalar(jobRow.address_text) !== normalizedBookingScalar(incoming.address_text)) return false;
@@ -921,8 +924,8 @@ function createBookingJobService(dependencies = {}) {
 
   // Full canonical match = scalar fields + service-line signature. Used identically
   // by the pre-flight replay and the in-transaction race path.
-  async function scheduledPayloadMatchesExisting(db, jobRow, incoming) {
-    if (!scheduledScalarsMatch(jobRow, incoming)) return false;
+  async function scheduledPayloadMatchesExisting(db, jobRow, incoming, options = {}) {
+    if (!scheduledScalarsMatch(jobRow, incoming, options)) return false;
     const storedSig = await loadStoredBookingLineSignature(db, jobRow.job_id);
     const incomingSig = await buildIncomingBookingLineSignature(db, incoming.payloadV2, incoming.itemIdQty, incoming.standardPrice);
     return storedSig === incomingSig;
@@ -941,6 +944,9 @@ function createBookingJobService(dependencies = {}) {
     const requestKey = incoming.urgent_request_key;
     if (!requestKey || requestKey.length < 16) {
       return res.status(400).json({ error: "MISSING_REQUEST_KEY", code: "MISSING_REQUEST_KEY" });
+    }
+    if (!urgentPublicAdapter.isStrictUrgentCleaningPayload(incoming)) {
+      return res.status(400).json({ error: "URGENT_CLEANING_ONLY", code: "URGENT_CLEANING_ONLY" });
     }
 
     req.cwfBookSource = "customer";
@@ -1129,11 +1135,7 @@ function createBookingJobService(dependencies = {}) {
     };
     if (Array.isArray(services) && services.length) payloadV2.services = services;
     if (bm === "urgent") {
-      const urgentServices = Array.isArray(payloadV2.services) && payloadV2.services.length
-        ? payloadV2.services
-        : [payloadV2];
-      const cleaningOnly = urgentServices.every((service) => /(?:ล้าง|wash|clean)/i.test(String(service?.job_type || "")));
-      if (!cleaningOnly) {
+      if (!urgentPublicAdapter.isStrictUrgentCleaningPayload(payloadV2)) {
         return res.status(400).json({ error: "URGENT_CLEANING_ONLY", code: "URGENT_CLEANING_ONLY" });
       }
     }
@@ -1220,7 +1222,7 @@ function createBookingJobService(dependencies = {}) {
           job_zone, job_type, customer_note, allow_time_proposal: allowTimeProposal,
           duration_min: duration_min_v2, payloadV2, itemIdQty, standardPrice: standard_price,
         };
-        if (!(await scheduledPayloadMatchesExisting(pool, prior, incomingBooking))) {
+        if (!(await scheduledPayloadMatchesExisting(pool, prior, incomingBooking, { serverAppointmentAuthoritative: bm === "urgent" }))) {
           // Same key, materially different booking. No mutation, no identifiers/PII.
           return res.status(409).json({
             error: "คำขอนี้ถูกใช้ไปแล้วกับการจองอื่น กรุณาเริ่มการจองใหม่",
@@ -1305,7 +1307,7 @@ function createBookingJobService(dependencies = {}) {
             job_zone, job_type, customer_note, allow_time_proposal: allowTimeProposal,
             duration_min: duration_min_v2, payloadV2, itemIdQty, standardPrice: standard_price,
           };
-          if (!(await scheduledPayloadMatchesExisting(pool, row, incomingBooking))) {
+          if (!(await scheduledPayloadMatchesExisting(pool, row, incomingBooking, { serverAppointmentAuthoritative: bm === "urgent" }))) {
             return res.status(409).json({
               error: "คำขอนี้ถูกใช้ไปแล้วกับการจองอื่น กรุณาเริ่มการจองใหม่",
               code: "IDEMPOTENCY_KEY_REUSED",
@@ -1554,7 +1556,7 @@ function createBookingJobService(dependencies = {}) {
         );
       }
 
-      await ensureJobUnits(job_id, client);
+      await ensureCanonicalBookingJobUnits(job_id, client);
       await client.query(`UPDATE public.jobs SET per_unit_evidence_enabled=TRUE WHERE job_id=$1`, [job_id]);
 
       await client.query("COMMIT");

--- a/server/services/public/customerScheduledAssignment.js
+++ b/server/services/public/customerScheduledAssignment.js
@@ -43,7 +43,8 @@ async function loadCustomerScheduledLoadMap(db, date, usernames = [], options = 
   const names = (Array.isArray(usernames) ? usernames : []).map((u) => String(u || "").trim()).filter(Boolean);
   if (!names.length || !db || typeof db.query !== "function") return new Map();
   const startMin = Number(options.start_min);
-  const params = [names, date, CANCELLED_STATUSES];
+  const ignoreJobId = Number(options.ignore_job_id || 0);
+  const params = [names, date, CANCELLED_STATUSES, ignoreJobId > 0 ? ignoreJobId : null];
   const result = await db.query(
     `WITH assigned AS (
        SELECT DISTINCT COALESCE(ja.technician_username, j.technician_username) AS technician_username,
@@ -59,6 +60,7 @@ async function loadCustomerScheduledLoadMap(db, date, usernames = [], options = 
           AND j.appointment_datetime IS NOT NULL
           AND (j.appointment_datetime AT TIME ZONE 'Asia/Bangkok')::date=$2::date
           AND COALESCE(j.job_status,'') <> ALL($3::text[])
+          AND ($4::bigint IS NULL OR j.job_id <> $4::bigint)
      ),
      item_units AS (
        SELECT a.technician_username, a.job_id, COALESCE(SUM(NULLIF(ji.qty,0)),0)::int AS units

--- a/server/services/urgentPublicAdapter.js
+++ b/server/services/urgentPublicAdapter.js
@@ -2,10 +2,30 @@
 
 const crypto = require("crypto");
 const jobTiming = require("./jobTiming");
+const { normalizeServiceType } = require("../normalizers");
 
 const URGENT_LEAD_TIME_MIN = 30;
 const UI_START_MIN = 9 * 60; // 09:00, matches the Admin Add locked business window
 const UI_END_MIN = 18 * 60; // 18:00
+const STRICT_CLEANING_JOB_TYPES = new Set([
+  "ล้าง",
+  "ล้างแอร์",
+  "งานล้าง",
+  "งานล้างแอร์",
+  "บริการล้างแอร์",
+  "wash",
+  "clean",
+  "cleaning",
+  "ac wash",
+  "ac clean",
+  "ac cleaning",
+  "aircon wash",
+  "aircon clean",
+  "aircon cleaning",
+  "air conditioner wash",
+  "air conditioner clean",
+  "air conditioner cleaning",
+]);
 
 function coerceNumber(value, fallback = 0) {
   const n = Number(value);
@@ -22,6 +42,19 @@ function sanitizeCustomerServiceLine(raw) {
     wash_variant: String(item.wash_variant || "").trim(),
     repair_variant: String(item.repair_variant || "").trim(),
   };
+}
+
+function canonicalUrgentCleaningJobType(value) {
+  const raw = String(value || "").trim();
+  const normalizedText = raw.toLowerCase().replace(/[_-]+/g, " ").replace(/\s+/g, " ").trim();
+  if (!STRICT_CLEANING_JOB_TYPES.has(normalizedText)) return null;
+  return normalizeServiceType(raw) === "ล้าง" ? "ล้าง" : null;
+}
+
+function isStrictUrgentCleaningPayload(payload = {}) {
+  if (canonicalUrgentCleaningJobType(payload.job_type) !== "ล้าง") return false;
+  const services = Array.isArray(payload.services) ? payload.services : [];
+  return services.every((service) => canonicalUrgentCleaningJobType(service?.job_type) === "ล้าง");
 }
 
 // Strict allowlist: only customer-safe fields are allowed to cross into the
@@ -113,6 +146,8 @@ module.exports = {
   UI_END_MIN,
   sanitizeCustomerServiceLine,
   sanitizeCustomerUrgentBody,
+  canonicalUrgentCleaningJobType,
+  isStrictUrgentCleaningPayload,
   computeCustomerUrgentAppointmentIso,
   deriveUrgentBookingToken,
 };

--- a/test/customerBookingAdminNotifications.test.js
+++ b/test/customerBookingAdminNotifications.test.js
@@ -236,7 +236,7 @@ test("scheduled customer booking has durable request-key idempotency before rese
   assert.match(bookingService, /function deriveCustomerScheduledBookingToken\(requestKey\)/);
   assert.match(bookingService, /scheduled_request_key/);
   assert.match(bookingService, /pg_advisory_xact_lock\(hashtext\(\$1\)\)/);
-  assert.match(bookingService, /WHERE booking_token=\$1[\s\S]*job_source='customer'[\s\S]*COALESCE\(booking_mode,'scheduled'\)='scheduled'/);
+  assert.match(bookingService, /WHERE booking_token=\$1[\s\S]*job_source='customer'[\s\S]*booking_mode=\$2/);
   assert.match(bookingService, /replayed:\s*true/);
   assert.match(bookingService, /validScheduledRequestKey/);
   assert.match(bookingService, /\^\[A-Za-z0-9_-\]\{16,128\}\$/);
@@ -308,7 +308,7 @@ test("admin review new-job notification uses first-load baseline and one sound p
 });
 
 test("admin/customer frontend cache versions are bumped for booking notification changes", () => {
-  assert.match(adminReviewHtml, /admin-review-v2\.js\?v=20260712_job_location_roundtrip_v1/);
+  assert.match(adminReviewHtml, /admin-review-v2\.js\?v=20260719_customer_booking_pr3_v1/);
   assert.doesNotMatch(adminReviewHtml, /admin-review-v2\.js\?v=20260707_customer_booking_notify_v2/);
   assert.match(adminReviewHtml, /admin-review-ai-intake\.js\?v=ai-booking-intake-customer-cards-v11-admin-alert-gate/);
   assert.doesNotMatch(adminReviewHtml, /admin-review-ai-intake\.js\?v=ai-booking-intake-customer-cards-v10/);

--- a/test/customerBookingAvailabilityCharacterization.test.js
+++ b/test/customerBookingAvailabilityCharacterization.test.js
@@ -297,8 +297,8 @@ test("public routes preserve scheduled, calendar, forced, legacy, cache, and err
 
   res = makeResponse();
   await app.routes.get("/public/availability_v2")[0]({ query: { date: "2026-06-02", forced: "1" } }, res);
-  assert.equal(calls.at(-1)[0], "forced");
-  assert.deepEqual(res.body, { date: "2026-06-02", forced: true, slots: [] });
+  assert.equal(res.statusCode, 403);
+  assert.deepEqual(res.body, { error: "FORCED_AVAILABILITY_ADMIN_ONLY", code: "FORCED_AVAILABILITY_ADMIN_ONLY" });
 
   res = makeResponse();
   await app.routes.get("/public/availability_calendar_v2")[0]({ query: { month: "bad" } }, res);
@@ -320,7 +320,8 @@ test("admin route preserves current middleware boundary and caller evidence", ()
     isEnabled: () => true,
     requireAdminSession,
   });
-  assert.equal(app.routes.get("/admin/availability_by_tech_v2").length, 1);
+  assert.equal(app.routes.get("/admin/availability_by_tech_v2").length, 2);
+  assert.equal(app.routes.get("/admin/availability_by_tech_v2")[0], requireAdminSession);
   assert.equal(app.routes.get("/admin/customer-eligibility-diagnostic").length, 2);
   assert.equal(app.routes.get("/admin/customer-eligibility-diagnostic")[0], requireAdminSession);
 
@@ -328,7 +329,8 @@ test("admin route preserves current middleware boundary and caller evidence", ()
   const adminAdd = read("admin-add-v2.js");
   const adminReview = read("admin-review-v2.js");
   assert.match(adminQueue, /\/admin\/availability_by_tech_v2[\s\S]*forced=1/);
-  assert.match(adminQueue, /\/public\/availability_v2[\s\S]*forced=1/);
-  assert.match(adminAdd, /\/public\/availability_v2/);
+  assert.doesNotMatch(adminQueue, /\/public\/availability_v2[^\n]*forced=1/);
+  assert.doesNotMatch(adminAdd, /apiFetch\(`\/public\/availability_v2/);
+  assert.match(adminAdd, /\/admin\/availability_by_tech_v2/);
   assert.match(adminReview, /\/public\/availability_v2/);
 });

--- a/test/customerBookingKillSwitch.test.js
+++ b/test/customerBookingKillSwitch.test.js
@@ -89,7 +89,8 @@ test("scheduled idempotency is payload-bound and checked before the availability
 
 test("idempotency payload comparison covers every canonical material field", () => {
   // Scalars persisted on the jobs row.
-  assert.match(bookingServiceSrc, /function scheduledScalarsMatch\(jobRow, incoming\)/);
+  assert.match(bookingServiceSrc, /function scheduledScalarsMatch\(jobRow, incoming, options = \{\}\)/);
+  assert.match(bookingServiceSrc, /options\.serverAppointmentAuthoritative !== true/);
   for (const field of ["customer_phone", "customer_name", "address_text", "maps_url", "job_zone", "job_type", "customer_note", "allow_time_proposal", "duration_min"]) {
     assert.match(bookingServiceSrc, new RegExp(field), `scalar comparison must include ${field}`);
   }
@@ -100,7 +101,7 @@ test("idempotency payload comparison covers every canonical material field", () 
   assert.match(bookingServiceSrc, /buildIncomingBookingLineSignature/);
   assert.match(bookingServiceSrc, /customerPricingHelpers\.buildCustomerServiceLineItemsFromPayload/);
   // The full match = scalars + line signature.
-  assert.match(bookingServiceSrc, /async function scheduledPayloadMatchesExisting\(db, jobRow, incoming\)/);
+  assert.match(bookingServiceSrc, /async function scheduledPayloadMatchesExisting\(db, jobRow, incoming, options = \{\}\)/);
   assert.match(bookingServiceSrc, /storedSig === incomingSig/);
   // The pre-flight replay lookup still precedes the availability gate.
   const preflightIdx = bookHandler.indexOf("Payload-bound idempotency (checked BEFORE the availability gate)");

--- a/test/customerBookingKillSwitch.test.js
+++ b/test/customerBookingKillSwitch.test.js
@@ -54,7 +54,7 @@ test("urgent routing keys off the canonical booking_mode, not client_app", () =>
   // Every public urgent request must reach the customer-safe adapter on mode
   // alone — an unauthenticated caller must not be able to drop/forge client_app
   // to skip the sanitiser and hit the raw urgent engine.
-  assert.match(bookHandler, /if \(canonicalBookingMode === "urgent"\) \{\s*\n\s*return handlePublicCustomerUrgentBook\(req, res\);/);
+  assert.match(bookHandler, /if \(canonicalBookingMode === "urgent" && req\.cwfPublicUrgentPrepared !== true\) \{\s*\n\s*return handlePublicCustomerUrgentBook\(req, res\);/);
   assert.doesNotMatch(bookHandler, /if \(isCustomerAppUrgentBook\(req\.body/);
 });
 
@@ -64,7 +64,7 @@ test("scheduled request-key/idempotency is required for ALL scheduled bookings, 
   assert.match(bookHandler, /if \(bm === "scheduled" && !validScheduledRequestKey\) \{/);
   assert.doesNotMatch(bookHandler, /clientApp === "customer_app_v2" && !validScheduledRequestKey/);
   // The idempotency replay itself keys only off the request key, not client_app.
-  assert.match(bookHandler, /if \(scheduledRequestKey && scheduledDeterministicToken\) \{/);
+  assert.match(bookHandler, /if \(bookingRequestKey && deterministicToken\) \{/);
 });
 
 test("scheduled availability + reservation no longer depend on client_app", () => {

--- a/test/customerBookingMutationCharacterization.test.js
+++ b/test/customerBookingMutationCharacterization.test.js
@@ -8,6 +8,9 @@ const { Pool } = require("pg");
 
 const { createBookingJobService } = require("../server/services/booking/createBookingJob");
 const { createBookingApprovalService } = require("../server/services/booking/bookingApprovalService");
+const availabilityEngine = require("../server/services/booking/availabilityEngine");
+const pricingHelpers = require("../server/pricing");
+const { parseCanonicalServiceItem } = require("../server/services/booking/bookingJobUnits");
 const {
   JOB_STATUS,
   ASSIGNMENT_STATUS,
@@ -179,7 +182,8 @@ test.before(async () => {
   }
 
   await pool.query(`
-    DROP TABLE IF EXISTS public.job_updates_v2, public.job_units, public.job_promotions, public.job_offers, public.job_assignments,
+    DROP TABLE IF EXISTS public.technician_monthly_work_calendar, public.technician_service_matrix,
+      public.job_updates_v2, public.job_units, public.job_promotions, public.job_offers, public.job_assignments,
       public.job_team_members, public.job_items, public.catalog_items,
       public.technician_profiles, public.users, public.jobs CASCADE
   `);
@@ -220,6 +224,7 @@ test.before(async () => {
   `);
   await pool.query(`
     CREATE TABLE public.job_items (
+      job_item_id BIGSERIAL PRIMARY KEY,
       job_id BIGINT,
       item_id BIGINT,
       item_name TEXT,
@@ -239,7 +244,25 @@ test.before(async () => {
   await pool.query(`CREATE TABLE public.job_assignments (job_id BIGINT, technician_username TEXT, status TEXT, UNIQUE(job_id, technician_username))`);
   await pool.query(`CREATE TABLE public.job_offers (offer_id BIGSERIAL PRIMARY KEY, job_id BIGINT, technician_username TEXT, status TEXT, expires_at TIMESTAMPTZ)`);
   await pool.query(`CREATE TABLE public.job_promotions (job_id BIGINT PRIMARY KEY, promo_id BIGINT, applied_discount NUMERIC)`);
-  await pool.query(`CREATE TABLE public.job_units (unit_id BIGSERIAL PRIMARY KEY, job_id BIGINT, unit_no INT, item_name TEXT, ac_type TEXT, wash_type TEXT, btu TEXT)`);
+  await pool.query(`
+    CREATE TABLE public.job_units (
+      unit_id BIGSERIAL PRIMARY KEY,
+      job_id BIGINT,
+      unit_code TEXT,
+      unit_no INT,
+      item_name TEXT,
+      ac_type TEXT,
+      wash_type TEXT,
+      btu TEXT,
+      location_label TEXT,
+      assigned_technician TEXT,
+      status TEXT DEFAULT 'pending',
+      created_at TIMESTAMPTZ DEFAULT NOW(),
+      updated_at TIMESTAMPTZ DEFAULT NOW(),
+      UNIQUE(job_id, unit_code),
+      UNIQUE(job_id, unit_no)
+    )
+  `);
   await pool.query(`CREATE TABLE public.job_updates_v2 (update_id BIGSERIAL PRIMARY KEY, job_id BIGINT, action TEXT, payload_json JSONB)`);
   await pool.query(`CREATE TABLE public.catalog_items (item_id BIGSERIAL PRIMARY KEY, item_name TEXT, base_price NUMERIC, is_active BOOLEAN, is_customer_visible BOOLEAN)`);
   await pool.query(`CREATE TABLE public.users (username TEXT PRIMARY KEY, role TEXT)`);
@@ -253,6 +276,22 @@ test.before(async () => {
       home_service_zone_code TEXT,
       secondary_service_zone_code TEXT,
       allow_out_of_zone BOOLEAN
+      ,customer_slot_visible BOOLEAN DEFAULT FALSE
+    )
+  `);
+  await pool.query(`CREATE TABLE public.technician_service_matrix (username TEXT PRIMARY KEY, matrix_json JSONB)`);
+  await pool.query(`
+    CREATE TABLE public.technician_monthly_work_calendar (
+      technician_username TEXT,
+      work_date DATE,
+      day_status TEXT,
+      can_accept_advance_job BOOLEAN,
+      start_time TEXT,
+      end_time TEXT,
+      max_jobs_per_day INT,
+      max_units_per_day INT,
+      source TEXT,
+      PRIMARY KEY (technician_username, work_date)
     )
   `);
 });
@@ -260,7 +299,8 @@ test.before(async () => {
 test.after(async () => {
   if (!pool) return;
   await pool.query(`
-    DROP TABLE IF EXISTS public.job_updates_v2, public.job_units, public.job_promotions, public.job_offers, public.job_assignments,
+    DROP TABLE IF EXISTS public.technician_monthly_work_calendar, public.technician_service_matrix,
+      public.job_updates_v2, public.job_units, public.job_promotions, public.job_offers, public.job_assignments,
       public.job_team_members, public.job_items, public.catalog_items,
       public.technician_profiles, public.users, public.jobs CASCADE
   `);
@@ -269,7 +309,8 @@ test.after(async () => {
 
 test.beforeEach(async () => {
   if (!pool) return;
-  await pool.query(`TRUNCATE public.job_updates_v2, public.job_units, public.job_promotions, public.job_offers, public.job_assignments,
+  await pool.query(`TRUNCATE public.technician_monthly_work_calendar, public.technician_service_matrix,
+    public.job_updates_v2, public.job_units, public.job_promotions, public.job_offers, public.job_assignments,
     public.job_team_members, public.job_items, public.catalog_items,
     public.technician_profiles, public.users, public.jobs RESTART IDENTITY CASCADE`);
 });
@@ -296,16 +337,9 @@ function makeDependencies(overrides = {}) {
     computeDurationMinMulti: () => 60,
     customerPricingHelpers: {
       resolveCustomerPricingMulti: async () => ({ active_price: 800, standard_price: 800 }),
-      buildCustomerServiceLineItemsFromPayload: async () => [{
-        item_id: null,
-        item_name: "ล้างแอร์",
-        qty: 1,
-        unit_price: 800,
-        line_total: 800,
-        assigned_technician_username: null,
-        is_service: true,
-        customer_price_source: "standard",
-      }],
+      buildCustomerServiceLineItemsFromPayload: async (payload) => pricingHelpers
+        .buildServiceLineItemsFromPayload(payload)
+        .map((item) => ({ ...item, customer_price_source: "standard" })),
     },
     coordFieldProvided: (value) => value !== undefined && value !== null && String(value).trim() !== "",
     strictLatLngPairOrNull: () => null,
@@ -323,7 +357,6 @@ function makeDependencies(overrides = {}) {
     technicianMatchesServiceZone: async () => ({ matches: true }),
     http409Conflict: (res, conflict) => res.status(409).json({ error: "ชนคิว", conflict }),
     generateUniqueBookingCode: async () => `CWF-PR2-${++bookingCodeSequence}`,
-    ensureJobUnits: async () => {},
     effectiveBlockMin: (duration) => Number(duration) + 30,
     isTechFree: async () => true,
     getJwtSecret: () => "",
@@ -361,11 +394,89 @@ async function seedTechnicians() {
   await pool.query(`INSERT INTO public.users (username, role) VALUES ('tech-a','technician'),('tech-b','technician')`);
   await pool.query(`
     INSERT INTO public.technician_profiles
-      (username, weekly_off_days, accept_status, accept_status_expires_at, employment_type, allow_out_of_zone)
+      (username, weekly_off_days, accept_status, accept_status_expires_at, employment_type, allow_out_of_zone, customer_slot_visible)
     VALUES
-      ('tech-a','','ready',NOW() + INTERVAL '1 day','partner',FALSE),
-      ('tech-b','','ready',NOW() + INTERVAL '1 day','company',FALSE)
+      ('tech-a','','ready',NOW() + INTERVAL '1 day','partner',FALSE,TRUE),
+      ('tech-b','','ready',NOW() + INTERVAL '1 day','company',FALSE,TRUE)
   `);
+}
+
+function toMinute(value) {
+  const [hour, minute] = String(value || "").slice(0, 5).split(":").map(Number);
+  return (hour * 60) + minute;
+}
+
+function collisionFreeIntervals(blocks, windowStart, windowEnd, durationMin) {
+  const sorted = (blocks || []).slice().sort((a, b) => a.start_min - b.start_min);
+  const intervals = [];
+  let cursor = windowStart;
+  for (const block of sorted) {
+    const latestStart = Number(block.start_min) - durationMin;
+    if (latestStart >= cursor) intervals.push({ startMin: cursor, endMin: latestStart });
+    cursor = Math.max(cursor, Number(block.end_min));
+  }
+  if (cursor + durationMin <= windowEnd) intervals.push({ startMin: cursor, endMin: windowEnd - durationMin });
+  return intervals;
+}
+
+function realAvailabilityDependencies(db) {
+  return {
+    pool: db,
+    db,
+    listTechniciansByType: async (type) => {
+      const result = await db.query(
+        `SELECT username, employment_type, customer_slot_visible
+           FROM public.technician_profiles
+          WHERE ($1='all' OR employment_type=$1)
+          ORDER BY username`,
+        [String(type || "all")]
+      );
+      return result.rows;
+    },
+    listBusyBlocksForTechOnDate: async (username, date, ignoreJobId) => {
+      const result = await db.query(
+        `SELECT
+           (EXTRACT(HOUR FROM appointment_datetime AT TIME ZONE 'Asia/Bangkok')::int * 60
+             + EXTRACT(MINUTE FROM appointment_datetime AT TIME ZONE 'Asia/Bangkok')::int) AS start_min,
+           (EXTRACT(HOUR FROM appointment_datetime AT TIME ZONE 'Asia/Bangkok')::int * 60
+             + EXTRACT(MINUTE FROM appointment_datetime AT TIME ZONE 'Asia/Bangkok')::int
+             + COALESCE(duration_min,60)::int) AS end_min
+           FROM public.jobs
+          WHERE technician_username=$1
+            AND (appointment_datetime AT TIME ZONE 'Asia/Bangkok')::date=$2::date
+            AND ($3::bigint IS NULL OR job_id <> $3::bigint)
+            AND COALESCE(job_status,'') <> 'ยกเลิก'`,
+        [username, date, ignoreJobId || null]
+      );
+      return result.rows.map((row) => ({ start_min: Number(row.start_min), end_min: Number(row.end_min) }));
+    },
+    buildStartIntervalsByCollision: collisionFreeIntervals,
+    toMin: toMinute,
+    minToHHMM: (minute) => `${String(Math.floor(Number(minute) / 60)).padStart(2, "0")}:${String(Number(minute) % 60).padStart(2, "0")}`,
+    getNowBangkokParts: () => ({ ymd: "2026-07-01", hour: 8, minute: 0 }),
+  };
+}
+
+async function seedRealAvailability() {
+  await seedTechnicians();
+  const matrix = {
+    job_types: { wash: true, repair: true, install: true },
+    ac_types: { wall: true, fourway: true, hanging: true, ceiling: true },
+    wash_wall_variants: { normal: true, premium: true, coil: true, overhaul: true },
+    repair_variants: { inspection: true, leak_check: true, parts: true, general: true },
+  };
+  await pool.query(
+    `INSERT INTO public.technician_service_matrix (username, matrix_json)
+     VALUES ('tech-a',$1::jsonb),('tech-b',$1::jsonb)`,
+    [JSON.stringify(matrix)]
+  );
+  await pool.query(
+    `INSERT INTO public.technician_monthly_work_calendar
+       (technician_username, work_date, day_status, can_accept_advance_job, start_time, end_time, max_jobs_per_day, max_units_per_day, source)
+     VALUES
+       ('tech-a','2026-08-01','working',TRUE,'09:00','18:00',5,10,'test'),
+       ('tech-b','2026-08-01','working',TRUE,'09:00','18:00',5,10,'test')`
+  );
 }
 
 dbTest("real PostgreSQL: public scheduled success preserves response, status, items, pricing, and assignment reservation", async () => {
@@ -383,7 +494,7 @@ dbTest("real PostgreSQL: public scheduled success preserves response, status, it
     "travel_buffer_min", "applied_promo", "base_total",
   ]);
   assert.equal(result.body.booking_mode, "scheduled");
-  assert.equal(result.body.base_total, 800);
+  assert.equal(result.body.base_total, 600);
   assert.equal(Object.hasOwn(result.body, "technician_username"), false);
   assert.equal(Object.hasOwn(result.body, "technician"), false);
 
@@ -391,8 +502,8 @@ dbTest("real PostgreSQL: public scheduled success preserves response, status, it
   const items = (await pool.query(`SELECT item_name, qty::int, line_total::int FROM public.job_items ORDER BY item_name`)).rows;
   assert.equal(job.job_status, JOB_STATUS.CUSTOMER_SCHEDULED_REVIEW);
   assert.equal(job.technician_username, "tech-a");
-  assert.equal(Number(job.job_price), 800);
-  assert.deepEqual(items, [{ item_name: "ล้างแอร์", qty: 1, line_total: 800 }]);
+  assert.equal(Number(job.job_price), 600);
+  assert.deepEqual(items, [{ item_name: "ล้างแอร์ผนัง • ล้างธรรมดา • 12000 BTU • 1 เครื่อง", qty: 1, line_total: 600 }]);
   assert.equal(Number((await pool.query(`SELECT COUNT(*) FROM public.job_assignments`)).rows[0].count), 0);
   assert.equal(Number((await pool.query(`SELECT COUNT(*) FROM public.job_team_members`)).rows[0].count), 0);
   assert.deepEqual(sideEffects, []);
@@ -415,6 +526,31 @@ dbTest("real PostgreSQL: public scheduled success preserves response, status, it
   assert.equal(reviewQueue.rows[0].count, 1);
 });
 
+test("canonical booking criteria preserve wash/repair variants, BTU, and line quantity without inference defaults", () => {
+  assert.deepEqual(parseCanonicalServiceItem({
+    item_name: "ล้างแอร์ผนัง • ล้างพรีเมียม • 18000 BTU • 2 เครื่อง",
+    qty: 2,
+  }), {
+    job_type: "ล้าง",
+    ac_type: "ผนัง",
+    wash_variant: "ล้างพรีเมียม",
+    repair_variant: "",
+    btu: 18000,
+    machine_count: 2,
+  });
+  assert.deepEqual(parseCanonicalServiceItem({
+    item_name: "ซ่อมแอร์ผนัง • ตรวจเช็ครั่ว • 12000 BTU • 1 เครื่อง",
+    qty: 1,
+  }), {
+    job_type: "ซ่อม",
+    ac_type: "ผนัง",
+    wash_variant: "",
+    repair_variant: "ตรวจเช็ครั่ว",
+    btu: 12000,
+    machine_count: 1,
+  });
+});
+
 dbTest("real PostgreSQL: scheduled retry replays the same job without duplicate items", async () => {
   const service = createBookingJobService(makeDependencies());
   const body = publicScheduledBody();
@@ -430,7 +566,7 @@ dbTest("real PostgreSQL: scheduled retry replays the same job without duplicate 
 
 dbTest("real PostgreSQL: scheduled rollback leaves no partial job or items", async () => {
   const service = createBookingJobService(makeDependencies({
-    ensureJobUnits: async () => { throw new Error("fixture assignment failure"); },
+    ensureBookingJobUnits: async () => { throw new Error("fixture assignment failure"); },
   }));
   const result = await invoke(service.handlePublicBook, publicScheduledBody({ scheduled_request_key: "scheduled-pr2-key-rollback" }));
   assert.equal(result.statusCode, 500);
@@ -465,6 +601,64 @@ dbTest("real PostgreSQL: public urgent waits for admin with zero offers, assignm
   assert.equal(urgentJob.technician_username, null);
   assert.equal(notifications.length, 0);
   assert.equal(income.length, 0);
+});
+
+dbTest("real PostgreSQL: urgent retry keeps the first server appointment authoritative and rejects material payload reuse", async () => {
+  const appointments = ["2026-08-01T09:00:00+07:00", "2026-08-01T09:30:00+07:00", "2026-08-01T10:00:00+07:00"];
+  let appointmentIndex = 0;
+  const adapter = {
+    ...urgentPublicAdapterBase,
+    computeCustomerUrgentAppointmentIso: () => appointments[Math.min(appointmentIndex++, appointments.length - 1)],
+  };
+  const service = createBookingJobService(makeDependencies({ urgentPublicAdapter: adapter }));
+  const body = publicUrgentBody({ urgent_request_key: "urgent-pr3-clock-replay-0001" });
+  const first = await invoke(service.handlePublicBook, body);
+  const replay = await invoke(service.handlePublicBook, body);
+  assert.equal(first.statusCode, 200);
+  assert.equal(replay.statusCode, 200);
+  assert.equal(replay.body.replayed, true);
+  assert.equal(replay.body.job_id, first.body.job_id);
+  const stored = (await pool.query(`SELECT appointment_datetime FROM public.jobs WHERE job_id=$1`, [first.body.job_id])).rows[0];
+  assert.equal(new Date(stored.appointment_datetime).getTime(), new Date(appointments[0]).getTime());
+  assert.equal(Number((await pool.query(`SELECT COUNT(*) FROM public.jobs`)).rows[0].count), 1);
+
+  const changed = await invoke(service.handlePublicBook, { ...body, customer_note: "materially changed" });
+  assert.equal(changed.statusCode, 409);
+  assert.equal(changed.body.code, "IDEMPOTENCY_KEY_REUSED");
+  assert.equal(Number((await pool.query(`SELECT COUNT(*) FROM public.jobs`)).rows[0].count), 1);
+});
+
+dbTest("real PostgreSQL: strict urgent cleaning classifier rejects tampering before pricing and DB mutation", async () => {
+  let pricingCalls = 0;
+  const baseDependencies = makeDependencies();
+  const service = createBookingJobService(makeDependencies({
+    customerPricingHelpers: {
+      ...baseDependencies.customerPricingHelpers,
+      resolveCustomerPricingMulti: async () => {
+        pricingCalls += 1;
+        throw new Error("pricing must not run for rejected urgent payload");
+      },
+    },
+  }));
+  const cleanLine = { job_type: "ล้าง", ac_type: "ผนัง", btu: 12000, machine_count: 1, wash_variant: "ล้างธรรมดา" };
+  const cases = [
+    { name: "top-level repair with cleaning services", patch: { job_type: "ซ่อม", services: [cleanLine] } },
+    { name: "Thai mixed cleaning and repair", patch: { job_type: "ล้างและซ่อม" } },
+    { name: "English mixed cleaning and repair", patch: { job_type: "clean and repair" } },
+    { name: "one non-cleaning service line", patch: { job_type: "ล้าง", services: [cleanLine, { ...cleanLine, job_type: "ซ่อม" }] } },
+  ];
+  for (let index = 0; index < cases.length; index += 1) {
+    const entry = cases[index];
+    const result = await invoke(service.handlePublicBook, publicUrgentBody({
+      urgent_request_key: `urgent-pr3-tamper-${String(index + 1).padStart(4, "0")}`,
+      ...entry.patch,
+    }));
+    assert.equal(result.statusCode, 400, entry.name);
+    assert.equal(result.body.code, "URGENT_CLEANING_ONLY", entry.name);
+    assert.equal(Number((await pool.query(`SELECT COUNT(*) FROM public.jobs`)).rows[0].count), 0, entry.name);
+    assert.equal(Number((await pool.query(`SELECT COUNT(*) FROM public.job_items`)).rows[0].count), 0, entry.name);
+  }
+  assert.equal(pricingCalls, 0);
 });
 
 dbTest("real PostgreSQL: concurrent scheduled retry commits exactly one job and item set", async () => {
@@ -523,6 +717,54 @@ function makeApprovalService(events = {}, overrides = {}) {
     ...overrides,
   });
 }
+
+dbTest("real PostgreSQL: production-shaped units and real availability engine approve multi-service scheduled booking", async () => {
+  await seedRealAvailability();
+  const depsFor = (db = pool) => realAvailabilityDependencies(db);
+  const booking = createBookingJobService(makeDependencies({
+    computeDurationMinMulti: (payload) => pricingHelpers.computeDurationMinMulti(payload, { source: "pr3_real_engine", conservative: true }),
+    customerAvailability: availabilityEngine,
+    publicCustomerAvailabilityDeps: depsFor,
+  }));
+  const created = await invoke(booking.handlePublicBook, publicScheduledBody({
+    scheduled_request_key: "scheduled-pr3-real-engine-0001",
+    job_type: "ล้าง",
+    ac_type: "ผนัง",
+    btu: 12000,
+    machine_count: 3,
+    services: [
+      { job_type: "ล้าง", ac_type: "ผนัง", wash_variant: "ล้างธรรมดา", btu: 12000, machine_count: 2 },
+      { job_type: "ล้าง", ac_type: "สี่ทิศทาง", wash_variant: "", btu: 24000, machine_count: 1 },
+    ],
+  }));
+  assert.equal(created.statusCode, 200);
+
+  const units = (await pool.query(
+    `SELECT unit_no, ac_type, wash_type, btu
+       FROM public.job_units
+      WHERE job_id=$1
+      ORDER BY unit_no`,
+    [created.body.job_id]
+  )).rows;
+  assert.deepEqual(units, [
+    { unit_no: 1, ac_type: "ผนัง", wash_type: "ล้างธรรมดา", btu: "12000" },
+    { unit_no: 2, ac_type: "ผนัง", wash_type: "ล้างธรรมดา", btu: "12000" },
+    { unit_no: 3, ac_type: "สี่ทิศทาง", wash_type: null, btu: "24000" },
+  ]);
+
+  const events = {};
+  const approval = makeApprovalService(events, {
+    availabilityEngine,
+    getAvailabilityDependencies: depsFor,
+  });
+  const approved = await invokeApproval(approval.approve, created.body.job_id);
+  assert.equal(approved.statusCode, 200);
+  assert.equal(approved.body.replayed, false);
+  assert.equal(Number((await pool.query(`SELECT COUNT(*) FROM public.job_assignments WHERE job_id=$1`, [created.body.job_id])).rows[0].count), 1);
+  assert.equal((await pool.query(`SELECT job_status FROM public.jobs WHERE job_id=$1`, [created.body.job_id])).rows[0].job_status, JOB_STATUS.ADMIN_SCHEDULED_PENDING);
+  assert.equal(events.income.length, 1);
+  assert.equal(events.direct.length, 1);
+});
 
 async function invokeApproval(handler, jobId, body = {}) {
   const req = { params: { job_id: String(jobId) }, body, auth: { username: "admin-test" } };
@@ -744,7 +986,7 @@ dbTest("real PostgreSQL: internal booking preserves validation and admin-notific
 dbTest("real PostgreSQL: urgent transaction rollback leaves no partial job, items, or offers", async () => {
   await seedTechnicians();
   const service = createBookingJobService(makeDependencies({
-    ensureJobUnits: async () => { throw new Error("fixture urgent rollback"); },
+    ensureBookingJobUnits: async () => { throw new Error("fixture urgent rollback"); },
   }));
   const result = await invoke(service.handlePublicBook, publicUrgentBody({ urgent_request_key: "urgent-pr2-key-rollback" }));
   assert.equal(result.statusCode, 500);

--- a/test/customerBookingMutationCharacterization.test.js
+++ b/test/customerBookingMutationCharacterization.test.js
@@ -7,7 +7,14 @@ const path = require("node:path");
 const { Pool } = require("pg");
 
 const { createBookingJobService } = require("../server/services/booking/createBookingJob");
-const { JOB_STATUS, ASSIGNMENT_STATUS, OFFER_STATUS } = require("../server/services/booking/bookingStatuses");
+const { createBookingApprovalService } = require("../server/services/booking/bookingApprovalService");
+const {
+  JOB_STATUS,
+  ASSIGNMENT_STATUS,
+  OFFER_STATUS,
+  pendingCustomerScheduledReservationSql,
+} = require("../server/services/booking/bookingStatuses");
+const { loadCustomerScheduledLoadMap } = require("../server/services/public/customerScheduledAssignment");
 const { registerPublicCustomerBookingRoutes } = require("../server/routes/public/customerBookings");
 const { registerAdminBookingRoutes } = require("../server/routes/admin/adminBookings");
 const urgentPublicAdapterBase = require("../server/services/urgentPublicAdapter");
@@ -172,7 +179,7 @@ test.before(async () => {
   }
 
   await pool.query(`
-    DROP TABLE IF EXISTS public.job_promotions, public.job_offers, public.job_assignments,
+    DROP TABLE IF EXISTS public.job_updates_v2, public.job_units, public.job_promotions, public.job_offers, public.job_assignments,
       public.job_team_members, public.job_items, public.catalog_items,
       public.technician_profiles, public.users, public.jobs CASCADE
   `);
@@ -206,6 +213,9 @@ test.before(async () => {
       canceled_at TIMESTAMPTZ,
       created_at TIMESTAMPTZ DEFAULT NOW(),
       booking_code TEXT
+      ,approved_by_admin TEXT
+      ,approved_at TIMESTAMPTZ
+      ,cancel_reason TEXT
     )
   `);
   await pool.query(`
@@ -229,6 +239,8 @@ test.before(async () => {
   await pool.query(`CREATE TABLE public.job_assignments (job_id BIGINT, technician_username TEXT, status TEXT, UNIQUE(job_id, technician_username))`);
   await pool.query(`CREATE TABLE public.job_offers (offer_id BIGSERIAL PRIMARY KEY, job_id BIGINT, technician_username TEXT, status TEXT, expires_at TIMESTAMPTZ)`);
   await pool.query(`CREATE TABLE public.job_promotions (job_id BIGINT PRIMARY KEY, promo_id BIGINT, applied_discount NUMERIC)`);
+  await pool.query(`CREATE TABLE public.job_units (unit_id BIGSERIAL PRIMARY KEY, job_id BIGINT, unit_no INT, item_name TEXT, ac_type TEXT, wash_type TEXT, btu TEXT)`);
+  await pool.query(`CREATE TABLE public.job_updates_v2 (update_id BIGSERIAL PRIMARY KEY, job_id BIGINT, action TEXT, payload_json JSONB)`);
   await pool.query(`CREATE TABLE public.catalog_items (item_id BIGSERIAL PRIMARY KEY, item_name TEXT, base_price NUMERIC, is_active BOOLEAN, is_customer_visible BOOLEAN)`);
   await pool.query(`CREATE TABLE public.users (username TEXT PRIMARY KEY, role TEXT)`);
   await pool.query(`
@@ -248,7 +260,7 @@ test.before(async () => {
 test.after(async () => {
   if (!pool) return;
   await pool.query(`
-    DROP TABLE IF EXISTS public.job_promotions, public.job_offers, public.job_assignments,
+    DROP TABLE IF EXISTS public.job_updates_v2, public.job_units, public.job_promotions, public.job_offers, public.job_assignments,
       public.job_team_members, public.job_items, public.catalog_items,
       public.technician_profiles, public.users, public.jobs CASCADE
   `);
@@ -257,7 +269,7 @@ test.after(async () => {
 
 test.beforeEach(async () => {
   if (!pool) return;
-  await pool.query(`TRUNCATE public.job_promotions, public.job_offers, public.job_assignments,
+  await pool.query(`TRUNCATE public.job_updates_v2, public.job_units, public.job_promotions, public.job_offers, public.job_assignments,
     public.job_team_members, public.job_items, public.catalog_items,
     public.technician_profiles, public.users, public.jobs RESTART IDENTITY CASCADE`);
 });
@@ -357,7 +369,12 @@ async function seedTechnicians() {
 }
 
 dbTest("real PostgreSQL: public scheduled success preserves response, status, items, pricing, and assignment reservation", async () => {
-  const service = createBookingJobService(makeDependencies());
+  const sideEffects = [];
+  const service = createBookingJobService(makeDependencies({
+    refreshTechnicianIncomePreviewForJob: async (...args) => { sideEffects.push(["income", args]); return {}; },
+    notifyUrgentOffer: async (...args) => { sideEffects.push(["urgent", args]); },
+    notifyDirectJobAssigned: async (...args) => { sideEffects.push(["direct", args]); },
+  }));
   const result = await invoke(service.handlePublicBook, publicScheduledBody());
   assert.equal(result.statusCode, 200);
   assert.deepEqual(Object.keys(result.body), [
@@ -367,6 +384,8 @@ dbTest("real PostgreSQL: public scheduled success preserves response, status, it
   ]);
   assert.equal(result.body.booking_mode, "scheduled");
   assert.equal(result.body.base_total, 800);
+  assert.equal(Object.hasOwn(result.body, "technician_username"), false);
+  assert.equal(Object.hasOwn(result.body, "technician"), false);
 
   const job = (await pool.query(`SELECT * FROM public.jobs`)).rows[0];
   const items = (await pool.query(`SELECT item_name, qty::int, line_total::int FROM public.job_items ORDER BY item_name`)).rows;
@@ -374,6 +393,26 @@ dbTest("real PostgreSQL: public scheduled success preserves response, status, it
   assert.equal(job.technician_username, "tech-a");
   assert.equal(Number(job.job_price), 800);
   assert.deepEqual(items, [{ item_name: "ล้างแอร์", qty: 1, line_total: 800 }]);
+  assert.equal(Number((await pool.query(`SELECT COUNT(*) FROM public.job_assignments`)).rows[0].count), 0);
+  assert.equal(Number((await pool.query(`SELECT COUNT(*) FROM public.job_team_members`)).rows[0].count), 0);
+  assert.deepEqual(sideEffects, []);
+  const capacity = await loadCustomerScheduledLoadMap(pool, "2026-08-01", ["tech-a"]);
+  assert.equal(capacity.get("tech-a").jobs_count, 1);
+  const collisionOccupancy = await pool.query(
+    `SELECT COUNT(*)::int AS count FROM public.jobs j
+      WHERE j.technician_username=$1
+        AND j.appointment_datetime >= $2::timestamptz
+        AND j.appointment_datetime < $3::timestamptz
+        AND COALESCE(j.job_status,'') <> 'ยกเลิก'`,
+    ["tech-a", "2026-08-01T00:00:00+07:00", "2026-08-02T00:00:00+07:00"]
+  );
+  assert.equal(collisionOccupancy.rows[0].count, 1);
+  const reviewQueue = await pool.query(
+    `SELECT COUNT(*)::int AS count FROM public.jobs
+      WHERE job_source='customer' AND booking_mode='scheduled' AND job_status=$1 AND canceled_at IS NULL`,
+    [JOB_STATUS.CUSTOMER_SCHEDULED_REVIEW]
+  );
+  assert.equal(reviewQueue.rows[0].count, 1);
 });
 
 dbTest("real PostgreSQL: scheduled retry replays the same job without duplicate items", async () => {
@@ -399,11 +438,13 @@ dbTest("real PostgreSQL: scheduled rollback leaves no partial job or items", asy
   assert.equal(Number((await pool.query(`SELECT COUNT(*) FROM public.job_items`)).rows[0].count), 0);
 });
 
-dbTest("real PostgreSQL: public urgent keeps immediate offers, response shape, and durable retry parity", async () => {
+dbTest("real PostgreSQL: public urgent waits for admin with zero offers, assignments, income, or notification", async () => {
   await seedTechnicians();
   const notifications = [];
+  const income = [];
   const service = createBookingJobService(makeDependencies({
     notifyUrgentOffer: async (payload) => { notifications.push(payload); },
+    refreshTechnicianIncomePreviewForJob: async (...args) => { income.push(args); return {}; },
   }));
   const body = publicUrgentBody();
   const first = await invoke(service.handlePublicBook, body);
@@ -411,13 +452,234 @@ dbTest("real PostgreSQL: public urgent keeps immediate offers, response shape, a
   assert.equal(first.statusCode, 200);
   assert.equal(first.body.booking_mode, "urgent");
   assert.equal(first.body.dispatch_mode, "offer");
-  assert.equal(first.body.offers_count, 1);
-  assert.equal(replay.body.duplicate, true);
+  assert.equal(first.body.offers_count, 0);
+  assert.equal(first.body.urgent_offer_enabled, false);
+  assert.equal(replay.body.replayed, true);
   assert.equal(replay.body.booking_code, first.body.booking_code);
   assert.equal(Number((await pool.query(`SELECT COUNT(*) FROM public.jobs`)).rows[0].count), 1);
-  assert.equal(Number((await pool.query(`SELECT COUNT(*) FROM public.job_offers`)).rows[0].count), 1);
-  assert.equal((await pool.query(`SELECT job_status FROM public.jobs`)).rows[0].job_status, JOB_STATUS.ADMIN_URGENT_WAITING);
-  assert.equal(notifications.length, 1);
+  assert.equal(Number((await pool.query(`SELECT COUNT(*) FROM public.job_offers`)).rows[0].count), 0);
+  assert.equal(Number((await pool.query(`SELECT COUNT(*) FROM public.job_assignments`)).rows[0].count), 0);
+  assert.equal(Number((await pool.query(`SELECT COUNT(*) FROM public.job_team_members`)).rows[0].count), 0);
+  const urgentJob = (await pool.query(`SELECT job_status, technician_username FROM public.jobs`)).rows[0];
+  assert.equal(urgentJob.job_status, JOB_STATUS.CUSTOMER_SCHEDULED_REVIEW);
+  assert.equal(urgentJob.technician_username, null);
+  assert.equal(notifications.length, 0);
+  assert.equal(income.length, 0);
+});
+
+dbTest("real PostgreSQL: concurrent scheduled retry commits exactly one job and item set", async () => {
+  const service = createBookingJobService(makeDependencies());
+  const body = publicScheduledBody({ scheduled_request_key: "scheduled-pr3-concurrent-0001" });
+  const [one, two] = await Promise.all([
+    invoke(service.handlePublicBook, body),
+    invoke(service.handlePublicBook, body),
+  ]);
+  assert.equal(one.statusCode, 200);
+  assert.equal(two.statusCode, 200);
+  assert.equal(one.body.job_id, two.body.job_id);
+  assert.equal(Number((await pool.query(`SELECT COUNT(*) FROM public.jobs`)).rows[0].count), 1);
+  assert.equal(Number((await pool.query(`SELECT COUNT(*) FROM public.job_items`)).rows[0].count), 1);
+  assert.equal(Number((await pool.query(`SELECT COUNT(*) FROM public.job_assignments`)).rows[0].count), 0);
+});
+
+dbTest("real PostgreSQL: public urgent non-cleaning rejects before any mutation", async () => {
+  const service = createBookingJobService(makeDependencies());
+  const result = await invoke(service.handlePublicBook, publicUrgentBody({ job_type: "ซ่อมแอร์" }));
+  assert.equal(result.statusCode, 400);
+  assert.equal(result.body.code, "URGENT_CLEANING_ONLY");
+  assert.equal(Number((await pool.query(`SELECT COUNT(*) FROM public.jobs`)).rows[0].count), 0);
+  assert.equal(Number((await pool.query(`SELECT COUNT(*) FROM public.job_items`)).rows[0].count), 0);
+});
+
+function makeApprovalService(events = {}, overrides = {}) {
+  return createBookingApprovalService({
+    pool,
+    availabilityEngine: {
+      reservePublicCustomerTechnician: async (_deps, options) => {
+        events.reserveOptions = (events.reserveOptions || []).concat([options]);
+        return { username: options.preferred_username || "tech-b" };
+      },
+    },
+    getAvailabilityDependencies: (db) => ({ db, pool: db }),
+    refreshTechnicianIncomePreviewForJob: async (...args) => {
+      events.income = (events.income || []).concat([args]);
+      return {};
+    },
+    notifyDirectJobAssigned: async (payload) => {
+      events.direct = (events.direct || []).concat([payload]);
+    },
+    notifyUrgentOffer: async (payload) => {
+      events.offers = (events.offers || []).concat([payload]);
+    },
+    isTechReady: async () => true,
+    checkTechCollision: async () => null,
+    logJobUpdate: async (jobId, payload, db) => {
+      events.audit = (events.audit || []).concat([payload]);
+      await db.query(
+        `INSERT INTO public.job_updates_v2 (job_id, action, payload_json) VALUES ($1,$2,$3::jsonb)`,
+        [jobId, payload.action, JSON.stringify(payload.payload || {})]
+      );
+    },
+    ...overrides,
+  });
+}
+
+async function invokeApproval(handler, jobId, body = {}) {
+  const req = { params: { job_id: String(jobId) }, body, auth: { username: "admin-test" } };
+  const res = responseHarness();
+  await handler(req, res);
+  return res;
+}
+
+dbTest("real PostgreSQL: scheduled approval creates one assignment after revalidation and replay has no duplicate side effect", async () => {
+  const booking = createBookingJobService(makeDependencies());
+  const created = await invoke(booking.handlePublicBook, publicScheduledBody());
+  const events = {};
+  const approval = makeApprovalService(events);
+  const first = await invokeApproval(approval.approve, created.body.job_id);
+  const replay = await invokeApproval(approval.approve, created.body.job_id);
+  assert.equal(first.statusCode, 200);
+  assert.equal(first.body.replayed, false);
+  assert.equal(replay.body.replayed, true);
+  assert.equal(events.reserveOptions.length, 1);
+  assert.equal(events.reserveOptions[0].preferred_username, "tech-a");
+  assert.equal(events.reserveOptions[0].ignore_job_id, created.body.job_id);
+  assert.equal(events.income.length, 1);
+  assert.equal(events.direct.length, 1);
+  assert.equal(events.audit.length, 1);
+  assert.equal(events.audit[0].action, "customer_booking_approved");
+  assert.equal(Number((await pool.query(`SELECT COUNT(*) FROM public.job_assignments WHERE job_id=$1`, [created.body.job_id])).rows[0].count), 1);
+  const job = (await pool.query(`SELECT job_status FROM public.jobs WHERE job_id=$1`, [created.body.job_id])).rows[0];
+  assert.equal(job.job_status, JOB_STATUS.ADMIN_SCHEDULED_PENDING);
+});
+
+dbTest("real PostgreSQL: invalid reserved technician is safely reassigned in the same approval transaction", async () => {
+  const booking = createBookingJobService(makeDependencies());
+  const created = await invoke(booking.handlePublicBook, publicScheduledBody());
+  const calls = [];
+  const approval = makeApprovalService({}, {
+    availabilityEngine: {
+      reservePublicCustomerTechnician: async (_deps, options) => {
+        calls.push(options);
+        if (options.preferred_username) {
+          const error = new Error("CUSTOMER_SLOT_STALE");
+          error.status = 409;
+          throw error;
+        }
+        return { username: "tech-b" };
+      },
+    },
+  });
+  const result = await invokeApproval(approval.approve, created.body.job_id);
+  assert.equal(result.statusCode, 200);
+  assert.equal(calls.length, 2);
+  assert.equal(calls[0].preferred_username, "tech-a");
+  assert.equal(calls[1].preferred_username, undefined);
+  const assignment = (await pool.query(`SELECT technician_username FROM public.job_assignments WHERE job_id=$1`, [created.body.job_id])).rows[0];
+  assert.equal(assignment.technician_username, "tech-b");
+});
+
+dbTest("real PostgreSQL: approval failure rolls back and leaves pending reservation intact", async () => {
+  const booking = createBookingJobService(makeDependencies());
+  const created = await invoke(booking.handlePublicBook, publicScheduledBody());
+  const approval = makeApprovalService({}, {
+    availabilityEngine: {
+      reservePublicCustomerTechnician: async () => {
+        const error = new Error("CUSTOMER_SLOT_STALE");
+        error.status = 409;
+        throw error;
+      },
+    },
+  });
+  const result = await invokeApproval(approval.approve, created.body.job_id);
+  assert.equal(result.statusCode, 409);
+  assert.equal(Number((await pool.query(`SELECT COUNT(*) FROM public.job_assignments WHERE job_id=$1`, [created.body.job_id])).rows[0].count), 0);
+  const job = (await pool.query(`SELECT job_status, technician_username FROM public.jobs WHERE job_id=$1`, [created.body.job_id])).rows[0];
+  assert.equal(job.job_status, JOB_STATUS.CUSTOMER_SCHEDULED_REVIEW);
+  assert.equal(job.technician_username, "tech-a");
+});
+
+dbTest("real PostgreSQL: approval fails closed when pending reservation already has assignment state", async () => {
+  const booking = createBookingJobService(makeDependencies());
+  const created = await invoke(booking.handlePublicBook, publicScheduledBody());
+  await pool.query(
+    `INSERT INTO public.job_assignments (job_id, technician_username, status) VALUES ($1,'unexpected-tech','in_progress')`,
+    [created.body.job_id]
+  );
+  const events = {};
+  const approval = makeApprovalService(events);
+  const result = await invokeApproval(approval.approve, created.body.job_id);
+  assert.equal(result.statusCode, 409);
+  assert.equal(result.body.code, "PENDING_RESERVATION_STATE_DRIFT");
+  assert.equal((await pool.query(`SELECT job_status FROM public.jobs WHERE job_id=$1`, [created.body.job_id])).rows[0].job_status, JOB_STATUS.CUSTOMER_SCHEDULED_REVIEW);
+});
+
+dbTest("real PostgreSQL: urgent approval creates only an offer and notifies after commit", async () => {
+  await seedTechnicians();
+  const booking = createBookingJobService(makeDependencies());
+  const created = await invoke(booking.handlePublicBook, publicUrgentBody());
+  const events = {};
+  const approval = makeApprovalService(events, {
+    notifyUrgentOffer: async (payload) => {
+      const committed = await pool.query(`SELECT job_status FROM public.jobs WHERE job_id=$1`, [payload.job_id]);
+      assert.equal(committed.rows[0].job_status, JOB_STATUS.ADMIN_URGENT_WAITING);
+      events.offers = (events.offers || []).concat([payload]);
+    },
+  });
+  const first = await invokeApproval(approval.approve, created.body.job_id, { technician_username: "tech-a" });
+  const replay = await invokeApproval(approval.approve, created.body.job_id, { technician_username: "tech-a" });
+  assert.equal(first.statusCode, 200);
+  assert.equal(replay.body.replayed, true);
+  assert.equal(events.offers.length, 1);
+  assert.equal(Number((await pool.query(`SELECT COUNT(*) FROM public.job_offers WHERE job_id=$1`, [created.body.job_id])).rows[0].count), 1);
+  assert.equal(Number((await pool.query(`SELECT COUNT(*) FROM public.job_assignments WHERE job_id=$1`, [created.body.job_id])).rows[0].count), 0);
+  assert.equal(Number((await pool.query(`SELECT COUNT(*) FROM public.job_team_members WHERE job_id=$1`, [created.body.job_id])).rows[0].count), 0);
+});
+
+dbTest("real PostgreSQL: reject clears hidden reservation and releases scheduled load", async () => {
+  const booking = createBookingJobService(makeDependencies());
+  const created = await invoke(booking.handlePublicBook, publicScheduledBody());
+  const before = await loadCustomerScheduledLoadMap(pool, "2026-08-01", ["tech-a"]);
+  assert.equal(before.get("tech-a").jobs_count, 1);
+  const events = {};
+  const approval = makeApprovalService(events);
+  const rejected = await invokeApproval(approval.reject, created.body.job_id, { reason: "not approved" });
+  assert.equal(rejected.statusCode, 200);
+  const after = await loadCustomerScheduledLoadMap(pool, "2026-08-01", ["tech-a"]);
+  assert.equal(after.get("tech-a").jobs_count, 0);
+  const row = (await pool.query(`SELECT technician_username, canceled_at, cancel_reason FROM public.jobs WHERE job_id=$1`, [created.body.job_id])).rows[0];
+  assert.equal(row.technician_username, null);
+  assert.ok(row.canceled_at);
+  assert.equal(row.cancel_reason, "not approved");
+  assert.equal(events.audit.length, 1);
+  assert.equal(events.audit[0].action, "customer_booking_rejected");
+  assert.equal(events.audit[0].payload.reserved_technician, "tech-a");
+  const audit = (await pool.query(`SELECT action, payload_json FROM public.job_updates_v2 WHERE job_id=$1`, [created.body.job_id])).rows[0];
+  assert.equal(audit.action, "customer_booking_rejected");
+  assert.equal(audit.payload_json.reserved_technician, "tech-a");
+});
+
+dbTest("real PostgreSQL: exact pending reservation is hidden until assignment approval", async () => {
+  const booking = createBookingJobService(makeDependencies());
+  const created = await invoke(booking.handlePublicBook, publicScheduledBody());
+  const hidden = await pool.query(
+    `SELECT job_id FROM public.jobs j
+      WHERE j.job_id=$1 AND j.technician_username=$2
+        AND NOT ${pendingCustomerScheduledReservationSql("j")}`,
+    [created.body.job_id, "tech-a"]
+  );
+  assert.equal(hidden.rows.length, 0);
+  const approval = makeApprovalService({});
+  await invokeApproval(approval.approve, created.body.job_id);
+  const visible = await pool.query(
+    `SELECT j.job_id FROM public.jobs j
+      WHERE j.job_id=$1 AND (
+        (j.technician_username=$2 AND NOT ${pendingCustomerScheduledReservationSql("j")})
+        OR EXISTS (SELECT 1 FROM public.job_assignments ja WHERE ja.job_id=j.job_id AND ja.technician_username=$2)
+      )`,
+    [created.body.job_id, "tech-a"]
+  );
+  assert.equal(visible.rows.length, 1);
 });
 
 dbTest("real PostgreSQL: Admin Auto, Single, Team, and Forced preserve assignments and status", async () => {

--- a/test/customerBookingPendingApproval.test.js
+++ b/test/customerBookingPendingApproval.test.js
@@ -1,0 +1,135 @@
+"use strict";
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+
+const {
+  JOB_STATUS,
+  isPendingCustomerScheduledReservation,
+  pendingCustomerScheduledReservationSql,
+} = require("../server/services/booking/bookingStatuses");
+const { registerPublicCustomerAvailabilityRoutes } = require("../server/routes/public/customerAvailability");
+const { registerAdminAvailabilityRoutes } = require("../server/routes/admin/adminAvailability");
+const { registerBookingApprovalRoutes } = require("../server/routes/admin/bookingApprovals");
+
+const ROOT = path.resolve(__dirname, "..");
+const read = (file) => fs.readFileSync(path.join(ROOT, file), "utf8");
+
+function responseHarness() {
+  return {
+    statusCode: 200,
+    body: null,
+    headers: {},
+    set(name, value) { this.headers[name] = value; return this; },
+    status(code) { this.statusCode = code; return this; },
+    json(body) { this.body = body; return body; },
+  };
+}
+
+test("pending reservation predicate is exact and does not hide approved/admin jobs", () => {
+  assert.equal(isPendingCustomerScheduledReservation({
+    job_source: "customer",
+    booking_mode: "scheduled",
+    job_status: JOB_STATUS.CUSTOMER_SCHEDULED_REVIEW,
+  }), true);
+  for (const row of [
+    { job_source: "admin", booking_mode: "scheduled", job_status: JOB_STATUS.CUSTOMER_SCHEDULED_REVIEW },
+    { job_source: "customer", booking_mode: "urgent", job_status: JOB_STATUS.CUSTOMER_SCHEDULED_REVIEW },
+    { job_source: "customer", booking_mode: "scheduled", job_status: JOB_STATUS.ADMIN_SCHEDULED_PENDING },
+  ]) assert.equal(isPendingCustomerScheduledReservation(row), false);
+  assert.equal(
+    pendingCustomerScheduledReservationSql("j"),
+    `(j.job_source='customer' AND j.booking_mode='scheduled' AND j.job_status='${JOB_STATUS.CUSTOMER_SCHEDULED_REVIEW}')`
+  );
+});
+
+test("public forced availability is rejected before availability calculation", async () => {
+  const registrations = [];
+  const app = { get(route, ...handlers) { registrations.push({ route, handlers }); } };
+  let engineCalls = 0;
+  registerPublicCustomerAvailabilityRoutes(app, {
+    engine: {
+      computeForcedAvailability: async () => { engineCalls += 1; return {}; },
+      computePublicCustomerSlots: async () => { engineCalls += 1; return {}; },
+    },
+    getDependencies: () => ({}),
+    getBangkokTodayYMD: () => "2026-07-19",
+  });
+  const route = registrations.find((entry) => entry.route === "/public/availability_v2");
+  const res = responseHarness();
+  await route.handlers.at(-1)({ query: { forced: "1" } }, res);
+  assert.equal(res.statusCode, 403);
+  assert.equal(res.body.code, "FORCED_AVAILABILITY_ADMIN_ONLY");
+  assert.equal(engineCalls, 0);
+});
+
+test("admin availability is session protected and aggregate keeps forced parity", async () => {
+  const registrations = [];
+  const app = { get(route, ...handlers) { registrations.push({ route, handlers }); } };
+  const requireAdminSession = function requireAdminSession() {};
+  const calls = [];
+  registerAdminAvailabilityRoutes(app, {
+    requireAdminSession,
+    getDependencies: () => ({ marker: true }),
+    engine: {
+      computeForcedAvailability: async (_deps, options) => { calls.push(["forced", options]); return { slots: [] }; },
+      computeAdminAvailabilityByTech: async (_deps, options) => { calls.push(["by-tech", options]); return { technicians: [] }; },
+    },
+  });
+  const route = registrations.find((entry) => entry.route === "/admin/availability_by_tech_v2");
+  assert.equal(route.handlers[0], requireAdminSession);
+  const res = responseHarness();
+  await route.handlers.at(-1)({ query: { aggregate: "1", forced: "1", date: "2026-08-01" } }, res);
+  assert.equal(res.statusCode, 200);
+  assert.equal(calls[0][0], "forced");
+  assert.equal(calls[0][1].include_paused, true);
+});
+
+test("approval routes use existing admin middleware", () => {
+  const registrations = [];
+  const app = { post(route, ...handlers) { registrations.push({ route, handlers }); } };
+  const requireAdminSession = function requireAdminSession() {};
+  const service = { approve() {}, reject() {} };
+  registerBookingApprovalRoutes(app, { service, requireAdminSession });
+  assert.deepEqual(registrations.map((entry) => entry.route), [
+    "/admin/customer-bookings/:job_id/approve",
+    "/admin/customer-bookings/:job_id/reject",
+  ]);
+  assert.ok(registrations.every((entry) => entry.handlers[0] === requireAdminSession));
+});
+
+test("technician visibility, ownership, and all audited mutation paths enforce pending isolation", () => {
+  const index = read("index.js");
+  assert.match(index, /j\.technician_username = \$2 AND NOT \$\{pendingCustomerScheduledReservationSql\("j"\)\}/);
+  assert.match(index, /j\.technician_username = ANY\(\$\{aliasParam\}::text\[\]\) AND NOT \$\{pendingCustomerScheduledReservationSql\("j"\)\}/);
+
+  const guardedRoutes = ["travel-start", "checkin", "units/:unit_id/checklist", "finalize", "assignment-done"];
+  for (const route of guardedRoutes) assert.match(index, new RegExp(route.replace(/[/:]/g, "\\$&")));
+  const checklist = index.slice(index.indexOf('app.put("/jobs/:job_id/units/:unit_id/checklist"'), index.indexOf("async function mediaRetentionRows"));
+  assert.ok(checklist.indexOf("assertJobActionableForTechnician") < checklist.indexOf("INSERT INTO public.job_unit_checklists"));
+  const assignmentDone = index.slice(index.indexOf('app.post("/jobs/:job_id/assignment-done"'), index.indexOf("async function expireTechnicianAcceptStatuses"));
+  assert.ok(assignmentDone.indexOf("assertJobActionableForTechnician") < assignmentDone.indexOf("INSERT INTO public.job_assignments"));
+
+  for (const route of ["photos/meta", "photos/:photo_id/upload"]) {
+    const start = index.indexOf(route);
+    const section = index.slice(start, start + 5000);
+    assert.match(section, /assertJobActionableForTechnician/);
+  }
+});
+
+test("Admin Add and Queue no longer call public forced availability", () => {
+  for (const file of ["admin-add-v2.js", "admin-queue-v2.js"]) {
+    const source = read(file);
+    assert.doesNotMatch(source, /public\/availability_v2[^\n]*forced=1/);
+    assert.match(source, /admin\/availability_by_tech_v2/);
+  }
+});
+
+test("changed Admin booking scripts have one shared cache-bust build", () => {
+  const build = "20260719_customer_booking_pr3_v1";
+  for (const page of ["admin-add-v2", "admin-queue-v2", "admin-review-v2"]) {
+    assert.match(read(`${page}.html`), new RegExp(`${page}\\.js\\?v=${build}`));
+  }
+});

--- a/test/jobLocationRoundtrip.test.js
+++ b/test/jobLocationRoundtrip.test.js
@@ -216,13 +216,14 @@ test("Test 14: check-in 500 m + accuracy policy is unchanged", () => {
 
 test("Test 15: PWA + admin cache build IDs are bumped consistently", () => {
   const BUILD = "20260712_job_location_roundtrip_v1";
+  const PR3_ADMIN_BUILD = "20260719_customer_booking_pr3_v1";
   assert.match(read("app.js"), new RegExp(`__CWF_TECH_APP_VERSION__ = "${BUILD}"`));
   assert.match(read("sw.js"), new RegExp(`CWF_TECH_BUILD_ID = "${BUILD}"`));
   assert.match(read("cwf-pwa.js"), new RegExp(`VERSION = '${BUILD}'`));
   assert.match(read("tech.html"), new RegExp(`app\\.js\\?v=${BUILD}`));
-  assert.match(read("admin-add-v2.html"), new RegExp(`admin-add-v2\\.js\\?v=${BUILD}`));
+  assert.match(read("admin-add-v2.html"), new RegExp(`admin-add-v2\\.js\\?v=${PR3_ADMIN_BUILD}`));
   assert.match(read("admin-job-view-v2.html"), new RegExp(`admin-job-view-v2\\.js\\?v=${BUILD}`));
-  assert.match(read("admin-review-v2.html"), new RegExp(`admin-review-v2\\.js\\?v=${BUILD}`));
+  assert.match(read("admin-review-v2.html"), new RegExp(`admin-review-v2\\.js\\?v=${PR3_ADMIN_BUILD}`));
 });
 
 // ---------------------------------------------------------------------------

--- a/test/urgentProductionHotfix.test.js
+++ b/test/urgentProductionHotfix.test.js
@@ -40,14 +40,16 @@ test("customer urgent zero-target commits job/items into admin review without ch
   assert.match(response, /admin_review: true/);
 });
 
-test("public urgent route remains adapter-only and public urgent status is read-only", () => {
+test("public urgent adapter sanitizes into pending-review creation and public urgent status is read-only", () => {
   const index = read("index.js");
   const service = read("server/services/booking/createBookingJob.js");
   const publicAdapter = section(service, "function handlePublicCustomerUrgentBook", "async function handlePublicBook");
   assert.match(publicAdapter, /req\.cwfBookSource = "customer"/);
   assert.match(publicAdapter, /booking_mode: "urgent"/);
   assert.match(publicAdapter, /dispatch_mode: "offer"/);
-  assert.match(publicAdapter, /return handleAdminBookV2\(req, res\)/);
+  assert.match(publicAdapter, /req\.cwfPublicUrgentPrepared = true/);
+  assert.match(publicAdapter, /return handlePublicBook\(req, res\)/);
+  assert.doesNotMatch(publicAdapter, /return handleAdminBookV2\(req, res\)/);
 
   const statusRoute = section(index, "app.get(\"/public/urgent-status\"", "app.get(\"/public/track\"");
   assert.doesNotMatch(statusRoute, /\bUPDATE\b|\bINSERT\b|\bDELETE\b/i);


### PR DESCRIPTION
Refs #187

## Base / head

- Base: `7cd5cca50a25cf93c551dfe45b059bd12c0cc8ef`
- Head: `d4f541aa0a430150b70efb8c54d3822de29c34e7`
- Branch: `codex/customer-booking-pr3-pending-approval`

## Root cause

Pending scheduled customer reservations deliberately use `jobs.technician_username` to reserve capacity before admin approval, but the technician read/ownership paths historically treated that column as an approved assignment. The checklist route and a few other technician mutations also lacked a consistent actionable-status check. Separately, forced availability still had a public entry point and customer urgent creation could enter assignment/offer side effects before admin review.

## Reservation contract

The hidden reservation predicate is exact:

```text
job_source = 'customer'
AND booking_mode = 'scheduled'
AND job_status = 'รอตรวจสอบ'
```

A scheduled customer request reserves one eligible technician in `jobs.technician_username`, creates all job items, and creates zero assignment/team rows, income previews, or technician notifications. Public responses do not expose technician identity.

Urgent customer requests are cleaning-only, remain pending with `technician_username = NULL`, and create zero assignment/team/offer/income/notification side effects until approval.

## Implementation summary

- Added a shared exact pending-reservation predicate for JavaScript and SQL consumers.
- Excluded pending reservations from `GET /jobs/tech/:username` and direct-column technician ownership while preserving approved assignment ownership.
- Enforced the existing actionable-status guard before checklist and all proven unguarded technician mutations.
- Added transactional approval/rejection service and authenticated admin routes.
  - Approval locks the pending job `FOR UPDATE`.
  - Scheduled approval revalidates the reserved technician through the shared availability engine while ignoring the current job; it safely reassigns if needed.
  - It creates/upserts exactly one `in_progress` assignment and transitions to the existing approved scheduled status.
  - Commit happens before income refresh and technician notification.
  - Approval replay does not duplicate assignment or notification.
  - Rejection preserves audit history, cancels the job, clears the reservation, and returns capacity.
- Added authenticated admin forced availability and rejected `/public/availability_v2?forced=1`.
- Migrated Admin Auto/Single/Team/Forced consumers to the authenticated admin availability route.
- Kept Admin Review Queue inclusion, availability/capacity/collision reservation behavior, and existing approved/admin job behavior.
- No migration, schema change, `app.js` change, Technician UI redesign, or production action.

## Technician mutation audit

Audited every backend technician mutation using technician ownership:

- travel start — ownership + actionable guard already present
- check-in — ownership + actionable guard already present
- unit checklist — fixed: actionable guard now runs before any write
- photo metadata — guard already present; fixed status propagation
- photo upload — guard already present; fixed status propagation
- unit load endpoint with write side effect — fixed: actionable guard added
- technician note — actionable guard already present
- finalize — ownership + actionable guard already present
- assignment done — fixed: shared ownership and actionable guard
- status update — fixed: actionable guard now applies to every target status before mutation

## Security considerations

- A pending reservation cannot be read through the technician job list, cannot grant ownership from `jobs.technician_username`, and cannot be mutated through technician routes.
- Admin availability and approval/rejection use existing admin-session middleware.
- Public forced availability fails closed.
- Public responses omit reserved technician identity.
- No auth redesign and no broader mutation/auth scope was introduced.

## Changed files

- `server/services/booking/bookingStatuses.js`
- `server/services/booking/bookingApprovalService.js`
- `server/services/booking/bookingJobUnits.js`
- `server/services/booking/createBookingJob.js`
- `server/services/booking/availabilityEngine.js`
- `server/services/public/customerScheduledAssignment.js`
- `server/routes/admin/bookingApprovals.js`
- `server/routes/admin/adminAvailability.js`
- `server/routes/public/customerAvailability.js`
- `index.js`
- `admin-add-v2.js`, `admin-queue-v2.js`, `admin-review-v2.js`
- corresponding admin HTML cache-version references
- focused booking/availability/mutation tests

## Validation

- `node --check` on all 19 changed/new JavaScript files: PASS
- Real isolated PostgreSQL focused mutation/approval suite:
  - `node --test test/customerBookingMutationCharacterization.test.js`
  - 23 tests, 23 passed, 0 failed, 0 skipped
- Additional focused suite:
  - `node --test test/customerBookingAdminNotifications.test.js test/customerBookingAvailabilityCharacterization.test.js test/customerBookingKillSwitch.test.js test/customerBookingPendingApproval.test.js test/urgentProductionHotfix.test.js test/jobLocationRoundtrip.test.js`
  - 80 tests, 76 passed, 0 failed, 4 skipped (PostgreSQL cases were covered in the isolated PostgreSQL run)
- Branch `npm test`: 1371 tests; 1297 passed, 21 failed, 53 skipped
- Untouched-base `npm test` with the same dependencies/environment: 1351 tests; 1289 passed, 21 failed, 41 skipped
- Exact failed-test-name sets: identical
- Branch-only failures: 0
- `git diff --check`: PASS
- Working tree: clean

## PostgreSQL proof covered

- pending reservation blocks availability/capacity/collision
- pending reservation remains in Admin Review Queue
- pending reservation is hidden from technician list and grants no ownership
- checklist and other technician mutations cannot write
- no income or technician notification before approval
- approval creates one assignment and makes the job visible
- approval replay does not duplicate assignment/notification
- invalid reservation safely reassigns; transactional rollback leaves no partial mutation
- reject releases the slot and preserves audit history
- approved/admin jobs retain existing behavior
- urgent cleaning has zero offers/assignments before approval
- urgent non-cleaning produces zero DB mutation
- public forced availability is blocked
- admin availability requires authentication
- Admin Auto/Single/Team/Forced parity is preserved

## P0 review blocker corrections

- **Scheduled real-engine approval**
  - New `bookingJobUnits` service writes canonical `ac_type`, variant, and BTU into existing `job_units` columns during the real booking creation transaction.
  - Approval reconstructs ordered service lines from canonical `job_items`, preserving exact job type, AC type, wash/repair variant, BTU, and machine count; it verifies the corresponding unit metadata and fails closed on missing/malformed/drifted criteria.
  - Multi-service ordering and quantity are deterministic and no schema migration is required.
  - Isolated PostgreSQL proof creates three real units across two service lines, uses the real availability engine, real DB service matrix, and real monthly calendar, then approves successfully without mocking `reservePublicCustomerTechnician`.

- **Urgent idempotency**
  - The first stored server-generated appointment is authoritative for urgent replay.
  - Replays still compare every customer-controlled scalar and the canonical service-line signature.
  - A retry across different generated appointment times returns the original job; a changed customer note returns `409 IDEMPOTENCY_KEY_REUSED`.

- **Strict urgent cleaning-only**
  - Top-level `job_type` and every `services[]` line pass through one strict canonical cleaning allowlist.
  - Mixed Thai/English cleaning+repair labels, top-level/service conflicts, and any non-cleaning service line are rejected before pricing, transaction, or database mutation.
  - PostgreSQL zero-mutation coverage includes all four review cases.

## Production / migration actions

None. This PR must not be merged or deployed by Codex and requires no database migration.

## Remaining risks

- Income refresh and technician notification are intentionally post-commit, best-effort side effects. A provider failure can leave an approved job committed while the side effect needs operational retry; replay is protected from duplicating successful notification.
- The existing audit logger is retained as-is and remains best-effort.
