### PR TITLE
Worker: #221 [Implementation Phase 3] Server-authoritative Service Package booking mutation

### DIFF
--- a/index.js
+++ b/index.js
@@ -14126,6 +14126,7 @@ const bookingJobService = createBookingJobService({
   customerAvailability,
   publicCustomerAvailabilityDeps,
   findBestCustomerPromotion,
+  createServicePackageResolver: (db) => createServicePackageResolver({ db }),
   availabilityEngine: customerAvailability,
   urgentDispatchService,
   resolveCustomerUrgentCapability: () => urgentCapability.resolveUrgentCapability(pool),

--- a/server/services/booking/createBookingJob.js
+++ b/server/services/booking/createBookingJob.js
@@ -3,7 +3,7 @@
 const crypto = require("crypto");
 const { JOB_STATUS, ASSIGNMENT_STATUS, OFFER_STATUS } = require("./bookingStatuses");
 const { ensureBookingJobUnits } = require("./bookingJobUnits");
-const { resolvePackageBooking } = require("./servicePackageBooking");
+const { packageRequest, resolvePackageBooking, packageBookingFromSnapshot } = require("./servicePackageBooking");
 
 function createBookingJobService(dependencies = {}) {
   const ensureCanonicalBookingJobUnits = dependencies.ensureBookingJobUnits || ensureBookingJobUnits;
@@ -935,6 +935,28 @@ function createBookingJobService(dependencies = {}) {
     return storedSig === incomingSig;
   }
 
+  async function historicalPackageBookingForReplay(db, jobId, body, appointmentDatetime) {
+    const result = await db.query(
+      `SELECT service_package_id, service_package_tier_id, service_package_snapshot
+         FROM public.job_items
+        WHERE job_id=$1
+          AND service_package_id IS NOT NULL
+          AND service_package_tier_id IS NOT NULL
+          AND service_package_snapshot IS NOT NULL
+        LIMIT 1`,
+      [jobId]
+    );
+    const item = result.rows[0];
+    if (!item) return null;
+    return packageBookingFromSnapshot({
+      body,
+      appointmentDatetime,
+      snapshot: item.service_package_snapshot,
+      packageId: item.service_package_id,
+      tierId: item.service_package_tier_id,
+    });
+  }
+
   // Customer App V2 urgent requests are just another entry point into the
   // existing public booking workflow: this adapter strips the request down to
   // a customer-safe allowlist and validates the customer's Bangkok wall-clock
@@ -1212,6 +1234,12 @@ function createBookingJobService(dependencies = {}) {
     // ✅ Soft customer identity: never required, never trusted blindly elsewhere —
     // this is only a best-effort linkage so a logged-in customer can later prove
     // ownership of *this* job for review eligibility. Booking proceeds for guests too.
+    try {
+      if (hasPackageRequest) packageRequest(packageRequestBody);
+    } catch (error) {
+      return res.status(Number(error.statusCode || 400)).json({ error: error.code, code: error.code });
+    }
+
     let customerSubForJob = null;
     try {
       const jwtSecretForBook = getJwtSecret();
@@ -1279,6 +1307,63 @@ function createBookingJobService(dependencies = {}) {
     }
     const persistedGpsLatitude = bm === "urgent" && gps_latitude != null ? Number(gps_latitude) : null;
     const persistedGpsLongitude = bm === "urgent" && gps_longitude != null ? Number(gps_longitude) : null;
+
+    // A committed package retry is resolved from immutable booking history before
+    // consulting today's package sale/configuration state.
+    if (bm === "scheduled" && hasPackageRequest && deterministicToken) {
+      const idem = await pool.connect();
+      let prior = null;
+      try {
+        await idem.query("BEGIN");
+        await idem.query("SELECT pg_advisory_xact_lock(hashtext($1))", [bookingRequestKey]);
+        const result = await idem.query(
+          `SELECT job_id, booking_code, booking_token, dispatch_mode, duration_min, job_price,
+                  appointment_datetime, customer_phone, customer_name, address_text, maps_url,
+                  job_zone, job_type, customer_note, allow_time_proposal, gps_latitude, gps_longitude
+             FROM public.jobs
+            WHERE booking_token=$1 AND job_source='customer' AND booking_mode=$2
+              AND canceled_at IS NULL
+            LIMIT 1`,
+          [deterministicToken, bm]
+        );
+        await idem.query("COMMIT");
+        prior = result.rows[0] || null;
+      } catch (error) {
+        try { await idem.query("ROLLBACK"); } catch (_) {}
+        throw error;
+      } finally {
+        idem.release();
+      }
+      if (prior) {
+        const historicalPackageBooking = await historicalPackageBookingForReplay(
+          pool, prior.job_id, packageRequestBody, appointment_datetime
+        );
+        const incomingBooking = historicalPackageBooking ? {
+          appointment_datetime, customer_phone, customer_name, address_text, maps_url,
+          job_zone, job_type: historicalPackageBooking.payload.job_type, customer_note,
+          allow_time_proposal: allowTimeProposal, gps_latitude: persistedGpsLatitude,
+          gps_longitude: persistedGpsLongitude, duration_min: historicalPackageBooking.durationMin,
+          payloadV2: historicalPackageBooking.payload, itemIdQty,
+          standardPrice: historicalPackageBooking.fixedTotal,
+          packageBooking: historicalPackageBooking,
+        } : null;
+        if (!incomingBooking || !(await scheduledPayloadMatchesExisting(pool, prior, incomingBooking))) {
+          return res.status(409).json({
+            error: "This request key was already used for another booking. Start a new booking.",
+            code: "IDEMPOTENCY_KEY_REUSED",
+          });
+        }
+        const replayDuration = Number(prior.duration_min || historicalPackageBooking.durationMin || 0);
+        return res.json({
+          success: true, replayed: true, job_id: prior.job_id,
+          booking_code: prior.booking_code, token: prior.booking_token,
+          booking_mode: bm, dispatch_mode: prior.dispatch_mode || "normal",
+          duration_min: replayDuration, effective_block_min: effectiveBlockMin(replayDuration),
+          travel_buffer_min: TRAVEL_BUFFER_MIN, base_total: Number(prior.job_price || 0),
+        });
+      }
+    }
+
     let payloadV2 = {
       job_type: String(job_type).trim(),
       ac_type: (ac_type || "").toString().trim(),
@@ -1501,23 +1586,6 @@ function createBookingJobService(dependencies = {}) {
     try {
       await client.query("BEGIN");
 
-      if (packageBooking) {
-        const revalidatedPackageBooking = await resolvePackageBooking({
-          body: packageRequestBody,
-          bookingMode: bm,
-          appointmentDatetime: appointment_datetime,
-          resolver: createServicePackageResolver(client),
-        });
-        if (JSON.stringify(revalidatedPackageBooking) !== JSON.stringify(packageBooking)) {
-          const changed = new Error("PACKAGE_UNAVAILABLE");
-          changed.code = "PACKAGE_UNAVAILABLE";
-          changed.statusCode = 409;
-          throw changed;
-        }
-        packageBooking = revalidatedPackageBooking;
-        payloadV2 = packageBooking.payload;
-      }
-
       if (bookingRequestKey && deterministicToken) {
         await client.query("SELECT pg_advisory_xact_lock(hashtext($1))", [bookingRequestKey]);
         const existing = await client.query(
@@ -1539,13 +1607,19 @@ function createBookingJobService(dependencies = {}) {
           // (no mutation, no identifiers/PII). Same comparison as the pre-flight path.
           const row = existing.rows[0];
           await client.query("COMMIT");
-          const incomingBooking = {
+          const replayPackageBooking = hasPackageRequest
+            ? await historicalPackageBookingForReplay(pool, row.job_id, packageRequestBody, appointment_datetime)
+            : null;
+          const incomingBooking = hasPackageRequest && !replayPackageBooking ? null : {
             appointment_datetime, customer_phone, customer_name, address_text, maps_url,
-            job_zone, job_type: packageBooking ? payloadV2.job_type : job_type, customer_note, allow_time_proposal: allowTimeProposal,
+            job_zone, job_type: replayPackageBooking ? replayPackageBooking.payload.job_type : job_type, customer_note, allow_time_proposal: allowTimeProposal,
             gps_latitude: persistedGpsLatitude, gps_longitude: persistedGpsLongitude,
-            duration_min: duration_min_v2, payloadV2, itemIdQty, standardPrice: standard_price, packageBooking,
+            duration_min: replayPackageBooking ? replayPackageBooking.durationMin : duration_min_v2,
+            payloadV2: replayPackageBooking ? replayPackageBooking.payload : payloadV2,
+            itemIdQty, standardPrice: replayPackageBooking ? replayPackageBooking.fixedTotal : standard_price,
+            packageBooking: replayPackageBooking,
           };
-          if (!(await scheduledPayloadMatchesExisting(pool, row, incomingBooking))) {
+          if (!incomingBooking || !(await scheduledPayloadMatchesExisting(pool, row, incomingBooking))) {
             return res.status(409).json({
               error: "คำขอนี้ถูกใช้ไปแล้วกับการจองอื่น กรุณาเริ่มการจองใหม่",
               code: "IDEMPOTENCY_KEY_REUSED",
@@ -1565,6 +1639,25 @@ function createBookingJobService(dependencies = {}) {
             base_total: Number(row.job_price || 0),
           });
         }
+      }
+
+      // Only a genuinely new mutation depends on current package state. The
+      // advisory-lock replay above must win if another request just committed.
+      if (packageBooking) {
+        const revalidatedPackageBooking = await resolvePackageBooking({
+          body: packageRequestBody,
+          bookingMode: bm,
+          appointmentDatetime: appointment_datetime,
+          resolver: createServicePackageResolver(client),
+        });
+        if (JSON.stringify(revalidatedPackageBooking) !== JSON.stringify(packageBooking)) {
+          const changed = new Error("PACKAGE_UNAVAILABLE");
+          changed.code = "PACKAGE_UNAVAILABLE";
+          changed.statusCode = 409;
+          throw changed;
+        }
+        packageBooking = revalidatedPackageBooking;
+        payloadV2 = packageBooking.payload;
       }
 
       let draftReservationTech = null;

--- a/server/services/booking/createBookingJob.js
+++ b/server/services/booking/createBookingJob.js
@@ -3,6 +3,7 @@
 const crypto = require("crypto");
 const { JOB_STATUS, ASSIGNMENT_STATUS, OFFER_STATUS } = require("./bookingStatuses");
 const { ensureBookingJobUnits } = require("./bookingJobUnits");
+const { resolvePackageBooking } = require("./servicePackageBooking");
 
 function createBookingJobService(dependencies = {}) {
   const ensureCanonicalBookingJobUnits = dependencies.ensureBookingJobUnits || ensureBookingJobUnits;
@@ -38,6 +39,7 @@ function createBookingJobService(dependencies = {}) {
     customerAvailability,
     publicCustomerAvailabilityDeps,
     findBestCustomerPromotion,
+    createServicePackageResolver,
   } = dependencies;
 
   const ENABLE_SERVICE_ZONE_FILTER = Boolean(dependencies.isServiceZoneFilterEnabled());
@@ -162,7 +164,7 @@ function createBookingJobService(dependencies = {}) {
       return hasTech ? 'single' : 'auto';
     })();
 
-    if (!customer_name || !job_type || !appointment_datetime || !address_text) {
+    if (!customer_name || (!hasPackageRequest && !job_type) || !appointment_datetime || !address_text) {
       return res.status(400).json({ error: "กรอกข้อมูลไม่ครบ (ชื่อ/ประเภทงาน/วันนัด/ที่อยู่)" });
     }
 
@@ -842,10 +844,10 @@ function createBookingJobService(dependencies = {}) {
   // Rebuild the incoming service + extra lines with the SAME normalizer used to
   // create a booking, so an identical service payload yields an identical
   // signature (and any material change yields a different one). Read-only.
-  async function buildIncomingBookingLineSignature(db, payloadV2, itemIdQty, standardPrice) {
+  async function buildIncomingBookingLineSignature(db, payloadV2, itemIdQty, standardPrice, packageBooking) {
     let computed = [];
     let total = Number(standardPrice || 0);
-    const serviceLines = await customerPricingHelpers.buildCustomerServiceLineItemsFromPayload(
+    const serviceLines = packageBooking ? [packageBooking.item] : await customerPricingHelpers.buildCustomerServiceLineItemsFromPayload(
       (payloadV2.services && Array.isArray(payloadV2.services))
         ? payloadV2
         : {
@@ -917,8 +919,19 @@ function createBookingJobService(dependencies = {}) {
   // by the pre-flight replay and the in-transaction race path.
   async function scheduledPayloadMatchesExisting(db, jobRow, incoming, options = {}) {
     if (!scheduledScalarsMatch(jobRow, incoming, options)) return false;
+    if (incoming.packageBooking) {
+      const packageLink = await db.query(
+        `SELECT 1 FROM public.job_items
+          WHERE job_id=$1 AND service_package_id=$2 AND service_package_tier_id=$3
+          LIMIT 1`,
+        [jobRow.job_id, incoming.packageBooking.packageId, incoming.packageBooking.tierId]
+      );
+      if (!packageLink.rows[0]) return false;
+    }
     const storedSig = await loadStoredBookingLineSignature(db, jobRow.job_id);
-    const incomingSig = await buildIncomingBookingLineSignature(db, incoming.payloadV2, incoming.itemIdQty, incoming.standardPrice);
+    const incomingSig = await buildIncomingBookingLineSignature(
+      db, incoming.payloadV2, incoming.itemIdQty, incoming.standardPrice, incoming.packageBooking
+    );
     return storedSig === incomingSig;
   }
 
@@ -1138,6 +1151,8 @@ function createBookingJobService(dependencies = {}) {
       scheduled_request_key,
       urgent_request_key,
       catalog_item_id, // optional: links this booking to the Store catalog item it was booked for
+      service_package_key,
+      service_package_tier_key,
     } = req.body || {};
 
     // 🔒 Kill switch (fail closed) — CANONICAL GATE. /public/book is entirely
@@ -1152,6 +1167,17 @@ function createBookingJobService(dependencies = {}) {
     if (canonicalBookingMode !== "scheduled" && canonicalBookingMode !== "urgent") {
       return res.status(400).json({ error: "ประเภทการจองไม่ถูกต้อง", code: "UNKNOWN_BOOKING_MODE" });
     }
+    let packageRequestBody;
+    let hasPackageRequest = false;
+    try {
+      packageRequestBody = { ...(req.body || {}) };
+      // Parse before urgent routing so package keys can never reach or alter urgent dispatch.
+      hasPackageRequest = service_package_key != null || service_package_tier_key != null
+        || req.body?.service_package_id != null || req.body?.service_package_tier_id != null;
+      if (canonicalBookingMode === "urgent" && hasPackageRequest) {
+        return res.status(400).json({ error: "PACKAGE_URGENT_UNSUPPORTED", code: "PACKAGE_URGENT_UNSUPPORTED" });
+      }
+    } catch (_) {}
     const urgentCapability = canonicalBookingMode === "urgent"
       ? await resolveCustomerUrgentCapability()
       : null;
@@ -1253,7 +1279,7 @@ function createBookingJobService(dependencies = {}) {
     }
     const persistedGpsLatitude = bm === "urgent" && gps_latitude != null ? Number(gps_latitude) : null;
     const persistedGpsLongitude = bm === "urgent" && gps_longitude != null ? Number(gps_longitude) : null;
-    const payloadV2 = {
+    let payloadV2 = {
       job_type: String(job_type).trim(),
       ac_type: (ac_type || "").toString().trim(),
       btu: Number(btu || 0),
@@ -1263,6 +1289,18 @@ function createBookingJobService(dependencies = {}) {
       admin_override_duration_min: 0, // ลูกค้าห้าม override
     };
     if (Array.isArray(services) && services.length) payloadV2.services = services;
+    let packageBooking = null;
+    try {
+      packageBooking = await resolvePackageBooking({
+        body: packageRequestBody,
+        bookingMode: bm,
+        appointmentDatetime: appointment_datetime,
+        resolver: hasPackageRequest ? createServicePackageResolver(pool) : null,
+      });
+      if (packageBooking) payloadV2 = packageBooking.payload;
+    } catch (error) {
+      return res.status(Number(error.statusCode || 400)).json({ error: error.code, code: error.code });
+    }
     if (bm === "urgent") {
       if (!urgentPublicAdapter.isStrictUrgentCleaningPayload(payloadV2)) {
         return res.status(400).json({ error: "URGENT_CLEANING_ONLY", code: "URGENT_CLEANING_ONLY" });
@@ -1285,7 +1323,9 @@ function createBookingJobService(dependencies = {}) {
       });
     }
     // CWF Spec: conservative duration for schedule/collision
-    const duration_min_v2 = computeDurationMinMulti(payloadV2, { source: "public_book", conservative: true });
+    const duration_min_v2 = packageBooking
+      ? packageBooking.durationMin
+      : computeDurationMinMulti(payloadV2, { source: "public_book", conservative: true });
     if (duration_min_v2 <= 0) return res.status(400).json({ error: "งานประเภทนี้ต้องให้แอดมินกำหนดเวลา (duration)" });
     if (bm === "scheduled") {
       const startIsoForCutoff = normalizeAppointmentDatetime(appointment_datetime);
@@ -1309,8 +1349,10 @@ function createBookingJobService(dependencies = {}) {
         });
       }
     }
-    const customerPrice = await customerPricingHelpers.resolveCustomerPricingMulti(payloadV2, pool);
-    const standard_price = Number(customerPrice.active_price ?? customerPrice.standard_price ?? 0);
+    const customerPrice = packageBooking ? null : await customerPricingHelpers.resolveCustomerPricingMulti(payloadV2, pool);
+    const standard_price = packageBooking
+      ? packageBooking.fixedTotal
+      : Number(customerPrice.active_price ?? customerPrice.standard_price ?? 0);
 
   // ✅ Parse lat/lng from maps_url or address_text (fail-open)
   const parsedLL = parseLatLngFromText(maps_url) || parseLatLngFromText(address_text);
@@ -1364,9 +1406,9 @@ function createBookingJobService(dependencies = {}) {
       if (prior) {
         const incomingBooking = {
           appointment_datetime, customer_phone, customer_name, address_text, maps_url,
-          job_zone, job_type, customer_note, allow_time_proposal: allowTimeProposal,
+          job_zone, job_type: packageBooking ? payloadV2.job_type : job_type, customer_note, allow_time_proposal: allowTimeProposal,
           gps_latitude: persistedGpsLatitude, gps_longitude: persistedGpsLongitude,
-          duration_min: duration_min_v2, payloadV2, itemIdQty, standardPrice: standard_price,
+          duration_min: duration_min_v2, payloadV2, itemIdQty, standardPrice: standard_price, packageBooking,
         };
         if (!(await scheduledPayloadMatchesExisting(pool, prior, incomingBooking))) {
           // Same key, materially different booking. No mutation, no identifiers/PII.
@@ -1459,6 +1501,23 @@ function createBookingJobService(dependencies = {}) {
     try {
       await client.query("BEGIN");
 
+      if (packageBooking) {
+        const revalidatedPackageBooking = await resolvePackageBooking({
+          body: packageRequestBody,
+          bookingMode: bm,
+          appointmentDatetime: appointment_datetime,
+          resolver: createServicePackageResolver(client),
+        });
+        if (JSON.stringify(revalidatedPackageBooking) !== JSON.stringify(packageBooking)) {
+          const changed = new Error("PACKAGE_UNAVAILABLE");
+          changed.code = "PACKAGE_UNAVAILABLE";
+          changed.statusCode = 409;
+          throw changed;
+        }
+        packageBooking = revalidatedPackageBooking;
+        payloadV2 = packageBooking.payload;
+      }
+
       if (bookingRequestKey && deterministicToken) {
         await client.query("SELECT pg_advisory_xact_lock(hashtext($1))", [bookingRequestKey]);
         const existing = await client.query(
@@ -1482,9 +1541,9 @@ function createBookingJobService(dependencies = {}) {
           await client.query("COMMIT");
           const incomingBooking = {
             appointment_datetime, customer_phone, customer_name, address_text, maps_url,
-            job_zone, job_type, customer_note, allow_time_proposal: allowTimeProposal,
+            job_zone, job_type: packageBooking ? payloadV2.job_type : job_type, customer_note, allow_time_proposal: allowTimeProposal,
             gps_latitude: persistedGpsLatitude, gps_longitude: persistedGpsLongitude,
-            duration_min: duration_min_v2, payloadV2, itemIdQty, standardPrice: standard_price,
+            duration_min: duration_min_v2, payloadV2, itemIdQty, standardPrice: standard_price, packageBooking,
           };
           if (!(await scheduledPayloadMatchesExisting(pool, row, incomingBooking))) {
             return res.status(409).json({
@@ -1524,7 +1583,7 @@ function createBookingJobService(dependencies = {}) {
       }
 
       // 1) ดึงราคา base_price จาก DB
-  const serviceLineItems = await customerPricingHelpers.buildCustomerServiceLineItemsFromPayload(
+  const serviceLineItems = packageBooking ? [packageBooking.item] : await customerPricingHelpers.buildCustomerServiceLineItemsFromPayload(
     (payloadV2.services && Array.isArray(payloadV2.services))
       ? payloadV2
       : { ...payloadV2, services: [{
@@ -1588,8 +1647,8 @@ function createBookingJobService(dependencies = {}) {
       // IMPORTANT: "ราคา" ของงานต้องเป็นราคาพื้นฐานเดิม (ห้ามเปลี่ยนราคา)
       // - jobs.job_price เก็บ base_total เท่านั้น
       // - ส่วนลดบันทึกแยกที่ job_promotions.applied_discount
-      const base_total = Number(total || 0);
-      const promoPick = await findBestCustomerPromotion(payloadV2, base_total, client);
+      const base_total = packageBooking ? packageBooking.fixedTotal : Number(total || 0);
+      const promoPick = packageBooking ? null : await findBestCustomerPromotion(payloadV2, base_total, client);
       const appliedPromo = promoPick?.promo || null;
       const appliedDiscount = Math.min(Number(base_total || 0), Number(promoPick?.discount || 0));
 
@@ -1610,9 +1669,9 @@ function createBookingJobService(dependencies = {}) {
       const jobInsertParams = [
         String(customer_name).trim(),
         (customer_phone || "").toString().trim(),
-        String(job_type).trim(),
+        String(packageBooking ? payloadV2.job_type : job_type).trim(),
         appointment_datetime,
-        Number(base_total || 0),
+        base_total,
         String(address_text).trim(),
         token,
         (customer_note || "").toString(),
@@ -1724,28 +1783,34 @@ function createBookingJobService(dependencies = {}) {
 
       // 3) บันทึกรายการ (ถ้ามี)
       for (const it of computedItems) {
+        const itemParams = [
+          job_id,
+          it.item_id || null,
+          it.item_name,
+          Number(it.qty || 0),
+          packageBooking ? it.unit_price : Number(it.unit_price || 0),
+          packageBooking ? it.line_total : Number(it.line_total || 0),
+          it.assigned_technician_username || null,
+          !!it.is_service,
+          it.customer_price_rule_id || null,
+          it.normal_unit_price || null,
+          it.customer_price_label || null,
+          it.customer_campaign_name || null,
+          it.customer_price_source || null,
+        ];
+        const packageColumns = packageBooking
+          ? ", service_package_id, service_package_tier_id, service_package_snapshot"
+          : "";
+        const packageValues = packageBooking ? ",$14,$15,$16" : "";
+        if (packageBooking) {
+          itemParams.push(packageBooking.packageId, packageBooking.tierId, JSON.stringify(packageBooking.snapshot));
+        }
         await client.query(
-          `
-          INSERT INTO public.job_items
+          `INSERT INTO public.job_items
             (job_id, item_id, item_name, qty, unit_price, line_total, assigned_technician_username, is_service,
-             customer_price_rule_id, normal_unit_price, customer_price_label, customer_campaign_name, customer_price_source)
-          VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13)
-          `,
-          [
-            job_id,
-            it.item_id || null,
-            it.item_name,
-            Number(it.qty || 0),
-            Number(it.unit_price || 0),
-            Number(it.line_total || 0),
-            it.assigned_technician_username || null,
-            !!it.is_service,
-            it.customer_price_rule_id || null,
-            it.normal_unit_price || null,
-            it.customer_price_label || null,
-            it.customer_campaign_name || null,
-            it.customer_price_source || null,
-          ]
+             customer_price_rule_id, normal_unit_price, customer_price_label, customer_campaign_name, customer_price_source${packageColumns})
+           VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13${packageValues})`,
+          itemParams
         );
       }
 
@@ -1822,6 +1887,15 @@ function createBookingJobService(dependencies = {}) {
       });
     } catch (e) {
       await client.query("ROLLBACK");
+      if (hasPackageRequest) {
+        const knownPackageCode = String(e?.code || "").startsWith("PACKAGE_") ? e.code : "PACKAGE_BOOKING_FAILED";
+        const statusCode = Number(e?.statusCode || e?.status || 500);
+        console.error(e);
+        return res.status(statusCode >= 400 && statusCode < 600 ? statusCode : 500).json({
+          error: knownPackageCode,
+          code: knownPackageCode,
+        });
+      }
       const statusCode = Number(e?.statusCode || e?.status || 500);
       console.error(e);
       res.status(statusCode >= 400 && statusCode < 600 ? statusCode : 500).json({

--- a/server/services/booking/createBookingJob.js
+++ b/server/services/booking/createBookingJob.js
@@ -164,7 +164,7 @@ function createBookingJobService(dependencies = {}) {
       return hasTech ? 'single' : 'auto';
     })();
 
-    if (!customer_name || (!hasPackageRequest && !job_type) || !appointment_datetime || !address_text) {
+    if (!customer_name || !job_type || !appointment_datetime || !address_text) {
       return res.status(400).json({ error: "กรอกข้อมูลไม่ครบ (ชื่อ/ประเภทงาน/วันนัด/ที่อยู่)" });
     }
 
@@ -1205,7 +1205,7 @@ function createBookingJobService(dependencies = {}) {
       return handlePublicCustomerUrgentBook(req, res);
     }
 
-    if (!customer_name || !job_type || !appointment_datetime || !address_text) {
+    if (!customer_name || (!hasPackageRequest && !job_type) || !appointment_datetime || !address_text) {
       return res.status(400).json({ error: "กรอกข้อมูลไม่ครบ (ชื่อ/ประเภทงาน/วันนัด/ที่อยู่)" });
     }
 

--- a/server/services/booking/servicePackageBooking.js
+++ b/server/services/booking/servicePackageBooking.js
@@ -1,0 +1,116 @@
+"use strict";
+
+const PACKAGE_ERROR_STATUS = Object.freeze({
+  PACKAGE_IDENTITY_REQUIRED: 400,
+  TIER_IDENTITY_REQUIRED: 400,
+  PACKAGE_NOT_FOUND: 404,
+  PACKAGE_INACTIVE: 409,
+  PACKAGE_NOT_CUSTOMER_VISIBLE: 409,
+  PACKAGE_NOT_ON_SALE: 409,
+  TIER_PACKAGE_MISMATCH: 409,
+  TIER_INACTIVE: 409,
+  INVALID_SERVICE_CONSTRAINTS: 409,
+  INVALID_PACKAGE_PRICE: 409,
+});
+
+function packageError(code, status = 400) {
+  const error = new Error(code);
+  error.code = code;
+  error.statusCode = status;
+  return error;
+}
+
+function packageRequest(body = {}) {
+  const hasPackageKey = Object.prototype.hasOwnProperty.call(body, "service_package_key");
+  const hasTierKey = Object.prototype.hasOwnProperty.call(body, "service_package_tier_key");
+  const packageKey = String(body.service_package_key || "").trim();
+  const tierKey = String(body.service_package_tier_key || "").trim();
+  const hasNumericIdentity = body.service_package_id != null || body.service_package_tier_id != null;
+  if (hasNumericIdentity) throw packageError("PACKAGE_IDENTITY_MALFORMED");
+  if (!hasPackageKey && !hasTierKey) return null;
+  if (!packageKey || !tierKey) throw packageError("PACKAGE_IDENTITY_MALFORMED");
+  if (packageKey.length > 128 || tierKey.length > 128) throw packageError("PACKAGE_IDENTITY_MALFORMED");
+  return { packageKey, tierKey };
+}
+
+function serviceItemName(line, btu) {
+  const constraints = line.service_constraints;
+  const parts = [];
+  if (constraints.job_type === "ล้าง") {
+    parts.push(`ล้างแอร์${constraints.ac_type || ""}`.trim());
+    if (constraints.ac_type === "ผนัง") parts.push(constraints.wash_variant);
+  } else if (constraints.job_type === "ซ่อม") {
+    parts.push(`ซ่อมแอร์${constraints.ac_type || ""}`.trim());
+  } else if (constraints.job_type === "ติดตั้ง") {
+    parts.push(`ติดตั้งแอร์${constraints.ac_type || ""}`.trim());
+  } else {
+    parts.push(constraints.job_type);
+  }
+  parts.push(`${btu} BTU`);
+  parts.push(`${line.quantity} เครื่อง`);
+  return parts.join(" • ");
+}
+
+function canonicalizeSelection(selection, body, appointmentDatetime) {
+  const line = selection?.service_lines?.[0];
+  const constraints = line?.service_constraints;
+  if (!line || !constraints) throw packageError("PACKAGE_SERVICE_MISMATCH", 409);
+  if ((Array.isArray(body.services) && body.services.length) || (Array.isArray(body.items) && body.items.length)) {
+    throw packageError("PACKAGE_MIXING_UNSUPPORTED", 400);
+  }
+  const btu = Number(body.btu);
+  if (!Number.isInteger(btu) || btu <= 0) throw packageError("PACKAGE_BTU_MISMATCH", 400);
+  if ((constraints.btu_min != null && btu < constraints.btu_min)
+      || (constraints.btu_max != null && btu > constraints.btu_max)) {
+    throw packageError("PACKAGE_BTU_MISMATCH", 400);
+  }
+  const appointment = new Date(appointmentDatetime);
+  if (!Number.isFinite(appointment.getTime())) throw packageError("PACKAGE_APPOINTMENT_INVALID", 400);
+  if (selection.redeem_until && appointment > new Date(selection.redeem_until)) {
+    throw packageError("PACKAGE_REDEEM_WINDOW_EXCEEDED", 409);
+  }
+  const quantity = Number(line.quantity);
+  const unitDuration = Number(line.unit_duration_minutes);
+  const fixedTotal = String(selection.fixed_total_price);
+  return {
+    packageId: String(selection.package.id),
+    tierId: String(selection.tier.id),
+    snapshot: selection.snapshot,
+    fixedTotal,
+    durationMin: quantity * unitDuration,
+    payload: {
+      job_type: constraints.job_type,
+      ac_type: constraints.ac_type,
+      btu,
+      machine_count: quantity,
+      wash_variant: constraints.wash_variant || "",
+      repair_variant: "",
+      admin_override_duration_min: 0,
+    },
+    item: {
+      item_id: null,
+      item_name: serviceItemName(line, btu),
+      qty: quantity,
+      unit_price: fixedTotal,
+      line_total: fixedTotal,
+      is_service: true,
+      customer_price_source: "service_package",
+    },
+  };
+}
+
+async function resolvePackageBooking({ body, bookingMode, appointmentDatetime, resolver }) {
+  const request = packageRequest(body);
+  if (!request) return null;
+  if (bookingMode !== "scheduled") throw packageError("PACKAGE_URGENT_UNSUPPORTED", 400);
+  try {
+    const selection = await resolver.resolveSelection(request, { identity: "customer" });
+    return canonicalizeSelection(selection, body, appointmentDatetime);
+  } catch (error) {
+    if (error?.statusCode) throw error;
+    const code = Object.hasOwn(PACKAGE_ERROR_STATUS, error?.code) ? error.code : "PACKAGE_UNAVAILABLE";
+    throw packageError(code, PACKAGE_ERROR_STATUS[code] || 409);
+  }
+}
+
+module.exports = { packageRequest, canonicalizeSelection, resolvePackageBooking };

--- a/server/services/booking/servicePackageBooking.js
+++ b/server/services/booking/servicePackageBooking.js
@@ -130,4 +130,26 @@ async function resolvePackageBooking({ body, bookingMode, appointmentDatetime, r
   }
 }
 
-module.exports = { packageRequest, canonicalizeSelection, resolvePackageBooking };
+function packageBookingFromSnapshot({ body, appointmentDatetime, snapshot, packageId, tierId }) {
+  let request;
+  try { request = packageRequest(body); } catch (_) { return null; }
+  if (!request) return null;
+  let selection = snapshot;
+  if (typeof selection === "string") {
+    try { selection = JSON.parse(selection); } catch (_) { return null; }
+  }
+  if (!selection || typeof selection !== "object") return null;
+  if (String(selection.package?.key || "") !== request.packageKey
+      || String(selection.tier?.key || "") !== request.tierKey
+      || String(selection.package?.id || "") !== String(packageId || "")
+      || String(selection.tier?.id || "") !== String(tierId || "")) {
+    return null;
+  }
+  try {
+    return canonicalizeSelection(selection, body, appointmentDatetime);
+  } catch (_) {
+    return null;
+  }
+}
+
+module.exports = { packageRequest, canonicalizeSelection, resolvePackageBooking, packageBookingFromSnapshot };

--- a/server/services/booking/servicePackageBooking.js
+++ b/server/services/booking/servicePackageBooking.js
@@ -51,6 +51,22 @@ function serviceItemName(line, btu) {
   return parts.join(" • ");
 }
 
+function allocateUnitPrice(fixedTotal, quantity) {
+  const match = /^(\d+)\.(\d{2})$/.exec(String(fixedTotal));
+  if (!match || !Number.isSafeInteger(quantity) || quantity <= 0) {
+    throw packageError("INVALID_PACKAGE_PRICE", 409);
+  }
+  const totalMinor = (BigInt(match[1]) * 100n) + BigInt(match[2]);
+  if (totalMinor <= 0n) throw packageError("INVALID_PACKAGE_PRICE", 409);
+  const divisor = BigInt(quantity);
+  const quotient = totalMinor / divisor;
+  const remainder = totalMinor % divisor;
+  const roundedMinor = quotient + (remainder * 2n >= divisor ? 1n : 0n);
+  const major = roundedMinor / 100n;
+  const minor = String(roundedMinor % 100n).padStart(2, "0");
+  return `${major}.${minor}`;
+}
+
 function canonicalizeSelection(selection, body, appointmentDatetime) {
   const line = selection?.service_lines?.[0];
   const constraints = line?.service_constraints;
@@ -72,6 +88,7 @@ function canonicalizeSelection(selection, body, appointmentDatetime) {
   const quantity = Number(line.quantity);
   const unitDuration = Number(line.unit_duration_minutes);
   const fixedTotal = String(selection.fixed_total_price);
+  const unitPrice = allocateUnitPrice(fixedTotal, quantity);
   return {
     packageId: String(selection.package.id),
     tierId: String(selection.tier.id),
@@ -91,7 +108,7 @@ function canonicalizeSelection(selection, body, appointmentDatetime) {
       item_id: null,
       item_name: serviceItemName(line, btu),
       qty: quantity,
-      unit_price: fixedTotal,
+      unit_price: unitPrice,
       line_total: fixedTotal,
       is_service: true,
       customer_price_source: "service_package",

--- a/test/customerServicePackageBooking.test.js
+++ b/test/customerServicePackageBooking.test.js
@@ -9,6 +9,49 @@ const {
   canonicalizeSelection,
   resolvePackageBooking,
 } = require("../server/services/booking/servicePackageBooking");
+const { createBookingJobService } = require("../server/services/booking/createBookingJob");
+
+function responseHarness() {
+  return {
+    statusCode: 200,
+    body: null,
+    status(code) { this.statusCode = Number(code); return this; },
+    json(payload) { this.body = payload; return payload; },
+  };
+}
+
+async function invoke(handler, requestBody) {
+  const res = responseHarness();
+  await handler({ body: requestBody }, res);
+  return res;
+}
+
+function bookingService(overrides = {}) {
+  return createBookingJobService({
+    isServiceZoneFilterEnabled: () => false,
+    isCustomerScheduledBookingEnabled: () => true,
+    genToken: () => "test-booking-token",
+    createServicePackageResolver: () => ({
+      async resolveSelection() {
+        const error = new Error("resolver reached");
+        error.code = "PACKAGE_NOT_ON_SALE";
+        throw error;
+      },
+    }),
+    ...overrides,
+  });
+}
+
+function scheduledRequest(overrides = {}) {
+  return {
+    customer_name: "Package customer",
+    appointment_datetime: "2026-12-01T09:00:00+07:00",
+    address_text: "Bangkok",
+    booking_mode: "scheduled",
+    scheduled_request_key: "package-gate-test-0001",
+    ...overrides,
+  };
+}
 
 function selection(overrides = {}) {
   const base = {
@@ -49,6 +92,44 @@ function body(overrides = {}) {
 
 test("no package keys preserves the ordinary booking branch", () => {
   assert.equal(packageRequest({}), null);
+});
+
+test("Admin validation remains callable and requires ordinary job_type", async () => {
+  const source = fs.readFileSync(path.join(__dirname, "../server/services/booking/createBookingJob.js"), "utf8");
+  const adminStart = source.indexOf("async function handleAdminBookV2");
+  const adminEnd = source.indexOf("\n  async function ", adminStart + 1);
+  const adminSource = source.slice(adminStart, adminEnd);
+  assert.doesNotMatch(adminSource, /hasPackageRequest/);
+
+  const result = await invoke(bookingService().handleAdminBookV2, scheduledRequest());
+  assert.equal(result.statusCode, 400);
+  assert.ok(result.body?.error);
+});
+
+test("public scheduled package without client job_type reaches package resolution", async () => {
+  const result = await invoke(bookingService().handlePublicBook, scheduledRequest({
+    service_package_key: "premium-day",
+    service_package_tier_key: "two-units",
+    btu: 12000,
+  }));
+  assert.equal(result.statusCode, 409);
+  assert.deepEqual(result.body, { error: "PACKAGE_NOT_ON_SALE", code: "PACKAGE_NOT_ON_SALE" });
+});
+
+test("ordinary scheduled booking without job_type keeps existing required-field rejection", async () => {
+  const result = await invoke(bookingService().handlePublicBook, scheduledRequest());
+  assert.equal(result.statusCode, 400);
+  assert.ok(result.body?.error);
+});
+
+test("partial package identity with no job_type fails safely before mutation", async () => {
+  let poolCalls = 0;
+  const result = await invoke(bookingService({
+    pool: { query() { poolCalls += 1; throw new Error("unexpected mutation"); } },
+  }).handlePublicBook, scheduledRequest({ service_package_key: "premium-day" }));
+  assert.equal(result.statusCode, 400);
+  assert.deepEqual(result.body, { error: "PACKAGE_IDENTITY_MALFORMED", code: "PACKAGE_IDENTITY_MALFORMED" });
+  assert.equal(poolCalls, 0);
 });
 
 test("package keys are paired and public numeric identities are rejected", () => {

--- a/test/customerServicePackageBooking.test.js
+++ b/test/customerServicePackageBooking.test.js
@@ -8,6 +8,7 @@ const {
   packageRequest,
   canonicalizeSelection,
   resolvePackageBooking,
+  packageBookingFromSnapshot,
 } = require("../server/services/booking/servicePackageBooking");
 const { createBookingJobService } = require("../server/services/booking/createBookingJob");
 
@@ -27,7 +28,12 @@ async function invoke(handler, requestBody) {
 }
 
 function bookingService(overrides = {}) {
+  const emptyClient = {
+    async query() { return { rows: [] }; },
+    release() {},
+  };
   return createBookingJobService({
+    pool: { async connect() { return emptyClient; } },
     isServiceZoneFilterEnabled: () => false,
     isCustomerScheduledBookingEnabled: () => true,
     genToken: () => "test-booking-token",
@@ -203,6 +209,100 @@ test("sell resolution and redeem eligibility remain distinct", async () => {
   );
 });
 
+test("committed package replay rebuilds from immutable snapshot without current resolver state", () => {
+  const historical = selection();
+  const replay = packageBookingFromSnapshot({
+    body: body(),
+    appointmentDatetime: "2026-12-01T09:00:00+07:00",
+    snapshot: historical.snapshot,
+    packageId: "41",
+    tierId: "73",
+  });
+
+  assert.equal(replay.packageId, "41");
+  assert.equal(replay.tierId, "73");
+  assert.equal(replay.fixedTotal, "1399.50");
+  assert.equal(replay.item.qty, 2);
+  assert.equal(replay.item.unit_price, "699.75");
+  assert.equal(replay.item.line_total, "1399.50");
+});
+
+test("historical package replay rejects changed package, tier, and BTU material", () => {
+  const historical = selection();
+  const args = {
+    appointmentDatetime: "2026-12-01T09:00:00+07:00",
+    snapshot: historical.snapshot,
+    packageId: "41",
+    tierId: "73",
+  };
+  assert.equal(packageBookingFromSnapshot({ ...args, body: body({ service_package_key: "other" }) }), null);
+  assert.equal(packageBookingFromSnapshot({ ...args, body: body({ service_package_tier_key: "other" }) }), null);
+  assert.equal(packageBookingFromSnapshot({ ...args, body: body({ btu: 18000 }) }), null);
+});
+
+test("advisory-locked committed package replay bypasses unavailable current resolver and creates nothing", async () => {
+  const historical = selection();
+  const canonical = canonicalizeSelection(historical.snapshot, body(), "2026-12-01T09:00:00+07:00");
+  const request = scheduledRequest({ ...body(), customer_phone: "0812345678" });
+  const prior = {
+    job_id: "501", booking_code: "CWF501", booking_token: "stored-token",
+    dispatch_mode: "normal", duration_min: 90, job_price: "1399.50",
+    appointment_datetime: request.appointment_datetime, customer_phone: request.customer_phone,
+    customer_name: request.customer_name, address_text: request.address_text,
+    maps_url: null, job_zone: null, job_type: canonical.payload.job_type,
+    customer_note: null, allow_time_proposal: false, gps_latitude: null, gps_longitude: null,
+  };
+  const calls = [];
+  const client = {
+    async query(sql) {
+      calls.push(sql);
+      if (/FROM public\.jobs/.test(sql)) return { rows: [prior] };
+      return { rows: [] };
+    },
+    release() {},
+  };
+  const replayPool = {
+    async connect() { return client; },
+    async query(sql) {
+      calls.push(sql);
+      if (/service_package_snapshot/.test(sql)) return { rows: [{
+        service_package_id: "41", service_package_tier_id: "73",
+        service_package_snapshot: historical.snapshot,
+      }] };
+      if (/SELECT 1 FROM public\.job_items/.test(sql)) return { rows: [{ "?column?": 1 }] };
+      if (/SELECT item_name, qty, line_total/.test(sql)) return { rows: [canonical.item] };
+      throw new Error(`unexpected query: ${sql}`);
+    },
+  };
+  let resolverCalls = 0;
+  const service = bookingService({
+    pool: replayPool,
+    normalizeAppointmentDatetime: (value) => value,
+    effectiveBlockMin: (value) => value,
+    createServicePackageResolver: () => ({
+      async resolveSelection() { resolverCalls += 1; throw Object.assign(new Error("expired"), { code: "PACKAGE_NOT_ON_SALE" }); },
+    }),
+  });
+
+  const result = await invoke(service.handlePublicBook, request);
+  assert.equal(result.statusCode, 200);
+  assert.equal(result.body.replayed, true);
+  assert.equal(result.body.job_id, "501");
+  assert.equal(result.body.base_total, 1399.5);
+  assert.equal(resolverCalls, 0);
+  assert.ok(calls.some((sql) => /pg_advisory_xact_lock/.test(sql)));
+  assert.equal(calls.some((sql) => /\bINSERT\b|\bUPDATE\b|\bDELETE\b/.test(sql)), false);
+
+  const changed = await invoke(service.handlePublicBook, {
+    ...request,
+    appointment_datetime: "2026-12-02T09:00:00+07:00",
+  });
+  assert.equal(changed.statusCode, 409);
+  assert.equal(changed.body.code, "IDEMPOTENCY_KEY_REUSED");
+  assert.equal(resolverCalls, 0);
+  assert.equal(calls.some((sql) => /\bINSERT\b|\bUPDATE\b|\bDELETE\b/.test(sql)), false);
+});
+
 test("mixed ordinary lines and urgent package booking are rejected", async () => {
   assert.throws(
     () => canonicalizeSelection(selection(), body({ services: [{ job_type: "ล้าง" }] }), "2026-12-01T09:00:00+07:00"),
@@ -230,4 +330,17 @@ test("booking mutation keeps package linkage, snapshot, price, promotion bypass,
   assert.match(source, /packageBooking \? packageBooking\.fixedTotal : Number\(total \|\| 0\)/);
   assert.match(source, /pg_advisory_xact_lock/);
   assert.match(source, /packageBooking \? \[packageBooking\.item\] : await customerPricingHelpers/);
+});
+
+test("package replay ordering uses persisted history before current resolution and locked revalidation", () => {
+  const source = fs.readFileSync(path.join(__dirname, "../server/services/booking/createBookingJob.js"), "utf8");
+  const handler = source.indexOf("async function handlePublicBook");
+  const historicalReplay = source.indexOf("historicalPackageBookingForReplay(", handler);
+  const currentResolve = source.indexOf("packageBooking = await resolvePackageBooking", handler);
+  assert.ok(historicalReplay > handler && historicalReplay < currentResolve);
+
+  const begin = source.indexOf('await client.query("BEGIN")', currentResolve);
+  const lockedLookup = source.indexOf('await client.query("SELECT pg_advisory_xact_lock', begin);
+  const revalidate = source.indexOf("const revalidatedPackageBooking", begin);
+  assert.ok(begin > currentResolve && lockedLookup > begin && revalidate > lockedLookup);
 });

--- a/test/customerServicePackageBooking.test.js
+++ b/test/customerServicePackageBooking.test.js
@@ -153,10 +153,31 @@ test("resolver authority replaces fake service, quantity, duration, and exact fi
   assert.equal(result.durationMin, 90);
   assert.equal(result.fixedTotal, "1399.50");
   assert.equal(result.item.qty, 2);
+  assert.equal(result.item.unit_price, "699.75");
   assert.equal(result.item.line_total, "1399.50");
+  const allocatedMinor = BigInt(result.item.unit_price.replace(".", "")) * BigInt(result.item.qty);
+  assert.equal(allocatedMinor, BigInt(result.item.line_total.replace(".", "")));
   assert.equal(result.item.customer_price_source, "service_package");
   assert.match(result.item.item_name, /ล้างพรีเมียม/);
   assert.deepEqual(result.snapshot, selection().snapshot);
+});
+
+test("awkward package division uses deterministic DB-scale allocation and preserves exact total", () => {
+  const awkward = selection();
+  awkward.service_lines[0].quantity = 4;
+  awkward.snapshot = structuredClone(awkward);
+
+  const result = canonicalizeSelection(awkward, body(), "2026-12-01T09:00:00+07:00");
+
+  assert.equal(result.item.qty, 4);
+  assert.equal(result.item.unit_price, "349.88");
+  assert.equal(result.item.line_total, "1399.50");
+  assert.equal(result.fixedTotal, "1399.50");
+  assert.equal(
+    canonicalizeSelection(awkward, body(), "2026-12-01T09:00:00+07:00").item.unit_price,
+    "349.88"
+  );
+  assert.equal(BigInt(result.item.line_total.replace(".", "")), 139950n);
 });
 
 test("server BTU maximum and minimum constraints accept only their actual ranges", () => {

--- a/test/customerServicePackageBooking.test.js
+++ b/test/customerServicePackageBooking.test.js
@@ -1,0 +1,131 @@
+"use strict";
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const {
+  packageRequest,
+  canonicalizeSelection,
+  resolvePackageBooking,
+} = require("../server/services/booking/servicePackageBooking");
+
+function selection(overrides = {}) {
+  const base = {
+    package: { id: "41", key: "premium-day", name: "Premium Day" },
+    tier: { id: "73", key: "two-units", name: "2 units" },
+    service_lines: [{
+      service_key: "wall-premium-small",
+      service_name: "Premium wall wash",
+      quantity: 2,
+      unit_duration_minutes: 45,
+      service_constraints: {
+        job_type: "ล้าง", ac_type: "ผนัง", wash_variant: "ล้างพรีเมียม", btu_min: null, btu_max: 12000,
+      },
+    }],
+    fixed_total_price: "1399.50",
+    redeem_until: "2026-12-31T16:59:59.000Z",
+  };
+  const value = { ...base, ...overrides };
+  value.snapshot = structuredClone(value);
+  return value;
+}
+
+function body(overrides = {}) {
+  return {
+    service_package_key: "premium-day",
+    service_package_tier_key: "two-units",
+    btu: 12000,
+    price: 1,
+    standard_price: 2,
+    machine_count: 99,
+    duration_min: 1,
+    job_type: "ซ่อม",
+    ac_type: "แขวน",
+    wash_variant: "ล้างธรรมดา",
+    ...overrides,
+  };
+}
+
+test("no package keys preserves the ordinary booking branch", () => {
+  assert.equal(packageRequest({}), null);
+});
+
+test("package keys are paired and public numeric identities are rejected", () => {
+  for (const value of [
+    { service_package_key: "premium-day" },
+    { service_package_tier_key: "two-units" },
+    { service_package_key: "", service_package_tier_key: "" },
+    { service_package_id: 41 },
+    { service_package_key: "premium-day", service_package_tier_key: "two-units", service_package_tier_id: 73 },
+  ]) {
+    assert.throws(() => packageRequest(value), { code: "PACKAGE_IDENTITY_MALFORMED", statusCode: 400 });
+  }
+});
+
+test("resolver authority replaces fake service, quantity, duration, and exact fixed total", () => {
+  const result = canonicalizeSelection(selection(), body(), "2026-12-01T09:00:00+07:00");
+  assert.deepEqual(result.payload, {
+    job_type: "ล้าง", ac_type: "ผนัง", btu: 12000, machine_count: 2,
+    wash_variant: "ล้างพรีเมียม", repair_variant: "", admin_override_duration_min: 0,
+  });
+  assert.equal(result.durationMin, 90);
+  assert.equal(result.fixedTotal, "1399.50");
+  assert.equal(result.item.qty, 2);
+  assert.equal(result.item.line_total, "1399.50");
+  assert.equal(result.item.customer_price_source, "service_package");
+  assert.match(result.item.item_name, /ล้างพรีเมียม/);
+  assert.deepEqual(result.snapshot, selection().snapshot);
+});
+
+test("server BTU maximum and minimum constraints accept only their actual ranges", () => {
+  assert.doesNotThrow(() => canonicalizeSelection(selection(), body({ btu: 12000 }), "2026-12-01T09:00:00+07:00"));
+  assert.throws(() => canonicalizeSelection(selection(), body({ btu: 18000 }), "2026-12-01T09:00:00+07:00"), { code: "PACKAGE_BTU_MISMATCH" });
+  const large = selection();
+  large.service_lines[0].service_constraints.btu_min = 18000;
+  large.service_lines[0].service_constraints.btu_max = null;
+  assert.doesNotThrow(() => canonicalizeSelection(large, body({ btu: 18000 }), "2026-12-01T09:00:00+07:00"));
+  assert.throws(() => canonicalizeSelection(large, body({ btu: 12000 }), "2026-12-01T09:00:00+07:00"), { code: "PACKAGE_BTU_MISMATCH" });
+});
+
+test("sell resolution and redeem eligibility remain distinct", async () => {
+  const resolver = { async resolveSelection() { return selection(); } };
+  await assert.rejects(
+    resolvePackageBooking({ body: body(), bookingMode: "scheduled", appointmentDatetime: "2027-01-01T09:00:00+07:00", resolver }),
+    { code: "PACKAGE_REDEEM_WINDOW_EXCEEDED", statusCode: 409 }
+  );
+  const errorResolver = { async resolveSelection() { const e = new Error("hidden detail"); e.code = "PACKAGE_NOT_ON_SALE"; throw e; } };
+  await assert.rejects(
+    resolvePackageBooking({ body: body(), bookingMode: "scheduled", appointmentDatetime: "2026-12-01T09:00:00+07:00", resolver: errorResolver }),
+    { code: "PACKAGE_NOT_ON_SALE", message: "PACKAGE_NOT_ON_SALE" }
+  );
+});
+
+test("mixed ordinary lines and urgent package booking are rejected", async () => {
+  assert.throws(
+    () => canonicalizeSelection(selection(), body({ services: [{ job_type: "ล้าง" }] }), "2026-12-01T09:00:00+07:00"),
+    { code: "PACKAGE_MIXING_UNSUPPORTED" }
+  );
+  assert.throws(
+    () => canonicalizeSelection(selection(), body({ items: [{ item_id: 1, qty: 1 }] }), "2026-12-01T09:00:00+07:00"),
+    { code: "PACKAGE_MIXING_UNSUPPORTED" }
+  );
+  await assert.rejects(
+    resolvePackageBooking({ body: body(), bookingMode: "urgent", appointmentDatetime: "2026-12-01T09:00:00+07:00", resolver: {} }),
+    { code: "PACKAGE_URGENT_UNSUPPORTED" }
+  );
+});
+
+test("booking mutation keeps package linkage, snapshot, price, promotion bypass, and revalidation inside its transaction", () => {
+  const source = fs.readFileSync(path.join(__dirname, "../server/services/booking/createBookingJob.js"), "utf8");
+  const begin = source.indexOf('await client.query("BEGIN")');
+  const revalidate = source.indexOf("resolver: createServicePackageResolver(client)", begin);
+  const itemInsert = source.indexOf("service_package_snapshot", revalidate);
+  const units = source.indexOf("ensureCanonicalBookingJobUnits(job_id, client)", itemInsert);
+  const commit = source.indexOf('await client.query("COMMIT")', units);
+  assert.ok(begin >= 0 && revalidate > begin && itemInsert > revalidate && units > itemInsert && commit > units);
+  assert.match(source, /const promoPick = packageBooking \? null : await findBestCustomerPromotion/);
+  assert.match(source, /packageBooking \? packageBooking\.fixedTotal : Number\(total \|\| 0\)/);
+  assert.match(source, /pg_advisory_xact_lock/);
+  assert.match(source, /packageBooking \? \[packageBooking\.item\] : await customerPricingHelpers/);
+});


### PR DESCRIPTION
﻿## CWF Codex Worker

Source task: #221

This pull request was created automatically as a **Draft**. It has not been merged or deployed.

### Changed files

- index.js
- server/services/booking/createBookingJob.js
- server/services/booking/servicePackageBooking.js
- test/customerServicePackageBooking.test.js

### Codex report

Implemented issue #221 on the locked base.

Summary

- Issue: #221
- Draft PR: Not opened by Codex; outer CWF Worker will create it
- Branch: `cwf-worker/issue-221-20260807-211817-implementation-phase-3-server-author`
- Base/Head SHA: `99e2016018d40ed26689855b091f085006ac8622` (uncommitted working-tree changes)

Package contract:

- Accepts paired `service_package_key` and `service_package_tier_key` on scheduled `/public/book`.
- Rejects partial, blank, numeric-ID, urgent, and mixed-line package requests.
- Resolver controls service, BTU bounds, wash variant, quantity, duration, fixed total, IDs, and snapshot.
- Revalidates package state inside the booking transaction.
- Persists package IDs and immutable snapshot on the service `job_item`.
- Bypasses ordinary pricing and Promotions.
- Preserves fixed-total decimal text through SQL parameters.
- Uses package quantity and unit duration for conservative availability/collision duration.
- Existing advisory-lock idempotency remains in place and includes package identity.
- No-package bookings retain the legacy pricing, Promotion, and migration-compatible item insert path.

Changed files

- [createBookingJob.js](D:/CWF/CodexWorker/workspace/cwf-services-system/server/services/booking/createBookingJob.js)
- [servicePackageBooking.js](D:/CWF/CodexWorker/workspace/cwf-services-system/server/services/booking/servicePackageBooking.js)
- [index.js](D:/CWF/CodexWorker/workspace/cwf-services-system/index.js)
- [customerServicePackageBooking.test.js](D:/CWF/CodexWorker/workspace/cwf-services-system/test/customerServicePackageBooking.test.js)

Tests run and results

- `node --check` on all four changed/new JavaScript files: passed
- Required focused suites plus new package suite: 64 tests
  - Passed: 44
  - Failed: 0
  - Skipped: 20
- `git diff --check`: passed
- Runtime: requested Codex Node runtime at `C:\Users\dtga2\AppData\Local\OpenAI\Codex\runtimes\cua_node\f1bf3cd3a5929acd\bin\node.exe`

Remaining risks or unverified items

- The 20 PostgreSQL integration tests were skipped because non-Production PostgreSQL at `127.0.0.1:5432` refused the connection.
- Consequently, end-to-end PostgreSQL verification of package persistence, rollback, and concurrent replay remains blocked. Unit/source-focused coverage passed.
- Package requests require the existing service-package migration before they can succeed; ordinary bookings avoid referencing package columns when the migration is absent.
- No cache changes or runtime installation.
- Rollback is limited to reverting the four working-tree files above.
- No Production migration, database/data/config change, commit, push, PR creation, merge, deploy, or restart was performed.

### Controller checklist

- [ ] Scope matches the issue
- [ ] No protected/high-risk files changed
- [ ] Tests and build results are credible
- [ ] Production behavior and rollback are understood
- [ ] Owner approval received before merge/deploy
