### PR TITLE
Worker: #215 [Implementation Phase 2] Public Service Package discovery + server preview (read-only)

### DIFF
--- a/index.js
+++ b/index.js
@@ -54,6 +54,9 @@ const { pendingCustomerScheduledReservationSql } = require("./server/services/bo
 const { createBookingApprovalService } = require("./server/services/booking/bookingApprovalService");
 const { registerBookingApprovalRoutes } = require("./server/routes/admin/bookingApprovals");
 const { registerPublicCustomerBookingRoutes } = require("./server/routes/public/customerBookings");
+const { registerPublicServicePackageRoutes } = require("./server/routes/public/servicePackages");
+const { createServicePackageResolver } = require("./server/services/packages/servicePackageResolver");
+const { createPublicServicePackageService } = require("./server/services/public/servicePackages");
 const { registerAdminBookingRoutes } = require("./server/routes/admin/adminBookings");
 const { createTechnicianJobMoneyHelpers } = require("./server/technicianJobMoneySummary");
 const createSystemRoutes = require("./server/routes/system");
@@ -24084,6 +24087,9 @@ registerAdminAvailabilityRoutes(app, {
 });
 
 registerPublicCustomerBookingRoutes(app, { service: bookingJobService });
+registerPublicServicePackageRoutes(app, {
+  service: createPublicServicePackageService({ resolver: createServicePackageResolver({ db: pool }) }),
+});
 
 
 

--- a/server/routes/public/servicePackages.js
+++ b/server/routes/public/servicePackages.js
@@ -1,0 +1,34 @@
+"use strict";
+
+const { PublicServicePackageError } = require("../../services/public/servicePackages");
+
+function sendError(res, error) {
+  const isPublic = error instanceof PublicServicePackageError;
+  const status = isPublic ? error.status : 503;
+  const code = isPublic ? error.code : "SERVICE_PACKAGES_UNAVAILABLE";
+  return res.status(status).json({ error: code, code });
+}
+
+function registerPublicServicePackageRoutes(app, { service } = {}) {
+  if (!service || typeof service.list !== "function" || typeof service.preview !== "function") {
+    throw new TypeError("public service package service is required");
+  }
+
+  app.get("/public/service-packages", async (_req, res) => {
+    try {
+      return res.json(await service.list());
+    } catch (error) {
+      return sendError(res, error);
+    }
+  });
+
+  app.post("/public/service-packages/preview", async (req, res) => {
+    try {
+      return res.json(await service.preview(req.body || {}));
+    } catch (error) {
+      return sendError(res, error);
+    }
+  });
+}
+
+module.exports = { registerPublicServicePackageRoutes };

--- a/server/services/public/servicePackages.js
+++ b/server/services/public/servicePackages.js
@@ -3,6 +3,7 @@
 const {
   ServicePackageResolutionError,
   buildSnapshot,
+  readSnapshot,
 } = require("../packages/servicePackageResolver");
 
 class PublicServicePackageError extends Error {
@@ -22,6 +23,7 @@ function isoInstant(value) {
 }
 
 function publicPreview(snapshot, metadata = {}) {
+  snapshot = readSnapshot(snapshot.snapshot || snapshot);
   const line = snapshot.service_lines[0];
   return {
     package_key: snapshot.package.key,

--- a/server/services/public/servicePackages.js
+++ b/server/services/public/servicePackages.js
@@ -1,0 +1,129 @@
+"use strict";
+
+const {
+  ServicePackageResolutionError,
+  buildSnapshot,
+} = require("../packages/servicePackageResolver");
+
+class PublicServicePackageError extends Error {
+  constructor(status, code) {
+    super(code);
+    this.name = "PublicServicePackageError";
+    this.status = status;
+    this.code = code;
+  }
+}
+
+function isoInstant(value) {
+  if (value == null) return null;
+  const date = new Date(value);
+  if (!Number.isFinite(date.getTime())) throw new Error("invalid package date");
+  return date.toISOString();
+}
+
+function publicPreview(snapshot, metadata = {}) {
+  const line = snapshot.service_lines[0];
+  return {
+    package_key: snapshot.package.key,
+    package_name: snapshot.package.name,
+    description: metadata.description == null ? null : String(metadata.description),
+    tier_key: snapshot.tier.key,
+    tier_name: snapshot.tier.name,
+    fixed_total_price: snapshot.fixed_total_price,
+    quantity: line.quantity,
+    unit_duration_minutes: line.unit_duration_minutes,
+    service: {
+      service_key: line.service_key,
+      service_name: line.service_name,
+      constraints: { ...line.service_constraints },
+    },
+    sell_start_at: isoInstant(metadata.sell_start_at),
+    sell_end_at: isoInstant(metadata.sell_end_at),
+    redeem_until: snapshot.redeem_until,
+  };
+}
+
+function mapResolutionError(error) {
+  if (!(error instanceof ServicePackageResolutionError)) return error;
+  if (["PACKAGE_IDENTITY_REQUIRED", "TIER_IDENTITY_REQUIRED"].includes(error.code)) {
+    return new PublicServicePackageError(400, "INVALID_PACKAGE_SELECTION");
+  }
+  if (["TIER_PACKAGE_MISMATCH", "TIER_INACTIVE"].includes(error.code)) {
+    return new PublicServicePackageError(404, "SERVICE_PACKAGE_TIER_NOT_AVAILABLE");
+  }
+  if (["PACKAGE_NOT_FOUND", "PACKAGE_INACTIVE", "PACKAGE_NOT_CUSTOMER_VISIBLE", "PACKAGE_NOT_ON_SALE"].includes(error.code)) {
+    return new PublicServicePackageError(404, "SERVICE_PACKAGE_NOT_AVAILABLE");
+  }
+  return new PublicServicePackageError(503, "SERVICE_PACKAGES_UNAVAILABLE");
+}
+
+function requireKey(value) {
+  return typeof value === "string" && value.trim() ? value.trim() : null;
+}
+
+function createPublicServicePackageService({ resolver }) {
+  if (!resolver || typeof resolver.listCustomerVisible !== "function" || typeof resolver.resolveSelection !== "function") {
+    throw new TypeError("service package resolver is required");
+  }
+
+  return {
+    async list() {
+      try {
+        const rows = await resolver.listCustomerVisible();
+        return {
+          service_packages: rows.map((packageRow) => {
+            const tiers = Array.isArray(packageRow.tiers) ? packageRow.tiers : [];
+            const previews = tiers.filter((tier) => tier.is_active !== false)
+              .map((tier) => publicPreview(buildSnapshot(packageRow, tier), packageRow));
+            const safeTiers = previews.map((preview) => ({
+              tier_key: preview.tier_key,
+              tier_name: preview.tier_name,
+              fixed_total_price: preview.fixed_total_price,
+              quantity: preview.quantity,
+            }));
+            const first = previews[0];
+            return first ? {
+              package_key: first.package_key,
+              package_name: first.package_name,
+              description: first.description,
+              service: first.service,
+              unit_duration_minutes: first.unit_duration_minutes,
+              sell_start_at: first.sell_start_at,
+              sell_end_at: first.sell_end_at,
+              redeem_until: first.redeem_until,
+              tiers: safeTiers,
+            } : null;
+          }).filter(Boolean),
+        };
+      } catch (error) {
+        const publicError = mapResolutionError(error);
+        throw publicError instanceof PublicServicePackageError
+          ? publicError
+          : new PublicServicePackageError(503, "SERVICE_PACKAGES_UNAVAILABLE");
+      }
+    },
+
+    async preview(input = {}) {
+      const packageKey = requireKey(input.package_key);
+      const tierKey = requireKey(input.tier_key);
+      if (!packageKey || !tierKey) throw new PublicServicePackageError(400, "INVALID_PACKAGE_SELECTION");
+      try {
+        const resolved = await resolver.resolveSelection(
+          { packageKey, tierKey },
+          { identity: "customer" }
+        );
+        const rows = await resolver.listCustomerVisible();
+        const metadata = rows.find((row) => row.package_key === resolved.package.key);
+        if (!metadata) throw new PublicServicePackageError(404, "SERVICE_PACKAGE_NOT_AVAILABLE");
+        return publicPreview(resolved, metadata);
+      } catch (error) {
+        const publicError = mapResolutionError(error);
+        throw publicError instanceof PublicServicePackageError
+          ? publicError
+          : new PublicServicePackageError(503, "SERVICE_PACKAGES_UNAVAILABLE");
+      }
+    },
+  };
+}
+
+module.exports = { PublicServicePackageError, createPublicServicePackageService };

--- a/test/publicServicePackages.test.js
+++ b/test/publicServicePackages.test.js
@@ -1,0 +1,116 @@
+"use strict";
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const { createPublicServicePackageService } = require("../server/services/public/servicePackages");
+const { createServicePackageResolver } = require("../server/services/packages/servicePackageResolver");
+const { registerPublicServicePackageRoutes } = require("../server/routes/public/servicePackages");
+
+const packageRow = {
+  service_package_id: 10, package_key: "premium-wall", display_name: "Premium Wall", description: "Fixed package",
+  service_key: "wall-premium", service_name: "Premium cleaning", service_unit_duration_minutes: 45,
+  job_type: "wash", ac_type: "wall", wash_variant: "premium", btu_min: null, btu_max: 12000,
+  sell_start_at: "2026-08-01T00:00:00.000Z", sell_end_at: "2026-08-31T23:59:59.000Z",
+  redeem_until: "2026-12-31T23:59:59.000Z", is_active: true, is_customer_visible: true,
+};
+const tierRow = {
+  service_package_tier_id: 21, service_package_id: 10, tier_key: "two", display_name: "Two units",
+  service_quantity: 2, fixed_total_price: "1399.50", is_active: true,
+};
+
+function harness(overrides = {}) {
+  const queries = [];
+  const repo = {
+    listCustomerVisiblePackages: async () => overrides.list || [{ ...packageRow, tiers: [{ ...tierRow }, { ...tierRow, service_package_tier_id: 22, tier_key: "off", is_active: false }] }],
+    findPackageByKey: async (_db, key) => key === packageRow.package_key ? { ...packageRow, ...(overrides.package || {}) } : null,
+    findTier: async (_db, identity) => identity.packageId === 10 && identity.tierKey === tierRow.tier_key
+      ? { ...tierRow, ...(overrides.tier || {}) }
+      : null,
+  };
+  const db = { query: async (...args) => { queries.push(args); throw new Error("unexpected database query"); } };
+  const resolver = createServicePackageResolver({ db, packageRepository: repo, now: () => new Date("2026-08-07T00:00:00Z") });
+  return { service: createPublicServicePackageService({ resolver }), queries };
+}
+
+function responseHarness() {
+  return {
+    statusCode: 200, body: null,
+    status(code) { this.statusCode = code; return this; },
+    json(body) { this.body = body; return this; },
+  };
+}
+
+test("discovery exposes only safe stable keys and active tiers", async () => {
+  const { service, queries } = harness();
+  const result = await service.list();
+  assert.equal(result.service_packages.length, 1);
+  assert.equal(result.service_packages[0].package_key, "premium-wall");
+  assert.deepEqual(result.service_packages[0].tiers.map((tier) => tier.tier_key), ["two"]);
+  assert.equal(result.service_packages[0].tiers[0].fixed_total_price, "1399.50");
+  assert.equal(JSON.stringify(result).includes("service_package_id"), false);
+  assert.equal(JSON.stringify(result).includes("snapshot"), false);
+  assert.deepEqual(queries, []);
+});
+
+test("discovery trusts resolver filtering and fails malformed rows safely", async () => {
+  assert.deepEqual(await harness({ list: [] }).service.list(), { service_packages: [] });
+  await assert.rejects(
+    () => harness({ list: [{ ...packageRow, service_unit_duration_minutes: 0, tiers: [tierRow] }] }).service.list(),
+    { status: 503, code: "SERVICE_PACKAGES_UNAVAILABLE" }
+  );
+});
+
+test("preview is server-authoritative and never exposes IDs or snapshots", async () => {
+  const { service, queries } = harness();
+  const result = await service.preview({
+    package_key: "premium-wall", tier_key: "two", fixed_total_price: "1.00", quantity: 99,
+    duration: 1, service: { service_key: "fake", constraints: { btu_max: 99999 } },
+  });
+  assert.equal(result.fixed_total_price, "1399.50");
+  assert.equal(result.quantity, 2);
+  assert.equal(result.unit_duration_minutes, 45);
+  assert.equal(result.service.service_key, "wall-premium");
+  assert.equal(result.service.constraints.btu_max, 12000);
+  assert.equal(result.sell_start_at, "2026-08-01T00:00:00.000Z");
+  assert.equal(result.sell_end_at, "2026-08-31T23:59:59.000Z");
+  assert.equal(result.redeem_until, "2026-12-31T23:59:59.000Z");
+  assert.equal(JSON.stringify(result).includes("service_package_id"), false);
+  assert.equal(JSON.stringify(result).includes("snapshot"), false);
+  assert.deepEqual(queries, []);
+});
+
+test("unavailable packages and mismatched tiers return safe public errors", async () => {
+  for (const packageOverride of [
+    { is_customer_visible: false }, { is_active: false },
+    { sell_start_at: "2026-08-08T00:00:00Z" }, { sell_end_at: "2026-08-06T00:00:00Z" },
+  ]) {
+    await assert.rejects(() => harness({ package: packageOverride }).service.preview({ package_key: "premium-wall", tier_key: "two" }),
+      { status: 404, code: "SERVICE_PACKAGE_NOT_AVAILABLE" });
+  }
+  await assert.rejects(() => harness().service.preview({ package_key: "premium-wall", tier_key: "wrong" }),
+    { status: 404, code: "SERVICE_PACKAGE_TIER_NOT_AVAILABLE" });
+  await assert.rejects(() => harness({ tier: { is_active: false } }).service.preview({ package_key: "premium-wall", tier_key: "two" }),
+    { status: 404, code: "SERVICE_PACKAGE_TIER_NOT_AVAILABLE" });
+  await assert.rejects(() => harness().service.preview({ package_key: "premium-wall" }),
+    { status: 400, code: "INVALID_PACKAGE_SELECTION" });
+});
+
+test("routes register both endpoints and hide internal error details", async () => {
+  const registrations = [];
+  const app = {
+    get(path, handler) { registrations.push({ method: "GET", path, handler }); },
+    post(path, handler) { registrations.push({ method: "POST", path, handler }); },
+  };
+  registerPublicServicePackageRoutes(app, { service: {
+    list: async () => { const error = new Error("SELECT secret FROM table"); error.code = "42P01"; error.stack = "raw SQL stack"; throw error; },
+    preview: async () => ({ ok: true }),
+  } });
+  assert.deepEqual(registrations.map(({ method, path }) => `${method} ${path}`), [
+    "GET /public/service-packages", "POST /public/service-packages/preview",
+  ]);
+  const res = responseHarness();
+  await registrations[0].handler({}, res);
+  assert.equal(res.statusCode, 503);
+  assert.deepEqual(res.body, { error: "SERVICE_PACKAGES_UNAVAILABLE", code: "SERVICE_PACKAGES_UNAVAILABLE" });
+  assert.doesNotMatch(JSON.stringify(res.body), /SELECT|stack|secret/i);
+});


### PR DESCRIPTION
﻿## CWF Codex Worker

Source task: #215

This pull request was created automatically as a **Draft**. It has not been merged or deployed.

### Changed files

- index.js
- server/routes/public/servicePackages.js
- server/services/public/servicePackages.js
- test/publicServicePackages.test.js

### Codex report

## Summary

Implemented issue #215โ€s read-only public Service Package API.

- Issue: #215
- Draft PR: Not opened; target PR was `0`, and the outer CWF Worker handles commit/push/PR creation.
- Branch: `cwf-worker/issue-215-20260807-200214-implementation-phase-2-public-servic`
- Base SHA: `c6fd71e9c7022d986884baa9792e028a384754d0`
- Current HEAD SHA: `c6fd71e9c7022d986884baa9792e028a384754d0` (changes remain uncommitted as required)

Routes added:

- `GET /public/service-packages`
- `POST /public/service-packages/preview`

The adapter exposes stable package/tier keys, exact decimal prices, canonical service constraints, duration, quantity, sell metadata, and redemption limits. Numeric IDs and immutable snapshots are never returned.

## Changed files

- [index.js](D:/CWF/CodexWorker/workspace/cwf-services-system/index.js)
  - Minimal imports, resolver/service construction, and route registration.
- [servicePackages.js](D:/CWF/CodexWorker/workspace/cwf-services-system/server/routes/public/servicePackages.js)
  - Read-only public route handlers and safe machine-readable errors.
- [servicePackages.js](D:/CWF/CodexWorker/workspace/cwf-services-system/server/services/public/servicePackages.js)
  - Public DTO boundary, resolver integration, input validation, and error normalization.
- [publicServicePackages.test.js](D:/CWF/CodexWorker/workspace/cwf-services-system/test/publicServicePackages.test.js)
  - Focused discovery, preview, authority, visibility, tier mismatch, leakage, and error-safety coverage.

No Phase 1 resolver, repository, migration, booking, pricing, UI, or protected files were modified.

## Public contract

Discovery returns:

```json
{
  "service_packages": [
    {
      "package_key": "premium-wall",
      "package_name": "Premium Wall",
      "description": "Fixed package",
      "service": {
        "service_key": "wall-premium",
        "service_name": "Premium cleaning",
        "constraints": {}
      },
      "unit_duration_minutes": 45,
      "sell_start_at": "...",
      "sell_end_at": "...",
      "redeem_until": "...",
      "tiers": [
        {
          "tier_key": "two",
          "tier_name": "Two units",
          "fixed_total_price": "1399.50",
          "quantity": 2
        }
      ]
    }
  ]
}
```

Preview accepts only:

```json
{
  "package_key": "premium-wall",
  "tier_key": "two"
}
```

Additional client price, quantity, duration, service, or BTU fields are ignored. Hidden, inactive, outside-window packages return the same safe `SERVICE_PACKAGE_NOT_AVAILABLE` 404 response.

## Tests run and results

Passed:

- Base/main SHA verification
- `git diff --check`
- Separate trailing-whitespace scan covering all new untracked files
- Static scope audit confirming `/public/pricing_preview` and `/public/book` remain in their existing locations
- Static mutation audit found no `INSERT`, `UPDATE`, or `DELETE` in the new implementation

Not run:

- Required `node --check` commands
- `test/publicServicePackages.test.js`
- `test/servicePackageResolver.test.js`
- `test/servicePackagesMigration.test.js`
- `test/customerPricingSafety.test.js`
- `test/customerBookingMutationCharacterization.test.js`

Exact blocker: `node` is unavailable on this workerโ€s `PATH`, producing `CommandNotFoundException`, and no repository-local Node executable exists.

## Remaining risks or unverified items

- JavaScript syntax and automated behavior remain runtime-unverified due to the missing Node executable.
- Preview performs only resolver/repository reads: package lookup, tier lookup, and customer-visible metadata listing. Discovery performs one listing read.
- No cache persistence, entitlement creation, booking mutation, schema change, or normal pricing/promotion behavior was introduced.
- Rollback is limited to removing the three new files and the six composition lines in `index.js`.

Confirmed: no Production migration, Production DB access, merge, deploy, Production data change, or configuration change was performed.

### Controller checklist

- [ ] Scope matches the issue
- [ ] No protected/high-risk files changed
- [ ] Tests and build results are credible
- [ ] Production behavior and rollback are understood
- [ ] Owner approval received before merge/deploy
