### PR TITLE
Fix Production migration checkout on restricted git system config

### DIFF
--- a/.github/workflows/cwf-production-service-package-migration.yml
+++ b/.github/workflows/cwf-production-service-package-migration.yml
@@ -25,6 +25,7 @@ jobs:
       - cwf-home
     timeout-minutes: 30
     env:
+      GIT_CONFIG_NOSYSTEM: "1"
       EXPECTED_PRODUCTION_REVISION: 8093ad5db19c3da10642b248b47f74ae739272e6
       REQUIRED_CONFIRMATION: MIGRATE_SERVICE_PACKAGES_8093AD5
     steps:


### PR DESCRIPTION
Fixes #245.

Confirmed failure from migration run 31214712655 occurred before any Production DB/preflight/DDL step: `actions/checkout@v4` failed because the self-hosted runner cannot read `/etc/gitconfig`.

This follow-up changes exactly one workflow file and adds job-level `GIT_CONFIG_NOSYSTEM: "1"` so checkout ignores the unreadable system Git config. All migration safety pins, confirmation token, Production revision, exact migration path, DB checks, and manual-only trigger remain unchanged.

No Production action is performed by this PR. Owner merge gate required before dispatching the migration again.