### PR TITLE
Add home-server production deploy workflow

### DIFF
--- a/.github/workflows/cwf-home-production.yml
+++ b/.github/workflows/cwf-home-production.yml
@@ -1,0 +1,87 @@
+name: CWF Home Production
+
+on:
+  push:
+    branches:
+      - production/home-server
+  workflow_dispatch:
+    inputs:
+      action:
+        description: Operation to run
+        required: true
+        default: deploy
+        type: choice
+        options:
+          - deploy
+          - restart
+          - rollback
+          - status
+          - list-backups
+          - restore
+      backup_file:
+        description: Backup filename for restore
+        required: false
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: cwf-home-production
+  cancel-in-progress: false
+
+jobs:
+  production:
+    name: Production operation
+    runs-on:
+      - self-hosted
+      - linux
+      - x64
+      - cwf-home
+    timeout-minutes: 90
+    steps:
+      - name: Auto deploy merged commit
+        if: github.event_name == 'push'
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+          sudo -n /usr/local/sbin/cwf-deployctl production deploy "$GITHUB_SHA" | tee /tmp/cwf-production-action.log
+          cat /tmp/cwf-production-action.log >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Manual operation
+        if: github.event_name == 'workflow_dispatch'
+        env:
+          CWF_ACTION: ${{ inputs.action }}
+          CWF_BACKUP_FILE: ${{ inputs.backup_file }}
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+          case "$CWF_ACTION" in
+            deploy)
+              sudo -n /usr/local/sbin/cwf-deployctl production deploy | tee /tmp/cwf-production-action.log
+              ;;
+            restart)
+              sudo -n /usr/local/sbin/cwf-deployctl production restart | tee /tmp/cwf-production-action.log
+              ;;
+            rollback)
+              sudo -n /usr/local/sbin/cwf-deployctl production rollback | tee /tmp/cwf-production-action.log
+              ;;
+            status)
+              sudo -n /usr/local/sbin/cwf-deployctl production status | tee /tmp/cwf-production-action.log
+              ;;
+            list-backups)
+              sudo -n /usr/local/sbin/cwf-deployctl production list-backups | tee /tmp/cwf-production-action.log
+              ;;
+            restore)
+              test -n "$CWF_BACKUP_FILE" || {
+                echo "backup_file is required for restore" >&2
+                exit 2
+              }
+              sudo -n /usr/local/sbin/cwf-deployctl production restore "$CWF_BACKUP_FILE" | tee /tmp/cwf-production-action.log
+              ;;
+            *)
+              echo "Unsupported action: $CWF_ACTION" >&2
+              exit 2
+              ;;
+          esac
+          cat /tmp/cwf-production-action.log >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
Adds merge-triggered production deployment on the CWF home self-hosted runner. Also exposes manual deploy, restart, rollback, status, backup listing, and database restore operations through GitHub Actions. The workflow does not check out or execute repository code directly; it calls the root-owned deploy controller installed on the server.