### PR TITLE
feat(booking): capture urgent preferred time and GPS

### DIFF
--- a/admin-review-v2.html
+++ b/admin-review-v2.html
@@ -115,6 +115,7 @@
           <input id="mAppt" type="datetime-local">
           <button class="btn btn-ghost" type="button" id="btnLoadSlots">⏱️ โหลดเวลาว่าง</button>
         </div>
+        <input id="mTimePreference" placeholder="เงื่อนไขเวลาที่ลูกค้าต้องการ" disabled>
         <div class="slotbox" id="slotBox" style="display:none"></div>
 
         <textarea id="mAddress" rows="2" placeholder="ที่อยู่"></textarea>
@@ -174,7 +175,7 @@
   </div>
 
   <script src="admin-v2-common.js?v=20260428_allpages_ui1"></script>
-  <script src="admin-review-v2.js?v=20260719_customer_booking_pr3_v1"></script>
+  <script src="admin-review-v2.js?v=20260726_urgent_preferred_time_gps_v1"></script>
   <script src="admin-review-ai-intake.js?v=ai-booking-intake-customer-cards-v11-admin-alert-gate"></script>
 </body>
 </html>

--- a/admin-review-v2.js
+++ b/admin-review-v2.js
@@ -113,7 +113,7 @@ function blockReadOnlyMutation(){
 function applyReadOnlyMode(readOnly){
   const ids = [
     "mCustomerName", "mCustomerPhone", "mJobType", "mAppt", "mAddress",
-    "mMaps", "mZone", "mNote", "mLat", "mLng", "mTechType",
+    "mMaps", "mZone", "mNote", "mLat", "mLng", "mTimePreference", "mTechType",
     "mPrimaryTech", "mDispatchMode", "mTeamSearch", "btnLoadSlots",
     "btnSave", "btnDispatch", "btnRebroadcast", "btnCancel",
   ];
@@ -740,6 +740,7 @@ async function openJob(jobId){
       job_type: full.job_type,
       duration_min: Number(full.duration_min||0) || 60,
       appointment_datetime: full.appointment_datetime,
+      allow_time_proposal: full.allow_time_proposal === true,
       customer_name: full.customer_name,
       customer_phone: full.customer_phone,
       address_text: full.address_text,
@@ -770,6 +771,9 @@ async function openJob(jobId){
     $("mJobType").value = text(CURRENT.job_type||"");
     $("mBookingCode").value = text(CURRENT.booking_code||"");
     $("mAppt").value = toLocalInputDatetime(CURRENT.appointment_datetime);
+    $("mTimePreference").value = CURRENT.allow_time_proposal
+      ? "เสนอเวลาใหม่ได้"
+      : "ต้องการตามเวลานี้";
     // Clear EVERY location field before populating so values from a previously
     // opened job can never leak into this one (esp. Lat/Lng, which were only set
     // conditionally and otherwise kept their stale value).

--- a/customer-app/assets/customer-app.js
+++ b/customer-app/assets/customer-app.js
@@ -3,7 +3,7 @@
 
   const App = window.CWFCustomerAppV2;
   const BOOT_TIMEOUT_MS = 3500;
-  const BUILD_ID = "20260720_customer_booking_postdeploy_hardening_v2";
+  const BUILD_ID = "20260726_urgent_preferred_time_gps_v1";
 
   function withTimeout(promise, timeoutMs) {
     return Promise.race([

--- a/customer-app/assets/customer-app.js
+++ b/customer-app/assets/customer-app.js
@@ -3,7 +3,7 @@
 
   const App = window.CWFCustomerAppV2;
   const BOOT_TIMEOUT_MS = 3500;
-  const BUILD_ID = "20260726_urgent_preferred_time_gps_v1";
+  const BUILD_ID = "20260726_urgent_preferred_time_gps_v2";
 
   function withTimeout(promise, timeoutMs) {
     return Promise.race([

--- a/customer-app/index.html
+++ b/customer-app/index.html
@@ -21,10 +21,10 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Noto+Sans+Thai:wght@400;500;600;700;800;900&display=swap" media="print" onload="this.media='all'">
   <noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Noto+Sans+Thai:wght@400;500;600;700;800;900&display=swap"></noscript>
-  <link rel="manifest" href="./manifest.webmanifest?v=20260720_customer_booking_postdeploy_hardening_v2">
+  <link rel="manifest" href="./manifest.webmanifest?v=20260726_urgent_preferred_time_gps_v1">
   <link rel="icon" type="image/png" sizes="192x192" href="./assets/icons/cwf-customer-192.png">
   <link rel="apple-touch-icon" sizes="180x180" href="./assets/icons/cwf-customer-180.png">
-  <link rel="stylesheet" href="./assets/customer-app.css?v=20260720_customer_booking_postdeploy_hardening_v2">
+  <link rel="stylesheet" href="./assets/customer-app.css?v=20260726_urgent_preferred_time_gps_v1">
 </head>
 <body class="is-app-booting">
   <div class="app-shell" data-app-shell>
@@ -62,25 +62,25 @@
     </nav>
   </div>
 
-  <script src="./modules/iconRegistry.js?v=20260720_customer_booking_postdeploy_hardening_v2"></script>
-  <script src="./modules/state.js?v=20260720_customer_booking_postdeploy_hardening_v2"></script>
-  <script src="./modules/utils.js?v=20260720_customer_booking_postdeploy_hardening_v2"></script>
-  <script src="./modules/customerCopy.js?v=20260720_customer_booking_postdeploy_hardening_v2"></script>
-  <script src="./modules/analytics.js?v=20260720_customer_booking_postdeploy_hardening_v2"></script>
-  <script src="./modules/api.js?v=20260720_customer_booking_postdeploy_hardening_v2"></script>
-  <script src="./modules/pageAvailability.js?v=20260720_customer_booking_postdeploy_hardening_v2"></script>
-  <script src="./modules/services.js?v=20260720_customer_booking_postdeploy_hardening_v2"></script>
-  <script src="./modules/advisor.js?v=20260720_customer_booking_postdeploy_hardening_v2"></script>
-  <script src="./modules/ui.js?v=20260720_customer_booking_postdeploy_hardening_v2"></script>
-  <script src="./modules/store.js?v=20260720_customer_booking_postdeploy_hardening_v2"></script>
-  <script src="./modules/auth.js?v=20260720_customer_booking_postdeploy_hardening_v2"></script>
-  <script src="./modules/pricing.js?v=20260720_customer_booking_postdeploy_hardening_v2"></script>
-  <script src="./modules/availability.js?v=20260720_customer_booking_postdeploy_hardening_v2"></script>
-  <script src="./modules/bookingScheduled.js?v=20260720_customer_booking_postdeploy_hardening_v2"></script>
-  <script src="./modules/bookingUrgent.js?v=20260720_customer_booking_postdeploy_hardening_v2"></script>
-  <script src="./modules/tracking.js?v=20260720_customer_booking_postdeploy_hardening_v2"></script>
-  <script src="./modules/profile.js?v=20260720_customer_booking_postdeploy_hardening_v2"></script>
-  <script src="./modules/router.js?v=20260720_customer_booking_postdeploy_hardening_v2"></script>
-  <script src="./assets/customer-app.js?v=20260720_customer_booking_postdeploy_hardening_v2"></script>
+  <script src="./modules/iconRegistry.js?v=20260726_urgent_preferred_time_gps_v1"></script>
+  <script src="./modules/state.js?v=20260726_urgent_preferred_time_gps_v1"></script>
+  <script src="./modules/utils.js?v=20260726_urgent_preferred_time_gps_v1"></script>
+  <script src="./modules/customerCopy.js?v=20260726_urgent_preferred_time_gps_v1"></script>
+  <script src="./modules/analytics.js?v=20260726_urgent_preferred_time_gps_v1"></script>
+  <script src="./modules/api.js?v=20260726_urgent_preferred_time_gps_v1"></script>
+  <script src="./modules/pageAvailability.js?v=20260726_urgent_preferred_time_gps_v1"></script>
+  <script src="./modules/services.js?v=20260726_urgent_preferred_time_gps_v1"></script>
+  <script src="./modules/advisor.js?v=20260726_urgent_preferred_time_gps_v1"></script>
+  <script src="./modules/ui.js?v=20260726_urgent_preferred_time_gps_v1"></script>
+  <script src="./modules/store.js?v=20260726_urgent_preferred_time_gps_v1"></script>
+  <script src="./modules/auth.js?v=20260726_urgent_preferred_time_gps_v1"></script>
+  <script src="./modules/pricing.js?v=20260726_urgent_preferred_time_gps_v1"></script>
+  <script src="./modules/availability.js?v=20260726_urgent_preferred_time_gps_v1"></script>
+  <script src="./modules/bookingScheduled.js?v=20260726_urgent_preferred_time_gps_v1"></script>
+  <script src="./modules/bookingUrgent.js?v=20260726_urgent_preferred_time_gps_v1"></script>
+  <script src="./modules/tracking.js?v=20260726_urgent_preferred_time_gps_v1"></script>
+  <script src="./modules/profile.js?v=20260726_urgent_preferred_time_gps_v1"></script>
+  <script src="./modules/router.js?v=20260726_urgent_preferred_time_gps_v1"></script>
+  <script src="./assets/customer-app.js?v=20260726_urgent_preferred_time_gps_v1"></script>
 </body>
 </html>

--- a/customer-app/index.html
+++ b/customer-app/index.html
@@ -21,10 +21,10 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Noto+Sans+Thai:wght@400;500;600;700;800;900&display=swap" media="print" onload="this.media='all'">
   <noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Noto+Sans+Thai:wght@400;500;600;700;800;900&display=swap"></noscript>
-  <link rel="manifest" href="./manifest.webmanifest?v=20260726_urgent_preferred_time_gps_v1">
+  <link rel="manifest" href="./manifest.webmanifest?v=20260726_urgent_preferred_time_gps_v2">
   <link rel="icon" type="image/png" sizes="192x192" href="./assets/icons/cwf-customer-192.png">
   <link rel="apple-touch-icon" sizes="180x180" href="./assets/icons/cwf-customer-180.png">
-  <link rel="stylesheet" href="./assets/customer-app.css?v=20260726_urgent_preferred_time_gps_v1">
+  <link rel="stylesheet" href="./assets/customer-app.css?v=20260726_urgent_preferred_time_gps_v2">
 </head>
 <body class="is-app-booting">
   <div class="app-shell" data-app-shell>
@@ -62,25 +62,25 @@
     </nav>
   </div>
 
-  <script src="./modules/iconRegistry.js?v=20260726_urgent_preferred_time_gps_v1"></script>
-  <script src="./modules/state.js?v=20260726_urgent_preferred_time_gps_v1"></script>
-  <script src="./modules/utils.js?v=20260726_urgent_preferred_time_gps_v1"></script>
-  <script src="./modules/customerCopy.js?v=20260726_urgent_preferred_time_gps_v1"></script>
-  <script src="./modules/analytics.js?v=20260726_urgent_preferred_time_gps_v1"></script>
-  <script src="./modules/api.js?v=20260726_urgent_preferred_time_gps_v1"></script>
-  <script src="./modules/pageAvailability.js?v=20260726_urgent_preferred_time_gps_v1"></script>
-  <script src="./modules/services.js?v=20260726_urgent_preferred_time_gps_v1"></script>
-  <script src="./modules/advisor.js?v=20260726_urgent_preferred_time_gps_v1"></script>
-  <script src="./modules/ui.js?v=20260726_urgent_preferred_time_gps_v1"></script>
-  <script src="./modules/store.js?v=20260726_urgent_preferred_time_gps_v1"></script>
-  <script src="./modules/auth.js?v=20260726_urgent_preferred_time_gps_v1"></script>
-  <script src="./modules/pricing.js?v=20260726_urgent_preferred_time_gps_v1"></script>
-  <script src="./modules/availability.js?v=20260726_urgent_preferred_time_gps_v1"></script>
-  <script src="./modules/bookingScheduled.js?v=20260726_urgent_preferred_time_gps_v1"></script>
-  <script src="./modules/bookingUrgent.js?v=20260726_urgent_preferred_time_gps_v1"></script>
-  <script src="./modules/tracking.js?v=20260726_urgent_preferred_time_gps_v1"></script>
-  <script src="./modules/profile.js?v=20260726_urgent_preferred_time_gps_v1"></script>
-  <script src="./modules/router.js?v=20260726_urgent_preferred_time_gps_v1"></script>
-  <script src="./assets/customer-app.js?v=20260726_urgent_preferred_time_gps_v1"></script>
+  <script src="./modules/iconRegistry.js?v=20260726_urgent_preferred_time_gps_v2"></script>
+  <script src="./modules/state.js?v=20260726_urgent_preferred_time_gps_v2"></script>
+  <script src="./modules/utils.js?v=20260726_urgent_preferred_time_gps_v2"></script>
+  <script src="./modules/customerCopy.js?v=20260726_urgent_preferred_time_gps_v2"></script>
+  <script src="./modules/analytics.js?v=20260726_urgent_preferred_time_gps_v2"></script>
+  <script src="./modules/api.js?v=20260726_urgent_preferred_time_gps_v2"></script>
+  <script src="./modules/pageAvailability.js?v=20260726_urgent_preferred_time_gps_v2"></script>
+  <script src="./modules/services.js?v=20260726_urgent_preferred_time_gps_v2"></script>
+  <script src="./modules/advisor.js?v=20260726_urgent_preferred_time_gps_v2"></script>
+  <script src="./modules/ui.js?v=20260726_urgent_preferred_time_gps_v2"></script>
+  <script src="./modules/store.js?v=20260726_urgent_preferred_time_gps_v2"></script>
+  <script src="./modules/auth.js?v=20260726_urgent_preferred_time_gps_v2"></script>
+  <script src="./modules/pricing.js?v=20260726_urgent_preferred_time_gps_v2"></script>
+  <script src="./modules/availability.js?v=20260726_urgent_preferred_time_gps_v2"></script>
+  <script src="./modules/bookingScheduled.js?v=20260726_urgent_preferred_time_gps_v2"></script>
+  <script src="./modules/bookingUrgent.js?v=20260726_urgent_preferred_time_gps_v2"></script>
+  <script src="./modules/tracking.js?v=20260726_urgent_preferred_time_gps_v2"></script>
+  <script src="./modules/profile.js?v=20260726_urgent_preferred_time_gps_v2"></script>
+  <script src="./modules/router.js?v=20260726_urgent_preferred_time_gps_v2"></script>
+  <script src="./assets/customer-app.js?v=20260726_urgent_preferred_time_gps_v2"></script>
 </body>
 </html>

--- a/customer-app/manifest.webmanifest
+++ b/customer-app/manifest.webmanifest
@@ -2,7 +2,7 @@
   "name": "CWF Customer Service",
   "short_name": "CWF Service",
   "description": "แอปลูกค้า Coldwindflow สำหรับเลือกบริการ จองคิว และติดตามงาน",
-  "start_url": "/customer-app/index.html?v=20260726_urgent_preferred_time_gps_v1#home",
+  "start_url": "/customer-app/index.html?v=20260726_urgent_preferred_time_gps_v2#home",
   "scope": "/customer-app/",
   "id": "/customer-app/",
   "display": "standalone",

--- a/customer-app/manifest.webmanifest
+++ b/customer-app/manifest.webmanifest
@@ -2,7 +2,7 @@
   "name": "CWF Customer Service",
   "short_name": "CWF Service",
   "description": "แอปลูกค้า Coldwindflow สำหรับเลือกบริการ จองคิว และติดตามงาน",
-  "start_url": "/customer-app/index.html?v=20260720_customer_booking_postdeploy_hardening_v2#home",
+  "start_url": "/customer-app/index.html?v=20260726_urgent_preferred_time_gps_v1#home",
   "scope": "/customer-app/",
   "id": "/customer-app/",
   "display": "standalone",

--- a/customer-app/modules/api.js
+++ b/customer-app/modules/api.js
@@ -211,7 +211,9 @@
         })),
       };
       delete body.dispatch_mode;
-      delete body.allow_time_proposal;
+      delete body.assign_mode;
+      delete body.technician_username;
+      delete body.team_members;
       return requestJson("/public/book", {
         method: "POST",
         body,

--- a/customer-app/modules/bookingUrgent.js
+++ b/customer-app/modules/bookingUrgent.js
@@ -7,6 +7,7 @@
   let pollTimer = null;
   let pollInFlight = null;
   let pollEpoch = 0;
+  let pricingEpoch = 0;
   let activeContainer = null;
   let visibilityRefresh = null;
 
@@ -14,37 +15,57 @@
     return root.state.draft.urgent || {};
   }
 
-  function canonicalCleaningPatch(input) {
-    const source = input || {};
-    const acOptions = root.services.bookableAcTypes || [];
-    const btuOptions = root.services.bookableBtuOptions || [];
-    const ac = acOptions.find((item) => item.value === source.ac_type) || acOptions[0];
-    const btu = btuOptions.find((item) => Number(item.btu) === Number(source.btu)) || btuOptions.find((item) => Number(item.btu) === 12000) || btuOptions[0];
-    const count = Math.max(1, Math.min(10, Number(source.machine_count || 1)));
-    const wallAc = root.services.WALL_AC;
-    const washOptions = root.services.washVariants || [];
-    const wash = washOptions.find((item) => item.value === source.wash_variant) || washOptions[0];
-    return {
-      service_kind: "clean",
+  function canonicalCleaningLine(input) {
+    const line = root.services.normalizeServiceLine(input || {});
+    return root.services.createServiceLine({
+      line_id: line.line_id,
       job_type: "ล้าง",
-      ac_type: ac?.value || wallAc || "ผนัง",
-      btu: String(btu?.btu || 12000),
-      machine_count: count,
-      wash_variant: (ac?.value || wallAc) === wallAc ? (wash?.value || "ล้างธรรมดา") : "",
-      repair_variant: "",
-    };
+      ac_type: line.ac_type,
+      btu: line.btu,
+      machine_count: line.machine_count,
+      wash_variant: line.wash_variant,
+    });
   }
 
   function sanitizeUrgentDraft() {
     const current = draft();
-    const patch = canonicalCleaningPatch(current);
-    const changed = Object.entries(patch).some(([key, value]) => String(current[key] ?? "") !== String(value));
-    if (changed) root.state.updateDraft("urgent", patch);
+    const sourceLines = Array.isArray(current.services) && current.services.length
+      ? current.services
+      : [current];
+    const lines = sourceLines.slice(0, 10).map(canonicalCleaningLine);
+    const first = lines[0] || canonicalCleaningLine({});
+    const patch = {
+      service_kind: "clean",
+      job_type: "ล้าง",
+      ac_type: first.ac_type,
+      btu: String(first.btu),
+      machine_count: first.machine_count,
+      wash_variant: first.wash_variant || "",
+      repair_variant: "",
+      services: lines,
+      allow_time_proposal: current.allow_time_proposal === true,
+    };
+    const scalarChanged = Object.entries(patch)
+      .filter(([key]) => key !== "services")
+      .some(([key, value]) => String(current[key] ?? "") !== String(value));
+    const linesChanged = JSON.stringify(root.services.normalizeServiceLines(current).map((line) => ({
+      line_id: line.line_id,
+      job_type: line.job_type,
+      ac_type: line.ac_type,
+      btu: line.btu,
+      machine_count: line.machine_count,
+      wash_variant: line.wash_variant,
+    }))) !== JSON.stringify(lines);
+    if (scalarChanged || linesChanged) root.state.updateDraft("urgent", patch);
     return { ...current, ...patch };
   }
 
-  function service() {
-    return root.services.normalizeServiceDraft({ ...sanitizeUrgentDraft(), services: [] });
+  function services() {
+    return root.services.normalizeServiceLines(sanitizeUrgentDraft());
+  }
+
+  function servicePayload() {
+    return root.services.payloadFromServiceLines(services());
   }
 
   function setStep(step, error) {
@@ -52,7 +73,7 @@
   }
 
   function serviceSummary() {
-    return root.services.serviceLabel(service());
+    return services().map((line) => root.services.serviceLabel(line)).join(" • ");
   }
 
   function ensureRequestKey() {
@@ -63,20 +84,27 @@
     return key;
   }
 
+  function appointmentDatetime() {
+    const d = draft();
+    if (!/^\d{4}-\d{2}-\d{2}$/.test(String(d.date || "")) || !/^\d{2}:\d{2}$/.test(String(d.time || ""))) return "";
+    return `${d.date}T${d.time}:00+07:00`;
+  }
+
   function buildSubmitPayload() {
     const d = sanitizeUrgentDraft();
-    const s = service();
-    const cleaningLine = {
+    const payload = servicePayload() || {};
+    const cleaningLines = (Array.isArray(payload.services) ? payload.services : []).map((line) => ({
+      ...line,
       job_type: "ล้าง",
-      ac_type: s.ac_type,
-      btu: s.btu || 0,
-      machine_count: s.machine_count || 1,
-      wash_variant: s.wash_variant || "",
       repair_variant: "",
-    };
+    }));
+    const latitude = Number(d.gps_latitude);
+    const longitude = Number(d.gps_longitude);
+    const hasGps = Number.isFinite(latitude) && Number.isFinite(longitude);
     return {
       customer_name: String(d.customer_name || "").trim(),
       customer_phone: String(d.customer_phone || "").trim(),
+      appointment_datetime: appointmentDatetime(),
       address_text: String(d.address_text || "").trim(),
       maps_url: String(d.maps_url || "").trim(),
       job_zone: String(d.job_zone || "").trim(),
@@ -84,70 +112,378 @@
       booking_mode: "urgent",
       client_app: "customer_app_v2",
       urgent_request_key: ensureRequestKey(),
-      job_type: "ล้าง",
-      ac_type: cleaningLine.ac_type,
-      btu: cleaningLine.btu,
-      machine_count: cleaningLine.machine_count,
-      wash_variant: cleaningLine.wash_variant,
-      repair_variant: "",
-      services: [cleaningLine],
+      allow_time_proposal: d.allow_time_proposal === true,
+      ...(hasGps ? { gps_latitude: latitude, gps_longitude: longitude } : {}),
+      ...payload,
+      services: cleaningLines,
     };
   }
 
-  function renderChoiceGroup(field, options, selected, extraClass) {
+  function markPayloadChanged() {
+    const flow = root.state.urgentFlow || {};
+    if (flow.submitAttempted && draft().urgent_request_key) {
+      root.state.updateDraft("urgent", { urgent_request_key: "" });
+      root.state.setUrgentFlow({ submitAttempted: false });
+    }
+  }
+
+  function choiceGroup(field, options, selected, className, lineId) {
+    return `<div class="choice-grid ${className || ""}">${options.map((option) => {
+      const active = String(selected || "") === String(option.value);
+      return `
+        <button class="choice-card ${active ? "is-selected" : ""}" type="button"
+          data-urgent-line-choice="${root.utils.escapeHtml(field)}"
+          data-urgent-choice="${root.utils.escapeHtml(field)}"
+          data-line-id="${root.utils.escapeHtml(lineId || "")}"
+          data-choice-value="${root.utils.escapeHtml(option.value)}"
+          aria-pressed="${active ? "true" : "false"}">
+          <strong>${root.utils.escapeHtml(option.label)}</strong>
+          ${option.copy ? `<span>${root.utils.escapeHtml(option.copy)}</span>` : ""}
+        </button>
+      `;
+    }).join("")}</div>`;
+  }
+
+  function priceData() {
+    return root.state.urgentFlow?.pricing?.data || null;
+  }
+
+  function finalPrice() {
+    const data = priceData();
+    if (!data) return null;
+    if (data.promo && data.promo.total_after_discount != null) return Number(data.promo.total_after_discount);
+    return Number(data.active_price || data.standard_price || 0);
+  }
+
+  function priceLineFor(index) {
+    const lines = Array.isArray(priceData()?.price_lines) ? priceData().price_lines : [];
+    return lines[index] || null;
+  }
+
+  function renderServiceLineCard(line, index) {
+    const s = root.services.normalizeServiceLine(line);
+    const summary = root.services.serviceLineSummary(s, index);
+    const canRemove = services().length > 1;
     return `
-      <div class="choice-grid ${extraClass || ""}">
-        ${options.map((option) => {
-          const active = String(selected || "") === String(option.value);
+      <article class="service-line-card" data-service-line-card="${root.utils.escapeHtml(s.line_id)}">
+        <div class="service-line-head">
+          <div>
+            <span class="section-kicker">${root.utils.escapeHtml(summary.title)}</span>
+            <strong>${root.utils.escapeHtml(summary.line1)}</strong>
+            <small>${root.utils.escapeHtml(summary.line2)}</small>
+          </div>
+          <button type="button" class="text-btn danger-text" data-urgent-action="remove-line" data-line-id="${root.utils.escapeHtml(s.line_id)}" ${canRemove ? "" : "disabled"}>ลบ</button>
+        </div>
+        <div class="field field-wide">
+          <label>ชนิดแอร์</label>
+          ${choiceGroup("ac_type", root.services.bookableAcTypes, s.ac_type, "ac-type-grid", s.line_id)}
+        </div>
+        ${s.ac_type === root.services.WALL_AC ? `
+          <div class="field field-wide">
+            <label>วิธีล้าง</label>
+            ${choiceGroup("wash_variant", root.services.washVariants, s.wash_variant, "wash-variant-grid", s.line_id)}
+          </div>
+        ` : ""}
+        <div class="field field-wide">
+          <label>BTU</label>
+          ${choiceGroup("btu", root.services.bookableBtuOptions, s.btu, "btu-choice-grid", s.line_id)}
+        </div>
+        <div class="field">
+          <label for="urgent-line-count-${root.utils.escapeHtml(s.line_id)}">จำนวนเครื่อง</label>
+          <select id="urgent-line-count-${root.utils.escapeHtml(s.line_id)}" class="select" data-urgent-line-field="machine_count" data-line-id="${root.utils.escapeHtml(s.line_id)}">
+            ${root.services.machineCounts.map((count) => `<option value="${count}" ${Number(s.machine_count) === count ? "selected" : ""}>${count} เครื่อง</option>`).join("")}
+          </select>
+        </div>
+      </article>
+    `;
+  }
+
+  function renderPricingSummary() {
+    const pricing = root.state.urgentFlow?.pricing || { status: "idle", data: null, error: "" };
+    if (pricing.status === "loading") return root.utils.stateBox("loading", "กำลังคำนวณราคาและเวลาทำงาน...");
+    if (pricing.status === "error") return root.utils.stateBox("error", pricing.error || "คำนวณราคาไม่สำเร็จ กรุณาลองอีกครั้ง");
+    if (!pricing.data) return root.utils.stateBox("", "ระบบจะคำนวณราคาจากรายการที่เลือก");
+    return `
+      <div class="wizard-price-summary">
+        <div><span>ราคารวมประมาณการ</span><strong>${root.utils.formatBaht(finalPrice())}</strong></div>
+        <div><span>เวลาทำงานรวม</span><strong>${root.utils.escapeHtml(pricing.data.duration_min || "-")} นาที</strong></div>
+        ${pricing.data.promo ? `<small>ใช้โปรโมชัน: ${root.utils.escapeHtml(pricing.data.promo.promo_name || "โปรโมชันปัจจุบัน")}</small>` : ""}
+      </div>
+    `;
+  }
+
+  function renderServiceReviewList() {
+    return `
+      <div class="service-line-review-list">
+        ${services().map((line, index) => {
+          const summary = root.services.serviceLineSummary(line, index);
+          const priceLine = priceLineFor(index);
+          const linePrice = priceLine && (priceLine.line_total != null || priceLine.total != null)
+            ? root.utils.formatBaht(priceLine.line_total ?? priceLine.total)
+            : "-";
           return `
-            <button class="choice-card ${active ? "is-selected" : ""}" type="button" data-urgent-choice="${field}" data-choice-value="${root.utils.escapeHtml(option.value)}" aria-pressed="${active ? "true" : "false"}">
-              <strong>${root.utils.escapeHtml(option.label)}</strong>
-              ${option.copy ? `<span>${root.utils.escapeHtml(option.copy)}</span>` : ""}
-            </button>
+            <div class="service-summary-box">
+              <span>${root.utils.escapeHtml(summary.title)}</span>
+              <strong>${root.utils.escapeHtml(summary.line1)}</strong>
+              <small>${root.utils.escapeHtml(summary.line2)} · ${root.utils.escapeHtml(linePrice)}</small>
+            </div>
           `;
         }).join("")}
       </div>
     `;
   }
 
-  function renderServiceFields() {
-    const d = draft();
-    const s = service();
+  function renderServicesStep() {
+    const error = root.state.urgentFlow.error;
     return `
-      <div class="field field-wide">
-        <label>ชนิดแอร์</label>
-        ${renderChoiceGroup("ac_type", root.services.bookableAcTypes, s.ac_type, "ac-type-grid")}
-      </div>
-      ${s.ac_type === root.services.WALL_AC ? `
-        <div class="field field-wide">
-          <label>รูปแบบการล้างสำหรับแอร์ผนัง</label>
-          ${renderChoiceGroup("wash_variant", root.services.washVariants, s.wash_variant || d.wash_variant, "wash-variant-grid")}
+      <section class="card form-card urgent-card-fx" data-urgent-step-panel="services">
+        <div class="section-head">
+          <span class="section-kicker">ขั้นตอน 1 จาก 3</span>
+          <h2>บริการและราคา</h2>
+          <p class="muted">เพิ่มรายการแยกตามชนิดแอร์ BTU จำนวน และวิธีล้าง</p>
         </div>
-      ` : ""}
-      <div class="field field-wide">
-        <label>BTU</label>
-        ${renderChoiceGroup("btu", root.services.bookableBtuOptions, d.btu, "btu-choice-grid")}
-      </div>
-      <div class="field">
-        <label for="urgent-count">จำนวนเครื่อง</label>
-        <select id="urgent-count" class="select" data-urgent-field="machine_count">
-          ${root.services.machineCounts.map((n) => `<option value="${n}" ${Number(s.machine_count) === n ? "selected" : ""}>${n} เครื่อง</option>`).join("")}
-        </select>
+        <div class="service-line-list">${services().map(renderServiceLineCard).join("")}</div>
+        <button type="button" class="secondary-btn" data-urgent-action="add-line">+ เพิ่มเครื่อง / เพิ่มรายการ</button>
+        <div class="slot-section-divider"></div>
+        ${renderServiceReviewList()}
+        ${renderPricingSummary()}
+      </section>
+      ${error ? `<div class="state-box is-error" role="alert">${root.utils.escapeHtml(error)}</div>` : ""}
+      <div class="button-row">
+        <button class="primary-btn btn-shine" type="button" data-urgent-action="to-details">กรอกข้อมูลหน้างาน</button>
       </div>
     `;
   }
 
-  function validate() {
+  function renderTimePreference() {
+    const flexible = draft().allow_time_proposal === true;
+    return `
+      <div class="choice-grid">
+        <button type="button" class="choice-card ${flexible ? "" : "is-selected"}" data-urgent-time-proposal="false" aria-pressed="${flexible ? "false" : "true"}">
+          <strong>ต้องการตามเวลาที่เลือก</strong>
+          <span>แอดมินจะตรวจสอบเวลานี้ก่อนยืนยัน</span>
+        </button>
+        <button type="button" class="choice-card ${flexible ? "is-selected" : ""}" data-urgent-time-proposal="true" aria-pressed="${flexible ? "true" : "false"}">
+          <strong>สามารถเสนอเวลาใหม่ให้ฉันได้</strong>
+          <span>แอดมินติดต่อกลับหากต้องปรับเวลา</span>
+        </button>
+      </div>
+    `;
+  }
+
+  function renderDetailsStep() {
     const d = sanitizeUrgentDraft();
-    const s = service();
+    const flow = root.state.urgentFlow || {};
+    return `
+      <section class="card form-card urgent-card-fx" data-urgent-step-panel="details">
+        <div class="section-head">
+          <span class="section-kicker">ขั้นตอน 2 จาก 3</span>
+          <h2>ข้อมูลหน้างานและเวลาที่ต้องการ</h2>
+        </div>
+        <div class="form-grid">
+          <div class="field">
+            <label for="urgent-name">ชื่อผู้ติดต่อ</label>
+            <input id="urgent-name" class="input" value="${root.utils.escapeHtml(d.customer_name || "")}" data-urgent-field="customer_name" autocomplete="name">
+          </div>
+          <div class="field">
+            <label for="urgent-phone">เบอร์โทร</label>
+            <input id="urgent-phone" class="input" value="${root.utils.escapeHtml(d.customer_phone || "")}" data-urgent-field="customer_phone" inputmode="tel" autocomplete="tel">
+          </div>
+          <div class="field">
+            <label for="urgent-date">วันที่ต้องการ</label>
+            <input id="urgent-date" class="input" type="date" value="${root.utils.escapeHtml(d.date || "")}" data-urgent-field="date">
+          </div>
+          <div class="field">
+            <label for="urgent-time">เวลาที่ต้องการ</label>
+            <input id="urgent-time" class="input" type="time" value="${root.utils.escapeHtml(d.time || "")}" data-urgent-field="time">
+          </div>
+          <div class="field field-wide">
+            <label>เงื่อนไขเวลา</label>
+            ${renderTimePreference()}
+          </div>
+          <div class="field field-wide">
+            <label for="urgent-address">ที่อยู่หน้างาน</label>
+            <textarea id="urgent-address" class="input textarea" data-urgent-field="address_text" rows="3">${root.utils.escapeHtml(d.address_text || "")}</textarea>
+          </div>
+          <div class="field field-wide">
+            <label for="urgent-maps">ลิงก์ Google Maps (ถ้ามี)</label>
+            <input id="urgent-maps" class="input" value="${root.utils.escapeHtml(d.maps_url || "")}" data-urgent-field="maps_url" inputmode="url">
+            <button class="secondary-btn" type="button" data-urgent-action="use-location" ${flow.locationStatus === "loading" ? "disabled" : ""}>
+              ${flow.locationStatus === "loading" ? "กำลังอ่านตำแหน่ง..." : "ใช้ตำแหน่งปัจจุบัน"}
+            </button>
+            ${flow.locationMessage ? `<small class="${flow.locationStatus === "success" ? "muted" : "danger-text"}" role="status">${root.utils.escapeHtml(flow.locationMessage)}</small>` : ""}
+          </div>
+          <div class="field">
+            <label for="urgent-zone">พื้นที่ / โซน (ถ้ามี)</label>
+            <input id="urgent-zone" class="input" value="${root.utils.escapeHtml(d.job_zone || "")}" data-urgent-field="job_zone">
+          </div>
+          <div class="field field-wide">
+            <label for="urgent-symptom">รายละเอียดเพิ่มเติม / หมายเหตุ (ไม่บังคับ)</label>
+            <textarea id="urgent-symptom" class="input textarea" data-urgent-field="symptom" rows="3">${root.utils.escapeHtml(d.symptom || "")}</textarea>
+          </div>
+        </div>
+      </section>
+      ${flow.error ? `<div class="state-box is-error" role="alert">${root.utils.escapeHtml(flow.error)}</div>` : ""}
+      <div class="button-row">
+        <button class="primary-btn btn-shine" type="button" data-urgent-action="to-review">ตรวจสอบรายละเอียด</button>
+        <button class="secondary-btn" type="button" data-urgent-action="back-services">กลับไปแก้บริการ</button>
+      </div>
+    `;
+  }
+
+  function formatAppointment() {
+    const d = draft();
+    if (!d.date || !d.time) return "-";
+    try {
+      return new Intl.DateTimeFormat("th-TH", {
+        timeZone: "Asia/Bangkok",
+        dateStyle: "medium",
+        timeStyle: "short",
+      }).format(new Date(`${d.date}T${d.time}:00+07:00`));
+    } catch (_) {
+      return `${d.date} ${d.time}`;
+    }
+  }
+
+  function timePreferenceLabel() {
+    return draft().allow_time_proposal === true
+      ? "สามารถเสนอเวลาใหม่ให้ฉันได้"
+      : "ต้องการตามเวลานี้";
+  }
+
+  function renderReview() {
+    const d = sanitizeUrgentDraft();
+    const flow = root.state.urgentFlow || {};
+    const submitting = flow.status === "submitting";
+    const hasGps = Number.isFinite(Number(d.gps_latitude)) && Number.isFinite(Number(d.gps_longitude));
+    return `
+      <section class="card review-card urgent-card-fx" data-urgent-step-panel="review">
+        <div class="section-head">
+          <span class="section-kicker">ขั้นตอน 3 จาก 3</span>
+          <h2>ตรวจสอบและส่งคำขอ</h2>
+        </div>
+        ${renderServiceReviewList()}
+        ${renderPricingSummary()}
+        <div class="data-list">
+          <div class="data-row"><strong>วันที่และเวลา</strong><span class="muted">${root.utils.escapeHtml(formatAppointment())}</span></div>
+          <div class="data-row"><strong>เงื่อนไขเวลา</strong><span class="muted">${root.utils.escapeHtml(timePreferenceLabel())}</span></div>
+          <div class="data-row"><strong>ผู้ติดต่อ</strong><span class="muted">${root.utils.escapeHtml(d.customer_name || "-")} / ${root.utils.escapeHtml(d.customer_phone || "-")}</span></div>
+          <div class="data-row"><strong>ที่อยู่</strong><span class="muted">${root.utils.escapeHtml(d.address_text || "-")}</span></div>
+          ${d.job_zone ? `<div class="data-row"><strong>พื้นที่</strong><span class="muted">${root.utils.escapeHtml(d.job_zone)}</span></div>` : ""}
+          ${d.maps_url ? `<div class="data-row"><strong>แผนที่</strong><span class="muted">${root.utils.escapeHtml(d.maps_url)}</span></div>` : ""}
+          ${hasGps ? `<div class="data-row"><strong>GPS</strong><span class="muted">${root.utils.escapeHtml(`${Number(d.gps_latitude)}, ${Number(d.gps_longitude)}`)}</span></div>` : ""}
+          ${String(d.symptom || "").trim() ? `<div class="data-row"><strong>หมายเหตุ</strong><span class="muted">${root.utils.escapeHtml(d.symptom)}</span></div>` : ""}
+        </div>
+        <div class="notice is-urgent">แอดมินจะตรวจสอบรายละเอียดก่อนส่งต่อให้ช่างที่ว่าง</div>
+        ${flow.error ? `<div class="state-box is-error" role="alert">${root.utils.escapeHtml(flow.error)}</div>` : ""}
+        <div class="button-row">
+          ${flow.disabled_line_url
+            ? `<a class="primary-btn line-fallback-btn" href="${ADMIN_LINE_URL}" target="_blank" rel="noopener noreferrer">ติดต่อแอดมินทาง LINE</a>`
+            : `<button class="primary-btn btn-shine" type="button" data-urgent-action="confirm" ${submitting ? "disabled" : ""}>${submitting ? "กำลังส่งคำขอ..." : "ส่งคำขอ"}</button>`}
+          <button class="secondary-btn" type="button" data-urgent-action="back-details" ${submitting ? "disabled" : ""}>กลับไปแก้ไข</button>
+        </div>
+      </section>
+    `;
+  }
+
+  function validateServices() {
+    if (!servicePayload() || !services().length) return "กรุณาเลือกข้อมูลบริการให้ครบ";
+    const pricing = root.state.urgentFlow?.pricing || {};
+    if (pricing.status === "loading") return "กรุณารอระบบคำนวณราคา";
+    if (pricing.status !== "success" || !pricing.data) return "กรุณาคำนวณราคาอีกครั้ง";
+    return "";
+  }
+
+  function validateDetails() {
+    const d = sanitizeUrgentDraft();
     const phoneDigits = String(d.customer_phone || "").replace(/\D/g, "");
     if (!String(d.customer_name || "").trim()) return "กรุณากรอกชื่อผู้ติดต่อ";
     if (phoneDigits.length < 9 || phoneDigits.length > 10) return "กรุณากรอกเบอร์โทร 9-10 หลัก";
     if (!String(d.address_text || "").trim()) return "กรุณากรอกที่อยู่หน้างาน";
-    if (!s.ac_type || !s.btu || s.machine_count < 1) return "กรุณาเลือกข้อมูลแอร์ให้ครบ";
-    if (s.ac_type === root.services.WALL_AC && !s.wash_variant) return "กรุณาเลือกรูปแบบการล้าง";
-    if (!String(d.symptom || "").trim()) return "กรุณากรอกรายละเอียดเพิ่มเติม";
+    if (!String(d.date || "").trim()) return "กรุณาเลือกวันที่ต้องการ";
+    if (!String(d.time || "").trim()) return "กรุณาเลือกเวลาที่ต้องการ";
+    const appointment = appointmentDatetime();
+    if (!appointment || Number.isNaN(new Date(appointment).getTime())) return "กรุณาเลือกวันที่และเวลาให้ถูกต้อง";
+    if (new Date(appointment).getTime() <= Date.now()) return "วันและเวลาที่เลือกย้อนหลังไม่ได้ กรุณาเลือกเวลาใหม่";
+    if (d.allow_time_proposal !== true && d.allow_time_proposal !== false) return "กรุณาเลือกเงื่อนไขเวลา";
+    const latProvided = d.gps_latitude !== undefined && d.gps_latitude !== null && String(d.gps_latitude).trim() !== "";
+    const lngProvided = d.gps_longitude !== undefined && d.gps_longitude !== null && String(d.gps_longitude).trim() !== "";
+    if (latProvided !== lngProvided) return "ข้อมูลตำแหน่งไม่ครบ กรุณากดใช้ตำแหน่งปัจจุบันอีกครั้ง";
+    if (latProvided) {
+      const lat = Number(d.gps_latitude);
+      const lng = Number(d.gps_longitude);
+      if (!Number.isFinite(lat) || !Number.isFinite(lng) || lat < -90 || lat > 90 || lng < -180 || lng > 180 || (lat === 0 && lng === 0)) {
+        return "ข้อมูลตำแหน่งไม่ถูกต้อง กรุณากดใช้ตำแหน่งปัจจุบันอีกครั้ง";
+      }
+    }
     return "";
+  }
+
+  async function refreshPricing(container) {
+    const payload = servicePayload();
+    if (!payload) return;
+    const requestEpoch = ++pricingEpoch;
+    root.state.setUrgentFlow({ pricing: { status: "loading", data: null, error: "" } });
+    if (container) paint(container);
+    try {
+      const data = await root.api.previewPricing(payload);
+      if (requestEpoch !== pricingEpoch || root.state.currentRoute !== "urgent") return;
+      root.state.setUrgentFlow({ pricing: { status: "success", data, error: "" } });
+    } catch (error) {
+      if (requestEpoch !== pricingEpoch || root.state.currentRoute !== "urgent") return;
+      root.state.setUrgentFlow({
+        pricing: { status: "error", data: null, error: root.customerCopy.bookingError(error) },
+      });
+    }
+    if (container && requestEpoch === pricingEpoch) paint(container);
+  }
+
+  function invalidatePricing() {
+    pricingEpoch += 1;
+    root.state.setUrgentFlow({ pricing: { status: "idle", data: null, error: "" }, error: "" });
+    markPayloadChanged();
+  }
+
+  function requestCurrentLocation() {
+    if (!navigator.geolocation || typeof navigator.geolocation.getCurrentPosition !== "function") {
+      root.state.setUrgentFlow({
+        locationStatus: "error",
+        locationMessage: "เบราว์เซอร์นี้ไม่รองรับการอ่านตำแหน่ง กรุณาวางลิงก์ Google Maps เอง",
+      });
+      return Promise.resolve(false);
+    }
+    root.state.setUrgentFlow({ locationStatus: "loading", locationMessage: "กำลังอ่านตำแหน่งปัจจุบัน..." });
+    return new Promise((resolve) => {
+      navigator.geolocation.getCurrentPosition(
+        (position) => {
+          const latitude = Number(position?.coords?.latitude);
+          const longitude = Number(position?.coords?.longitude);
+          if (!Number.isFinite(latitude) || !Number.isFinite(longitude) || latitude < -90 || latitude > 90 || longitude < -180 || longitude > 180 || (latitude === 0 && longitude === 0)) {
+            root.state.setUrgentFlow({ locationStatus: "error", locationMessage: "อ่านตำแหน่งไม่สำเร็จ กรุณาลองอีกครั้ง" });
+            resolve(false);
+            return;
+          }
+          markPayloadChanged();
+          root.state.updateDraft("urgent", {
+            gps_latitude: latitude,
+            gps_longitude: longitude,
+            maps_url: `https://www.google.com/maps?q=${latitude},${longitude}`,
+          });
+          root.state.setUrgentFlow({ locationStatus: "success", locationMessage: "บันทึกตำแหน่งปัจจุบันสำเร็จ" });
+          resolve(true);
+        },
+        (error) => {
+          const message = Number(error?.code) === 1
+            ? "คุณปฏิเสธสิทธิ์ตำแหน่ง กรุณาอนุญาตสิทธิ์หรือวางลิงก์ Google Maps เอง"
+            : Number(error?.code) === 3
+              ? "อ่านตำแหน่งหมดเวลา กรุณาลองอีกครั้ง"
+              : "อ่านตำแหน่งไม่สำเร็จ กรุณาลองอีกครั้ง";
+          root.state.setUrgentFlow({ locationStatus: "error", locationMessage: message });
+          resolve(false);
+        },
+        { enableHighAccuracy: false, timeout: 10000, maximumAge: 0 }
+      );
+    });
   }
 
   function trackingKeyFromResult(result) {
@@ -161,18 +497,18 @@
         <div class="urgent-spark" aria-hidden="true"></div>
         <div class="hero-badge">บริการงานล้าง</div>
         <h2>จองล้างแอร์ด่วน</h2>
-        <p>ส่งรายละเอียดเพื่อให้แอดมินตรวจสอบและจัดหาช่างที่ว่าง</p>
+        <p>เลือกบริการและเวลาที่ต้องการเพื่อให้แอดมินตรวจสอบและจัดงาน</p>
       </div>
     `;
   }
 
   function flowRail(active, submittedView) {
     const steps = [
-      { key: "form", label: "กรอกข้อมูล" },
-      { key: "review", label: "ตรวจสอบ" },
-      { key: "submitted", label: submittedView?.railLabel || "รอแอดมิน" },
+      { key: "services", label: "บริการ" },
+      { key: "details", label: "หน้างานและเวลา" },
+      { key: "review", label: active === "submitted" ? (submittedView?.railLabel || "รอแอดมิน") : "ตรวจสอบ" },
     ];
-    const order = { form: 0, review: 1, submitted: 2 };
+    const order = { services: 0, details: 1, review: 2, submitted: 2 };
     const activeIndex = order[active] ?? 0;
     return `
       <div class="flow-rail" aria-label="ขั้นตอนจองล้างแอร์ด่วน">
@@ -183,91 +519,6 @@
           </div>
         `).join('<span class="flow-bar" aria-hidden="true"></span>')}
       </div>
-    `;
-  }
-
-  function renderForm() {
-    const d = sanitizeUrgentDraft();
-    const error = root.state.urgentFlow.error;
-    return `
-      <section class="card form-card urgent-card-fx">
-        <div class="section-head">
-          <span class="section-kicker">ข้อมูลลูกค้าและหน้างาน</span>
-          <h2>รายละเอียดสำหรับติดต่อ</h2>
-        </div>
-        <div class="form-grid">
-          <div class="field">
-            <label for="urgent-name">ชื่อผู้ติดต่อ</label>
-            <input id="urgent-name" class="input" value="${root.utils.escapeHtml(d.customer_name || "")}" data-urgent-field="customer_name" autocomplete="name" placeholder="เช่น คุณสมชาย">
-          </div>
-          <div class="field">
-            <label for="urgent-phone">เบอร์โทร</label>
-            <input id="urgent-phone" class="input" value="${root.utils.escapeHtml(d.customer_phone || "")}" data-urgent-field="customer_phone" inputmode="tel" autocomplete="tel" placeholder="08X-XXX-XXXX">
-          </div>
-          <div class="field field-wide">
-            <label for="urgent-address">ที่อยู่หน้างาน</label>
-            <textarea id="urgent-address" class="input textarea" data-urgent-field="address_text" rows="3" placeholder="บ้าน/คอนโด อาคาร ชั้น ห้อง เขต/อำเภอ">${root.utils.escapeHtml(d.address_text || "")}</textarea>
-          </div>
-          <div class="field">
-            <label for="urgent-maps">ลิงก์แผนที่ (ถ้ามี)</label>
-            <input id="urgent-maps" class="input" value="${root.utils.escapeHtml(d.maps_url || "")}" data-urgent-field="maps_url" inputmode="url" placeholder="วางลิงก์ Google Maps ถ้ามี">
-          </div>
-          <div class="field">
-            <label for="urgent-zone">พื้นที่ / โซน (ถ้ามี)</label>
-            <input id="urgent-zone" class="input" value="${root.utils.escapeHtml(d.job_zone || "")}" data-urgent-field="job_zone" placeholder="เช่น สุขุมวิท อ่อนนุช ลาดพร้าว">
-          </div>
-        </div>
-      </section>
-
-      <section class="card form-card urgent-card-fx">
-        <div class="section-head">
-          <span class="section-kicker">งานล้างแอร์เท่านั้น</span>
-          <h2>ข้อมูลแอร์</h2>
-        </div>
-        <div class="form-grid service-taxonomy-grid">
-          ${renderServiceFields()}
-          <div class="field field-wide">
-            <label for="urgent-symptom">รายละเอียดเพิ่มเติม</label>
-            <textarea id="urgent-symptom" class="input textarea" data-urgent-field="symptom" rows="3" placeholder="เช่น ต้องการล้างด่วนวันนี้ มีฝุ่นหรือกลิ่นผิดปกติ">${root.utils.escapeHtml(d.symptom || "")}</textarea>
-          </div>
-        </div>
-      </section>
-
-      <div class="notice is-urgent">คำขอนี้จะส่งให้แอดมินตรวจสอบก่อนจัดหาช่างที่ว่าง</div>
-      ${error ? `<div class="state-box is-error" role="alert">${root.utils.escapeHtml(error)}</div>` : ""}
-      <div class="button-row">
-        <button class="primary-btn btn-shine" type="button" data-urgent-action="to-review">ตรวจสอบรายละเอียด</button>
-      </div>
-    `;
-  }
-
-  function renderReview() {
-    const d = sanitizeUrgentDraft();
-    const flow = root.state.urgentFlow || {};
-    const submitting = flow.status === "submitting";
-    return `
-      <section class="card review-card urgent-card-fx">
-        <div class="section-head">
-          <span class="section-kicker">ตรวจสอบก่อนส่ง</span>
-          <h2>ตรวจสอบรายละเอียดงานล้าง</h2>
-        </div>
-        <div class="data-list">
-          <div class="data-row"><strong>ผู้ติดต่อ</strong><span class="muted">${root.utils.escapeHtml(d.customer_name || "-")} / ${root.utils.escapeHtml(d.customer_phone || "-")}</span></div>
-          <div class="data-row"><strong>บริการ</strong><span class="muted">${root.utils.escapeHtml(serviceSummary())}</span></div>
-          <div class="data-row"><strong>รายละเอียด</strong><span class="muted">${root.utils.escapeHtml(d.symptom || "-")}</span></div>
-          <div class="data-row"><strong>ที่อยู่</strong><span class="muted">${root.utils.escapeHtml(d.address_text || "-")}</span></div>
-          ${d.job_zone ? `<div class="data-row"><strong>พื้นที่</strong><span class="muted">${root.utils.escapeHtml(d.job_zone)}</span></div>` : ""}
-          ${d.maps_url ? '<div class="data-row"><strong>แผนที่</strong><span class="muted">มีลิงก์แผนที่แนบ</span></div>' : ""}
-        </div>
-        <div class="notice is-urgent">แอดมินจะตรวจสอบรายละเอียดก่อนส่งต่อให้ช่างที่ว่าง</div>
-        ${flow.error ? `<div class="state-box is-error" role="alert">${root.utils.escapeHtml(flow.error)}</div>` : ""}
-        <div class="button-row">
-          ${flow.disabled_line_url
-            ? `<a class="primary-btn line-fallback-btn" href="${ADMIN_LINE_URL}" target="_blank" rel="noopener noreferrer">ติดต่อแอดมินทาง LINE</a>`
-            : `<button class="primary-btn btn-shine" type="button" data-urgent-action="confirm" ${submitting ? "disabled" : ""}>${submitting ? "กำลังส่งคำขอ..." : "ส่งคำขอ"}</button>`}
-          <button class="secondary-btn" type="button" data-urgent-action="back-form" ${submitting ? "disabled" : ""}>กลับไปแก้ไข</button>
-        </div>
-      </section>
     `;
   }
 
@@ -287,7 +538,7 @@
         <div class="data-list">
           <div class="data-row"><strong>รหัสการจอง</strong><span class="booking-code-value">${root.utils.escapeHtml(result.booking_code || "-")}</span></div>
           <div class="data-row"><strong>บริการ</strong><span class="muted">${root.utils.escapeHtml(serviceSummary())}</span></div>
-          <div class="data-row"><strong>พื้นที่</strong><span class="muted">${root.utils.escapeHtml(d.job_zone || "-")}</span></div>
+          <div class="data-row"><strong>เวลาที่ต้องการ</strong><span class="muted">${root.utils.escapeHtml(formatAppointment())}</span></div>
           <div class="data-row"><strong>สถานะ</strong><span class="muted">${root.utils.escapeHtml(view.statusLabel)}</span></div>
         </div>
         ${flow.liveStatusError ? `<div class="state-box is-error" role="alert">${root.utils.escapeHtml(flow.liveStatusError)}</div>` : ""}
@@ -307,7 +558,14 @@
     const submitEpoch = pollEpoch;
     const submitAttempt = { epoch: submitEpoch };
     activeSubmit = submitAttempt;
-    root.state.setUrgentFlow({ step: "review", status: "submitting", error: "", result: null, disabled_line_url: "" });
+    root.state.setUrgentFlow({
+      step: "review",
+      status: "submitting",
+      submitAttempted: true,
+      error: "",
+      result: null,
+      disabled_line_url: "",
+    });
     paint(container);
     try {
       const result = await root.api.submitUrgentRequest(buildSubmitPayload());
@@ -351,10 +609,7 @@
     const flow = root.state.urgentFlow || {};
     const key = trackingKeyFromResult(flow.result || null);
     const view = root.customerCopy.urgentSubmittedView(flow.liveStatus);
-    return Boolean(key)
-      && onSubmittedScreen()
-      && !flow.liveStatusError
-      && view.state === "pending";
+    return Boolean(key) && onSubmittedScreen() && !flow.liveStatusError && view.state === "pending";
   }
 
   async function pollUrgentStatus(container) {
@@ -418,14 +673,15 @@
   }
 
   function body(submittedView) {
-    const step = root.state.urgentFlow.step || "form";
+    const step = root.state.urgentFlow.step || "services";
+    if (step === "details") return renderDetailsStep();
     if (step === "review") return renderReview();
     if (step === "submitted") return renderSubmitted(submittedView);
-    return renderForm();
+    return renderServicesStep();
   }
 
   function paint(container) {
-    const step = root.state.urgentFlow.step || "form";
+    const step = root.state.urgentFlow.step || "services";
     const submittedView = step === "submitted"
       ? root.customerCopy.urgentSubmittedView(root.state.urgentFlow.liveStatus)
       : null;
@@ -441,27 +697,62 @@
     else stopPolling();
   }
 
-  function servicePatch(field, value) {
-    const patch = { [field]: value, service_kind: "clean", job_type: "ล้าง", repair_variant: "" };
-    if (field === "ac_type") patch.wash_variant = value === root.services.WALL_AC ? (draft().wash_variant || "ล้างธรรมดา") : "";
-    return patch;
+  function updateLine(lineId, patch) {
+    const next = root.services.linePatchToDraftServices(draft(), lineId, patch);
+    root.state.updateDraft("urgent", { services: next });
+    sanitizeUrgentDraft();
+    invalidatePricing();
   }
 
   function bind(container) {
     container.querySelectorAll("[data-urgent-field]").forEach((element) => {
       const handler = () => {
-        root.state.updateDraft("urgent", { [element.getAttribute("data-urgent-field")]: element.value });
+        const field = element.getAttribute("data-urgent-field");
+        const patch = { [field]: element.value };
+        if (field === "maps_url") {
+          const currentGpsUrl = Number.isFinite(Number(draft().gps_latitude)) && Number.isFinite(Number(draft().gps_longitude))
+            ? `https://www.google.com/maps?q=${Number(draft().gps_latitude)},${Number(draft().gps_longitude)}`
+            : "";
+          if (String(element.value || "").trim() !== currentGpsUrl) {
+            patch.gps_latitude = null;
+            patch.gps_longitude = null;
+            root.state.setUrgentFlow({ locationStatus: "idle", locationMessage: "" });
+          }
+        }
+        markPayloadChanged();
+        root.state.updateDraft("urgent", patch);
         if (root.state.urgentFlow.error) root.state.setUrgentFlow({ error: "" });
       };
       element.addEventListener("input", handler);
       element.addEventListener("change", handler);
     });
 
-    container.querySelectorAll("[data-urgent-choice]").forEach((button) => {
+    container.querySelectorAll("[data-urgent-line-choice]").forEach((button) => {
       button.addEventListener("click", () => {
-        const field = button.getAttribute("data-urgent-choice");
+        const field = button.getAttribute("data-urgent-line-choice");
         const value = button.getAttribute("data-choice-value");
-        root.state.updateDraft("urgent", servicePatch(field, value));
+        const patch = { [field]: field === "btu" ? Number(value) : value };
+        if (field === "ac_type") patch.wash_variant = value === root.services.WALL_AC ? "ล้างธรรมดา" : "";
+        updateLine(button.getAttribute("data-line-id"), patch);
+        paint(container);
+        refreshPricing(container);
+      });
+    });
+
+    container.querySelectorAll("[data-urgent-line-field]").forEach((element) => {
+      element.addEventListener("change", () => {
+        updateLine(element.getAttribute("data-line-id"), {
+          [element.getAttribute("data-urgent-line-field")]: Number(element.value),
+        });
+        paint(container);
+        refreshPricing(container);
+      });
+    });
+
+    container.querySelectorAll("[data-urgent-time-proposal]").forEach((button) => {
+      button.addEventListener("click", () => {
+        markPayloadChanged();
+        root.state.updateDraft("urgent", { allow_time_proposal: button.getAttribute("data-urgent-time-proposal") === "true" });
         root.state.setUrgentFlow({ error: "" });
         paint(container);
       });
@@ -470,13 +761,39 @@
     container.querySelectorAll("[data-urgent-action]").forEach((button) => {
       button.addEventListener("click", async () => {
         const action = button.getAttribute("data-urgent-action");
-        if (action === "to-review") {
-          const error = validate();
-          if (error) setStep("form", error);
+        if (action === "add-line") {
+          const next = [...services(), root.services.createServiceLine()];
+          root.state.updateDraft("urgent", { services: next });
+          invalidatePricing();
+          paint(container);
+          refreshPricing(container);
+        } else if (action === "remove-line") {
+          const lineId = button.getAttribute("data-line-id");
+          const next = services().filter((line) => String(line.line_id) !== String(lineId));
+          if (next.length) {
+            root.state.updateDraft("urgent", { services: next });
+            invalidatePricing();
+            paint(container);
+            refreshPricing(container);
+          }
+        } else if (action === "to-details") {
+          const error = validateServices();
+          if (error) setStep("services", error);
+          else setStep("details");
+          paint(container);
+        } else if (action === "back-services") {
+          setStep("services");
+          paint(container);
+        } else if (action === "to-review") {
+          const error = validateDetails();
+          if (error) setStep("details", error);
           else setStep("review");
           paint(container);
-        } else if (action === "back-form") {
-          setStep("form");
+        } else if (action === "back-details") {
+          setStep("details");
+          paint(container);
+        } else if (action === "use-location") {
+          await requestCurrentLocation();
           paint(container);
         } else if (action === "confirm") {
           await submitUrgent(container);
@@ -486,6 +803,7 @@
         } else if (action === "new-request") {
           root.state.resetUrgentDraft();
           paint(container);
+          refreshPricing(container);
         } else if (action === "track-created") {
           const key = button.getAttribute("data-tracking-key") || "";
           root.state.updateDraft("tracking", { trackingCode: key });
@@ -503,14 +821,26 @@
       if (lifecycleEpoch === pollEpoch && root.state.currentRoute === "urgent") render(container);
     });
     if (!root.state.urgentFlow || !root.state.urgentFlow.step) {
-      root.state.setUrgentFlow({ step: "form", status: "idle", error: "", result: null, liveStatus: null, liveStatusError: "" });
+      root.state.setUrgentFlow({
+        step: "services",
+        status: "idle",
+        error: "",
+        result: null,
+        pricing: { status: "idle", data: null, error: "" },
+        liveStatus: null,
+        liveStatusError: "",
+      });
     }
     bindVisibilityRefresh();
     paint(container);
+    if (root.state.urgentFlow.step === "services" && root.state.urgentFlow.pricing?.status === "idle") {
+      refreshPricing(container);
+    }
   }
 
   render.onLeave = () => {
     pollEpoch += 1;
+    pricingEpoch += 1;
     pollInFlight = null;
     activeSubmit = null;
     if (root.state.urgentFlow.status === "submitting") {
@@ -524,13 +854,16 @@
   root.bookingUrgent = {
     render,
     _test: {
-      canonicalCleaningPatch,
       sanitizeUrgentDraft,
       buildSubmitPayload,
-      validate,
-      renderForm,
+      validateServices,
+      validateDetails,
+      renderServicesStep,
+      renderDetailsStep,
       renderReview,
       renderSubmitted,
+      requestCurrentLocation,
+      refreshPricing,
     },
   };
 })();

--- a/customer-app/modules/bookingUrgent.js
+++ b/customer-app/modules/bookingUrgent.js
@@ -90,6 +90,20 @@
     return `${d.date}T${d.time}:00+07:00`;
   }
 
+  function validGpsPair(source) {
+    const rawLatitude = source?.gps_latitude;
+    const rawLongitude = source?.gps_longitude;
+    const latitudeProvided = rawLatitude !== null && rawLatitude !== undefined && String(rawLatitude).trim() !== "";
+    const longitudeProvided = rawLongitude !== null && rawLongitude !== undefined && String(rawLongitude).trim() !== "";
+    if (!(latitudeProvided && longitudeProvided)) return null;
+    const latitude = Number(rawLatitude);
+    const longitude = Number(rawLongitude);
+    if (!Number.isFinite(latitude) || !Number.isFinite(longitude)) return null;
+    if (latitude < -90 || latitude > 90 || longitude < -180 || longitude > 180) return null;
+    if (latitude === 0 && longitude === 0) return null;
+    return { latitude, longitude };
+  }
+
   function buildSubmitPayload() {
     const d = sanitizeUrgentDraft();
     const payload = servicePayload() || {};
@@ -98,9 +112,7 @@
       job_type: "ล้าง",
       repair_variant: "",
     }));
-    const latitude = Number(d.gps_latitude);
-    const longitude = Number(d.gps_longitude);
-    const hasGps = Number.isFinite(latitude) && Number.isFinite(longitude);
+    const gps = validGpsPair(d);
     return {
       customer_name: String(d.customer_name || "").trim(),
       customer_phone: String(d.customer_phone || "").trim(),
@@ -113,7 +125,7 @@
       client_app: "customer_app_v2",
       urgent_request_key: ensureRequestKey(),
       allow_time_proposal: d.allow_time_proposal === true,
-      ...(hasGps ? { gps_latitude: latitude, gps_longitude: longitude } : {}),
+      ...(gps ? { gps_latitude: gps.latitude, gps_longitude: gps.longitude } : {}),
       ...payload,
       services: cleaningLines,
     };
@@ -355,7 +367,7 @@
     const d = sanitizeUrgentDraft();
     const flow = root.state.urgentFlow || {};
     const submitting = flow.status === "submitting";
-    const hasGps = Number.isFinite(Number(d.gps_latitude)) && Number.isFinite(Number(d.gps_longitude));
+    const gps = validGpsPair(d);
     return `
       <section class="card review-card urgent-card-fx" data-urgent-step-panel="review">
         <div class="section-head">
@@ -371,7 +383,7 @@
           <div class="data-row"><strong>ที่อยู่</strong><span class="muted">${root.utils.escapeHtml(d.address_text || "-")}</span></div>
           ${d.job_zone ? `<div class="data-row"><strong>พื้นที่</strong><span class="muted">${root.utils.escapeHtml(d.job_zone)}</span></div>` : ""}
           ${d.maps_url ? `<div class="data-row"><strong>แผนที่</strong><span class="muted">${root.utils.escapeHtml(d.maps_url)}</span></div>` : ""}
-          ${hasGps ? `<div class="data-row"><strong>GPS</strong><span class="muted">${root.utils.escapeHtml(`${Number(d.gps_latitude)}, ${Number(d.gps_longitude)}`)}</span></div>` : ""}
+          ${gps ? `<div class="data-row"><strong>GPS</strong><span class="muted">${root.utils.escapeHtml(`${gps.latitude}, ${gps.longitude}`)}</span></div>` : ""}
           ${String(d.symptom || "").trim() ? `<div class="data-row"><strong>หมายเหตุ</strong><span class="muted">${root.utils.escapeHtml(d.symptom)}</span></div>` : ""}
         </div>
         <div class="notice is-urgent">แอดมินจะตรวจสอบรายละเอียดก่อนส่งต่อให้ช่างที่ว่าง</div>
@@ -710,9 +722,8 @@
         const field = element.getAttribute("data-urgent-field");
         const patch = { [field]: element.value };
         if (field === "maps_url") {
-          const currentGpsUrl = Number.isFinite(Number(draft().gps_latitude)) && Number.isFinite(Number(draft().gps_longitude))
-            ? `https://www.google.com/maps?q=${Number(draft().gps_latitude)},${Number(draft().gps_longitude)}`
-            : "";
+          const gps = validGpsPair(draft());
+          const currentGpsUrl = gps ? `https://www.google.com/maps?q=${gps.latitude},${gps.longitude}` : "";
           if (String(element.value || "").trim() !== currentGpsUrl) {
             patch.gps_latitude = null;
             patch.gps_longitude = null;

--- a/customer-app/modules/state.js
+++ b/customer-app/modules/state.js
@@ -92,6 +92,7 @@
 
   function defaultUrgentDraft(current) {
     const source = current || {};
+    const firstLine = defaultServiceLine(1);
     return {
       customer_name: String(source.customer_name || ""),
       customer_phone: String(source.customer_phone || ""),
@@ -99,11 +100,17 @@
       maps_url: String(source.maps_url || ""),
       service_kind: "clean",
       job_type: "ล้าง",
-      ac_type: "ผนัง",
-      wash_variant: "ล้างธรรมดา",
+      ac_type: firstLine.ac_type,
+      wash_variant: firstLine.wash_variant,
       repair_variant: "",
-      btu: "12000",
-      machine_count: 1,
+      btu: String(firstLine.btu),
+      machine_count: firstLine.machine_count,
+      services: [firstLine],
+      date: "",
+      time: "",
+      allow_time_proposal: false,
+      gps_latitude: null,
+      gps_longitude: null,
       symptom: "",
       job_zone: String(source.job_zone || ""),
       urgent_request_key: "",
@@ -184,8 +191,11 @@
       result: null,
     },
     urgentFlow: {
-      step: "form",
+      step: "services",
       error: "",
+      pricing: { status: "idle", data: null, error: "" },
+      locationMessage: "",
+      locationStatus: "idle",
     },
     tracking: { status: "idle", data: null, error: "" },
     draft: {
@@ -422,9 +432,12 @@
     resetUrgentDraft() {
       this.draft.urgent = defaultUrgentDraft(this.draft.urgent);
       this.urgentFlow = {
-        step: "form",
+        step: "services",
         status: "idle",
         error: "",
+        pricing: { status: "idle", data: null, error: "" },
+        locationMessage: "",
+        locationStatus: "idle",
         result: null,
         liveStatus: null,
         liveStatusError: "",

--- a/customer-app/sw.js
+++ b/customer-app/sw.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const BUILD_ID = "20260726_urgent_preferred_time_gps_v1";
+const BUILD_ID = "20260726_urgent_preferred_time_gps_v2";
 const CACHE_NAME = `cwf-customer-app-v2-${BUILD_ID}`;
 const APP_SHELL = [
   `./index.html?v=${BUILD_ID}`,

--- a/customer-app/sw.js
+++ b/customer-app/sw.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const BUILD_ID = "20260720_customer_booking_postdeploy_hardening_v2";
+const BUILD_ID = "20260726_urgent_preferred_time_gps_v1";
 const CACHE_NAME = `cwf-customer-app-v2-${BUILD_ID}`;
 const APP_SHELL = [
   `./index.html?v=${BUILD_ID}`,

--- a/server/services/booking/createBookingJob.js
+++ b/server/services/booking/createBookingJob.js
@@ -918,6 +918,11 @@ function createBookingJobService(dependencies = {}) {
     if (normalizedBookingScalar(jobRow.job_type) !== normalizedBookingScalar(incoming.job_type)) return false;
     if (normalizedBookingScalar(jobRow.customer_note) !== normalizedBookingScalar(incoming.customer_note)) return false;
     if (Boolean(jobRow.allow_time_proposal) !== Boolean(incoming.allow_time_proposal)) return false;
+    const storedLat = jobRow.gps_latitude == null || String(jobRow.gps_latitude).trim() === "" ? null : Number(jobRow.gps_latitude);
+    const storedLng = jobRow.gps_longitude == null || String(jobRow.gps_longitude).trim() === "" ? null : Number(jobRow.gps_longitude);
+    const incomingLat = incoming.gps_latitude == null || String(incoming.gps_latitude).trim() === "" ? null : Number(incoming.gps_latitude);
+    const incomingLng = incoming.gps_longitude == null || String(incoming.gps_longitude).trim() === "" ? null : Number(incoming.gps_longitude);
+    if (storedLat !== incomingLat || storedLng !== incomingLng) return false;
     if (Number(jobRow.duration_min || 0) !== Number(incoming.duration_min || 0)) return false;
     return true;
   }
@@ -932,11 +937,11 @@ function createBookingJobService(dependencies = {}) {
   }
 
   // Customer App V2 urgent requests are just another entry point into the
-  // existing admin urgent offer engine (handleAdminBookV2): this adapter only
-  // (a) strips the request down to a customer-safe allowlist and (b) computes
-  // a rounded, business-hours-aware appointment time. Deduplication of
+  // existing public booking workflow: this adapter strips the request down to
+  // a customer-safe allowlist and validates the customer's Bangkok wall-clock
+  // preference before any pricing or database work. Deduplication of
   // retried/duplicate submits sharing the same client-generated
-  // urgent_request_key is handled durably inside handleAdminBookV2's existing
+  // urgent_request_key is handled durably inside handlePublicBook's existing
   // transaction (advisory lock + deterministic booking_token lookup), not
   // here, so it survives process restarts and works across instances.
   function handlePublicCustomerUrgentBook(req, res) {
@@ -948,19 +953,35 @@ function createBookingJobService(dependencies = {}) {
     if (!urgentPublicAdapter.isStrictUrgentCleaningPayload(incoming)) {
       return res.status(400).json({ error: "URGENT_CLEANING_ONLY", code: "URGENT_CLEANING_ONLY" });
     }
+    const appointment = urgentPublicAdapter.normalizeCustomerUrgentAppointment(incoming.appointment_datetime);
+    if (!appointment) {
+      return res.status(400).json({ error: "วันและเวลาที่ต้องการไม่ถูกต้อง", code: "INVALID_APPOINTMENT_DATETIME" });
+    }
+    if (urgentPublicAdapter.isCustomerUrgentAppointmentPast(appointment)) {
+      return res.status(409).json({ error: "วันและเวลาที่เลือกย้อนหลังไม่ได้ กรุณาเลือกเวลาใหม่", code: "APPOINTMENT_IN_PAST" });
+    }
+    if (incoming.allow_time_proposal !== true && incoming.allow_time_proposal !== false) {
+      return res.status(400).json({ error: "กรุณาเลือกเงื่อนไขการเสนอเวลา", code: "INVALID_TIME_PROPOSAL_PREFERENCE" });
+    }
+    const gps = urgentPublicAdapter.validateCustomerUrgentGps(incoming.gps_latitude, incoming.gps_longitude);
+    if (!gps.ok) {
+      return res.status(400).json({ error: "ข้อมูล GPS ไม่ถูกต้อง กรุณาส่งละติจูดและลองจิจูดที่ถูกต้องพร้อมกัน", code: "INVALID_GPS" });
+    }
 
     req.cwfBookSource = "customer";
     req.cwfPublicUrgentPrepared = true;
     req.body = {
       ...incoming,
-      appointment_datetime: urgentPublicAdapter.computeCustomerUrgentAppointmentIso(),
+      appointment_datetime: appointment,
       booking_mode: "urgent",
       dispatch_mode: "offer",
       tech_type: "partner",
       assign_mode: "auto",
       technician_username: "",
       team_members: [],
-      allow_time_proposal: true,
+      allow_time_proposal: incoming.allow_time_proposal,
+      gps_latitude: gps.latitude,
+      gps_longitude: gps.longitude,
     };
 
     return handlePublicBook(req, res);
@@ -997,6 +1018,8 @@ function createBookingJobService(dependencies = {}) {
       address_text,
       customer_note,
       maps_url,
+      gps_latitude,
+      gps_longitude,
       job_zone,
       items, // [{item_id, qty}] (extras)
       booking_mode,
@@ -1124,6 +1147,8 @@ function createBookingJobService(dependencies = {}) {
     if (clientApp === "customer_app_v2" && allowTimeProposal == null) {
       return res.status(400).json({ error: "กรุณาเลือกเงื่อนไขการเสนอเวลา" });
     }
+    const persistedGpsLatitude = bm === "urgent" && gps_latitude != null ? Number(gps_latitude) : null;
+    const persistedGpsLongitude = bm === "urgent" && gps_longitude != null ? Number(gps_longitude) : null;
     const payloadV2 = {
       job_type: String(job_type).trim(),
       ac_type: (ac_type || "").toString().trim(),
@@ -1199,7 +1224,7 @@ function createBookingJobService(dependencies = {}) {
         const r = await idem.query(
           `SELECT job_id, booking_code, booking_token, dispatch_mode, duration_min, job_price,
                   appointment_datetime, customer_phone, customer_name, address_text, maps_url,
-                  job_zone, job_type, customer_note, allow_time_proposal
+                  job_zone, job_type, customer_note, allow_time_proposal, gps_latitude, gps_longitude
              FROM public.jobs
             WHERE booking_token=$1
               AND job_source='customer'
@@ -1220,9 +1245,10 @@ function createBookingJobService(dependencies = {}) {
         const incomingBooking = {
           appointment_datetime, customer_phone, customer_name, address_text, maps_url,
           job_zone, job_type, customer_note, allow_time_proposal: allowTimeProposal,
+          gps_latitude: persistedGpsLatitude, gps_longitude: persistedGpsLongitude,
           duration_min: duration_min_v2, payloadV2, itemIdQty, standardPrice: standard_price,
         };
-        if (!(await scheduledPayloadMatchesExisting(pool, prior, incomingBooking, { serverAppointmentAuthoritative: bm === "urgent" }))) {
+        if (!(await scheduledPayloadMatchesExisting(pool, prior, incomingBooking))) {
           // Same key, materially different booking. No mutation, no identifiers/PII.
           return res.status(409).json({
             error: "คำขอนี้ถูกใช้ไปแล้วกับการจองอื่น กรุณาเริ่มการจองใหม่",
@@ -1287,7 +1313,8 @@ function createBookingJobService(dependencies = {}) {
         const existing = await client.query(
           `SELECT job_id, booking_code, booking_token, booking_mode, dispatch_mode,
                   duration_min, job_price, appointment_datetime, customer_phone, customer_name,
-                  address_text, maps_url, job_zone, job_type, customer_note, allow_time_proposal
+                  address_text, maps_url, job_zone, job_type, customer_note, allow_time_proposal,
+                  gps_latitude, gps_longitude
              FROM public.jobs
             WHERE booking_token=$1
               AND job_source='customer'
@@ -1305,9 +1332,10 @@ function createBookingJobService(dependencies = {}) {
           const incomingBooking = {
             appointment_datetime, customer_phone, customer_name, address_text, maps_url,
             job_zone, job_type, customer_note, allow_time_proposal: allowTimeProposal,
+            gps_latitude: persistedGpsLatitude, gps_longitude: persistedGpsLongitude,
             duration_min: duration_min_v2, payloadV2, itemIdQty, standardPrice: standard_price,
           };
-          if (!(await scheduledPayloadMatchesExisting(pool, row, incomingBooking, { serverAppointmentAuthoritative: bm === "urgent" }))) {
+          if (!(await scheduledPayloadMatchesExisting(pool, row, incomingBooking))) {
             return res.status(409).json({
               error: "คำขอนี้ถูกใช้ไปแล้วกับการจองอื่น กรุณาเริ่มการจองใหม่",
               code: "IDEMPOTENCY_KEY_REUSED",
@@ -1425,8 +1453,9 @@ function createBookingJobService(dependencies = {}) {
         "address_text", "technician_team", "technician_username", "job_status",
         "booking_token", "job_source", "dispatch_mode", "customer_note",
         "maps_url", "job_zone", "duration_min", "booking_mode", "allow_time_proposal",
+        "gps_latitude", "gps_longitude",
       ];
-      const jobInsertValuesSql = ["$1", "$2", "$3", "$4", "$5", "$6", "NULL", "$16", "$11", "$7", "'customer'", "$14", "$8", "$9", "$10", "$12", "$13", "$15"];
+      const jobInsertValuesSql = ["$1", "$2", "$3", "$4", "$5", "$6", "NULL", "$16", "$11", "$7", "'customer'", "$14", "$8", "$9", "$10", "$12", "$13", "$15", "$17", "$18"];
       const jobInsertParams = [
         String(customer_name).trim(),
         (customer_phone || "").toString().trim(),
@@ -1444,6 +1473,8 @@ function createBookingJobService(dependencies = {}) {
         dispatchMode,
         allowTimeProposal,
         draftReservationTech ? draftReservationTech.username : null,
+        persistedGpsLatitude,
+        persistedGpsLongitude,
       ];
       if (catalogLinkReady) {
         jobInsertColumns.push("catalog_item_id", "customer_sub");

--- a/server/services/urgentPublicAdapter.js
+++ b/server/services/urgentPublicAdapter.js
@@ -4,9 +4,6 @@ const crypto = require("crypto");
 const jobTiming = require("./jobTiming");
 const { normalizeServiceType } = require("../normalizers");
 
-const URGENT_LEAD_TIME_MIN = 30;
-const UI_START_MIN = 9 * 60; // 09:00, matches the Admin Add locked business window
-const UI_END_MIN = 18 * 60; // 18:00
 const STRICT_CLEANING_JOB_TYPES = new Set([
   "ล้าง",
   "ล้างแอร์",
@@ -74,6 +71,10 @@ function sanitizeCustomerUrgentBody(body) {
     customer_phone: String(src.customer_phone || "").trim(),
     address_text: String(src.address_text || "").trim(),
     maps_url: String(src.maps_url || "").trim(),
+    appointment_datetime: String(src.appointment_datetime || "").trim(),
+    allow_time_proposal: src.allow_time_proposal,
+    gps_latitude: src.gps_latitude,
+    gps_longitude: src.gps_longitude,
     job_zone: String(src.job_zone || "").trim(),
     customer_note: String(src.customer_note || "").trim(),
     job_type: String(src.job_type || "").trim(),
@@ -88,32 +89,49 @@ function sanitizeCustomerUrgentBody(body) {
   };
 }
 
-function addDaysToYmd(ymd, days) {
-  const d = new Date(`${String(ymd)}T00:00:00Z`);
-  d.setUTCDate(d.getUTCDate() + Number(days || 0));
-  return d.toISOString().slice(0, 10);
+function normalizeCustomerUrgentAppointment(value) {
+  const match = String(value || "").trim().match(
+    /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2})(?::(\d{2}))?(?:\+07:00)?$/
+  );
+  if (!match) return null;
+  const [, year, month, day, hour, minute, second = "00"] = match;
+  const numbers = [year, month, day, hour, minute, second].map(Number);
+  if (numbers.some((part) => !Number.isInteger(part))) return null;
+  if (numbers[1] < 1 || numbers[1] > 12 || numbers[3] > 23 || numbers[4] > 59 || numbers[5] > 59) return null;
+  const check = new Date(Date.UTC(numbers[0], numbers[1] - 1, numbers[2]));
+  if (
+    check.getUTCFullYear() !== numbers[0]
+    || check.getUTCMonth() !== numbers[1] - 1
+    || check.getUTCDate() !== numbers[2]
+  ) return null;
+  return `${year}-${month}-${day}T${hour}:${minute}:00+07:00`;
 }
 
-// Server-side, Asia/Bangkok, business-hours-aware urgent appointment
-// timestamp: now + lead time, rounded UP to the nearest slot step, clamped
-// to the 09:00-18:00 window (rolling to next day's open if past close).
-// Reuses jobTiming's canonical Bangkok-now/step-rounding helpers instead of
-// duplicating that formula; only the "roll to next business day" extension
-// (specific to this urgent lead-time use case) lives here.
-function computeCustomerUrgentAppointmentIso(now = jobTiming.getBangkokNow()) {
-  const nowMin = (Number(now.hour || 0) * 60) + Number(now.minute || 0);
-  const rounded = jobTiming.ceilMinuteToStep(nowMin + URGENT_LEAD_TIME_MIN, jobTiming.SLOT_STEP_MIN);
-  let targetDate = now.ymd;
-  let targetMin;
-  if (rounded <= UI_END_MIN) {
-    targetMin = Math.max(UI_START_MIN, rounded);
-  } else {
-    targetDate = addDaysToYmd(now.ymd, 1);
-    targetMin = UI_START_MIN;
-  }
-  const hh = String(Math.floor(targetMin / 60)).padStart(2, "0");
-  const mm = String(targetMin % 60).padStart(2, "0");
-  return `${targetDate}T${hh}:${mm}:00+07:00`;
+function isCustomerUrgentAppointmentPast(appointmentIso, now = jobTiming.getBangkokNow()) {
+  const normalized = normalizeCustomerUrgentAppointment(appointmentIso);
+  if (!normalized) return true;
+  const nowYmd = String(now?.ymd || "");
+  const nowHour = String(Number(now?.hour || 0)).padStart(2, "0");
+  const nowMinute = String(Number(now?.minute || 0)).padStart(2, "0");
+  const nowKey = `${nowYmd}T${nowHour}:${nowMinute}`;
+  return normalized.slice(0, 16) <= nowKey;
+}
+
+function gpsFieldProvided(value) {
+  return value !== undefined && value !== null && String(value).trim() !== "";
+}
+
+function validateCustomerUrgentGps(latitude, longitude) {
+  const latProvided = gpsFieldProvided(latitude);
+  const lngProvided = gpsFieldProvided(longitude);
+  if (!latProvided && !lngProvided) return { ok: true, latitude: null, longitude: null };
+  if (!(latProvided && lngProvided)) return { ok: false, latitude: null, longitude: null };
+  const lat = Number(latitude);
+  const lng = Number(longitude);
+  if (!Number.isFinite(lat) || !Number.isFinite(lng)) return { ok: false, latitude: null, longitude: null };
+  if (lat < -90 || lat > 90 || lng < -180 || lng > 180) return { ok: false, latitude: null, longitude: null };
+  if (lat === 0 && lng === 0) return { ok: false, latitude: null, longitude: null };
+  return { ok: true, latitude: lat, longitude: lng };
 }
 
 // ---------------------------------------------------------------------------
@@ -141,13 +159,12 @@ function deriveUrgentBookingToken(requestKey) {
 }
 
 module.exports = {
-  URGENT_LEAD_TIME_MIN,
-  UI_START_MIN,
-  UI_END_MIN,
   sanitizeCustomerServiceLine,
   sanitizeCustomerUrgentBody,
   canonicalUrgentCleaningJobType,
   isStrictUrgentCleaningPayload,
-  computeCustomerUrgentAppointmentIso,
+  normalizeCustomerUrgentAppointment,
+  isCustomerUrgentAppointmentPast,
+  validateCustomerUrgentGps,
   deriveUrgentBookingToken,
 };

--- a/test/customerAppPageAvailability.test.js
+++ b/test/customerAppPageAvailability.test.js
@@ -281,7 +281,7 @@ test("api exposes loadCustomerAppConfig as a no-store GET to /public/customer-ap
 });
 
 test("build wiring: pageAvailability.js is registered in the HTML shell and the SW cache, with the new build id", () => {
-  const build = "20260726_urgent_preferred_time_gps_v1";
+  const build = "20260726_urgent_preferred_time_gps_v2";
   assert.match(indexHtml, new RegExp(`modules/pageAvailability\\.js\\?v=${build}`));
   assert.match(swSrc, new RegExp(`BUILD_ID = "${build}"`));
   assert.match(swSrc, /modules\/pageAvailability\.js\?v=\$\{BUILD_ID\}/);
@@ -294,7 +294,7 @@ test("build wiring: pageAvailability.js is registered in the HTML shell and the 
    RUNTIME tests (execute the real code in a VM — not regex assertions).
    ========================================================================== */
 
-const BUILD = "20260726_urgent_preferred_time_gps_v1";
+const BUILD = "20260726_urgent_preferred_time_gps_v2";
 const adminSrc = read("admin-homepage-cms.js");
 
 function reqUrlOf(req) {

--- a/test/customerAppPageAvailability.test.js
+++ b/test/customerAppPageAvailability.test.js
@@ -281,7 +281,7 @@ test("api exposes loadCustomerAppConfig as a no-store GET to /public/customer-ap
 });
 
 test("build wiring: pageAvailability.js is registered in the HTML shell and the SW cache, with the new build id", () => {
-  const build = "20260720_customer_booking_postdeploy_hardening_v2";
+  const build = "20260726_urgent_preferred_time_gps_v1";
   assert.match(indexHtml, new RegExp(`modules/pageAvailability\\.js\\?v=${build}`));
   assert.match(swSrc, new RegExp(`BUILD_ID = "${build}"`));
   assert.match(swSrc, /modules\/pageAvailability\.js\?v=\$\{BUILD_ID\}/);
@@ -294,7 +294,7 @@ test("build wiring: pageAvailability.js is registered in the HTML shell and the 
    RUNTIME tests (execute the real code in a VM — not regex assertions).
    ========================================================================== */
 
-const BUILD = "20260720_customer_booking_postdeploy_hardening_v2";
+const BUILD = "20260726_urgent_preferred_time_gps_v1";
 const adminSrc = read("admin-homepage-cms.js");
 
 function reqUrlOf(req) {

--- a/test/customerAppRecovery.test.js
+++ b/test/customerAppRecovery.test.js
@@ -293,7 +293,7 @@ test("Customer App build id is consistent across shell and service worker", () =
   const sw = read("customer-app/sw.js");
   const app = read("customer-app/assets/customer-app.js");
   const manifest = read("customer-app/manifest.webmanifest");
-  const build = "20260726_urgent_preferred_time_gps_v1";
+  const build = "20260726_urgent_preferred_time_gps_v2";
 
   assert.match(index, new RegExp(`customer-app\\.css\\?v=${build}`));
   assert.match(index, new RegExp(`modules\\/api\\.js\\?v=${build}`));
@@ -311,7 +311,7 @@ test("Customer App build id is consistent across shell and service worker", () =
 test("store module is loaded in index.html and precached in the service worker app shell", () => {
   const index = read("customer-app/index.html");
   const sw = read("customer-app/sw.js");
-  const build = "20260726_urgent_preferred_time_gps_v1";
+  const build = "20260726_urgent_preferred_time_gps_v2";
 
   assert.match(index, new RegExp(`modules/store\\.js\\?v=${build}`));
   assert.match(sw, /`\.\/modules\/store\.js\?v=\$\{BUILD_ID\}`/);

--- a/test/customerAppRecovery.test.js
+++ b/test/customerAppRecovery.test.js
@@ -293,7 +293,7 @@ test("Customer App build id is consistent across shell and service worker", () =
   const sw = read("customer-app/sw.js");
   const app = read("customer-app/assets/customer-app.js");
   const manifest = read("customer-app/manifest.webmanifest");
-  const build = "20260720_customer_booking_postdeploy_hardening_v2";
+  const build = "20260726_urgent_preferred_time_gps_v1";
 
   assert.match(index, new RegExp(`customer-app\\.css\\?v=${build}`));
   assert.match(index, new RegExp(`modules\\/api\\.js\\?v=${build}`));
@@ -311,7 +311,7 @@ test("Customer App build id is consistent across shell and service worker", () =
 test("store module is loaded in index.html and precached in the service worker app shell", () => {
   const index = read("customer-app/index.html");
   const sw = read("customer-app/sw.js");
-  const build = "20260720_customer_booking_postdeploy_hardening_v2";
+  const build = "20260726_urgent_preferred_time_gps_v1";
 
   assert.match(index, new RegExp(`modules/store\\.js\\?v=${build}`));
   assert.match(sw, /`\.\/modules\/store\.js\?v=\$\{BUILD_ID\}`/);
@@ -830,21 +830,23 @@ test("urgent route is registered and renders distinct urgent screen", () => {
   root.state.setRoute("urgent");
   const container = new WizardContainer(root);
   root.bookingUrgent.render(container);
-  assert.match(container.innerHTML, /data-urgent-step="form"/);
+  assert.match(container.innerHTML, /data-urgent-step="services"/);
   assert.match(container.innerHTML, /จองล้างแอร์ด่วน/);
 });
 
-test("customer urgent booking uses the PR3 pending-approval contract without client fake appointment", () => {
+test("customer urgent booking uses the preferred-time pending-approval contract", () => {
   const urgent = read("customer-app/modules/bookingUrgent.js");
   const api = read("customer-app/modules/api.js");
   const server = read("server/services/booking/createBookingJob.js");
 
   assert.doesNotMatch(urgent, /nextUrgentAppointmentIso/);
-  assert.doesNotMatch(urgent, /appointment_datetime:\s*nextUrgentAppointmentIso/);
+  assert.match(urgent, /appointment_datetime:\s*appointmentDatetime\(\)/);
   assert.match(urgent, /job_type:\s*"ล้าง"/);
   const urgentApi = api.slice(api.indexOf("async submitUrgentRequest"), api.indexOf("async loadCatalogItemReviews"));
   assert.match(urgentApi, /delete body\.dispatch_mode/);
-  assert.match(urgentApi, /delete body\.allow_time_proposal/);
+  assert.doesNotMatch(urgentApi, /delete body\.allow_time_proposal/);
+  assert.match(urgent, /allow_time_proposal:\s*d\.allow_time_proposal === true/);
+  assert.match(urgent, /gps_latitude/);
   assert.match(server, /function handlePublicCustomerUrgentBook/);
   assert.match(server, /req\.cwfBookSource = "customer"/);
   assert.match(server, /const urgentOfferEnabled = false/);

--- a/test/customerAppStorePayment.test.js
+++ b/test/customerAppStorePayment.test.js
@@ -58,7 +58,7 @@ test("store falls back to the LINE hand-off when payment is unconfigured or the 
 test("payment step styles exist and the Customer App payment build id is bumped", () => {
   assert.match(cssSrc, /\.pay-method-btn/);
   assert.match(cssSrc, /\.pay-qr-img/);
-  assert.match(read("customer-app/index.html"), /modules\/store\.js\?v=20260720_customer_booking_postdeploy_hardening_v2/);
-  assert.match(read("customer-app/sw.js"), /BUILD_ID = "20260720_customer_booking_postdeploy_hardening_v2"/);
+  assert.match(read("customer-app/index.html"), /modules\/store\.js\?v=20260726_urgent_preferred_time_gps_v1/);
+  assert.match(read("customer-app/sw.js"), /BUILD_ID = "20260726_urgent_preferred_time_gps_v1"/);
   assert.match(storeSrc, /payment-security 20260705 loaded/);
 });

--- a/test/customerAppStorePayment.test.js
+++ b/test/customerAppStorePayment.test.js
@@ -58,7 +58,7 @@ test("store falls back to the LINE hand-off when payment is unconfigured or the 
 test("payment step styles exist and the Customer App payment build id is bumped", () => {
   assert.match(cssSrc, /\.pay-method-btn/);
   assert.match(cssSrc, /\.pay-qr-img/);
-  assert.match(read("customer-app/index.html"), /modules\/store\.js\?v=20260726_urgent_preferred_time_gps_v1/);
-  assert.match(read("customer-app/sw.js"), /BUILD_ID = "20260726_urgent_preferred_time_gps_v1"/);
+  assert.match(read("customer-app/index.html"), /modules\/store\.js\?v=20260726_urgent_preferred_time_gps_v2/);
+  assert.match(read("customer-app/sw.js"), /BUILD_ID = "20260726_urgent_preferred_time_gps_v2"/);
   assert.match(storeSrc, /payment-security 20260705 loaded/);
 });

--- a/test/customerBookingAdminNotifications.test.js
+++ b/test/customerBookingAdminNotifications.test.js
@@ -142,7 +142,7 @@ function createAdminReviewSandbox(options = {}) {
   [
     "approvalAlert", "overlay", "list", "pillCount", "filterStatus", "slotBox",
     "mCustomerName", "mCustomerPhone", "mJobType", "mBookingCode", "mAppt",
-    "mAddress", "mMaps", "mZone", "mLat", "mLng", "mNote", "mTitle", "mSub",
+    "mAddress", "mMaps", "mZone", "mLat", "mLng", "mNote", "mTimePreference", "mTitle", "mSub",
     "mTechType", "mPrimaryTech", "mDispatchMode", "mTeamSearch", "mTeamSuggest",
     "mTeamSelected", "mPricing", "mReadOnlyNotice", "btnLoadSlots", "btnSave",
     "btnDispatch", "btnRebroadcast", "btnCancel", "btnLoadPricing", "btnReload",
@@ -308,14 +308,14 @@ test("admin review new-job notification uses first-load baseline and one sound p
 });
 
 test("admin/customer frontend cache versions are bumped for booking notification changes", () => {
-  assert.match(adminReviewHtml, /admin-review-v2\.js\?v=20260719_customer_booking_pr3_v1/);
+  assert.match(adminReviewHtml, /admin-review-v2\.js\?v=20260726_urgent_preferred_time_gps_v1/);
   assert.doesNotMatch(adminReviewHtml, /admin-review-v2\.js\?v=20260707_customer_booking_notify_v2/);
   assert.match(adminReviewHtml, /admin-review-ai-intake\.js\?v=ai-booking-intake-customer-cards-v11-admin-alert-gate/);
   assert.doesNotMatch(adminReviewHtml, /admin-review-ai-intake\.js\?v=ai-booking-intake-customer-cards-v10/);
-  assert.match(customerIndex, /bookingScheduled\.js\?v=20260720_customer_booking_postdeploy_hardening_v2/);
-  assert.match(customerIndex, /state\.js\?v=20260720_customer_booking_postdeploy_hardening_v2/);
-  assert.match(customerSw, /const BUILD_ID = "20260720_customer_booking_postdeploy_hardening_v2"/);
-  assert.match(customerManifest, /20260720_customer_booking_postdeploy_hardening_v2/);
+  assert.match(customerIndex, /bookingScheduled\.js\?v=20260726_urgent_preferred_time_gps_v1/);
+  assert.match(customerIndex, /state\.js\?v=20260726_urgent_preferred_time_gps_v1/);
+  assert.match(customerSw, /const BUILD_ID = "20260726_urgent_preferred_time_gps_v1"/);
+  assert.match(customerManifest, /20260726_urgent_preferred_time_gps_v1/);
 });
 
 test("behavior: review queue only includes customer urgent waiting rows while preserving review statuses", () => {
@@ -512,6 +512,46 @@ test("behavior: urgent waiting modal is viewable but all mutation paths are read
   await hooks.rebroadcastOffer();
   await hooks.rebroadcastOfferQuick(7);
   await hooks.cancelJob();
+});
+
+test("behavior: Existing Admin Review/Edit renders urgent preferred time, preference, address, map, GPS, and note from job detail", async () => {
+  const detail = {
+    job_id: 17,
+    booking_code: "URG-17",
+    booking_mode: "urgent",
+    job_status: "รอตรวจสอบ",
+    appointment_datetime: "2026-08-01T13:45:00+07:00",
+    allow_time_proposal: true,
+    customer_name: "ลูกค้าด่วน",
+    customer_phone: "0812345678",
+    address_text: "123 ถนนสุขุมวิท",
+    maps_url: "https://www.google.com/maps?q=13.7563,100.5018",
+    gps_latitude: 13.7563,
+    gps_longitude: 100.5018,
+    customer_note: "โทรก่อนถึง",
+    job_type: "ล้าง",
+    duration_min: 120,
+    admin_action_required: true,
+  };
+  const sandbox = createAdminReviewSandbox({
+    apiFetch: async (url, requestOptions = {}) => {
+      if (requestOptions.method) throw new Error(`unexpected mutation ${requestOptions.method} ${url}`);
+      if (/\/admin\/job_v2\/17/.test(url)) return { job: detail };
+      if (/\/team/.test(url)) return { members: [] };
+      if (/\/pricing/.test(url)) return { total: 0, discount: 0 };
+      return {};
+    },
+  });
+  const hooks = sandbox.window.__CWF_ADMIN_REVIEW_TEST__;
+  hooks.setRowMap([{ job_id: 17, booking_code: "URG-17", booking_mode: "urgent", job_status: "รอตรวจสอบ" }]);
+  await hooks.openJob(17);
+  assert.equal(sandbox.__elements.get("mAppt").value, "2026-08-01T13:45");
+  assert.equal(sandbox.__elements.get("mTimePreference").value, "เสนอเวลาใหม่ได้");
+  assert.equal(sandbox.__elements.get("mAddress").value, detail.address_text);
+  assert.equal(sandbox.__elements.get("mMaps").value, detail.maps_url);
+  assert.equal(sandbox.__elements.get("mLat").value, "13.7563");
+  assert.equal(sandbox.__elements.get("mLng").value, "100.5018");
+  assert.equal(sandbox.__elements.get("mNote").value, detail.customer_note);
 });
 
 test("behavior: notification checks all queue rows even when selected display filter hides the new job", () => {

--- a/test/customerBookingAdminNotifications.test.js
+++ b/test/customerBookingAdminNotifications.test.js
@@ -312,10 +312,10 @@ test("admin/customer frontend cache versions are bumped for booking notification
   assert.doesNotMatch(adminReviewHtml, /admin-review-v2\.js\?v=20260707_customer_booking_notify_v2/);
   assert.match(adminReviewHtml, /admin-review-ai-intake\.js\?v=ai-booking-intake-customer-cards-v11-admin-alert-gate/);
   assert.doesNotMatch(adminReviewHtml, /admin-review-ai-intake\.js\?v=ai-booking-intake-customer-cards-v10/);
-  assert.match(customerIndex, /bookingScheduled\.js\?v=20260726_urgent_preferred_time_gps_v1/);
-  assert.match(customerIndex, /state\.js\?v=20260726_urgent_preferred_time_gps_v1/);
-  assert.match(customerSw, /const BUILD_ID = "20260726_urgent_preferred_time_gps_v1"/);
-  assert.match(customerManifest, /20260726_urgent_preferred_time_gps_v1/);
+  assert.match(customerIndex, /bookingScheduled\.js\?v=20260726_urgent_preferred_time_gps_v2/);
+  assert.match(customerIndex, /state\.js\?v=20260726_urgent_preferred_time_gps_v2/);
+  assert.match(customerSw, /const BUILD_ID = "20260726_urgent_preferred_time_gps_v2"/);
+  assert.match(customerManifest, /20260726_urgent_preferred_time_gps_v2/);
 });
 
 test("behavior: review queue only includes customer urgent waiting rows while preserving review statuses", () => {

--- a/test/customerBookingMutationCharacterization.test.js
+++ b/test/customerBookingMutationCharacterization.test.js
@@ -132,10 +132,12 @@ function publicUrgentBody(overrides = {}) {
     customer_name: "ลูกค้าด่วน",
     customer_phone: "0899999999",
     job_type: "ล้างแอร์",
+    appointment_datetime: "2026-08-01T13:45:00+07:00",
     address_text: "กรุงเทพฯ",
     maps_url: "",
     job_zone: "",
     customer_note: "",
+    allow_time_proposal: false,
     booking_mode: "urgent",
     ac_type: "ผนัง",
     btu: 12000,
@@ -324,10 +326,7 @@ function dbTest(name, fn) {
 
 function makeDependencies(overrides = {}) {
   let bookingCodeSequence = 0;
-  const urgentPublicAdapter = {
-    ...urgentPublicAdapterBase,
-    computeCustomerUrgentAppointmentIso: () => "2026-08-01T09:00:00+07:00",
-  };
+  const urgentPublicAdapter = urgentPublicAdapterBase;
   return {
     pool,
     urgentPublicAdapter,
@@ -603,14 +602,8 @@ dbTest("real PostgreSQL: public urgent waits for admin with zero offers, assignm
   assert.equal(income.length, 0);
 });
 
-dbTest("real PostgreSQL: urgent retry keeps the first server appointment authoritative and rejects material payload reuse", async () => {
-  const appointments = ["2026-08-01T09:00:00+07:00", "2026-08-01T09:30:00+07:00", "2026-08-01T10:00:00+07:00"];
-  let appointmentIndex = 0;
-  const adapter = {
-    ...urgentPublicAdapterBase,
-    computeCustomerUrgentAppointmentIso: () => appointments[Math.min(appointmentIndex++, appointments.length - 1)],
-  };
-  const service = createBookingJobService(makeDependencies({ urgentPublicAdapter: adapter }));
+dbTest("real PostgreSQL: urgent retry preserves customer preferred time/GPS and rejects every material payload reuse", async () => {
+  const service = createBookingJobService(makeDependencies());
   const body = publicUrgentBody({ urgent_request_key: "urgent-pr3-clock-replay-0001" });
   const first = await invoke(service.handlePublicBook, body);
   const replay = await invoke(service.handlePublicBook, body);
@@ -618,14 +611,64 @@ dbTest("real PostgreSQL: urgent retry keeps the first server appointment authori
   assert.equal(replay.statusCode, 200);
   assert.equal(replay.body.replayed, true);
   assert.equal(replay.body.job_id, first.body.job_id);
-  const stored = (await pool.query(`SELECT appointment_datetime FROM public.jobs WHERE job_id=$1`, [first.body.job_id])).rows[0];
-  assert.equal(new Date(stored.appointment_datetime).getTime(), new Date(appointments[0]).getTime());
+  const stored = (await pool.query(
+    `SELECT appointment_datetime, allow_time_proposal, gps_latitude, gps_longitude
+       FROM public.jobs WHERE job_id=$1`,
+    [first.body.job_id]
+  )).rows[0];
+  assert.equal(new Date(stored.appointment_datetime).getTime(), new Date(body.appointment_datetime).getTime());
+  assert.equal(stored.allow_time_proposal, false);
+  assert.equal(stored.gps_latitude, null);
+  assert.equal(stored.gps_longitude, null);
   assert.equal(Number((await pool.query(`SELECT COUNT(*) FROM public.jobs`)).rows[0].count), 1);
 
-  const changed = await invoke(service.handlePublicBook, { ...body, customer_note: "materially changed" });
-  assert.equal(changed.statusCode, 409);
-  assert.equal(changed.body.code, "IDEMPOTENCY_KEY_REUSED");
+  const mutations = [
+    { appointment_datetime: "2026-08-01T14:00:00+07:00" },
+    { gps_latitude: 13.7563, gps_longitude: 100.5018 },
+    { maps_url: "https://www.google.com/maps?q=13.7563,100.5018" },
+    { allow_time_proposal: true },
+    { customer_note: "materially changed" },
+  ];
+  for (const patch of mutations) {
+    const changed = await invoke(service.handlePublicBook, { ...body, ...patch });
+    assert.equal(changed.statusCode, 409, JSON.stringify(patch));
+    assert.equal(changed.body.code, "IDEMPOTENCY_KEY_REUSED", JSON.stringify(patch));
+  }
   assert.equal(Number((await pool.query(`SELECT COUNT(*) FROM public.jobs`)).rows[0].count), 1);
+});
+
+dbTest("real PostgreSQL: urgent persists multiple cleaning lines, customer GPS, preference, and no pre-approval technician side effects", async () => {
+  const service = createBookingJobService(makeDependencies());
+  const body = publicUrgentBody({
+    urgent_request_key: "urgent-preferred-gps-multi-0001",
+    maps_url: "https://www.google.com/maps?q=13.7563,100.5018",
+    gps_latitude: 13.7563,
+    gps_longitude: 100.5018,
+    allow_time_proposal: true,
+    services: [
+      { job_type: "ล้าง", ac_type: "ผนัง", btu: 12000, machine_count: 2, wash_variant: "ล้างธรรมดา", repair_variant: "" },
+      { job_type: "ล้าง", ac_type: "สี่ทิศทาง", btu: 24000, machine_count: 1, wash_variant: "", repair_variant: "" },
+    ],
+  });
+  const result = await invoke(service.handlePublicBook, body);
+  assert.equal(result.statusCode, 200);
+  const job = (await pool.query(
+    `SELECT appointment_datetime, maps_url, gps_latitude, gps_longitude, allow_time_proposal,
+            technician_username, job_status
+       FROM public.jobs WHERE job_id=$1`,
+    [result.body.job_id]
+  )).rows[0];
+  assert.equal(new Date(job.appointment_datetime).getTime(), new Date(body.appointment_datetime).getTime());
+  assert.equal(job.maps_url, body.maps_url);
+  assert.equal(Number(job.gps_latitude), body.gps_latitude);
+  assert.equal(Number(job.gps_longitude), body.gps_longitude);
+  assert.equal(job.allow_time_proposal, true);
+  assert.equal(job.technician_username, null);
+  assert.equal(job.job_status, JOB_STATUS.CUSTOMER_SCHEDULED_REVIEW);
+  assert.equal(Number((await pool.query(`SELECT COUNT(*) FROM public.job_items WHERE job_id=$1`, [result.body.job_id])).rows[0].count), 2);
+  assert.equal(Number((await pool.query(`SELECT COUNT(*) FROM public.job_offers WHERE job_id=$1`, [result.body.job_id])).rows[0].count), 0);
+  assert.equal(Number((await pool.query(`SELECT COUNT(*) FROM public.job_assignments WHERE job_id=$1`, [result.body.job_id])).rows[0].count), 0);
+  assert.equal(Number((await pool.query(`SELECT COUNT(*) FROM public.job_team_members WHERE job_id=$1`, [result.body.job_id])).rows[0].count), 0);
 });
 
 dbTest("real PostgreSQL: strict urgent cleaning classifier rejects tampering before pricing and DB mutation", async () => {

--- a/test/customerBookingPendingApproval.test.js
+++ b/test/customerBookingPendingApproval.test.js
@@ -128,8 +128,9 @@ test("Admin Add and Queue no longer call public forced availability", () => {
 });
 
 test("changed Admin booking scripts have one shared cache-bust build", () => {
-  const build = "20260719_customer_booking_pr3_v1";
-  for (const page of ["admin-add-v2", "admin-queue-v2", "admin-review-v2"]) {
-    assert.match(read(`${page}.html`), new RegExp(`${page}\\.js\\?v=${build}`));
+  const pr3Build = "20260719_customer_booking_pr3_v1";
+  for (const page of ["admin-add-v2", "admin-queue-v2"]) {
+    assert.match(read(`${page}.html`), new RegExp(`${page}\\.js\\?v=${pr3Build}`));
   }
+  assert.match(read("admin-review-v2.html"), /admin-review-v2\.js\?v=20260726_urgent_preferred_time_gps_v1/);
 });

--- a/test/customerBookingProductionCopy.test.js
+++ b/test/customerBookingProductionCopy.test.js
@@ -5,7 +5,7 @@ const path = require("node:path");
 const vm = require("node:vm");
 
 const ROOT = path.resolve(__dirname, "..");
-const BUILD = "20260720_customer_booking_postdeploy_hardening_v2";
+const BUILD = "20260726_urgent_preferred_time_gps_v1";
 
 function read(relativePath) {
   return fs.readFileSync(path.join(ROOT, relativePath), "utf8");
@@ -222,8 +222,8 @@ test("urgent UI is cleaning-only and a stale repair draft cannot alter its paylo
     services: [{ job_type: "ซ่อม", ac_type: "ผนัง", btu: 12000, machine_count: 3 }],
   });
 
-  const html = root.bookingUrgent._test.renderForm();
-  assert.match(html, /จองล้างแอร์|งานล้างแอร์เท่านั้น|ชนิดแอร์|รูปแบบการล้างสำหรับแอร์ผนัง|BTU|จำนวนเครื่อง/);
+  const html = root.bookingUrgent._test.renderServicesStep();
+  assert.match(html, /บริการและราคา|ชนิดแอร์|วิธีล้าง|BTU|จำนวนเครื่อง/);
   assert.doesNotMatch(html, /ซ่อม|ติดตั้ง|ย้ายแอร์|ตรวจอาการ|service_kind/);
 
   const payload = root.bookingUrgent._test.buildSubmitPayload();
@@ -233,7 +233,7 @@ test("urgent UI is cleaning-only and a stale repair draft cannot alter its paylo
   assert.equal(payload.repair_variant, "");
   assert.equal(payload.services[0].repair_variant, "");
   assert.equal(Object.hasOwn(payload, "dispatch_mode"), false);
-  assert.equal(Object.hasOwn(payload, "allow_time_proposal"), false);
+  assert.equal(payload.allow_time_proposal, false);
 });
 
 test("urgent API boundary forces cleaning on every line and preserves structured safe error metadata", async () => {
@@ -258,7 +258,7 @@ test("urgent API boundary forces cleaning on every line and preserves structured
   assert.equal(body.repair_variant, "");
   assert.equal(body.services[0].repair_variant, "");
   assert.equal(Object.hasOwn(body, "dispatch_mode"), false);
-  assert.equal(Object.hasOwn(body, "allow_time_proposal"), false);
+  assert.equal(body.allow_time_proposal, true);
 
   context.fetch = async () => ({
     ok: false,

--- a/test/customerBookingProductionCopy.test.js
+++ b/test/customerBookingProductionCopy.test.js
@@ -5,7 +5,7 @@ const path = require("node:path");
 const vm = require("node:vm");
 
 const ROOT = path.resolve(__dirname, "..");
-const BUILD = "20260726_urgent_preferred_time_gps_v1";
+const BUILD = "20260726_urgent_preferred_time_gps_v2";
 
 function read(relativePath) {
   return fs.readFileSync(path.join(ROOT, relativePath), "utf8");

--- a/test/customerHistoryClaim.test.js
+++ b/test/customerHistoryClaim.test.js
@@ -845,7 +845,7 @@ test("Customer History search and preview keep 360px and 390px width contracts",
 });
 
 test("Customer App cache version is bumped consistently", () => {
-  const expected = "20260720_customer_booking_postdeploy_hardening_v2";
+  const expected = "20260726_urgent_preferred_time_gps_v1";
   for (const file of [
     "customer-app/index.html",
     "customer-app/sw.js",

--- a/test/customerHistoryClaim.test.js
+++ b/test/customerHistoryClaim.test.js
@@ -845,7 +845,7 @@ test("Customer History search and preview keep 360px and 390px width contracts",
 });
 
 test("Customer App cache version is bumped consistently", () => {
-  const expected = "20260726_urgent_preferred_time_gps_v1";
+  const expected = "20260726_urgent_preferred_time_gps_v2";
   for (const file of [
     "customer-app/index.html",
     "customer-app/sw.js",

--- a/test/customerHomepageFeaturedRotation.test.js
+++ b/test/customerHomepageFeaturedRotation.test.js
@@ -418,6 +418,6 @@ test("compact CSS and cache build remain consistent with six-card rotation", () 
   assert.match(css, /\.homepage-featured-page\s*\{[^}]*grid-area:\s*1\s*\/\s*1/s);
   assert.match(css, /transition:\s*opacity 350ms/);
   assert.match(css, /prefers-reduced-motion:\s*reduce/);
-  const build = "20260726_urgent_preferred_time_gps_v1";
+  const build = "20260726_urgent_preferred_time_gps_v2";
   for (const source of [html, sw, boot, manifest]) assert.match(source, new RegExp(build));
 });

--- a/test/customerHomepageFeaturedRotation.test.js
+++ b/test/customerHomepageFeaturedRotation.test.js
@@ -418,6 +418,6 @@ test("compact CSS and cache build remain consistent with six-card rotation", () 
   assert.match(css, /\.homepage-featured-page\s*\{[^}]*grid-area:\s*1\s*\/\s*1/s);
   assert.match(css, /transition:\s*opacity 350ms/);
   assert.match(css, /prefers-reduced-motion:\s*reduce/);
-  const build = "20260720_customer_booking_postdeploy_hardening_v2";
+  const build = "20260726_urgent_preferred_time_gps_v1";
   for (const source of [html, sw, boot, manifest]) assert.match(source, new RegExp(build));
 });

--- a/test/customerSameDayTiming.test.js
+++ b/test/customerSameDayTiming.test.js
@@ -161,7 +161,7 @@ test("customer app disables availability HTTP cache and refreshes same-day slots
 });
 
 test("customer app build and service worker cache IDs changed", () => {
-  const id = "20260726_urgent_preferred_time_gps_v1";
+  const id = "20260726_urgent_preferred_time_gps_v2";
   for (const file of [
     "customer-app/index.html",
     "customer-app/sw.js",

--- a/test/customerSameDayTiming.test.js
+++ b/test/customerSameDayTiming.test.js
@@ -161,7 +161,7 @@ test("customer app disables availability HTTP cache and refreshes same-day slots
 });
 
 test("customer app build and service worker cache IDs changed", () => {
-  const id = "20260720_customer_booking_postdeploy_hardening_v2";
+  const id = "20260726_urgent_preferred_time_gps_v1";
   for (const file of [
     "customer-app/index.html",
     "customer-app/sw.js",

--- a/test/customerSmartAdvisor.test.js
+++ b/test/customerSmartAdvisor.test.js
@@ -1174,7 +1174,7 @@ test("Home places built-in advisor after Quick Actions and before Featured Servi
 });
 
 test("advisor module is loaded before ui.js and precached under the shared build id", () => {
-  const build = "20260720_customer_booking_postdeploy_hardening_v2";
+  const build = "20260726_urgent_preferred_time_gps_v1";
   assert.ok(INDEX_SOURCE.indexOf(`modules/advisor.js?v=${build}`) < INDEX_SOURCE.indexOf(`modules/ui.js?v=${build}`));
   assert.match(SW_SOURCE, new RegExp(`BUILD_ID = "${build}"`));
   assert.match(SW_SOURCE, /modules\/advisor\.js\?v=\$\{BUILD_ID\}/);

--- a/test/customerSmartAdvisor.test.js
+++ b/test/customerSmartAdvisor.test.js
@@ -1174,7 +1174,7 @@ test("Home places built-in advisor after Quick Actions and before Featured Servi
 });
 
 test("advisor module is loaded before ui.js and precached under the shared build id", () => {
-  const build = "20260726_urgent_preferred_time_gps_v1";
+  const build = "20260726_urgent_preferred_time_gps_v2";
   assert.ok(INDEX_SOURCE.indexOf(`modules/advisor.js?v=${build}`) < INDEX_SOURCE.indexOf(`modules/ui.js?v=${build}`));
   assert.match(SW_SOURCE, new RegExp(`BUILD_ID = "${build}"`));
   assert.match(SW_SOURCE, /modules\/advisor\.js\?v=\$\{BUILD_ID\}/);

--- a/test/customerTrackingFullReadUi.test.js
+++ b/test/customerTrackingFullReadUi.test.js
@@ -1158,7 +1158,7 @@ test("tracking UI exposes loading, not-found, rate-limit and offline states", ()
 });
 
 test("tracking assets share the full-read cache build id", () => {
-  const build = "20260720_customer_booking_postdeploy_hardening_v2";
+  const build = "20260726_urgent_preferred_time_gps_v1";
   for (const file of [
     "customer-app/index.html",
     "customer-app/sw.js",

--- a/test/customerTrackingFullReadUi.test.js
+++ b/test/customerTrackingFullReadUi.test.js
@@ -1158,7 +1158,7 @@ test("tracking UI exposes loading, not-found, rate-limit and offline states", ()
 });
 
 test("tracking assets share the full-read cache build id", () => {
-  const build = "20260726_urgent_preferred_time_gps_v1";
+  const build = "20260726_urgent_preferred_time_gps_v2";
   for (const file of [
     "customer-app/index.html",
     "customer-app/sw.js",

--- a/test/customerUrgentPreferredTimeGps.test.js
+++ b/test/customerUrgentPreferredTimeGps.test.js
@@ -1,0 +1,252 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const vm = require("node:vm");
+const { createBookingJobService } = require("../server/services/booking/createBookingJob");
+const urgentPublicAdapter = require("../server/services/urgentPublicAdapter");
+
+const ROOT = path.resolve(__dirname, "..");
+
+function read(relativePath) {
+  return fs.readFileSync(path.join(ROOT, relativePath), "utf8");
+}
+
+function makeContext() {
+  const window = {
+    CWFCustomerAppV2: {},
+    location: { protocol: "https:", origin: "https://app.example.test", hostname: "app.example.test", pathname: "/customer-app/", search: "", hash: "" },
+    sessionStorage: { getItem() { return null; }, setItem() {}, removeItem() {} },
+    localStorage: { getItem() { return null; }, setItem() {}, removeItem() {} },
+    addEventListener() {},
+    removeEventListener() {},
+  };
+  const context = {
+    window,
+    document: {
+      visibilityState: "visible",
+      body: { classList: { add() {}, remove() {} } },
+      addEventListener() {},
+      removeEventListener() {},
+      createElement() { return { setAttribute() {}, appendChild() {}, classList: { add() {}, remove() {} } }; },
+    },
+    navigator: {},
+    history: { replaceState() {} },
+    URL,
+    URLSearchParams,
+    Intl,
+    Date,
+    console,
+    setTimeout,
+    clearTimeout,
+    setInterval() { return 1; },
+    clearInterval() {},
+    requestAnimationFrame(callback) { callback(); },
+  };
+  context.globalThis = context;
+  return vm.createContext(context);
+}
+
+function loadUrgent() {
+  const context = makeContext();
+  for (const modulePath of [
+    "customer-app/modules/state.js",
+    "customer-app/modules/utils.js",
+    "customer-app/modules/customerCopy.js",
+    "customer-app/modules/services.js",
+    "customer-app/modules/bookingUrgent.js",
+  ]) {
+    vm.runInContext(read(modulePath), context, { filename: modulePath });
+  }
+  return { context, root: context.window.CWFCustomerAppV2 };
+}
+
+function futureDraft(root) {
+  const services = [
+    root.services.createServiceLine({ line_id: "a", ac_type: "ผนัง", btu: 12000, machine_count: 2, wash_variant: "ล้างธรรมดา" }),
+    root.services.createServiceLine({ line_id: "b", ac_type: "สี่ทิศทาง", btu: 24000, machine_count: 1 }),
+  ];
+  root.state.updateDraft("urgent", {
+    services,
+    customer_name: "สมชาย",
+    customer_phone: "0812345678",
+    address_text: "กรุงเทพฯ",
+    date: "2099-08-01",
+    time: "13:45",
+    allow_time_proposal: false,
+    maps_url: "https://www.google.com/maps?q=13.7563,100.5018",
+    gps_latitude: 13.7563,
+    gps_longitude: 100.5018,
+    symptom: "",
+  });
+}
+
+test("urgent flow has three customer steps, native date/time, multiple cleaning lines, and shared pricing", () => {
+  const { root } = loadUrgent();
+  futureDraft(root);
+  root.state.setUrgentFlow({
+    pricing: {
+      status: "success",
+      data: {
+        active_price: 1800,
+        duration_min: 150,
+        price_lines: [{ line_total: 1000 }, { line_total: 800 }],
+      },
+      error: "",
+    },
+  });
+
+  const serviceHtml = root.bookingUrgent._test.renderServicesStep();
+  const detailsHtml = root.bookingUrgent._test.renderDetailsStep();
+  const reviewHtml = root.bookingUrgent._test.renderReview();
+  assert.match(serviceHtml, /ขั้นตอน 1 จาก 3|เพิ่มเครื่อง \/ เพิ่มรายการ|ราคารวมประมาณการ|1,800/);
+  assert.match(detailsHtml, /ขั้นตอน 2 จาก 3|type="date"|type="time"|ใช้ตำแหน่งปัจจุบัน/);
+  assert.match(reviewHtml, /ขั้นตอน 3 จาก 3|รายการที่ 1|รายการที่ 2|13:45|ต้องการตามเวลานี้|1,800/);
+  assert.doesNotMatch(`${serviceHtml}\n${detailsHtml}\n${reviewHtml}`, /availability_v2|availability_calendar|เลือกคิวว่าง|ตัวตนช่าง/i);
+});
+
+test("urgent submit payload persists preferred time, preference, GPS, optional note, and all cleaning lines", () => {
+  const { root } = loadUrgent();
+  futureDraft(root);
+  const payload = root.bookingUrgent._test.buildSubmitPayload();
+  assert.equal(payload.appointment_datetime, "2099-08-01T13:45:00+07:00");
+  assert.equal(payload.allow_time_proposal, false);
+  assert.equal(payload.gps_latitude, 13.7563);
+  assert.equal(payload.gps_longitude, 100.5018);
+  assert.equal(payload.maps_url, "https://www.google.com/maps?q=13.7563,100.5018");
+  assert.equal(payload.customer_note, "");
+  assert.equal(payload.services.length, 2);
+  assert.ok(payload.services.every((line) => line.job_type === "ล้าง" && !line.repair_variant));
+});
+
+test("urgent validation requires contact/date/time but allows an empty note and rejects a past time", () => {
+  const { root } = loadUrgent();
+  futureDraft(root);
+  assert.equal(root.bookingUrgent._test.validateDetails(), "");
+  root.state.updateDraft("urgent", { date: "" });
+  assert.match(root.bookingUrgent._test.validateDetails(), /วันที่/);
+  root.state.updateDraft("urgent", { date: "2000-01-01", time: "09:00" });
+  assert.match(root.bookingUrgent._test.validateDetails(), /ย้อนหลัง/);
+});
+
+test("geolocation is user-triggered and handles success, denied, timeout, and unsupported browser in Thai", async () => {
+  const { context, root } = loadUrgent();
+  context.navigator.geolocation = {
+    getCurrentPosition(success) {
+      success({ coords: { latitude: 13.7563, longitude: 100.5018 } });
+    },
+  };
+  assert.equal(await root.bookingUrgent._test.requestCurrentLocation(), true);
+  assert.equal(root.state.draft.urgent.maps_url, "https://www.google.com/maps?q=13.7563,100.5018");
+  assert.match(root.state.urgentFlow.locationMessage, /สำเร็จ/);
+
+  for (const [code, expected] of [[1, /ปฏิเสธสิทธิ์/], [3, /หมดเวลา/]]) {
+    context.navigator.geolocation = { getCurrentPosition(_success, failure) { failure({ code }); } };
+    assert.equal(await root.bookingUrgent._test.requestCurrentLocation(), false);
+    assert.match(root.state.urgentFlow.locationMessage, expected);
+  }
+  delete context.navigator.geolocation;
+  assert.equal(await root.bookingUrgent._test.requestCurrentLocation(), false);
+  assert.match(root.state.urgentFlow.locationMessage, /ไม่รองรับ/);
+});
+
+test("urgent runtime never calls availability/calendar APIs and API boundary preserves safe urgent fields", async () => {
+  const urgentSource = read("customer-app/modules/bookingUrgent.js");
+  assert.doesNotMatch(urgentSource, /loadAvailability|loadAvailabilityCalendar|availability_v2|availability_calendar/);
+
+  const context = makeContext();
+  const calls = [];
+  context.fetch = async (url, options) => {
+    calls.push({ url, options });
+    return { ok: true, status: 200, async text() { return JSON.stringify({ success: true }); } };
+  };
+  vm.runInContext(read("customer-app/modules/api.js"), context, { filename: "customer-app/modules/api.js" });
+  await context.window.CWFCustomerAppV2.api.submitUrgentRequest({
+    appointment_datetime: "2099-08-01T13:45:00+07:00",
+    allow_time_proposal: true,
+    gps_latitude: 13.7563,
+    gps_longitude: 100.5018,
+    services: [{ job_type: "ซ่อม", repair_variant: "ตรวจอาการ" }],
+  });
+  assert.equal(calls.length, 1);
+  assert.match(String(calls[0].url), /\/public\/book$/);
+  const body = JSON.parse(calls[0].options.body);
+  assert.equal(body.allow_time_proposal, true);
+  assert.equal(body.gps_latitude, 13.7563);
+  assert.equal(body.gps_longitude, 100.5018);
+  assert.equal(body.services[0].job_type, "ล้าง");
+  assert.equal(body.services[0].repair_variant, "");
+  assert.equal(Object.hasOwn(body, "dispatch_mode"), false);
+});
+
+test("Existing Admin Review/Edit displays urgent preferred time, preference, address, map, GPS, and note", () => {
+  const runtime = read("admin-review-v2.js");
+  const template = read("admin-review-v2.html");
+  for (const field of ["appointment_datetime", "allow_time_proposal", "address_text", "maps_url", "gps_latitude", "gps_longitude", "customer_note"]) {
+    assert.match(runtime, new RegExp(field));
+  }
+  assert.match(runtime, /ต้องการตามเวลานี้|เสนอเวลาใหม่ได้/);
+  assert.match(template, /mTimePreference/);
+});
+
+function backendValidationService() {
+  let databaseTouched = false;
+  const service = createBookingJobService({
+    pool: {
+      async connect() { databaseTouched = true; throw new Error("database must not be touched"); },
+      async query() { databaseTouched = true; throw new Error("database must not be touched"); },
+    },
+    urgentPublicAdapter,
+    isServiceZoneFilterEnabled: () => false,
+    isCustomerUrgentBookingEnabled: () => true,
+    isCustomerScheduledBookingEnabled: () => true,
+    isUrgentFlowEnabled: () => true,
+  });
+  return { service, touched: () => databaseTouched };
+}
+
+async function invokeInvalidUrgent(body) {
+  const { service, touched } = backendValidationService();
+  const req = { body: {
+    customer_name: "ลูกค้าทดสอบ",
+    customer_phone: "0812345678",
+    address_text: "กรุงเทพฯ",
+    job_type: "ล้าง",
+    booking_mode: "urgent",
+    urgent_request_key: "urgent-validation-key-0001",
+    appointment_datetime: "2099-08-01T13:45:00+07:00",
+    allow_time_proposal: false,
+    services: [{ job_type: "ล้าง", ac_type: "ผนัง", btu: 12000, machine_count: 1 }],
+    ...body,
+  } };
+  const res = {
+    statusCode: 200,
+    body: null,
+    status(code) { this.statusCode = code; return this; },
+    json(payload) { this.body = payload; return payload; },
+  };
+  await service.handlePublicBook(req, res);
+  return { res, touched: touched() };
+}
+
+test("backend rejects past appointment and partial/invalid/out-of-range/zero GPS before DB mutation", async () => {
+  const past = await invokeInvalidUrgent({ appointment_datetime: "2000-01-01T09:00:00+07:00" });
+  assert.equal(past.res.statusCode, 409);
+  assert.equal(past.res.body.code, "APPOINTMENT_IN_PAST");
+  assert.equal(past.touched, false);
+
+  for (const patch of [
+    { gps_latitude: 13.7 },
+    { gps_longitude: 100.5 },
+    { gps_latitude: "abc", gps_longitude: 100.5 },
+    { gps_latitude: "NaN", gps_longitude: 100.5 },
+    { gps_latitude: 91, gps_longitude: 100.5 },
+    { gps_latitude: 13.7, gps_longitude: 181 },
+    { gps_latitude: 0, gps_longitude: 0 },
+  ]) {
+    const result = await invokeInvalidUrgent(patch);
+    assert.equal(result.res.statusCode, 400, JSON.stringify(patch));
+    assert.equal(result.res.body.code, "INVALID_GPS", JSON.stringify(patch));
+    assert.equal(result.touched, false, JSON.stringify(patch));
+  }
+});

--- a/test/customerUrgentPreferredTimeGps.test.js
+++ b/test/customerUrgentPreferredTimeGps.test.js
@@ -81,6 +81,45 @@ function futureDraft(root) {
   });
 }
 
+function futureNoGpsDraft(root) {
+  root.state.updateDraft("urgent", {
+    services: [
+      root.services.createServiceLine({
+        line_id: "no-gps",
+        ac_type: "ผนัง",
+        btu: 12000,
+        machine_count: 1,
+        wash_variant: "ล้างธรรมดา",
+      }),
+    ],
+    customer_name: "ลูกค้าไม่ใช้ GPS",
+    customer_phone: "0812345678",
+    address_text: "กรุงเทพฯ",
+    date: "2099-08-01",
+    time: "13:45",
+    allow_time_proposal: false,
+    maps_url: "",
+    symptom: "",
+  });
+}
+
+test("default no-GPS urgent draft omits coordinates, hides the GPS review row, and is accepted by backend GPS validation", () => {
+  const { root } = loadUrgent();
+  futureNoGpsDraft(root);
+
+  const payload = root.bookingUrgent._test.buildSubmitPayload();
+  const reviewHtml = root.bookingUrgent._test.renderReview();
+  const backendGps = urgentPublicAdapter.validateCustomerUrgentGps(
+    payload.gps_latitude,
+    payload.gps_longitude
+  );
+
+  assert.equal(Object.hasOwn(payload, "gps_latitude"), false);
+  assert.equal(Object.hasOwn(payload, "gps_longitude"), false);
+  assert.doesNotMatch(reviewHtml, /<strong>GPS<\/strong>|GPS\s*0\s*,\s*0/);
+  assert.deepEqual(backendGps, { ok: true, latitude: null, longitude: null });
+});
+
 test("urgent flow has three customer steps, native date/time, multiple cleaning lines, and shared pricing", () => {
   const { root } = loadUrgent();
   futureDraft(root);

--- a/test/homepageCms.test.js
+++ b/test/homepageCms.test.js
@@ -305,7 +305,7 @@ test("customer homepage has no admin control, bottom nav is fixed five-tab, and 
   const sw = read("customer-app/sw.js");
   const app = read("customer-app/assets/customer-app.js");
   const manifest = read("customer-app/manifest.webmanifest");
-  const build = "20260726_urgent_preferred_time_gps_v1";
+  const build = "20260726_urgent_preferred_time_gps_v2";
 
   assert.doesNotMatch(index + ui, /โหมดแอดมิน|openCms|localStorage\.getItem\('cwfHomeCmsDemo'/);
   assert.match(index, /data-route="store"[\s\S]*ร้านค้า/);

--- a/test/homepageCms.test.js
+++ b/test/homepageCms.test.js
@@ -305,7 +305,7 @@ test("customer homepage has no admin control, bottom nav is fixed five-tab, and 
   const sw = read("customer-app/sw.js");
   const app = read("customer-app/assets/customer-app.js");
   const manifest = read("customer-app/manifest.webmanifest");
-  const build = "20260720_customer_booking_postdeploy_hardening_v2";
+  const build = "20260726_urgent_preferred_time_gps_v1";
 
   assert.doesNotMatch(index + ui, /โหมดแอดมิน|openCms|localStorage\.getItem\('cwfHomeCmsDemo'/);
   assert.match(index, /data-route="store"[\s\S]*ร้านค้า/);

--- a/test/jobLocationRoundtrip.test.js
+++ b/test/jobLocationRoundtrip.test.js
@@ -217,13 +217,14 @@ test("Test 14: check-in 500 m + accuracy policy is unchanged", () => {
 test("Test 15: PWA + admin cache build IDs are bumped consistently", () => {
   const BUILD = "20260712_job_location_roundtrip_v1";
   const PR3_ADMIN_BUILD = "20260719_customer_booking_pr3_v1";
+  const URGENT_REVIEW_BUILD = "20260726_urgent_preferred_time_gps_v1";
   assert.match(read("app.js"), new RegExp(`__CWF_TECH_APP_VERSION__ = "${BUILD}"`));
   assert.match(read("sw.js"), new RegExp(`CWF_TECH_BUILD_ID = "${BUILD}"`));
   assert.match(read("cwf-pwa.js"), new RegExp(`VERSION = '${BUILD}'`));
   assert.match(read("tech.html"), new RegExp(`app\\.js\\?v=${BUILD}`));
   assert.match(read("admin-add-v2.html"), new RegExp(`admin-add-v2\\.js\\?v=${PR3_ADMIN_BUILD}`));
   assert.match(read("admin-job-view-v2.html"), new RegExp(`admin-job-view-v2\\.js\\?v=${BUILD}`));
-  assert.match(read("admin-review-v2.html"), new RegExp(`admin-review-v2\\.js\\?v=${PR3_ADMIN_BUILD}`));
+  assert.match(read("admin-review-v2.html"), new RegExp(`admin-review-v2\\.js\\?v=${URGENT_REVIEW_BUILD}`));
 });
 
 // ---------------------------------------------------------------------------

--- a/test/urgentPublicAdapter.test.js
+++ b/test/urgentPublicAdapter.test.js
@@ -9,6 +9,10 @@ test("sanitizeCustomerUrgentBody drops admin-only fields and keeps customer-safe
     customer_phone: "0812345678",
     address_text: "123 Test Rd",
     maps_url: "https://maps.app.goo.gl/x",
+    appointment_datetime: "2026-08-01T13:45:00+07:00",
+    allow_time_proposal: false,
+    gps_latitude: 13.7563,
+    gps_longitude: 100.5018,
     job_zone: "north",
     customer_note: "leaking",
     job_type: "ล้าง",
@@ -37,8 +41,13 @@ test("sanitizeCustomerUrgentBody drops admin-only fields and keeps customer-safe
   assert.deepEqual(Object.keys(out).sort(), [
     "ac_type", "address_text", "btu", "client_app", "customer_name", "customer_note",
     "customer_phone", "job_type", "job_zone", "machine_count", "maps_url",
+    "appointment_datetime", "allow_time_proposal", "gps_latitude", "gps_longitude",
     "repair_variant", "services", "urgent_request_key", "wash_variant",
   ].sort());
+  assert.equal(out.appointment_datetime, "2026-08-01T13:45:00+07:00");
+  assert.equal(out.allow_time_proposal, false);
+  assert.equal(out.gps_latitude, 13.7563);
+  assert.equal(out.gps_longitude, 100.5018);
   assert.equal(out.service_zone_code, undefined);
   assert.equal(out.override_price, undefined);
   assert.equal(out.override_duration_min, undefined);
@@ -66,26 +75,50 @@ test("sanitizeCustomerUrgentBody caps services list at 10 entries", () => {
   assert.equal(out.services.length, 10);
 });
 
-test("computeCustomerUrgentAppointmentIso rounds up to the next slot step within business hours", () => {
-  const iso = urgentPublicAdapter.computeCustomerUrgentAppointmentIso({ ymd: "2026-06-22", hour: 10, minute: 5 });
-  // 10:05 + 30min lead = 10:35, ceil to 30-step => 11:00
-  assert.equal(iso, "2026-06-22T11:00:00+07:00");
+test("customer urgent appointment is normalized as an explicit Asia/Bangkok wall-clock time", () => {
+  assert.equal(
+    urgentPublicAdapter.normalizeCustomerUrgentAppointment("2026-08-01T13:45"),
+    "2026-08-01T13:45:00+07:00"
+  );
+  assert.equal(
+    urgentPublicAdapter.normalizeCustomerUrgentAppointment("2026-08-01T13:45:00+07:00"),
+    "2026-08-01T13:45:00+07:00"
+  );
+  for (const invalid of [
+    "",
+    "2026-02-30T10:00",
+    "2026-08-01T25:00",
+    "2026-08-01T13:45:00Z",
+    "not-a-date",
+  ]) {
+    assert.equal(urgentPublicAdapter.normalizeCustomerUrgentAppointment(invalid), null, invalid);
+  }
 });
 
-test("computeCustomerUrgentAppointmentIso clamps to opening time when lead time lands before 09:00", () => {
-  const iso = urgentPublicAdapter.computeCustomerUrgentAppointmentIso({ ymd: "2026-06-22", hour: 8, minute: 10 });
-  assert.equal(iso, "2026-06-22T09:00:00+07:00");
+test("customer urgent appointment rejects a past Bangkok time", () => {
+  const now = { ymd: "2026-08-01", hour: 13, minute: 45 };
+  assert.equal(urgentPublicAdapter.isCustomerUrgentAppointmentPast("2026-08-01T13:44:00+07:00", now), true);
+  assert.equal(urgentPublicAdapter.isCustomerUrgentAppointmentPast("2026-08-01T13:45:00+07:00", now), true);
+  assert.equal(urgentPublicAdapter.isCustomerUrgentAppointmentPast("2026-08-01T13:46:00+07:00", now), false);
 });
 
-test("computeCustomerUrgentAppointmentIso rolls over to next day's opening when lead time lands after 18:00", () => {
-  const iso = urgentPublicAdapter.computeCustomerUrgentAppointmentIso({ ymd: "2026-06-22", hour: 17, minute: 45 });
-  // 17:45 + 30min lead = 18:15, past UI_END_MIN(18:00) => roll to next day 09:00
-  assert.equal(iso, "2026-06-23T09:00:00+07:00");
-});
-
-test("computeCustomerUrgentAppointmentIso rolls month/year boundaries correctly", () => {
-  const iso = urgentPublicAdapter.computeCustomerUrgentAppointmentIso({ ymd: "2026-12-31", hour: 17, minute: 50 });
-  assert.equal(iso, "2027-01-01T09:00:00+07:00");
+test("customer urgent GPS must be a complete valid non-zero pair", () => {
+  assert.deepEqual(
+    urgentPublicAdapter.validateCustomerUrgentGps(13.7563, 100.5018),
+    { ok: true, latitude: 13.7563, longitude: 100.5018 }
+  );
+  assert.deepEqual(urgentPublicAdapter.validateCustomerUrgentGps("", ""), { ok: true, latitude: null, longitude: null });
+  for (const pair of [
+    [13.7, ""],
+    ["", 100.5],
+    ["abc", 100.5],
+    [Number.NaN, 100.5],
+    [91, 100.5],
+    [13.7, 181],
+    [0, 0],
+  ]) {
+    assert.equal(urgentPublicAdapter.validateCustomerUrgentGps(pair[0], pair[1]).ok, false, String(pair));
+  }
 });
 
 test("deriveUrgentBookingToken is deterministic for the same request key", () => {


### PR DESCRIPTION
## Summary

Implements the Issue #187 urgent-booking correction so customer urgent cleaning requests carry enough real data for Admin Review/Edit without checking technician availability or dispatching technicians before approval.

- convert Customer Urgent into a 3-step flow using the existing Scheduled service/pricing model
- require customer/contact/address/preferred date/preferred time while keeping note optional
- add explicit time preference: exact requested time or allow a proposed replacement time
- add native browser geolocation with no paid API or reverse geocoding; persist GPS and a Google Maps coordinate URL
- allow booking without GPS; absent coordinates are omitted rather than converted to `0,0`
- accept customer-selected urgent appointment time instead of replacing it with a server-generated value
- validate Bangkok-time past appointments and strict GPS pairs
- include appointment, GPS/maps, time preference, and note in idempotency matching
- keep urgent jobs in Admin approval first: no availability/calendar lookup, technician reservation, offer, assignment, team, income preview, or technician notification before approval
- expose preferred time, time preference, address, map/GPS, and note in the existing Admin Review/Edit flow
- Customer App PWA build ID: `20260726_urgent_preferred_time_gps_v2`

## Scope

Customer App urgent flow, urgent public adapter, shared booking creation path, existing Admin Review/Edit display, focused tests, and final PWA build references only.

No migration/schema, production data, payment, auth, Technician App, router, backend monolith, unrelated Admin refactor, merge, or deploy.

Refs #187

## Validation reported on head `d03aa4ee7e7b6795fd971207ee7b3d7c9bb806ce`

Initial implementation validation:
- focused: 273 tests, 249 passed, 0 failed, 24 DB-dependent skipped
- isolated PostgreSQL 18.3: 24/24 passed
- branch/base full-suite failure names identical; branch-only failures 0

No-GPS correction validation:
- focused tests: 356/356 passed
- urgent GPS regression: 8/8 passed
- isolated PostgreSQL no-GPS booking: 1/1 passed
- `node --check`: passed for changed JavaScript
- manifest parse: passed
- `git diff --check`: passed
- worktree clean; local/remote head aligned

## Source review

The prior no-GPS blocker is resolved: `null`, `undefined`, blank, or incomplete coordinate pairs are not treated as valid GPS; no-GPS payloads omit both coordinate fields and the review screen does not display `GPS 0,0`. The corrective commit only changes Customer App runtime/build references and focused tests; it adds no new backend or Admin diff.

## Remaining risk

No real browser session was available for manual 360px/390px click-through and screenshot verification. Keep this PR Draft until mobile QA covers both no-GPS and GPS-granted paths, navigation/back/retry behavior, and Admin Review visibility.