### PR TITLE
Repair staging technician profile schema

### DIFF
--- a/scripts/bootstrap-staging-database.js
+++ b/scripts/bootstrap-staging-database.js
@@ -163,6 +163,25 @@ async function assertSchema(client) {
   if (missingColumns.length) {
     throw new Error(`users schema incomplete; missing: ${missingColumns.join(", ")}`);
   }
+
+  const technicianColumns = await client.query(
+    `SELECT column_name
+       FROM information_schema.columns
+      WHERE table_schema='public'
+        AND table_name='technician_profiles'
+        AND column_name = ANY($1::text[])`,
+    [["done_count", "position", "technician_code"]]
+  );
+  const presentTechnicianColumns = new Set(
+    technicianColumns.rows.map((row) => row.column_name)
+  );
+  const missingTechnicianColumns = ["done_count", "position", "technician_code"]
+    .filter((name) => !presentTechnicianColumns.has(name));
+  if (missingTechnicianColumns.length) {
+    throw new Error(
+      `technician_profiles schema incomplete; missing: ${missingTechnicianColumns.join(", ")}`
+    );
+  }
 }
 
 async function main() {
@@ -179,6 +198,9 @@ async function main() {
 
     await client.query("ALTER TABLE public.users ADD COLUMN IF NOT EXISTS password TEXT");
     await client.query("ALTER TABLE public.users ADD COLUMN IF NOT EXISTS position TEXT");
+    await client.query("ALTER TABLE public.technician_profiles ADD COLUMN IF NOT EXISTS technician_code TEXT");
+    await client.query("ALTER TABLE public.technician_profiles ADD COLUMN IF NOT EXISTS position TEXT");
+    await client.query("ALTER TABLE public.technician_profiles ADD COLUMN IF NOT EXISTS done_count INT DEFAULT 0");
 
     const sourceFiles = [
       path.join(REPO_ROOT, "index.js"),

--- a/test/e2e/schema-core.sql
+++ b/test/e2e/schema-core.sql
@@ -13,13 +13,16 @@ CREATE TABLE IF NOT EXISTS public.users (
 
 CREATE TABLE IF NOT EXISTS public.technician_profiles (
   username             TEXT PRIMARY KEY,
+  technician_code      TEXT,
   full_name            TEXT,
   phone                TEXT,
   photo_path           TEXT,
+  position             TEXT,
   rank_level           INT,
   rank_key             TEXT,
   rating               NUMERIC,
   grade                TEXT,
+  done_count            INT DEFAULT 0,
   employment_type      TEXT DEFAULT 'company',
   work_start           TEXT DEFAULT '09:00',
   work_end             TEXT DEFAULT '18:00',

--- a/test/stagingDatabaseBootstrap.test.js
+++ b/test/stagingDatabaseBootstrap.test.js
@@ -1,0 +1,36 @@
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const test = require("node:test");
+
+const root = path.resolve(__dirname, "..");
+
+function read(relativePath) {
+  return fs.readFileSync(path.join(root, relativePath), "utf8");
+}
+
+test("staging bootstrap supplies technician columns required by admin creation and listing", () => {
+  const coreSchema = read("test/e2e/schema-core.sql");
+  const bootstrap = read("scripts/bootstrap-staging-database.js");
+
+  for (const column of ["technician_code", "position", "done_count"]) {
+    assert.match(
+      coreSchema,
+      new RegExp(`\\b${column}\\s+`),
+      `fresh staging schema must declare ${column}`
+    );
+    assert.match(
+      bootstrap,
+      new RegExp(
+        `ALTER TABLE public\\.technician_profiles ADD COLUMN IF NOT EXISTS ${column}\\b`
+      ),
+      `existing staging databases must be repaired with ${column}`
+    );
+  }
+
+  assert.match(
+    bootstrap,
+    /technician_profiles schema incomplete; missing:/,
+    "bootstrap must fail closed if the required technician columns are absent"
+  );
+});


### PR DESCRIPTION
## What changed

- add the foundational technician profile columns to the fresh Staging core schema
- repair existing disposable Staging databases with idempotent `ALTER TABLE ... ADD COLUMN IF NOT EXISTS`
- fail the Staging schema bootstrap when the technician columns required by Admin creation/listing are absent
- add a focused regression guard for fresh and existing Staging databases

## Root cause

The disposable Staging bootstrap created `public.technician_profiles` without `technician_code`, `position`, or `done_count`. The Admin technician list failed first on `p.technician_code`, and technician creation also depends on all three columns. With no eligible technician, the public booking calendar had no open slots.

## Impact

This is scoped to Staging bootstrap/recovery. It does not touch Production data or deployment.

## Validation

- Node syntax checks: passed
- `test/stagingDatabaseBootstrap.test.js`: 1 passed
- related package/booking suite: 17 passed, 0 failed, 46 skipped because the local PostgreSQL integration credential is unavailable
- `git diff --check`: passed
