### PR TITLE
Fix CWF home release promotion pipeline

### DIFF
--- a/.github/workflows/cwf-home-release-promotion.yml
+++ b/.github/workflows/cwf-home-release-promotion.yml
@@ -1,0 +1,137 @@
+name: CWF Home Release Promotion
+
+on:
+  push:
+    branches:
+      - main
+  workflow_run:
+    workflows:
+      - CWF Home Staging
+    types:
+      - completed
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: cwf-home-release-promotion
+  cancel-in-progress: false
+
+jobs:
+  main-to-staging:
+    name: Open main to staging promotion
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create or reuse staging promotion PR
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const headBranch = 'main';
+            const baseBranch = 'staging/home-server-test';
+            const head = `${owner}:${headBranch}`;
+
+            const { data: existing } = await github.rest.pulls.list({
+              owner,
+              repo,
+              state: 'open',
+              head,
+              base: baseBranch,
+              per_page: 20,
+            });
+
+            if (existing.length) {
+              core.notice(`Staging promotion PR already open: #${existing[0].number}`);
+              return;
+            }
+
+            const { data: comparison } = await github.rest.repos.compareCommitsWithBasehead({
+              owner,
+              repo,
+              basehead: `${baseBranch}...${headBranch}`,
+            });
+
+            if (!comparison.ahead_by) {
+              core.notice('No new main commits need promotion to staging.');
+              return;
+            }
+
+            const { data: pr } = await github.rest.pulls.create({
+              owner,
+              repo,
+              title: 'Promote main to CWF home staging',
+              head: headBranch,
+              base: baseBranch,
+              draft: false,
+              body: [
+                'Automated release promotion PR.',
+                '',
+                'Merge this PR to deploy the merged code to `test-app.cwf-air.com` through the self-hosted runner.',
+                '',
+                'Do not bypass staging. After the staging deployment succeeds, the release pipeline will open the Production promotion PR automatically.',
+              ].join('\n'),
+            });
+            core.notice(`Created staging promotion PR #${pr.number}`);
+
+  staging-to-production:
+    name: Open staging to production promotion
+    if: >-
+      github.event_name == 'workflow_run' &&
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.head_branch == 'staging/home-server-test'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create or reuse production promotion PR
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const headBranch = 'staging/home-server-test';
+            const baseBranch = 'production/home-server';
+            const head = `${owner}:${headBranch}`;
+
+            const { data: existing } = await github.rest.pulls.list({
+              owner,
+              repo,
+              state: 'open',
+              head,
+              base: baseBranch,
+              per_page: 20,
+            });
+
+            if (existing.length) {
+              core.notice(`Production promotion PR already open: #${existing[0].number}`);
+              return;
+            }
+
+            const { data: comparison } = await github.rest.repos.compareCommitsWithBasehead({
+              owner,
+              repo,
+              basehead: `${baseBranch}...${headBranch}`,
+            });
+
+            if (!comparison.ahead_by) {
+              core.notice('No staged commits need promotion to Production.');
+              return;
+            }
+
+            const { data: pr } = await github.rest.pulls.create({
+              owner,
+              repo,
+              title: 'Promote verified staging to CWF home production',
+              head: headBranch,
+              base: baseBranch,
+              draft: false,
+              body: [
+                'Automated Production promotion PR created only after `CWF Home Staging` completed successfully.',
+                '',
+                'Before merge, verify `https://test-app.cwf-air.com` and any required migration/data gates.',
+                '',
+                'Merging this PR is the Production release event. The existing `CWF Home Production` workflow must then perform backup, deploy, health check, and automatic rollback on failure.',
+              ].join('\n'),
+            });
+            core.notice(`Created Production promotion PR #${pr.number}`);


### PR DESCRIPTION
Root cause: recent application PRs merge to `main`, while the staging and production deploy workflows only trigger on pushes to `staging/home-server-test` and `production/home-server`. Both environment branches have been unchanged since 2026-08-03, so no current application merge can trigger deployment.

This PR adds a release-promotion workflow on the default branch:

1. A merge/push to `main` automatically opens/reuses a PR from `main` to `staging/home-server-test`.
2. Merging that PR triggers the existing CWF Home Staging deployment.
3. Only after the staging workflow completes successfully, an automatic PR from `staging/home-server-test` to `production/home-server` is opened/reused.
4. Merging the Production promotion PR triggers the existing Production backup/deploy/health-check/rollback workflow.

This PR does not deploy Production and does not change database, Compose, ENV, or runtime code.