### PR TITLE
Worker: #237 [Correction #236] Split protected workflow from Worker implementation

### DIFF
--- a/.github/workflows/cwf-production-service-package-migration.yml
+++ b/.github/workflows/cwf-production-service-package-migration.yml
@@ -1,0 +1,111 @@
+name: CWF Production Service Package Migration
+
+on:
+  workflow_dispatch:
+    inputs:
+      confirmation:
+        description: Type MIGRATE_SERVICE_PACKAGES_8093AD5 to run the approved one-time migration
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: cwf-home-production
+  cancel-in-progress: false
+
+jobs:
+  migrate:
+    name: Apply guarded Service Package schema migration
+    runs-on:
+      - self-hosted
+      - linux
+      - x64
+      - cwf-home
+    timeout-minutes: 30
+    env:
+      EXPECTED_PRODUCTION_REVISION: 8093ad5db19c3da10642b248b47f74ae739272e6
+      REQUIRED_CONFIRMATION: MIGRATE_SERVICE_PACKAGES_8093AD5
+    steps:
+      - name: Validate manual gate
+        shell: bash
+        env:
+          CONFIRMATION: ${{ inputs.confirmation }}
+        run: |
+          set -Eeuo pipefail
+          [[ "$GITHUB_REF" == "refs/heads/main" ]] || {
+            echo "This migration workflow may only be dispatched from main." >&2
+            exit 2
+          }
+          [[ "$CONFIRMATION" == "$REQUIRED_CONFIRMATION" ]] || {
+            echo "Typed confirmation does not match the approved migration gate." >&2
+            exit 2
+          }
+
+      - name: Checkout reviewed operator
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.sha }}
+          path: operator
+          fetch-depth: 1
+
+      - name: Checkout deployed Production release
+        uses: actions/checkout@v4
+        with:
+          ref: production/home-server
+          path: production
+          fetch-depth: 1
+
+      - name: Verify pinned release and operator files
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+          actual="$(git -C production rev-parse HEAD)"
+          [[ "$actual" == "$EXPECTED_PRODUCTION_REVISION" ]] || {
+            echo "Production branch moved: expected $EXPECTED_PRODUCTION_REVISION, got $actual" >&2
+            exit 3
+          }
+          [[ -f operator/scripts/run-production-service-package-migration.sh ]] || {
+            echo "Reviewed migration operator is missing." >&2
+            exit 3
+          }
+          [[ -f production/migrations/20260807_service_packages.sql ]] || {
+            echo "Approved migration file is missing from the deployed Production release." >&2
+            exit 3
+          }
+
+      - name: Prepare trusted command wrappers
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+          mkdir -p "$RUNNER_TEMP/cwf-production-migration-bin"
+
+          cat > "$RUNNER_TEMP/cwf-production-migration-bin/cwf-deployctl" <<'EOF'
+          #!/usr/bin/env bash
+          set -Eeuo pipefail
+          exec sudo -n /usr/local/sbin/cwf-deployctl "$@"
+          EOF
+
+          cat > "$RUNNER_TEMP/cwf-production-migration-bin/docker" <<'EOF'
+          #!/usr/bin/env bash
+          set -Eeuo pipefail
+          if /usr/bin/docker info >/dev/null 2>&1; then
+            exec /usr/bin/docker "$@"
+          fi
+          exec sudo -n /usr/bin/docker "$@"
+          EOF
+
+          chmod 0755 "$RUNNER_TEMP/cwf-production-migration-bin/cwf-deployctl" \
+            "$RUNNER_TEMP/cwf-production-migration-bin/docker"
+
+      - name: Apply exact migration with pre/post verification
+        shell: bash
+        working-directory: production
+        env:
+          OPERATOR_SCRIPT: ${{ github.workspace }}/operator/scripts/run-production-service-package-migration.sh
+        run: |
+          set -Eeuo pipefail
+          export PATH="$RUNNER_TEMP/cwf-production-migration-bin:$PATH"
+          bash "$OPERATOR_SCRIPT" | tee /tmp/cwf-production-service-package-migration.log
+          cat /tmp/cwf-production-service-package-migration.log >> "$GITHUB_STEP_SUMMARY"

--- a/scripts/run-production-service-package-migration.sh
+++ b/scripts/run-production-service-package-migration.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+readonly EXPECTED_PRODUCTION_REVISION="8093ad5db19c3da10642b248b47f74ae739272e6"
+readonly MIGRATION_PATH="migrations/20260807_service_packages.sql"
+readonly DB_CONTAINER="cwf-production-db"
+readonly PRODUCTION_ORIGIN="https://app.cwf-air.com"
+
+die() {
+  printf 'ERROR: %s\n' "$*" >&2
+  exit 1
+}
+
+log() {
+  printf '%s\n' "$*"
+}
+
+require_command() {
+  command -v "$1" >/dev/null 2>&1 || die "required command is unavailable: $1"
+}
+
+validate_production_status() {
+  local status_output="$1"
+  grep -Fq "$EXPECTED_PRODUCTION_REVISION" <<<"$status_output" ||
+    die "Production revision does not match the approved revision"
+  grep -Eiq '(^|[^[:alpha:]])(healthy|running|ok)([^[:alpha:]]|$)' <<<"$status_output" ||
+    die "Production status does not contain healthy/running evidence"
+  grep -Eiq '(unhealthy|degraded|failed|stopped|exited)' <<<"$status_output" &&
+    die "Production status contains unhealthy evidence"
+}
+
+db_query() {
+  local sql="$1"
+  docker exec "$DB_CONTAINER" sh -ceu \
+    'exec psql -X -U "${POSTGRES_USER:?}" -d "${POSTGRES_DB:?}" -v ON_ERROR_STOP=1 -Atqc "$1"' \
+    sh "$sql"
+}
+
+assert_db_value() {
+  local description="$1"
+  local sql="$2"
+  local expected="$3"
+  local actual
+  actual="$(db_query "$sql")" || die "database verification failed: $description"
+  [[ "$actual" == "$expected" ]] ||
+    die "$description: expected '$expected', got '$actual'"
+}
+
+[[ "$#" -eq 0 ]] || die "this operator accepts no arguments"
+[[ -f "$MIGRATION_PATH" ]] || die "approved migration file is missing: $MIGRATION_PATH"
+require_command cwf-deployctl
+require_command docker
+require_command curl
+
+log "Running read-only Production preflight checks"
+pre_status="$(cwf-deployctl production status)" || die "Production status preflight failed"
+validate_production_status "$pre_status"
+
+backup_evidence="$(cwf-deployctl production list-backups)" || die "Production backup listing failed"
+[[ -n "${backup_evidence//[[:space:]]/}" ]] || die "Production backup listing was empty"
+grep -Eiq '(no backups?|none found|0 backups?)' <<<"$backup_evidence" &&
+  die "Production backup listing reported no usable backups"
+grep -Eiq '(\.sql(\.gz)?|\.dump|\.tar|backup[-_][^[:space:]]*[0-9]{8})' <<<"$backup_evidence" ||
+  die "Production backup listing did not contain recognizable backup evidence"
+
+[[ "$(docker inspect -f '{{.State.Running}}' "$DB_CONTAINER" 2>/dev/null)" == "true" ]] ||
+  die "Production database container is not running"
+assert_db_value "Production database connectivity" "SELECT 1" "1"
+
+job_items_before="$(db_query 'SELECT count(*) FROM public.job_items')" ||
+  die "could not record the pre-migration job_items count"
+[[ "$job_items_before" =~ ^[0-9]+$ ]] || die "invalid pre-migration job_items count"
+
+log "Applying the single hard-pinned service-package migration"
+docker exec -i "$DB_CONTAINER" sh -ceu \
+  'exec psql -X -U "${POSTGRES_USER:?}" -d "${POSTGRES_DB:?}" -v ON_ERROR_STOP=1' \
+  < "$MIGRATION_PATH" || die "service-package migration failed"
+
+assert_db_value "service_packages table" \
+  "SELECT to_regclass('public.service_packages') IS NOT NULL" "t"
+assert_db_value "service_package_tiers table" \
+  "SELECT to_regclass('public.service_package_tiers') IS NOT NULL" "t"
+assert_db_value "nullable job_items service-package columns" \
+  "SELECT count(*) FROM information_schema.columns WHERE table_schema='public' AND table_name='job_items' AND is_nullable='YES' AND ((column_name='service_package_id' AND data_type='bigint') OR (column_name='service_package_tier_id' AND data_type='bigint') OR (column_name='service_package_snapshot' AND data_type='jsonb'))" "3"
+assert_db_value "job_items_service_package_fk ON DELETE RESTRICT" \
+  "SELECT count(*) FROM pg_constraint WHERE conrelid='public.job_items'::regclass AND conname='job_items_service_package_fk' AND contype='f' AND confdeltype='r'" "1"
+assert_db_value "job_items_service_package_tier_fk ON DELETE RESTRICT" \
+  "SELECT count(*) FROM pg_constraint WHERE conrelid='public.job_items'::regclass AND conname='job_items_service_package_tier_fk' AND contype='f' AND confdeltype='r'" "1"
+assert_db_value "service_package_tiers parent FK ON DELETE RESTRICT" \
+  "SELECT count(*) FROM pg_constraint WHERE conrelid='public.service_package_tiers'::regclass AND conname='service_package_tiers_service_package_id_fkey' AND contype='f' AND confrelid='public.service_packages'::regclass AND confdeltype='r'" "1"
+assert_db_value "expected service-package indexes" \
+  "SELECT count(*) FROM pg_indexes WHERE schemaname='public' AND indexname IN ('idx_service_packages_customer_listing','idx_service_package_tiers_lookup','idx_job_items_service_package_id')" "3"
+assert_db_value "service_packages remains unseeded" \
+  "SELECT count(*) FROM public.service_packages" "0"
+assert_db_value "service_package_tiers remains unseeded" \
+  "SELECT count(*) FROM public.service_package_tiers" "0"
+
+job_items_after="$(db_query 'SELECT count(*) FROM public.job_items')" ||
+  die "could not record the post-migration job_items count"
+[[ "$job_items_after" == "$job_items_before" ]] ||
+  die "job_items count changed (before=$job_items_before, after=$job_items_after)"
+
+log "Running read-only Production post-checks"
+post_status="$(cwf-deployctl production status)" || die "Production status post-check failed"
+validate_production_status "$post_status"
+
+version_response="$(curl --fail --silent --show-error --max-time 15 "$PRODUCTION_ORIGIN/api/version")" ||
+  die "Production version endpoint check failed"
+grep -Eq '"ok"[[:space:]]*:[[:space:]]*true' <<<"$version_response" ||
+  die "Production version endpoint did not report ok=true"
+curl --fail --silent --show-error --max-time 15 \
+  "$PRODUCTION_ORIGIN/public/service-packages" >/dev/null ||
+  die "Production public service-package read check failed"
+
+log "Migration verified successfully; job_items count remained $job_items_after and package/tier counts remained zero"

--- a/test/productionServicePackageMigrationOperator.test.js
+++ b/test/productionServicePackageMigrationOperator.test.js
@@ -1,0 +1,93 @@
+"use strict";
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const { spawnSync } = require("node:child_process");
+
+const root = path.join(__dirname, "..");
+const scriptPath = path.join(root, "scripts", "run-production-service-package-migration.sh");
+const source = fs.readFileSync(scriptPath, "utf8");
+
+test("operator shell has valid Bash syntax", (t) => {
+  const check = spawnSync("bash", ["-n", scriptPath], { encoding: "utf8" });
+  if (check.error?.code === "ENOENT") {
+    t.skip("bash is unavailable on this platform");
+    return;
+  }
+  assert.equal(check.status, 0, check.stderr);
+});
+
+test("operator hard-pins the approved revision and migration with no generic inputs", () => {
+  assert.match(source, /readonly EXPECTED_PRODUCTION_REVISION="8093ad5db19c3da10642b248b47f74ae739272e6"/);
+  assert.match(source, /readonly MIGRATION_PATH="migrations\/20260807_service_packages\.sql"/);
+  assert.match(source, /\[\[ "\$#" -eq 0 \]\] \|\| die/);
+  assert.doesNotMatch(source, /getopts|eval\b|MIGRATION_PATH="\$|EXPECTED_PRODUCTION_REVISION="\$/);
+  assert.match(source, /cwf-deployctl production status/g);
+  assert.match(source, /cwf-deployctl production list-backups/);
+});
+
+test("operator fails closed before DDL on revision, health, backup, Docker, and DB evidence", () => {
+  const ddlPosition = source.indexOf("docker exec -i");
+  assert.ok(ddlPosition > 0, "DDL execution must be explicit");
+  for (const evidence of [
+    "validate_production_status \"$pre_status\"",
+    "backup listing was empty",
+    "reported no usable backups",
+    "recognizable backup evidence",
+    "docker inspect",
+    "Production database connectivity",
+    "pre-migration job_items count",
+  ]) {
+    const position = source.indexOf(evidence);
+    assert.ok(position >= 0 && position < ddlPosition, `${evidence} must gate DDL`);
+  }
+  assert.match(source, /set -Eeuo pipefail/);
+  assert.match(source, /unhealthy\|degraded\|failed\|stopped\|exited/);
+});
+
+test("operator uses the running Production DB safely and stops psql errors", () => {
+  assert.match(source, /readonly DB_CONTAINER="cwf-production-db"/);
+  assert.match(source, /docker inspect -f '\{\{\.State\.Running\}\}'/);
+  assert.match(source, /psql[^\n]*-v ON_ERROR_STOP=1/g);
+  assert.doesNotMatch(source, /set -x|echo[^\n]*POSTGRES_PASSWORD|printf[^\n]*POSTGRES_PASSWORD/);
+  assert.doesNotMatch(source, /docker exec[^\n]*POSTGRES_PASSWORD/);
+});
+
+test("operator proves all pre/post data and schema invariants", () => {
+  assert.match(source, /job_items_before=.*count\(\*\) FROM public\.job_items/);
+  assert.match(source, /job_items_after=.*count\(\*\) FROM public\.job_items/);
+  assert.match(source, /job_items_after" == "\$job_items_before/);
+  assert.match(source, /to_regclass\('public\.service_packages'\)/);
+  assert.match(source, /to_regclass\('public\.service_package_tiers'\)/);
+  assert.match(source, /service_package_snapshot/);
+  assert.match(source, /is_nullable='YES'/);
+  assert.match(source, /job_items_service_package_fk/);
+  assert.match(source, /job_items_service_package_tier_fk/);
+  assert.match(source, /service_package_tiers_service_package_id_fkey/);
+  assert.match(source, /confdeltype='r'/);
+  for (const index of [
+    "idx_service_packages_customer_listing",
+    "idx_service_package_tiers_lookup",
+    "idx_job_items_service_package_id",
+  ]) assert.match(source, new RegExp(index));
+  assert.match(source, /service_packages remains unseeded/);
+  assert.match(source, /service_package_tiers remains unseeded/);
+});
+
+test("operator performs only allowed post-run control-plane and HTTP reads", () => {
+  assert.equal((source.match(/cwf-deployctl production status/g) || []).length, 2);
+  assert.equal((source.match(/cwf-deployctl production list-backups/g) || []).length, 1);
+  assert.match(source, /\/api\/version/);
+  assert.match(source, /\/public\/service-packages/);
+  assert.doesNotMatch(source, /curl[^\n]*(?:--request|-X)[^\n]*(?:POST|PUT|PATCH|DELETE)/i);
+  assert.doesNotMatch(source, /cwf-deployctl production (?:deploy|restart|rollback|restore)\b/);
+});
+
+test("operator contains no seed DML or forbidden workflow contract", () => {
+  assert.doesNotMatch(source, /\b(?:INSERT\s+INTO|UPDATE\s+\S+\s+SET|DELETE\s+FROM|MERGE\s+INTO|COPY\s+\S+\s+FROM)\b/i);
+  assert.doesNotMatch(source, /\.github\/workflows|workflow_dispatch/);
+  // Controller-owned follow-up contract: a future manual workflow should invoke
+  // this exact no-argument script and must not accept arbitrary SQL or commands.
+});


### PR DESCRIPTION
﻿## CWF Codex Worker

Source task: #237

This pull request was created automatically as a **Draft**. It has not been merged or deployed.

### Changed files

- scripts/run-production-service-package-migration.sh
- test/productionServicePackageMigrationOperator.test.js

### Codex report

Summary

Implemented the guarded Production service-package migration operator on branch `cwf-worker/issue-237-20260808-013038-correction-236-split-protected-workf`.

- Base/head before changes: `main` at `2acfdae2423044a7e65769eba4623eade386cd5f`
- PR: none yet; outer Worker will create the Draft PR
- No Production commands, migration, deployment, restart, rollback, or restore were executed
- `.github/workflows/*` remains untouched for the controller-owned follow-up

Changed files

- [run-production-service-package-migration.sh](D:/CWF/CodexWorker/workspace/cwf-services-system/scripts/run-production-service-package-migration.sh)
- [productionServicePackageMigrationOperator.test.js](D:/CWF/CodexWorker/workspace/cwf-services-system/test/productionServicePackageMigrationOperator.test.js)

Tests run and results

- `git diff --check` โ€” passed
- Exact changed-filename verification โ€” passed; only the two authorized files changed
- Trailing-whitespace validation โ€” passed
- Bash syntax test โ€” not run; Bash/WSL is unavailable
- Focused Node test โ€” not run; Node.js is unavailable

Remaining risks or unverified items

- Runtime execution of the Node test and `bash -n` remains unverified due to missing local runtimes.
- The controller must independently add/review the manual-only workflow wrapper on this same branch/PR if possible.
- The script intentionally has not been exercised against Production.

### Controller checklist

- [ ] Scope matches the issue
- [ ] No protected/high-risk files changed
- [ ] Tests and build results are credible
- [ ] Production behavior and rollback are understood
- [ ] Owner approval received before merge/deploy
