### PR TITLE
Add home-server staging deploy workflow

### DIFF
--- a/.github/workflows/cwf-home-staging.yml
+++ b/.github/workflows/cwf-home-staging.yml
@@ -1,0 +1,70 @@
+name: CWF Home Staging
+
+on:
+  push:
+    branches:
+      - staging/home-server-test
+  workflow_dispatch:
+    inputs:
+      action:
+        description: Operation to run
+        required: true
+        default: deploy
+        type: choice
+        options:
+          - deploy
+          - restart
+          - rollback
+          - status
+
+permissions:
+  contents: read
+
+concurrency:
+  group: cwf-home-staging
+  cancel-in-progress: false
+
+jobs:
+  staging:
+    name: Staging operation
+    runs-on:
+      - self-hosted
+      - linux
+      - x64
+      - cwf-home
+    timeout-minutes: 60
+    steps:
+      - name: Auto deploy merged commit
+        if: github.event_name == 'push'
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+          sudo -n /usr/local/sbin/cwf-deployctl staging deploy "$GITHUB_SHA" | tee /tmp/cwf-staging-action.log
+          cat /tmp/cwf-staging-action.log >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Manual operation
+        if: github.event_name == 'workflow_dispatch'
+        env:
+          CWF_ACTION: ${{ inputs.action }}
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+          case "$CWF_ACTION" in
+            deploy)
+              sudo -n /usr/local/sbin/cwf-deployctl staging deploy | tee /tmp/cwf-staging-action.log
+              ;;
+            restart)
+              sudo -n /usr/local/sbin/cwf-deployctl staging restart | tee /tmp/cwf-staging-action.log
+              ;;
+            rollback)
+              sudo -n /usr/local/sbin/cwf-deployctl staging rollback | tee /tmp/cwf-staging-action.log
+              ;;
+            status)
+              sudo -n /usr/local/sbin/cwf-deployctl staging status | tee /tmp/cwf-staging-action.log
+              ;;
+            *)
+              echo "Unsupported action: $CWF_ACTION" >&2
+              exit 2
+              ;;
+          esac
+          cat /tmp/cwf-staging-action.log >> "$GITHUB_STEP_SUMMARY"

--- a/compose.staging.yml
+++ b/compose.staging.yml
@@ -68,11 +68,11 @@ services:
       DB_PASSWORD: ${POSTGRES_PASSWORD}
       DB_SSL: "false"
       NODE_OPTIONS: --require=/app/scripts/staging-postgres-preload.js
-      PUBLIC_APP_URL: http://192.168.1.113:8781
+      PUBLIC_APP_URL: https://test-app.cwf-air.com
       TZ: Asia/Bangkok
       PUPPETEER_EXECUTABLE_PATH: /usr/bin/chromium
     ports:
-      - "8781:3000"
+      - "127.0.0.1:8781:3000"
     volumes:
       - cwf_staging_files:/app/storage
     healthcheck:


### PR DESCRIPTION
Adds merge-triggered staging deployment on the CWF home self-hosted runner, with manual deploy, restart, rollback, and status operations. Also binds staging to localhost:8781 and sets the public staging URL to https://test-app.cwf-air.com.