### PR TITLE
Fix healthy Production status false-failure in migration operator

### DIFF
--- a/scripts/run-production-service-package-migration.sh
+++ b/scripts/run-production-service-package-migration.sh
@@ -27,6 +27,7 @@ validate_production_status() {
     die "Production status does not contain healthy/running evidence"
   grep -Eiq '(unhealthy|degraded|failed|stopped|exited)' <<<"$status_output" &&
     die "Production status contains unhealthy evidence"
+  return 0
 }
 
 db_query() {

--- a/test/productionServicePackageMigrationOperator.test.js
+++ b/test/productionServicePackageMigrationOperator.test.js
@@ -28,6 +28,12 @@ test("operator hard-pins the approved revision and migration with no generic inp
   assert.match(source, /cwf-deployctl production list-backups/);
 });
 
+test("healthy Production status validator returns success under set -e", () => {
+  const match = source.match(/validate_production_status\(\) \{([\s\S]*?)\n\}/);
+  assert.ok(match, "validate_production_status must exist");
+  assert.match(match[1], /return 0\s*$/m);
+});
+
 test("operator fails closed before DDL on revision, health, backup, Docker, and DB evidence", () => {
   const ddlPosition = source.indexOf("docker exec -i");
   assert.ok(ddlPosition > 0, "DDL execution must be explicit");


### PR DESCRIPTION
Fixes #247.

Confirmed run #2 reached the migration operator, verified the production branch/revision, then exited immediately after the read-only status preflight. Root cause is Bash return semantics: the final negative `grep` in `validate_production_status()` returns 1 for a healthy status, so under `set -e` the function falsely fails.

This PR adds an explicit successful return and a focused regression guard. No migration SQL, workflow trigger, confirmation token, revision pin, backup/DB/schema checks, deployment behavior, or Production data is changed. No Production action was executed by this PR.