### PR TITLE
Worker: #240 [Implementation] Manage Service Package promotions from existing Admin Store Catalog

### DIFF
--- a/admin-store-catalog.css
+++ b/admin-store-catalog.css
@@ -183,6 +183,15 @@
 .asc-modal-error{ color:#b91c1c; font-size:12px; margin-top:6px; display:none; }
 .asc-loading, .asc-empty, .asc-error{ padding:14px; text-align:center; color:#64748b; font-size:13px; }
 .asc-error{ color:#b91c1c; }
+.hidden{ display:none !important; }
+.asc-type-modal{ max-width:420px; }
+.asc-type-choice{ width:100%; margin-top:8px; }
+.asc-package-tier{ border:1px solid #dbe4ee; border-radius:10px; padding:10px; margin-bottom:10px; }
+.asc-package-badge{ background:#ede9fe; color:#6d28d9; }
+.asc-lifecycle-on-sale{ background:#dcfce7; color:#15803d; }
+.asc-lifecycle-upcoming{ background:#dbeafe; color:#1d4ed8; }
+.asc-lifecycle-draft,.asc-lifecycle-hidden,.asc-lifecycle-disabled{ background:#e2e8f0; color:#475569; }
+.asc-lifecycle-sale-ended,.asc-lifecycle-redeem-ended{ background:#fee2e2; color:#b91c1c; }
 
 @media (max-width: 360px) {
   .asc-grid2{ grid-template-columns:1fr; }

--- a/admin-store-catalog.html
+++ b/admin-store-catalog.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
   <title>Admin • รายการบริการในร้านค้า</title>
   <link rel="stylesheet" href="/style.css"/>
-  <link rel="stylesheet" href="/admin-store-catalog.css?v=20260702_cat_v2"/>
+  <link rel="stylesheet" href="/admin-store-catalog.css?v=20260808_service_packages"/>
 </head>
 <body>
   <div class="topbar">
@@ -43,6 +43,14 @@
     </div>
 
     <div class="card" style="margin-top:12px">
+      <div class="asc-toolbar-row">
+        <div><b>Service Package promotions</b><div class="muted2 mini">Separate package pricing and lifecycle; expired and disabled packages remain visible here.</div></div>
+        <button id="btnReloadPackages" class="secondary btn-small" type="button">Refresh packages</button>
+      </div>
+      <div id="package_catalog_list" class="asc-card-list">Loading packages...</div>
+    </div>
+
+    <div class="card" style="margin-top:12px">
       <b>👀 ดูตัวอย่างร้านค้าลูกค้า (Read-only Preview)</b>
       <div class="muted2 mini" style="margin-top:4px">แสดงเฉพาะรายการที่ "เปิดใช้งาน" และ "แสดงให้ลูกค้าเห็น" พร้อมกัน ตามข้อมูลจริงที่โหลดมาด้านบน</div>
       <div id="catalog_preview" style="margin-top:10px"></div>
@@ -76,6 +84,6 @@
   </div>
 
   <script src="/admin-v2-common.js?v=20260622_admin_menu_catalog_entry"></script>
-  <script src="/admin-store-catalog.js?v=20260708_price_rule_safety_v3"></script>
+  <script src="/admin-store-catalog.js?v=20260808_service_packages"></script>
 </body>
 </html>

--- a/admin-store-catalog.js
+++ b/admin-store-catalog.js
@@ -10,6 +10,9 @@ let galleryUploading = false;
 let galleryUploadQueue = [];
 let galleryPickNotice = "";
 let deleteModalItemId = null;
+let servicePackages = [];
+let editingPackageKey = null;
+let packageTierDrafts = [];
 const BOOKING_MODES = ["bookable", "contact_admin", "purchase"];
 // Must mirror the backend's MAX_CATALOG_IMAGES_PER_ITEM (server/routes/catalog/items.js)
 const MAX_GALLERY_IMAGES = 4;
@@ -1073,6 +1076,186 @@ function bindCatalogListActions() {
   });
 }
 
+/* ---------- Service Package catalog (separate pricing domain) ---------- */
+
+function packageLifecycleLabel(status) {
+  return ({ draft: "Draft", disabled: "Disabled", hidden: "Hidden", upcoming: "Upcoming", "on-sale": "On sale",
+    "sale-ended": "Sale ended", "redeem-ended": "Redeem ended" })[status] || "Draft";
+}
+
+function packageJobTypeInput(value) {
+  const text = String(value || "").toLowerCase();
+  if (text.includes("ล้าง") || text.includes("wash")) return "wash";
+  if (text.includes("ซ่อม") || text.includes("repair")) return "repair";
+  return "install";
+}
+function packageAcTypeInput(value) {
+  const text = String(value || "").toLowerCase();
+  if (text.includes("ผนัง") || text.includes("wall")) return "wall";
+  if (text.includes("สี่ทิศ") || text.includes("cassette")) return "cassette";
+  if (text.includes("แขวน") || text.includes("floor")) return "floor";
+  return "ceiling";
+}
+function packageWashVariantInput(value) {
+  const text = String(value || "").toLowerCase();
+  if (text.includes("พรีเมียม") || text.includes("premium")) return "premium";
+  if (text.includes("แขวนคอยล์") || text.includes("coil")) return "coil";
+  if (text.includes("ตัดล้าง") || text.includes("overhaul")) return "overhaul";
+  if (text.includes("ธรรมดา") || text.includes("normal")) return "normal";
+  return "";
+}
+
+function dateTimeLocalValue(value) {
+  if (!value) return "";
+  const d = new Date(value);
+  if (Number.isNaN(d.getTime())) return "";
+  const local = new Date(d.getTime() - d.getTimezoneOffset() * 60000);
+  return local.toISOString().slice(0, 16);
+}
+
+function ensureCreateTypeChooser() {
+  if (el("catalog_type_backdrop")) return;
+  const wrap = document.createElement("div");
+  wrap.innerHTML = `<div id="catalog_type_backdrop" class="cwf-modal-backdrop hidden"><div class="cwf-modal asc-type-modal">
+    <div class="cwf-modal-head"><div class="cwf-modal-title">Choose item type</div></div>
+    <div class="cwf-modal-body"><p>Type is permanent after the item is saved.</p>
+      <button id="new_ordinary_item" class="secondary asc-type-choice" type="button">Ordinary catalog item</button>
+      <button id="new_package_item" class="primary asc-type-choice" type="button">Service Package promotion</button></div>
+    <div class="cwf-modal-foot"><button id="new_type_cancel" class="secondary" type="button">Cancel</button></div>
+  </div></div>`;
+  document.body.appendChild(wrap.firstElementChild);
+  el("new_ordinary_item").addEventListener("click", () => { el("catalog_type_backdrop").classList.add("hidden"); openCatalogModalForNew(); });
+  el("new_package_item").addEventListener("click", () => { el("catalog_type_backdrop").classList.add("hidden"); openPackageModal(); });
+  el("new_type_cancel").addEventListener("click", () => el("catalog_type_backdrop").classList.add("hidden"));
+}
+
+function openCreateTypeChooser() {
+  ensureCreateTypeChooser();
+  el("catalog_type_backdrop").classList.remove("hidden");
+}
+
+function ensurePackageModal() {
+  if (el("package_modal_backdrop")) return;
+  const wrap = document.createElement("div");
+  wrap.innerHTML = `<div id="package_modal_backdrop" class="cwf-modal-backdrop hidden"><div class="cwf-modal">
+    <div class="cwf-modal-head"><div id="package_modal_title" class="cwf-modal-title">New Service Package</div><button id="package_modal_close" class="cwf-modal-close" type="button">×</button></div>
+    <div class="cwf-modal-body">
+      <div class="asc-section"><div class="asc-section-title">Package identity</div>
+        <div class="asc-field"><label>Item type</label><input value="Service Package promotion" disabled></div>
+        <div id="pm_key_field" class="asc-field hidden"><label>Package key (server-controlled)</label><input id="pm_package_key" disabled></div>
+        <div class="asc-field"><label>Display name *</label><input id="pm_display_name"></div>
+        <div class="asc-field"><label>Description</label><textarea id="pm_description" rows="3"></textarea></div>
+        <div class="asc-grid2"><div class="asc-field"><label>Service key *</label><input id="pm_service_key"></div><div class="asc-field"><label>Service name *</label><input id="pm_service_name"></div></div>
+      </div>
+      <div class="asc-section"><div class="asc-section-title">Server-enforced service constraints</div>
+        <div class="asc-grid2"><div class="asc-field"><label>Job type *</label><select id="pm_job_type"><option value="wash">Wash</option><option value="repair">Repair</option><option value="install">Install</option></select></div>
+        <div class="asc-field"><label>AC type *</label><select id="pm_ac_type"><option value="wall">Wall</option><option value="cassette">Cassette</option><option value="floor">Floor/Hanging</option><option value="ceiling">Concealed ceiling</option></select></div></div>
+        <div class="asc-field"><label>Wash variant (required for wall wash)</label><select id="pm_wash_variant"><option value="">None</option><option value="normal">Normal wash</option><option value="premium">Premium wash</option><option value="coil">Coil wash</option><option value="overhaul">Overhaul wash</option></select></div>
+        <div class="asc-grid2"><div class="asc-field"><label>BTU min</label><input id="pm_btu_min" type="number" min="1" step="1"></div><div class="asc-field"><label>BTU max</label><input id="pm_btu_max" type="number" min="1" step="1"></div></div>
+        <div class="asc-field"><label>Duration per service unit (minutes) *</label><input id="pm_duration" type="number" min="1" step="1"></div>
+      </div>
+      <div class="asc-section"><div class="asc-section-title">Sale and redemption lifecycle</div>
+        <div class="asc-grid2"><div class="asc-field"><label>Sell start</label><input id="pm_sell_start" type="datetime-local"></div><div class="asc-field"><label>Sell end</label><input id="pm_sell_end" type="datetime-local"></div></div>
+        <div class="asc-field"><label>Redeem until</label><input id="pm_redeem_until" type="datetime-local"></div>
+        <div class="asc-grid2"><div class="asc-field"><label>Active</label><select id="pm_active"><option value="0">Disabled</option><option value="1">Active</option></select></div><div class="asc-field"><label>Customer visible</label><select id="pm_visible"><option value="0">Hidden</option><option value="1">Visible</option></select></div></div>
+      </div>
+      <div class="asc-section"><div class="asc-section-title">Package tiers</div><div id="pm_tiers"></div><button id="pm_add_tier" class="secondary btn-small" type="button">+ Add tier</button></div>
+      <div id="package_modal_error" class="asc-modal-error"></div>
+    </div><div class="cwf-modal-foot"><button id="package_modal_cancel" class="secondary" type="button">Cancel</button><button id="package_modal_save" class="primary" type="button">Save package</button></div>
+  </div></div>`;
+  document.body.appendChild(wrap.firstElementChild);
+  el("package_modal_close").addEventListener("click", closePackageModal);
+  el("package_modal_cancel").addEventListener("click", closePackageModal);
+  el("package_modal_save").addEventListener("click", saveServicePackage);
+  el("pm_add_tier").addEventListener("click", () => { packageTierDrafts.push({ display_name: "", service_quantity: 1, fixed_total_price: "", sort_order: packageTierDrafts.length, is_active: true }); renderPackageTiers(); });
+  el("pm_tiers").addEventListener("input", updatePackageTierDraft);
+  el("pm_tiers").addEventListener("change", updatePackageTierDraft);
+  el("pm_tiers").addEventListener("click", (event) => { const button = event.target.closest("[data-remove-tier]"); if (!button) return; packageTierDrafts.splice(Number(button.dataset.removeTier), 1); renderPackageTiers(); });
+}
+
+function renderPackageTiers() {
+  el("pm_tiers").innerHTML = packageTierDrafts.map((tier, i) => `<div class="asc-package-tier" data-tier-index="${i}">
+    ${tier.tier_key ? `<div class="muted2 mini">Existing tier key is fixed</div>` : `<div class="muted2 mini">New tier key will be generated by the server</div>`}
+    <div class="asc-grid2"><div class="asc-field"><label>Display name *</label><input data-tier-field="display_name" value="${escapeHtml(tier.display_name)}"></div><div class="asc-field"><label>Quantity *</label><input data-tier-field="service_quantity" type="number" min="1" step="1" value="${tier.service_quantity}"></div></div>
+    <div class="asc-grid2"><div class="asc-field"><label>Fixed total (exact 2 decimals) *</label><input data-tier-field="fixed_total_price" inputmode="decimal" value="${escapeHtml(tier.fixed_total_price)}"></div><div class="asc-field"><label>Sort order</label><input data-tier-field="sort_order" type="number" step="1" value="${tier.sort_order}"></div></div>
+    <div class="asc-grid2"><div class="asc-field"><label>Status</label><select data-tier-field="is_active"><option value="1" ${tier.is_active ? "selected" : ""}>Active</option><option value="0" ${tier.is_active ? "" : "selected"}>Inactive</option></select></div><div><button class="secondary btn-small" data-remove-tier="${i}" type="button">Omit / deactivate</button></div></div>
+  </div>`).join("") || `<div class="muted2 mini">No tiers. Draft packages may be saved without tiers.</div>`;
+}
+
+function updatePackageTierDraft(event) {
+  const row = event.target.closest("[data-tier-index]");
+  const field = event.target.dataset.tierField;
+  if (!row || !field) return;
+  const tier = packageTierDrafts[Number(row.dataset.tierIndex)];
+  tier[field] = field === "is_active" ? event.target.value === "1" : event.target.value;
+}
+
+function openPackageModal(packageKey = null) {
+  ensurePackageModal();
+  editingPackageKey = packageKey;
+  const item = packageKey ? servicePackages.find((p) => p.package_key === packageKey) : null;
+  el("package_modal_title").textContent = item ? `Edit ${item.display_name}` : "New Service Package";
+  el("pm_key_field").classList.toggle("hidden", !item);
+  el("pm_package_key").value = item?.package_key || "";
+  for (const [id, value] of Object.entries({ pm_display_name: item?.display_name, pm_description: item?.description,
+    pm_service_key: item?.service_key, pm_service_name: item?.service_name, pm_job_type: item ? packageJobTypeInput(item.job_type) : "wash",
+    pm_ac_type: item ? packageAcTypeInput(item.ac_type) : "wall", pm_wash_variant: item ? packageWashVariantInput(item.wash_variant) : "", pm_btu_min: item?.btu_min,
+    pm_btu_max: item?.btu_max, pm_duration: item?.service_unit_duration_minutes,
+    pm_sell_start: dateTimeLocalValue(item?.sell_start_at), pm_sell_end: dateTimeLocalValue(item?.sell_end_at),
+    pm_redeem_until: dateTimeLocalValue(item?.redeem_until), pm_active: item?.is_active ? "1" : "0", pm_visible: item?.is_customer_visible ? "1" : "0" })) el(id).value = value == null ? "" : value;
+  packageTierDrafts = (item?.tiers || []).map((tier) => ({ ...tier }));
+  if (!item) packageTierDrafts.push({ display_name: "", service_quantity: 1, fixed_total_price: "", sort_order: 0, is_active: true });
+  renderPackageTiers();
+  el("package_modal_error").style.display = "none";
+  el("package_modal_backdrop").classList.remove("hidden");
+}
+
+function closePackageModal() { if (!isSaving) el("package_modal_backdrop").classList.add("hidden"); }
+function packageDateValue(id) { const value = el(id).value; return value ? new Date(value).toISOString() : null; }
+function packagePayload() {
+  const optionalInt = (id) => el(id).value === "" ? null : Number(el(id).value);
+  return { display_name: el("pm_display_name").value.trim(), description: el("pm_description").value.trim() || null,
+    service_key: el("pm_service_key").value.trim(), service_name: el("pm_service_name").value.trim(),
+    job_type: el("pm_job_type").value, ac_type: el("pm_ac_type").value, wash_variant: el("pm_wash_variant").value || null,
+    btu_min: optionalInt("pm_btu_min"), btu_max: optionalInt("pm_btu_max"), service_unit_duration_minutes: Number(el("pm_duration").value),
+    sell_start_at: packageDateValue("pm_sell_start"), sell_end_at: packageDateValue("pm_sell_end"), redeem_until: packageDateValue("pm_redeem_until"),
+    is_active: el("pm_active").value === "1", is_customer_visible: el("pm_visible").value === "1",
+    tiers: packageTierDrafts.map((tier) => ({ ...(tier.tier_key ? { tier_key: tier.tier_key } : {}), display_name: String(tier.display_name).trim(),
+      service_quantity: Number(tier.service_quantity), fixed_total_price: String(tier.fixed_total_price).trim(), sort_order: Number(tier.sort_order), is_active: tier.is_active })) };
+}
+
+async function saveServicePackage() {
+  if (isSaving) return;
+  isSaving = true; el("package_modal_save").disabled = true;
+  const box = el("package_modal_error"); box.style.display = "none";
+  try {
+    const url = editingPackageKey ? `/admin/service-packages/catalog/${encodeURIComponent(editingPackageKey)}` : "/admin/service-packages/catalog";
+    await apiFetch(url, { method: editingPackageKey ? "PATCH" : "POST", body: JSON.stringify(packagePayload()) });
+    el("package_modal_backdrop").classList.add("hidden"); await loadServicePackages(); showToast("Service Package saved", "success");
+  } catch (error) { box.textContent = error.message || "Unable to save package"; box.style.display = "block"; }
+  finally { isSaving = false; el("package_modal_save").disabled = false; }
+}
+
+function renderServicePackages() {
+  const box = el("package_catalog_list");
+  box.innerHTML = servicePackages.length ? servicePackages.map((item) => `<div class="asc-item-card">
+    <div class="asc-item-main"><div class="asc-item-title">${escapeHtml(item.display_name)} <span class="asc-badge asc-package-badge">Service Package</span></div>
+      <div class="asc-item-meta">${escapeHtml(item.service_name)} · ${escapeHtml(item.job_type)} · ${escapeHtml(item.ac_type)}</div>
+      <div class="asc-item-meta">${item.tiers.length} tiers · ${item.service_unit_duration_minutes} min/unit</div>
+      <div class="asc-badges"><span class="asc-badge asc-lifecycle-${escapeHtml(item.lifecycle_status)}">${packageLifecycleLabel(item.lifecycle_status)}</span></div></div>
+    <div class="asc-item-actions"><button class="secondary btn-small" data-edit-package="${escapeHtml(item.package_key)}" type="button">Edit</button></div></div>`).join("") : `<div class="asc-empty">No Service Package promotions yet.</div>`;
+}
+
+async function loadServicePackages() {
+  const box = el("package_catalog_list"); box.innerHTML = `<div class="asc-loading">Loading packages...</div>`;
+  try { const items = await apiFetch("/admin/service-packages/catalog"); servicePackages = Array.isArray(items) ? items : []; renderServicePackages(); }
+  catch (error) { box.innerHTML = `<div class="asc-error">${escapeHtml(error.message || "Unable to load packages")}</div>`; }
+}
+
+function bindServicePackageActions() {
+  el("package_catalog_list").addEventListener("click", (event) => { const button = event.target.closest("[data-edit-package]"); if (button) openPackageModal(button.dataset.editPackage); });
+}
+
 /* ---------- Review moderation ---------- */
 
 let reviewItems = [];
@@ -1362,12 +1545,15 @@ function bindReviewListActions() {
 
 document.addEventListener("DOMContentLoaded", () => {
   bindCatalogListActions();
-  el("btnNewItem").addEventListener("click", openCatalogModalForNew);
+  el("btnNewItem").addEventListener("click", openCreateTypeChooser);
   el("btnReloadCatalog").addEventListener("click", loadCatalogItems);
   el("catalog_search").addEventListener("input", renderCatalogList);
   el("catalog_filter_active").addEventListener("change", renderCatalogList);
   el("catalog_filter_visible").addEventListener("change", renderCatalogList);
   loadCatalogItems();
+  bindServicePackageActions();
+  el("btnReloadPackages").addEventListener("click", loadServicePackages);
+  loadServicePackages();
 
   bindReviewListActions();
   el("btnReloadReviews").addEventListener("click", loadReviews);

--- a/index.js
+++ b/index.js
@@ -58,6 +58,8 @@ const { registerPublicServicePackageRoutes } = require("./server/routes/public/s
 const { createServicePackageResolver } = require("./server/services/packages/servicePackageResolver");
 const { createPublicServicePackageService } = require("./server/services/public/servicePackages");
 const { registerAdminBookingRoutes } = require("./server/routes/admin/adminBookings");
+const { createServicePackageCatalogService } = require("./server/services/packages/servicePackageCatalogService");
+const { createServicePackageCatalogRoutes } = require("./server/routes/admin/servicePackageCatalog");
 const { createTechnicianJobMoneyHelpers } = require("./server/technicianJobMoneySummary");
 const createSystemRoutes = require("./server/routes/system");
 const createTechnicianDirectoryRoutes = require("./server/routes/users/technicians");
@@ -12973,6 +12975,10 @@ app.use(createCatalogItemRoutes({
   buildStartIntervalsByCollision,
   toMin,
   minToHHMM,
+}));
+app.use(createServicePackageCatalogRoutes({
+  service: createServicePackageCatalogService({ pool }),
+  requireAdminSession,
 }));
 app.use(createCatalogReviewRoutes({ pool, requireCustomerJwt, requireAdminSession }));
 app.use(createHomepageRoutes({ pool, requireAdminSession, requireCustomerJwt, upload, cloudinaryUploadBuffer, cloudinaryDestroyPublicId }));

--- a/server/routes/admin/servicePackageCatalog.js
+++ b/server/routes/admin/servicePackageCatalog.js
@@ -1,0 +1,24 @@
+"use strict";
+
+const express = require("express");
+const { ServicePackageCatalogError } = require("../../services/packages/servicePackageCatalogService");
+
+function createServicePackageCatalogRoutes({ service, requireAdminSession }) {
+  if (!service || typeof service.list !== "function") throw new TypeError("Service package catalog service is required");
+  if (typeof requireAdminSession !== "function") throw new TypeError("Admin session middleware is required");
+  const router = express.Router();
+  const handle = (action) => async (req, res) => {
+    try { return res.json(await action(req)); }
+    catch (error) {
+      if (error instanceof ServicePackageCatalogError) return res.status(error.status).json({ error: error.message, code: error.code });
+      console.error("Service package catalog request failed", { name: error?.name, code: error?.code });
+      return res.status(500).json({ error: "Unable to save service package", code: "SERVICE_PACKAGE_CATALOG_ERROR" });
+    }
+  };
+  router.get("/admin/service-packages/catalog", requireAdminSession, handle(() => service.list()));
+  router.post("/admin/service-packages/catalog", requireAdminSession, handle((req) => service.create(req.body)));
+  router.patch("/admin/service-packages/catalog/:packageKey", requireAdminSession, handle((req) => service.update(req.params.packageKey, req.body)));
+  return router;
+}
+
+module.exports = { createServicePackageCatalogRoutes };

--- a/server/services/packages/servicePackageCatalogService.js
+++ b/server/services/packages/servicePackageCatalogService.js
@@ -1,0 +1,161 @@
+"use strict";
+
+const crypto = require("node:crypto");
+const repository = require("./servicePackageRepository");
+const { normalizeServiceType, normalizeAcType, normalizeWashVariantLabel, normalizeWashKey } = require("../../normalizers");
+
+const JOB_TYPES = new Set(["wash", "repair", "install"].map(normalizeServiceType));
+const AC_TYPES = new Set(["wall", "cassette", "floor", "ceiling"].map(normalizeAcType));
+
+class ServicePackageCatalogError extends Error {
+  constructor(code, message, status = 400) { super(message); this.name = "ServicePackageCatalogError"; this.code = code; this.status = status; }
+}
+
+function fail(code, message, status) { throw new ServicePackageCatalogError(code, message, status); }
+function text(value, field, max = 200) {
+  const result = String(value == null ? "" : value).trim();
+  if (!result || result.length > max) fail("INVALID_PACKAGE", `${field} is required and must not exceed ${max} characters`);
+  return result;
+}
+function optionalText(value, max = 2000) {
+  if (value == null || String(value).trim() === "") return null;
+  const result = String(value).trim();
+  if (result.length > max) fail("INVALID_PACKAGE", `Text must not exceed ${max} characters`);
+  return result;
+}
+function bool(value, field) {
+  if (typeof value !== "boolean") fail("INVALID_PACKAGE", `${field} must be boolean`);
+  return value;
+}
+function positiveInt(value, field, optional = false) {
+  if (optional && (value == null || value === "")) return null;
+  const result = Number(value);
+  if (!Number.isInteger(result) || result <= 0) fail("INVALID_PACKAGE", `${field} must be a positive integer`);
+  return result;
+}
+function date(value, field) {
+  if (value == null || value === "") return null;
+  if (typeof value !== "string" || !Number.isFinite(Date.parse(value))) fail("INVALID_PACKAGE", `${field} must be a valid date-time`);
+  return new Date(value).toISOString();
+}
+function money(value) {
+  const result = String(value == null ? "" : value).trim();
+  if (!/^\d+\.\d{2}$/.test(result)) {
+    fail("INVALID_TIER", "fixed_total_price must be positive decimal text with exactly two fractional digits");
+  }
+  if (Number(result) <= 0) fail("INVALID_TIER", "fixed_total_price must be positive");
+  return Number(result).toFixed(2);
+}
+function key(prefix) { return `${prefix}-${crypto.randomUUID().replace(/-/g, "").slice(0, 16)}`; }
+
+function validate(input) {
+  if (!input || typeof input !== "object" || Array.isArray(input)) fail("INVALID_PACKAGE", "Package payload is required");
+  if (Object.prototype.hasOwnProperty.call(input, "package_key") || Object.prototype.hasOwnProperty.call(input, "packageKey")) {
+    fail("IMMUTABLE_KEY", "package_key is server-controlled");
+  }
+  const jobType = normalizeServiceType(text(input.job_type, "job_type", 80));
+  const acType = normalizeAcType(text(input.ac_type, "ac_type", 80));
+  if (!JOB_TYPES.has(jobType) || !AC_TYPES.has(acType)) fail("INVALID_SERVICE_CONSTRAINTS", "Unsupported job_type or ac_type");
+  let washVariant = optionalText(input.wash_variant, 100);
+  if (washVariant) washVariant = normalizeWashVariantLabel(washVariant);
+  if (jobType === normalizeServiceType("wash") && acType === normalizeAcType("wall") && !normalizeWashKey(washVariant)) {
+    fail("INVALID_SERVICE_CONSTRAINTS", "Wall cleaning packages require a supported wash_variant");
+  }
+  const btuMin = positiveInt(input.btu_min, "btu_min", true);
+  const btuMax = positiveInt(input.btu_max, "btu_max", true);
+  if (btuMin && btuMax && btuMin > btuMax) fail("INVALID_SERVICE_CONSTRAINTS", "btu_min must not exceed btu_max");
+  const sellStart = date(input.sell_start_at, "sell_start_at");
+  const sellEnd = date(input.sell_end_at, "sell_end_at");
+  const redeemUntil = date(input.redeem_until, "redeem_until");
+  if (sellStart && sellEnd && sellEnd < sellStart) fail("INVALID_SELL_WINDOW", "sell_end_at must not precede sell_start_at");
+  if (redeemUntil && ((sellEnd && redeemUntil < sellEnd) || (sellStart && redeemUntil < sellStart))) {
+    fail("INVALID_REDEEM_WINDOW", "redeem_until must not precede the sale window");
+  }
+  if (!Array.isArray(input.tiers)) fail("INVALID_TIER", "tiers must be an array");
+  const tiers = input.tiers.map((tier, index) => {
+    if (!tier || typeof tier !== "object" || Array.isArray(tier)) fail("INVALID_TIER", "Each tier must be an object");
+    const tierKey = tier.tier_key == null ? null : text(tier.tier_key, "tier_key", 200);
+    return { tier_key: tierKey, display_name: text(tier.display_name, "tier display_name"),
+      service_quantity: positiveInt(tier.service_quantity, "service_quantity"),
+      fixed_total_price: money(tier.fixed_total_price), sort_order: Number.isInteger(Number(tier.sort_order)) ? Number(tier.sort_order) : index,
+      is_active: bool(tier.is_active, "tier is_active") };
+  });
+  const suppliedKeys = tiers.map((tier) => tier.tier_key).filter(Boolean);
+  if (new Set(suppliedKeys).size !== suppliedKeys.length) fail("INVALID_TIER_KEY", "Duplicate tier_key values are not allowed");
+  const isActive = bool(input.is_active, "is_active");
+  const isVisible = bool(input.is_customer_visible, "is_customer_visible");
+  if ((isActive || isVisible) && !tiers.some((tier) => tier.is_active)) fail("INVALID_TIER", "An active or visible package requires an active tier");
+  return { display_name: text(input.display_name, "display_name"), description: optionalText(input.description),
+    service_key: text(input.service_key, "service_key"), service_name: text(input.service_name, "service_name"),
+    job_type: jobType, ac_type: acType, wash_variant: washVariant, btu_min: btuMin, btu_max: btuMax,
+    service_unit_duration_minutes: positiveInt(input.service_unit_duration_minutes, "service_unit_duration_minutes"),
+    sell_start_at: sellStart, sell_end_at: sellEnd, redeem_until: redeemUntil,
+    is_active: isActive, is_customer_visible: isVisible, tiers };
+}
+
+function lifecycle(row, at = new Date()) {
+  if (!row.is_active && !row.is_customer_visible) return "draft";
+  if (!row.is_active) return "disabled";
+  if (!row.is_customer_visible) return "hidden";
+  if (row.redeem_until && at > new Date(row.redeem_until)) return "redeem-ended";
+  if (row.sell_end_at && at > new Date(row.sell_end_at)) return "sale-ended";
+  if (row.sell_start_at && at < new Date(row.sell_start_at)) return "upcoming";
+  return "on-sale";
+}
+function dto(row, at) {
+  return { package_key: row.package_key, display_name: row.display_name, description: row.description,
+    service_key: row.service_key, service_name: row.service_name, job_type: row.job_type, ac_type: row.ac_type,
+    wash_variant: row.wash_variant, btu_min: row.btu_min, btu_max: row.btu_max,
+    service_unit_duration_minutes: row.service_unit_duration_minutes,
+    sell_start_at: row.sell_start_at, sell_end_at: row.sell_end_at, redeem_until: row.redeem_until,
+    is_active: row.is_active, is_customer_visible: row.is_customer_visible, lifecycle_status: lifecycle(row, at),
+    tiers: (row.tiers || []).map((tier) => ({ tier_key: tier.tier_key, display_name: tier.display_name,
+      service_quantity: Number(tier.service_quantity), fixed_total_price: Number(tier.fixed_total_price).toFixed(2),
+      sort_order: Number(tier.sort_order), is_active: tier.is_active })) };
+}
+
+function createServicePackageCatalogService({ pool, packageRepository = repository, now = () => new Date() }) {
+  if (!pool || typeof pool.query !== "function" || typeof pool.connect !== "function") throw new TypeError("PostgreSQL pool is required");
+  async function list() { return (await packageRepository.listCatalogPackages(pool)).map((row) => dto(row, now())); }
+  async function save(input, packageKey) {
+    const value = validate(input);
+    const client = await pool.connect();
+    try {
+      await client.query("BEGIN");
+      let packageRow;
+      let existingTiers = [];
+      if (packageKey) {
+        packageRow = await packageRepository.findPackageByKeyForUpdate(client, packageKey);
+        if (!packageRow) fail("PACKAGE_NOT_FOUND", "Service package was not found", 404);
+        existingTiers = await packageRepository.listTiersForUpdate(client, packageRow.service_package_id);
+        packageRow = await packageRepository.updatePackage(client, packageRow.service_package_id, value);
+      } else {
+        packageRow = await packageRepository.insertPackage(client, { ...value, package_key: key("pkg") });
+      }
+      const existingByKey = new Map(existingTiers.map((tier) => [tier.tier_key, tier]));
+      const keptIds = [];
+      const savedTiers = [];
+      for (const tier of value.tiers) {
+        if (tier.tier_key) {
+          const existing = existingByKey.get(tier.tier_key);
+          if (!existing) fail("INVALID_TIER_KEY", "tier_key does not belong to this package");
+          const saved = await packageRepository.updateTier(client, existing.service_package_tier_id, tier);
+          keptIds.push(existing.service_package_tier_id); savedTiers.push(saved);
+        } else {
+          const saved = await packageRepository.insertTier(client, packageRow.service_package_id, { ...tier, tier_key: key("tier") });
+          keptIds.push(saved.service_package_tier_id); savedTiers.push(saved);
+        }
+      }
+      if (packageKey) await packageRepository.deactivateTiers(client, packageRow.service_package_id, keptIds);
+      await client.query("COMMIT");
+      return dto({ ...packageRow, tiers: savedTiers }, now());
+    } catch (error) {
+      try { await client.query("ROLLBACK"); } catch (_) { /* preserve original error */ }
+      if (error?.code === "23505") fail("PACKAGE_KEY_CONFLICT", "A generated package or tier key conflicted; please retry", 409);
+      throw error;
+    } finally { client.release(); }
+  }
+  return { list, create: (input) => save(input, null), update: (packageKey, input) => save(input, text(packageKey, "package_key")) };
+}
+
+module.exports = { ServicePackageCatalogError, createServicePackageCatalogService, validate, lifecycle };

--- a/server/services/packages/servicePackageCatalogService.js
+++ b/server/services/packages/servicePackageCatalogService.js
@@ -6,6 +6,9 @@ const { normalizeServiceType, normalizeAcType, normalizeWashVariantLabel, normal
 
 const JOB_TYPES = new Set(["wash", "repair", "install"].map(normalizeServiceType));
 const AC_TYPES = new Set(["wall", "cassette", "floor", "ceiling"].map(normalizeAcType));
+const PG_INTEGER_MIN = -2147483648;
+const PG_INTEGER_MAX = 2147483647;
+const MAX_FIXED_TOTAL_CENTS = 999999999999n;
 
 class ServicePackageCatalogError extends Error {
   constructor(code, message, status = 400) { super(message); this.name = "ServicePackageCatalogError"; this.code = code; this.status = status; }
@@ -30,7 +33,17 @@ function bool(value, field) {
 function positiveInt(value, field, optional = false) {
   if (optional && (value == null || value === "")) return null;
   const result = Number(value);
-  if (!Number.isInteger(result) || result <= 0) fail("INVALID_PACKAGE", `${field} must be a positive integer`);
+  if (!Number.isInteger(result) || result <= 0 || result > PG_INTEGER_MAX) {
+    fail("INVALID_PACKAGE", `${field} must be a positive PostgreSQL integer`);
+  }
+  return result;
+}
+function integer(value, field, fallback) {
+  if (value == null || value === "") return fallback;
+  const result = Number(value);
+  if (!Number.isInteger(result) || result < PG_INTEGER_MIN || result > PG_INTEGER_MAX) {
+    fail("INVALID_TIER", `${field} must be a PostgreSQL integer`);
+  }
   return result;
 }
 function date(value, field) {
@@ -40,11 +53,14 @@ function date(value, field) {
 }
 function money(value) {
   const result = String(value == null ? "" : value).trim();
-  if (!/^\d+\.\d{2}$/.test(result)) {
+  const match = /^(\d+)\.(\d{2})$/.exec(result);
+  if (!match) {
     fail("INVALID_TIER", "fixed_total_price must be positive decimal text with exactly two fractional digits");
   }
-  if (Number(result) <= 0) fail("INVALID_TIER", "fixed_total_price must be positive");
-  return Number(result).toFixed(2);
+  const cents = (BigInt(match[1]) * 100n) + BigInt(match[2]);
+  if (cents <= 0n) fail("INVALID_TIER", "fixed_total_price must be positive");
+  if (cents > MAX_FIXED_TOTAL_CENTS) fail("INVALID_TIER", "fixed_total_price exceeds the NUMERIC(12,2) range");
+  return result;
 }
 function key(prefix) { return `${prefix}-${crypto.randomUUID().replace(/-/g, "").slice(0, 16)}`; }
 
@@ -77,7 +93,7 @@ function validate(input) {
     const tierKey = tier.tier_key == null ? null : text(tier.tier_key, "tier_key", 200);
     return { tier_key: tierKey, display_name: text(tier.display_name, "tier display_name"),
       service_quantity: positiveInt(tier.service_quantity, "service_quantity"),
-      fixed_total_price: money(tier.fixed_total_price), sort_order: Number.isInteger(Number(tier.sort_order)) ? Number(tier.sort_order) : index,
+      fixed_total_price: money(tier.fixed_total_price), sort_order: integer(tier.sort_order, "sort_order", index),
       is_active: bool(tier.is_active, "tier is_active") };
   });
   const suppliedKeys = tiers.map((tier) => tier.tier_key).filter(Boolean);

--- a/server/services/packages/servicePackageRepository.js
+++ b/server/services/packages/servicePackageRepository.js
@@ -49,4 +49,96 @@ async function listCustomerVisiblePackages(db, { at = new Date() } = {}) {
   return result.rows;
 }
 
-module.exports = { findPackageById, findPackageByKey, findTier, listCustomerVisiblePackages };
+async function listCatalogPackages(db) {
+  const result = await requireDb(db).query(
+    `SELECT p.*, COALESCE(json_agg(t ORDER BY t.sort_order, t.service_package_tier_id)
+       FILTER (WHERE t.service_package_tier_id IS NOT NULL), '[]'::json) AS tiers
+     FROM public.service_packages p
+     LEFT JOIN public.service_package_tiers t ON t.service_package_id=p.service_package_id
+     GROUP BY p.service_package_id
+     ORDER BY p.created_at DESC, p.service_package_id DESC`
+  );
+  return result.rows;
+}
+
+async function findPackageByKeyForUpdate(db, packageKey) {
+  const result = await requireDb(db).query(
+    "SELECT * FROM public.service_packages WHERE package_key=$1 FOR UPDATE",
+    [packageKey]
+  );
+  return result.rows[0] || null;
+}
+
+async function listTiersForUpdate(db, packageId) {
+  const result = await requireDb(db).query(
+    `SELECT * FROM public.service_package_tiers WHERE service_package_id=$1
+     ORDER BY sort_order, service_package_tier_id FOR UPDATE`,
+    [packageId]
+  );
+  return result.rows;
+}
+
+async function insertPackage(db, value) {
+  const result = await requireDb(db).query(
+    `INSERT INTO public.service_packages
+       (package_key, display_name, description, service_key, service_name, job_type, ac_type,
+        wash_variant, btu_min, btu_max, service_unit_duration_minutes, sell_start_at, sell_end_at,
+        redeem_until, is_active, is_customer_visible)
+     VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16) RETURNING *`,
+    [value.package_key, value.display_name, value.description, value.service_key, value.service_name,
+      value.job_type, value.ac_type, value.wash_variant, value.btu_min, value.btu_max,
+      value.service_unit_duration_minutes, value.sell_start_at, value.sell_end_at, value.redeem_until,
+      value.is_active, value.is_customer_visible]
+  );
+  return result.rows[0];
+}
+
+async function updatePackage(db, packageId, value) {
+  const result = await requireDb(db).query(
+    `UPDATE public.service_packages SET display_name=$2, description=$3, service_key=$4,
+       service_name=$5, job_type=$6, ac_type=$7, wash_variant=$8, btu_min=$9, btu_max=$10,
+       service_unit_duration_minutes=$11, sell_start_at=$12, sell_end_at=$13, redeem_until=$14,
+       is_active=$15, is_customer_visible=$16, updated_at=NOW()
+     WHERE service_package_id=$1 RETURNING *`,
+    [packageId, value.display_name, value.description, value.service_key, value.service_name,
+      value.job_type, value.ac_type, value.wash_variant, value.btu_min, value.btu_max,
+      value.service_unit_duration_minutes, value.sell_start_at, value.sell_end_at, value.redeem_until,
+      value.is_active, value.is_customer_visible]
+  );
+  return result.rows[0];
+}
+
+async function insertTier(db, packageId, value) {
+  const result = await requireDb(db).query(
+    `INSERT INTO public.service_package_tiers
+       (service_package_id, tier_key, display_name, service_quantity, fixed_total_price, sort_order, is_active)
+     VALUES ($1,$2,$3,$4,$5,$6,$7) RETURNING *`,
+    [packageId, value.tier_key, value.display_name, value.service_quantity,
+      value.fixed_total_price, value.sort_order, value.is_active]
+  );
+  return result.rows[0];
+}
+
+async function updateTier(db, tierId, value) {
+  const result = await requireDb(db).query(
+    `UPDATE public.service_package_tiers SET display_name=$2, service_quantity=$3,
+       fixed_total_price=$4, sort_order=$5, is_active=$6, updated_at=NOW()
+     WHERE service_package_tier_id=$1 RETURNING *`,
+    [tierId, value.display_name, value.service_quantity, value.fixed_total_price, value.sort_order, value.is_active]
+  );
+  return result.rows[0];
+}
+
+async function deactivateTiers(db, packageId, keepTierIds) {
+  await requireDb(db).query(
+    `UPDATE public.service_package_tiers SET is_active=FALSE, updated_at=NOW()
+     WHERE service_package_id=$1 AND NOT (service_package_tier_id = ANY($2::bigint[]))`,
+    [packageId, keepTierIds]
+  );
+}
+
+module.exports = {
+  findPackageById, findPackageByKey, findTier, listCustomerVisiblePackages, listCatalogPackages,
+  findPackageByKeyForUpdate, listTiersForUpdate, insertPackage, updatePackage, insertTier,
+  updateTier, deactivateTiers,
+};

--- a/test/adminServicePackageCatalog.test.js
+++ b/test/adminServicePackageCatalog.test.js
@@ -1,0 +1,115 @@
+"use strict";
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const { createServicePackageCatalogService, validate, lifecycle } = require("../server/services/packages/servicePackageCatalogService");
+
+function valid(overrides = {}) {
+  return { display_name: "Season package", description: "A managed package", service_key: "wash_wall",
+    service_name: "Wall wash", job_type: "wash", ac_type: "wall", wash_variant: "premium",
+    btu_min: 9000, btu_max: 18000, service_unit_duration_minutes: 45,
+    sell_start_at: "2026-08-01T00:00:00.000Z", sell_end_at: "2026-08-31T00:00:00.000Z",
+    redeem_until: "2026-09-30T00:00:00.000Z", is_active: false, is_customer_visible: false,
+    tiers: [{ display_name: "Two units", service_quantity: 2, fixed_total_price: "1399.50", sort_order: 0, is_active: true },
+      { display_name: "Four units", service_quantity: 4, fixed_total_price: "2499.00", sort_order: 1, is_active: true }], ...overrides };
+}
+
+function row(value, id = 41) {
+  return { service_package_id: id, package_key: "pkg-server", ...value, tiers: [] };
+}
+
+test("validation accepts exact package fields and rejects dates, BTU, duration, price, quantity and service constraints before connecting", async () => {
+  assert.equal(validate(valid()).tiers[0].fixed_total_price, "1399.50");
+  const invalid = [
+    { sell_end_at: "2026-07-01T00:00:00Z" }, { redeem_until: "2026-07-01T00:00:00Z" },
+    { btu_min: 18000, btu_max: 9000 }, { service_unit_duration_minutes: 0 },
+    { tiers: [{ display_name: "x", service_quantity: 1, fixed_total_price: "12.5", sort_order: 0, is_active: true }] },
+    { tiers: [{ display_name: "x", service_quantity: 0, fixed_total_price: "12.50", sort_order: 0, is_active: true }] },
+    { job_type: "unknown" }, { wash_variant: "unknown" },
+  ];
+  for (const change of invalid) assert.throws(() => validate(valid(change)));
+  let connects = 0;
+  const service = createServicePackageCatalogService({ pool: { query() {}, async connect() { connects += 1; } } });
+  await assert.rejects(service.create(valid({ service_unit_duration_minutes: 0 })));
+  assert.equal(connects, 0);
+});
+
+test("create is one transaction, returns safe keys/round-trip values and rolls back a tier failure", async () => {
+  const queries = [];
+  const client = { async query(sql) { queries.push(sql); }, release() { queries.push("RELEASE"); } };
+  const repo = {
+    async insertPackage(_db, value) { return row(value); },
+    async insertTier(_db, _id, tier) { return { service_package_tier_id: 70 + queries.length, ...tier }; },
+  };
+  const pool = { async query() {}, async connect() { return client; } };
+  const service = createServicePackageCatalogService({ pool, packageRepository: repo, now: () => new Date("2026-08-08T00:00:00Z") });
+  const result = await service.create(valid());
+  assert.match(result.package_key, /^pkg-/);
+  assert.equal(result.tiers[0].fixed_total_price, "1399.50");
+  assert.equal("service_package_id" in result, false);
+  assert.equal("service_package_tier_id" in result.tiers[0], false);
+  assert.deepEqual(queries, ["BEGIN", "COMMIT", "RELEASE"]);
+
+  queries.length = 0;
+  repo.insertTier = async () => { throw new Error("simulated write failure"); };
+  await assert.rejects(service.create(valid()), /simulated write failure/);
+  assert.deepEqual(queries, ["BEGIN", "ROLLBACK", "RELEASE"]);
+});
+
+test("patch locks by immutable package key, keeps existing tier key and deactivates omitted tiers", async () => {
+  const queries = [];
+  const client = { async query(sql) { queries.push(sql); }, release() {} };
+  const existing = { service_package_tier_id: 71, tier_key: "tier-stable" };
+  let deactivated;
+  const repo = {
+    async findPackageByKeyForUpdate(_db, key) { assert.equal(key, "pkg-stable"); return row(valid(), 41); },
+    async listTiersForUpdate() { return [existing, { service_package_tier_id: 72, tier_key: "tier-omitted" }]; },
+    async updatePackage(_db, id, value) { assert.equal(id, 41); return row(value, 41); },
+    async updateTier(_db, id, tier) { assert.equal(id, 71); return { ...existing, ...tier }; },
+    async insertTier() { throw new Error("unexpected insert"); },
+    async deactivateTiers(_db, id, kept) { deactivated = { id, kept }; },
+  };
+  const service = createServicePackageCatalogService({ pool: { async query() {}, async connect() { return client; } }, packageRepository: repo });
+  const result = await service.update("pkg-stable", valid({ tiers: [{ tier_key: "tier-stable", display_name: "Updated", service_quantity: 3, fixed_total_price: "1500.00", sort_order: 2, is_active: true }] }));
+  assert.equal(result.package_key, "pkg-server");
+  assert.equal(result.tiers[0].tier_key, "tier-stable");
+  assert.deepEqual(deactivated, { id: 41, kept: [71] });
+  assert.deepEqual(queries, ["BEGIN", "COMMIT"]);
+  await assert.rejects(service.update("pkg-stable", valid({ package_key: "changed" })), { code: "IMMUTABLE_KEY" });
+});
+
+test("management list includes every lifecycle and emits no numeric authority", async () => {
+  const base = row({ ...valid(), is_active: true, is_customer_visible: true });
+  const variants = [
+    { ...base, package_key: "up", sell_start_at: "2026-09-01T00:00:00Z" },
+    { ...base, package_key: "sale", sell_start_at: null, sell_end_at: null },
+    { ...base, package_key: "ended", sell_end_at: "2026-08-01T00:00:00Z", redeem_until: "2026-09-01T00:00:00Z" },
+    { ...base, package_key: "redeemed", sell_end_at: "2026-07-01T00:00:00Z", redeem_until: "2026-08-01T00:00:00Z" },
+    { ...base, package_key: "hidden", is_customer_visible: false },
+    { ...base, package_key: "off", is_active: false },
+    { ...base, package_key: "draft", is_active: false, is_customer_visible: false },
+  ];
+  const service = createServicePackageCatalogService({ pool: { async query() {}, async connect() {} },
+    packageRepository: { async listCatalogPackages() { return variants; } }, now: () => new Date("2026-08-08T00:00:00Z") });
+  assert.deepEqual((await service.list()).map((item) => item.lifecycle_status), ["upcoming", "on-sale", "sale-ended", "redeem-ended", "hidden", "disabled", "draft"]);
+  assert.deepEqual(variants.map((item) => lifecycle(item, new Date("2026-08-08T00:00:00Z"))), ["upcoming", "on-sale", "sale-ended", "redeem-ended", "hidden", "disabled", "draft"]);
+});
+
+test("management routes retain existing Admin auth and booking-selection routes remain unchanged", () => {
+  const route = fs.readFileSync(path.join(__dirname, "../server/routes/admin/servicePackageCatalog.js"), "utf8");
+  const booking = fs.readFileSync(path.join(__dirname, "../server/routes/admin/adminBookings.js"), "utf8");
+  for (const method of ["get", "post", "patch"]) assert.match(route, new RegExp(`router\\.${method}\\([^\\n]+requireAdminSession`));
+  assert.match(booking, /app\.get\("\/admin\/service-packages", requireAdminSession, service\.handleAdminServicePackageList\)/);
+  assert.match(booking, /app\.post\("\/admin\/service-packages\/preview", requireAdminSession, service\.handleAdminServicePackagePreview\)/);
+  assert.doesNotMatch(route, /service_package_id|service_package_tier_id|stack|sql/i);
+});
+
+test("management source never touches job snapshots or physically deletes package history", () => {
+  const files = ["../server/services/packages/servicePackageCatalogService.js", "../server/services/packages/servicePackageRepository.js"];
+  const source = files.map((file) => fs.readFileSync(path.join(__dirname, file), "utf8")).join("\n");
+  assert.doesNotMatch(source, /job_items|service_package_snapshot/);
+  assert.doesNotMatch(source, /DELETE\s+FROM\s+public\.service_package/i);
+  assert.match(source, /SET is_active=FALSE/);
+});

--- a/test/adminServicePackageCatalog.test.js
+++ b/test/adminServicePackageCatalog.test.js
@@ -5,6 +5,7 @@ const assert = require("node:assert/strict");
 const fs = require("node:fs");
 const path = require("node:path");
 const { createServicePackageCatalogService, validate, lifecycle } = require("../server/services/packages/servicePackageCatalogService");
+const { createServicePackageResolver } = require("../server/services/packages/servicePackageResolver");
 
 function valid(overrides = {}) {
   return { display_name: "Season package", description: "A managed package", service_key: "wash_wall",
@@ -34,6 +35,63 @@ test("validation accepts exact package fields and rejects dates, BTU, duration, 
   const service = createServicePackageCatalogService({ pool: { query() {}, async connect() { connects += 1; } } });
   await assert.rejects(service.create(valid({ service_unit_duration_minutes: 0 })));
   assert.equal(connects, 0);
+});
+
+test("schema-range numeric failures are rejected exactly before connecting", async () => {
+  const invalid = [
+    { btu_min: 2147483648 },
+    { btu_max: 2147483648 },
+    { service_unit_duration_minutes: 2147483648 },
+    { tiers: [{ display_name: "x", service_quantity: 2147483648, fixed_total_price: "12.50", sort_order: 0, is_active: true }] },
+    { tiers: [{ display_name: "x", service_quantity: 1, fixed_total_price: "10000000000.00", sort_order: 0, is_active: true }] },
+    { tiers: [{ display_name: "x", service_quantity: 1, fixed_total_price: "9999999999.999", sort_order: 0, is_active: true }] },
+    { tiers: [{ display_name: "x", service_quantity: 1, fixed_total_price: "12.50", sort_order: 2147483648, is_active: true }] },
+    { tiers: [{ display_name: "x", service_quantity: 1, fixed_total_price: "12.50", sort_order: -2147483649, is_active: true }] },
+  ];
+  assert.equal(validate(valid({ tiers: [{ display_name: "max", service_quantity: 2147483647,
+    fixed_total_price: "9999999999.99", sort_order: -2147483648, is_active: true }] })).tiers[0].fixed_total_price, "9999999999.99");
+  let connects = 0;
+  const service = createServicePackageCatalogService({ pool: { query() {}, async connect() { connects += 1; } } });
+  for (const change of invalid) await assert.rejects(service.create(valid(change)), { status: 400 });
+  assert.equal(connects, 0);
+});
+
+test("managed package state feeds the existing customer discovery seam and excludes unavailable packages", async () => {
+  const packages = [];
+  let nextId = 1;
+  const repo = {
+    async insertPackage(_db, value) {
+      const saved = row(value, nextId++);
+      packages.push(saved);
+      return saved;
+    },
+    async insertTier(_db, packageId, tier) {
+      const saved = { service_package_tier_id: packageId * 10, service_package_id: packageId, ...tier };
+      packages.find((item) => item.service_package_id === packageId).tiers.push(saved);
+      return saved;
+    },
+    async listCustomerVisiblePackages(_db, { at } = {}) {
+      const clock = at || new Date();
+      return packages.filter((item) => item.is_active && item.is_customer_visible
+        && (!item.sell_start_at || clock >= new Date(item.sell_start_at))
+        && (!item.sell_end_at || clock <= new Date(item.sell_end_at)));
+    },
+  };
+  const client = { async query() {}, release() {} };
+  const pool = { async query() {}, async connect() { return client; } };
+  const management = createServicePackageCatalogService({ pool, packageRepository: repo });
+  const states = [
+    ["available", { is_active: true, is_customer_visible: true }],
+    ["future", { is_active: true, is_customer_visible: true, sell_start_at: "2026-09-01T00:00:00Z",
+      sell_end_at: "2026-09-30T00:00:00Z", redeem_until: "2026-10-31T00:00:00Z" }],
+    ["expired", { is_active: true, is_customer_visible: true, sell_end_at: "2026-08-01T00:00:00Z" }],
+    ["hidden", { is_active: true, is_customer_visible: false }],
+    ["inactive", { is_active: false, is_customer_visible: true }],
+  ];
+  for (const [name, overrides] of states) await management.create(valid({ display_name: name, ...overrides }));
+  const discovery = createServicePackageResolver({ db: pool, packageRepository: repo });
+  const visible = await discovery.listCustomerVisible({ at: new Date("2026-08-08T00:00:00Z") });
+  assert.deepEqual(visible.map((item) => item.display_name), ["available"]);
 });
 
 test("create is one transaction, returns safe keys/round-trip values and rolls back a tier failure", async () => {

--- a/test/adminStoreCatalogServicePackages.test.js
+++ b/test/adminStoreCatalogServicePackages.test.js
@@ -1,0 +1,42 @@
+"use strict";
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+
+const js = fs.readFileSync(path.join(__dirname, "../admin-store-catalog.js"), "utf8");
+const html = fs.readFileSync(path.join(__dirname, "../admin-store-catalog.html"), "utf8");
+
+test("new flow offers immutable ordinary or Service Package type while ordinary save payload stays on its original endpoint", () => {
+  assert.match(js, /Choose item type/);
+  assert.match(js, /Ordinary catalog item/);
+  assert.match(js, /Service Package promotion/);
+  assert.match(js, /new_ordinary_item[\s\S]*openCatalogModalForNew/);
+  assert.match(js, /new_package_item[\s\S]*openPackageModal/);
+  assert.match(js, /savedItem = await apiFetch\("\/admin\/catalog\/items", \{ method: "POST", body: JSON\.stringify\(payload\) \}\)/);
+});
+
+test("package form sends only management-domain fields and no ordinary price, rule, image, booking-mode, delete or key mutation", () => {
+  const payload = js.match(/function packagePayload\(\)[\s\S]*?\n}\n/)[0];
+  for (const forbidden of ["base_price", "normal_price", "customer_service_price_rules", "booking_mode", "item_id", "package_key"]) assert.doesNotMatch(payload, new RegExp(forbidden));
+  assert.match(payload, /display_name/); assert.match(payload, /service_unit_duration_minutes/); assert.match(payload, /fixed_total_price/);
+  assert.match(js, /\/admin\/service-packages\/catalog/);
+  assert.match(js, /pm_package_key" disabled/);
+  assert.doesNotMatch(js.match(/async function saveServicePackage\(\)[\s\S]*?\n}\n/)[0], /\/admin\/catalog\/items/);
+});
+
+test("package tier editor is repeatable, supports inactive tiers and preserves form state on safe failure", () => {
+  assert.match(js, /pm_add_tier/); assert.match(js, /packageTierDrafts\.push/); assert.match(js, /data-remove-tier/);
+  assert.match(js, /data-tier-field="is_active"/);
+  const save = js.match(/async function saveServicePackage\(\)[\s\S]*?\n}\n/)[0];
+  assert.match(save, /catch \(error\)[\s\S]*box\.textContent/);
+  assert.doesNotMatch(save, /catch \(error\)[\s\S]*openCatalogModalForNew/);
+});
+
+test("same Admin page renders full package history lifecycle statuses and uses cache-busted assets", () => {
+  assert.match(html, /id="package_catalog_list"/);
+  for (const status of ["Draft", "Disabled", "Hidden", "Upcoming", "On sale", "Sale ended", "Redeem ended"]) assert.match(js, new RegExp(status));
+  assert.match(html, /admin-store-catalog\.js\?v=20260808_service_packages/);
+  assert.match(html, /admin-store-catalog\.css\?v=20260808_service_packages/);
+});

--- a/test/adminStoreCatalogUi.test.js
+++ b/test/adminStoreCatalogUi.test.js
@@ -12,9 +12,19 @@ const catalogCssSource = fs.readFileSync(path.join(__dirname, "..", "admin-store
 const VOID_TAGS = new Set(["area", "base", "br", "col", "embed", "hr", "img", "input", "link", "meta", "param", "source", "track", "wbr"]);
 
 function extractCatalogModalHtml() {
-  const m = catalogJsSource.match(/wrap\.innerHTML = `([\s\S]*?)`;\n  document\.body\.appendChild/);
+  const ensureCatalogModal = extractFunctionMatch("function ensureCatalogModal()")?.[0] || "";
+  const m = ensureCatalogModal.match(/wrap\.innerHTML = `([\s\S]*?)`;\r?\n  document\.body\.appendChild/);
   if (!m) throw new Error("could not find ensureCatalogModal's wrap.innerHTML template");
   return m[1];
+}
+
+function extractFunctionMatch(signature) {
+  const start = catalogJsSource.indexOf(signature);
+  if (start < 0) return null;
+  const tail = catalogJsSource.slice(start);
+  const closing = tail.match(/^}\r?$/m);
+  if (!closing) return null;
+  return [tail.slice(0, closing.index + closing[0].length)];
 }
 
 // Walks the modal's HTML template as a real tag stack (not just text matching), so a
@@ -143,7 +153,7 @@ test("catalog list renders loading, empty, and error states", () => {
 });
 
 test("image upload only happens after the item is saved and an itemId exists", () => {
-  const saveFnMatch = catalogJsSource.match(/async function saveCatalogItem\(\)[\s\S]*?\n}\n/);
+  const saveFnMatch = extractFunctionMatch("async function saveCatalogItem()");
   assert.ok(saveFnMatch, "saveCatalogItem function not found");
   const body = saveFnMatch[0];
   const saveCallIndex = body.search(/await apiFetch\(`\/admin\/catalog\/items/);
@@ -183,7 +193,7 @@ test("openCatalogModalForEdit reads raw pricing_* fields first, falling back to 
 });
 
 test("openCatalogModalForEdit never assigns blank/empty values when raw pricing data exists (no data loss on open+save)", () => {
-  const fnMatch = catalogJsSource.match(/function openCatalogModalForEdit\(itemId\)[\s\S]*?\n}\n/);
+  const fnMatch = extractFunctionMatch("function openCatalogModalForEdit(itemId)");
   assert.ok(fnMatch, "openCatalogModalForEdit function not found");
   const body = fnMatch[0];
   assert.doesNotMatch(body, /el\("cm_normal_price"\)\.value = "";/);
@@ -198,8 +208,8 @@ test("catalogModalPayload sends pricing.pricing_is_active, not pricing.is_active
 });
 
 test("the 7-section reorganization does not change which element id backs each field: every id read in catalogModalPayload is also written in openCatalogModalForEdit, so reordering sections never drops a value on open+save", () => {
-  const payloadMatch = catalogJsSource.match(/function catalogModalPayload\(\)[\s\S]*?\n}\n/);
-  const editMatch = catalogJsSource.match(/function openCatalogModalForEdit\(itemId\)[\s\S]*?\n}\n/);
+  const payloadMatch = extractFunctionMatch("function catalogModalPayload()");
+  const editMatch = extractFunctionMatch("function openCatalogModalForEdit(itemId)");
   assert.ok(payloadMatch, "catalogModalPayload function not found");
   assert.ok(editMatch, "openCatalogModalForEdit function not found");
   const payloadIds = [...payloadMatch[0].matchAll(/el\("(cm_[a-z_]+)"\)/g)].map((m) => m[1]);
@@ -217,7 +227,7 @@ test("no two distinct DOM elements in the modal share the same id (no duplicate 
 });
 
 test("hidden/collapsed fields (price-rule-matching accordion, booking advanced subsection) are populated on edit just like visible fields, so collapsing them never clears stored values", () => {
-  const editMatch = catalogJsSource.match(/function openCatalogModalForEdit\(itemId\)[\s\S]*?\n}\n/);
+  const editMatch = extractFunctionMatch("function openCatalogModalForEdit(itemId)");
   assert.ok(editMatch, "openCatalogModalForEdit function not found");
   const body = editMatch[0];
   for (const id of ["cm_job_category", "cm_ac_type", "cm_wash_variant", "cm_btu_min", "cm_btu_max", "cm_booking_service_key"]) {
@@ -241,7 +251,7 @@ test("modal includes booking_mode and is_featured under their own sections, plus
 });
 
 test("booking section shows only booking_mode/ac_type/btu/wash_variant prominently; service_key is tucked into a collapsed Advanced subsection", () => {
-  const sectionMatch = catalogJsSource.match(/4\) การจอง[\s\S]*?<\/div>\n\n        <div class="asc-section">\n          <div class="asc-section-title">5\)/);
+  const sectionMatch = extractCatalogModalHtml().match(/4\) การจอง[\s\S]*?<\/div>\r?\n\r?\n        <div class="asc-section">\r?\n          <div class="asc-section-title">5\)/);
   assert.ok(sectionMatch, "booking section not found");
   const section = sectionMatch[0];
   const detailsMatch = section.match(/<details class="asc-booking-advanced">[\s\S]*?<\/details>/);
@@ -369,8 +379,8 @@ test("gallery delete and set-primary actions ask for confirmation only on delete
 });
 
 test("admin-store-catalog.html keeps CSS cache and bumps JS cache for pricing safety", () => {
-  assert.match(catalogHtmlSource, /admin-store-catalog\.css\?v=20260702_cat_v2/);
-  assert.match(catalogHtmlSource, /admin-store-catalog\.js\?v=20260708_price_rule_safety_v3/);
+  assert.match(catalogHtmlSource, /admin-store-catalog\.css\?v=20260808_service_packages/);
+  assert.match(catalogHtmlSource, /admin-store-catalog\.js\?v=20260808_service_packages/);
 });
 
 test("the item_category field is a service/product dropdown, not free text", () => {
@@ -568,10 +578,12 @@ test("loadReviews sends status/source as server-side query params (so unassigned
     console,
   };
   vm.createContext(context);
-  const effectiveIdFn = catalogJsSource.match(/function reviewEffectiveItemId\(review\)[\s\S]*?\n}\n/)[0];
-  const effectiveNameFn = catalogJsSource.match(/function reviewEffectiveItemName\(review\)[\s\S]*?\n}\n/)[0];
-  const fnSource = catalogJsSource.match(/function renderReviewItemFilterOptions\(\)[\s\S]*?\n}\n\nasync function loadReviews\(\)[\s\S]*?\n}\n/)[0];
-  vm.runInContext(`let reviewItems = [];\n${effectiveIdFn}\n${effectiveNameFn}\n${fnSource}`, context);
+  const effectiveIdFn = extractFunctionMatch("function reviewEffectiveItemId(review)")[0];
+  const effectiveNameFn = extractFunctionMatch("function reviewEffectiveItemName(review)")[0];
+  const renderFilterFn = extractFunctionMatch("function renderReviewItemFilterOptions()")[0];
+  const renderListFn = extractFunctionMatch("function renderReviewList()")[0];
+  const loadReviewsFn = extractFunctionMatch("async function loadReviews()")[0];
+  vm.runInContext(`let reviewItems = [];\n${effectiveIdFn}\n${effectiveNameFn}\n${renderFilterFn}\n${renderListFn}\n${loadReviewsFn}`, context);
 
   await vm.runInContext("loadReviews()", context);
   assert.equal(calls[0], "/admin/catalog/reviews", "no filters selected must not send an empty querystring");
@@ -593,7 +605,7 @@ test("status/source filter selects re-fetch from the server (loadReviews), item 
 });
 
 test("setReviewModerationStatus confirms before acting, PATCHes the review, and updates state without a full reload", () => {
-  const fnMatch = catalogJsSource.match(/async function setReviewModerationStatus\(reviewId, nextStatus\)[\s\S]*?\n}\n/);
+  const fnMatch = extractFunctionMatch("async function setReviewModerationStatus(reviewId, nextStatus)");
   assert.ok(fnMatch, "setReviewModerationStatus function not found");
   const body = fnMatch[0];
   assert.match(body, /confirm\(/);
@@ -603,7 +615,7 @@ test("setReviewModerationStatus confirms before acting, PATCHes the review, and 
 });
 
 test("review action buttons never expose customer phone/email/internal IDs beyond completed_job_id and a display identity", () => {
-  const fnMatch = catalogJsSource.match(/function reviewCardHtml\(review\)[\s\S]*?\n}\n/);
+  const fnMatch = extractFunctionMatch("function reviewCardHtml(review)");
   assert.ok(fnMatch, "reviewCardHtml function not found");
   const body = fnMatch[0];
   assert.doesNotMatch(body, /\bphone\b/i);
@@ -613,7 +625,7 @@ test("review action buttons never expose customer phone/email/internal IDs beyon
 });
 
 test("review action buttons support approve/reject/hide/restore-to-pending depending on current status", () => {
-  const fnMatch = catalogJsSource.match(/function reviewActionButtons\(review\)[\s\S]*?\n}\n/);
+  const fnMatch = extractFunctionMatch("function reviewActionButtons(review)");
   assert.ok(fnMatch, "reviewActionButtons function not found");
   const body = fnMatch[0];
   assert.match(body, /"approved"/);

--- a/test/customerPricingSafety.test.js
+++ b/test/customerPricingSafety.test.js
@@ -532,5 +532,5 @@ test("admin UI source exposes safety warnings and cache-busted assets", () => {
   assert.match(catalogJs, /ราคาสินค้าเท่านั้น ไม่ใช้คำนวณค่าบริการ/);
   assert.match(catalogJs, /modalPricingRisk/);
   assert.match(promoHtml, /admin-promotions-v2\.js\?v=20260708_price_rule_safety_v2/);
-  assert.match(catalogHtml, /admin-store-catalog\.js\?v=20260708_price_rule_safety_v3/);
+  assert.match(catalogHtml, /admin-store-catalog\.js\?v=20260808_service_packages/);
 });


### PR DESCRIPTION
﻿## CWF Codex Worker

Source task: #240

This pull request was created automatically as a **Draft**. It has not been merged or deployed.

### Changed files

- admin-store-catalog.css
- admin-store-catalog.html
- admin-store-catalog.js
- index.js
- server/services/packages/servicePackageRepository.js
- server/routes/admin/servicePackageCatalog.js
- server/services/packages/servicePackageCatalogService.js
- test/adminServicePackageCatalog.test.js
- test/adminStoreCatalogServicePackages.test.js

### Codex report

Implemented issue #240 on the existing worker branch. No commit or PR was created by Codex.

## Summary

- Added separate Admin management API:
  - `GET /admin/service-packages/catalog`
  - `POST /admin/service-packages/catalog`
  - `PATCH /admin/service-packages/catalog/:packageKey`
- Added transactional package/header and tier writes using one PostgreSQL client.
- Omitted tiers are deactivated, never deleted.
- Package/tier keys are server-controlled; existing keys remain immutable.
- Added server-side lifecycle, service-constraint, date, BTU, duration, quantity, and exact-money validation.
- Added safe DTOs without numeric database IDs.
- Added package creation/editing and lifecycle display to the existing Admin Store Catalog page.
- Ordinary catalog payload, pricing, images, reviews, deletion, and booking-mode behavior remain on their existing code path.
- Existing booking-selection endpoints were not modified.

Thai root cause and implementation summary:

> เธชเธฒเน€เธซเธ•เธธเน€เธ”เธดเธกเธเธทเธญเธซเธเนเธฒ `admin-store-catalog` เธเธฑเธ”เธเธฒเธฃเนเธ”เนเน€เธเธเธฒเธฐ `catalog_items` เนเธฅเธฐเธเธเธฃเธฒเธเธฒเธเธเธ•เธด เนเธ•เน Service Package เธญเธขเธนเนเธเธเธฅเธฐเนเธ”เน€เธกเธเนเธฅเธฐเนเธกเนเธกเธต Management API เธเธถเธเธ•เนเธญเธเน€เธเธดเนเธกเธเนเธญเธกเธนเธฅเธเนเธฒเธ SQL/seed เน€เธญเธ เธเธฒเธฃเนเธเนเนเธเธเธฃเธฑเนเธเธเธตเนเน€เธเธดเนเธก API เนเธฅเธฐ UI เธชเธณเธซเธฃเธฑเธเธเธฑเธ”เธเธฒเธฃ `service_packages`/`service_package_tiers` เนเธ”เธขเธ•เธฃเธ เธเธฃเนเธญเธก transaction, validation, stable key เนเธฅเธฐเธเธฒเธฃเธเธดเธ” tier เนเธ—เธเธเธฒเธฃเธฅเธ เนเธ”เธขเนเธกเนเธฃเธงเธกเธฃเธฒเธเธฒเธเธฑเธ catalog เธเธเธ•เธดเนเธฅเธฐเนเธกเนเน€เธเธฅเธตเนเธขเธ booking resolver เน€เธ”เธดเธก

## Repository state

- Issue: `#240`
- Target PR: `0` โ€” no PR created by Codex
- Branch: `cwf-worker/issue-240-20260808-014401-implementation-manage-service-packag`
- Base SHA: `2acfdae2423044a7e65769eba4623eade386cd5f`
- Current HEAD: `2acfdae2423044a7e65769eba4623eade386cd5f`
- Merge-base with `main`: `2acfdae2423044a7e65769eba4623eade386cd5f`

## Changed files

- [admin-store-catalog.html](D:/CWF/CodexWorker/workspace/cwf-services-system/admin-store-catalog.html)
- [admin-store-catalog.js](D:/CWF/CodexWorker/workspace/cwf-services-system/admin-store-catalog.js)
- [admin-store-catalog.css](D:/CWF/CodexWorker/workspace/cwf-services-system/admin-store-catalog.css)
- [index.js](D:/CWF/CodexWorker/workspace/cwf-services-system/index.js)
- [servicePackageRepository.js](D:/CWF/CodexWorker/workspace/cwf-services-system/server/services/packages/servicePackageRepository.js)
- [servicePackageCatalogService.js](D:/CWF/CodexWorker/workspace/cwf-services-system/server/services/packages/servicePackageCatalogService.js)
- [servicePackageCatalog.js](D:/CWF/CodexWorker/workspace/cwf-services-system/server/routes/admin/servicePackageCatalog.js)
- [adminServicePackageCatalog.test.js](D:/CWF/CodexWorker/workspace/cwf-services-system/test/adminServicePackageCatalog.test.js)
- [adminStoreCatalogServicePackages.test.js](D:/CWF/CodexWorker/workspace/cwf-services-system/test/adminStoreCatalogServicePackages.test.js)

DB impact: runtime CRUD only against the existing Service Package tables. No migration, seed, snapshot, or ordinary catalog pricing changes.

Cache impact: only versioned query strings for the catalog JS/CSS assets were updated. No application/server cache was introduced.

## Tests run and results

- `git diff --check` โ€” passed.
- Exact branch/base/merge-base verification โ€” passed.
- Changed/protected-path audit โ€” passed; only authorized files changed.
- Snapshot/delete source audit โ€” passed; management implementation does not touch `job_items.service_package_snapshot` or physically delete packages/tiers.

Not run:

- `node --check`
- Focused Node tests
- Existing resolver/customer/Admin booking tests
- Full catalog characterization tests
- Isolated PostgreSQL integration test

Reason: Node is unavailable on `PATH`, in standard Windows installation locations, and through WSL. No isolated PostgreSQL test environment was available.

## Remaining risks or unverified items

- JavaScript syntax and test behavior still require execution in the outer Workerโ€s Node environment.
- Transaction SQL has not been exercised against isolated PostgreSQL.
- Browser interaction/layout has not received live visual QA.
- Rollback is code-only: revert these files. Any packages created later should be deactivated rather than physically deleted.

Explicit confirmation: no Merge, no Deploy, no Production migration/data change, no seed change, no commit, and no push were performed.

### Controller checklist

- [ ] Scope matches the issue
- [ ] No protected/high-risk files changed
- [ ] Tests and build results are credible
- [ ] Production behavior and rollback are understood
- [ ] Owner approval received before merge/deploy
