### PR TITLE
Promote Issue #267 Store service-package bundles to CWF home staging

### DIFF
--- a/admin-add-v2.html
+++ b/admin-add-v2.html
@@ -608,7 +608,7 @@
   </div>
 
   <script src="admin-v2-common.js?v=20260428_allpages_ui1"></script>
-  <script src="admin-add-v2.js?v=20260809_issue267_catalog_flow_v2"></script>
+  <script src="admin-add-v2.js?v=20260809_issue267_catalog_flow_v8"></script>
   <script src="admin-add-ai-intake-prefill.js?v=line-ai-prefill-real-v8"></script>
 </body>
 </html>

--- a/admin-add-v2.html
+++ b/admin-add-v2.html
@@ -296,9 +296,12 @@
 <!-- MULTI-SERVICE (หลายรายการในใบงานเดียว) -->
 <div id="service_package_box" class="card card-lite" style="margin-top:12px">
   <b>Service Package (optional)</b>
-  <div class="muted2 mini">Package totals, quantity, duration, and service rules come from the server. Packages cannot be mixed with ordinary lines, extras, overrides, or promotions.</div>
+  <div class="muted2 mini">Choose a Store package parent for mixed BTU/arbitrary quantities, or a legacy standalone package. Totals and rules come from the server.</div>
+  <div style="margin-top:10px"><label>Ordinary Store service (optional)</label><select id="store_bookable_item_id"><option value="">Use manual service fields</option></select></div>
+  <div style="margin-top:10px"><label>Store service-package item</label><select id="store_service_bundle_key"><option value="">No Store package</option></select></div>
+  <div id="store_service_bundle_groups" style="display:none;margin-top:10px"></div>
   <div class="grid2" style="margin-top:10px">
-    <div><label>Package</label><select id="service_package_key"><option value="">No package</option></select></div>
+    <div><label>Legacy standalone package</label><select id="service_package_key"><option value="">No legacy package</option></select></div>
     <div><label>Tier</label><select id="service_package_tier_key" disabled><option value="">Select tier</option></select></div>
   </div>
   <div id="service_package_btu_wrap" style="display:none;margin-top:10px">

--- a/admin-add-v2.html
+++ b/admin-add-v2.html
@@ -608,7 +608,7 @@
   </div>
 
   <script src="admin-v2-common.js?v=20260428_allpages_ui1"></script>
-  <script src="admin-add-v2.js?v=20260807_admin_service_packages_v1"></script>
+  <script src="admin-add-v2.js?v=20260809_issue267_catalog_flow_v2"></script>
   <script src="admin-add-ai-intake-prefill.js?v=line-ai-prefill-real-v8"></script>
 </body>
 </html>

--- a/admin-add-v2.js
+++ b/admin-add-v2.js
@@ -27,6 +27,12 @@ let state = {
   service_package_preview: null,
   service_package_preview_selection: null,
   service_package_preview_request_id: 0,
+  service_bundles: [],
+  service_bundle_quote: null,
+  service_bundle_quote_fingerprint: "",
+  selected_store_catalog_item_id: null,
+  admin_request_key: "",
+  admin_request_fingerprint: "",
   service_lines: [], // [{job_type, ac_type, btu, machine_count, wash_variant}]
   selected_slot_iso: "",
   selected_slot_key: "",
@@ -1360,19 +1366,70 @@ return true;
 
 let previewTimer = null;
 
-function packageSelected() { return !!String(el("service_package_key")?.value || "").trim(); }
+function bundleSelected() { return !!String(el("store_service_bundle_key")?.value || "").trim(); }
+function packageSelected() { return bundleSelected() || !!String(el("service_package_key")?.value || "").trim(); }
 
 function packagePreviewIsFresh() {
+  if (bundleSelected()) return !!state.service_bundle_quote && state.service_bundle_quote_fingerprint === bundleFingerprint();
   const selection = state.service_package_preview_selection;
   return !!state.service_package_preview && !!selection
     && selection.package_key === String(el("service_package_key")?.value || "")
     && selection.tier_key === String(el("service_package_tier_key")?.value || "");
 }
 
+function bundleFingerprint() {
+  const key = String(el("store_service_bundle_key")?.value || "");
+  const groups = [...document.querySelectorAll("[data-admin-bundle-group]")].map((row) => ({
+    package_key: row.getAttribute("data-admin-bundle-group"),
+    btu: Number(row.querySelector("[data-admin-bundle-btu]")?.value || 0),
+    quantity: Number(row.querySelector("[data-admin-bundle-quantity]")?.value || 0),
+  })).filter((group) => group.quantity > 0);
+  return JSON.stringify({ key, groups, mode: String(el("booking_mode")?.value || "scheduled") });
+}
+
+function selectedBundleGroups() {
+  try { return JSON.parse(bundleFingerprint()).groups; } catch (_) { return []; }
+}
+
+function renderServiceBundleGroups() {
+  const wrap = el("store_service_bundle_groups");
+  const bundle = state.service_bundles.find((item) => item.service_bundle_key === String(el("store_service_bundle_key")?.value || ""));
+  if (!wrap) return;
+  if (!bundle) { wrap.style.display = "none"; wrap.innerHTML = ""; return; }
+  wrap.style.display = "";
+  wrap.innerHTML = (bundle.variants || []).filter((variant) => variant.is_active !== false).map((variant) => `
+    <div class="grid3" data-admin-bundle-group="${escapeHtml(variant.package_key)}" style="margin-top:8px">
+      <div><label>${escapeHtml(variant.display_name)}</label><div class="muted2 mini">BTU ${variant.btu_min ?? "any"}-${variant.btu_max ?? "any"}</div></div>
+      <div><label>Actual BTU</label><input type="number" min="1" step="1" data-admin-bundle-btu value="${escapeHtml(variant.btu_min || variant.btu_max || "")}"></div>
+      <div><label>Quantity</label><input type="number" min="0" step="1" value="0" data-admin-bundle-quantity></div>
+    </div>`).join("") + '<div id="store_service_bundle_quote" class="muted2" style="margin-top:8px"></div>';
+  wrap.querySelectorAll("input").forEach((input) => input.addEventListener("change", () => previewServiceBundle().catch((e) => showToast(e.message, "error"))));
+}
+
+async function previewServiceBundle() {
+  state.service_bundle_quote = null;
+  state.service_bundle_quote_fingerprint = "";
+  const groups = selectedBundleGroups();
+  const panel = el("store_service_bundle_quote");
+  if (!bundleSelected() || !groups.length) { if (panel) panel.textContent = "Select at least one quantity"; return; }
+  const appointment = localDatetimeToBangkokISO(String(el("appointment_datetime")?.value || "").trim()) || new Date(Date.now() + 86400000).toISOString();
+  const quote = await apiFetch("/admin/catalog/service-package-bundles/quote", { method: "POST", body: JSON.stringify({
+    service_package_groups: groups, booking_mode: String(el("booking_mode")?.value || "scheduled"), appointment_datetime: appointment,
+  }) });
+  state.service_bundle_quote = quote;
+  state.service_bundle_quote_fingerprint = bundleFingerprint();
+  state.standard_price = Number(quote.fixed_total_price); state.normal_price = state.standard_price;
+  state.duration_min = Number(quote.duration_minutes); state.effective_block_min = state.duration_min + Number(state.travel_buffer_min || 30);
+  if (panel) panel.textContent = `${quote.machine_count} units | ${quote.fixed_total_price} | ${quote.duration_minutes} min | ${(quote.components || []).map((x) => `${x.tier_name} x ${x.quantity}`).join(", ")}`;
+  updateTotalPreview();
+}
+
 function invalidateServicePackagePreview({ loading = false } = {}) {
   state.service_package_preview_request_id += 1;
   state.service_package_preview = null;
   state.service_package_preview_selection = null;
+  state.service_bundle_quote = null;
+  state.service_bundle_quote_fingerprint = "";
   state.standard_price = 0;
   state.normal_price = 0;
   state.duration_min = 0;
@@ -1457,6 +1514,14 @@ async function loadServicePackages() {
       const option = document.createElement("option"); option.value = pkg.package_key; option.textContent = pkg.package_name; select.appendChild(option);
     }
   } catch (_) { /* ordinary Admin booking remains available */ }
+  try {
+    const data = await apiFetch("/admin/catalog/service-package-bundles");
+    state.service_bundles = Array.isArray(data.bundles) ? data.bundles : [];
+    const select = el("store_service_bundle_key");
+    for (const bundle of state.service_bundles.filter((item) => item.is_active !== false)) {
+      const option = document.createElement("option"); option.value = bundle.service_bundle_key; option.textContent = bundle.item_name; select.appendChild(option);
+    }
+  } catch (_) { /* legacy Admin booking remains available */ }
 }
 
 async function refreshPreviewDebounced() {
@@ -1573,6 +1638,12 @@ async function loadCatalog() {
   try {
     const items = await apiFetch("/catalog/items");
     state.catalog = Array.isArray(items) ? items : [];
+    const storeSelect = el("store_bookable_item_id");
+    if (storeSelect) {
+      for (const it of state.catalog.filter((item) => item?.booking_mode === "bookable" && item?.is_active !== false)) {
+        const option = document.createElement("option"); option.value = String(it.item_id); option.textContent = it.item_name; storeSelect.appendChild(option);
+      }
+    }
     const sel = el("extras_select");
     if(!sel) return;
     sel.innerHTML = "";
@@ -2876,6 +2947,14 @@ async function submitBooking() {
   }
   syncModesFromUI();
   const uiMode = (el('dispatch_mode_ui')?.value || 'normal').toString();
+  const selectedStorePromotion = bundleSelected()
+    ? state.service_bundles.find((item) => item.service_bundle_key === String(el("store_service_bundle_key")?.value || ""))
+    : state.catalog.find((item) => Number(item.item_id) === Number(state.selected_store_catalog_item_id));
+  if (uiMode === "urgent" && selectedStorePromotion
+      && String(selectedStorePromotion.booking_flow_policy || "scheduled_only") !== "scheduled_and_urgent") {
+    showToast("รายการร้านค้านี้อนุญาตเฉพาะการจองล่วงหน้า", "error");
+    return;
+  }
   const techSource = syncManualTechnicianSelection({ forSubmit: true });
   const expectedSingleTechnician = (uiMode !== 'urgent' && techSource.assign_mode === 'single')
     ? String(techSource.technician_username || '').trim()
@@ -2944,6 +3023,7 @@ async function submitBooking() {
       return mode === 'team' ? getTeamMembersForPayload() : [];
     })(),
     allow_time_proposal: uiMode === 'urgent' ? !!el('allow_time_proposal')?.checked : false,
+    catalog_item_id: state.selected_store_catalog_item_id,
     // wash split assignment (optional, lock mode only)
     split_assignments: (()=>{
       try {
@@ -2960,6 +3040,20 @@ async function submitBooking() {
   const services = getServicesPayload();
   if(services) payload.services = services;
   if (packageSelected()) {
+    if (bundleSelected()) {
+      if (!packagePreviewIsFresh()) {
+        showToast("Select Store package quantities and wait for the server quote", "error");
+        el("btnSubmit").disabled = false; return;
+      }
+      payload.service_package_groups = selectedBundleGroups();
+      delete payload.service_package_key;
+      delete payload.service_package_tier_key;
+      delete payload.services;
+      payload.items = [];
+      payload.promotion_id = null;
+      payload.override_price = 0;
+      payload.override_duration_min = 0;
+    } else {
     const preview = state.service_package_preview;
     const actualBtu = Number(el("service_package_btu")?.value || 0);
     if (!packagePreviewIsFresh() || !actualBtu) {
@@ -2978,8 +3072,15 @@ async function submitBooking() {
     payload.promotion_id = null;
     payload.override_price = 0;
     payload.override_duration_min = 0;
+    }
   }
   // NOTE: split_assignments is optional and backward compatible
+  const adminPayloadFingerprint = JSON.stringify(payload);
+  if (!state.admin_request_key || state.admin_request_fingerprint !== adminPayloadFingerprint) {
+    state.admin_request_key = (globalThis.crypto?.randomUUID?.() || `admin_${Date.now()}_${Math.random().toString(36).slice(2)}`).replace(/-/g, "_");
+    state.admin_request_fingerprint = adminPayloadFingerprint;
+  }
+  payload.admin_request_key = state.admin_request_key;
 
   console.info('[admin-add] submit technician source', {
     assign_mode: payload.assign_mode,
@@ -3112,11 +3213,39 @@ async function submitBooking() {
 }
 
 function wireEvents() {
+  el("store_bookable_item_id")?.addEventListener("change", () => {
+    const id = Number(el("store_bookable_item_id").value || 0);
+    const item = state.catalog.find((entry) => Number(entry.item_id) === id);
+    state.selected_store_catalog_item_id = item ? id : null;
+    if (!item) return;
+    el("job_type").value = item.booking_job_type || "";
+    el("ac_type").value = item.booking_ac_type || "";
+    buildVariantUI();
+    el("btu").value = String(item.booking_btu || "");
+    const wash = el("wash_variant"); if (wash) wash.value = item.booking_wash_variant || "";
+    refreshPreviewDebounced();
+  });
+  el("store_service_bundle_key")?.addEventListener("change", () => {
+    const selected = bundleSelected();
+    if (selected) {
+      state.selected_store_catalog_item_id = null;
+      if (el("store_bookable_item_id")) el("store_bookable_item_id").value = "";
+      el("service_package_key").value = "";
+      el("service_package_tier_key").innerHTML = '<option value="">Select tier</option>';
+      el("service_package_tier_key").disabled = true;
+    }
+    state.admin_request_key = "";
+    state.admin_request_fingerprint = "";
+    invalidateServicePackagePreview();
+    renderServiceBundleGroups();
+    setPackageControlsLocked(selected);
+  });
   el("service_package_key")?.addEventListener("change", async () => {
     const key = String(el("service_package_key").value || "");
     const tier = el("service_package_tier_key");
     tier.innerHTML = '<option value="">Select tier</option>';
     const pkg = state.service_packages.find((item) => item.package_key === key);
+    if (pkg) { el("store_service_bundle_key").value = ""; renderServiceBundleGroups(); }
     for (const item of (pkg?.tiers || [])) {
       const option = document.createElement("option"); option.value = item.tier_key;
       option.textContent = `${item.tier_name} (${item.quantity} / ${item.fixed_total_price})`; tier.appendChild(option);

--- a/admin-add-v2.js
+++ b/admin-add-v2.js
@@ -13,6 +13,7 @@ let state = {
   standard_price: 0,
   normal_price: 0,
   active_price: 0,
+  exact_total: "",
   customer_price_label: "",
   campaign_name: "",
   customer_price_source: "",
@@ -1431,6 +1432,7 @@ function renderServiceBundleGroups() {
 async function previewServiceBundle() {
   state.service_bundle_quote = null;
   state.service_bundle_quote_fingerprint = "";
+  state.exact_total = "";
   const groups = selectedBundleGroups();
   const panel = el("store_service_bundle_quote");
   if (!bundleSelected() || !groups.length) { if (panel) panel.textContent = "Select at least one quantity"; return; }
@@ -1441,7 +1443,8 @@ async function previewServiceBundle() {
   }) });
   state.service_bundle_quote = quote;
   state.service_bundle_quote_fingerprint = bundleFingerprint();
-  state.standard_price = Number(quote.fixed_total_price); state.normal_price = state.standard_price;
+  state.exact_total = String(quote.fixed_total_price || "");
+  state.standard_price = Number(state.exact_total); state.normal_price = state.standard_price;
   state.duration_min = Number(quote.duration_minutes); state.effective_block_min = state.duration_min + Number(state.travel_buffer_min || 30);
   if (panel) panel.textContent = `${quote.machine_count} units | ${quote.fixed_total_price} | ${quote.duration_minutes} min | ${(quote.components || []).map((x) => `${x.tier_name} x ${x.quantity}`).join(", ")}`;
   updateTotalPreview();
@@ -1453,6 +1456,7 @@ function invalidateServicePackagePreview({ loading = false } = {}) {
   state.service_package_preview_selection = null;
   state.service_bundle_quote = null;
   state.service_bundle_quote_fingerprint = "";
+  state.exact_total = "";
   state.standard_price = 0;
   state.normal_price = 0;
   state.duration_min = 0;
@@ -1521,7 +1525,8 @@ async function previewServicePackage() {
   el("service_package_btu_wrap").style.display = "";
   const panel = el("service_package_preview"); panel.style.display = "";
   panel.textContent = `${preview.package_name} / ${preview.tier_name} | ${preview.service.service_name} | quantity ${preview.quantity} | duration ${preview.duration_minutes} min | fixed total ${preview.fixed_total_price} | BTU ${c.btu_min || "any"}-${c.btu_max || "any"} | redeem by ${preview.redeem_until || "no limit"}`;
-  state.standard_price = Number(preview.fixed_total_price); state.normal_price = state.standard_price;
+  state.exact_total = String(preview.fixed_total_price || "");
+  state.standard_price = Number(state.exact_total); state.normal_price = state.standard_price;
   state.duration_min = Number(preview.duration_minutes); state.effective_block_min = state.duration_min + Number(state.travel_buffer_min || 30);
   setPackageControlsLocked(true);
   el("btnSubmit").disabled = false;
@@ -1557,9 +1562,9 @@ async function refreshPreview() {
     if (packagePreviewIsFresh()) {
       el("pv_duration").textContent = String(state.duration_min);
       el("pv_block").textContent = String(state.effective_block_min);
-      el("pv_price").textContent = fmtMoney(state.standard_price);
-      el("pv_normal_price").textContent = fmtMoney(state.standard_price);
-      el("pv_line_total").textContent = fmtMoney(state.standard_price);
+      el("pv_price").textContent = state.exact_total || fmtMoney(state.standard_price);
+      el("pv_normal_price").textContent = state.exact_total || fmtMoney(state.standard_price);
+      el("pv_line_total").textContent = state.exact_total || fmtMoney(state.standard_price);
       if (el("appt_date").value) loadAvailability();
     }
     return;
@@ -1586,7 +1591,8 @@ async function refreshPreview() {
         machine_count: payload.machine_count,
       }) });
       state.normal_price = Number(quote.normal_unit_price || quote.unit_price || 0) * Number(quote.machine_count || 1);
-      state.active_price = Number(quote.exact_total || 0);
+      state.exact_total = String(quote.exact_total || "");
+      state.active_price = Number(state.exact_total || 0);
       state.standard_price = state.active_price;
       state.customer_price_label = quote.price_label || "";
       state.campaign_name = quote.campaign_name || "";
@@ -1596,13 +1602,13 @@ async function refreshPreview() {
       state.travel_buffer_min = Number(quote.travel_buffer_min || 30);
       el("pv_duration").textContent = String(state.duration_min);
       el("pv_block").textContent = String(state.effective_block_min);
-      el("pv_price").textContent = fmtMoney(state.standard_price);
+      el("pv_price").textContent = state.exact_total || fmtMoney(state.standard_price);
       if (el("pv_normal_price")) el("pv_normal_price").textContent = fmtMoney(state.normal_price);
       if (el("pv_price_source")) {
         const campaign = state.campaign_name || state.customer_price_label || "-";
         el("pv_price_source").textContent = `แคมเปญที่ใช้: ${campaign} • แหล่งราคา: Store catalog`;
       }
-      if (el("pv_line_total")) el("pv_line_total").textContent = fmtMoney(state.standard_price);
+      if (el("pv_line_total")) el("pv_line_total").textContent = state.exact_total || fmtMoney(state.standard_price);
       updateTotalPreview();
       if (el("appt_date").value) loadAvailability();
     } catch (e) {
@@ -1616,6 +1622,7 @@ async function refreshPreview() {
     }
     return;
   }
+  state.exact_total = "";
   if (!validateRequiredForPreview()) {
     el("pv_duration").textContent = "-";
     el("pv_block").textContent = "-";
@@ -1662,6 +1669,7 @@ async function refreshPreview() {
       loadAvailability();
     }
   } catch (e) {
+    state.exact_total = "";
     el("pv_duration").textContent = "-";
     el("pv_block").textContent = "-";
     el("pv_price").textContent = "-";
@@ -1692,6 +1700,12 @@ function updateTotalPreview() {
     if (discount > subtotal) discount = subtotal;
   }
   const total = Math.max(0, subtotal - discount);
+  if (state.selected_store_catalog_item_id && state.exact_total) {
+    const pd = el("pv_discount"); if (pd) pd.textContent = "0.00";
+    const ps = el("pv_subtotal"); if (ps) ps.textContent = state.exact_total;
+    const tp = el("total_preview"); if (tp) tp.value = state.exact_total;
+    return;
+  }
   // pv_total removed (use total_preview)
 
   const srcBox = el("pv_price_source");

--- a/admin-add-v2.js
+++ b/admin-add-v2.js
@@ -1369,6 +1369,28 @@ let previewTimer = null;
 function bundleSelected() { return !!String(el("store_service_bundle_key")?.value || "").trim(); }
 function packageSelected() { return bundleSelected() || !!String(el("service_package_key")?.value || "").trim(); }
 
+function selectedStorePromotion() {
+  if (bundleSelected()) {
+    return state.service_bundles.find((item) => item.service_bundle_key === String(el("store_service_bundle_key")?.value || "")) || null;
+  }
+  return state.catalog.find((item) => Number(item.item_id) === Number(state.selected_store_catalog_item_id)) || null;
+}
+
+function applySelectedStoreFlowPolicy() {
+  const select = el("dispatch_mode_ui");
+  const urgent = select?.querySelector?.('option[value="urgent"]');
+  if (!select || !urgent) return;
+  const promotion = selectedStorePromotion();
+  const legacyPackage = !promotion && !!String(el("service_package_key")?.value || "").trim();
+  const blocked = legacyPackage || (promotion
+    && String(promotion.booking_flow_policy || "scheduled_only") !== "scheduled_and_urgent");
+  urgent.disabled = !!blocked;
+  if (blocked && select.value === "urgent") {
+    select.value = "assign";
+    syncModesFromUI();
+  }
+}
+
 function packagePreviewIsFresh() {
   if (bundleSelected()) return !!state.service_bundle_quote && state.service_bundle_quote_fingerprint === bundleFingerprint();
   const selection = state.service_package_preview_selection;
@@ -1456,8 +1478,8 @@ function invalidateServicePackagePreview({ loading = false } = {}) {
   if (submit) submit.disabled = packageSelected();
 }
 
-function setPackageControlsLocked(locked) {
-  ["job_type", "ac_type", "btu", "machine_count", "override_price", "override_duration_min",
+function setPackageControlsLocked(locked, { allowQuantity = false } = {}) {
+  ["job_type", "ac_type", "btu", ...(allowQuantity ? [] : ["machine_count"]), "override_price", "override_duration_min",
     "extras_select", "extras_qty", "btnAddExtra", "promotion_id"].forEach((id) => {
     const node = el(id); if (node) node.disabled = !!locked;
   });
@@ -1538,6 +1560,58 @@ async function refreshPreview() {
       el("pv_normal_price").textContent = fmtMoney(state.standard_price);
       el("pv_line_total").textContent = fmtMoney(state.standard_price);
       if (el("appt_date").value) loadAvailability();
+    }
+    return;
+  }
+  if (state.selected_store_catalog_item_id) {
+    if (!validateRequiredForPreview()) {
+      el("pv_duration").textContent = "-";
+      el("pv_block").textContent = "-";
+      el("pv_price").textContent = "-";
+      if (el("pv_normal_price")) el("pv_normal_price").textContent = "-";
+      if (el("pv_price_source")) el("pv_price_source").textContent = "-";
+      if (el("pv_line_total")) el("pv_line_total").textContent = "-";
+      return;
+    }
+    try {
+      const payload = getPayloadV2();
+      const quote = await apiFetch("/admin/catalog-booking-preview", { method: "POST", body: JSON.stringify({
+        catalog_item_id: state.selected_store_catalog_item_id,
+        booking_mode: String(el("booking_mode")?.value || "scheduled"),
+        job_type: payload.job_type,
+        ac_type: payload.ac_type,
+        btu: payload.btu,
+        wash_variant: payload.wash_variant,
+        machine_count: payload.machine_count,
+      }) });
+      state.normal_price = Number(quote.normal_unit_price || quote.unit_price || 0) * Number(quote.machine_count || 1);
+      state.active_price = Number(quote.exact_total || 0);
+      state.standard_price = state.active_price;
+      state.customer_price_label = quote.price_label || "";
+      state.campaign_name = quote.campaign_name || "";
+      state.customer_price_source = quote.price_source || "";
+      state.duration_min = Number(quote.duration_min || 0);
+      state.effective_block_min = Number(quote.effective_block_min || 0);
+      state.travel_buffer_min = Number(quote.travel_buffer_min || 30);
+      el("pv_duration").textContent = String(state.duration_min);
+      el("pv_block").textContent = String(state.effective_block_min);
+      el("pv_price").textContent = fmtMoney(state.standard_price);
+      if (el("pv_normal_price")) el("pv_normal_price").textContent = fmtMoney(state.normal_price);
+      if (el("pv_price_source")) {
+        const campaign = state.campaign_name || state.customer_price_label || "-";
+        el("pv_price_source").textContent = `แคมเปญที่ใช้: ${campaign} • แหล่งราคา: Store catalog`;
+      }
+      if (el("pv_line_total")) el("pv_line_total").textContent = fmtMoney(state.standard_price);
+      updateTotalPreview();
+      if (el("appt_date").value) loadAvailability();
+    } catch (e) {
+      el("pv_duration").textContent = "-";
+      el("pv_block").textContent = "-";
+      el("pv_price").textContent = "-";
+      if (el("pv_normal_price")) el("pv_normal_price").textContent = "-";
+      if (el("pv_price_source")) el("pv_price_source").textContent = "-";
+      if (el("pv_line_total")) el("pv_line_total").textContent = "-";
+      showToast(e.message || "คำนวณรายการร้านค้าไม่สำเร็จ", "error");
     }
     return;
   }
@@ -3074,6 +3148,13 @@ async function submitBooking() {
     payload.override_duration_min = 0;
     }
   }
+  if (state.selected_store_catalog_item_id) {
+    delete payload.services;
+    payload.items = [];
+    payload.promotion_id = null;
+    payload.override_price = 0;
+    payload.override_duration_min = 0;
+  }
   // NOTE: split_assignments is optional and backward compatible
   const adminPayloadFingerprint = JSON.stringify(payload);
   if (!state.admin_request_key || state.admin_request_fingerprint !== adminPayloadFingerprint) {
@@ -3217,12 +3298,33 @@ function wireEvents() {
     const id = Number(el("store_bookable_item_id").value || 0);
     const item = state.catalog.find((entry) => Number(entry.item_id) === id);
     state.selected_store_catalog_item_id = item ? id : null;
-    if (!item) return;
+    state.admin_request_key = "";
+    state.admin_request_fingerprint = "";
+    if (!item) {
+      setPackageControlsLocked(packageSelected());
+      applySelectedStoreFlowPolicy();
+      return;
+    }
+    el("store_service_bundle_key").value = "";
+    el("service_package_key").value = "";
+    el("service_package_tier_key").innerHTML = '<option value="">Select tier</option>';
+    el("service_package_tier_key").disabled = true;
+    renderServiceBundleGroups();
+    invalidateServicePackagePreview();
+    state.service_lines = [];
+    state.selected_items = [];
+    renderServiceLines();
+    renderExtras();
+    el("promotion_id").value = "";
+    el("override_price").value = "0";
+    el("override_duration_min").value = "0";
     el("job_type").value = item.booking_job_type || "";
     el("ac_type").value = item.booking_ac_type || "";
     buildVariantUI();
     el("btu").value = String(item.booking_btu || "");
     const wash = el("wash_variant"); if (wash) wash.value = item.booking_wash_variant || "";
+    setPackageControlsLocked(true, { allowQuantity: true });
+    applySelectedStoreFlowPolicy();
     refreshPreviewDebounced();
   });
   el("store_service_bundle_key")?.addEventListener("change", () => {
@@ -3239,13 +3341,19 @@ function wireEvents() {
     invalidateServicePackagePreview();
     renderServiceBundleGroups();
     setPackageControlsLocked(selected);
+    applySelectedStoreFlowPolicy();
   });
   el("service_package_key")?.addEventListener("change", async () => {
     const key = String(el("service_package_key").value || "");
     const tier = el("service_package_tier_key");
     tier.innerHTML = '<option value="">Select tier</option>';
     const pkg = state.service_packages.find((item) => item.package_key === key);
-    if (pkg) { el("store_service_bundle_key").value = ""; renderServiceBundleGroups(); }
+    if (pkg) {
+      state.selected_store_catalog_item_id = null;
+      if (el("store_bookable_item_id")) el("store_bookable_item_id").value = "";
+      el("store_service_bundle_key").value = "";
+      renderServiceBundleGroups();
+    }
     for (const item of (pkg?.tiers || [])) {
       const option = document.createElement("option"); option.value = item.tier_key;
       option.textContent = `${item.tier_name} (${item.quantity} / ${item.fixed_total_price})`; tier.appendChild(option);
@@ -3253,6 +3361,7 @@ function wireEvents() {
     tier.disabled = !pkg;
     invalidateServicePackagePreview();
     setPackageControlsLocked(!!pkg);
+    applySelectedStoreFlowPolicy();
     if (!pkg) refreshPreviewDebounced();
   });
   el("service_package_tier_key")?.addEventListener("change", () => previewServicePackage().then(refreshPreview).catch((e) => {

--- a/admin-add-v2.js
+++ b/admin-add-v2.js
@@ -1436,6 +1436,7 @@ async function previewServiceBundle() {
   if (!bundleSelected() || !groups.length) { if (panel) panel.textContent = "Select at least one quantity"; return; }
   const appointment = localDatetimeToBangkokISO(String(el("appointment_datetime")?.value || "").trim()) || new Date(Date.now() + 86400000).toISOString();
   const quote = await apiFetch("/admin/catalog/service-package-bundles/quote", { method: "POST", body: JSON.stringify({
+    catalog_item_id: state.selected_store_catalog_item_id,
     service_package_groups: groups, booking_mode: String(el("booking_mode")?.value || "scheduled"), appointment_datetime: appointment,
   }) });
   state.service_bundle_quote = quote;
@@ -3318,7 +3319,7 @@ function wireEvents() {
     el("promotion_id").value = "";
     el("override_price").value = "0";
     el("override_duration_min").value = "0";
-    el("job_type").value = item.booking_job_type || "";
+    el("job_type").value = item.job_category || "";
     el("ac_type").value = item.booking_ac_type || "";
     buildVariantUI();
     el("btu").value = String(item.booking_btu || "");
@@ -3330,7 +3331,8 @@ function wireEvents() {
   el("store_service_bundle_key")?.addEventListener("change", () => {
     const selected = bundleSelected();
     if (selected) {
-      state.selected_store_catalog_item_id = null;
+      const bundle = state.service_bundles.find((item) => item.service_bundle_key === selected);
+      state.selected_store_catalog_item_id = bundle ? Number(bundle.item_id) : null;
       if (el("store_bookable_item_id")) el("store_bookable_item_id").value = "";
       el("service_package_key").value = "";
       el("service_package_tier_key").innerHTML = '<option value="">Select tier</option>';

--- a/admin-store-catalog.css
+++ b/admin-store-catalog.css
@@ -276,3 +276,27 @@
   .asc-item-thumb{ width:72px; height:72px; min-width:72px; }
 }
 .asc-mobile-preview { width: min(100%, 390px); margin-inline: auto; }
+.asc-campaign-preview { border:1px solid var(--line,#d8e1e8); border-radius:16px; overflow:hidden; background:#fff; }
+.asc-campaign-preview-card { display:grid; gap:0; }
+.asc-campaign-preview-media { min-height:112px; display:grid; place-items:center; background:#eef3f5; color:#66737b; }
+.asc-campaign-preview-copy { display:grid; gap:8px; padding:12px; }
+.asc-campaign-preview-copy .primary { min-height:44px; }
+.asc-campaign-badge { width:max-content; max-width:100%; padding:4px 10px; border-radius:999px; background:#0d6b58; color:#fff; font-size:.78rem; font-weight:800; }
+.asc-campaign-support { color:#445066; font-size:.82rem; overflow-wrap:anywhere; }
+.asc-campaign-countdown { color:#8b3d13; font-size:.8rem; font-weight:750; }
+.asc-campaign-theme-premium { border-color:#b78a31; }
+.asc-campaign-theme-limited_time { border-color:#bd4b35; }
+.asc-campaign-theme-new { border-color:#247b68; }
+.asc-campaign-effect-soft_glow { animation:asc-campaign-glow 2.8s ease-in-out infinite; }
+.asc-campaign-effect-shimmer_border { background-image:linear-gradient(110deg,transparent 20%,rgba(255,255,255,.6) 45%,transparent 70%); background-size:250% 100%; animation:asc-campaign-shimmer 4s linear infinite; }
+.asc-campaign-effect-badge_pulse .asc-campaign-badge { animation:asc-campaign-pulse 2.4s ease-in-out infinite; }
+@keyframes asc-campaign-glow { 50% { box-shadow:0 0 0 3px rgba(183,138,49,.2); } }
+@keyframes asc-campaign-shimmer { to { background-position:-250% 0; } }
+@keyframes asc-campaign-pulse { 50% { opacity:.78; } }
+@media (prefers-reduced-motion: reduce) {
+  .asc-campaign-effect-soft_glow,
+  .asc-campaign-effect-shimmer_border,
+  .asc-campaign-effect-badge_pulse .asc-campaign-badge { animation:none !important; }
+}
+@media (max-width:390px) { .asc-campaign-preview-copy { padding:10px; } }
+@media (max-width:360px) { .asc-campaign-preview-copy { padding:8px; } }

--- a/admin-store-catalog.css
+++ b/admin-store-catalog.css
@@ -275,3 +275,4 @@
 @media (max-width: 360px) {
   .asc-item-thumb{ width:72px; height:72px; min-width:72px; }
 }
+.asc-mobile-preview { width: min(100%, 390px); margin-inline: auto; }

--- a/admin-store-catalog.html
+++ b/admin-store-catalog.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
   <title>Admin • รายการบริการในร้านค้า</title>
   <link rel="stylesheet" href="/style.css"/>
-  <link rel="stylesheet" href="/admin-store-catalog.css?v=20260809_issue267_admin_builder_v2"/>
+  <link rel="stylesheet" href="/admin-store-catalog.css?v=20260809_issue267_merchandising_v3"/>
 </head>
 <body>
   <div class="topbar">
@@ -84,6 +84,6 @@
   </div>
 
   <script src="/admin-v2-common.js?v=20260622_admin_menu_catalog_entry"></script>
-  <script src="/admin-store-catalog.js?v=20260809_issue267_admin_builder_v2"></script>
+  <script src="/admin-store-catalog.js?v=20260809_issue267_merchandising_v3"></script>
 </body>
 </html>

--- a/admin-store-catalog.html
+++ b/admin-store-catalog.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
   <title>Admin • รายการบริการในร้านค้า</title>
   <link rel="stylesheet" href="/style.css"/>
-  <link rel="stylesheet" href="/admin-store-catalog.css?v=20260809_store_service_package_bundles_v1"/>
+  <link rel="stylesheet" href="/admin-store-catalog.css?v=20260809_issue267_admin_builder_v2"/>
 </head>
 <body>
   <div class="topbar">
@@ -84,6 +84,6 @@
   </div>
 
   <script src="/admin-v2-common.js?v=20260622_admin_menu_catalog_entry"></script>
-  <script src="/admin-store-catalog.js?v=20260809_store_service_package_bundles_v1"></script>
+  <script src="/admin-store-catalog.js?v=20260809_issue267_admin_builder_v2"></script>
 </body>
 </html>

--- a/admin-store-catalog.html
+++ b/admin-store-catalog.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
   <title>Admin • รายการบริการในร้านค้า</title>
   <link rel="stylesheet" href="/style.css"/>
-  <link rel="stylesheet" href="/admin-store-catalog.css?v=20260808_service_packages_responsive_v2"/>
+  <link rel="stylesheet" href="/admin-store-catalog.css?v=20260809_store_service_package_bundles_v1"/>
 </head>
 <body>
   <div class="topbar">
@@ -84,6 +84,6 @@
   </div>
 
   <script src="/admin-v2-common.js?v=20260622_admin_menu_catalog_entry"></script>
-  <script src="/admin-store-catalog.js?v=20260808_service_packages_th_v1"></script>
+  <script src="/admin-store-catalog.js?v=20260809_store_service_package_bundles_v1"></script>
 </body>
 </html>

--- a/admin-store-catalog.js
+++ b/admin-store-catalog.js
@@ -237,6 +237,11 @@ function ensureCatalogModal() {
           <div class="asc-field"><label>นับถอยหลังถึงเวลาปิดขาย</label><select id="cm_show_sale_countdown"><option value="0">ไม่แสดง</option><option value="1">แสดงจากเวลาปิดขายจริง</option></select></div>
         </div>
 
+        <div class="asc-section">
+          <div class="asc-section-title">ตัวอย่างโปรโมชั่นบนมือถือก่อนเผยแพร่</div>
+          <div id="cm_campaign_preview" class="asc-mobile-preview asc-campaign-preview" aria-live="polite"></div>
+        </div>
+
         <details class="asc-section asc-accordion">
           <summary class="asc-section-title asc-accordion-summary">7) ข้อมูลจับคู่ระบบราคา (กดเพื่อแก้ไข)</summary>
           <div class="asc-warning">การแก้ไขค่าด้านล่างนี้จะเปลี่ยนการจับคู่กับระบบราคาอัตโนมัติ (customer_service_price_rules) โปรดมั่นใจก่อนแก้ไข</div>
@@ -271,7 +276,62 @@ function ensureCatalogModal() {
   el("cm_image_delete").addEventListener("click", onCatalogImageDeleteClick);
   el("cm_booking_mode").addEventListener("change", updateBookingFieldsVisibility);
   el("cm_booking_ac_type").addEventListener("change", updateBookingFieldsVisibility);
+  bindAdminCampaignPreview("cm");
   bindGalleryActions();
+}
+
+const ADMIN_CAMPAIGN_THEMES = new Set(["default", "premium", "limited_time", "new"]);
+const ADMIN_CAMPAIGN_EFFECTS = new Set(["none", "soft_glow", "shimmer_border", "badge_pulse"]);
+function renderAdminCampaignPreview(prefix) {
+  const box = el(`${prefix}_campaign_preview`);
+  if (!box) return;
+  const bundle = prefix === "bm";
+  const name = String(el(`${prefix}_item_name`)?.value || "").trim() || "ตัวอย่างชื่อสินค้า";
+  const badge = String(el(`${prefix}_promotion_badge_text`)?.value || "").trim();
+  const support = String(el(`${prefix}_promotion_supporting_text`)?.value || "").trim();
+  const themeValue = String(el(`${prefix}_promotion_theme_preset`)?.value || "default");
+  const effectValue = String(el(`${prefix}_promotion_effect_preset`)?.value || "none");
+  const theme = ADMIN_CAMPAIGN_THEMES.has(themeValue) ? themeValue : "default";
+  const effect = ADMIN_CAMPAIGN_EFFECTS.has(effectValue) ? effectValue : "none";
+  const featuredId = bundle ? "bm_featured" : "cm_is_featured";
+  const endId = bundle ? "bm_sell_end" : "cm_effective_to";
+  const showCountdown = el(`${prefix}_show_sale_countdown`)?.value === "1";
+  const endValue = String(el(endId)?.value || "").trim();
+  let countdown = "";
+  if (showCountdown) {
+    const parsed = endValue ? new Date(endValue) : null;
+    const label = parsed && Number.isFinite(parsed.getTime())
+      ? `นับถอยหลังถึง ${parsed.toLocaleString("th-TH", { dateStyle: "short", timeStyle: "short" })}`
+      : "จะแสดงเวลานับถอยหลังเมื่อระบุเวลาปิดขาย";
+    countdown = `<span class="asc-campaign-countdown">${escapeHtml(label)}</span>`;
+  }
+  box.className = `asc-mobile-preview asc-campaign-preview asc-campaign-theme-${theme} asc-campaign-effect-${effect}`;
+  box.innerHTML = `<article class="asc-campaign-preview-card">
+    <div class="asc-campaign-preview-media" aria-hidden="true">รูปสินค้า/แกลเลอรีเดิม</div>
+    <div class="asc-campaign-preview-copy">
+      ${el(featuredId)?.value === "1" ? `<span class="asc-badge asc-badge-featured">Featured Services</span>` : ""}
+      ${badge ? `<span class="asc-campaign-badge">${escapeHtml(badge)}</span>` : ""}
+      <strong>${escapeHtml(name)}</strong>
+      ${support ? `<span class="asc-campaign-support">${escapeHtml(support)}</span>` : ""}
+      ${countdown}
+      <button class="primary" type="button" disabled aria-disabled="true">ตัวอย่างปุ่มหลัก</button>
+    </div>
+  </article>`;
+}
+function bindAdminCampaignPreview(prefix) {
+  const bundle = prefix === "bm";
+  const ids = [
+    `${prefix}_item_name`, bundle ? "bm_featured" : "cm_is_featured",
+    `${prefix}_promotion_badge_text`, `${prefix}_promotion_supporting_text`,
+    `${prefix}_promotion_theme_preset`, `${prefix}_promotion_effect_preset`,
+    `${prefix}_show_sale_countdown`, bundle ? "bm_sell_end" : "cm_effective_to",
+  ];
+  ids.forEach((id) => {
+    const input = el(id);
+    input?.addEventListener("input", () => renderAdminCampaignPreview(prefix));
+    input?.addEventListener("change", () => renderAdminCampaignPreview(prefix));
+  });
+  renderAdminCampaignPreview(prefix);
 }
 
 function updateBookingFieldsVisibility() {
@@ -377,6 +437,7 @@ function resetCatalogModalFields() {
   galleryPickNotice = "";
   renderGalleryManager();
   hideCatalogModalError();
+  renderAdminCampaignPreview("cm");
 }
 
 function openCatalogModalForNew() {
@@ -445,6 +506,7 @@ function openCatalogModalForEdit(itemId) {
   el("cm_service_conditions").value = item.service_conditions || "";
   updateBookingFieldsVisibility();
   loadGalleryImages(itemId);
+  renderAdminCampaignPreview("cm");
   el("catalog_modal_backdrop").classList.remove("hidden");
 }
 
@@ -1182,6 +1244,7 @@ function ensureBundleModal() {
       <div class="asc-grid2"><div class="asc-field"><label>ข้อความป้ายโปรโมชั่น</label><input id="bm_promotion_badge_text" maxlength="80"></div><div class="asc-field"><label>ข้อความสนับสนุนโปรโมชั่น</label><input id="bm_promotion_supporting_text" maxlength="200"></div></div>
       <div class="asc-grid2"><div class="asc-field"><label>ธีม</label><select id="bm_promotion_theme_preset"><option value="default">ปกติ</option><option value="premium">พรีเมียม</option><option value="limited_time">เวลาจำกัด</option><option value="new">ใหม่</option></select></div><div class="asc-field"><label>เอฟเฟกต์</label><select id="bm_promotion_effect_preset"><option value="none">ไม่มี</option><option value="soft_glow">แสงนุ่ม</option><option value="shimmer_border">ขอบประกาย</option><option value="badge_pulse">ป้ายเต้นเบา</option></select></div></div>
       <div class="asc-field"><label>นับถอยหลังถึงเวลาปิดขาย</label><select id="bm_show_sale_countdown"><option value="0">ไม่แสดง</option><option value="1">แสดงจากเวลาปิดขายจริง</option></select></div>
+      <div class="asc-section-title">ตัวอย่างโปรโมชั่นบนมือถือก่อนเผยแพร่</div><div id="bm_campaign_preview" class="asc-mobile-preview asc-campaign-preview" aria-live="polite"></div>
       <div class="asc-field"><label>เพิ่มรูปภาพ/แกลเลอรี</label><input id="bm_images" type="file" accept="image/jpeg,image/png,image/webp" multiple><p class="muted2 mini">ใช้ระบบรูปภาพ catalog เดิม รูปที่มีอยู่จะไม่ถูกลบเมื่อบันทึก</p></div>
     </div><div class="asc-section"><div class="asc-toolbar-row"><div><div class="asc-section-title">รูปแบบบริการและระดับราคา</div><p class="muted2 mini">เลือก taxonomy จากระบบ เพิ่มจำนวน variant/tier ได้ตามต้องการ ระบบรักษารหัสเดิมและเก็บรายการที่ปิดใช้งาน</p></div><button id="bm_add_variant" class="secondary btn-small" type="button">+ เพิ่มรูปแบบบริการ</button></div><div id="bm_variant_editor"></div></div>
     <div id="bundle_modal_error" class="asc-modal-error"></div></div>
@@ -1196,6 +1259,7 @@ function ensureBundleModal() {
   el("bm_variant_editor").addEventListener("input", updateBundleVariantDraft);
   el("bm_variant_editor").addEventListener("change", updateBundleVariantDraft);
   el("bm_variant_editor").addEventListener("click", handleBundleEditorAction);
+  bindAdminCampaignPreview("bm");
 }
 
 let editingBundleKey = null;
@@ -1306,6 +1370,7 @@ async function openBundleModal(bundleKey = null) {
   el("bm_show_sale_countdown").value = bundle?.show_sale_countdown ? "1" : "0";
   bundleVariantDrafts = (bundle?.variants || []).map(bundleVariantDraft);
   renderBundleVariantEditor();
+  renderAdminCampaignPreview("bm");
   el("bundle_modal_error").style.display = "none";
   el("bundle_modal_backdrop").classList.remove("hidden");
 }

--- a/admin-store-catalog.js
+++ b/admin-store-catalog.js
@@ -231,6 +231,10 @@ function ensureCatalogModal() {
               </select>
             </div>
           </div>
+          <div class="asc-field"><label>ช่องทางการจองบริการ *</label><select id="cm_booking_flow_policy"><option value="scheduled_only">จองล่วงหน้าเท่านั้น</option><option value="scheduled_and_urgent">จองล่วงหน้า + จองด่วน</option></select></div>
+          <div class="asc-grid2"><div class="asc-field"><label>ข้อความป้ายโปรโมชั่น</label><input id="cm_promotion_badge_text" maxlength="80"></div><div class="asc-field"><label>ข้อความสนับสนุนโปรโมชั่น</label><input id="cm_promotion_supporting_text" maxlength="200"></div></div>
+          <div class="asc-grid2"><div class="asc-field"><label>ธีม</label><select id="cm_promotion_theme_preset"><option value="default">ปกติ</option><option value="premium">พรีเมียม</option><option value="limited_time">เวลาจำกัด</option><option value="new">ใหม่</option></select></div><div class="asc-field"><label>เอฟเฟกต์</label><select id="cm_promotion_effect_preset"><option value="none">ไม่มี</option><option value="soft_glow">แสงนุ่ม</option><option value="shimmer_border">ขอบประกาย</option><option value="badge_pulse">ป้ายเต้นเบา</option></select></div></div>
+          <div class="asc-field"><label>นับถอยหลังถึงเวลาปิดขาย</label><select id="cm_show_sale_countdown"><option value="0">ไม่แสดง</option><option value="1">แสดงจากเวลาปิดขายจริง</option></select></div>
         </div>
 
         <details class="asc-section asc-accordion">
@@ -356,6 +360,12 @@ function resetCatalogModalFields() {
   el("cm_booking_wash_variant").value = "";
   el("cm_is_featured").value = "0";
   el("cm_is_hot").value = "0";
+  el("cm_booking_flow_policy").value = "scheduled_only";
+  el("cm_promotion_badge_text").value = "";
+  el("cm_promotion_supporting_text").value = "";
+  el("cm_promotion_theme_preset").value = "default";
+  el("cm_promotion_effect_preset").value = "none";
+  el("cm_show_sale_countdown").value = "0";
   el("cm_short_description").value = "";
   el("cm_long_description").value = "";
   el("cm_highlights").value = "";
@@ -423,6 +433,12 @@ function openCatalogModalForEdit(itemId) {
   el("cm_booking_wash_variant").value = item.booking_wash_variant || "";
   el("cm_is_featured").value = item.is_featured ? "1" : "0";
   el("cm_is_hot").value = item.is_hot ? "1" : "0";
+  el("cm_booking_flow_policy").value = item.booking_flow_policy === "scheduled_and_urgent" ? "scheduled_and_urgent" : "scheduled_only";
+  el("cm_promotion_badge_text").value = item.promotion_badge_text || "";
+  el("cm_promotion_supporting_text").value = item.promotion_supporting_text || "";
+  el("cm_promotion_theme_preset").value = item.promotion_theme_preset || "default";
+  el("cm_promotion_effect_preset").value = item.promotion_effect_preset || "none";
+  el("cm_show_sale_countdown").value = item.show_sale_countdown ? "1" : "0";
   el("cm_short_description").value = item.short_description || "";
   el("cm_long_description").value = item.long_description || "";
   el("cm_highlights").value = Array.isArray(item.highlights) ? item.highlights.join("\n") : "";
@@ -463,6 +479,12 @@ function catalogModalPayload() {
     booking_wash_variant: trimmedOrEmpty("cm_booking_wash_variant"),
     is_featured: el("cm_is_featured").value === "1",
     is_hot: el("cm_is_hot").value === "1",
+    booking_flow_policy: el("cm_booking_flow_policy").value,
+    promotion_badge_text: trimmedOrEmpty("cm_promotion_badge_text"),
+    promotion_supporting_text: trimmedOrEmpty("cm_promotion_supporting_text"),
+    promotion_theme_preset: el("cm_promotion_theme_preset").value,
+    promotion_effect_preset: el("cm_promotion_effect_preset").value,
+    show_sale_countdown: el("cm_show_sale_countdown").value === "1",
     short_description: trimmedOrEmpty("cm_short_description"),
     long_description: trimmedOrEmpty("cm_long_description"),
     highlights: (el("cm_highlights").value || "").split("\n").map((line) => line.trim()).filter(Boolean),
@@ -1047,7 +1069,7 @@ function renderCatalogPreview() {
     box.innerHTML = `<div class="muted2">ยังไม่มีรายการที่จะแสดงในร้านค้าลูกค้าในขณะนี้</div>`;
     return;
   }
-  box.innerHTML = visibleItems.map(catalogItemCard).join("");
+  box.innerHTML = `<div class="asc-mobile-preview" aria-label="ตัวอย่างหน้าลูกค้าความกว้างมือถือ 390 พิกเซล">${visibleItems.map(catalogItemCard).join("")}</div>`;
 }
 
 async function loadCatalogItems() {
@@ -1149,10 +1171,19 @@ function ensureBundleModal() {
     <div class="cwf-modal-body"><div class="asc-section"><div class="asc-section-title">สินค้าแม่ใน Store</div>
       <div class="asc-field"><label>ชื่อสินค้า *</label><input id="bm_item_name"></div>
       <div class="asc-field"><label>คำอธิบายสั้น</label><textarea id="bm_short_description" rows="2"></textarea></div>
+      <div class="asc-field"><label>รายละเอียด</label><textarea id="bm_long_description" rows="3"></textarea></div>
+      <div class="asc-field"><label>จุดเด่น (หนึ่งรายการต่อบรรทัด)</label><textarea id="bm_highlights" rows="3"></textarea></div>
+      <div class="asc-field"><label>เงื่อนไขบริการ</label><textarea id="bm_service_conditions" rows="2"></textarea></div>
       <div class="asc-grid2"><div class="asc-field"><label>เริ่มขาย</label><input id="bm_sell_start" type="datetime-local"></div><div class="asc-field"><label>สิ้นสุดการขาย</label><input id="bm_sell_end" type="datetime-local"></div></div>
       <div class="asc-field"><label>ใช้สิทธิ์ได้ถึง</label><input id="bm_redeem_until" type="datetime-local"></div>
       <div class="asc-grid2"><div class="asc-field"><label>สถานะ</label><select id="bm_active"><option value="0">แบบร่าง</option><option value="1">เปิดใช้งาน</option></select></div><div class="asc-field"><label>Store</label><select id="bm_visible"><option value="0">ซ่อน</option><option value="1">แสดง</option></select></div></div>
-    </div><div class="asc-section"><div class="asc-section-title">BTU variants และ tiers</div><p class="muted2 mini">กำหนดเป็น JSON array; package_key/tier_key ที่ระบบสร้างให้ต้องคงเดิมเมื่อแก้ไข</p><textarea id="bm_variants" rows="18" spellcheck="false"></textarea></div>
+      <div class="asc-grid2"><div class="asc-field"><label>แสดงใน Featured Services</label><select id="bm_featured"><option value="0">ไม่แสดง</option><option value="1">แสดง</option></select></div><div class="asc-field"><label>อนุญาตการหมุนภาพเดิม</label><select id="bm_autoplay"><option value="1">อนุญาต</option><option value="0">ปิด</option></select></div></div>
+      <div class="asc-field"><label>ช่องทางการจองบริการ *</label><select id="bm_booking_flow_policy"><option value="scheduled_only">จองล่วงหน้าเท่านั้น</option><option value="scheduled_and_urgent">จองล่วงหน้า + จองด่วน</option></select></div>
+      <div class="asc-grid2"><div class="asc-field"><label>ข้อความป้ายโปรโมชั่น</label><input id="bm_promotion_badge_text" maxlength="80"></div><div class="asc-field"><label>ข้อความสนับสนุนโปรโมชั่น</label><input id="bm_promotion_supporting_text" maxlength="200"></div></div>
+      <div class="asc-grid2"><div class="asc-field"><label>ธีม</label><select id="bm_promotion_theme_preset"><option value="default">ปกติ</option><option value="premium">พรีเมียม</option><option value="limited_time">เวลาจำกัด</option><option value="new">ใหม่</option></select></div><div class="asc-field"><label>เอฟเฟกต์</label><select id="bm_promotion_effect_preset"><option value="none">ไม่มี</option><option value="soft_glow">แสงนุ่ม</option><option value="shimmer_border">ขอบประกาย</option><option value="badge_pulse">ป้ายเต้นเบา</option></select></div></div>
+      <div class="asc-field"><label>นับถอยหลังถึงเวลาปิดขาย</label><select id="bm_show_sale_countdown"><option value="0">ไม่แสดง</option><option value="1">แสดงจากเวลาปิดขายจริง</option></select></div>
+      <div class="asc-field"><label>เพิ่มรูปภาพ/แกลเลอรี</label><input id="bm_images" type="file" accept="image/jpeg,image/png,image/webp" multiple><p class="muted2 mini">ใช้ระบบรูปภาพ catalog เดิม รูปที่มีอยู่จะไม่ถูกลบเมื่อบันทึก</p></div>
+    </div><div class="asc-section"><div class="asc-toolbar-row"><div><div class="asc-section-title">รูปแบบบริการและระดับราคา</div><p class="muted2 mini">เลือก taxonomy จากระบบ เพิ่มจำนวน variant/tier ได้ตามต้องการ ระบบรักษารหัสเดิมและเก็บรายการที่ปิดใช้งาน</p></div><button id="bm_add_variant" class="secondary btn-small" type="button">+ เพิ่มรูปแบบบริการ</button></div><div id="bm_variant_editor"></div></div>
     <div id="bundle_modal_error" class="asc-modal-error"></div></div>
     <div class="cwf-modal-foot"><button id="bundle_modal_cancel" class="secondary" type="button">ยกเลิก</button><button id="bundle_modal_save" class="primary" type="button">บันทึกสินค้าและแพ็กเกจ</button></div>
   </div></div>`;
@@ -1161,43 +1192,167 @@ function ensureBundleModal() {
   el("bundle_modal_close").addEventListener("click", close);
   el("bundle_modal_cancel").addEventListener("click", close);
   el("bundle_modal_save").addEventListener("click", saveBundle);
+  el("bm_add_variant").addEventListener("click", () => { bundleVariantDrafts.push(newBundleVariant()); renderBundleVariantEditor(); });
+  el("bm_variant_editor").addEventListener("input", updateBundleVariantDraft);
+  el("bm_variant_editor").addEventListener("change", updateBundleVariantDraft);
+  el("bm_variant_editor").addEventListener("click", handleBundleEditorAction);
 }
 
 let editingBundleKey = null;
-function defaultBundleVariant() {
-  return [{ display_name: "", description: null, service_key: "", service_name: "", job_type: "wash", ac_type: "wall",
-    wash_variant: "premium", btu_min: null, btu_max: null, service_unit_duration_minutes: 45, is_active: false,
-    is_customer_visible: false, tiers: [{ display_name: "1 เครื่อง", service_quantity: 1, fixed_total_price: "0.00", sort_order: 0, is_active: false }] }];
+let bundleTaxonomy = null;
+let bundleVariantDrafts = [];
+
+async function loadBundleTaxonomy() {
+  if (!bundleTaxonomy) bundleTaxonomy = await apiFetch("/admin/catalog/service-package-bundles/taxonomy");
+  return bundleTaxonomy;
 }
-function openBundleModal(bundleKey = null) {
+function taxonomyOptions(entries, selected, blankLabel = "") {
+  const blank = blankLabel ? `<option value="">${escapeHtml(blankLabel)}</option>` : "";
+  return blank + (entries || []).map((entry) => `<option value="${escapeHtml(entry.value)}" ${entry.value === selected ? "selected" : ""}>${escapeHtml(entry.label)}</option>`).join("");
+}
+function newBundleVariant() {
+  return {
+    display_name: "", description: null,
+    job_type: bundleTaxonomy?.job_types?.[0]?.value || "",
+    ac_type: bundleTaxonomy?.ac_types?.[0]?.value || "",
+    wash_variant: null, btu_min: null, btu_max: null, service_unit_duration_minutes: "",
+    sort_order: bundleVariantDrafts.length, is_active: false, is_customer_visible: false, tiers: [],
+  };
+}
+function bundleVariantDraft(value = {}, index = 0) {
+  return {
+    ...value, description: value.description || null, wash_variant: value.wash_variant || null,
+    sort_order: Number.isInteger(Number(value.sort_order)) ? Number(value.sort_order) : index,
+    tiers: (value.tiers || []).map((tier, tierIndex) => ({ ...tier,
+      sort_order: Number.isInteger(Number(tier.sort_order)) ? Number(tier.sort_order) : tierIndex })),
+  };
+}
+function renderBundleVariantEditor() {
+  const host = el("bm_variant_editor");
+  host.innerHTML = bundleVariantDrafts.length ? bundleVariantDrafts.map((variant, variantIndex) => `<article class="asc-package-tier asc-bundle-variant" data-bundle-variant-index="${variantIndex}">
+    <div class="asc-toolbar-row"><div><b>รูปแบบบริการ ${variantIndex + 1}</b>${variant.package_key ? `<div class="muted2 mini">รหัสถาวร: ${escapeHtml(variant.package_key)}</div>` : `<div class="muted2 mini">ระบบจะสร้างรหัสถาวรเมื่อบันทึก</div>`}</div><div class="asc-item-actions"><button class="secondary btn-small" data-bundle-action="variant-up" type="button" ${variantIndex === 0 ? "disabled" : ""}>↑</button><button class="secondary btn-small" data-bundle-action="variant-down" type="button" ${variantIndex === bundleVariantDrafts.length - 1 ? "disabled" : ""}>↓</button><button class="secondary btn-small" data-bundle-action="variant-archive" type="button">${variant.package_key ? "ปิดใช้งาน" : "นำออก"}</button></div></div>
+    <div class="asc-grid2"><div class="asc-field"><label>ชื่อตัวเลือกที่ลูกค้าเห็น *</label><input data-variant-field="display_name" value="${escapeHtml(variant.display_name || "")}"></div><div class="asc-field"><label>คำอธิบายช่วยเลือก</label><input data-variant-field="description" value="${escapeHtml(variant.description || "")}"></div></div>
+    <div class="asc-grid2"><div class="asc-field"><label>ประเภทงาน *</label><select data-variant-field="job_type">${taxonomyOptions(bundleTaxonomy.job_types, variant.job_type)}</select></div><div class="asc-field"><label>ประเภทแอร์ *</label><select data-variant-field="ac_type">${taxonomyOptions(bundleTaxonomy.ac_types, variant.ac_type)}</select></div></div>
+    <div class="asc-field"><label>รูปแบบล้าง/บริการ</label><select data-variant-field="wash_variant">${taxonomyOptions(bundleTaxonomy.wash_variants, variant.wash_variant || "", "ไม่ระบุ")}</select></div>
+    <div class="asc-grid2"><div class="asc-field"><label>BTU ต่ำสุด (เว้นว่างได้)</label><input data-variant-field="btu_min" type="number" min="1" step="1" value="${variant.btu_min == null ? "" : variant.btu_min}"></div><div class="asc-field"><label>BTU สูงสุด (เว้นว่างได้)</label><input data-variant-field="btu_max" type="number" min="1" step="1" value="${variant.btu_max == null ? "" : variant.btu_max}"></div></div>
+    <div class="asc-grid2"><div class="asc-field"><label>เวลาต่อเครื่อง (นาที) *</label><input data-variant-field="service_unit_duration_minutes" type="number" min="1" step="1" value="${escapeHtml(variant.service_unit_duration_minutes || "")}"></div><div class="asc-field"><label>สถานะ</label><select data-variant-field="is_active"><option value="0" ${variant.is_active ? "" : "selected"}>ปิดใช้งาน</option><option value="1" ${variant.is_active ? "selected" : ""}>เปิดใช้งาน</option></select></div></div>
+    <div class="asc-field"><label>แสดงต่อลูกค้า</label><select data-variant-field="is_customer_visible"><option value="0" ${variant.is_customer_visible ? "" : "selected"}>ซ่อน</option><option value="1" ${variant.is_customer_visible ? "selected" : ""}>แสดง</option></select></div>
+    <div class="asc-toolbar-row"><b>ระดับราคา</b><button class="secondary btn-small" data-bundle-action="tier-add" type="button">+ เพิ่มระดับราคา</button></div>
+    <div class="asc-bundle-tiers">${(variant.tiers || []).map((tier, tierIndex) => `<div class="asc-package-tier" data-bundle-tier-index="${tierIndex}">${tier.tier_key ? `<div class="muted2 mini">รหัสถาวร: ${escapeHtml(tier.tier_key)}</div>` : ""}<div class="asc-grid2"><div class="asc-field"><label>ชื่อลูกค้าเห็น *</label><input data-tier-field="display_name" value="${escapeHtml(tier.display_name || "")}"></div><div class="asc-field"><label>จำนวน *</label><input data-tier-field="service_quantity" type="number" min="1" step="1" value="${escapeHtml(tier.service_quantity || "")}"></div></div><div class="asc-grid2"><div class="asc-field"><label>ราคารวมคงที่ *</label><input data-tier-field="fixed_total_price" inputmode="decimal" placeholder="0.00" value="${escapeHtml(tier.fixed_total_price || "")}"></div><div class="asc-field"><label>สถานะ</label><select data-tier-field="is_active"><option value="0" ${tier.is_active ? "" : "selected"}>ปิดใช้งาน</option><option value="1" ${tier.is_active ? "selected" : ""}>เปิดใช้งาน</option></select></div></div><div class="asc-item-actions"><button class="secondary btn-small" data-bundle-action="tier-up" type="button" ${tierIndex === 0 ? "disabled" : ""}>↑</button><button class="secondary btn-small" data-bundle-action="tier-down" type="button" ${tierIndex === variant.tiers.length - 1 ? "disabled" : ""}>↓</button><button class="secondary btn-small" data-bundle-action="tier-archive" type="button">${tier.tier_key ? "ปิดใช้งาน" : "นำออก"}</button></div></div>`).join("") || `<div class="muted2 mini">ยังไม่มีระดับราคา เพิ่มได้โดยไม่จำกัดจำนวนระดับ</div>`}</div>
+  </article>`).join("") : `<div class="asc-empty">ยังไม่มีรูปแบบบริการ กด “เพิ่มรูปแบบบริการ” เพื่อเริ่มกำหนดแพ็กเกจ</div>`;
+}
+function updateBundleVariantDraft(event) {
+  const variantRow = event.target.closest("[data-bundle-variant-index]");
+  if (!variantRow) return;
+  const variant = bundleVariantDrafts[Number(variantRow.dataset.bundleVariantIndex)];
+  const variantField = event.target.dataset.variantField;
+  if (variantField) {
+    if (["is_active", "is_customer_visible"].includes(variantField)) variant[variantField] = event.target.value === "1";
+    else variant[variantField] = event.target.value === "" ? null : event.target.value;
+  }
+  const tierRow = event.target.closest("[data-bundle-tier-index]");
+  const tierField = event.target.dataset.tierField;
+  if (tierRow && tierField) {
+    const tier = variant.tiers[Number(tierRow.dataset.bundleTierIndex)];
+    tier[tierField] = tierField === "is_active" ? event.target.value === "1" : event.target.value;
+  }
+}
+function moveDraft(list, index, direction) {
+  const target = index + direction;
+  if (target < 0 || target >= list.length) return;
+  [list[index], list[target]] = [list[target], list[index]];
+  list.forEach((entry, order) => { entry.sort_order = order; });
+}
+function handleBundleEditorAction(event) {
+  const button = event.target.closest("[data-bundle-action]");
+  if (!button) return;
+  const variantRow = button.closest("[data-bundle-variant-index]");
+  const variantIndex = Number(variantRow?.dataset.bundleVariantIndex);
+  const variant = bundleVariantDrafts[variantIndex];
+  const tierRow = button.closest("[data-bundle-tier-index]");
+  const tierIndex = Number(tierRow?.dataset.bundleTierIndex);
+  const action = button.dataset.bundleAction;
+  if (action === "variant-up") moveDraft(bundleVariantDrafts, variantIndex, -1);
+  if (action === "variant-down") moveDraft(bundleVariantDrafts, variantIndex, 1);
+  if (action === "variant-archive") variant.package_key ? Object.assign(variant, { is_active: false, is_customer_visible: false }) : bundleVariantDrafts.splice(variantIndex, 1);
+  if (action === "tier-add") variant.tiers.push({ display_name: "", service_quantity: "", fixed_total_price: "", sort_order: variant.tiers.length, is_active: false });
+  if (action === "tier-up") moveDraft(variant.tiers, tierIndex, -1);
+  if (action === "tier-down") moveDraft(variant.tiers, tierIndex, 1);
+  if (action === "tier-archive") variant.tiers[tierIndex].tier_key ? (variant.tiers[tierIndex].is_active = false) : variant.tiers.splice(tierIndex, 1);
+  renderBundleVariantEditor();
+}
+async function openBundleModal(bundleKey = null) {
+  try { await loadBundleTaxonomy(); } catch (_) { showToast("ไม่สามารถโหลดตัวเลือกประเภทบริการจากระบบได้", "error"); return; }
   ensureBundleModal(); editingBundleKey = bundleKey;
   const bundle = bundleKey ? servicePackages.find((item) => item.service_bundle_key === bundleKey) : null;
   el("bundle_modal_title").textContent = bundle ? `แก้ไข ${bundle.item_name}` : "สร้าง Store service package";
   el("bm_item_name").value = bundle?.item_name || "";
   el("bm_short_description").value = bundle?.short_description || "";
+  el("bm_long_description").value = bundle?.long_description || "";
+  el("bm_highlights").value = (bundle?.highlights || []).join("\n");
+  el("bm_service_conditions").value = bundle?.service_conditions || "";
   el("bm_sell_start").value = dateTimeLocalValue(bundle?.sell_start_at);
   el("bm_sell_end").value = dateTimeLocalValue(bundle?.sell_end_at);
   el("bm_redeem_until").value = dateTimeLocalValue(bundle?.redeem_until);
   el("bm_active").value = bundle?.is_active ? "1" : "0";
   el("bm_visible").value = bundle?.is_customer_visible ? "1" : "0";
-  el("bm_variants").value = JSON.stringify(bundle?.variants || defaultBundleVariant(), null, 2);
+  el("bm_featured").value = bundle?.is_featured ? "1" : "0";
+  el("bm_autoplay").value = bundle?.is_autoplay_enabled === false ? "0" : "1";
+  el("bm_booking_flow_policy").value = bundle?.booking_flow_policy === "scheduled_and_urgent" ? "scheduled_and_urgent" : "scheduled_only";
+  el("bm_promotion_badge_text").value = bundle?.promotion_badge_text || "";
+  el("bm_promotion_supporting_text").value = bundle?.promotion_supporting_text || "";
+  el("bm_promotion_theme_preset").value = bundle?.promotion_theme_preset || "default";
+  el("bm_promotion_effect_preset").value = bundle?.promotion_effect_preset || "none";
+  el("bm_show_sale_countdown").value = bundle?.show_sale_countdown ? "1" : "0";
+  bundleVariantDrafts = (bundle?.variants || []).map(bundleVariantDraft);
+  renderBundleVariantEditor();
   el("bundle_modal_error").style.display = "none";
   el("bundle_modal_backdrop").classList.remove("hidden");
 }
 function bundleDateValue(id) { const value = el(id).value; return value ? new Date(value).toISOString() : null; }
+function bundlePayload() {
+  const optionalInteger = (value) => value == null || value === "" ? null : Number(value);
+  return {
+    item_name: el("bm_item_name").value.trim(), short_description: el("bm_short_description").value.trim() || null,
+    long_description: el("bm_long_description").value.trim() || null,
+    highlights: el("bm_highlights").value.split(/\r?\n/).map((value) => value.trim()).filter(Boolean),
+    service_conditions: el("bm_service_conditions").value.trim() || null,
+    sell_start_at: bundleDateValue("bm_sell_start"), sell_end_at: bundleDateValue("bm_sell_end"), redeem_until: bundleDateValue("bm_redeem_until"),
+    is_active: el("bm_active").value === "1", is_customer_visible: el("bm_visible").value === "1",
+    is_featured: el("bm_featured").value === "1", is_autoplay_enabled: el("bm_autoplay").value === "1",
+    booking_flow_policy: el("bm_booking_flow_policy").value,
+    promotion_badge_text: el("bm_promotion_badge_text").value.trim() || null,
+    promotion_supporting_text: el("bm_promotion_supporting_text").value.trim() || null,
+    promotion_theme_preset: el("bm_promotion_theme_preset").value,
+    promotion_effect_preset: el("bm_promotion_effect_preset").value,
+    show_sale_countdown: el("bm_show_sale_countdown").value === "1",
+    variants: bundleVariantDrafts.map((variant, variantIndex) => ({
+      ...(variant.package_key ? { package_key: variant.package_key } : {}), display_name: String(variant.display_name || "").trim(),
+      description: String(variant.description || "").trim() || null, job_type: variant.job_type, ac_type: variant.ac_type,
+      wash_variant: variant.wash_variant || null, btu_min: optionalInteger(variant.btu_min), btu_max: optionalInteger(variant.btu_max),
+      service_unit_duration_minutes: Number(variant.service_unit_duration_minutes), sort_order: variantIndex,
+      is_active: Boolean(variant.is_active), is_customer_visible: Boolean(variant.is_customer_visible),
+      tiers: (variant.tiers || []).map((tier, tierIndex) => ({ ...(tier.tier_key ? { tier_key: tier.tier_key } : {}),
+        display_name: String(tier.display_name || "").trim(), service_quantity: Number(tier.service_quantity),
+        fixed_total_price: String(tier.fixed_total_price || "").trim(), sort_order: tierIndex, is_active: Boolean(tier.is_active) })),
+    })),
+  };
+}
 async function saveBundle() {
   if (isSaving) return;
   const box = el("bundle_modal_error"); box.style.display = "none"; isSaving = true; el("bundle_modal_save").disabled = true;
   try {
-    const payload = { item_name: el("bm_item_name").value.trim(), short_description: el("bm_short_description").value.trim() || null,
-      sell_start_at: bundleDateValue("bm_sell_start"), sell_end_at: bundleDateValue("bm_sell_end"), redeem_until: bundleDateValue("bm_redeem_until"),
-      is_active: el("bm_active").value === "1", is_customer_visible: el("bm_visible").value === "1",
-      variants: JSON.parse(el("bm_variants").value) };
+    const payload = bundlePayload();
     const url = editingBundleKey ? `/admin/catalog/service-package-bundles/${encodeURIComponent(editingBundleKey)}` : "/admin/catalog/service-package-bundles";
-    await apiFetch(url, { method: editingBundleKey ? "PATCH" : "POST", body: JSON.stringify(payload) });
+    const saved = await apiFetch(url, { method: editingBundleKey ? "PATCH" : "POST", body: JSON.stringify(payload) });
+    const files = Array.from(el("bm_images")?.files || []);
+    for (const file of files) {
+      const formData = new FormData(); formData.append("image", file);
+      await apiFetch(`/admin/catalog/items/${saved.item_id}/images`, { method: "POST", body: formData });
+    }
     el("bundle_modal_backdrop").classList.add("hidden"); await Promise.all([loadServicePackages(), loadCatalogItems()]);
     showToast("บันทึก Store service package แล้ว สามารถจัดการรูปภาพจากการ์ดสินค้าแม่ได้", "success");
-  } catch (error) { box.textContent = error?.message || "ข้อมูล variants ไม่ถูกต้อง"; box.style.display = "block"; }
+  } catch (error) { box.textContent = error?.message || "ข้อมูลรูปแบบบริการหรือระดับราคาไม่ถูกต้อง"; box.style.display = "block"; }
   finally { isSaving = false; el("bundle_modal_save").disabled = false; }
 }
 

--- a/admin-store-catalog.js
+++ b/admin-store-catalog.js
@@ -13,7 +13,7 @@ let deleteModalItemId = null;
 let servicePackages = [];
 let editingPackageKey = null;
 let packageTierDrafts = [];
-const BOOKING_MODES = ["bookable", "contact_admin", "purchase"];
+const BOOKING_MODES = ["bookable", "contact_admin", "purchase", "service_package"];
 // Must mirror the backend's MAX_CATALOG_IMAGES_PER_ITEM (server/routes/catalog/items.js)
 const MAX_GALLERY_IMAGES = 4;
 
@@ -1071,7 +1071,8 @@ function bindCatalogListActions() {
     const item = catalogItems.find((x) => Number(x.item_id) === id);
     if (!item) return;
     const act = button.getAttribute("data-act");
-    if (act === "edit") openCatalogModalForEdit(id);
+    if (act === "edit" && item.booking_mode === "service_package") openBundleModal(item.service_bundle_key);
+    else if (act === "edit") openCatalogModalForEdit(id);
     else if (act === "more") openMoreSheet(id);
   });
 }
@@ -1131,13 +1132,73 @@ function ensureCreateTypeChooser() {
   </div></div>`;
   document.body.appendChild(wrap.firstElementChild);
   el("new_ordinary_item").addEventListener("click", () => { el("catalog_type_backdrop").classList.add("hidden"); openCatalogModalForNew(); });
-  el("new_package_item").addEventListener("click", () => { el("catalog_type_backdrop").classList.add("hidden"); openPackageModal(); });
+  el("new_package_item").addEventListener("click", () => { el("catalog_type_backdrop").classList.add("hidden"); openBundleModal(); });
   el("new_type_cancel").addEventListener("click", () => el("catalog_type_backdrop").classList.add("hidden"));
 }
 
 function openCreateTypeChooser() {
   ensureCreateTypeChooser();
   el("catalog_type_backdrop").classList.remove("hidden");
+}
+
+function ensureBundleModal() {
+  if (el("bundle_modal_backdrop")) return;
+  const wrap = document.createElement("div");
+  wrap.innerHTML = `<div id="bundle_modal_backdrop" class="cwf-modal-backdrop hidden"><div class="cwf-modal">
+    <div class="cwf-modal-head"><div id="bundle_modal_title" class="cwf-modal-title">สร้าง Store service package</div><button id="bundle_modal_close" class="cwf-modal-close" type="button">×</button></div>
+    <div class="cwf-modal-body"><div class="asc-section"><div class="asc-section-title">สินค้าแม่ใน Store</div>
+      <div class="asc-field"><label>ชื่อสินค้า *</label><input id="bm_item_name"></div>
+      <div class="asc-field"><label>คำอธิบายสั้น</label><textarea id="bm_short_description" rows="2"></textarea></div>
+      <div class="asc-grid2"><div class="asc-field"><label>เริ่มขาย</label><input id="bm_sell_start" type="datetime-local"></div><div class="asc-field"><label>สิ้นสุดการขาย</label><input id="bm_sell_end" type="datetime-local"></div></div>
+      <div class="asc-field"><label>ใช้สิทธิ์ได้ถึง</label><input id="bm_redeem_until" type="datetime-local"></div>
+      <div class="asc-grid2"><div class="asc-field"><label>สถานะ</label><select id="bm_active"><option value="0">แบบร่าง</option><option value="1">เปิดใช้งาน</option></select></div><div class="asc-field"><label>Store</label><select id="bm_visible"><option value="0">ซ่อน</option><option value="1">แสดง</option></select></div></div>
+    </div><div class="asc-section"><div class="asc-section-title">BTU variants และ tiers</div><p class="muted2 mini">กำหนดเป็น JSON array; package_key/tier_key ที่ระบบสร้างให้ต้องคงเดิมเมื่อแก้ไข</p><textarea id="bm_variants" rows="18" spellcheck="false"></textarea></div>
+    <div id="bundle_modal_error" class="asc-modal-error"></div></div>
+    <div class="cwf-modal-foot"><button id="bundle_modal_cancel" class="secondary" type="button">ยกเลิก</button><button id="bundle_modal_save" class="primary" type="button">บันทึกสินค้าและแพ็กเกจ</button></div>
+  </div></div>`;
+  document.body.appendChild(wrap.firstElementChild);
+  const close = () => { if (!isSaving) el("bundle_modal_backdrop").classList.add("hidden"); };
+  el("bundle_modal_close").addEventListener("click", close);
+  el("bundle_modal_cancel").addEventListener("click", close);
+  el("bundle_modal_save").addEventListener("click", saveBundle);
+}
+
+let editingBundleKey = null;
+function defaultBundleVariant() {
+  return [{ display_name: "", description: null, service_key: "", service_name: "", job_type: "wash", ac_type: "wall",
+    wash_variant: "premium", btu_min: null, btu_max: null, service_unit_duration_minutes: 45, is_active: false,
+    is_customer_visible: false, tiers: [{ display_name: "1 เครื่อง", service_quantity: 1, fixed_total_price: "0.00", sort_order: 0, is_active: false }] }];
+}
+function openBundleModal(bundleKey = null) {
+  ensureBundleModal(); editingBundleKey = bundleKey;
+  const bundle = bundleKey ? servicePackages.find((item) => item.service_bundle_key === bundleKey) : null;
+  el("bundle_modal_title").textContent = bundle ? `แก้ไข ${bundle.item_name}` : "สร้าง Store service package";
+  el("bm_item_name").value = bundle?.item_name || "";
+  el("bm_short_description").value = bundle?.short_description || "";
+  el("bm_sell_start").value = dateTimeLocalValue(bundle?.sell_start_at);
+  el("bm_sell_end").value = dateTimeLocalValue(bundle?.sell_end_at);
+  el("bm_redeem_until").value = dateTimeLocalValue(bundle?.redeem_until);
+  el("bm_active").value = bundle?.is_active ? "1" : "0";
+  el("bm_visible").value = bundle?.is_customer_visible ? "1" : "0";
+  el("bm_variants").value = JSON.stringify(bundle?.variants || defaultBundleVariant(), null, 2);
+  el("bundle_modal_error").style.display = "none";
+  el("bundle_modal_backdrop").classList.remove("hidden");
+}
+function bundleDateValue(id) { const value = el(id).value; return value ? new Date(value).toISOString() : null; }
+async function saveBundle() {
+  if (isSaving) return;
+  const box = el("bundle_modal_error"); box.style.display = "none"; isSaving = true; el("bundle_modal_save").disabled = true;
+  try {
+    const payload = { item_name: el("bm_item_name").value.trim(), short_description: el("bm_short_description").value.trim() || null,
+      sell_start_at: bundleDateValue("bm_sell_start"), sell_end_at: bundleDateValue("bm_sell_end"), redeem_until: bundleDateValue("bm_redeem_until"),
+      is_active: el("bm_active").value === "1", is_customer_visible: el("bm_visible").value === "1",
+      variants: JSON.parse(el("bm_variants").value) };
+    const url = editingBundleKey ? `/admin/catalog/service-package-bundles/${encodeURIComponent(editingBundleKey)}` : "/admin/catalog/service-package-bundles";
+    await apiFetch(url, { method: editingBundleKey ? "PATCH" : "POST", body: JSON.stringify(payload) });
+    el("bundle_modal_backdrop").classList.add("hidden"); await Promise.all([loadServicePackages(), loadCatalogItems()]);
+    showToast("บันทึก Store service package แล้ว สามารถจัดการรูปภาพจากการ์ดสินค้าแม่ได้", "success");
+  } catch (error) { box.textContent = error?.message || "ข้อมูล variants ไม่ถูกต้อง"; box.style.display = "block"; }
+  finally { isSaving = false; el("bundle_modal_save").disabled = false; }
 }
 
 function ensurePackageModal() {
@@ -1245,21 +1306,21 @@ async function saveServicePackage() {
 function renderServicePackages() {
   const box = el("package_catalog_list");
   box.innerHTML = servicePackages.length ? servicePackages.map((item) => `<div class="asc-item-card">
-    <div class="asc-item-main"><div class="asc-item-title">${escapeHtml(item.display_name)} <span class="asc-badge asc-package-badge">แพ็กเกจบริการ</span></div>
-      <div class="asc-item-meta">${escapeHtml(item.service_name)} · ${packageJobTypeLabel(item.job_type)} · ${packageAcTypeLabel(item.ac_type)}</div>
-      <div class="asc-item-meta">${item.tiers.length} ระดับ · ${item.service_unit_duration_minutes} นาที/ครั้งบริการ</div>
-      <div class="asc-badges"><span class="asc-badge asc-lifecycle-${escapeHtml(item.lifecycle_status)}">${packageLifecycleLabel(item.lifecycle_status)}</span></div></div>
-    <div class="asc-item-actions"><button class="secondary btn-small" data-edit-package="${escapeHtml(item.package_key)}" type="button">แก้ไข</button></div></div>`).join("") : `<div class="asc-empty">ยังไม่มีโปรโมชั่นแพ็กเกจบริการ</div>`;
+    <div class="asc-item-main"><div class="asc-item-title">${escapeHtml(item.item_name)} <span class="asc-badge asc-package-badge">Store service package</span></div>
+      <div class="asc-item-meta">${item.variants.length} BTU variants · ${item.variants.reduce((sum, variant) => sum + variant.tiers.length, 0)} tiers</div>
+      <div class="asc-item-meta">รหัสสินค้าแม่: ${escapeHtml(item.service_bundle_key)}</div>
+      <div class="asc-badges"><span class="asc-badge">${item.is_active ? "เปิดใช้งาน" : "แบบร่าง"}</span><span class="asc-badge">${item.is_customer_visible ? "แสดงใน Store" : "ซ่อน"}</span></div></div>
+    <div class="asc-item-actions"><button class="secondary btn-small" data-edit-bundle="${escapeHtml(item.service_bundle_key)}" type="button">แก้ไข</button></div></div>`).join("") : `<div class="asc-empty">ยังไม่มี Store service package</div>`;
 }
 
 async function loadServicePackages() {
   const box = el("package_catalog_list"); box.innerHTML = `<div class="asc-loading">กำลังโหลดโปรโมชั่น...</div>`;
-  try { const items = await apiFetch("/admin/service-packages/catalog"); servicePackages = Array.isArray(items) ? items : []; renderServicePackages(); }
+  try { const result = await apiFetch("/admin/catalog/service-package-bundles"); servicePackages = Array.isArray(result?.bundles) ? result.bundles : []; renderServicePackages(); }
   catch (_error) { box.innerHTML = `<div class="asc-error">ไม่สามารถโหลดโปรโมชั่นแพ็กเกจได้ โปรดลองอีกครั้ง</div>`; }
 }
 
 function bindServicePackageActions() {
-  el("package_catalog_list").addEventListener("click", (event) => { const button = event.target.closest("[data-edit-package]"); if (button) openPackageModal(button.dataset.editPackage); });
+  el("package_catalog_list").addEventListener("click", (event) => { const button = event.target.closest("[data-edit-bundle]"); if (button) openBundleModal(button.dataset.editBundle); });
 }
 
 /* ---------- Review moderation ---------- */

--- a/customer-app/assets/customer-app.css
+++ b/customer-app/assets/customer-app.css
@@ -7284,6 +7284,26 @@ body.has-advisor-sheet { overflow: hidden; }
 }
 .route-page-heading ~ .page-header-mount:empty { display: none; }
 .route-page-heading ~ .page-header-mount .page-header-banner { margin-bottom: 0; }
+.route-page-heading.is-accessible-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  white-space: nowrap;
+  border: 0;
+}
+.booking-ticket-handoff {
+  margin-top: 16px;
+  padding: 14px;
+  border: 1px solid var(--line, #d8dee8);
+  border-radius: 14px;
+}
+.booking-ticket-handoff .button-row > button,
+.booking-ticket-handoff .button-row > a { min-height: 44px; }
+.booking-ticket-handoff textarea { width: 100%; margin-top: 8px; }
 .profile-slot-icon { display: inline-flex; margin: 0 0 8px; color: var(--blue); }
 [data-cwf-action-icon] { display: inline-flex; margin-right: 6px; vertical-align: middle; }
 
@@ -7319,3 +7339,23 @@ body.has-advisor-sheet { overflow: hidden; }
 .store-bundle-row label { display: grid; gap: 5px; font-size: 13px; }
 .store-bundle-live-total { margin-top: 14px; font-weight: 700; }
 @media (max-width: 480px) { .store-bundle-row { grid-template-columns: 1fr 1fr; } .store-bundle-row > div { grid-column: 1 / -1; } }
+
+/* Catalog-configured promotion presentation: bounded server presets only. */
+.store-campaign-presentation { display:flex; flex-wrap:wrap; align-items:center; gap:8px; padding:10px 14px 0; }
+.store-campaign-badge { display:inline-flex; min-height:28px; align-items:center; padding:4px 10px; border-radius:999px; background:#0d6b58; color:#fff; font-size:.78rem; font-weight:800; }
+.store-campaign-support { color:#445066; font-size:.82rem; }
+.store-campaign-countdown { color:#8b3d13; font-size:.8rem; font-weight:750; }
+.campaign-theme-premium { --campaign-accent:#b78a31; border-color:color-mix(in srgb, var(--campaign-accent) 55%, #dfe5ee); }
+.campaign-theme-limited_time { --campaign-accent:#bd4b35; border-color:color-mix(in srgb, var(--campaign-accent) 48%, #dfe5ee); }
+.campaign-theme-new { --campaign-accent:#247b68; border-color:color-mix(in srgb, var(--campaign-accent) 48%, #dfe5ee); }
+.campaign-effect-soft_glow { animation:cwf-campaign-soft-glow 2.8s ease-in-out infinite; }
+.campaign-effect-shimmer_border { background-image:linear-gradient(110deg, transparent 20%, rgba(255,255,255,.55) 45%, transparent 70%); background-size:250% 100%; animation:cwf-campaign-shimmer 4s linear infinite; }
+.campaign-effect-badge_pulse .store-campaign-badge { animation:cwf-campaign-badge-pulse 2.4s ease-in-out infinite; }
+@keyframes cwf-campaign-soft-glow { 50% { box-shadow:0 0 0 3px color-mix(in srgb, var(--campaign-accent, #2b7a68) 20%, transparent); } }
+@keyframes cwf-campaign-shimmer { to { background-position:-250% 0; } }
+@keyframes cwf-campaign-badge-pulse { 50% { opacity:.78; } }
+@media (prefers-reduced-motion: reduce) {
+  .campaign-effect-soft_glow,
+  .campaign-effect-shimmer_border,
+  .campaign-effect-badge_pulse .store-campaign-badge { animation:none !important; }
+}

--- a/customer-app/assets/customer-app.css
+++ b/customer-app/assets/customer-app.css
@@ -7352,6 +7352,7 @@ body.has-advisor-sheet { overflow: hidden; }
 
 /* Catalog-configured promotion presentation: bounded server presets only. */
 .store-campaign-presentation { display:flex; flex-wrap:wrap; align-items:center; gap:8px; padding:10px 14px 0; }
+.store-campaign-presentation.is-expiry-sentinel { display:none; padding:0; }
 .store-campaign-badge { display:inline-flex; min-height:28px; align-items:center; padding:4px 10px; border-radius:999px; background:#0d6b58; color:#fff; font-size:.78rem; font-weight:800; }
 .store-campaign-support { color:#445066; font-size:.82rem; }
 .store-campaign-countdown { color:#8b3d13; font-size:.8rem; font-weight:750; }

--- a/customer-app/assets/customer-app.css
+++ b/customer-app/assets/customer-app.css
@@ -7282,9 +7282,10 @@ body.has-advisor-sheet { overflow: hidden; }
 .booking-wizard-page > .route-page-heading {
   margin: 0;
 }
-.route-page-heading ~ .page-header-mount:empty { display: none; }
-.route-page-heading ~ .page-header-mount .page-header-banner { margin-bottom: 0; }
-.route-page-heading.is-accessible-only {
+.page-header-mount:empty { display: none; }
+.route-page-heading ~ .page-header-mount .page-header-banner,
+.route-accessible-page-name ~ .page-header-mount .page-header-banner { margin-bottom: 0; }
+.route-accessible-page-name {
   position: absolute;
   width: 1px;
   height: 1px;
@@ -7294,6 +7295,7 @@ body.has-advisor-sheet { overflow: hidden; }
   clip: rect(0 0 0 0);
   white-space: nowrap;
   border: 0;
+  animation: none !important;
 }
 .booking-ticket-handoff {
   margin-top: 16px;

--- a/customer-app/assets/customer-app.css
+++ b/customer-app/assets/customer-app.css
@@ -7306,6 +7306,14 @@ body.has-advisor-sheet { overflow: hidden; }
 .booking-ticket-handoff .button-row > button,
 .booking-ticket-handoff .button-row > a { min-height: 44px; }
 .booking-ticket-handoff textarea { width: 100%; margin-top: 8px; }
+@media (max-width: 390px) {
+  .booking-ticket-handoff { padding: 12px; }
+  .booking-ticket-handoff .button-row > button,
+  .booking-ticket-handoff .button-row > a { width: 100%; }
+}
+@media (max-width: 360px) {
+  .booking-ticket-handoff { padding-inline: 10px; overflow-wrap: anywhere; }
+}
 .profile-slot-icon { display: inline-flex; margin: 0 0 8px; color: var(--blue); }
 [data-cwf-action-icon] { display: inline-flex; margin-right: 6px; vertical-align: middle; }
 

--- a/customer-app/assets/customer-app.css
+++ b/customer-app/assets/customer-app.css
@@ -7312,3 +7312,10 @@ body.has-advisor-sheet { overflow: hidden; }
 .has-package-selection .ordinary-service-controls,
 .has-package-selection [data-action="add-line"],
 .has-package-selection .service-line-review-list { display: none; }
+.store-bundle-config { margin: 16px 0; padding: 16px; border: 1px solid var(--line, #dfe6ee); border-radius: 16px; background: #fff; }
+.store-bundle-config h3 { margin: 0 0 4px; }
+.store-bundle-row { display: grid; grid-template-columns: minmax(140px, 1fr) minmax(120px, .7fr) minmax(110px, .55fr); gap: 12px; align-items: end; padding: 14px 0; border-bottom: 1px solid var(--line, #e5e7eb); }
+.store-bundle-row > div { display: grid; gap: 4px; }
+.store-bundle-row label { display: grid; gap: 5px; font-size: 13px; }
+.store-bundle-live-total { margin-top: 14px; font-weight: 700; }
+@media (max-width: 480px) { .store-bundle-row { grid-template-columns: 1fr 1fr; } .store-bundle-row > div { grid-column: 1 / -1; } }

--- a/customer-app/assets/customer-app.css
+++ b/customer-app/assets/customer-app.css
@@ -7345,6 +7345,11 @@ body.has-advisor-sheet { overflow: hidden; }
 .store-campaign-badge { display:inline-flex; min-height:28px; align-items:center; padding:4px 10px; border-radius:999px; background:#0d6b58; color:#fff; font-size:.78rem; font-weight:800; }
 .store-campaign-support { color:#445066; font-size:.82rem; }
 .store-campaign-countdown { color:#8b3d13; font-size:.8rem; font-weight:750; }
+.homepage-service-card .store-campaign-presentation { padding:8px 10px 0; align-content:flex-start; }
+.homepage-service-card .store-campaign-support { flex-basis:100%; }
+.homepage-service-action,
+.store-card-actions button,
+.store-detail-actions button { min-height:44px; }
 .campaign-theme-premium { --campaign-accent:#b78a31; border-color:color-mix(in srgb, var(--campaign-accent) 55%, #dfe5ee); }
 .campaign-theme-limited_time { --campaign-accent:#bd4b35; border-color:color-mix(in srgb, var(--campaign-accent) 48%, #dfe5ee); }
 .campaign-theme-new { --campaign-accent:#247b68; border-color:color-mix(in srgb, var(--campaign-accent) 48%, #dfe5ee); }
@@ -7358,4 +7363,16 @@ body.has-advisor-sheet { overflow: hidden; }
   .campaign-effect-soft_glow,
   .campaign-effect-shimmer_border,
   .campaign-effect-badge_pulse .store-campaign-badge { animation:none !important; }
+}
+@media (max-width: 390px) {
+  .store-campaign-presentation { gap:6px; padding-inline:10px; }
+  .store-campaign-badge { max-width:100%; white-space:normal; text-align:left; }
+  .store-campaign-support,
+  .store-campaign-countdown { flex-basis:100%; overflow-wrap:anywhere; }
+}
+@media (max-width: 360px) {
+  .store-campaign-presentation { padding-inline:8px; }
+  .store-campaign-badge,
+  .store-campaign-support,
+  .store-campaign-countdown { font-size:.76rem; }
 }

--- a/customer-app/assets/customer-app.js
+++ b/customer-app/assets/customer-app.js
@@ -3,7 +3,7 @@
 
   const App = window.CWFCustomerAppV2;
   const BOOT_TIMEOUT_MS = 3500;
-  const BUILD_ID = "20260809_issue267_catalog_flow_v7";
+  const BUILD_ID = "20260809_issue267_catalog_flow_v8";
 
   function withTimeout(promise, timeoutMs) {
     return Promise.race([

--- a/customer-app/assets/customer-app.js
+++ b/customer-app/assets/customer-app.js
@@ -3,7 +3,7 @@
 
   const App = window.CWFCustomerAppV2;
   const BOOT_TIMEOUT_MS = 3500;
-  const BUILD_ID = "20260809_store_service_package_bundles_v1";
+  const BUILD_ID = "20260809_issue267_admin_builder_v2";
 
   function withTimeout(promise, timeoutMs) {
     return Promise.race([

--- a/customer-app/assets/customer-app.js
+++ b/customer-app/assets/customer-app.js
@@ -3,7 +3,7 @@
 
   const App = window.CWFCustomerAppV2;
   const BOOT_TIMEOUT_MS = 3500;
-  const BUILD_ID = "20260809_issue267_merchandising_v3";
+  const BUILD_ID = "20260809_issue267_heading_cleanup_v4";
 
   function withTimeout(promise, timeoutMs) {
     return Promise.race([

--- a/customer-app/assets/customer-app.js
+++ b/customer-app/assets/customer-app.js
@@ -3,7 +3,7 @@
 
   const App = window.CWFCustomerAppV2;
   const BOOT_TIMEOUT_MS = 3500;
-  const BUILD_ID = "20260809_issue267_catalog_flow_v8";
+  const BUILD_ID = "20260809_issue267_catalog_flow_v9";
 
   function withTimeout(promise, timeoutMs) {
     return Promise.race([

--- a/customer-app/assets/customer-app.js
+++ b/customer-app/assets/customer-app.js
@@ -3,7 +3,7 @@
 
   const App = window.CWFCustomerAppV2;
   const BOOT_TIMEOUT_MS = 3500;
-  const BUILD_ID = "20260809_issue267_admin_builder_v2";
+  const BUILD_ID = "20260809_issue267_merchandising_v3";
 
   function withTimeout(promise, timeoutMs) {
     return Promise.race([

--- a/customer-app/assets/customer-app.js
+++ b/customer-app/assets/customer-app.js
@@ -3,7 +3,7 @@
 
   const App = window.CWFCustomerAppV2;
   const BOOT_TIMEOUT_MS = 3500;
-  const BUILD_ID = "20260808_homepage_service_packages_v2";
+  const BUILD_ID = "20260809_store_service_package_bundles_v1";
 
   function withTimeout(promise, timeoutMs) {
     return Promise.race([

--- a/customer-app/assets/customer-app.js
+++ b/customer-app/assets/customer-app.js
@@ -3,7 +3,7 @@
 
   const App = window.CWFCustomerAppV2;
   const BOOT_TIMEOUT_MS = 3500;
-  const BUILD_ID = "20260809_issue267_booking_ticket_v5";
+  const BUILD_ID = "20260809_issue267_catalog_flow_v6";
 
   function withTimeout(promise, timeoutMs) {
     return Promise.race([

--- a/customer-app/assets/customer-app.js
+++ b/customer-app/assets/customer-app.js
@@ -3,7 +3,7 @@
 
   const App = window.CWFCustomerAppV2;
   const BOOT_TIMEOUT_MS = 3500;
-  const BUILD_ID = "20260809_issue267_catalog_flow_v6";
+  const BUILD_ID = "20260809_issue267_catalog_flow_v7";
 
   function withTimeout(promise, timeoutMs) {
     return Promise.race([

--- a/customer-app/assets/customer-app.js
+++ b/customer-app/assets/customer-app.js
@@ -3,7 +3,7 @@
 
   const App = window.CWFCustomerAppV2;
   const BOOT_TIMEOUT_MS = 3500;
-  const BUILD_ID = "20260809_issue267_heading_cleanup_v4";
+  const BUILD_ID = "20260809_issue267_booking_ticket_v5";
 
   function withTimeout(promise, timeoutMs) {
     return Promise.race([

--- a/customer-app/index.html
+++ b/customer-app/index.html
@@ -21,10 +21,10 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Noto+Sans+Thai:wght@400;500;600;700;800;900&display=swap" media="print" onload="this.media='all'">
   <noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Noto+Sans+Thai:wght@400;500;600;700;800;900&display=swap"></noscript>
-  <link rel="manifest" href="./manifest.webmanifest?v=20260809_issue267_catalog_flow_v6">
+  <link rel="manifest" href="./manifest.webmanifest?v=20260809_issue267_catalog_flow_v7">
   <link rel="icon" type="image/png" sizes="192x192" href="./assets/icons/cwf-customer-192.png">
   <link rel="apple-touch-icon" sizes="180x180" href="./assets/icons/cwf-customer-180.png">
-  <link rel="stylesheet" href="./assets/customer-app.css?v=20260809_issue267_catalog_flow_v6">
+  <link rel="stylesheet" href="./assets/customer-app.css?v=20260809_issue267_catalog_flow_v7">
 </head>
 <body class="is-app-booting">
   <div class="app-shell" data-app-shell>
@@ -62,26 +62,26 @@
     </nav>
   </div>
 
-  <script src="./modules/iconRegistry.js?v=20260809_issue267_catalog_flow_v6"></script>
-  <script src="./modules/state.js?v=20260809_issue267_catalog_flow_v6"></script>
-  <script src="./modules/utils.js?v=20260809_issue267_catalog_flow_v6"></script>
-  <script src="./modules/customerCopy.js?v=20260809_issue267_catalog_flow_v6"></script>
-  <script src="./modules/analytics.js?v=20260809_issue267_catalog_flow_v6"></script>
-  <script src="./modules/api.js?v=20260809_issue267_catalog_flow_v6"></script>
-  <script src="./modules/pageAvailability.js?v=20260809_issue267_catalog_flow_v6"></script>
-  <script src="./modules/services.js?v=20260809_issue267_catalog_flow_v6"></script>
-  <script src="./modules/advisor.js?v=20260809_issue267_catalog_flow_v6"></script>
-  <script src="./modules/ui.js?v=20260809_issue267_catalog_flow_v6"></script>
-  <script src="./modules/store.js?v=20260809_issue267_catalog_flow_v6"></script>
-  <script src="./modules/auth.js?v=20260809_issue267_catalog_flow_v6"></script>
-  <script src="./modules/pricing.js?v=20260809_issue267_catalog_flow_v6"></script>
-  <script src="./modules/availability.js?v=20260809_issue267_catalog_flow_v6"></script>
-  <script src="./modules/bookingTicket.js?v=20260809_issue267_catalog_flow_v6"></script>
-  <script src="./modules/bookingScheduled.js?v=20260809_issue267_catalog_flow_v6"></script>
-  <script src="./modules/bookingUrgent.js?v=20260809_issue267_catalog_flow_v6"></script>
-  <script src="./modules/tracking.js?v=20260809_issue267_catalog_flow_v6"></script>
-  <script src="./modules/profile.js?v=20260809_issue267_catalog_flow_v6"></script>
-  <script src="./modules/router.js?v=20260809_issue267_catalog_flow_v6"></script>
-  <script src="./assets/customer-app.js?v=20260809_issue267_catalog_flow_v6"></script>
+  <script src="./modules/iconRegistry.js?v=20260809_issue267_catalog_flow_v7"></script>
+  <script src="./modules/state.js?v=20260809_issue267_catalog_flow_v7"></script>
+  <script src="./modules/utils.js?v=20260809_issue267_catalog_flow_v7"></script>
+  <script src="./modules/customerCopy.js?v=20260809_issue267_catalog_flow_v7"></script>
+  <script src="./modules/analytics.js?v=20260809_issue267_catalog_flow_v7"></script>
+  <script src="./modules/api.js?v=20260809_issue267_catalog_flow_v7"></script>
+  <script src="./modules/pageAvailability.js?v=20260809_issue267_catalog_flow_v7"></script>
+  <script src="./modules/services.js?v=20260809_issue267_catalog_flow_v7"></script>
+  <script src="./modules/advisor.js?v=20260809_issue267_catalog_flow_v7"></script>
+  <script src="./modules/ui.js?v=20260809_issue267_catalog_flow_v7"></script>
+  <script src="./modules/store.js?v=20260809_issue267_catalog_flow_v7"></script>
+  <script src="./modules/auth.js?v=20260809_issue267_catalog_flow_v7"></script>
+  <script src="./modules/pricing.js?v=20260809_issue267_catalog_flow_v7"></script>
+  <script src="./modules/availability.js?v=20260809_issue267_catalog_flow_v7"></script>
+  <script src="./modules/bookingTicket.js?v=20260809_issue267_catalog_flow_v7"></script>
+  <script src="./modules/bookingScheduled.js?v=20260809_issue267_catalog_flow_v7"></script>
+  <script src="./modules/bookingUrgent.js?v=20260809_issue267_catalog_flow_v7"></script>
+  <script src="./modules/tracking.js?v=20260809_issue267_catalog_flow_v7"></script>
+  <script src="./modules/profile.js?v=20260809_issue267_catalog_flow_v7"></script>
+  <script src="./modules/router.js?v=20260809_issue267_catalog_flow_v7"></script>
+  <script src="./assets/customer-app.js?v=20260809_issue267_catalog_flow_v7"></script>
 </body>
 </html>

--- a/customer-app/index.html
+++ b/customer-app/index.html
@@ -21,10 +21,10 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Noto+Sans+Thai:wght@400;500;600;700;800;900&display=swap" media="print" onload="this.media='all'">
   <noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Noto+Sans+Thai:wght@400;500;600;700;800;900&display=swap"></noscript>
-  <link rel="manifest" href="./manifest.webmanifest?v=20260809_store_service_package_bundles_v1">
+  <link rel="manifest" href="./manifest.webmanifest?v=20260809_issue267_admin_builder_v2">
   <link rel="icon" type="image/png" sizes="192x192" href="./assets/icons/cwf-customer-192.png">
   <link rel="apple-touch-icon" sizes="180x180" href="./assets/icons/cwf-customer-180.png">
-  <link rel="stylesheet" href="./assets/customer-app.css?v=20260809_store_service_package_bundles_v1">
+  <link rel="stylesheet" href="./assets/customer-app.css?v=20260809_issue267_admin_builder_v2">
 </head>
 <body class="is-app-booting">
   <div class="app-shell" data-app-shell>
@@ -62,25 +62,25 @@
     </nav>
   </div>
 
-  <script src="./modules/iconRegistry.js?v=20260809_store_service_package_bundles_v1"></script>
-  <script src="./modules/state.js?v=20260809_store_service_package_bundles_v1"></script>
-  <script src="./modules/utils.js?v=20260809_store_service_package_bundles_v1"></script>
-  <script src="./modules/customerCopy.js?v=20260809_store_service_package_bundles_v1"></script>
-  <script src="./modules/analytics.js?v=20260809_store_service_package_bundles_v1"></script>
-  <script src="./modules/api.js?v=20260809_store_service_package_bundles_v1"></script>
-  <script src="./modules/pageAvailability.js?v=20260809_store_service_package_bundles_v1"></script>
-  <script src="./modules/services.js?v=20260809_store_service_package_bundles_v1"></script>
-  <script src="./modules/advisor.js?v=20260809_store_service_package_bundles_v1"></script>
-  <script src="./modules/ui.js?v=20260809_store_service_package_bundles_v1"></script>
-  <script src="./modules/store.js?v=20260809_store_service_package_bundles_v1"></script>
-  <script src="./modules/auth.js?v=20260809_store_service_package_bundles_v1"></script>
-  <script src="./modules/pricing.js?v=20260809_store_service_package_bundles_v1"></script>
-  <script src="./modules/availability.js?v=20260809_store_service_package_bundles_v1"></script>
-  <script src="./modules/bookingScheduled.js?v=20260809_store_service_package_bundles_v1"></script>
-  <script src="./modules/bookingUrgent.js?v=20260809_store_service_package_bundles_v1"></script>
-  <script src="./modules/tracking.js?v=20260809_store_service_package_bundles_v1"></script>
-  <script src="./modules/profile.js?v=20260809_store_service_package_bundles_v1"></script>
-  <script src="./modules/router.js?v=20260809_store_service_package_bundles_v1"></script>
-  <script src="./assets/customer-app.js?v=20260809_store_service_package_bundles_v1"></script>
+  <script src="./modules/iconRegistry.js?v=20260809_issue267_admin_builder_v2"></script>
+  <script src="./modules/state.js?v=20260809_issue267_admin_builder_v2"></script>
+  <script src="./modules/utils.js?v=20260809_issue267_admin_builder_v2"></script>
+  <script src="./modules/customerCopy.js?v=20260809_issue267_admin_builder_v2"></script>
+  <script src="./modules/analytics.js?v=20260809_issue267_admin_builder_v2"></script>
+  <script src="./modules/api.js?v=20260809_issue267_admin_builder_v2"></script>
+  <script src="./modules/pageAvailability.js?v=20260809_issue267_admin_builder_v2"></script>
+  <script src="./modules/services.js?v=20260809_issue267_admin_builder_v2"></script>
+  <script src="./modules/advisor.js?v=20260809_issue267_admin_builder_v2"></script>
+  <script src="./modules/ui.js?v=20260809_issue267_admin_builder_v2"></script>
+  <script src="./modules/store.js?v=20260809_issue267_admin_builder_v2"></script>
+  <script src="./modules/auth.js?v=20260809_issue267_admin_builder_v2"></script>
+  <script src="./modules/pricing.js?v=20260809_issue267_admin_builder_v2"></script>
+  <script src="./modules/availability.js?v=20260809_issue267_admin_builder_v2"></script>
+  <script src="./modules/bookingScheduled.js?v=20260809_issue267_admin_builder_v2"></script>
+  <script src="./modules/bookingUrgent.js?v=20260809_issue267_admin_builder_v2"></script>
+  <script src="./modules/tracking.js?v=20260809_issue267_admin_builder_v2"></script>
+  <script src="./modules/profile.js?v=20260809_issue267_admin_builder_v2"></script>
+  <script src="./modules/router.js?v=20260809_issue267_admin_builder_v2"></script>
+  <script src="./assets/customer-app.js?v=20260809_issue267_admin_builder_v2"></script>
 </body>
 </html>

--- a/customer-app/index.html
+++ b/customer-app/index.html
@@ -21,10 +21,10 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Noto+Sans+Thai:wght@400;500;600;700;800;900&display=swap" media="print" onload="this.media='all'">
   <noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Noto+Sans+Thai:wght@400;500;600;700;800;900&display=swap"></noscript>
-  <link rel="manifest" href="./manifest.webmanifest?v=20260809_issue267_booking_ticket_v5">
+  <link rel="manifest" href="./manifest.webmanifest?v=20260809_issue267_catalog_flow_v6">
   <link rel="icon" type="image/png" sizes="192x192" href="./assets/icons/cwf-customer-192.png">
   <link rel="apple-touch-icon" sizes="180x180" href="./assets/icons/cwf-customer-180.png">
-  <link rel="stylesheet" href="./assets/customer-app.css?v=20260809_issue267_booking_ticket_v5">
+  <link rel="stylesheet" href="./assets/customer-app.css?v=20260809_issue267_catalog_flow_v6">
 </head>
 <body class="is-app-booting">
   <div class="app-shell" data-app-shell>
@@ -62,26 +62,26 @@
     </nav>
   </div>
 
-  <script src="./modules/iconRegistry.js?v=20260809_issue267_booking_ticket_v5"></script>
-  <script src="./modules/state.js?v=20260809_issue267_booking_ticket_v5"></script>
-  <script src="./modules/utils.js?v=20260809_issue267_booking_ticket_v5"></script>
-  <script src="./modules/customerCopy.js?v=20260809_issue267_booking_ticket_v5"></script>
-  <script src="./modules/analytics.js?v=20260809_issue267_booking_ticket_v5"></script>
-  <script src="./modules/api.js?v=20260809_issue267_booking_ticket_v5"></script>
-  <script src="./modules/pageAvailability.js?v=20260809_issue267_booking_ticket_v5"></script>
-  <script src="./modules/services.js?v=20260809_issue267_booking_ticket_v5"></script>
-  <script src="./modules/advisor.js?v=20260809_issue267_booking_ticket_v5"></script>
-  <script src="./modules/ui.js?v=20260809_issue267_booking_ticket_v5"></script>
-  <script src="./modules/store.js?v=20260809_issue267_booking_ticket_v5"></script>
-  <script src="./modules/auth.js?v=20260809_issue267_booking_ticket_v5"></script>
-  <script src="./modules/pricing.js?v=20260809_issue267_booking_ticket_v5"></script>
-  <script src="./modules/availability.js?v=20260809_issue267_booking_ticket_v5"></script>
-  <script src="./modules/bookingTicket.js?v=20260809_issue267_booking_ticket_v5"></script>
-  <script src="./modules/bookingScheduled.js?v=20260809_issue267_booking_ticket_v5"></script>
-  <script src="./modules/bookingUrgent.js?v=20260809_issue267_booking_ticket_v5"></script>
-  <script src="./modules/tracking.js?v=20260809_issue267_booking_ticket_v5"></script>
-  <script src="./modules/profile.js?v=20260809_issue267_booking_ticket_v5"></script>
-  <script src="./modules/router.js?v=20260809_issue267_booking_ticket_v5"></script>
-  <script src="./assets/customer-app.js?v=20260809_issue267_booking_ticket_v5"></script>
+  <script src="./modules/iconRegistry.js?v=20260809_issue267_catalog_flow_v6"></script>
+  <script src="./modules/state.js?v=20260809_issue267_catalog_flow_v6"></script>
+  <script src="./modules/utils.js?v=20260809_issue267_catalog_flow_v6"></script>
+  <script src="./modules/customerCopy.js?v=20260809_issue267_catalog_flow_v6"></script>
+  <script src="./modules/analytics.js?v=20260809_issue267_catalog_flow_v6"></script>
+  <script src="./modules/api.js?v=20260809_issue267_catalog_flow_v6"></script>
+  <script src="./modules/pageAvailability.js?v=20260809_issue267_catalog_flow_v6"></script>
+  <script src="./modules/services.js?v=20260809_issue267_catalog_flow_v6"></script>
+  <script src="./modules/advisor.js?v=20260809_issue267_catalog_flow_v6"></script>
+  <script src="./modules/ui.js?v=20260809_issue267_catalog_flow_v6"></script>
+  <script src="./modules/store.js?v=20260809_issue267_catalog_flow_v6"></script>
+  <script src="./modules/auth.js?v=20260809_issue267_catalog_flow_v6"></script>
+  <script src="./modules/pricing.js?v=20260809_issue267_catalog_flow_v6"></script>
+  <script src="./modules/availability.js?v=20260809_issue267_catalog_flow_v6"></script>
+  <script src="./modules/bookingTicket.js?v=20260809_issue267_catalog_flow_v6"></script>
+  <script src="./modules/bookingScheduled.js?v=20260809_issue267_catalog_flow_v6"></script>
+  <script src="./modules/bookingUrgent.js?v=20260809_issue267_catalog_flow_v6"></script>
+  <script src="./modules/tracking.js?v=20260809_issue267_catalog_flow_v6"></script>
+  <script src="./modules/profile.js?v=20260809_issue267_catalog_flow_v6"></script>
+  <script src="./modules/router.js?v=20260809_issue267_catalog_flow_v6"></script>
+  <script src="./assets/customer-app.js?v=20260809_issue267_catalog_flow_v6"></script>
 </body>
 </html>

--- a/customer-app/index.html
+++ b/customer-app/index.html
@@ -21,10 +21,10 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Noto+Sans+Thai:wght@400;500;600;700;800;900&display=swap" media="print" onload="this.media='all'">
   <noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Noto+Sans+Thai:wght@400;500;600;700;800;900&display=swap"></noscript>
-  <link rel="manifest" href="./manifest.webmanifest?v=20260809_issue267_heading_cleanup_v4">
+  <link rel="manifest" href="./manifest.webmanifest?v=20260809_issue267_booking_ticket_v5">
   <link rel="icon" type="image/png" sizes="192x192" href="./assets/icons/cwf-customer-192.png">
   <link rel="apple-touch-icon" sizes="180x180" href="./assets/icons/cwf-customer-180.png">
-  <link rel="stylesheet" href="./assets/customer-app.css?v=20260809_issue267_heading_cleanup_v4">
+  <link rel="stylesheet" href="./assets/customer-app.css?v=20260809_issue267_booking_ticket_v5">
 </head>
 <body class="is-app-booting">
   <div class="app-shell" data-app-shell>
@@ -62,25 +62,26 @@
     </nav>
   </div>
 
-  <script src="./modules/iconRegistry.js?v=20260809_issue267_heading_cleanup_v4"></script>
-  <script src="./modules/state.js?v=20260809_issue267_heading_cleanup_v4"></script>
-  <script src="./modules/utils.js?v=20260809_issue267_heading_cleanup_v4"></script>
-  <script src="./modules/customerCopy.js?v=20260809_issue267_heading_cleanup_v4"></script>
-  <script src="./modules/analytics.js?v=20260809_issue267_heading_cleanup_v4"></script>
-  <script src="./modules/api.js?v=20260809_issue267_heading_cleanup_v4"></script>
-  <script src="./modules/pageAvailability.js?v=20260809_issue267_heading_cleanup_v4"></script>
-  <script src="./modules/services.js?v=20260809_issue267_heading_cleanup_v4"></script>
-  <script src="./modules/advisor.js?v=20260809_issue267_heading_cleanup_v4"></script>
-  <script src="./modules/ui.js?v=20260809_issue267_heading_cleanup_v4"></script>
-  <script src="./modules/store.js?v=20260809_issue267_heading_cleanup_v4"></script>
-  <script src="./modules/auth.js?v=20260809_issue267_heading_cleanup_v4"></script>
-  <script src="./modules/pricing.js?v=20260809_issue267_heading_cleanup_v4"></script>
-  <script src="./modules/availability.js?v=20260809_issue267_heading_cleanup_v4"></script>
-  <script src="./modules/bookingScheduled.js?v=20260809_issue267_heading_cleanup_v4"></script>
-  <script src="./modules/bookingUrgent.js?v=20260809_issue267_heading_cleanup_v4"></script>
-  <script src="./modules/tracking.js?v=20260809_issue267_heading_cleanup_v4"></script>
-  <script src="./modules/profile.js?v=20260809_issue267_heading_cleanup_v4"></script>
-  <script src="./modules/router.js?v=20260809_issue267_heading_cleanup_v4"></script>
-  <script src="./assets/customer-app.js?v=20260809_issue267_heading_cleanup_v4"></script>
+  <script src="./modules/iconRegistry.js?v=20260809_issue267_booking_ticket_v5"></script>
+  <script src="./modules/state.js?v=20260809_issue267_booking_ticket_v5"></script>
+  <script src="./modules/utils.js?v=20260809_issue267_booking_ticket_v5"></script>
+  <script src="./modules/customerCopy.js?v=20260809_issue267_booking_ticket_v5"></script>
+  <script src="./modules/analytics.js?v=20260809_issue267_booking_ticket_v5"></script>
+  <script src="./modules/api.js?v=20260809_issue267_booking_ticket_v5"></script>
+  <script src="./modules/pageAvailability.js?v=20260809_issue267_booking_ticket_v5"></script>
+  <script src="./modules/services.js?v=20260809_issue267_booking_ticket_v5"></script>
+  <script src="./modules/advisor.js?v=20260809_issue267_booking_ticket_v5"></script>
+  <script src="./modules/ui.js?v=20260809_issue267_booking_ticket_v5"></script>
+  <script src="./modules/store.js?v=20260809_issue267_booking_ticket_v5"></script>
+  <script src="./modules/auth.js?v=20260809_issue267_booking_ticket_v5"></script>
+  <script src="./modules/pricing.js?v=20260809_issue267_booking_ticket_v5"></script>
+  <script src="./modules/availability.js?v=20260809_issue267_booking_ticket_v5"></script>
+  <script src="./modules/bookingTicket.js?v=20260809_issue267_booking_ticket_v5"></script>
+  <script src="./modules/bookingScheduled.js?v=20260809_issue267_booking_ticket_v5"></script>
+  <script src="./modules/bookingUrgent.js?v=20260809_issue267_booking_ticket_v5"></script>
+  <script src="./modules/tracking.js?v=20260809_issue267_booking_ticket_v5"></script>
+  <script src="./modules/profile.js?v=20260809_issue267_booking_ticket_v5"></script>
+  <script src="./modules/router.js?v=20260809_issue267_booking_ticket_v5"></script>
+  <script src="./assets/customer-app.js?v=20260809_issue267_booking_ticket_v5"></script>
 </body>
 </html>

--- a/customer-app/index.html
+++ b/customer-app/index.html
@@ -21,10 +21,10 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Noto+Sans+Thai:wght@400;500;600;700;800;900&display=swap" media="print" onload="this.media='all'">
   <noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Noto+Sans+Thai:wght@400;500;600;700;800;900&display=swap"></noscript>
-  <link rel="manifest" href="./manifest.webmanifest?v=20260808_homepage_service_packages_v2">
+  <link rel="manifest" href="./manifest.webmanifest?v=20260809_store_service_package_bundles_v1">
   <link rel="icon" type="image/png" sizes="192x192" href="./assets/icons/cwf-customer-192.png">
   <link rel="apple-touch-icon" sizes="180x180" href="./assets/icons/cwf-customer-180.png">
-  <link rel="stylesheet" href="./assets/customer-app.css?v=20260808_homepage_service_packages_v2">
+  <link rel="stylesheet" href="./assets/customer-app.css?v=20260809_store_service_package_bundles_v1">
 </head>
 <body class="is-app-booting">
   <div class="app-shell" data-app-shell>
@@ -62,25 +62,25 @@
     </nav>
   </div>
 
-  <script src="./modules/iconRegistry.js?v=20260808_homepage_service_packages_v2"></script>
-  <script src="./modules/state.js?v=20260808_homepage_service_packages_v2"></script>
-  <script src="./modules/utils.js?v=20260808_homepage_service_packages_v2"></script>
-  <script src="./modules/customerCopy.js?v=20260808_homepage_service_packages_v2"></script>
-  <script src="./modules/analytics.js?v=20260808_homepage_service_packages_v2"></script>
-  <script src="./modules/api.js?v=20260808_homepage_service_packages_v2"></script>
-  <script src="./modules/pageAvailability.js?v=20260808_homepage_service_packages_v2"></script>
-  <script src="./modules/services.js?v=20260808_homepage_service_packages_v2"></script>
-  <script src="./modules/advisor.js?v=20260808_homepage_service_packages_v2"></script>
-  <script src="./modules/ui.js?v=20260808_homepage_service_packages_v2"></script>
-  <script src="./modules/store.js?v=20260808_homepage_service_packages_v2"></script>
-  <script src="./modules/auth.js?v=20260808_homepage_service_packages_v2"></script>
-  <script src="./modules/pricing.js?v=20260808_homepage_service_packages_v2"></script>
-  <script src="./modules/availability.js?v=20260808_homepage_service_packages_v2"></script>
-  <script src="./modules/bookingScheduled.js?v=20260808_homepage_service_packages_v2"></script>
-  <script src="./modules/bookingUrgent.js?v=20260808_homepage_service_packages_v2"></script>
-  <script src="./modules/tracking.js?v=20260808_homepage_service_packages_v2"></script>
-  <script src="./modules/profile.js?v=20260808_homepage_service_packages_v2"></script>
-  <script src="./modules/router.js?v=20260808_homepage_service_packages_v2"></script>
-  <script src="./assets/customer-app.js?v=20260808_homepage_service_packages_v2"></script>
+  <script src="./modules/iconRegistry.js?v=20260809_store_service_package_bundles_v1"></script>
+  <script src="./modules/state.js?v=20260809_store_service_package_bundles_v1"></script>
+  <script src="./modules/utils.js?v=20260809_store_service_package_bundles_v1"></script>
+  <script src="./modules/customerCopy.js?v=20260809_store_service_package_bundles_v1"></script>
+  <script src="./modules/analytics.js?v=20260809_store_service_package_bundles_v1"></script>
+  <script src="./modules/api.js?v=20260809_store_service_package_bundles_v1"></script>
+  <script src="./modules/pageAvailability.js?v=20260809_store_service_package_bundles_v1"></script>
+  <script src="./modules/services.js?v=20260809_store_service_package_bundles_v1"></script>
+  <script src="./modules/advisor.js?v=20260809_store_service_package_bundles_v1"></script>
+  <script src="./modules/ui.js?v=20260809_store_service_package_bundles_v1"></script>
+  <script src="./modules/store.js?v=20260809_store_service_package_bundles_v1"></script>
+  <script src="./modules/auth.js?v=20260809_store_service_package_bundles_v1"></script>
+  <script src="./modules/pricing.js?v=20260809_store_service_package_bundles_v1"></script>
+  <script src="./modules/availability.js?v=20260809_store_service_package_bundles_v1"></script>
+  <script src="./modules/bookingScheduled.js?v=20260809_store_service_package_bundles_v1"></script>
+  <script src="./modules/bookingUrgent.js?v=20260809_store_service_package_bundles_v1"></script>
+  <script src="./modules/tracking.js?v=20260809_store_service_package_bundles_v1"></script>
+  <script src="./modules/profile.js?v=20260809_store_service_package_bundles_v1"></script>
+  <script src="./modules/router.js?v=20260809_store_service_package_bundles_v1"></script>
+  <script src="./assets/customer-app.js?v=20260809_store_service_package_bundles_v1"></script>
 </body>
 </html>

--- a/customer-app/index.html
+++ b/customer-app/index.html
@@ -21,10 +21,10 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Noto+Sans+Thai:wght@400;500;600;700;800;900&display=swap" media="print" onload="this.media='all'">
   <noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Noto+Sans+Thai:wght@400;500;600;700;800;900&display=swap"></noscript>
-  <link rel="manifest" href="./manifest.webmanifest?v=20260809_issue267_merchandising_v3">
+  <link rel="manifest" href="./manifest.webmanifest?v=20260809_issue267_heading_cleanup_v4">
   <link rel="icon" type="image/png" sizes="192x192" href="./assets/icons/cwf-customer-192.png">
   <link rel="apple-touch-icon" sizes="180x180" href="./assets/icons/cwf-customer-180.png">
-  <link rel="stylesheet" href="./assets/customer-app.css?v=20260809_issue267_merchandising_v3">
+  <link rel="stylesheet" href="./assets/customer-app.css?v=20260809_issue267_heading_cleanup_v4">
 </head>
 <body class="is-app-booting">
   <div class="app-shell" data-app-shell>
@@ -62,25 +62,25 @@
     </nav>
   </div>
 
-  <script src="./modules/iconRegistry.js?v=20260809_issue267_merchandising_v3"></script>
-  <script src="./modules/state.js?v=20260809_issue267_merchandising_v3"></script>
-  <script src="./modules/utils.js?v=20260809_issue267_merchandising_v3"></script>
-  <script src="./modules/customerCopy.js?v=20260809_issue267_merchandising_v3"></script>
-  <script src="./modules/analytics.js?v=20260809_issue267_merchandising_v3"></script>
-  <script src="./modules/api.js?v=20260809_issue267_merchandising_v3"></script>
-  <script src="./modules/pageAvailability.js?v=20260809_issue267_merchandising_v3"></script>
-  <script src="./modules/services.js?v=20260809_issue267_merchandising_v3"></script>
-  <script src="./modules/advisor.js?v=20260809_issue267_merchandising_v3"></script>
-  <script src="./modules/ui.js?v=20260809_issue267_merchandising_v3"></script>
-  <script src="./modules/store.js?v=20260809_issue267_merchandising_v3"></script>
-  <script src="./modules/auth.js?v=20260809_issue267_merchandising_v3"></script>
-  <script src="./modules/pricing.js?v=20260809_issue267_merchandising_v3"></script>
-  <script src="./modules/availability.js?v=20260809_issue267_merchandising_v3"></script>
-  <script src="./modules/bookingScheduled.js?v=20260809_issue267_merchandising_v3"></script>
-  <script src="./modules/bookingUrgent.js?v=20260809_issue267_merchandising_v3"></script>
-  <script src="./modules/tracking.js?v=20260809_issue267_merchandising_v3"></script>
-  <script src="./modules/profile.js?v=20260809_issue267_merchandising_v3"></script>
-  <script src="./modules/router.js?v=20260809_issue267_merchandising_v3"></script>
-  <script src="./assets/customer-app.js?v=20260809_issue267_merchandising_v3"></script>
+  <script src="./modules/iconRegistry.js?v=20260809_issue267_heading_cleanup_v4"></script>
+  <script src="./modules/state.js?v=20260809_issue267_heading_cleanup_v4"></script>
+  <script src="./modules/utils.js?v=20260809_issue267_heading_cleanup_v4"></script>
+  <script src="./modules/customerCopy.js?v=20260809_issue267_heading_cleanup_v4"></script>
+  <script src="./modules/analytics.js?v=20260809_issue267_heading_cleanup_v4"></script>
+  <script src="./modules/api.js?v=20260809_issue267_heading_cleanup_v4"></script>
+  <script src="./modules/pageAvailability.js?v=20260809_issue267_heading_cleanup_v4"></script>
+  <script src="./modules/services.js?v=20260809_issue267_heading_cleanup_v4"></script>
+  <script src="./modules/advisor.js?v=20260809_issue267_heading_cleanup_v4"></script>
+  <script src="./modules/ui.js?v=20260809_issue267_heading_cleanup_v4"></script>
+  <script src="./modules/store.js?v=20260809_issue267_heading_cleanup_v4"></script>
+  <script src="./modules/auth.js?v=20260809_issue267_heading_cleanup_v4"></script>
+  <script src="./modules/pricing.js?v=20260809_issue267_heading_cleanup_v4"></script>
+  <script src="./modules/availability.js?v=20260809_issue267_heading_cleanup_v4"></script>
+  <script src="./modules/bookingScheduled.js?v=20260809_issue267_heading_cleanup_v4"></script>
+  <script src="./modules/bookingUrgent.js?v=20260809_issue267_heading_cleanup_v4"></script>
+  <script src="./modules/tracking.js?v=20260809_issue267_heading_cleanup_v4"></script>
+  <script src="./modules/profile.js?v=20260809_issue267_heading_cleanup_v4"></script>
+  <script src="./modules/router.js?v=20260809_issue267_heading_cleanup_v4"></script>
+  <script src="./assets/customer-app.js?v=20260809_issue267_heading_cleanup_v4"></script>
 </body>
 </html>

--- a/customer-app/index.html
+++ b/customer-app/index.html
@@ -21,10 +21,10 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Noto+Sans+Thai:wght@400;500;600;700;800;900&display=swap" media="print" onload="this.media='all'">
   <noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Noto+Sans+Thai:wght@400;500;600;700;800;900&display=swap"></noscript>
-  <link rel="manifest" href="./manifest.webmanifest?v=20260809_issue267_admin_builder_v2">
+  <link rel="manifest" href="./manifest.webmanifest?v=20260809_issue267_merchandising_v3">
   <link rel="icon" type="image/png" sizes="192x192" href="./assets/icons/cwf-customer-192.png">
   <link rel="apple-touch-icon" sizes="180x180" href="./assets/icons/cwf-customer-180.png">
-  <link rel="stylesheet" href="./assets/customer-app.css?v=20260809_issue267_admin_builder_v2">
+  <link rel="stylesheet" href="./assets/customer-app.css?v=20260809_issue267_merchandising_v3">
 </head>
 <body class="is-app-booting">
   <div class="app-shell" data-app-shell>
@@ -62,25 +62,25 @@
     </nav>
   </div>
 
-  <script src="./modules/iconRegistry.js?v=20260809_issue267_admin_builder_v2"></script>
-  <script src="./modules/state.js?v=20260809_issue267_admin_builder_v2"></script>
-  <script src="./modules/utils.js?v=20260809_issue267_admin_builder_v2"></script>
-  <script src="./modules/customerCopy.js?v=20260809_issue267_admin_builder_v2"></script>
-  <script src="./modules/analytics.js?v=20260809_issue267_admin_builder_v2"></script>
-  <script src="./modules/api.js?v=20260809_issue267_admin_builder_v2"></script>
-  <script src="./modules/pageAvailability.js?v=20260809_issue267_admin_builder_v2"></script>
-  <script src="./modules/services.js?v=20260809_issue267_admin_builder_v2"></script>
-  <script src="./modules/advisor.js?v=20260809_issue267_admin_builder_v2"></script>
-  <script src="./modules/ui.js?v=20260809_issue267_admin_builder_v2"></script>
-  <script src="./modules/store.js?v=20260809_issue267_admin_builder_v2"></script>
-  <script src="./modules/auth.js?v=20260809_issue267_admin_builder_v2"></script>
-  <script src="./modules/pricing.js?v=20260809_issue267_admin_builder_v2"></script>
-  <script src="./modules/availability.js?v=20260809_issue267_admin_builder_v2"></script>
-  <script src="./modules/bookingScheduled.js?v=20260809_issue267_admin_builder_v2"></script>
-  <script src="./modules/bookingUrgent.js?v=20260809_issue267_admin_builder_v2"></script>
-  <script src="./modules/tracking.js?v=20260809_issue267_admin_builder_v2"></script>
-  <script src="./modules/profile.js?v=20260809_issue267_admin_builder_v2"></script>
-  <script src="./modules/router.js?v=20260809_issue267_admin_builder_v2"></script>
-  <script src="./assets/customer-app.js?v=20260809_issue267_admin_builder_v2"></script>
+  <script src="./modules/iconRegistry.js?v=20260809_issue267_merchandising_v3"></script>
+  <script src="./modules/state.js?v=20260809_issue267_merchandising_v3"></script>
+  <script src="./modules/utils.js?v=20260809_issue267_merchandising_v3"></script>
+  <script src="./modules/customerCopy.js?v=20260809_issue267_merchandising_v3"></script>
+  <script src="./modules/analytics.js?v=20260809_issue267_merchandising_v3"></script>
+  <script src="./modules/api.js?v=20260809_issue267_merchandising_v3"></script>
+  <script src="./modules/pageAvailability.js?v=20260809_issue267_merchandising_v3"></script>
+  <script src="./modules/services.js?v=20260809_issue267_merchandising_v3"></script>
+  <script src="./modules/advisor.js?v=20260809_issue267_merchandising_v3"></script>
+  <script src="./modules/ui.js?v=20260809_issue267_merchandising_v3"></script>
+  <script src="./modules/store.js?v=20260809_issue267_merchandising_v3"></script>
+  <script src="./modules/auth.js?v=20260809_issue267_merchandising_v3"></script>
+  <script src="./modules/pricing.js?v=20260809_issue267_merchandising_v3"></script>
+  <script src="./modules/availability.js?v=20260809_issue267_merchandising_v3"></script>
+  <script src="./modules/bookingScheduled.js?v=20260809_issue267_merchandising_v3"></script>
+  <script src="./modules/bookingUrgent.js?v=20260809_issue267_merchandising_v3"></script>
+  <script src="./modules/tracking.js?v=20260809_issue267_merchandising_v3"></script>
+  <script src="./modules/profile.js?v=20260809_issue267_merchandising_v3"></script>
+  <script src="./modules/router.js?v=20260809_issue267_merchandising_v3"></script>
+  <script src="./assets/customer-app.js?v=20260809_issue267_merchandising_v3"></script>
 </body>
 </html>

--- a/customer-app/index.html
+++ b/customer-app/index.html
@@ -21,10 +21,10 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Noto+Sans+Thai:wght@400;500;600;700;800;900&display=swap" media="print" onload="this.media='all'">
   <noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Noto+Sans+Thai:wght@400;500;600;700;800;900&display=swap"></noscript>
-  <link rel="manifest" href="./manifest.webmanifest?v=20260809_issue267_catalog_flow_v8">
+  <link rel="manifest" href="./manifest.webmanifest?v=20260809_issue267_catalog_flow_v9">
   <link rel="icon" type="image/png" sizes="192x192" href="./assets/icons/cwf-customer-192.png">
   <link rel="apple-touch-icon" sizes="180x180" href="./assets/icons/cwf-customer-180.png">
-  <link rel="stylesheet" href="./assets/customer-app.css?v=20260809_issue267_catalog_flow_v8">
+  <link rel="stylesheet" href="./assets/customer-app.css?v=20260809_issue267_catalog_flow_v9">
 </head>
 <body class="is-app-booting">
   <div class="app-shell" data-app-shell>
@@ -62,26 +62,26 @@
     </nav>
   </div>
 
-  <script src="./modules/iconRegistry.js?v=20260809_issue267_catalog_flow_v8"></script>
-  <script src="./modules/state.js?v=20260809_issue267_catalog_flow_v8"></script>
-  <script src="./modules/utils.js?v=20260809_issue267_catalog_flow_v8"></script>
-  <script src="./modules/customerCopy.js?v=20260809_issue267_catalog_flow_v8"></script>
-  <script src="./modules/analytics.js?v=20260809_issue267_catalog_flow_v8"></script>
-  <script src="./modules/api.js?v=20260809_issue267_catalog_flow_v8"></script>
-  <script src="./modules/pageAvailability.js?v=20260809_issue267_catalog_flow_v8"></script>
-  <script src="./modules/services.js?v=20260809_issue267_catalog_flow_v8"></script>
-  <script src="./modules/advisor.js?v=20260809_issue267_catalog_flow_v8"></script>
-  <script src="./modules/ui.js?v=20260809_issue267_catalog_flow_v8"></script>
-  <script src="./modules/store.js?v=20260809_issue267_catalog_flow_v8"></script>
-  <script src="./modules/auth.js?v=20260809_issue267_catalog_flow_v8"></script>
-  <script src="./modules/pricing.js?v=20260809_issue267_catalog_flow_v8"></script>
-  <script src="./modules/availability.js?v=20260809_issue267_catalog_flow_v8"></script>
-  <script src="./modules/bookingTicket.js?v=20260809_issue267_catalog_flow_v8"></script>
-  <script src="./modules/bookingScheduled.js?v=20260809_issue267_catalog_flow_v8"></script>
-  <script src="./modules/bookingUrgent.js?v=20260809_issue267_catalog_flow_v8"></script>
-  <script src="./modules/tracking.js?v=20260809_issue267_catalog_flow_v8"></script>
-  <script src="./modules/profile.js?v=20260809_issue267_catalog_flow_v8"></script>
-  <script src="./modules/router.js?v=20260809_issue267_catalog_flow_v8"></script>
-  <script src="./assets/customer-app.js?v=20260809_issue267_catalog_flow_v8"></script>
+  <script src="./modules/iconRegistry.js?v=20260809_issue267_catalog_flow_v9"></script>
+  <script src="./modules/state.js?v=20260809_issue267_catalog_flow_v9"></script>
+  <script src="./modules/utils.js?v=20260809_issue267_catalog_flow_v9"></script>
+  <script src="./modules/customerCopy.js?v=20260809_issue267_catalog_flow_v9"></script>
+  <script src="./modules/analytics.js?v=20260809_issue267_catalog_flow_v9"></script>
+  <script src="./modules/api.js?v=20260809_issue267_catalog_flow_v9"></script>
+  <script src="./modules/pageAvailability.js?v=20260809_issue267_catalog_flow_v9"></script>
+  <script src="./modules/services.js?v=20260809_issue267_catalog_flow_v9"></script>
+  <script src="./modules/advisor.js?v=20260809_issue267_catalog_flow_v9"></script>
+  <script src="./modules/ui.js?v=20260809_issue267_catalog_flow_v9"></script>
+  <script src="./modules/store.js?v=20260809_issue267_catalog_flow_v9"></script>
+  <script src="./modules/auth.js?v=20260809_issue267_catalog_flow_v9"></script>
+  <script src="./modules/pricing.js?v=20260809_issue267_catalog_flow_v9"></script>
+  <script src="./modules/availability.js?v=20260809_issue267_catalog_flow_v9"></script>
+  <script src="./modules/bookingTicket.js?v=20260809_issue267_catalog_flow_v9"></script>
+  <script src="./modules/bookingScheduled.js?v=20260809_issue267_catalog_flow_v9"></script>
+  <script src="./modules/bookingUrgent.js?v=20260809_issue267_catalog_flow_v9"></script>
+  <script src="./modules/tracking.js?v=20260809_issue267_catalog_flow_v9"></script>
+  <script src="./modules/profile.js?v=20260809_issue267_catalog_flow_v9"></script>
+  <script src="./modules/router.js?v=20260809_issue267_catalog_flow_v9"></script>
+  <script src="./assets/customer-app.js?v=20260809_issue267_catalog_flow_v9"></script>
 </body>
 </html>

--- a/customer-app/index.html
+++ b/customer-app/index.html
@@ -21,10 +21,10 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Noto+Sans+Thai:wght@400;500;600;700;800;900&display=swap" media="print" onload="this.media='all'">
   <noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Noto+Sans+Thai:wght@400;500;600;700;800;900&display=swap"></noscript>
-  <link rel="manifest" href="./manifest.webmanifest?v=20260809_issue267_catalog_flow_v7">
+  <link rel="manifest" href="./manifest.webmanifest?v=20260809_issue267_catalog_flow_v8">
   <link rel="icon" type="image/png" sizes="192x192" href="./assets/icons/cwf-customer-192.png">
   <link rel="apple-touch-icon" sizes="180x180" href="./assets/icons/cwf-customer-180.png">
-  <link rel="stylesheet" href="./assets/customer-app.css?v=20260809_issue267_catalog_flow_v7">
+  <link rel="stylesheet" href="./assets/customer-app.css?v=20260809_issue267_catalog_flow_v8">
 </head>
 <body class="is-app-booting">
   <div class="app-shell" data-app-shell>
@@ -62,26 +62,26 @@
     </nav>
   </div>
 
-  <script src="./modules/iconRegistry.js?v=20260809_issue267_catalog_flow_v7"></script>
-  <script src="./modules/state.js?v=20260809_issue267_catalog_flow_v7"></script>
-  <script src="./modules/utils.js?v=20260809_issue267_catalog_flow_v7"></script>
-  <script src="./modules/customerCopy.js?v=20260809_issue267_catalog_flow_v7"></script>
-  <script src="./modules/analytics.js?v=20260809_issue267_catalog_flow_v7"></script>
-  <script src="./modules/api.js?v=20260809_issue267_catalog_flow_v7"></script>
-  <script src="./modules/pageAvailability.js?v=20260809_issue267_catalog_flow_v7"></script>
-  <script src="./modules/services.js?v=20260809_issue267_catalog_flow_v7"></script>
-  <script src="./modules/advisor.js?v=20260809_issue267_catalog_flow_v7"></script>
-  <script src="./modules/ui.js?v=20260809_issue267_catalog_flow_v7"></script>
-  <script src="./modules/store.js?v=20260809_issue267_catalog_flow_v7"></script>
-  <script src="./modules/auth.js?v=20260809_issue267_catalog_flow_v7"></script>
-  <script src="./modules/pricing.js?v=20260809_issue267_catalog_flow_v7"></script>
-  <script src="./modules/availability.js?v=20260809_issue267_catalog_flow_v7"></script>
-  <script src="./modules/bookingTicket.js?v=20260809_issue267_catalog_flow_v7"></script>
-  <script src="./modules/bookingScheduled.js?v=20260809_issue267_catalog_flow_v7"></script>
-  <script src="./modules/bookingUrgent.js?v=20260809_issue267_catalog_flow_v7"></script>
-  <script src="./modules/tracking.js?v=20260809_issue267_catalog_flow_v7"></script>
-  <script src="./modules/profile.js?v=20260809_issue267_catalog_flow_v7"></script>
-  <script src="./modules/router.js?v=20260809_issue267_catalog_flow_v7"></script>
-  <script src="./assets/customer-app.js?v=20260809_issue267_catalog_flow_v7"></script>
+  <script src="./modules/iconRegistry.js?v=20260809_issue267_catalog_flow_v8"></script>
+  <script src="./modules/state.js?v=20260809_issue267_catalog_flow_v8"></script>
+  <script src="./modules/utils.js?v=20260809_issue267_catalog_flow_v8"></script>
+  <script src="./modules/customerCopy.js?v=20260809_issue267_catalog_flow_v8"></script>
+  <script src="./modules/analytics.js?v=20260809_issue267_catalog_flow_v8"></script>
+  <script src="./modules/api.js?v=20260809_issue267_catalog_flow_v8"></script>
+  <script src="./modules/pageAvailability.js?v=20260809_issue267_catalog_flow_v8"></script>
+  <script src="./modules/services.js?v=20260809_issue267_catalog_flow_v8"></script>
+  <script src="./modules/advisor.js?v=20260809_issue267_catalog_flow_v8"></script>
+  <script src="./modules/ui.js?v=20260809_issue267_catalog_flow_v8"></script>
+  <script src="./modules/store.js?v=20260809_issue267_catalog_flow_v8"></script>
+  <script src="./modules/auth.js?v=20260809_issue267_catalog_flow_v8"></script>
+  <script src="./modules/pricing.js?v=20260809_issue267_catalog_flow_v8"></script>
+  <script src="./modules/availability.js?v=20260809_issue267_catalog_flow_v8"></script>
+  <script src="./modules/bookingTicket.js?v=20260809_issue267_catalog_flow_v8"></script>
+  <script src="./modules/bookingScheduled.js?v=20260809_issue267_catalog_flow_v8"></script>
+  <script src="./modules/bookingUrgent.js?v=20260809_issue267_catalog_flow_v8"></script>
+  <script src="./modules/tracking.js?v=20260809_issue267_catalog_flow_v8"></script>
+  <script src="./modules/profile.js?v=20260809_issue267_catalog_flow_v8"></script>
+  <script src="./modules/router.js?v=20260809_issue267_catalog_flow_v8"></script>
+  <script src="./assets/customer-app.js?v=20260809_issue267_catalog_flow_v8"></script>
 </body>
 </html>

--- a/customer-app/manifest.webmanifest
+++ b/customer-app/manifest.webmanifest
@@ -2,7 +2,7 @@
   "name": "CWF Customer Service",
   "short_name": "CWF Service",
   "description": "แอปลูกค้า Coldwindflow สำหรับเลือกบริการ จองคิว และติดตามงาน",
-  "start_url": "/customer-app/index.html?v=20260809_issue267_booking_ticket_v5#home",
+  "start_url": "/customer-app/index.html?v=20260809_issue267_catalog_flow_v6#home",
   "scope": "/customer-app/",
   "id": "/customer-app/",
   "display": "standalone",

--- a/customer-app/manifest.webmanifest
+++ b/customer-app/manifest.webmanifest
@@ -2,7 +2,7 @@
   "name": "CWF Customer Service",
   "short_name": "CWF Service",
   "description": "แอปลูกค้า Coldwindflow สำหรับเลือกบริการ จองคิว และติดตามงาน",
-  "start_url": "/customer-app/index.html?v=20260808_homepage_service_packages_v2#home",
+  "start_url": "/customer-app/index.html?v=20260809_store_service_package_bundles_v1#home",
   "scope": "/customer-app/",
   "id": "/customer-app/",
   "display": "standalone",

--- a/customer-app/manifest.webmanifest
+++ b/customer-app/manifest.webmanifest
@@ -2,7 +2,7 @@
   "name": "CWF Customer Service",
   "short_name": "CWF Service",
   "description": "แอปลูกค้า Coldwindflow สำหรับเลือกบริการ จองคิว และติดตามงาน",
-  "start_url": "/customer-app/index.html?v=20260809_issue267_merchandising_v3#home",
+  "start_url": "/customer-app/index.html?v=20260809_issue267_heading_cleanup_v4#home",
   "scope": "/customer-app/",
   "id": "/customer-app/",
   "display": "standalone",

--- a/customer-app/manifest.webmanifest
+++ b/customer-app/manifest.webmanifest
@@ -2,7 +2,7 @@
   "name": "CWF Customer Service",
   "short_name": "CWF Service",
   "description": "แอปลูกค้า Coldwindflow สำหรับเลือกบริการ จองคิว และติดตามงาน",
-  "start_url": "/customer-app/index.html?v=20260809_store_service_package_bundles_v1#home",
+  "start_url": "/customer-app/index.html?v=20260809_issue267_admin_builder_v2#home",
   "scope": "/customer-app/",
   "id": "/customer-app/",
   "display": "standalone",

--- a/customer-app/manifest.webmanifest
+++ b/customer-app/manifest.webmanifest
@@ -2,7 +2,7 @@
   "name": "CWF Customer Service",
   "short_name": "CWF Service",
   "description": "แอปลูกค้า Coldwindflow สำหรับเลือกบริการ จองคิว และติดตามงาน",
-  "start_url": "/customer-app/index.html?v=20260809_issue267_admin_builder_v2#home",
+  "start_url": "/customer-app/index.html?v=20260809_issue267_merchandising_v3#home",
   "scope": "/customer-app/",
   "id": "/customer-app/",
   "display": "standalone",

--- a/customer-app/manifest.webmanifest
+++ b/customer-app/manifest.webmanifest
@@ -2,7 +2,7 @@
   "name": "CWF Customer Service",
   "short_name": "CWF Service",
   "description": "แอปลูกค้า Coldwindflow สำหรับเลือกบริการ จองคิว และติดตามงาน",
-  "start_url": "/customer-app/index.html?v=20260809_issue267_catalog_flow_v7#home",
+  "start_url": "/customer-app/index.html?v=20260809_issue267_catalog_flow_v8#home",
   "scope": "/customer-app/",
   "id": "/customer-app/",
   "display": "standalone",

--- a/customer-app/manifest.webmanifest
+++ b/customer-app/manifest.webmanifest
@@ -2,7 +2,7 @@
   "name": "CWF Customer Service",
   "short_name": "CWF Service",
   "description": "แอปลูกค้า Coldwindflow สำหรับเลือกบริการ จองคิว และติดตามงาน",
-  "start_url": "/customer-app/index.html?v=20260809_issue267_heading_cleanup_v4#home",
+  "start_url": "/customer-app/index.html?v=20260809_issue267_booking_ticket_v5#home",
   "scope": "/customer-app/",
   "id": "/customer-app/",
   "display": "standalone",

--- a/customer-app/manifest.webmanifest
+++ b/customer-app/manifest.webmanifest
@@ -2,7 +2,7 @@
   "name": "CWF Customer Service",
   "short_name": "CWF Service",
   "description": "แอปลูกค้า Coldwindflow สำหรับเลือกบริการ จองคิว และติดตามงาน",
-  "start_url": "/customer-app/index.html?v=20260809_issue267_catalog_flow_v8#home",
+  "start_url": "/customer-app/index.html?v=20260809_issue267_catalog_flow_v9#home",
   "scope": "/customer-app/",
   "id": "/customer-app/",
   "display": "standalone",

--- a/customer-app/manifest.webmanifest
+++ b/customer-app/manifest.webmanifest
@@ -2,7 +2,7 @@
   "name": "CWF Customer Service",
   "short_name": "CWF Service",
   "description": "แอปลูกค้า Coldwindflow สำหรับเลือกบริการ จองคิว และติดตามงาน",
-  "start_url": "/customer-app/index.html?v=20260809_issue267_catalog_flow_v6#home",
+  "start_url": "/customer-app/index.html?v=20260809_issue267_catalog_flow_v7#home",
   "scope": "/customer-app/",
   "id": "/customer-app/",
   "display": "standalone",

--- a/customer-app/modules/api.js
+++ b/customer-app/modules/api.js
@@ -108,6 +108,14 @@
       });
     },
 
+    async quoteCatalogBooking(payload) {
+      return requestJson("/public/catalog-booking-quote", {
+        method: "POST",
+        body: payload || {},
+        cache: "no-store",
+      });
+    },
+
     async loadServicePackages() {
       return requestJson("/public/service-packages", { cache: "no-store" });
     },

--- a/customer-app/modules/bookingScheduled.js
+++ b/customer-app/modules/bookingScheduled.js
@@ -931,8 +931,10 @@
       catalog_item_id: catalogItemId,
     };
     if (hasPackageSelection()) {
+      if (hasCompositeSelection()) return { ...common,
+        ...(Number.isSafeInteger(Number(d.catalog_item_id)) && Number(d.catalog_item_id) > 0 ? { catalog_item_id: Number(d.catalog_item_id) } : {}),
+        service_package_groups: draft().service_package_groups.map((group) => ({ package_key: group.package_key, btu: Number(group.btu), quantity: Number(group.quantity) })) };
       delete common.catalog_item_id;
-      if (hasCompositeSelection()) return { ...common, service_package_groups: draft().service_package_groups.map((group) => ({ package_key: group.package_key, btu: Number(group.btu), quantity: Number(group.quantity) })) };
       return {
         ...common,
         service_package_key: String(d.service_package_key).trim(),

--- a/customer-app/modules/bookingScheduled.js
+++ b/customer-app/modules/bookingScheduled.js
@@ -22,11 +22,15 @@
   }
 
   function hasPackageSelection() {
-    return Boolean(String(draft().service_package_key || "").trim() && String(draft().service_package_tier_key || "").trim());
+    return hasCompositeSelection() || Boolean(String(draft().service_package_key || "").trim() && String(draft().service_package_tier_key || "").trim());
+  }
+
+  function hasCompositeSelection() {
+    return Array.isArray(draft().service_package_groups) && draft().service_package_groups.length > 0;
   }
 
   function packagePreview() {
-    return root.state.scheduledPreview.package?.data || null;
+    return draft().service_package_bundle_preview || root.state.scheduledPreview.package?.data || null;
   }
 
   function packageBtuOptions(preview = packagePreview()) {
@@ -53,6 +57,7 @@
   function payloadFromDraft() {
     if (hasPackageSelection()) {
       const preview = packagePreview();
+      if (hasCompositeSelection()) return preview?.payload || null;
       if (!preview || !packageBtuIsValid(preview)) return null;
       const constraints = preview.service?.constraints || {};
       return {
@@ -339,7 +344,8 @@
   }
 
   function clearPackageSelection() {
-    root.state.updateDraft("scheduled", { service_package_key: "", service_package_tier_key: "", service_package_btu: "", service_package_preview: null, scheduled_request_key: "" });
+    root.state.updateDraft("scheduled", { service_package_key: "", service_package_tier_key: "", service_package_btu: "", service_package_preview: null,
+      service_package_groups: [], service_package_bundle_preview: null, scheduled_request_key: "" });
     root.state.setScheduledPreview("package", { status: "idle", data: null, error: "", verified: false });
     clearPriceCalendarSlots();
   }
@@ -394,6 +400,10 @@
   function renderSelectedPackage() {
     const preview = packagePreview();
     if (!hasPackageSelection() || !preview) return "";
+    if (hasCompositeSelection()) {
+      const groups = Array.isArray(preview.groups) ? preview.groups : [];
+      return `<div class="selected-package-summary"><strong>${root.utils.escapeHtml(preview.package_name || "แพ็กเกจบริการ")}</strong>${groups.map((group) => `<span>${root.utils.escapeHtml(group.package_name || group.package_key)} · ${root.utils.escapeHtml(String(group.btu))} BTU · ${root.utils.escapeHtml(String(group.quantity))} เครื่อง</span>`).join("")}<span>ยอดรวม ${root.utils.escapeHtml(String(preview.fixed_total_price))} บาท · ${root.utils.escapeHtml(String(preview.duration_min))} นาที</span>${preview.redeem_until ? `<small>เลือกวันใช้บริการได้ถึง ${root.utils.escapeHtml(String(preview.redeem_until).slice(0, 10))}</small>` : ""}</div>`;
+    }
     return `<div class="selected-package-summary"><strong>${root.utils.escapeHtml(preview.package_name || "แพ็กเกจบริการ")} · ${root.utils.escapeHtml(preview.tier_name || "")}</strong><span>${root.utils.escapeHtml(preview.service?.service_name || "")} · ${root.utils.escapeHtml(String(preview.quantity))} เครื่อง</span><span>ยอดรวม ${root.utils.escapeHtml(String(preview.fixed_total_price))} บาท · ${root.utils.escapeHtml(String(Number(preview.quantity) * Number(preview.unit_duration_minutes)))} นาที</span>${preview.redeem_until ? `<small>เลือกวันใช้บริการได้ถึง ${root.utils.escapeHtml(String(preview.redeem_until).slice(0, 10))}</small>` : ""}<div class="field field-wide"><label>BTU จริงของเครื่องปรับอากาศ</label>${choiceGroup("service_package_btu", packageBtuOptions(preview), draft().service_package_btu, "btu-choice-grid", "package")}</div></div>`;
   }
 
@@ -448,7 +458,8 @@
     if (hasPackageSelection()) {
       const preview = packagePreview();
       if (!preview) return root.utils.stateBox("", "กรุณาเลือกแพ็กเกจและรอการตรวจสอบ");
-      return `<div class="wizard-price-summary"><div><span>ยอดรวมแพ็กเกจ</span><strong>${root.utils.escapeHtml(String(preview.fixed_total_price))} บาท</strong></div><div><span>เวลาทำงานรวม</span><strong>${root.utils.escapeHtml(String(Number(preview.quantity) * Number(preview.unit_duration_minutes)))} นาที</strong></div></div>`;
+      const minutes = hasCompositeSelection() ? Number(preview.duration_min) : Number(preview.quantity) * Number(preview.unit_duration_minutes);
+      return `<div class="wizard-price-summary"><div><span>ยอดรวมแพ็กเกจ</span><strong>${root.utils.escapeHtml(String(preview.fixed_total_price))} บาท</strong></div><div><span>เวลาทำงานรวม</span><strong>${root.utils.escapeHtml(String(minutes))} นาที</strong></div></div>`;
     }
     const pricing = root.state.scheduledPreview.pricing;
     const data = pricing.data;
@@ -750,6 +761,9 @@
     const pricing = root.state.scheduledPreview.pricing.data || {};
     if (hasPackageSelection()) {
       const preview = packagePreview() || {};
+      if (hasCompositeSelection()) {
+        return `<div class="data-list review-data-list"><div class="data-row"><strong>แพ็กเกจ</strong><span class="muted">${root.utils.escapeHtml(preview.package_name || "-")}</span></div>${(preview.groups || []).map((group) => `<div class="data-row"><strong>${root.utils.escapeHtml(group.package_name || group.package_key)}</strong><span class="muted">${root.utils.escapeHtml(String(group.btu))} BTU · ${root.utils.escapeHtml(String(group.quantity))} เครื่อง</span></div>`).join("")}<div class="data-row"><strong>ยอดรวมคงที่</strong><span class="muted">${root.utils.escapeHtml(String(preview.fixed_total_price || "-"))} บาท</span></div><div class="data-row"><strong>ผู้ติดต่อ</strong><span class="muted">${root.utils.escapeHtml(d.customer_name || "-")} · ${root.utils.escapeHtml(d.customer_phone || "-")}</span></div><div class="data-row"><strong>ที่อยู่</strong><span class="muted">${root.utils.escapeHtml(d.address_text || "-")}</span></div><div class="data-row"><strong>วันและเวลา</strong><span class="muted">${root.utils.escapeHtml(d.date || "-")} · ${root.utils.escapeHtml(selected.start || "-")}-${root.utils.escapeHtml(selected.end || "-")} น.</span></div></div>`;
+      }
       return `<div class="data-list review-data-list">
         <div class="data-row"><strong>แพ็กเกจ</strong><span class="muted">${root.utils.escapeHtml(preview.package_name || "-")} · ${root.utils.escapeHtml(preview.tier_name || "-")}</span></div>
         <div class="data-row"><strong>บริการและจำนวน</strong><span class="muted">${root.utils.escapeHtml(preview.service?.service_name || "-")} · ${root.utils.escapeHtml(String(preview.quantity || "-"))} เครื่อง</span></div>
@@ -845,6 +859,7 @@
   function validateServiceStep() {
     if (hasPackageSelection()) {
       if (root.state.scheduledPreview.package?.verified !== true || !packagePreview()) return "กรุณารอให้ระบบตรวจสอบแพ็กเกจอีกครั้ง";
+      if (hasCompositeSelection()) return "";
       if (!packageBtuIsValid()) return "กรุณาเลือก BTU จริงที่อยู่ในช่วงของแพ็กเกจ";
       return "";
     }
@@ -903,6 +918,7 @@
     };
     if (hasPackageSelection()) {
       delete common.catalog_item_id;
+      if (hasCompositeSelection()) return { ...common, service_package_groups: draft().service_package_groups.map((group) => ({ package_key: group.package_key, btu: Number(group.btu), quantity: Number(group.quantity) })) };
       return {
         ...common,
         service_package_key: String(d.service_package_key).trim(),
@@ -917,7 +933,7 @@
     if (hasPackageSelection()) {
       const preview = packagePreview();
       if (!preview) throw new Error("แพ็กเกจยังไม่พร้อม");
-      const data = { duration_min: Number(preview.quantity) * Number(preview.unit_duration_minutes), fixed_total_price: preview.fixed_total_price };
+      const data = { duration_min: hasCompositeSelection() ? Number(preview.duration_min) : Number(preview.quantity) * Number(preview.unit_duration_minutes), fixed_total_price: preview.fixed_total_price };
       root.state.setScheduledPreview("pricing", { status: "success", data, error: "" });
       if (!opts.preserveDependents) clearCalendarSlots();
       paint(container);
@@ -1347,7 +1363,7 @@
   async function recoverScheduledDependencies(container) {
     if (recoveryInFlight) return;
     if (step() < 2) return;
-    if (hasPackageSelection() && root.state.scheduledPreview.package?.verified !== true) {
+    if (hasPackageSelection() && !hasCompositeSelection() && root.state.scheduledPreview.package?.verified !== true) {
       const restoredBtu = draft().service_package_btu;
       const restored = await selectServicePackage(draft().service_package_key, draft().service_package_tier_key, container, { restoredBtu, restore: true });
       if (!restored) return;
@@ -1383,7 +1399,7 @@
     paint(container);
     if (root.state.scheduledPreview.packages.status === "idle") loadServicePackages(container);
     if (step() === 1) {
-      if (hasPackageSelection() && root.state.scheduledPreview.package?.verified !== true) {
+      if (hasPackageSelection() && !hasCompositeSelection() && root.state.scheduledPreview.package?.verified !== true) {
         selectServicePackage(draft().service_package_key, draft().service_package_tier_key, container, { restoredBtu: draft().service_package_btu, restore: true });
         return;
       }

--- a/customer-app/modules/bookingScheduled.js
+++ b/customer-app/modules/bookingScheduled.js
@@ -14,17 +14,6 @@
   let latestContainer = null;
   let ticketCopyState = { status: "idle", error: "" };
 
-  function bookingTicketText(ticket) {
-    if (!ticket || !ticket.booking_code || !Array.isArray(ticket.components)) return "";
-    const lines = [ticket.heading || "CWF BOOKING TICKET", `รหัสการจอง: ${ticket.booking_code}`,
-      `ชื่อผู้ติดต่อ: ${ticket.customer_name || "-"}`, `เบอร์โทร: ${ticket.customer_phone || "-"}`, "รายการบริการ:"];
-    ticket.components.forEach((item) => lines.push(`- ${item.label} x ${item.quantity}`));
-    lines.push(`จำนวนรวม: ${ticket.total_machine_count} เครื่อง`, `วันเวลานัด: ${ticket.appointment_datetime}`,
-      `ยอดยืนยันจากระบบ: ${ticket.exact_total} บาท`, `สถานะ: ${ticket.public_status}`,
-      "ผู้ส่งยืนยันว่า LINE บัญชีนี้เป็นผู้ติดต่อสำหรับรายการจองนี้");
-    return lines.join("\n");
-  }
-
   function draft() {
     return root.state.draft.scheduled || {};
   }
@@ -835,7 +824,7 @@
     const result = root.state.scheduledSubmit.result || {};
     const selected = draft().selectedSlot || {};
     const trackingKey = result.token || result.booking_code || "";
-    const ticketText = bookingTicketText(result.booking_ticket);
+    const ticketText = root.bookingTicket?.formatText?.(result.booking_ticket) || "";
     const copied = ticketCopyState.status === "copied";
     const manual = ticketCopyState.status === "manual";
     return `
@@ -856,7 +845,7 @@
           <p>ส่ง Ticket นี้ใน LINE OA เพื่อให้แอดมินทราบว่า LINE นี้เป็นผู้ติดต่อของรายการจองใด</p>
           <p class="muted">Ticket มีชื่อและเบอร์โทรที่ใช้จอง กรุณาตรวจสอบก่อนคัดลอก</p>
           <div class="button-row">
-            <button type="button" class="secondary-btn" data-action="copy-booking-ticket" ${ticketCopyState.status === "copying" ? "disabled" : ""}>${copied ? "คัดลอกแล้ว" : "คัดลอก Ticket ส่งให้แอดมิน"}</button>
+            <button type="button" class="secondary-btn" data-action="copy-booking-ticket" ${ticketCopyState.status === "copying" || copied ? "disabled" : ""}>${copied ? "คัดลอกแล้ว" : "คัดลอก Ticket ส่งให้แอดมิน"}</button>
             ${copied ? '<a class="primary-btn" href="https://lin.ee/fG1Oq7y" target="_blank" rel="noopener noreferrer">เปิด LINE OA เพื่อส่ง Ticket</a>' : ""}
           </div>
           <div role="status" aria-live="polite">${copied ? "คัดลอกแล้ว" : root.utils.escapeHtml(ticketCopyState.error || "")}</div>
@@ -1371,16 +1360,10 @@
         if (action === "submit-scheduled") await submit(container);
         if (action === "copy-booking-ticket") {
           if (ticketCopyState.status === "copying" || ticketCopyState.status === "copied") return;
-          const ticketText = bookingTicketText(root.state.scheduledSubmit.result?.booking_ticket);
+          const ticketText = root.bookingTicket?.formatText?.(root.state.scheduledSubmit.result?.booking_ticket) || "";
           if (!ticketText) { ticketCopyState = { status: "manual", error: "ไม่พบข้อมูล Ticket ที่ยืนยันจากระบบ" }; paint(container); return; }
           ticketCopyState = { status: "copying", error: "" }; paint(container);
-          try {
-            if (!navigator.clipboard?.writeText || window.isSecureContext === false) throw new Error("CLIPBOARD_UNAVAILABLE");
-            await navigator.clipboard.writeText(ticketText);
-            ticketCopyState = { status: "copied", error: "" };
-          } catch (_) {
-            ticketCopyState = { status: "manual", error: "เบราว์เซอร์ไม่อนุญาตให้คัดลอกอัตโนมัติ กรุณาคัดลอกข้อความด้านล่าง" };
-          }
+          ticketCopyState = await root.bookingTicket.copyText(ticketText);
           paint(container);
           if (ticketCopyState.status === "manual") container.querySelector("#booking-ticket-manual")?.select?.();
         }

--- a/customer-app/modules/bookingScheduled.js
+++ b/customer-app/modules/bookingScheduled.js
@@ -174,7 +174,12 @@
   function clearPriceCalendarSlots() {
     availabilityRequestSeq += 1;
     calendarRequestSeq += 1;
-    root.state.updateDraft("scheduled", { selectedSlot: null });
+    root.state.updateDraft("scheduled", {
+      selectedSlot: null,
+      catalog_item_id: null,
+      catalog_booking_quote: null,
+      catalog_booking_pricing: null,
+    });
     root.state.setScheduledPreview("pricing", { status: "idle", data: null, error: "" });
     root.state.setScheduledPreview("availability", { status: "idle", data: null, error: "", query_key: "", loaded_at: "" });
     root.state.setScheduledPreview("calendar", { status: "idle", data: null, error: "", query_key: "", loaded_at: "" });
@@ -827,6 +832,7 @@
     const ticketText = root.bookingTicket?.formatText?.(result.booking_ticket) || "";
     const copied = ticketCopyState.status === "copied";
     const manual = ticketCopyState.status === "manual";
+    const confirmedNetTotal = root.bookingTicket?.confirmedNetTotal?.(result) || "0.00";
     return `
       <section class="card success-card booking-result-card">
         <div class="success-mark">✓</div>
@@ -837,7 +843,7 @@
         <div class="data-list">
           <div class="data-row"><strong>รหัสการจอง</strong><span class="booking-code-value">${root.utils.escapeHtml(result.booking_code || "-")}</span></div>
           <div class="data-row"><strong>วันและเวลา</strong><span class="muted">${root.utils.escapeHtml(selected.date || draft().date || "-")} · ${root.utils.escapeHtml(selected.start || "-")}-${root.utils.escapeHtml(selected.end || "-")} น.</span></div>
-          <div class="data-row"><strong>ราคา</strong><span class="muted">${root.utils.formatBaht(result.base_total)}</span></div>
+          <div class="data-row"><strong>ราคา</strong><span class="muted">${root.utils.escapeHtml(confirmedNetTotal)} บาท</span></div>
           <div class="data-row"><strong>เวลาทำงาน</strong><span class="muted">${root.utils.escapeHtml(result.duration_min || "-")} นาที</span></div>
           <div class="data-row"><strong>สถานะ</strong><span class="muted">รอแอดมินยืนยัน</span></div>
         </div>
@@ -846,7 +852,7 @@
           <p class="muted">Ticket มีชื่อและเบอร์โทรที่ใช้จอง กรุณาตรวจสอบก่อนคัดลอก</p>
           <div class="button-row">
             <button type="button" class="secondary-btn" data-action="copy-booking-ticket" ${ticketCopyState.status === "copying" || copied ? "disabled" : ""}>${copied ? "คัดลอกแล้ว" : "คัดลอก Ticket ส่งให้แอดมิน"}</button>
-            ${copied ? '<a class="primary-btn" href="https://lin.ee/fG1Oq7y" target="_blank" rel="noopener noreferrer">เปิด LINE OA เพื่อส่ง Ticket</a>' : ""}
+            <a class="primary-btn" href="https://lin.ee/fG1Oq7y" target="_blank" rel="noopener noreferrer">เปิด LINE OA เพื่อส่ง Ticket</a>
           </div>
           <div role="status" aria-live="polite">${copied ? "คัดลอกแล้ว" : root.utils.escapeHtml(ticketCopyState.error || "")}</div>
           ${manual ? `<label for="booking-ticket-manual">คัดลอกข้อความด้านล่างด้วยตนเอง</label><textarea id="booking-ticket-manual" class="input textarea" rows="10" readonly>${root.utils.escapeHtml(ticketText)}</textarea>` : ""}
@@ -951,6 +957,13 @@
       if (!preview) throw new Error("แพ็กเกจยังไม่พร้อม");
       const data = { duration_min: hasCompositeSelection() ? Number(preview.duration_min) : Number(preview.quantity) * Number(preview.unit_duration_minutes), fixed_total_price: preview.fixed_total_price };
       root.state.setScheduledPreview("pricing", { status: "success", data, error: "" });
+      if (!opts.preserveDependents) clearCalendarSlots();
+      paint(container);
+      return data;
+    }
+    if (root.services.catalogQuoteMatchesDraft(draft(), "scheduled") && draft().catalog_booking_pricing) {
+      const data = draft().catalog_booking_pricing;
+      root.state.setScheduledPreview("pricing", { status: "success", data, error: "", verified: true });
       if (!opts.preserveDependents) clearCalendarSlots();
       paint(container);
       return data;

--- a/customer-app/modules/bookingScheduled.js
+++ b/customer-app/modules/bookingScheduled.js
@@ -12,6 +12,18 @@
   let sameDayVisibilityRefresh = null;
   let scheduledLifecycleEpoch = 0;
   let latestContainer = null;
+  let ticketCopyState = { status: "idle", error: "" };
+
+  function bookingTicketText(ticket) {
+    if (!ticket || !ticket.booking_code || !Array.isArray(ticket.components)) return "";
+    const lines = [ticket.heading || "CWF BOOKING TICKET", `รหัสการจอง: ${ticket.booking_code}`,
+      `ชื่อผู้ติดต่อ: ${ticket.customer_name || "-"}`, `เบอร์โทร: ${ticket.customer_phone || "-"}`, "รายการบริการ:"];
+    ticket.components.forEach((item) => lines.push(`- ${item.label} x ${item.quantity}`));
+    lines.push(`จำนวนรวม: ${ticket.total_machine_count} เครื่อง`, `วันเวลานัด: ${ticket.appointment_datetime}`,
+      `ยอดยืนยันจากระบบ: ${ticket.exact_total} บาท`, `สถานะ: ${ticket.public_status}`,
+      "ผู้ส่งยืนยันว่า LINE บัญชีนี้เป็นผู้ติดต่อสำหรับรายการจองนี้");
+    return lines.join("\n");
+  }
 
   function draft() {
     return root.state.draft.scheduled || {};
@@ -823,6 +835,9 @@
     const result = root.state.scheduledSubmit.result || {};
     const selected = draft().selectedSlot || {};
     const trackingKey = result.token || result.booking_code || "";
+    const ticketText = bookingTicketText(result.booking_ticket);
+    const copied = ticketCopyState.status === "copied";
+    const manual = ticketCopyState.status === "manual";
     return `
       <section class="card success-card booking-result-card">
         <div class="success-mark">✓</div>
@@ -837,6 +852,16 @@
           <div class="data-row"><strong>เวลาทำงาน</strong><span class="muted">${root.utils.escapeHtml(result.duration_min || "-")} นาที</span></div>
           <div class="data-row"><strong>สถานะ</strong><span class="muted">รอแอดมินยืนยัน</span></div>
         </div>
+        ${ticketText ? `<div class="booking-ticket-handoff">
+          <p>ส่ง Ticket นี้ใน LINE OA เพื่อให้แอดมินทราบว่า LINE นี้เป็นผู้ติดต่อของรายการจองใด</p>
+          <p class="muted">Ticket มีชื่อและเบอร์โทรที่ใช้จอง กรุณาตรวจสอบก่อนคัดลอก</p>
+          <div class="button-row">
+            <button type="button" class="secondary-btn" data-action="copy-booking-ticket" ${ticketCopyState.status === "copying" ? "disabled" : ""}>${copied ? "คัดลอกแล้ว" : "คัดลอก Ticket ส่งให้แอดมิน"}</button>
+            ${copied ? '<a class="primary-btn" href="https://lin.ee/fG1Oq7y" target="_blank" rel="noopener noreferrer">เปิด LINE OA เพื่อส่ง Ticket</a>' : ""}
+          </div>
+          <div role="status" aria-live="polite">${copied ? "คัดลอกแล้ว" : root.utils.escapeHtml(ticketCopyState.error || "")}</div>
+          ${manual ? `<label for="booking-ticket-manual">คัดลอกข้อความด้านล่างด้วยตนเอง</label><textarea id="booking-ticket-manual" class="input textarea" rows="10" readonly>${root.utils.escapeHtml(ticketText)}</textarea>` : ""}
+        </div>` : ""}
         <div class="button-row">
           <button type="button" class="primary-btn" data-action="track-created" data-tracking-key="${root.utils.escapeHtml(trackingKey)}">ติดตามสถานะงาน</button>
           <button type="button" class="secondary-btn" data-action="new-cleaning-booking">จองล้างแอร์เพิ่ม</button>
@@ -1119,6 +1144,7 @@
       const result = await root.api.submitScheduledBooking(buildSubmitPayload());
       if (lifecycleEpoch !== scheduledLifecycleEpoch) return;
       if (!result?.success || (!result.booking_code && !result.token)) throw new Error("ระบบไม่ได้ส่งรหัสติดตามกลับมา");
+      ticketCopyState = { status: "idle", error: "" };
       root.state.setScheduledSubmit({ status: "success", error: "", result });
       try {
         window.sessionStorage.removeItem("cwf_customer_app_v2_scheduled_v5");
@@ -1343,12 +1369,28 @@
           paint(container);
         }
         if (action === "submit-scheduled") await submit(container);
+        if (action === "copy-booking-ticket") {
+          if (ticketCopyState.status === "copying" || ticketCopyState.status === "copied") return;
+          const ticketText = bookingTicketText(root.state.scheduledSubmit.result?.booking_ticket);
+          if (!ticketText) { ticketCopyState = { status: "manual", error: "ไม่พบข้อมูล Ticket ที่ยืนยันจากระบบ" }; paint(container); return; }
+          ticketCopyState = { status: "copying", error: "" }; paint(container);
+          try {
+            if (!navigator.clipboard?.writeText || window.isSecureContext === false) throw new Error("CLIPBOARD_UNAVAILABLE");
+            await navigator.clipboard.writeText(ticketText);
+            ticketCopyState = { status: "copied", error: "" };
+          } catch (_) {
+            ticketCopyState = { status: "manual", error: "เบราว์เซอร์ไม่อนุญาตให้คัดลอกอัตโนมัติ กรุณาคัดลอกข้อความด้านล่าง" };
+          }
+          paint(container);
+          if (ticketCopyState.status === "manual") container.querySelector("#booking-ticket-manual")?.select?.();
+        }
         if (action === "track-created") {
           const key = button.getAttribute("data-tracking-key") || "";
           if (key) root.state.updateDraft("tracking", { trackingCode: key });
           root.utils.routeTo("tracking");
         }
         if (action === "new-cleaning-booking") {
+          ticketCopyState = { status: "idle", error: "" };
           root.state.resetScheduledDraft();
           paint(container);
         }

--- a/customer-app/modules/bookingScheduled.js
+++ b/customer-app/modules/bookingScheduled.js
@@ -832,6 +832,7 @@
     const ticketText = root.bookingTicket?.formatText?.(result.booking_ticket) || "";
     const copied = ticketCopyState.status === "copied";
     const manual = ticketCopyState.status === "manual";
+    const showLineHandoff = copied || manual;
     const confirmedNetTotal = root.bookingTicket?.confirmedNetTotal?.(result) || "0.00";
     return `
       <section class="card success-card booking-result-card">
@@ -852,7 +853,7 @@
           <p class="muted">Ticket มีชื่อและเบอร์โทรที่ใช้จอง กรุณาตรวจสอบก่อนคัดลอก</p>
           <div class="button-row">
             <button type="button" class="secondary-btn" data-action="copy-booking-ticket" ${ticketCopyState.status === "copying" || copied ? "disabled" : ""}>${copied ? "คัดลอกแล้ว" : "คัดลอก Ticket ส่งให้แอดมิน"}</button>
-            <a class="primary-btn" href="https://lin.ee/fG1Oq7y" target="_blank" rel="noopener noreferrer">เปิด LINE OA เพื่อส่ง Ticket</a>
+            ${showLineHandoff ? '<a class="primary-btn" href="https://lin.ee/fG1Oq7y" target="_blank" rel="noopener noreferrer">เปิด LINE OA เพื่อส่ง Ticket</a>' : ""}
           </div>
           <div role="status" aria-live="polite">${copied ? "คัดลอกแล้ว" : root.utils.escapeHtml(ticketCopyState.error || "")}</div>
           ${manual ? `<label for="booking-ticket-manual">คัดลอกข้อความด้านล่างด้วยตนเอง</label><textarea id="booking-ticket-manual" class="input textarea" rows="10" readonly>${root.utils.escapeHtml(ticketText)}</textarea>` : ""}

--- a/customer-app/modules/bookingTicket.js
+++ b/customer-app/modules/bookingTicket.js
@@ -1,0 +1,62 @@
+(function () {
+  "use strict";
+
+  const root = window.CWFCustomerAppV2 = window.CWFCustomerAppV2 || {};
+  const LINE_OA_URL = "https://lin.ee/fG1Oq7y";
+  const HEADING = "CWF BOOKING TICKET";
+  const MANUAL_COPY_ERROR = "เบราว์เซอร์ไม่อนุญาตให้คัดลอกอัตโนมัติ กรุณาคัดลอกข้อความด้านล่าง";
+
+  function safeText(value, maxLength) {
+    return String(value == null ? "" : value)
+      .replace(/[\r\n\u2028\u2029]+/g, " ")
+      .trim()
+      .slice(0, maxLength);
+  }
+
+  function formatText(ticket) {
+    if (!ticket || typeof ticket !== "object" || Array.isArray(ticket)) return "";
+    const bookingCode = safeText(ticket.booking_code, 40);
+    const components = Array.isArray(ticket.components)
+      ? ticket.components.map((item) => ({
+          label: safeText(item?.label, 200),
+          quantity: Number(item?.quantity),
+        })).filter((item) => item.label && Number.isInteger(item.quantity) && item.quantity > 0)
+      : [];
+    if (!bookingCode || !components.length) return "";
+
+    const lines = [
+      HEADING,
+      `รหัสการจอง: ${bookingCode}`,
+      `ชื่อผู้ติดต่อ: ${safeText(ticket.customer_name, 120) || "-"}`,
+      `เบอร์โทร: ${safeText(ticket.customer_phone, 30) || "-"}`,
+      "รายการบริการ:",
+    ];
+    components.forEach((item) => lines.push(`- ${item.label} x ${item.quantity}`));
+    lines.push(
+      `จำนวนรวม: ${Number.isInteger(Number(ticket.total_machine_count)) ? Number(ticket.total_machine_count) : 0} เครื่อง`,
+      `วันเวลานัด: ${safeText(ticket.appointment_datetime, 80) || "-"}`,
+      `ยอดยืนยันจากระบบ: ${safeText(ticket.exact_total, 40) || "0.00"} บาท`,
+      `สถานะ: ${safeText(ticket.public_status, 80) || "รอแอดมินยืนยัน"}`,
+      "ผู้ส่งยืนยันว่า LINE บัญชีนี้เป็นผู้ติดต่อสำหรับรายการจองนี้",
+    );
+    return lines.join("\n");
+  }
+
+  async function copyText(value) {
+    const ticketText = String(value || "");
+    if (!ticketText) return { status: "manual", error: "ไม่พบข้อมูล Ticket ที่ยืนยันจากระบบ" };
+    try {
+      if (!navigator.clipboard?.writeText || window.isSecureContext === false) throw new Error("CLIPBOARD_UNAVAILABLE");
+      await navigator.clipboard.writeText(ticketText);
+      return { status: "copied", error: "" };
+    } catch (_) {
+      return { status: "manual", error: MANUAL_COPY_ERROR };
+    }
+  }
+
+  root.bookingTicket = Object.freeze({
+    lineUrl: LINE_OA_URL,
+    formatText,
+    copyText,
+  });
+})();

--- a/customer-app/modules/bookingTicket.js
+++ b/customer-app/modules/bookingTicket.js
@@ -13,6 +13,19 @@
       .slice(0, maxLength);
   }
 
+  function exactMoney(value) {
+    const match = /^(\d+)(?:\.(\d{1,2}))?$/.exec(safeText(value, 40));
+    return match ? `${match[1]}.${String(match[2] || "").padEnd(2, "0")}` : "";
+  }
+
+  function confirmedNetTotal(result) {
+    return exactMoney(result?.net_total)
+      || exactMoney(result?.booking_ticket?.exact_total)
+      || exactMoney(result?.base_total_exact)
+      || exactMoney(result?.base_total)
+      || "0.00";
+  }
+
   function formatText(ticket) {
     if (!ticket || typeof ticket !== "object" || Array.isArray(ticket)) return "";
     const bookingCode = safeText(ticket.booking_code, 40);
@@ -58,5 +71,6 @@
     lineUrl: LINE_OA_URL,
     formatText,
     copyText,
+    confirmedNetTotal,
   });
 })();

--- a/customer-app/modules/bookingUrgent.js
+++ b/customer-app/modules/bookingUrgent.js
@@ -24,7 +24,8 @@
   }
 
   function hasCompositePackage() {
-    return Array.isArray(draft().service_package_groups) && draft().service_package_groups.length > 0 && !!bundlePreview();
+    return Array.isArray(draft().service_package_groups) && draft().service_package_groups.length > 0
+      && bundlePreview()?.server_verified === true;
   }
 
   function canonicalCleaningLine(input) {

--- a/customer-app/modules/bookingUrgent.js
+++ b/customer-app/modules/bookingUrgent.js
@@ -28,24 +28,32 @@
       && bundlePreview()?.server_verified === true;
   }
 
-  function canonicalCleaningLine(input) {
-    const line = root.services.normalizeServiceLine(input || {});
-    return root.services.createServiceLine({
+  function canonicalCleaningLine(input, composite = false) {
+    const line = composite
+      ? root.services.normalizeCompositeServiceLine(input || {})
+      : root.services.normalizeServiceLine(input || {});
+    if (!line) return null;
+    return {
       line_id: line.line_id,
       job_type: "ล้าง",
       ac_type: line.ac_type,
       btu: line.btu,
       machine_count: line.machine_count,
       wash_variant: line.wash_variant,
-    });
+      repair_variant: "",
+    };
   }
 
   function sanitizeUrgentDraft() {
     const current = draft();
-    const sourceLines = Array.isArray(current.services) && current.services.length
-      ? current.services
+    const composite = hasCompositePackage();
+    const authoritativeLines = composite && Array.isArray(bundlePreview()?.payload?.services)
+      ? bundlePreview().payload.services
+      : current.services;
+    const sourceLines = Array.isArray(authoritativeLines) && authoritativeLines.length
+      ? authoritativeLines
       : [current];
-    const lines = sourceLines.slice(0, 10).map(canonicalCleaningLine);
+    const lines = sourceLines.slice(0, 10).map((line) => canonicalCleaningLine(line, composite)).filter(Boolean);
     const first = lines[0] || canonicalCleaningLine({});
     const patch = {
       service_kind: "clean",
@@ -61,7 +69,10 @@
     const scalarChanged = Object.entries(patch)
       .filter(([key]) => key !== "services")
       .some(([key, value]) => String(current[key] ?? "") !== String(value));
-    const linesChanged = JSON.stringify(root.services.normalizeServiceLines(current).map((line) => ({
+    const normalizedCurrentLines = composite
+      ? (current.services || []).map(root.services.normalizeCompositeServiceLine).filter(Boolean)
+      : root.services.normalizeServiceLines(current);
+    const linesChanged = JSON.stringify(normalizedCurrentLines.map((line) => ({
       line_id: line.line_id,
       job_type: line.job_type,
       ac_type: line.ac_type,
@@ -74,10 +85,13 @@
   }
 
   function services() {
-    return root.services.normalizeServiceLines(sanitizeUrgentDraft());
+    const sanitized = sanitizeUrgentDraft();
+    if (hasCompositePackage()) return (sanitized.services || []).map(root.services.normalizeCompositeServiceLine).filter(Boolean);
+    return root.services.normalizeServiceLines(sanitized);
   }
 
   function servicePayload() {
+    if (hasCompositePackage()) return root.services.payloadFromCompositeServiceLines(services());
     return root.services.payloadFromServiceLines(services());
   }
 
@@ -86,6 +100,9 @@
   }
 
   function serviceSummary() {
+    if (hasCompositePackage()) {
+      return (bundlePreview()?.groups || []).map((group) => `${group.package_name || group.package_key} • ${group.btu} BTU • ${group.quantity} เครื่อง`).join(" • ");
+    }
     return services().map((line) => root.services.serviceLabel(line)).join(" • ");
   }
 
@@ -238,11 +255,15 @@
   }
 
   function dispatchFingerprint() {
+    const canonicalPayload = servicePayload();
     return JSON.stringify({
       zone: zoneFingerprint(),
       appointment_datetime: appointmentDatetime(),
       allow_time_proposal: draft().allow_time_proposal === true,
-      services: services().map((line) => root.services.normalizeServiceLine(line)),
+      services: canonicalPayload?.services || [],
+      catalog_item_id: Number(draft().catalog_item_id || 0) || null,
+      service_package_groups: Array.isArray(draft().service_package_groups) ? draft().service_package_groups : [],
+      authoritative_duration_min: Number(bundlePreview()?.duration_min || 0),
     });
   }
 
@@ -262,6 +283,13 @@
       delete payload.urgent_request_key;
       const result = await root.api.preflightUrgentDispatch(payload);
       if (requestEpoch !== preflightEpoch || dispatchFingerprint() !== fingerprint) return null;
+      if (hasCompositePackage()) {
+        const expectedQuantity = draft().service_package_groups.reduce((sum, group) => sum + Number(group.quantity || 0), 0);
+        if (Number(result?.duration_min) !== Number(bundlePreview()?.duration_min)
+            || Number(result?.machine_count) !== expectedQuantity) {
+          throw new Error("PACKAGE_PREFLIGHT_MISMATCH");
+        }
+      }
       const canDispatch = result?.can_dispatch === true;
       const error = canDispatch
         ? ""
@@ -387,6 +415,12 @@
   }
 
   function renderServiceReviewList() {
+    if (hasCompositePackage()) {
+      const preview = bundlePreview();
+      return `<div class="service-line-review-list">${(preview.groups || []).map((group) => `
+        <div class="service-summary-box"><span>${root.utils.escapeHtml(group.package_name || group.package_key)}</span>
+          <strong>${root.utils.escapeHtml(String(group.btu))} BTU · ${root.utils.escapeHtml(String(group.quantity))} เครื่อง</strong></div>`).join("")}</div>`;
+    }
     return `
       <div class="service-line-review-list">
         ${services().map((line, index) => {
@@ -625,9 +659,14 @@
     if (hasCompositePackage()) {
       const preview = bundlePreview();
       root.state.setUrgentFlow({ pricing: { status: "success", data: {
-        standard_price: Number(preview.fixed_total_price), active_price: Number(preview.fixed_total_price),
+        standard_price: preview.fixed_total_price, active_price: preview.fixed_total_price,
         duration_min: Number(preview.duration_min), price_lines: [], package_snapshot: true,
       }, error: "" } });
+      if (container) paint(container);
+      return;
+    }
+    if (root.services.catalogQuoteMatchesDraft(draft(), "urgent") && draft().catalog_booking_pricing) {
+      root.state.setUrgentFlow({ pricing: { status: "success", data: draft().catalog_booking_pricing, error: "" } });
       if (container) paint(container);
       return;
     }
@@ -652,6 +691,11 @@
   function invalidatePricing() {
     pricingEpoch += 1;
     root.state.setUrgentFlow({ pricing: { status: "idle", data: null, error: "" }, error: "" });
+    if (!hasCompositePackage()) root.state.updateDraft("urgent", {
+      catalog_item_id: null,
+      catalog_booking_quote: null,
+      catalog_booking_pricing: null,
+    });
     markPayloadChanged();
   }
 
@@ -750,6 +794,7 @@
     const ticketText = root.bookingTicket?.formatText?.(result.booking_ticket) || "";
     const copied = ticketCopyState.status === "copied";
     const manual = ticketCopyState.status === "manual";
+    const confirmedNetTotal = root.bookingTicket?.confirmedNetTotal?.(result) || "0.00";
     return `
       ${view.state === "pending" ? `
         <section class="card waiting-room waiting-room-fx" data-urgent-search-animation>
@@ -780,12 +825,13 @@
           <div class="data-row"><strong>รหัสการจอง</strong><span class="booking-code-value">${root.utils.escapeHtml(result.booking_code || "-")}</span></div>
           <div class="data-row"><strong>บริการ</strong><span class="muted">${root.utils.escapeHtml(serviceSummary())}</span></div>
           <div class="data-row"><strong>เวลาที่ต้องการ</strong><span class="muted">${root.utils.escapeHtml(formatAppointment())}</span></div>
+          <div class="data-row"><strong>ราคา</strong><span class="muted">${root.utils.escapeHtml(confirmedNetTotal)} บาท</span></div>
           <div class="data-row"><strong>สถานะ</strong><span class="muted">${root.utils.escapeHtml(view.statusLabel)}</span></div>
         </div>
         ${ticketText ? `<div class="booking-ticket-handoff"><p>ส่ง Ticket นี้ใน LINE OA เพื่อให้แอดมินทราบว่า LINE นี้เป็นผู้ติดต่อของรายการจองใด</p>
           <p class="muted">Ticket มีชื่อและเบอร์โทรที่ใช้จอง กรุณาตรวจสอบก่อนคัดลอก</p>
           <div class="button-row"><button type="button" class="secondary-btn" data-urgent-action="copy-booking-ticket" ${ticketCopyState.status === "copying" || copied ? "disabled" : ""}>${copied ? "คัดลอกแล้ว" : "คัดลอก Ticket ส่งให้แอดมิน"}</button>
-          ${copied ? '<a class="primary-btn" href="https://lin.ee/fG1Oq7y" target="_blank" rel="noopener noreferrer">เปิด LINE OA เพื่อส่ง Ticket</a>' : ""}</div>
+          <a class="primary-btn" href="https://lin.ee/fG1Oq7y" target="_blank" rel="noopener noreferrer">เปิด LINE OA เพื่อส่ง Ticket</a></div>
           <div role="status" aria-live="polite">${copied ? "คัดลอกแล้ว" : root.utils.escapeHtml(ticketCopyState.error || "")}</div>
           ${manual ? `<label for="urgent-ticket-manual">คัดลอกข้อความด้านล่างด้วยตนเอง</label><textarea id="urgent-ticket-manual" class="input textarea" rows="10" readonly>${root.utils.escapeHtml(ticketText)}</textarea>` : ""}
         </div>` : ""}

--- a/customer-app/modules/bookingUrgent.js
+++ b/customer-app/modules/bookingUrgent.js
@@ -794,6 +794,7 @@
     const ticketText = root.bookingTicket?.formatText?.(result.booking_ticket) || "";
     const copied = ticketCopyState.status === "copied";
     const manual = ticketCopyState.status === "manual";
+    const showLineHandoff = copied || manual;
     const confirmedNetTotal = root.bookingTicket?.confirmedNetTotal?.(result) || "0.00";
     return `
       ${view.state === "pending" ? `
@@ -831,7 +832,7 @@
         ${ticketText ? `<div class="booking-ticket-handoff"><p>ส่ง Ticket นี้ใน LINE OA เพื่อให้แอดมินทราบว่า LINE นี้เป็นผู้ติดต่อของรายการจองใด</p>
           <p class="muted">Ticket มีชื่อและเบอร์โทรที่ใช้จอง กรุณาตรวจสอบก่อนคัดลอก</p>
           <div class="button-row"><button type="button" class="secondary-btn" data-urgent-action="copy-booking-ticket" ${ticketCopyState.status === "copying" || copied ? "disabled" : ""}>${copied ? "คัดลอกแล้ว" : "คัดลอก Ticket ส่งให้แอดมิน"}</button>
-          <a class="primary-btn" href="https://lin.ee/fG1Oq7y" target="_blank" rel="noopener noreferrer">เปิด LINE OA เพื่อส่ง Ticket</a></div>
+          ${showLineHandoff ? '<a class="primary-btn" href="https://lin.ee/fG1Oq7y" target="_blank" rel="noopener noreferrer">เปิด LINE OA เพื่อส่ง Ticket</a>' : ""}</div>
           <div role="status" aria-live="polite">${copied ? "คัดลอกแล้ว" : root.utils.escapeHtml(ticketCopyState.error || "")}</div>
           ${manual ? `<label for="urgent-ticket-manual">คัดลอกข้อความด้านล่างด้วยตนเอง</label><textarea id="urgent-ticket-manual" class="input textarea" rows="10" readonly>${root.utils.escapeHtml(ticketText)}</textarea>` : ""}
         </div>` : ""}

--- a/customer-app/modules/bookingUrgent.js
+++ b/customer-app/modules/bookingUrgent.js
@@ -15,17 +15,6 @@
   let visibilityRefresh = null;
   let ticketCopyState = { status: "idle", error: "" };
 
-  function bookingTicketText(ticket) {
-    if (!ticket || !ticket.booking_code || !Array.isArray(ticket.components)) return "";
-    const lines = [ticket.heading || "CWF BOOKING TICKET", `รหัสการจอง: ${ticket.booking_code}`,
-      `ชื่อผู้ติดต่อ: ${ticket.customer_name || "-"}`, `เบอร์โทร: ${ticket.customer_phone || "-"}`, "รายการบริการ:"];
-    ticket.components.forEach((item) => lines.push(`- ${item.label} x ${item.quantity}`));
-    lines.push(`จำนวนรวม: ${ticket.total_machine_count} เครื่อง`, `วันเวลานัด: ${ticket.appointment_datetime}`,
-      `ยอดยืนยันจากระบบ: ${ticket.exact_total} บาท`, `สถานะ: ${ticket.public_status}`,
-      "ผู้ส่งยืนยันว่า LINE บัญชีนี้เป็นผู้ติดต่อสำหรับรายการจองนี้");
-    return lines.join("\n");
-  }
-
   function draft() {
     return root.state.draft.urgent || {};
   }
@@ -757,7 +746,7 @@
     const canCancel = Boolean(cancellationToken)
       && ["pending", "fallback", "actionable"].includes(view.state)
       && flow.liveStatus?.can_cancel !== false;
-    const ticketText = bookingTicketText(result.booking_ticket);
+    const ticketText = root.bookingTicket?.formatText?.(result.booking_ticket) || "";
     const copied = ticketCopyState.status === "copied";
     const manual = ticketCopyState.status === "manual";
     return `
@@ -794,7 +783,7 @@
         </div>
         ${ticketText ? `<div class="booking-ticket-handoff"><p>ส่ง Ticket นี้ใน LINE OA เพื่อให้แอดมินทราบว่า LINE นี้เป็นผู้ติดต่อของรายการจองใด</p>
           <p class="muted">Ticket มีชื่อและเบอร์โทรที่ใช้จอง กรุณาตรวจสอบก่อนคัดลอก</p>
-          <div class="button-row"><button type="button" class="secondary-btn" data-urgent-action="copy-booking-ticket" ${ticketCopyState.status === "copying" ? "disabled" : ""}>${copied ? "คัดลอกแล้ว" : "คัดลอก Ticket ส่งให้แอดมิน"}</button>
+          <div class="button-row"><button type="button" class="secondary-btn" data-urgent-action="copy-booking-ticket" ${ticketCopyState.status === "copying" || copied ? "disabled" : ""}>${copied ? "คัดลอกแล้ว" : "คัดลอก Ticket ส่งให้แอดมิน"}</button>
           ${copied ? '<a class="primary-btn" href="https://lin.ee/fG1Oq7y" target="_blank" rel="noopener noreferrer">เปิด LINE OA เพื่อส่ง Ticket</a>' : ""}</div>
           <div role="status" aria-live="polite">${copied ? "คัดลอกแล้ว" : root.utils.escapeHtml(ticketCopyState.error || "")}</div>
           ${manual ? `<label for="urgent-ticket-manual">คัดลอกข้อความด้านล่างด้วยตนเอง</label><textarea id="urgent-ticket-manual" class="input textarea" rows="10" readonly>${root.utils.escapeHtml(ticketText)}</textarea>` : ""}
@@ -1119,15 +1108,11 @@
           root.utils.routeTo("tracking");
         } else if (action === "copy-booking-ticket") {
           if (ticketCopyState.status === "copying" || ticketCopyState.status === "copied") return;
-          const text = bookingTicketText(root.state.urgentFlow?.result?.booking_ticket);
+          const text = root.bookingTicket?.formatText?.(root.state.urgentFlow?.result?.booking_ticket) || "";
           ticketCopyState = { status: "copying", error: "" }; paint(container);
-          try {
-            if (!text || !navigator.clipboard?.writeText || window.isSecureContext === false) throw new Error("CLIPBOARD_UNAVAILABLE");
-            await navigator.clipboard.writeText(text);
-            ticketCopyState = { status: "copied", error: "" };
-          } catch (_) {
-            ticketCopyState = { status: "manual", error: "เบราว์เซอร์ไม่อนุญาตให้คัดลอกอัตโนมัติ กรุณาคัดลอกข้อความด้านล่าง" };
-          }
+          ticketCopyState = text
+            ? await root.bookingTicket.copyText(text)
+            : { status: "manual", error: "ไม่พบข้อมูล Ticket ที่ยืนยันจากระบบ" };
           paint(container);
           if (ticketCopyState.status === "manual") container.querySelector("#urgent-ticket-manual")?.select?.();
         } else if (action === "cancel-request") {

--- a/customer-app/modules/bookingUrgent.js
+++ b/customer-app/modules/bookingUrgent.js
@@ -13,9 +13,29 @@
   let preflightEpoch = 0;
   let activeContainer = null;
   let visibilityRefresh = null;
+  let ticketCopyState = { status: "idle", error: "" };
+
+  function bookingTicketText(ticket) {
+    if (!ticket || !ticket.booking_code || !Array.isArray(ticket.components)) return "";
+    const lines = [ticket.heading || "CWF BOOKING TICKET", `รหัสการจอง: ${ticket.booking_code}`,
+      `ชื่อผู้ติดต่อ: ${ticket.customer_name || "-"}`, `เบอร์โทร: ${ticket.customer_phone || "-"}`, "รายการบริการ:"];
+    ticket.components.forEach((item) => lines.push(`- ${item.label} x ${item.quantity}`));
+    lines.push(`จำนวนรวม: ${ticket.total_machine_count} เครื่อง`, `วันเวลานัด: ${ticket.appointment_datetime}`,
+      `ยอดยืนยันจากระบบ: ${ticket.exact_total} บาท`, `สถานะ: ${ticket.public_status}`,
+      "ผู้ส่งยืนยันว่า LINE บัญชีนี้เป็นผู้ติดต่อสำหรับรายการจองนี้");
+    return lines.join("\n");
+  }
 
   function draft() {
     return root.state.draft.urgent || {};
+  }
+
+  function bundlePreview() {
+    return draft().service_package_bundle_preview || null;
+  }
+
+  function hasCompositePackage() {
+    return Array.isArray(draft().service_package_groups) && draft().service_package_groups.length > 0 && !!bundlePreview();
   }
 
   function canonicalCleaningLine(input) {
@@ -136,6 +156,12 @@
       ...(gps ? { gps_latitude: gps.latitude, gps_longitude: gps.longitude } : {}),
       ...payload,
       services: cleaningLines,
+      ...(Number.isSafeInteger(Number(d.catalog_item_id)) && Number(d.catalog_item_id) > 0
+        ? { catalog_item_id: Number(d.catalog_item_id) } : {}),
+      ...(Array.isArray(d.service_package_groups) && d.service_package_groups.length
+        ? { service_package_groups: d.service_package_groups.map((group) => ({
+          package_key: String(group.package_key || ""), btu: Number(group.btu), quantity: Number(group.quantity),
+        })) } : {}),
     };
   }
 
@@ -393,6 +419,18 @@
 
   function renderServicesStep() {
     const error = root.state.urgentFlow.error;
+    if (hasCompositePackage()) {
+      const preview = bundlePreview();
+      return `
+        <section class="card form-card urgent-card-fx" data-urgent-step-panel="services">
+          <div class="section-head"><span class="section-kicker">ขั้นตอน 1 จาก 3</span><h2>${root.utils.escapeHtml(preview.package_name || "แพ็กเกจบริการ")}</h2>
+            <p class="muted">สิทธิ์ ราคา และจำนวนยึดตามแพ็กเกจที่เลือกจากร้านค้า</p></div>
+          <div class="service-line-review-list">${(preview.groups || []).map((group) => `<div class="service-summary-box"><strong>${root.utils.escapeHtml(group.package_name || group.package_key)}</strong><small>${root.utils.escapeHtml(group.btu)} BTU · ${root.utils.escapeHtml(group.quantity)} เครื่อง</small></div>`).join("")}</div>
+          ${renderPricingSummary()}
+        </section>
+        ${error ? `<div class="state-box is-error" role="alert">${root.utils.escapeHtml(error)}</div>` : ""}
+        <div class="button-row"><button class="primary-btn btn-shine" type="button" data-urgent-action="to-details">กรอกข้อมูลหน้างาน</button></div>`;
+    }
     return `
       <section class="card form-card urgent-card-fx" data-urgent-step-panel="services">
         <div class="section-head">
@@ -594,6 +632,15 @@
   }
 
   async function refreshPricing(container) {
+    if (hasCompositePackage()) {
+      const preview = bundlePreview();
+      root.state.setUrgentFlow({ pricing: { status: "success", data: {
+        standard_price: Number(preview.fixed_total_price), active_price: Number(preview.fixed_total_price),
+        duration_min: Number(preview.duration_min), price_lines: [], package_snapshot: true,
+      }, error: "" } });
+      if (container) paint(container);
+      return;
+    }
     const payload = servicePayload();
     if (!payload) return;
     const requestEpoch = ++pricingEpoch;
@@ -710,6 +757,9 @@
     const canCancel = Boolean(cancellationToken)
       && ["pending", "fallback", "actionable"].includes(view.state)
       && flow.liveStatus?.can_cancel !== false;
+    const ticketText = bookingTicketText(result.booking_ticket);
+    const copied = ticketCopyState.status === "copied";
+    const manual = ticketCopyState.status === "manual";
     return `
       ${view.state === "pending" ? `
         <section class="card waiting-room waiting-room-fx" data-urgent-search-animation>
@@ -742,6 +792,13 @@
           <div class="data-row"><strong>เวลาที่ต้องการ</strong><span class="muted">${root.utils.escapeHtml(formatAppointment())}</span></div>
           <div class="data-row"><strong>สถานะ</strong><span class="muted">${root.utils.escapeHtml(view.statusLabel)}</span></div>
         </div>
+        ${ticketText ? `<div class="booking-ticket-handoff"><p>ส่ง Ticket นี้ใน LINE OA เพื่อให้แอดมินทราบว่า LINE นี้เป็นผู้ติดต่อของรายการจองใด</p>
+          <p class="muted">Ticket มีชื่อและเบอร์โทรที่ใช้จอง กรุณาตรวจสอบก่อนคัดลอก</p>
+          <div class="button-row"><button type="button" class="secondary-btn" data-urgent-action="copy-booking-ticket" ${ticketCopyState.status === "copying" ? "disabled" : ""}>${copied ? "คัดลอกแล้ว" : "คัดลอก Ticket ส่งให้แอดมิน"}</button>
+          ${copied ? '<a class="primary-btn" href="https://lin.ee/fG1Oq7y" target="_blank" rel="noopener noreferrer">เปิด LINE OA เพื่อส่ง Ticket</a>' : ""}</div>
+          <div role="status" aria-live="polite">${copied ? "คัดลอกแล้ว" : root.utils.escapeHtml(ticketCopyState.error || "")}</div>
+          ${manual ? `<label for="urgent-ticket-manual">คัดลอกข้อความด้านล่างด้วยตนเอง</label><textarea id="urgent-ticket-manual" class="input textarea" rows="10" readonly>${root.utils.escapeHtml(ticketText)}</textarea>` : ""}
+        </div>` : ""}
         ${flow.liveStatusError ? `<div class="state-box is-error" role="alert">${root.utils.escapeHtml(flow.liveStatusError)}</div>` : ""}
         <div class="button-row">
           ${flow.liveStatusError ? `<button class="primary-btn" type="button" data-urgent-action="retry-status">ลองตรวจสอบสถานะอีกครั้ง</button>` : ""}
@@ -779,6 +836,7 @@
     try {
       const result = await root.api.submitUrgentRequest(buildSubmitPayload());
       if (submitEpoch !== pollEpoch) return;
+      ticketCopyState = { status: "idle", error: "" };
       const trackingKey = trackingKeyFromResult(result);
       if (trackingKey) root.state.updateDraft("tracking", { trackingCode: trackingKey });
       root.state.setUrgentFlow({ step: "submitted", status: "success", error: "", result, liveStatus: null, liveStatusError: "" });
@@ -1050,6 +1108,7 @@
           root.state.setUrgentFlow({ liveStatusError: "" });
           paint(container);
         } else if (action === "new-request") {
+          ticketCopyState = { status: "idle", error: "" };
           root.state.resetUrgentDraft();
           paint(container);
           refreshPricing(container);
@@ -1058,6 +1117,19 @@
           root.state.updateDraft("tracking", { trackingCode: key });
           root.state.setTracking({ status: "idle", data: null, error: "" });
           root.utils.routeTo("tracking");
+        } else if (action === "copy-booking-ticket") {
+          if (ticketCopyState.status === "copying" || ticketCopyState.status === "copied") return;
+          const text = bookingTicketText(root.state.urgentFlow?.result?.booking_ticket);
+          ticketCopyState = { status: "copying", error: "" }; paint(container);
+          try {
+            if (!text || !navigator.clipboard?.writeText || window.isSecureContext === false) throw new Error("CLIPBOARD_UNAVAILABLE");
+            await navigator.clipboard.writeText(text);
+            ticketCopyState = { status: "copied", error: "" };
+          } catch (_) {
+            ticketCopyState = { status: "manual", error: "เบราว์เซอร์ไม่อนุญาตให้คัดลอกอัตโนมัติ กรุณาคัดลอกข้อความด้านล่าง" };
+          }
+          paint(container);
+          if (ticketCopyState.status === "manual") container.querySelector("#urgent-ticket-manual")?.select?.();
         } else if (action === "cancel-request") {
           await cancelUrgent(container);
         }

--- a/customer-app/modules/services.js
+++ b/customer-app/modules/services.js
@@ -225,8 +225,8 @@
     const line = normalizeServiceLine(item.draft);
     const catalogItemId = Number.isFinite(Number(item.id)) && Number(item.id) > 0 ? Number(item.id) : null;
     root.state.updateDraft(scope, {
-      service_kind: "clean",
-      job_type: "ล้าง",
+      service_kind: line.job_type === "ล้าง" ? "clean" : line.job_type,
+      job_type: line.job_type,
       ac_type: line.ac_type,
       btu: String(line.btu),
       machine_count: line.machine_count,
@@ -235,6 +235,7 @@
       selectedSlot: null,
       catalog_item_id: catalogItemId,
       ...(scope === "scheduled" ? { scheduled_request_key: "" } : {}),
+      ...(scope === "urgent" ? { urgent_request_key: "", service_package_groups: [], service_package_bundle_preview: null } : {}),
     });
     root.state.selectedService = { id: item.id || item.title || "", route: scope };
     if (scope === "scheduled") {

--- a/customer-app/modules/services.js
+++ b/customer-app/modules/services.js
@@ -234,6 +234,8 @@
       services: [line],
       selectedSlot: null,
       catalog_item_id: catalogItemId,
+      catalog_booking_quote: item.catalog_quote || null,
+      catalog_booking_pricing: item.pricing || null,
       ...(scope === "scheduled" ? { scheduled_request_key: "" } : {}),
       ...(scope === "urgent" ? { urgent_request_key: "", service_package_groups: [], service_package_bundle_preview: null } : {}),
     });
@@ -306,6 +308,106 @@
     };
   }
 
+  function normalizeCompositeServiceLine(line) {
+    const normalized = normalizeServiceLine({ ...(line || {}), machine_count: 1 });
+    const quantity = Number(line?.machine_count);
+    if (!Number.isSafeInteger(quantity) || quantity <= 0 || quantity > 99) return null;
+    return { ...normalized, machine_count: quantity };
+  }
+
+  function payloadFromCompositeServiceLines(lines) {
+    const normalized = (Array.isArray(lines) ? lines : []).map(normalizeCompositeServiceLine);
+    if (!normalized.length || normalized.some((line) => !line || line.needs_admin_estimate)) return null;
+    const backend = normalized.map((line) => ({
+      job_type: line.job_type,
+      ac_type: line.ac_type,
+      btu: line.btu,
+      machine_count: line.machine_count,
+      ...(line.ac_type === WALL_AC && line.wash_variant ? { wash_variant: line.wash_variant } : {}),
+    }));
+    const first = backend[0];
+    return {
+      job_type: first.job_type,
+      ac_type: first.ac_type,
+      btu: first.btu,
+      machine_count: backend.reduce((sum, line) => sum + line.machine_count, 0),
+      wash_variant: first.wash_variant || "",
+      repair_variant: "",
+      services: backend,
+    };
+  }
+
+  function exactMoneyText(value) {
+    const match = /^(\d+)(?:\.(\d{1,2}))?$/.exec(String(value == null ? "" : value).trim());
+    return match ? `${match[1]}.${String(match[2] || "").padEnd(2, "0")}` : "";
+  }
+
+  function catalogQuoteToCommerceDraft(catalogItem, quote, bookingMode) {
+    const item = catalogItemToCommerceDraft(catalogItem);
+    const totalExact = exactMoneyText(quote?.fixed_total_price);
+    const durationMin = Number(quote?.duration_minutes);
+    const machineCount = Number(quote?.machine_count);
+    const selected = item?.draft || {};
+    const service = quote?.service || {};
+    if (!item || quote?.kind !== "bookable" || Number(quote?.catalog_item_id) !== Number(catalogItem.item_id)
+        || !totalExact || !Number.isSafeInteger(machineCount)
+        || machineCount <= 0 || !Number.isSafeInteger(durationMin) || durationMin <= 0) return null;
+    if (String(service.job_type || "") !== String(selected.job_type || "")
+        || String(service.ac_type || "") !== String(selected.ac_type || "")
+        || Number(service.btu) !== Number(selected.btu)
+        || String(service.wash_variant || "") !== String(selected.wash_variant || "")
+        || machineCount !== Number(selected.machine_count)) return null;
+    const scope = String(bookingMode || "scheduled") === "urgent" ? "urgent" : "scheduled";
+    const quoteState = Object.freeze({
+      catalog_item_id: Number(catalogItem.item_id),
+      booking_mode: scope,
+      fixed_total_price: totalExact,
+      duration_min: durationMin,
+      machine_count: machineCount,
+      unit_price: exactMoneyText(quote.unit_price),
+      normal_unit_price: exactMoneyText(quote.normal_unit_price),
+      price_label: String(quote.price_label || ""),
+      campaign_name: String(quote.campaign_name || ""),
+      service: Object.freeze({
+        job_type: String(service.job_type || ""),
+        ac_type: String(service.ac_type || ""),
+        btu: Number(service.btu),
+        wash_variant: String(service.wash_variant || ""),
+        machine_count: machineCount,
+      }),
+      server_verified: true,
+    });
+    const pricing = {
+      standard_price: totalExact,
+      active_price: totalExact,
+      fixed_total_price: totalExact,
+      duration_min: durationMin,
+      price_lines: [{ line_total: totalExact }],
+      ...(quoteState.campaign_name || quoteState.price_label ? { promo: {
+        promo_name: quoteState.campaign_name || quoteState.price_label,
+        total_after_discount: totalExact,
+      } } : {}),
+      catalog_quote: quoteState,
+    };
+    return { ...item, catalog_quote: quoteState, pricing };
+  }
+
+  function catalogQuoteMatchesDraft(source, scope) {
+    const d = source || {};
+    const quote = d.catalog_booking_quote;
+    if (!quote || quote.server_verified !== true || quote.booking_mode !== scope
+        || Number(quote.catalog_item_id) !== Number(d.catalog_item_id)) return false;
+    const lines = normalizeServiceLines(d);
+    const line = lines[0];
+    const service = quote.service || {};
+    return lines.length === 1
+      && String(line.job_type || "") === String(service.job_type || "")
+      && String(line.ac_type || "") === String(service.ac_type || "")
+      && Number(line.btu) === Number(service.btu)
+      && String(line.wash_variant || "") === String(service.wash_variant || "")
+      && Number(line.machine_count) === Number(quote.machine_count);
+  }
+
   root.services = {
     UNKNOWN_AC,
     UNKNOWN_BTU,
@@ -337,11 +439,15 @@
     commerceItem,
     applyCommerceDraft,
     catalogItemToCommerceDraft,
+    catalogQuoteToCommerceDraft,
+    catalogQuoteMatchesDraft,
     createServiceLine,
     normalizeServiceLine,
+    normalizeCompositeServiceLine,
     normalizeServiceLines,
     linePatchToDraftServices,
     payloadFromServiceLines,
+    payloadFromCompositeServiceLines,
     payloadFromScheduledDraft,
     normalizeServiceDraft,
     payloadFromServiceDraft,

--- a/customer-app/modules/state.js
+++ b/customer-app/modules/state.js
@@ -91,6 +91,8 @@
       service_package_tier_key: "",
       service_package_btu: "",
       service_package_preview: null,
+      service_package_groups: [],
+      service_package_bundle_preview: null,
     };
   }
 
@@ -296,6 +298,8 @@
         restored.service_package_btu = String(restored.service_package_btu || "").trim();
         // Persisted display metadata is never authoritative for a new booking.
         restored.service_package_preview = null;
+        restored.service_package_groups = Array.isArray(restored.service_package_groups) ? restored.service_package_groups : [];
+        restored.service_package_bundle_preview = null;
         if (!restored.service_package_key || !restored.service_package_tier_key) {
           restored.service_package_key = "";
           restored.service_package_tier_key = "";

--- a/customer-app/modules/state.js
+++ b/customer-app/modules/state.js
@@ -120,6 +120,9 @@
       symptom: "",
       job_zone: String(source.job_zone || ""),
       urgent_request_key: "",
+      catalog_item_id: null,
+      service_package_groups: [],
+      service_package_bundle_preview: null,
     };
   }
 

--- a/customer-app/modules/store.js
+++ b/customer-app/modules/store.js
@@ -104,15 +104,25 @@
     })).filter((tier) => Number.isInteger(tier.quantity) && tier.quantity > 0);
     const exact = usable.filter((tier) => tier.quantity === requestedQuantity).sort((a, b) => a.minor < b.minor ? -1 : 1)[0];
     if (exact) return { minor: exact.minor, components: [exact] };
+    const compare = (candidate, current) => {
+      if (!current) return -1;
+      if (candidate.components.length !== current.components.length) return candidate.components.length - current.components.length;
+      if (candidate.minor !== current.minor) return candidate.minor < current.minor ? -1 : 1;
+      const left = candidate.components.map((item) => item.quantity).sort((a, b) => b - a);
+      const right = current.components.map((item) => item.quantity).sort((a, b) => b - a);
+      for (let index = 0; index < Math.max(left.length, right.length); index += 1) {
+        if ((left[index] || 0) !== (right[index] || 0)) return (right[index] || 0) - (left[index] || 0);
+      }
+      return 0;
+    };
     const best = Array(requestedQuantity + 1).fill(null); best[0] = { minor: 0n, components: [] };
     for (let target = 1; target <= requestedQuantity; target += 1) {
       for (const tier of usable) {
         const prior = best[target - tier.quantity];
-        if (tier.quantity > target || !prior || (tier.quantity === 1 && prior.components.some((part) => part.quantity === 1))) continue;
+        if (tier.quantity > target || !prior) continue;
         const candidate = { minor: prior.minor + tier.minor, components: [...prior.components, tier] };
         const current = best[target];
-        if (!current || candidate.minor < current.minor
-            || (candidate.minor === current.minor && candidate.components.length < current.components.length)) best[target] = candidate;
+        if (compare(candidate, current) < 0) best[target] = candidate;
       }
     }
     return best[requestedQuantity];
@@ -122,7 +132,7 @@
     if (!isServicePackageBundle(item)) return "";
     return `<section class="store-bundle-config" data-store-bundle-config><h3>เลือก BTU และจำนวนเครื่อง</h3><p class="muted">รวมแอร์หลายขนาดในงานเดียวได้ และเลือกมากกว่า 4 เครื่องได้</p>${item.service_package_variants.map((variant) => {
       const options = bundleBtuOptions(variant);
-      return `<div class="store-bundle-row" data-bundle-package="${root.utils.escapeHtml(variant.package_key)}"><div><strong>${root.utils.escapeHtml(variant.package_name)}</strong>${variant.description ? `<small>${root.utils.escapeHtml(variant.description)}</small>` : ""}</div><label>BTU<select class="select" data-bundle-btu>${options.map((option) => `<option value="${option.btu}">${root.utils.escapeHtml(option.label || `${option.btu} BTU`)}</option>`).join("")}</select></label><label>จำนวน<select class="select" data-bundle-quantity>${Array.from({ length: 11 }, (_, quantity) => `<option value="${quantity}">${quantity} เครื่อง</option>`).join("")}</select></label></div>`;
+      return `<div class="store-bundle-row" data-bundle-package="${root.utils.escapeHtml(variant.package_key)}"><div><strong>${root.utils.escapeHtml(variant.package_name)}</strong>${variant.description ? `<small>${root.utils.escapeHtml(variant.description)}</small>` : ""}</div><label>BTU<select class="select" data-bundle-btu>${options.map((option) => `<option value="${option.btu}">${root.utils.escapeHtml(option.label || `${option.btu} BTU`)}</option>`).join("")}</select></label><label>จำนวน<input class="input" data-bundle-quantity type="number" min="0" step="1" inputmode="numeric" value="0" aria-label="จำนวนเครื่องสำหรับ ${root.utils.escapeHtml(variant.package_name)}"></label></div>`;
     }).join("")}<div class="store-bundle-live-total" data-bundle-total>เลือกอย่างน้อย 1 เครื่อง</div><div class="inline-error" data-bundle-error aria-live="polite"></div></section>`;
   }
 
@@ -131,6 +141,7 @@
     let total = 0n; let durationMin = 0;
     container.querySelectorAll("[data-bundle-package]").forEach((row) => {
       const quantity = Number(row.querySelector("[data-bundle-quantity]")?.value || 0);
+      if (!Number.isSafeInteger(quantity) || quantity < 0) throw new Error("จำนวนเครื่องต้องเป็นจำนวนเต็มตั้งแต่ 0 ขึ้นไป");
       if (!quantity) return;
       const packageKey = row.getAttribute("data-bundle-package");
       const variant = item.service_package_variants.find((entry) => entry.package_key === packageKey);
@@ -149,15 +160,19 @@
       duration_min: durationMin, redeem_until: item.service_package_redeem_until, payload: { services } } };
   }
 
-  function beginBundleBooking(container, item) {
+  function beginBundleBooking(container, item, scope = "scheduled") {
     const errorBox = container.querySelector("[data-bundle-error]");
     try {
       const result = collectBundleDraft(container, item);
-      root.state.updateDraft("scheduled", { service_package_key: "", service_package_tier_key: "", service_package_btu: "",
-        service_package_groups: result.groups, service_package_bundle_preview: result.preview, services: [], selectedSlot: null, scheduled_request_key: "" });
-      root.state.setScheduledPreview("package", { status: "success", data: result.preview, error: "", verified: true });
-      root.state.setScheduledPreview("pricing", { status: "idle", data: null, error: "" });
-      root.utils.routeTo("scheduled");
+      const common = { catalog_item_id: Number(item.item_id), service_package_key: "", service_package_tier_key: "", service_package_btu: "",
+        service_package_groups: result.groups, service_package_bundle_preview: result.preview,
+        services: result.preview.payload.services, selectedSlot: null };
+      root.state.updateDraft(scope, scope === "urgent" ? { ...common, urgent_request_key: "" } : { ...common, scheduled_request_key: "" });
+      if (scope === "scheduled") {
+        root.state.setScheduledPreview("package", { status: "success", data: result.preview, error: "", verified: true });
+        root.state.setScheduledPreview("pricing", { status: "idle", data: null, error: "" });
+      }
+      root.utils.routeTo(scope);
     } catch (error) {
       if (errorBox) errorBox.textContent = error.message;
     }
@@ -511,6 +526,21 @@
     return `<div class="store-promo-info">${parts.join("")}</div>`;
   }
 
+  const CAMPAIGN_THEMES = new Set(["default", "premium", "limited_time", "new"]);
+  const CAMPAIGN_EFFECTS = new Set(["none", "soft_glow", "shimmer_border", "badge_pulse"]);
+  function campaignTheme(item) { return CAMPAIGN_THEMES.has(item?.promotion_theme_preset) ? item.promotion_theme_preset : "default"; }
+  function campaignEffect(item) { return CAMPAIGN_EFFECTS.has(item?.promotion_effect_preset) ? item.promotion_effect_preset : "none"; }
+  function campaignSaleEnd(item) { return item?.service_package_sell_end_at || item?.effective_to || null; }
+  function renderCampaignPresentation(item) {
+    const badge = String(item?.promotion_badge_text || "").trim();
+    const support = String(item?.promotion_supporting_text || "").trim();
+    const end = campaignSaleEnd(item);
+    const countdown = item?.show_sale_countdown === true && end
+      ? `<span class="store-campaign-countdown" data-campaign-countdown="${root.utils.escapeHtml(end)}" aria-label="เวลาที่เหลือของโปรโมชั่น"></span>` : "";
+    if (!badge && !support && !countdown) return "";
+    return `<div class="store-campaign-presentation">${badge ? `<span class="store-campaign-badge">${root.utils.escapeHtml(badge)}</span>` : ""}${support ? `<span class="store-campaign-support">${root.utils.escapeHtml(support)}</span>` : ""}${countdown}</div>`;
+  }
+
   // Real review aggregates only. item.rating_average/review_count come straight
   // from the backend's catalog_item_reviews aggregation (approved reviews only —
   // see attachCatalogRatings() in server/routes/catalog/items.js). There is no
@@ -611,6 +641,23 @@
     return badges.length ? `<div class="store-card-badges">${badges.join("")}</div>` : "";
   }
 
+  function allowsUrgentBooking(item) {
+    return String(item?.booking_flow_policy || "scheduled_only") === "scheduled_and_urgent";
+  }
+
+  function urgentBookingAvailable() {
+    return root.pageAvailability?.isEnabled?.("urgent") === true;
+  }
+
+  function renderBookingActions(item, id, detail = false) {
+    const attribute = detail ? "data-store-detail" : "data-store";
+    const value = detail ? "1" : root.utils.escapeHtml(id);
+    const scheduled = `<button class="primary-btn" type="button" ${attribute}-book="${value}">${isServicePackageBundle(item) ? "จองแพ็กเกจ" : "จองคิว"}</button>`;
+    if (!allowsUrgentBooking(item)) return scheduled;
+    const enabled = urgentBookingAvailable();
+    return `${scheduled}<button class="secondary-btn" type="button" ${attribute}-urgent="${value}"${enabled ? "" : " disabled"}>${enabled ? "จองด่วน" : "คิวด่วนปิดชั่วคราว"}</button>`;
+  }
+
   function renderCard(item) {
     const id = String(item.item_id || "");
     const name = item.item_name || "-";
@@ -621,8 +668,9 @@
     const promo = hasPromo(item);
     const bookable = isBookable(item);
     return `
-      <article class="store-card" data-store-item="${root.utils.escapeHtml(id)}" tabindex="0" role="button" aria-label="ดูรายละเอียด ${root.utils.escapeHtml(name)}">
+      <article class="store-card campaign-theme-${campaignTheme(item)} campaign-effect-${campaignEffect(item)}" data-store-item="${root.utils.escapeHtml(id)}" tabindex="0" role="button" aria-label="ดูรายละเอียด ${root.utils.escapeHtml(name)}">
         ${renderCardGallery(item, name)}
+        ${renderCampaignPresentation(item)}
         ${renderBadges(item)}
         <div class="store-card-head">
           ${category ? `<span class="tag">${root.utils.escapeHtml(category)}</span>` : ""}
@@ -639,7 +687,7 @@
         ${renderPromoInfo(item)}
         <div class="store-card-actions">
           ${bookable
-            ? `<button class="primary-btn" type="button" data-store-book="${root.utils.escapeHtml(id)}">จองคิว</button>`
+            ? renderBookingActions(item, id)
             : isPurchase(item)
               ? `<button class="primary-btn" type="button" data-store-buy="${root.utils.escapeHtml(id)}">ซื้อ</button>`
               : `<button class="secondary-btn" type="button" data-store-contact="${root.utils.escapeHtml(id)}" data-store-contact-name="${root.utils.escapeHtml(name)}">สอบถามแอดมิน</button>`}
@@ -818,10 +866,43 @@
   }
 
   let cardAutoplayCleanups = [];
+  let campaignCountdownCleanups = [];
 
   function clearCardAutoplay() {
     cardAutoplayCleanups.forEach((cleanup) => cleanup());
     cardAutoplayCleanups = [];
+  }
+
+  function clearCampaignCountdowns() {
+    campaignCountdownCleanups.forEach((cleanup) => cleanup());
+    campaignCountdownCleanups = [];
+  }
+  function bindCampaignCountdowns(scope) {
+    clearCampaignCountdowns();
+    scope.querySelectorAll("[data-campaign-countdown]").forEach((node) => {
+      const end = new Date(node.getAttribute("data-campaign-countdown"));
+      if (!Number.isFinite(end.getTime())) return;
+      let timer = null;
+      const tick = () => {
+        if (!node.isConnected) return;
+        const remaining = end.getTime() - Date.now();
+        if (remaining <= 0) {
+          node.textContent = "ปิดรับจองแล้ว";
+          node.closest(".store-card, .store-detail-screen")?.querySelectorAll("[data-store-book], [data-store-urgent], [data-store-detail-book], [data-store-detail-urgent]").forEach((button) => { button.disabled = true; });
+          if (timer) clearTimeout(timer);
+          timer = null;
+          return;
+        }
+        const minutes = Math.ceil(remaining / 60000);
+        const days = Math.floor(minutes / 1440); const hours = Math.floor((minutes % 1440) / 60); const mins = minutes % 60;
+        node.textContent = days ? `เหลือ ${days} วัน ${hours} ชม.` : `เหลือ ${hours} ชม. ${mins} นาที`;
+        timer = setTimeout(tick, 60000);
+      };
+      const onVisibility = () => { if (!document.hidden) tick(); };
+      document.addEventListener("visibilitychange", onVisibility);
+      tick();
+      campaignCountdownCleanups.push(() => { if (timer) clearTimeout(timer); document.removeEventListener("visibilitychange", onVisibility); });
+    });
   }
 
   function bindGallerySliders(scope) {
@@ -851,12 +932,12 @@
     container.querySelectorAll("[data-store-item]").forEach((card) => {
       const id = card.getAttribute("data-store-item");
       card.addEventListener("click", (event) => {
-        if (event.target.closest("[data-store-book], [data-store-contact], [data-store-buy]")) return;
+        if (event.target.closest("[data-store-book], [data-store-urgent], [data-store-contact], [data-store-buy]")) return;
         goToDetail(id);
       });
       card.addEventListener("keydown", (event) => {
         if (event.key !== "Enter" && event.key !== " ") return;
-        if (event.target.closest("[data-store-book], [data-store-contact], [data-store-buy]")) return;
+        if (event.target.closest("[data-store-book], [data-store-urgent], [data-store-contact], [data-store-buy]")) return;
         event.preventDefault();
         goToDetail(id);
       });
@@ -903,6 +984,7 @@
       });
     });
     bindGallerySliders(container);
+    bindCampaignCountdowns(container);
   }
 
   function patchGrid(container) {
@@ -1534,7 +1616,7 @@
     const bookable = isBookable(item);
     const showCompare = canonicalAcType(item) === "wall" && canonicalJobCategory(item) === "wash";
     const ctaButton = bookable
-      ? `<button class="primary-btn" type="button" data-store-detail-book="1">${isServicePackageBundle(item) ? "จองแพ็กเกจ" : "จองคิว"}</button>`
+      ? renderBookingActions(item, item.item_id, true)
       : isPurchase(item)
         ? `<button class="primary-btn" type="button" data-store-detail-buy="1">ซื้อสินค้า</button>`
         : `<button class="primary-btn" type="button" data-store-detail-contact="1">สอบถามแอดมิน</button>`;
@@ -1542,6 +1624,7 @@
     return `
       <button class="store-detail-back" type="button" data-store-detail-back>${root.utils.icon("pin", 16)}กลับไปหน้าร้านค้า</button>
       ${renderDetailGallery(item, name)}
+      <div class="campaign-theme-${campaignTheme(item)} campaign-effect-${campaignEffect(item)}">${renderCampaignPresentation(item)}</div>
       ${renderBadges(item)}
       <div class="store-detail-head">
         ${category ? `<span class="tag">${root.utils.escapeHtml(category)}</span>` : ""}
@@ -1666,6 +1749,31 @@
         }
       });
     });
+    container.querySelectorAll("[data-store-detail-urgent]").forEach((bookButton) => {
+      bookButton.addEventListener("click", () => {
+        if (bookButton.disabled) return;
+        const item = root.state.storeDetail?.data;
+        if (!item || !allowsUrgentBooking(item)) return;
+        if (isServicePackageBundle(item)) { beginBundleBooking(container, item, "urgent"); return; }
+        const draftItem = root.services.catalogItemToCommerceDraft(item);
+        if (!draftItem || !root.services.applyCommerceDraft("urgent", draftItem)) return;
+        trackItemEvent("cwf_store_begin_urgent_booking", item, { source: "store_detail" });
+        root.utils.routeTo("urgent");
+      });
+    });
+    container.querySelectorAll("[data-store-urgent]").forEach((button) => {
+      button.addEventListener("click", (event) => {
+        event.stopPropagation && event.stopPropagation();
+        if (button.disabled) return;
+        const id = button.getAttribute("data-store-urgent");
+        const item = (root.state.catalog.items || []).find((it) => String(it.item_id) === String(id));
+        if (isServicePackageBundle(item)) { goToDetail(id); return; }
+        const draftItem = root.services.catalogItemToCommerceDraft(item);
+        if (!draftItem || !root.services.applyCommerceDraft("urgent", draftItem)) return;
+        trackItemEvent("cwf_store_begin_urgent_booking", item, { source: "store_list" });
+        root.utils.routeTo("urgent");
+      });
+    });
     container.querySelectorAll("[data-store-detail-contact]").forEach((contactButton) => {
       contactButton.addEventListener("click", () => {
         const item = root.state.storeDetail?.data;
@@ -1717,6 +1825,7 @@
     const item = root.state.storeDetail?.data;
     if (item) bindReviewsSection(container, item);
     bindDetailGallery(container);
+    bindCampaignCountdowns(container);
   }
 
   function patchDetailBody(container) {
@@ -2186,9 +2295,11 @@
 
   store.render.onLeave = () => {
     clearCardAutoplay();
+    clearCampaignCountdowns();
   };
   store.renderDetail.onLeave = () => {
     clearDetailAutoplay();
+    clearCampaignCountdowns();
   };
 
   store._test = { loadDetail, loadReviewsList, loadEligibility, detailItemId, renderDetailBody, renderReviewsSectionBody,

--- a/customer-app/modules/store.js
+++ b/customer-app/modules/store.js
@@ -11,6 +11,8 @@
   let reviewsRequestSeq = 0;
   let eligibilityRequestSeq = 0;
   let reviewSubmitSeq = 0;
+  let ordinaryQuoteRequestSeq = 0;
+  const ordinaryQuotesInFlight = new Set();
 
   console.info("[customer-store] payment-security 20260705 loaded");
 
@@ -189,6 +191,13 @@
     const draftItem = root.services.catalogItemToCommerceDraft(item);
     if (!draftItem) return false;
     const line = draftItem.draft;
+    const requestKey = `${scope}:${item.item_id}`;
+    if (ordinaryQuotesInFlight.has(requestKey)) return false;
+    ordinaryQuotesInFlight.add(requestKey);
+    const requestId = ++ordinaryQuoteRequestSeq;
+    const routeAtStart = root.state.currentRoute;
+    container.querySelectorAll(`[data-store-book="${item.item_id}"], [data-store-urgent="${item.item_id}"], [data-store-detail-book], [data-store-detail-urgent]`)
+      .forEach((button) => { button.disabled = true; button.setAttribute("aria-busy", "true"); });
     let status = container.querySelector("[data-catalog-quote-status]");
     if (!status && typeof document.createElement === "function") {
       status = document.createElement("div");
@@ -199,18 +208,30 @@
     }
     if (status) status.textContent = "กำลังตรวจสอบราคาและสิทธิ์จากระบบ...";
     try {
-      await root.api.quoteCatalogBooking({ catalog_item_id: Number(item.item_id), booking_mode: scope,
+      const quote = await root.api.quoteCatalogBooking({ catalog_item_id: Number(item.item_id), booking_mode: scope,
         job_type: line.job_type, ac_type: line.ac_type, btu: line.btu,
         wash_variant: line.wash_variant, machine_count: line.machine_count });
+      if (requestId !== ordinaryQuoteRequestSeq || root.state.currentRoute !== routeAtStart) return false;
+      const verifiedDraft = root.services.catalogQuoteToCommerceDraft(item, quote, scope);
+      if (!verifiedDraft || !root.services.applyCommerceDraft(scope, verifiedDraft)) throw new Error("CATALOG_QUOTE_MISMATCH");
+      if (scope === "scheduled") {
+        root.state.setScheduledPreview("pricing", { status: "success", data: verifiedDraft.pricing, error: "", verified: true });
+      } else {
+        root.state.setUrgentFlow({ pricing: { status: "success", data: verifiedDraft.pricing, error: "" } });
+      }
+      if (status) status.textContent = "";
+      trackItemEvent(scope === "urgent" ? "cwf_store_begin_urgent_booking" : "cwf_store_begin_booking", item, { source });
+      root.utils.routeTo(scope);
+      return true;
     } catch (_) {
+      if (requestId !== ordinaryQuoteRequestSeq) return false;
       if (status) status.textContent = "ไม่สามารถยืนยันราคาและสิทธิ์ได้ กรุณากดจองเพื่อลองใหม่";
       return false;
+    } finally {
+      ordinaryQuotesInFlight.delete(requestKey);
+      container.querySelectorAll(`[data-store-book="${item.item_id}"], [data-store-urgent="${item.item_id}"], [data-store-detail-book], [data-store-detail-urgent]`)
+        .forEach((button) => { button.disabled = false; button.removeAttribute("aria-busy"); });
     }
-    if (status) status.textContent = "";
-    if (!root.services.applyCommerceDraft(scope, draftItem)) return false;
-    trackItemEvent(scope === "urgent" ? "cwf_store_begin_urgent_booking" : "cwf_store_begin_booking", item, { source });
-    root.utils.routeTo(scope);
-    return true;
   }
 
   // Physical product the customer can buy (e.g. an AC unit) — gets a "ซื้อ"
@@ -2357,7 +2378,8 @@
   };
 
   store._test = { loadDetail, loadReviewsList, loadEligibility, detailItemId, renderDetailBody, renderReviewsSectionBody,
-    composeBundleTiers, renderBundleConfigurator, collectBundleDraft, bindCampaignCountdowns, clearCampaignCountdowns };
+    composeBundleTiers, renderBundleConfigurator, collectBundleDraft, beginOrdinaryBooking,
+    bindCampaignCountdowns, clearCampaignCountdowns };
 
   root.store = store;
 })();

--- a/customer-app/modules/store.js
+++ b/customer-app/modules/store.js
@@ -99,6 +99,7 @@
   }
 
   function composeBundleTiers(tiers, requestedQuantity) {
+    if (!Number.isSafeInteger(requestedQuantity) || requestedQuantity <= 0 || requestedQuantity > 99) return null;
     const usable = (tiers || []).filter((tier) => tier.is_active !== false).map((tier) => ({
       ...tier, quantity: Number(tier.quantity), minor: BigInt(String(tier.fixed_total_price).replace(".", "")),
     })).filter((tier) => Number.isInteger(tier.quantity) && tier.quantity > 0);
@@ -106,8 +107,8 @@
     if (exact) return { minor: exact.minor, components: [exact] };
     const compare = (candidate, current) => {
       if (!current) return -1;
-      if (candidate.components.length !== current.components.length) return candidate.components.length - current.components.length;
       if (candidate.minor !== current.minor) return candidate.minor < current.minor ? -1 : 1;
+      if (candidate.components.length !== current.components.length) return candidate.components.length - current.components.length;
       const left = candidate.components.map((item) => item.quantity).sort((a, b) => b - a);
       const right = current.components.map((item) => item.quantity).sort((a, b) => b - a);
       for (let index = 0; index < Math.max(left.length, right.length); index += 1) {
@@ -137,45 +138,79 @@
   }
 
   function collectBundleDraft(container, item) {
-    const groups = []; const previewGroups = []; const services = [];
-    let total = 0n; let durationMin = 0;
+    const groups = [];
     container.querySelectorAll("[data-bundle-package]").forEach((row) => {
       const quantity = Number(row.querySelector("[data-bundle-quantity]")?.value || 0);
-      if (!Number.isSafeInteger(quantity) || quantity < 0) throw new Error("จำนวนเครื่องต้องเป็นจำนวนเต็มตั้งแต่ 0 ขึ้นไป");
+      if (!Number.isSafeInteger(quantity) || quantity < 0 || quantity > 99) throw new Error("จำนวนเครื่องต้องเป็นจำนวนเต็มระหว่าง 0 ถึง 99");
       if (!quantity) return;
       const packageKey = row.getAttribute("data-bundle-package");
       const variant = item.service_package_variants.find((entry) => entry.package_key === packageKey);
       const btu = Number(row.querySelector("[data-bundle-btu]")?.value || 0);
-      const plan = variant ? composeBundleTiers(variant.tiers, quantity) : null;
-      if (!variant || !plan || !btu) throw new Error("จำนวนที่เลือกไม่สามารถจัดเป็นแพ็กเกจได้");
-      total += plan.minor; durationMin += quantity * Number(variant.unit_duration_minutes);
+      if (!variant || !btu) throw new Error("ข้อมูลแพ็กเกจไม่ครบ กรุณาลองใหม่");
       groups.push({ package_key: packageKey, btu, quantity });
-      previewGroups.push({ package_key: packageKey, package_name: variant.package_name, btu, quantity });
-      services.push({ job_type: variant.service.job_type, ac_type: variant.service.ac_type, btu, machine_count: quantity,
-        wash_variant: variant.service.wash_variant || "", repair_variant: "" });
     });
     if (!groups.length) throw new Error("กรุณาเลือกอย่างน้อย 1 เครื่อง");
-    const fixedTotal = `${total / 100n}.${String(total % 100n).padStart(2, "0")}`;
-    return { groups, preview: { package_name: item.item_name, groups: previewGroups, fixed_total_price: fixedTotal,
-      duration_min: durationMin, redeem_until: item.service_package_redeem_until, payload: { services } } };
+    if (groups.reduce((sum, group) => sum + group.quantity, 0) > 99) throw new Error("หนึ่งงานรองรับได้ไม่เกิน 99 เครื่อง");
+    return { groups };
   }
 
-  function beginBundleBooking(container, item, scope = "scheduled") {
+  let bundleQuoteRequestId = 0;
+  async function beginBundleBooking(container, item, scope = "scheduled") {
     const errorBox = container.querySelector("[data-bundle-error]");
+    const requestId = ++bundleQuoteRequestId;
     try {
       const result = collectBundleDraft(container, item);
+      if (errorBox) errorBox.textContent = "กำลังตรวจสอบราคาและสิทธิ์จากระบบ...";
+      const quote = await root.api.quoteCatalogBooking({
+        catalog_item_id: Number(item.item_id), service_package_groups: result.groups, booking_mode: scope,
+      });
+      if (requestId !== bundleQuoteRequestId || String(root.state.storeDetail?.data?.item_id) !== String(item.item_id)) return;
+      const preview = { package_name: item.item_name, groups: quote.groups, components: quote.components,
+        fixed_total_price: quote.fixed_total_price, duration_min: quote.duration_minutes,
+        redeem_until: item.service_package_redeem_until, payload: { services: quote.services }, server_verified: true };
       const common = { catalog_item_id: Number(item.item_id), service_package_key: "", service_package_tier_key: "", service_package_btu: "",
-        service_package_groups: result.groups, service_package_bundle_preview: result.preview,
-        services: result.preview.payload.services, selectedSlot: null };
+        service_package_groups: result.groups, service_package_bundle_preview: preview,
+        services: quote.services, selectedSlot: null };
       root.state.updateDraft(scope, scope === "urgent" ? { ...common, urgent_request_key: "" } : { ...common, scheduled_request_key: "" });
       if (scope === "scheduled") {
-        root.state.setScheduledPreview("package", { status: "success", data: result.preview, error: "", verified: true });
+        root.state.setScheduledPreview("package", { status: "success", data: preview, error: "", verified: true });
         root.state.setScheduledPreview("pricing", { status: "idle", data: null, error: "" });
       }
+      if (errorBox) errorBox.textContent = "";
       root.utils.routeTo(scope);
     } catch (error) {
-      if (errorBox) errorBox.textContent = error.message;
+      if (requestId !== bundleQuoteRequestId) return;
+      if (scope === "scheduled") root.state.setScheduledPreview("package", { status: "error", data: null, error: "ไม่สามารถยืนยันแพ็กเกจได้ กรุณาลองใหม่", verified: false });
+      if (errorBox) errorBox.textContent = "ไม่สามารถยืนยันราคาและสิทธิ์ได้ กรุณาลองใหม่";
     }
+  }
+
+  async function beginOrdinaryBooking(container, item, scope, source) {
+    const draftItem = root.services.catalogItemToCommerceDraft(item);
+    if (!draftItem) return false;
+    const line = draftItem.draft;
+    let status = container.querySelector("[data-catalog-quote-status]");
+    if (!status && typeof document.createElement === "function") {
+      status = document.createElement("div");
+      status.className = "inline-error";
+      status.setAttribute("data-catalog-quote-status", "");
+      status.setAttribute("aria-live", "polite");
+      container.prepend(status);
+    }
+    if (status) status.textContent = "กำลังตรวจสอบราคาและสิทธิ์จากระบบ...";
+    try {
+      await root.api.quoteCatalogBooking({ catalog_item_id: Number(item.item_id), booking_mode: scope,
+        job_type: line.job_type, ac_type: line.ac_type, btu: line.btu,
+        wash_variant: line.wash_variant, machine_count: line.machine_count });
+    } catch (_) {
+      if (status) status.textContent = "ไม่สามารถยืนยันราคาและสิทธิ์ได้ กรุณากดจองเพื่อลองใหม่";
+      return false;
+    }
+    if (status) status.textContent = "";
+    if (!root.services.applyCommerceDraft(scope, draftItem)) return false;
+    trackItemEvent(scope === "urgent" ? "cwf_store_begin_urgent_booking" : "cwf_store_begin_booking", item, { source });
+    root.utils.routeTo(scope);
+    return true;
   }
 
   // Physical product the customer can buy (e.g. an AC unit) — gets a "ซื้อ"
@@ -536,9 +571,10 @@
     const support = String(item?.promotion_supporting_text || "").trim();
     const end = campaignSaleEnd(item);
     const countdown = item?.show_sale_countdown === true && end
-      ? `<span class="store-campaign-countdown" data-campaign-countdown="${root.utils.escapeHtml(end)}" aria-label="เวลาที่เหลือของโปรโมชั่น"></span>` : "";
-    if (!badge && !support && !countdown) return "";
-    return `<div class="store-campaign-presentation">${badge ? `<span class="store-campaign-badge">${root.utils.escapeHtml(badge)}</span>` : ""}${support ? `<span class="store-campaign-support">${root.utils.escapeHtml(support)}</span>` : ""}${countdown}</div>`;
+      ? `<span class="store-campaign-countdown" data-campaign-countdown aria-label="เวลาที่เหลือของโปรโมชั่น"></span>` : "";
+    if (!badge && !support && !countdown && !end) return "";
+    const sentinel = !badge && !support && !countdown ? " is-expiry-sentinel" : "";
+    return `<div class="store-campaign-presentation${sentinel}"${end ? ` data-campaign-sale-end="${root.utils.escapeHtml(end)}"` : ""}>${badge ? `<span class="store-campaign-badge">${root.utils.escapeHtml(badge)}</span>` : ""}${support ? `<span class="store-campaign-support">${root.utils.escapeHtml(support)}</span>` : ""}${countdown}</div>`;
   }
 
   // Real review aggregates only. item.rating_average/review_count come straight
@@ -879,8 +915,8 @@
   }
   function bindCampaignCountdowns(scope) {
     clearCampaignCountdowns();
-    scope.querySelectorAll("[data-campaign-countdown]").forEach((node) => {
-      const end = new Date(node.getAttribute("data-campaign-countdown"));
+    scope.querySelectorAll("[data-campaign-sale-end]").forEach((node) => {
+      const end = new Date(node.getAttribute("data-campaign-sale-end"));
       if (!Number.isFinite(end.getTime())) return;
       let timer = null;
       let disposed = false;
@@ -892,7 +928,10 @@
         stop();
         const remaining = end.getTime() - Date.now();
         if (remaining <= 0) {
-          node.textContent = "ปิดรับจองแล้ว";
+          const countdown = typeof node.querySelector === "function" ? node.querySelector("[data-campaign-countdown]") : node;
+          if (countdown) countdown.textContent = "ปิดรับจองแล้ว";
+          node.querySelectorAll(".store-campaign-badge, .store-campaign-support").forEach((part) => { part.hidden = true; });
+          node.classList.add("is-expired");
           node.closest(".store-card, .store-detail-screen, .homepage-service-card")
             ?.querySelectorAll("[data-store-book], [data-store-urgent], [data-store-detail-book], [data-store-detail-urgent], [data-home-featured-action]")
             .forEach((button) => { button.disabled = true; button.setAttribute("aria-disabled", "true"); });
@@ -901,8 +940,9 @@
         }
         const minutes = Math.ceil(remaining / 60000);
         const days = Math.floor(minutes / 1440); const hours = Math.floor((minutes % 1440) / 60); const mins = minutes % 60;
-        node.textContent = days ? `เหลือ ${days} วัน ${hours} ชม.` : `เหลือ ${hours} ชม. ${mins} นาที`;
-        if (!document.hidden) timer = setTimeout(tick, 60000);
+        const countdown = typeof node.querySelector === "function" ? node.querySelector("[data-campaign-countdown]") : node;
+        if (countdown) countdown.textContent = days ? `เหลือ ${days} วัน ${hours} ชม.` : `เหลือ ${hours} ชม. ${mins} นาที`;
+        if (!document.hidden) timer = setTimeout(tick, Math.min(60000, Math.max(1, remaining)));
       };
       const onVisibility = () => { if (document.hidden) stop(); else tick(); };
       cleanup = () => {
@@ -955,33 +995,28 @@
       });
     });
     container.querySelectorAll("[data-store-book]").forEach((button) => {
-      button.addEventListener("click", (event) => {
+      button.addEventListener("click", async (event) => {
         event.stopPropagation && event.stopPropagation();
         const id = button.getAttribute("data-store-book");
         const item = (root.state.catalog.items || []).find((it) => String(it.item_id) === String(id));
         if (isServicePackageBundle(item)) { goToDetail(id); return; }
-        const draftItem = root.services.catalogItemToCommerceDraft(item);
-        if (!draftItem || !root.services.applyCommerceDraft("scheduled", draftItem)) {
+        if (!root.services.catalogItemToCommerceDraft(item)) {
           trackItemEvent("cwf_store_contact_admin", item, { source: "store_list" });
           root.ui.openContactSheet(container, { title: item?.item_name || "รายการนี้" });
           return;
         }
-        trackItemEvent("cwf_store_begin_booking", item, { source: "store_list" });
-        root.utils.routeTo("scheduled");
+        await beginOrdinaryBooking(container, item, "scheduled", "store_list");
       });
     });
     container.querySelectorAll("[data-store-urgent]").forEach((button) => {
-      button.addEventListener("click", (event) => {
+      button.addEventListener("click", async (event) => {
         event.stopPropagation && event.stopPropagation();
         if (button.disabled) return;
         const id = button.getAttribute("data-store-urgent");
         const item = (root.state.catalog.items || []).find((it) => String(it.item_id) === String(id));
         if (!item || !allowsUrgentBooking(item) || !urgentBookingAvailable()) return;
         if (isServicePackageBundle(item)) { goToDetail(id); return; }
-        const draftItem = root.services.catalogItemToCommerceDraft(item);
-        if (!draftItem || !root.services.applyCommerceDraft("urgent", draftItem)) return;
-        trackItemEvent("cwf_store_begin_urgent_booking", item, { source: "store_list" });
-        root.utils.routeTo("urgent");
+        await beginOrdinaryBooking(container, item, "urgent", "store_list");
       });
     });
     container.querySelectorAll("[data-store-buy]").forEach((button) => {
@@ -1747,18 +1782,16 @@
     const retry = container.querySelector("[data-store-detail-retry]");
     if (retry) retry.addEventListener("click", () => loadDetail(container, detailItemId()));
     container.querySelectorAll("[data-store-detail-book]").forEach((bookButton) => {
-      bookButton.addEventListener("click", () => {
+      bookButton.addEventListener("click", async () => {
         const item = root.state.storeDetail?.data;
         if (!item) return;
         if (isServicePackageBundle(item)) { beginBundleBooking(container, item); return; }
-        const draftItem = root.services.catalogItemToCommerceDraft(item);
-        if (!draftItem || !root.services.applyCommerceDraft("scheduled", draftItem)) {
+        if (!root.services.catalogItemToCommerceDraft(item)) {
           trackItemEvent("cwf_store_contact_admin", item, { source: "store_detail" });
           root.ui.openContactSheet(container, { title: item?.item_name || "รายการนี้" });
           return;
         }
-        trackItemEvent("cwf_store_begin_booking", item, { source: "store_detail" });
-        root.utils.routeTo("scheduled");
+        await beginOrdinaryBooking(container, item, "scheduled", "store_detail");
       });
     });
     container.querySelectorAll("[data-bundle-quantity], [data-bundle-btu]").forEach((control) => {
@@ -1769,22 +1802,19 @@
         if (error) error.textContent = "";
         try {
           const result = collectBundleDraft(container, item);
-          if (total) total.textContent = `รวม ${result.preview.groups.reduce((sum, group) => sum + group.quantity, 0)} เครื่อง · ${result.preview.fixed_total_price} บาท · ${result.preview.duration_min} นาที`;
+          if (total) total.textContent = `รวม ${result.groups.reduce((sum, group) => sum + group.quantity, 0)} เครื่อง · ระบบจะยืนยันราคาเมื่อกดจอง`;
         } catch (cause) {
           if (total) total.textContent = cause.message;
         }
       });
     });
     container.querySelectorAll("[data-store-detail-urgent]").forEach((bookButton) => {
-      bookButton.addEventListener("click", () => {
+      bookButton.addEventListener("click", async () => {
         if (bookButton.disabled) return;
         const item = root.state.storeDetail?.data;
         if (!item || !allowsUrgentBooking(item)) return;
         if (isServicePackageBundle(item)) { beginBundleBooking(container, item, "urgent"); return; }
-        const draftItem = root.services.catalogItemToCommerceDraft(item);
-        if (!draftItem || !root.services.applyCommerceDraft("urgent", draftItem)) return;
-        trackItemEvent("cwf_store_begin_urgent_booking", item, { source: "store_detail" });
-        root.utils.routeTo("urgent");
+        await beginOrdinaryBooking(container, item, "urgent", "store_detail");
       });
     });
     container.querySelectorAll("[data-store-detail-contact]").forEach((contactButton) => {

--- a/customer-app/modules/store.js
+++ b/customer-app/modules/store.js
@@ -44,6 +44,11 @@
   }
 
   function effectiveSalePrice(item) {
+    if (item?.booking_mode === "service_package") {
+      const prices = (item.service_package_variants || []).flatMap((variant) => (variant.tiers || []))
+        .filter((tier) => tier.is_active !== false).map((tier) => Number(tier.fixed_total_price)).filter((price) => Number.isFinite(price) && price > 0);
+      if (prices.length) return Math.min(...prices);
+    }
     const display = Number(item.display_price);
     if (Number.isFinite(display) && display > 0) return display;
     const base = Number(item.base_price);
@@ -58,7 +63,7 @@
   function priceLabel(item) {
     const sale = effectiveSalePrice(item);
     if (sale === null) return "สอบถามราคา";
-    return root.utils.formatBaht(sale);
+    return `${item?.booking_mode === "service_package" ? "เริ่ม " : ""}${root.utils.formatBaht(sale)}`;
   }
 
   function hasPromo(item) {
@@ -79,7 +84,83 @@
   }
 
   function isBookable(item) {
-    return item.booking_mode === "bookable";
+    return item.booking_mode === "bookable" || item.booking_mode === "service_package";
+  }
+
+  function isServicePackageBundle(item) {
+    return item?.booking_mode === "service_package" && Array.isArray(item.service_package_variants);
+  }
+
+  function bundleBtuOptions(variant) {
+    const service = variant?.service || {};
+    const min = Number(service.btu_min || 0);
+    const max = Number(service.btu_max || Number.MAX_SAFE_INTEGER);
+    return root.services.bookableBtuOptions.filter((option) => option.btu >= min && option.btu <= max);
+  }
+
+  function composeBundleTiers(tiers, requestedQuantity) {
+    const usable = (tiers || []).filter((tier) => tier.is_active !== false).map((tier) => ({
+      ...tier, quantity: Number(tier.quantity), minor: BigInt(String(tier.fixed_total_price).replace(".", "")),
+    })).filter((tier) => Number.isInteger(tier.quantity) && tier.quantity > 0);
+    const exact = usable.filter((tier) => tier.quantity === requestedQuantity).sort((a, b) => a.minor < b.minor ? -1 : 1)[0];
+    if (exact) return { minor: exact.minor, components: [exact] };
+    const best = Array(requestedQuantity + 1).fill(null); best[0] = { minor: 0n, components: [] };
+    for (let target = 1; target <= requestedQuantity; target += 1) {
+      for (const tier of usable) {
+        const prior = best[target - tier.quantity];
+        if (tier.quantity > target || !prior || (tier.quantity === 1 && prior.components.some((part) => part.quantity === 1))) continue;
+        const candidate = { minor: prior.minor + tier.minor, components: [...prior.components, tier] };
+        const current = best[target];
+        if (!current || candidate.minor < current.minor
+            || (candidate.minor === current.minor && candidate.components.length < current.components.length)) best[target] = candidate;
+      }
+    }
+    return best[requestedQuantity];
+  }
+
+  function renderBundleConfigurator(item) {
+    if (!isServicePackageBundle(item)) return "";
+    return `<section class="store-bundle-config" data-store-bundle-config><h3>เลือก BTU และจำนวนเครื่อง</h3><p class="muted">รวมแอร์หลายขนาดในงานเดียวได้ และเลือกมากกว่า 4 เครื่องได้</p>${item.service_package_variants.map((variant) => {
+      const options = bundleBtuOptions(variant);
+      return `<div class="store-bundle-row" data-bundle-package="${root.utils.escapeHtml(variant.package_key)}"><div><strong>${root.utils.escapeHtml(variant.package_name)}</strong>${variant.description ? `<small>${root.utils.escapeHtml(variant.description)}</small>` : ""}</div><label>BTU<select class="select" data-bundle-btu>${options.map((option) => `<option value="${option.btu}">${root.utils.escapeHtml(option.label || `${option.btu} BTU`)}</option>`).join("")}</select></label><label>จำนวน<select class="select" data-bundle-quantity>${Array.from({ length: 11 }, (_, quantity) => `<option value="${quantity}">${quantity} เครื่อง</option>`).join("")}</select></label></div>`;
+    }).join("")}<div class="store-bundle-live-total" data-bundle-total>เลือกอย่างน้อย 1 เครื่อง</div><div class="inline-error" data-bundle-error aria-live="polite"></div></section>`;
+  }
+
+  function collectBundleDraft(container, item) {
+    const groups = []; const previewGroups = []; const services = [];
+    let total = 0n; let durationMin = 0;
+    container.querySelectorAll("[data-bundle-package]").forEach((row) => {
+      const quantity = Number(row.querySelector("[data-bundle-quantity]")?.value || 0);
+      if (!quantity) return;
+      const packageKey = row.getAttribute("data-bundle-package");
+      const variant = item.service_package_variants.find((entry) => entry.package_key === packageKey);
+      const btu = Number(row.querySelector("[data-bundle-btu]")?.value || 0);
+      const plan = variant ? composeBundleTiers(variant.tiers, quantity) : null;
+      if (!variant || !plan || !btu) throw new Error("จำนวนที่เลือกไม่สามารถจัดเป็นแพ็กเกจได้");
+      total += plan.minor; durationMin += quantity * Number(variant.unit_duration_minutes);
+      groups.push({ package_key: packageKey, btu, quantity });
+      previewGroups.push({ package_key: packageKey, package_name: variant.package_name, btu, quantity });
+      services.push({ job_type: variant.service.job_type, ac_type: variant.service.ac_type, btu, machine_count: quantity,
+        wash_variant: variant.service.wash_variant || "", repair_variant: "" });
+    });
+    if (!groups.length) throw new Error("กรุณาเลือกอย่างน้อย 1 เครื่อง");
+    const fixedTotal = `${total / 100n}.${String(total % 100n).padStart(2, "0")}`;
+    return { groups, preview: { package_name: item.item_name, groups: previewGroups, fixed_total_price: fixedTotal,
+      duration_min: durationMin, redeem_until: item.service_package_redeem_until, payload: { services } } };
+  }
+
+  function beginBundleBooking(container, item) {
+    const errorBox = container.querySelector("[data-bundle-error]");
+    try {
+      const result = collectBundleDraft(container, item);
+      root.state.updateDraft("scheduled", { service_package_key: "", service_package_tier_key: "", service_package_btu: "",
+        service_package_groups: result.groups, service_package_bundle_preview: result.preview, services: [], selectedSlot: null, scheduled_request_key: "" });
+      root.state.setScheduledPreview("package", { status: "success", data: result.preview, error: "", verified: true });
+      root.state.setScheduledPreview("pricing", { status: "idle", data: null, error: "" });
+      root.utils.routeTo("scheduled");
+    } catch (error) {
+      if (errorBox) errorBox.textContent = error.message;
+    }
   }
 
   // Physical product the customer can buy (e.g. an AC unit) — gets a "ซื้อ"
@@ -785,6 +866,7 @@
         event.stopPropagation && event.stopPropagation();
         const id = button.getAttribute("data-store-book");
         const item = (root.state.catalog.items || []).find((it) => String(it.item_id) === String(id));
+        if (isServicePackageBundle(item)) { goToDetail(id); return; }
         const draftItem = root.services.catalogItemToCommerceDraft(item);
         if (!draftItem || !root.services.applyCommerceDraft("scheduled", draftItem)) {
           trackItemEvent("cwf_store_contact_admin", item, { source: "store_list" });
@@ -1452,7 +1534,7 @@
     const bookable = isBookable(item);
     const showCompare = canonicalAcType(item) === "wall" && canonicalJobCategory(item) === "wash";
     const ctaButton = bookable
-      ? `<button class="primary-btn" type="button" data-store-detail-book="1">จองคิว</button>`
+      ? `<button class="primary-btn" type="button" data-store-detail-book="1">${isServicePackageBundle(item) ? "จองแพ็กเกจ" : "จองคิว"}</button>`
       : isPurchase(item)
         ? `<button class="primary-btn" type="button" data-store-detail-buy="1">ซื้อสินค้า</button>`
         : `<button class="primary-btn" type="button" data-store-detail-contact="1">สอบถามแอดมิน</button>`;
@@ -1475,6 +1557,7 @@
       ${renderPromoInfo(item)}
       ${renderVariantSelector(item, siblings)}
       ${item.short_description ? `<div class="store-detail-section store-detail-summary"><p>${root.utils.escapeHtml(item.short_description)}</p></div>` : ""}
+      ${renderBundleConfigurator(item)}
       <div class="store-detail-inline-cta">${ctaButton}</div>
       <div class="store-detail-accordion-group">
         ${renderAccordionSection("จุดเด่นของบริการ", highlights.length ? `
@@ -1558,6 +1641,7 @@
       bookButton.addEventListener("click", () => {
         const item = root.state.storeDetail?.data;
         if (!item) return;
+        if (isServicePackageBundle(item)) { beginBundleBooking(container, item); return; }
         const draftItem = root.services.catalogItemToCommerceDraft(item);
         if (!draftItem || !root.services.applyCommerceDraft("scheduled", draftItem)) {
           trackItemEvent("cwf_store_contact_admin", item, { source: "store_detail" });
@@ -1566,6 +1650,20 @@
         }
         trackItemEvent("cwf_store_begin_booking", item, { source: "store_detail" });
         root.utils.routeTo("scheduled");
+      });
+    });
+    container.querySelectorAll("[data-bundle-quantity], [data-bundle-btu]").forEach((control) => {
+      control.addEventListener("change", () => {
+        const item = root.state.storeDetail?.data;
+        const total = container.querySelector("[data-bundle-total]");
+        const error = container.querySelector("[data-bundle-error]");
+        if (error) error.textContent = "";
+        try {
+          const result = collectBundleDraft(container, item);
+          if (total) total.textContent = `รวม ${result.preview.groups.reduce((sum, group) => sum + group.quantity, 0)} เครื่อง · ${result.preview.fixed_total_price} บาท · ${result.preview.duration_min} นาที`;
+        } catch (cause) {
+          if (total) total.textContent = cause.message;
+        }
       });
     });
     container.querySelectorAll("[data-store-detail-contact]").forEach((contactButton) => {
@@ -2093,7 +2191,8 @@
     clearDetailAutoplay();
   };
 
-  store._test = { loadDetail, loadReviewsList, loadEligibility, detailItemId, renderDetailBody, renderReviewsSectionBody };
+  store._test = { loadDetail, loadReviewsList, loadEligibility, detailItemId, renderDetailBody, renderReviewsSectionBody,
+    composeBundleTiers, renderBundleConfigurator, collectBundleDraft };
 
   root.store = store;
 })();

--- a/customer-app/modules/store.js
+++ b/customer-app/modules/store.js
@@ -970,6 +970,20 @@
         root.utils.routeTo("scheduled");
       });
     });
+    container.querySelectorAll("[data-store-urgent]").forEach((button) => {
+      button.addEventListener("click", (event) => {
+        event.stopPropagation && event.stopPropagation();
+        if (button.disabled) return;
+        const id = button.getAttribute("data-store-urgent");
+        const item = (root.state.catalog.items || []).find((it) => String(it.item_id) === String(id));
+        if (!item || !allowsUrgentBooking(item) || !urgentBookingAvailable()) return;
+        if (isServicePackageBundle(item)) { goToDetail(id); return; }
+        const draftItem = root.services.catalogItemToCommerceDraft(item);
+        if (!draftItem || !root.services.applyCommerceDraft("urgent", draftItem)) return;
+        trackItemEvent("cwf_store_begin_urgent_booking", item, { source: "store_list" });
+        root.utils.routeTo("urgent");
+      });
+    });
     container.querySelectorAll("[data-store-buy]").forEach((button) => {
       button.addEventListener("click", (event) => {
         event.stopPropagation && event.stopPropagation();
@@ -1770,19 +1784,6 @@
         const draftItem = root.services.catalogItemToCommerceDraft(item);
         if (!draftItem || !root.services.applyCommerceDraft("urgent", draftItem)) return;
         trackItemEvent("cwf_store_begin_urgent_booking", item, { source: "store_detail" });
-        root.utils.routeTo("urgent");
-      });
-    });
-    container.querySelectorAll("[data-store-urgent]").forEach((button) => {
-      button.addEventListener("click", (event) => {
-        event.stopPropagation && event.stopPropagation();
-        if (button.disabled) return;
-        const id = button.getAttribute("data-store-urgent");
-        const item = (root.state.catalog.items || []).find((it) => String(it.item_id) === String(id));
-        if (isServicePackageBundle(item)) { goToDetail(id); return; }
-        const draftItem = root.services.catalogItemToCommerceDraft(item);
-        if (!draftItem || !root.services.applyCommerceDraft("urgent", draftItem)) return;
-        trackItemEvent("cwf_store_begin_urgent_booking", item, { source: "store_list" });
         root.utils.routeTo("urgent");
       });
     });

--- a/customer-app/modules/store.js
+++ b/customer-app/modules/store.js
@@ -883,25 +883,37 @@
       const end = new Date(node.getAttribute("data-campaign-countdown"));
       if (!Number.isFinite(end.getTime())) return;
       let timer = null;
+      let disposed = false;
+      const stop = () => { if (timer) clearTimeout(timer); timer = null; };
+      let cleanup = () => {};
       const tick = () => {
-        if (!node.isConnected) return;
+        if (disposed) return;
+        if (!node.isConnected) { cleanup(); return; }
+        stop();
         const remaining = end.getTime() - Date.now();
         if (remaining <= 0) {
           node.textContent = "ปิดรับจองแล้ว";
-          node.closest(".store-card, .store-detail-screen")?.querySelectorAll("[data-store-book], [data-store-urgent], [data-store-detail-book], [data-store-detail-urgent]").forEach((button) => { button.disabled = true; });
-          if (timer) clearTimeout(timer);
-          timer = null;
+          node.closest(".store-card, .store-detail-screen, .homepage-service-card")
+            ?.querySelectorAll("[data-store-book], [data-store-urgent], [data-store-detail-book], [data-store-detail-urgent], [data-home-featured-action]")
+            .forEach((button) => { button.disabled = true; button.setAttribute("aria-disabled", "true"); });
+          cleanup();
           return;
         }
         const minutes = Math.ceil(remaining / 60000);
         const days = Math.floor(minutes / 1440); const hours = Math.floor((minutes % 1440) / 60); const mins = minutes % 60;
         node.textContent = days ? `เหลือ ${days} วัน ${hours} ชม.` : `เหลือ ${hours} ชม. ${mins} นาที`;
-        timer = setTimeout(tick, 60000);
+        if (!document.hidden) timer = setTimeout(tick, 60000);
       };
-      const onVisibility = () => { if (!document.hidden) tick(); };
+      const onVisibility = () => { if (document.hidden) stop(); else tick(); };
+      cleanup = () => {
+        if (disposed) return;
+        disposed = true;
+        stop();
+        document.removeEventListener("visibilitychange", onVisibility);
+      };
       document.addEventListener("visibilitychange", onVisibility);
       tick();
-      campaignCountdownCleanups.push(() => { if (timer) clearTimeout(timer); document.removeEventListener("visibilitychange", onVisibility); });
+      campaignCountdownCleanups.push(cleanup);
     });
   }
 
@@ -2302,8 +2314,19 @@
     clearCampaignCountdowns();
   };
 
+  // Shared presentation renderer/lifecycle for both Store and the existing
+  // Homepage Featured Services cards. CSS effects stay decorative; callers can
+  // omit this API and still render/navigate/book normally.
+  store.campaignPresentation = {
+    theme: campaignTheme,
+    effect: campaignEffect,
+    render: renderCampaignPresentation,
+    bind: bindCampaignCountdowns,
+    clear: clearCampaignCountdowns,
+  };
+
   store._test = { loadDetail, loadReviewsList, loadEligibility, detailItemId, renderDetailBody, renderReviewsSectionBody,
-    composeBundleTiers, renderBundleConfigurator, collectBundleDraft };
+    composeBundleTiers, renderBundleConfigurator, collectBundleDraft, bindCampaignCountdowns, clearCampaignCountdowns };
 
   root.store = store;
 })();

--- a/customer-app/modules/ui.js
+++ b/customer-app/modules/ui.js
@@ -1659,19 +1659,24 @@
     return ["home", "store", "booking", "tracking", "profile"].includes(route) ? route : "home";
   }
 
+  const ACCESSIBLE_ONLY_ROUTE_HEADINGS = new Set(["home", "store", "scheduled", "tracking"]);
+
   function ensureRouteHeading(container, route) {
     const page = routeIconPage(route);
-    const hideStandalone = route === "home" || route === "store" || route === "storeItem"
-      || /^storeItem-\d+$/.test(String(route || "")) || route === "scheduled" || route === "tracking";
+    const accessibleOnly = ACCESSIBLE_ONLY_ROUTE_HEADINGS.has(route);
     const screen = container.querySelector?.(".screen, .booking-wizard-page");
     if (screen && !screen.querySelector("[data-page-icon-heading]")) {
       const registry = window.CWFIconRegistry;
       const item = registry?.navigationItem?.(homepageConfig(), page) || { label: page };
-      screen.insertAdjacentHTML("afterbegin", `
-        <header class="route-page-heading${hideStandalone ? " is-accessible-only" : ""}" data-page-icon-heading="${root.utils.escapeHtml(page)}">
-          <h2 class="route-page-heading__title">${root.utils.escapeHtml(item.label)}</h2>
-        </header>
-      `);
+      const safePage = root.utils.escapeHtml(page);
+      const safeLabel = root.utils.escapeHtml(item.label);
+      screen.insertAdjacentHTML("afterbegin", accessibleOnly
+        ? `<h2 class="route-accessible-page-name" data-page-icon-heading="${safePage}">${safeLabel}</h2>`
+        : `
+          <header class="route-page-heading" data-page-icon-heading="${safePage}">
+            <h2 class="route-page-heading__title">${safeLabel}</h2>
+          </header>
+        `);
     }
   }
 

--- a/customer-app/modules/ui.js
+++ b/customer-app/modules/ui.js
@@ -1644,12 +1644,14 @@
 
   function ensureRouteHeading(container, route) {
     const page = routeIconPage(route);
+    const hideStandalone = route === "home" || route === "store" || route === "storeItem"
+      || /^storeItem-\d+$/.test(String(route || "")) || route === "scheduled" || route === "tracking";
     const screen = container.querySelector?.(".screen, .booking-wizard-page");
     if (screen && !screen.querySelector("[data-page-icon-heading]")) {
       const registry = window.CWFIconRegistry;
       const item = registry?.navigationItem?.(homepageConfig(), page) || { label: page };
       screen.insertAdjacentHTML("afterbegin", `
-        <header class="route-page-heading" data-page-icon-heading="${root.utils.escapeHtml(page)}">
+        <header class="route-page-heading${hideStandalone ? " is-accessible-only" : ""}" data-page-icon-heading="${root.utils.escapeHtml(page)}">
           <h2 class="route-page-heading__title">${root.utils.escapeHtml(item.label)}</h2>
         </header>
       `);

--- a/customer-app/modules/ui.js
+++ b/customer-app/modules/ui.js
@@ -288,18 +288,29 @@
     return pages;
   }
 
-  // One compact featured card: image, name, price, book button — nothing else.
-  // The old card also carried a two-line description and a promo line, which
-  // made the homepage section very tall; customers asked for just the essentials
-  // shown as small cards.
+  function featuredCampaignPresentation(item) {
+    try {
+      const api = root.store?.campaignPresentation;
+      if (!api) return { theme: "default", effect: "none", html: "" };
+      return { theme: api.theme(item), effect: api.effect(item), html: api.render(item) };
+    } catch (_error) {
+      // Presentation is progressive enhancement. A missing/failed effect must
+      // never prevent the card, detail navigation, quote, or booking action.
+      return { theme: "default", effect: "none", html: "" };
+    }
+  }
+
+  // One compact featured card: existing image/name/price/action plus the
+  // bounded parent-item campaign presentation. No second carousel is created.
   function renderFeaturedMiniCard(item, showPrice, showBadge, interactive = true) {
     const id = root.utils.escapeHtml(item.item_id);
     const imageUrl = firstCatalogImage(item);
-    const bookable = item.booking_mode === "bookable";
+    const bookable = item.booking_mode === "bookable" || item.booking_mode === "service_package";
+    const campaign = featuredCampaignPresentation(item);
     const price = catalogDisplayPrice(item);
     const tabIndex = interactive ? "" : ` tabindex="-1"`;
     return `
-      <article class="homepage-service-card">
+      <article class="homepage-service-card campaign-theme-${campaign.theme} campaign-effect-${campaign.effect}">
         <button type="button" class="homepage-card-link" data-home-featured-detail="${id}"${tabIndex}>
           <div class="homepage-card-image">
             ${imageUrl
@@ -307,13 +318,14 @@
               : root.utils.icon("sparkle", 28)}
             ${showBadge ? `<span class="homepage-service-badge">${bookable ? "จองได้" : "สอบถาม"}</span>` : ""}
           </div>
+          ${campaign.html}
           <div class="homepage-card-body">
             <strong>${root.utils.escapeHtml(item.item_name || "-")}</strong>
             ${showPrice ? `<span>${root.utils.escapeHtml(price)}${item.unit_label && price !== "สอบถามราคา" ? ` / ${root.utils.escapeHtml(item.unit_label)}` : ""}</span>` : ""}
           </div>
         </button>
         <button type="button" class="${bookable ? "primary-btn" : "secondary-btn"} homepage-service-action" data-home-featured-action="${id}"${tabIndex}>
-          ${bookable ? "จอง" : "สอบถาม"}
+          ${item.booking_mode === "service_package" ? "ดูแพ็กเกจ" : bookable ? "จอง" : "สอบถาม"}
         </button>
       </article>
     `;
@@ -1137,6 +1149,7 @@
     bindHomepageHeroSliders(container);
     bindHomepagePromoBannerSlider(container);
     bindHomepageFeaturedRotators(container);
+    root.store?.campaignPresentation?.bind?.(container);
     container.querySelectorAll("[data-home-package-key][data-home-package-tier-key]").forEach((button) => {
       button.addEventListener("click", () => {
         const packageKey = String(button.getAttribute("data-home-package-key") || "").trim();
@@ -1178,6 +1191,10 @@
         const id = button.getAttribute("data-home-featured-action");
         const item = (root.state.catalog?.items || []).find((row) => String(row.item_id) === String(id));
         if (!item) return;
+        if (item.booking_mode === "service_package") {
+          root.utils.routeTo(`storeItem-${id}`);
+          return;
+        }
         if (item.booking_mode === "bookable") {
           const draftItem = strictCatalogCommerceDraft(item);
           if (draftItem && root.services.applyCommerceDraft("scheduled", draftItem)) {
@@ -1700,6 +1717,7 @@
 
     renderHome(container) {
       cleanupHomepageFeaturedRotators(container);
+      root.store?.campaignPresentation?.clear?.();
       root.advisor?.cleanup?.(container);
       const sectionsHtml = renderHomepageSectionsWithAdvisor();
       container.innerHTML = `
@@ -1804,6 +1822,7 @@
   ui.renderHome.onLeave = () => {
     const container = document.getElementById("app");
     cleanupHomepageFeaturedRotators(container);
+    root.store?.campaignPresentation?.clear?.();
     root.advisor?.cleanup?.(container);
   };
   root.ui = ui;

--- a/customer-app/sw.js
+++ b/customer-app/sw.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const BUILD_ID = "20260809_issue267_admin_builder_v2";
+const BUILD_ID = "20260809_issue267_merchandising_v3";
 const CACHE_NAME = `cwf-customer-app-v2-${BUILD_ID}`;
 const APP_SHELL = [
   `./index.html?v=${BUILD_ID}`,

--- a/customer-app/sw.js
+++ b/customer-app/sw.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const BUILD_ID = "20260809_issue267_merchandising_v3";
+const BUILD_ID = "20260809_issue267_heading_cleanup_v4";
 const CACHE_NAME = `cwf-customer-app-v2-${BUILD_ID}`;
 const APP_SHELL = [
   `./index.html?v=${BUILD_ID}`,

--- a/customer-app/sw.js
+++ b/customer-app/sw.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const BUILD_ID = "20260809_store_service_package_bundles_v1";
+const BUILD_ID = "20260809_issue267_admin_builder_v2";
 const CACHE_NAME = `cwf-customer-app-v2-${BUILD_ID}`;
 const APP_SHELL = [
   `./index.html?v=${BUILD_ID}`,

--- a/customer-app/sw.js
+++ b/customer-app/sw.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const BUILD_ID = "20260809_issue267_booking_ticket_v5";
+const BUILD_ID = "20260809_issue267_catalog_flow_v6";
 const CACHE_NAME = `cwf-customer-app-v2-${BUILD_ID}`;
 const APP_SHELL = [
   `./index.html?v=${BUILD_ID}`,

--- a/customer-app/sw.js
+++ b/customer-app/sw.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const BUILD_ID = "20260809_issue267_heading_cleanup_v4";
+const BUILD_ID = "20260809_issue267_booking_ticket_v5";
 const CACHE_NAME = `cwf-customer-app-v2-${BUILD_ID}`;
 const APP_SHELL = [
   `./index.html?v=${BUILD_ID}`,
@@ -22,6 +22,7 @@ const APP_SHELL = [
   `./modules/auth.js?v=${BUILD_ID}`,
   `./modules/pricing.js?v=${BUILD_ID}`,
   `./modules/availability.js?v=${BUILD_ID}`,
+  `./modules/bookingTicket.js?v=${BUILD_ID}`,
   `./modules/bookingScheduled.js?v=${BUILD_ID}`,
   `./modules/bookingUrgent.js?v=${BUILD_ID}`,
   `./modules/tracking.js?v=${BUILD_ID}`,

--- a/customer-app/sw.js
+++ b/customer-app/sw.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const BUILD_ID = "20260809_issue267_catalog_flow_v8";
+const BUILD_ID = "20260809_issue267_catalog_flow_v9";
 const CACHE_NAME = `cwf-customer-app-v2-${BUILD_ID}`;
 const APP_SHELL = [
   `./index.html?v=${BUILD_ID}`,

--- a/customer-app/sw.js
+++ b/customer-app/sw.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const BUILD_ID = "20260808_homepage_service_packages_v2";
+const BUILD_ID = "20260809_store_service_package_bundles_v1";
 const CACHE_NAME = `cwf-customer-app-v2-${BUILD_ID}`;
 const APP_SHELL = [
   `./index.html?v=${BUILD_ID}`,

--- a/customer-app/sw.js
+++ b/customer-app/sw.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const BUILD_ID = "20260809_issue267_catalog_flow_v7";
+const BUILD_ID = "20260809_issue267_catalog_flow_v8";
 const CACHE_NAME = `cwf-customer-app-v2-${BUILD_ID}`;
 const APP_SHELL = [
   `./index.html?v=${BUILD_ID}`,

--- a/customer-app/sw.js
+++ b/customer-app/sw.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const BUILD_ID = "20260809_issue267_catalog_flow_v6";
+const BUILD_ID = "20260809_issue267_catalog_flow_v7";
 const CACHE_NAME = `cwf-customer-app-v2-${BUILD_ID}`;
 const APP_SHELL = [
   `./index.html?v=${BUILD_ID}`,

--- a/index.js
+++ b/index.js
@@ -50,6 +50,8 @@ const customerAvailability = require("./server/services/public/customerAvailabil
 const { registerPublicCustomerAvailabilityRoutes } = require("./server/routes/public/customerAvailability");
 const { registerAdminAvailabilityRoutes } = require("./server/routes/admin/adminAvailability");
 const { createBookingJobService } = require("./server/services/booking/createBookingJob");
+const { createCustomerCatalogQuoteService } = require("./server/services/booking/customerCatalogQuote");
+const { calcBookingPricing } = require("./server/services/booking/exactPricing");
 const { pendingCustomerScheduledReservationSql } = require("./server/services/booking/bookingStatuses");
 const { createBookingApprovalService } = require("./server/services/booking/bookingApprovalService");
 const { registerBookingApprovalRoutes } = require("./server/routes/admin/bookingApprovals");
@@ -12714,27 +12716,7 @@ ensureSchema();
 // 🧮 Helper: pricing
 // =======================================
 function calcPricing(items, promo) {
-  const safeItems = Array.isArray(items) ? items : [];
-  const subtotal = safeItems.reduce((sum, it) => {
-    const qty = Number(it.qty || 0);
-    const price = Number(it.unit_price || 0);
-    const line = Math.max(0, qty) * Math.max(0, price);
-    return sum + line;
-  }, 0);
-
-  let discount = 0;
-  if (promo) {
-    const v = Number(promo.promo_value || 0);
-    if (promo.promo_type === "percent") discount = subtotal * (Math.max(0, v) / 100);
-    if (promo.promo_type === "amount") discount = Math.max(0, v);
-  }
-
-  const total = Math.max(0, subtotal - discount);
-  return {
-    subtotal: Number(subtotal.toFixed(2)),
-    discount: Number(discount.toFixed(2)),
-    total: Number(total.toFixed(2)),
-  };
+  return calcBookingPricing(items, promo);
 }
 
 // =======================================
@@ -24099,7 +24081,14 @@ registerAdminAvailabilityRoutes(app, {
   requireAdminSession,
 });
 
-registerPublicCustomerBookingRoutes(app, { service: bookingJobService });
+registerPublicCustomerBookingRoutes(app, {
+  service: bookingJobService,
+  quoteService: createCustomerCatalogQuoteService({
+    pool,
+    createServicePackageResolver: (db) => createServicePackageResolver({ db }),
+    computeDurationMinMulti,
+  }),
+});
 registerPublicServicePackageRoutes(app, {
   service: createPublicServicePackageService({ resolver: createServicePackageResolver({ db: pool }) }),
 });

--- a/index.js
+++ b/index.js
@@ -60,6 +60,8 @@ const { createPublicServicePackageService } = require("./server/services/public/
 const { registerAdminBookingRoutes } = require("./server/routes/admin/adminBookings");
 const { createServicePackageCatalogService } = require("./server/services/packages/servicePackageCatalogService");
 const { createServicePackageCatalogRoutes } = require("./server/routes/admin/servicePackageCatalog");
+const { createStoreServicePackageCatalogService } = require("./server/services/packages/storeServicePackageCatalogService");
+const { createStoreServicePackageCatalogRoutes } = require("./server/routes/admin/storeServicePackageCatalog");
 const { createTechnicianJobMoneyHelpers } = require("./server/technicianJobMoneySummary");
 const createSystemRoutes = require("./server/routes/system");
 const createTechnicianDirectoryRoutes = require("./server/routes/users/technicians");
@@ -12978,6 +12980,10 @@ app.use(createCatalogItemRoutes({
 }));
 app.use(createServicePackageCatalogRoutes({
   service: createServicePackageCatalogService({ pool }),
+  requireAdminSession,
+}));
+app.use(createStoreServicePackageCatalogRoutes({
+  service: createStoreServicePackageCatalogService({ pool }),
   requireAdminSession,
 }));
 app.use(createCatalogReviewRoutes({ pool, requireCustomerJwt, requireAdminSession }));

--- a/migrations/20260809_store_service_package_bundles.rollback.sql
+++ b/migrations/20260809_store_service_package_bundles.rollback.sql
@@ -1,5 +1,6 @@
 -- PRE-DATA ROLLBACK ONLY. Never run after a service-package bundle or booking exists.
 DROP INDEX IF EXISTS public.uq_jobs_admin_request_key;
+ALTER TABLE public.jobs DROP COLUMN IF EXISTS booking_request_fingerprint;
 ALTER TABLE public.jobs DROP COLUMN IF EXISTS admin_request_fingerprint;
 ALTER TABLE public.jobs DROP COLUMN IF EXISTS admin_request_key;
 DROP INDEX IF EXISTS public.idx_service_packages_catalog_item;

--- a/migrations/20260809_store_service_package_bundles.rollback.sql
+++ b/migrations/20260809_store_service_package_bundles.rollback.sql
@@ -1,0 +1,16 @@
+-- PRE-DATA ROLLBACK ONLY. Never run after a service-package bundle or booking exists.
+DROP INDEX IF EXISTS public.idx_service_packages_catalog_item;
+ALTER TABLE public.service_packages DROP CONSTRAINT IF EXISTS service_packages_catalog_item_fk;
+ALTER TABLE public.service_packages DROP COLUMN IF EXISTS sort_order;
+ALTER TABLE public.service_packages DROP COLUMN IF EXISTS catalog_item_id;
+DROP INDEX IF EXISTS public.uq_catalog_items_service_bundle_key;
+ALTER TABLE public.catalog_items DROP CONSTRAINT IF EXISTS catalog_items_service_package_redeem_valid;
+ALTER TABLE public.catalog_items DROP CONSTRAINT IF EXISTS catalog_items_service_package_window_valid;
+ALTER TABLE public.catalog_items DROP CONSTRAINT IF EXISTS catalog_items_service_bundle_key_nonempty;
+ALTER TABLE public.catalog_items DROP COLUMN IF EXISTS service_package_redeem_until;
+ALTER TABLE public.catalog_items DROP COLUMN IF EXISTS service_package_sell_end_at;
+ALTER TABLE public.catalog_items DROP COLUMN IF EXISTS service_package_sell_start_at;
+ALTER TABLE public.catalog_items DROP COLUMN IF EXISTS service_bundle_key;
+ALTER TABLE public.catalog_items DROP CONSTRAINT IF EXISTS catalog_items_booking_mode_check;
+ALTER TABLE public.catalog_items ADD CONSTRAINT catalog_items_booking_mode_check
+  CHECK (booking_mode IN ('bookable', 'contact_admin', 'purchase'));

--- a/migrations/20260809_store_service_package_bundles.rollback.sql
+++ b/migrations/20260809_store_service_package_bundles.rollback.sql
@@ -1,9 +1,21 @@
 -- PRE-DATA ROLLBACK ONLY. Never run after a service-package bundle or booking exists.
+DROP INDEX IF EXISTS public.uq_jobs_admin_request_key;
+ALTER TABLE public.jobs DROP COLUMN IF EXISTS admin_request_fingerprint;
+ALTER TABLE public.jobs DROP COLUMN IF EXISTS admin_request_key;
 DROP INDEX IF EXISTS public.idx_service_packages_catalog_item;
 ALTER TABLE public.service_packages DROP CONSTRAINT IF EXISTS service_packages_catalog_item_fk;
 ALTER TABLE public.service_packages DROP COLUMN IF EXISTS sort_order;
 ALTER TABLE public.service_packages DROP COLUMN IF EXISTS catalog_item_id;
 DROP INDEX IF EXISTS public.uq_catalog_items_service_bundle_key;
+ALTER TABLE public.catalog_items DROP CONSTRAINT IF EXISTS catalog_items_booking_flow_policy_check;
+ALTER TABLE public.catalog_items DROP CONSTRAINT IF EXISTS catalog_items_promotion_effect_check;
+ALTER TABLE public.catalog_items DROP CONSTRAINT IF EXISTS catalog_items_promotion_theme_check;
+ALTER TABLE public.catalog_items DROP COLUMN IF EXISTS booking_flow_policy;
+ALTER TABLE public.catalog_items DROP COLUMN IF EXISTS promotion_supporting_text;
+ALTER TABLE public.catalog_items DROP COLUMN IF EXISTS show_sale_countdown;
+ALTER TABLE public.catalog_items DROP COLUMN IF EXISTS promotion_effect_preset;
+ALTER TABLE public.catalog_items DROP COLUMN IF EXISTS promotion_theme_preset;
+ALTER TABLE public.catalog_items DROP COLUMN IF EXISTS promotion_badge_text;
 ALTER TABLE public.catalog_items DROP CONSTRAINT IF EXISTS catalog_items_service_package_redeem_valid;
 ALTER TABLE public.catalog_items DROP CONSTRAINT IF EXISTS catalog_items_service_package_window_valid;
 ALTER TABLE public.catalog_items DROP CONSTRAINT IF EXISTS catalog_items_service_bundle_key_nonempty;

--- a/migrations/20260809_store_service_package_bundles.sql
+++ b/migrations/20260809_store_service_package_bundles.sql
@@ -1,0 +1,77 @@
+-- Store service-package bundles. A catalog item owns presentation/media and
+-- sale/redeem windows; linked service_packages are selectable BTU variants.
+-- Existing unlinked service packages remain valid and keep their own windows.
+
+ALTER TABLE public.catalog_items DROP CONSTRAINT IF EXISTS catalog_items_booking_mode_check;
+ALTER TABLE public.catalog_items
+  ADD CONSTRAINT catalog_items_booking_mode_check
+  CHECK (booking_mode IN ('bookable', 'contact_admin', 'purchase', 'service_package'));
+
+ALTER TABLE public.catalog_items ADD COLUMN IF NOT EXISTS service_bundle_key TEXT;
+ALTER TABLE public.catalog_items ADD COLUMN IF NOT EXISTS service_package_sell_start_at TIMESTAMPTZ;
+ALTER TABLE public.catalog_items ADD COLUMN IF NOT EXISTS service_package_sell_end_at TIMESTAMPTZ;
+ALTER TABLE public.catalog_items ADD COLUMN IF NOT EXISTS service_package_redeem_until TIMESTAMPTZ;
+
+CREATE UNIQUE INDEX IF NOT EXISTS uq_catalog_items_service_bundle_key
+  ON public.catalog_items (service_bundle_key)
+  WHERE service_bundle_key IS NOT NULL;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+     WHERE conname = 'catalog_items_service_bundle_key_nonempty'
+       AND conrelid = 'public.catalog_items'::regclass
+  ) THEN
+    ALTER TABLE public.catalog_items ADD CONSTRAINT catalog_items_service_bundle_key_nonempty
+      CHECK (service_bundle_key IS NULL OR btrim(service_bundle_key) <> '');
+  END IF;
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+     WHERE conname = 'catalog_items_service_package_window_valid'
+       AND conrelid = 'public.catalog_items'::regclass
+  ) THEN
+    ALTER TABLE public.catalog_items ADD CONSTRAINT catalog_items_service_package_window_valid
+      CHECK (service_package_sell_end_at IS NULL OR service_package_sell_start_at IS NULL
+        OR service_package_sell_end_at >= service_package_sell_start_at);
+  END IF;
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+     WHERE conname = 'catalog_items_service_package_redeem_valid'
+       AND conrelid = 'public.catalog_items'::regclass
+  ) THEN
+    ALTER TABLE public.catalog_items ADD CONSTRAINT catalog_items_service_package_redeem_valid
+      CHECK (service_package_redeem_until IS NULL OR service_package_sell_end_at IS NULL
+        OR service_package_redeem_until >= service_package_sell_end_at);
+  END IF;
+END $$;
+
+ALTER TABLE public.service_packages ADD COLUMN IF NOT EXISTS catalog_item_id BIGINT;
+ALTER TABLE public.service_packages ADD COLUMN IF NOT EXISTS sort_order INTEGER NOT NULL DEFAULT 0;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+     WHERE conname = 'service_packages_catalog_item_fk'
+       AND conrelid = 'public.service_packages'::regclass
+  ) THEN
+    ALTER TABLE public.service_packages ADD CONSTRAINT service_packages_catalog_item_fk
+      FOREIGN KEY (catalog_item_id) REFERENCES public.catalog_items(item_id) ON DELETE RESTRICT;
+  END IF;
+END $$;
+
+CREATE INDEX IF NOT EXISTS idx_service_packages_catalog_item
+  ON public.service_packages (catalog_item_id, sort_order, service_package_id)
+  WHERE catalog_item_id IS NOT NULL;
+
+-- Future pre-data rollback only. Do not execute after a linked bundle booking:
+-- DROP INDEX IF EXISTS public.idx_service_packages_catalog_item;
+-- ALTER TABLE public.service_packages DROP CONSTRAINT IF EXISTS service_packages_catalog_item_fk;
+-- ALTER TABLE public.service_packages DROP COLUMN IF EXISTS sort_order;
+-- ALTER TABLE public.service_packages DROP COLUMN IF EXISTS catalog_item_id;
+-- DROP INDEX IF EXISTS public.uq_catalog_items_service_bundle_key;
+-- ALTER TABLE public.catalog_items DROP COLUMN IF EXISTS service_package_redeem_until;
+-- ALTER TABLE public.catalog_items DROP COLUMN IF EXISTS service_package_sell_end_at;
+-- ALTER TABLE public.catalog_items DROP COLUMN IF EXISTS service_package_sell_start_at;
+-- ALTER TABLE public.catalog_items DROP COLUMN IF EXISTS service_bundle_key;

--- a/migrations/20260809_store_service_package_bundles.sql
+++ b/migrations/20260809_store_service_package_bundles.sql
@@ -94,7 +94,8 @@ CREATE INDEX IF NOT EXISTS idx_service_packages_catalog_item
 
 ALTER TABLE public.jobs
   ADD COLUMN IF NOT EXISTS admin_request_key VARCHAR(128),
-  ADD COLUMN IF NOT EXISTS admin_request_fingerprint CHAR(64);
+  ADD COLUMN IF NOT EXISTS admin_request_fingerprint CHAR(64),
+  ADD COLUMN IF NOT EXISTS booking_request_fingerprint CHAR(64);
 CREATE UNIQUE INDEX IF NOT EXISTS uq_jobs_admin_request_key
   ON public.jobs(admin_request_key) WHERE admin_request_key IS NOT NULL;
 

--- a/migrations/20260809_store_service_package_bundles.sql
+++ b/migrations/20260809_store_service_package_bundles.sql
@@ -11,6 +11,12 @@ ALTER TABLE public.catalog_items ADD COLUMN IF NOT EXISTS service_bundle_key TEX
 ALTER TABLE public.catalog_items ADD COLUMN IF NOT EXISTS service_package_sell_start_at TIMESTAMPTZ;
 ALTER TABLE public.catalog_items ADD COLUMN IF NOT EXISTS service_package_sell_end_at TIMESTAMPTZ;
 ALTER TABLE public.catalog_items ADD COLUMN IF NOT EXISTS service_package_redeem_until TIMESTAMPTZ;
+ALTER TABLE public.catalog_items ADD COLUMN IF NOT EXISTS promotion_badge_text VARCHAR(80);
+ALTER TABLE public.catalog_items ADD COLUMN IF NOT EXISTS promotion_theme_preset TEXT NOT NULL DEFAULT 'default';
+ALTER TABLE public.catalog_items ADD COLUMN IF NOT EXISTS promotion_effect_preset TEXT NOT NULL DEFAULT 'none';
+ALTER TABLE public.catalog_items ADD COLUMN IF NOT EXISTS show_sale_countdown BOOLEAN NOT NULL DEFAULT FALSE;
+ALTER TABLE public.catalog_items ADD COLUMN IF NOT EXISTS promotion_supporting_text VARCHAR(200);
+ALTER TABLE public.catalog_items ADD COLUMN IF NOT EXISTS booking_flow_policy TEXT NOT NULL DEFAULT 'scheduled_only';
 
 CREATE UNIQUE INDEX IF NOT EXISTS uq_catalog_items_service_bundle_key
   ON public.catalog_items (service_bundle_key)
@@ -44,6 +50,27 @@ BEGIN
       CHECK (service_package_redeem_until IS NULL OR service_package_sell_end_at IS NULL
         OR service_package_redeem_until >= service_package_sell_end_at);
   END IF;
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'catalog_items_promotion_theme_check'
+      AND conrelid = 'public.catalog_items'::regclass
+  ) THEN
+    ALTER TABLE public.catalog_items ADD CONSTRAINT catalog_items_promotion_theme_check
+      CHECK (promotion_theme_preset IN ('default','premium','limited_time','new'));
+  END IF;
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'catalog_items_promotion_effect_check'
+      AND conrelid = 'public.catalog_items'::regclass
+  ) THEN
+    ALTER TABLE public.catalog_items ADD CONSTRAINT catalog_items_promotion_effect_check
+      CHECK (promotion_effect_preset IN ('none','soft_glow','shimmer_border','badge_pulse'));
+  END IF;
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'catalog_items_booking_flow_policy_check'
+      AND conrelid = 'public.catalog_items'::regclass
+  ) THEN
+    ALTER TABLE public.catalog_items ADD CONSTRAINT catalog_items_booking_flow_policy_check
+      CHECK (booking_flow_policy IN ('scheduled_only','scheduled_and_urgent'));
+  END IF;
 END $$;
 
 ALTER TABLE public.service_packages ADD COLUMN IF NOT EXISTS catalog_item_id BIGINT;
@@ -64,6 +91,12 @@ END $$;
 CREATE INDEX IF NOT EXISTS idx_service_packages_catalog_item
   ON public.service_packages (catalog_item_id, sort_order, service_package_id)
   WHERE catalog_item_id IS NOT NULL;
+
+ALTER TABLE public.jobs
+  ADD COLUMN IF NOT EXISTS admin_request_key VARCHAR(128),
+  ADD COLUMN IF NOT EXISTS admin_request_fingerprint CHAR(64);
+CREATE UNIQUE INDEX IF NOT EXISTS uq_jobs_admin_request_key
+  ON public.jobs(admin_request_key) WHERE admin_request_key IS NOT NULL;
 
 -- Future pre-data rollback only. Do not execute after a linked bundle booking:
 -- DROP INDEX IF EXISTS public.idx_service_packages_catalog_item;

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "migrate:homepage-article-sync": "node scripts/run-homepage-article-sync-migration.js",
     "migrate:customer-orders": "node scripts/run-customer-orders-migration.js",
     "migrate:catalog-booking-mode-purchase": "node scripts/run-catalog-booking-mode-purchase-migration.js",
+    "migrate:store-service-package-bundles": "node scripts/run-store-service-package-bundles-migration.js",
     "migrate:customer-orders-payment": "node scripts/run-customer-orders-payment-migration.js",
     "migrate:customer-orders-fulfillment": "node scripts/run-customer-orders-fulfillment-migration.js",
     "migrate:store-buy": "node scripts/run-store-buy-migrations.js",

--- a/scripts/run-store-service-package-bundles-migration.js
+++ b/scripts/run-store-service-package-bundles-migration.js
@@ -1,0 +1,65 @@
+"use strict";
+
+const fs = require("node:fs");
+const path = require("node:path");
+const { Client } = require("pg");
+
+const MIGRATION_RELATIVE_PATH = "migrations/20260809_store_service_package_bundles.sql";
+const ADVISORY_LOCK_KEY = "202608090267";
+
+function clean(value) { return String(value == null ? "" : value).trim(); }
+function safeErrorMessage(error) {
+  return clean(error?.message || error)
+    .replace(/postgres(?:ql)?:\/\/[^\s"'<>]+/gi, "[REDACTED_DATABASE_URL]")
+    .replace(/(password|passwd|pwd|secret|token)=([^&\s]+)/gi, "$1=[REDACTED]");
+}
+function resolveMigrationPath(repoRoot = path.resolve(__dirname, "..")) {
+  const root = path.resolve(repoRoot);
+  const result = path.resolve(root, MIGRATION_RELATIVE_PATH);
+  if (result !== path.resolve(root, "migrations", "20260809_store_service_package_bundles.sql") || !result.startsWith(`${root}${path.sep}`)) {
+    throw new Error("migration path rejected");
+  }
+  return result;
+}
+function createClientConfig(env = process.env) {
+  const url = clean(env.DATABASE_URL);
+  if (url) return { connectionString: url, options: "-c timezone=Asia/Bangkok", ssl: env.CWF_E2E_TEST_MODE === "1" ? false : { rejectUnauthorized: false } };
+  return { host: clean(env.DB_HOST), port: Number(env.DB_PORT || 5432), user: clean(env.DB_USER), password: env.DB_PASSWORD,
+    database: clean(env.DB_NAME), options: "-c timezone=Asia/Bangkok", ssl: env.CWF_E2E_TEST_MODE === "1" ? false : { rejectUnauthorized: false } };
+}
+async function verifySchema(client) {
+  const result = await client.query(`
+    SELECT
+      EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema='public' AND table_name='service_packages' AND column_name='catalog_item_id') AS linked,
+      EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema='public' AND table_name='catalog_items' AND column_name='service_bundle_key') AS parent_key,
+      EXISTS (SELECT 1 FROM pg_constraint WHERE conname='service_packages_catalog_item_fk') AS parent_fk,
+      COALESCE((SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conname='catalog_items_booking_mode_check' LIMIT 1),'') AS booking_mode_def
+  `);
+  const row = result.rows[0] || {};
+  if (!row.linked || !row.parent_key || !row.parent_fk || !/service_package/.test(row.booking_mode_def)) throw new Error("store service-package bundle schema verification failed");
+}
+async function runMigration({ env = process.env, logger = console, clientFactory = (config) => new Client(config), repoRoot } = {}) {
+  const client = clientFactory(createClientConfig(env)); let locked = false;
+  logger.log("STORE_SERVICE_PACKAGE_BUNDLES_MIGRATION_START");
+  try {
+    await client.connect(); await client.query("SELECT pg_advisory_lock($1::bigint)", [ADVISORY_LOCK_KEY]); locked = true;
+    await client.query("BEGIN");
+    try {
+      await client.query(fs.readFileSync(resolveMigrationPath(repoRoot), "utf8")); await verifySchema(client);
+      await client.query("COMMIT");
+    } catch (error) {
+      await client.query("ROLLBACK").catch(() => {});
+      throw error;
+    }
+    logger.log("STORE_SERVICE_PACKAGE_BUNDLES_MIGRATION_OK");
+  } finally {
+    if (locked) await client.query("SELECT pg_advisory_unlock($1::bigint)", [ADVISORY_LOCK_KEY]).catch(() => {});
+    await client.end();
+  }
+}
+async function runCli(options = {}) {
+  try { await runMigration(options); return 0; }
+  catch (error) { (options.logger || console).error(`STORE_SERVICE_PACKAGE_BUNDLES_MIGRATION_FAILED: ${safeErrorMessage(error)}`); return 1; }
+}
+if (require.main === module) runCli().then((code) => { process.exitCode = code; });
+module.exports = { MIGRATION_RELATIVE_PATH, ADVISORY_LOCK_KEY, safeErrorMessage, resolveMigrationPath, createClientConfig, verifySchema, runMigration, runCli };

--- a/scripts/run-store-service-package-bundles-migration.js
+++ b/scripts/run-store-service-package-bundles-migration.js
@@ -32,11 +32,20 @@ async function verifySchema(client) {
     SELECT
       EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema='public' AND table_name='service_packages' AND column_name='catalog_item_id') AS linked,
       EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema='public' AND table_name='catalog_items' AND column_name='service_bundle_key') AS parent_key,
+      EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema='public' AND table_name='catalog_items' AND column_name='promotion_theme_preset') AS presentation,
+      EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema='public' AND table_name='catalog_items' AND column_name='booking_flow_policy') AS flow_policy,
+      EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema='public' AND table_name='jobs' AND column_name='admin_request_key') AS admin_request_key,
+      EXISTS (SELECT 1 FROM pg_indexes WHERE schemaname='public' AND indexname='uq_jobs_admin_request_key') AS admin_request_unique,
       EXISTS (SELECT 1 FROM pg_constraint WHERE conname='service_packages_catalog_item_fk') AS parent_fk,
+      EXISTS (SELECT 1 FROM pg_constraint WHERE conname='catalog_items_promotion_theme_check') AS presentation_check,
+      EXISTS (SELECT 1 FROM pg_constraint WHERE conname='catalog_items_booking_flow_policy_check') AS flow_policy_check,
       COALESCE((SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conname='catalog_items_booking_mode_check' LIMIT 1),'') AS booking_mode_def
   `);
   const row = result.rows[0] || {};
-  if (!row.linked || !row.parent_key || !row.parent_fk || !/service_package/.test(row.booking_mode_def)) throw new Error("store service-package bundle schema verification failed");
+  if (!row.linked || !row.parent_key || !row.presentation || !row.flow_policy || !row.admin_request_key || !row.admin_request_unique || !row.parent_fk
+      || !row.presentation_check || !row.flow_policy_check || !/service_package/.test(row.booking_mode_def)) {
+    throw new Error("store service-package bundle schema verification failed");
+  }
 }
 async function runMigration({ env = process.env, logger = console, clientFactory = (config) => new Client(config), repoRoot } = {}) {
   const client = clientFactory(createClientConfig(env)); let locked = false;

--- a/scripts/run-store-service-package-bundles-migration.js
+++ b/scripts/run-store-service-package-bundles-migration.js
@@ -35,6 +35,7 @@ async function verifySchema(client) {
       EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema='public' AND table_name='catalog_items' AND column_name='promotion_theme_preset') AS presentation,
       EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema='public' AND table_name='catalog_items' AND column_name='booking_flow_policy') AS flow_policy,
       EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema='public' AND table_name='jobs' AND column_name='admin_request_key') AS admin_request_key,
+      EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema='public' AND table_name='jobs' AND column_name='booking_request_fingerprint') AS booking_request_fingerprint,
       EXISTS (SELECT 1 FROM pg_indexes WHERE schemaname='public' AND indexname='uq_jobs_admin_request_key') AS admin_request_unique,
       EXISTS (SELECT 1 FROM pg_constraint WHERE conname='service_packages_catalog_item_fk') AS parent_fk,
       EXISTS (SELECT 1 FROM pg_constraint WHERE conname='catalog_items_promotion_theme_check') AS presentation_check,
@@ -42,7 +43,7 @@ async function verifySchema(client) {
       COALESCE((SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conname='catalog_items_booking_mode_check' LIMIT 1),'') AS booking_mode_def
   `);
   const row = result.rows[0] || {};
-  if (!row.linked || !row.parent_key || !row.presentation || !row.flow_policy || !row.admin_request_key || !row.admin_request_unique || !row.parent_fk
+  if (!row.linked || !row.parent_key || !row.presentation || !row.flow_policy || !row.admin_request_key || !row.booking_request_fingerprint || !row.admin_request_unique || !row.parent_fk
       || !row.presentation_check || !row.flow_policy_check || !/service_package/.test(row.booking_mode_def)) {
     throw new Error("store service-package bundle schema verification failed");
   }

--- a/server/customerPricing.js
+++ b/server/customerPricing.js
@@ -32,18 +32,38 @@ function boolish(value, fallback = false) {
   return fallback;
 }
 
-const SUPPORTED_JOB_TYPES = new Set([
-  normalizeServiceType("clean"),
-  normalizeServiceType("repair"),
-  normalizeServiceType("install"),
-]);
-const SUPPORTED_AC_TYPES = new Set([
-  normalizeAcType("wall"),
-  normalizeAcType("cassette"),
-  normalizeAcType("hanging"),
-  normalizeAcType("concealed"),
-]);
-const SUPPORTED_WASH_KEYS = new Set(["normal", "premium", "coil", "overhaul"]);
+// Canonical service values already enforced by the shared customer price-book
+// contract. Other catalog features consume this contract instead of carrying
+// product-specific copies of the same taxonomy.
+const SUPPORTED_SERVICE_TAXONOMY = Object.freeze({
+  job_types: Object.freeze([
+    Object.freeze({ key: "wash", value: normalizeServiceType("clean") }),
+    Object.freeze({ key: "repair", value: normalizeServiceType("repair") }),
+    Object.freeze({ key: "install", value: normalizeServiceType("install") }),
+  ]),
+  ac_types: Object.freeze([
+    Object.freeze({ key: "wall", value: normalizeAcType("wall") }),
+    Object.freeze({ key: "cassette", value: normalizeAcType("cassette") }),
+    Object.freeze({ key: "hanging", value: normalizeAcType("hanging") }),
+    Object.freeze({ key: "concealed", value: normalizeAcType("concealed") }),
+  ]),
+  wash_variants: Object.freeze([
+    Object.freeze({ key: "normal", value: normalizeWashVariantLabel("normal") }),
+    Object.freeze({ key: "premium", value: normalizeWashVariantLabel("premium") }),
+    Object.freeze({ key: "coil", value: normalizeWashVariantLabel("coil") }),
+    Object.freeze({ key: "overhaul", value: normalizeWashVariantLabel("overhaul") }),
+  ]),
+});
+const SUPPORTED_JOB_TYPES = new Set(SUPPORTED_SERVICE_TAXONOMY.job_types.map((entry) => entry.value));
+const SUPPORTED_AC_TYPES = new Set(SUPPORTED_SERVICE_TAXONOMY.ac_types.map((entry) => entry.value));
+const SUPPORTED_WASH_KEYS = new Set(SUPPORTED_SERVICE_TAXONOMY.wash_variants.map((entry) => entry.key));
+
+function supportedServiceTaxonomy() {
+  return Object.fromEntries(Object.entries(SUPPORTED_SERVICE_TAXONOMY).map(([name, entries]) => [
+    name,
+    entries.map((entry) => ({ ...entry, label: entry.value })),
+  ]));
+}
 const MAX_RULE_PRIORITY = 1000;
 const MIN_RULE_PRIORITY = -1000;
 
@@ -927,4 +947,5 @@ module.exports = {
   canonicalFallbackUnitForRule,
   validateServicePriceRuleForWrite,
   annotateRuleRisks,
+  supportedServiceTaxonomy,
 };

--- a/server/routes/admin/adminBookings.js
+++ b/server/routes/admin/adminBookings.js
@@ -4,13 +4,15 @@ function registerAdminBookingRoutes(app, options = {}) {
   const service = options.service;
   const requireAdminSession = options.requireAdminSession;
   const requireInternalApiKeyOnly = options.requireInternalApiKeyOnly;
-  if (!service || typeof service.handleAdminBookV2 !== "function" || typeof service.handleInternalBookFromAi !== "function") {
+  if (!service || typeof service.handleAdminBookV2 !== "function" || typeof service.handleInternalBookFromAi !== "function"
+      || typeof service.handleAdminCatalogBookingPreview !== "function") {
     throw new TypeError("admin booking service is required");
   }
 
   app.post("/admin/book_v2", requireAdminSession, service.handleAdminBookV2);
   app.get("/admin/service-packages", requireAdminSession, service.handleAdminServicePackageList);
   app.post("/admin/service-packages/preview", requireAdminSession, service.handleAdminServicePackagePreview);
+  app.post("/admin/catalog-booking-preview", requireAdminSession, service.handleAdminCatalogBookingPreview);
   app.post("/admin/urgent_broadcast_v2", requireAdminSession, (req, res) => {
     req.body = {
       ...(req.body || {}),

--- a/server/routes/admin/storeServicePackageCatalog.js
+++ b/server/routes/admin/storeServicePackageCatalog.js
@@ -10,11 +10,17 @@ function createStoreServicePackageCatalogRoutes({ service, requireAdminSession }
     try { return await fn(req, res); }
     catch (error) {
       if (error instanceof StoreServicePackageCatalogError) return res.status(error.status).json({ error: error.code, code: error.code });
+      if (error?.code && Number(error?.statusCode || 0) >= 400 && Number(error.statusCode) < 500) {
+        return res.status(Number(error.statusCode)).json({ error: String(error.code), code: String(error.code) });
+      }
       console.error("STORE_SERVICE_PACKAGE_CATALOG_ERROR", error);
       return res.status(500).json({ error: "STORE_SERVICE_PACKAGE_CATALOG_UNAVAILABLE", code: "STORE_SERVICE_PACKAGE_CATALOG_UNAVAILABLE" });
     }
   };
+  router.get("/admin/catalog/service-package-bundles/taxonomy", requireAdminSession,
+    handle(async (_req, res) => res.json(await service.taxonomy())));
   router.get("/admin/catalog/service-package-bundles", requireAdminSession, handle(async (_req, res) => res.json({ bundles: await service.list() })));
+  router.post("/admin/catalog/service-package-bundles/quote", requireAdminSession, handle(async (req, res) => res.json(await service.quote(req.body || {}))));
   router.post("/admin/catalog/service-package-bundles", requireAdminSession, handle(async (req, res) => res.status(201).json(await service.create(req.body || {}))));
   router.patch("/admin/catalog/service-package-bundles/:bundleKey", requireAdminSession, handle(async (req, res) => res.json(await service.update(req.params.bundleKey, req.body || {}))));
   return router;

--- a/server/routes/admin/storeServicePackageCatalog.js
+++ b/server/routes/admin/storeServicePackageCatalog.js
@@ -1,0 +1,23 @@
+"use strict";
+
+const express = require("express");
+const { StoreServicePackageCatalogError } = require("../../services/packages/storeServicePackageCatalogService");
+
+function createStoreServicePackageCatalogRoutes({ service, requireAdminSession }) {
+  if (!service) throw new TypeError("store service-package catalog service is required");
+  const router = express.Router();
+  const handle = (fn) => async (req, res) => {
+    try { return await fn(req, res); }
+    catch (error) {
+      if (error instanceof StoreServicePackageCatalogError) return res.status(error.status).json({ error: error.code, code: error.code });
+      console.error("STORE_SERVICE_PACKAGE_CATALOG_ERROR", error);
+      return res.status(500).json({ error: "STORE_SERVICE_PACKAGE_CATALOG_UNAVAILABLE", code: "STORE_SERVICE_PACKAGE_CATALOG_UNAVAILABLE" });
+    }
+  };
+  router.get("/admin/catalog/service-package-bundles", requireAdminSession, handle(async (_req, res) => res.json({ bundles: await service.list() })));
+  router.post("/admin/catalog/service-package-bundles", requireAdminSession, handle(async (req, res) => res.status(201).json(await service.create(req.body || {}))));
+  router.patch("/admin/catalog/service-package-bundles/:bundleKey", requireAdminSession, handle(async (req, res) => res.json(await service.update(req.params.bundleKey, req.body || {}))));
+  return router;
+}
+
+module.exports = { createStoreServicePackageCatalogRoutes };

--- a/server/routes/catalog/items.js
+++ b/server/routes/catalog/items.js
@@ -3,6 +3,7 @@ const cloudinaryImageUpload = require("../../lib/cloudinaryImageUpload");
 const customerAvailability = require("../../services/public/customerAvailability");
 const { getBangkokNow, computeJobTiming } = require("../../services/jobTiming");
 const servicePackageRepository = require("../../services/packages/servicePackageRepository");
+const { validateCatalogCampaignPolicy, safeCatalogCampaignPolicy } = require("../../services/catalogCampaignPolicy");
 
 const MAX_CATALOG_IMAGES_PER_ITEM = 4;
 
@@ -82,6 +83,10 @@ const CATALOG_MARKETPLACE_FIELDS = [
 // its own whitelist, mirroring CATALOG_MARKETPLACE_FIELDS, since it ships in a later
 // migration and needs its own independent schema-readiness gate.
 const CATALOG_HOT_FIELDS = ["is_hot"];
+const CATALOG_CAMPAIGN_FIELDS = [
+  "promotion_badge_text", "promotion_theme_preset", "promotion_effect_preset",
+  "show_sale_countdown", "promotion_supporting_text", "booking_flow_policy",
+];
 
 // "purchase" = a physical product the customer can buy (e.g. an AC unit),
 // validated like "contact_admin" (no booking ac_type/btu required) — the buy
@@ -108,6 +113,9 @@ function mergeCatalogItemPayload(existing, body) {
   CATALOG_HOT_FIELDS.forEach((key) => {
     merged[key] = Object.prototype.hasOwnProperty.call(body, key) ? body[key] : existing[key];
   });
+  CATALOG_CAMPAIGN_FIELDS.forEach((key) => {
+    merged[key] = Object.prototype.hasOwnProperty.call(body, key) ? body[key] : existing[key];
+  });
   return merged;
 }
 
@@ -120,6 +128,11 @@ function validateHotField(merged) {
   );
   if (!isHotResult.ok) return { ok: false, errors: [isHotResult.error] };
   return { ok: true, value: { is_hot: isHotResult.value } };
+}
+
+function validateCampaignFields(merged) {
+  try { return { ok: true, value: validateCatalogCampaignPolicy(merged, { oldClient: true }) }; }
+  catch (error) { return { ok: false, errors: [error.code || "INVALID_CATALOG_CAMPAIGN_POLICY"] }; }
 }
 
 function parseOptionalText(value, fieldLabel, maxLen) {
@@ -560,6 +573,23 @@ async function attachCatalogServicePackages(pool, rows, { customer = false } = {
   return rows;
 }
 
+async function attachCatalogCampaignPolicy(pool, rows, ready = true) {
+  if (!rows.length) return rows;
+  if (!ready) {
+    rows.forEach((row) => Object.assign(row, safeCatalogCampaignPolicy({})));
+    return rows;
+  }
+  const result = await pool.query(
+    `SELECT item_id,promotion_badge_text,promotion_theme_preset,promotion_effect_preset,
+            show_sale_countdown,promotion_supporting_text,booking_flow_policy
+       FROM public.catalog_items WHERE item_id=ANY($1::bigint[])`,
+    [rows.map((row) => row.item_id)]
+  );
+  const byId = new Map(result.rows.map((row) => [String(row.item_id), safeCatalogCampaignPolicy(row)]));
+  rows.forEach((row) => Object.assign(row, byId.get(String(row.item_id)) || safeCatalogCampaignPolicy({})));
+  return rows;
+}
+
 // Same migration as catalog_item_reviews; gates whether rating aggregation
 // can take admin-assigned reviews (assigned_item_id, set on originally
 // ambiguous service_type/overall-scoped tracking reviews) into account.
@@ -834,6 +864,7 @@ function computeEffectivePricing(row) {
 // a customer see right now". Do not add raw rule fields here; see serializeAdminCatalogRow.
 function serializeCatalogRow(row) {
   const pricing = computeEffectivePricing(row);
+  const campaign = safeCatalogCampaignPolicy(row);
   // Multi-image gallery, ordered by sort_order. Falls back to the legacy single
   // image_url/image_public_id pair (as one synthetic primary image) so items
   // created before the marketplace v2 migration still render a photo.
@@ -900,6 +931,7 @@ function serializeCatalogRow(row) {
     booking_btu: row.booking_mode === "bookable" ? (row.booking_btu || null) : null,
     booking_wash_variant: row.booking_mode === "bookable" ? (row.booking_wash_variant || null) : null,
     is_featured: Boolean(row.is_featured),
+    ...campaign,
     // Fail-safe disabled: row.is_autoplay_enabled is undefined until the autoplay
     // migration has actually run, and a pre-migration item must never be silently
     // treated as autoplay-enabled.
@@ -1134,6 +1166,20 @@ module.exports = function createCatalogItemRoutes(deps = {}) {
     return ready;
   }
 
+  let campaignSchemaReadyCache = false;
+  async function isCampaignSchemaReady(db) {
+    if (campaignSchemaReadyCache) return true;
+    const r = await db.query(`
+      SELECT COUNT(*)::int AS cnt FROM information_schema.columns
+       WHERE table_schema='public' AND table_name='catalog_items'
+         AND column_name IN ('promotion_badge_text','promotion_theme_preset','promotion_effect_preset',
+           'show_sale_countdown','promotion_supporting_text','booking_flow_policy')
+    `);
+    const ready = Number(r.rows?.[0]?.cnt || 0) === 6;
+    if (ready) campaignSchemaReadyCache = true;
+    return ready;
+  }
+
   // Same migration adds public.catalog_item_reviews; gated independently since a
   // deployment could in principle have is_hot but not yet have run far enough for
   // the table (both ship in the same file, but this stays defensive/explicit).
@@ -1171,6 +1217,7 @@ module.exports = function createCatalogItemRoutes(deps = {}) {
       const hotReady = await isHotSchemaReady(pool);
       const reviewsReady = await isReviewsSchemaReady(pool);
       const jobsCatalogLinkReady = await isJobsCatalogLinkSchemaReady(pool);
+      const campaignReady = await isCampaignSchemaReady(pool);
       const select = buildCatalogSelect({ pricingReady, marketplaceReady, autoplayReady, hotReady });
       const customer = String(req.query.customer || "").trim() === "1";
       const job_category = (req.query.job_category || "").toString().trim();
@@ -1197,6 +1244,7 @@ module.exports = function createCatalogItemRoutes(deps = {}) {
       );
       await attachCatalogImages(pool, r.rows, imagesReady);
       await attachCatalogServicePackages(pool, r.rows, { customer });
+      await attachCatalogCampaignPolicy(pool, r.rows, campaignReady);
       await attachCatalogRatings(pool, r.rows, reviewsReady);
       await attachBookingCounts(pool, r.rows, jobsCatalogLinkReady);
       await attachTodayQueueAvailability(pool, r.rows, queueSlotDeps);
@@ -1219,6 +1267,7 @@ module.exports = function createCatalogItemRoutes(deps = {}) {
       const hotReady = await isHotSchemaReady(pool);
       const reviewsReady = await isReviewsSchemaReady(pool);
       const jobsCatalogLinkReady = await isJobsCatalogLinkSchemaReady(pool);
+      const campaignReady = await isCampaignSchemaReady(pool);
       const select = buildCatalogSelect({ pricingReady, marketplaceReady, autoplayReady, hotReady });
 
       const r = await pool.query(
@@ -1229,6 +1278,7 @@ module.exports = function createCatalogItemRoutes(deps = {}) {
       if (!row) return res.status(404).json({ error: "ไม่พบรายการนี้" });
       await attachCatalogImages(pool, [row], imagesReady);
       await attachCatalogServicePackages(pool, [row], { customer: true });
+      await attachCatalogCampaignPolicy(pool, [row], campaignReady);
       await attachCatalogRatings(pool, [row], reviewsReady);
       await attachBookingCounts(pool, [row], jobsCatalogLinkReady);
       await attachTodayQueueAvailability(pool, [row], queueSlotDeps);
@@ -1248,10 +1298,12 @@ module.exports = function createCatalogItemRoutes(deps = {}) {
       const hotReady = await isHotSchemaReady(pool);
       const reviewsReady = await isReviewsSchemaReady(pool);
       const jobsCatalogLinkReady = await isJobsCatalogLinkSchemaReady(pool);
+      const campaignReady = await isCampaignSchemaReady(pool);
       const select = buildCatalogSelect({ pricingReady, marketplaceReady, autoplayReady, hotReady });
       const r = await pool.query(`${select} ORDER BY ci.item_category, ci.item_name`);
       await attachCatalogImages(pool, r.rows, imagesReady);
       await attachCatalogServicePackages(pool, r.rows);
+      await attachCatalogCampaignPolicy(pool, r.rows, campaignReady);
       await attachCatalogRatings(pool, r.rows, reviewsReady);
       await attachBookingCounts(pool, r.rows, jobsCatalogLinkReady);
       res.json(r.rows.map(serializeAdminCatalogRow));
@@ -1279,6 +1331,8 @@ module.exports = function createCatalogItemRoutes(deps = {}) {
 
     const hotResult = validateHotField(merged);
     if (!hotResult.ok) return res.status(400).json({ error: hotResult.errors.join(", ") });
+    const campaignResult = validateCampaignFields(merged);
+    if (!campaignResult.ok) return res.status(400).json({ error: campaignResult.errors.join(", "), code: campaignResult.errors[0] });
 
     const hasPricingKey = req.body && Object.prototype.hasOwnProperty.call(req.body, "pricing");
     const pricingResult = hasPricingKey ? validatePricingInput(req.body.pricing) : { ok: true, value: undefined };
@@ -1286,10 +1340,12 @@ module.exports = function createCatalogItemRoutes(deps = {}) {
 
     const hasMarketplaceKey = CATALOG_MARKETPLACE_FIELDS.some((key) => Object.prototype.hasOwnProperty.call(req.body || {}, key));
     const hasHotKey = CATALOG_HOT_FIELDS.some((key) => Object.prototype.hasOwnProperty.call(req.body || {}, key));
+    const hasCampaignKey = CATALOG_CAMPAIGN_FIELDS.some((key) => Object.prototype.hasOwnProperty.call(req.body || {}, key));
     const schemaReady = await isMediaPricingSchemaReady(pool);
     const marketplaceReady = await isMarketplaceSchemaReady(pool);
     const autoplayReady = await isAutoplaySchemaReady(pool);
     const hotReady = await isHotSchemaReady(pool);
+    const campaignReady = await isCampaignSchemaReady(pool);
     if (pricingResult.value && !schemaReady) {
       return res.status(503).json({ error: "ระบบราคาโปรโมชันยังไม่พร้อมใช้งาน (ยังไม่ได้รัน migration)" });
     }
@@ -1299,10 +1355,14 @@ module.exports = function createCatalogItemRoutes(deps = {}) {
     if (hasHotKey && !hotReady) {
       return res.status(503).json({ error: "ระบบ HOT badge ยังไม่พร้อมใช้งาน (ยังไม่ได้รัน migration)" });
     }
+    if (hasCampaignKey && !campaignReady) {
+      return res.status(503).json({ error: "ระบบการนำเสนอโปรโมชั่น/นโยบายการจองยังไม่พร้อมใช้งาน", code: "CATALOG_CAMPAIGN_MIGRATION_REQUIRED" });
+    }
 
     const v = result.value;
     const mv = marketplaceResult.value;
     const hv = hotResult.value;
+    const cv = campaignResult.value;
     const pricingScopeResult = validateCatalogPricingScope(pricingResult.value, { ...v, booking_mode: mv.booking_mode });
     if (!pricingScopeResult.ok) return res.status(400).json({ error: pricingScopeResult.error, code: pricingScopeResult.error, risk_codes: pricingScopeResult.risk_codes || [] });
     const client = await pool.connect();
@@ -1362,6 +1422,16 @@ module.exports = function createCatalogItemRoutes(deps = {}) {
       }
       const itemId = insertRes.rows[0].item_id;
 
+      if (campaignReady) {
+        await client.query(
+          `UPDATE public.catalog_items SET promotion_badge_text=$1,promotion_theme_preset=$2,
+             promotion_effect_preset=$3,show_sale_countdown=$4,promotion_supporting_text=$5,booking_flow_policy=$6
+           WHERE item_id=$7`,
+          [cv.promotion_badge_text, cv.promotion_theme_preset, cv.promotion_effect_preset,
+            cv.show_sale_countdown, cv.promotion_supporting_text, cv.booking_flow_policy, itemId]
+        );
+      }
+
       if (pricingResult.value) {
         const ruleId = await savePriceRuleForCatalogItem(client, {
           ruleId: null,
@@ -1378,6 +1448,7 @@ module.exports = function createCatalogItemRoutes(deps = {}) {
       const select = buildCatalogSelect({ pricingReady: schemaReady, marketplaceReady, autoplayReady, hotReady });
       const final = await client.query(`${select} WHERE ci.item_id = $1`, [itemId]);
       await attachCatalogImages(client, final.rows, imagesReady);
+      await attachCatalogCampaignPolicy(client, final.rows, campaignReady);
       await attachCatalogRatings(client, final.rows, await isReviewsSchemaReady(client));
       res.status(201).json(serializeAdminCatalogRow(final.rows[0]));
     } catch (e) {
@@ -1397,8 +1468,10 @@ module.exports = function createCatalogItemRoutes(deps = {}) {
     const marketplaceReady = await isMarketplaceSchemaReady(pool);
     const autoplayReady = await isAutoplaySchemaReady(pool);
     const hotReady = await isHotSchemaReady(pool);
+    const campaignReady = await isCampaignSchemaReady(pool);
     const select = buildCatalogSelect({ pricingReady: schemaReady, marketplaceReady, autoplayReady, hotReady });
     const existingResult = await pool.query(`${select} WHERE ci.item_id = $1`, [itemId]);
+    await attachCatalogCampaignPolicy(pool, existingResult.rows, campaignReady);
     const existing = existingResult.rows[0];
     if (!existing) return res.status(404).json({ error: "ไม่พบรายการนี้" });
 
@@ -1414,6 +1487,8 @@ module.exports = function createCatalogItemRoutes(deps = {}) {
 
     const hotResult = validateHotField(merged);
     if (!hotResult.ok) return res.status(400).json({ error: hotResult.errors.join(", ") });
+    const campaignResult = validateCampaignFields(merged);
+    if (!campaignResult.ok) return res.status(400).json({ error: campaignResult.errors.join(", "), code: campaignResult.errors[0] });
 
     const hasPricingKey = req.body && Object.prototype.hasOwnProperty.call(req.body, "pricing");
     const pricingResult = hasPricingKey ? validatePricingInput(req.body.pricing) : { ok: true, value: undefined };
@@ -1431,10 +1506,15 @@ module.exports = function createCatalogItemRoutes(deps = {}) {
     if (hasHotKey && !hotReady) {
       return res.status(503).json({ error: "ระบบ HOT badge ยังไม่พร้อมใช้งาน (ยังไม่ได้รัน migration)" });
     }
+    const hasCampaignKey = CATALOG_CAMPAIGN_FIELDS.some((key) => Object.prototype.hasOwnProperty.call(req.body || {}, key));
+    if (hasCampaignKey && !campaignReady) {
+      return res.status(503).json({ error: "ระบบการนำเสนอโปรโมชั่น/นโยบายการจองยังไม่พร้อมใช้งาน", code: "CATALOG_CAMPAIGN_MIGRATION_REQUIRED" });
+    }
 
     const v = result.value;
     const mv = marketplaceResult.value;
     const hv = hotResult.value;
+    const cv = campaignResult.value;
     const pricingScopeResult = validateCatalogPricingScope(pricingResult.value, { ...v, booking_mode: mv.booking_mode });
     if (!pricingScopeResult.ok) return res.status(400).json({ error: pricingScopeResult.error, code: pricingScopeResult.error, risk_codes: pricingScopeResult.risk_codes || [] });
     const client = await pool.connect();
@@ -1502,6 +1582,16 @@ module.exports = function createCatalogItemRoutes(deps = {}) {
         );
       }
 
+      if (campaignReady) {
+        await client.query(
+          `UPDATE public.catalog_items SET promotion_badge_text=$1,promotion_theme_preset=$2,
+             promotion_effect_preset=$3,show_sale_countdown=$4,promotion_supporting_text=$5,booking_flow_policy=$6
+           WHERE item_id=$7`,
+          [cv.promotion_badge_text, cv.promotion_theme_preset, cv.promotion_effect_preset,
+            cv.show_sale_countdown, cv.promotion_supporting_text, cv.booking_flow_policy, itemId]
+        );
+      }
+
       // pricingResult.value === undefined -> field omitted, leave pricing untouched.
       // pricingResult.value === null      -> caller sent no pricing changes; the existing
       //                                       linked price rule (if any) is preserved as-is.
@@ -1523,6 +1613,7 @@ module.exports = function createCatalogItemRoutes(deps = {}) {
       const imagesReady = await isCatalogImagesSchemaReady(client);
       const final = await client.query(`${select} WHERE ci.item_id = $1`, [itemId]);
       await attachCatalogImages(client, final.rows, imagesReady);
+      await attachCatalogCampaignPolicy(client, final.rows, campaignReady);
       await attachCatalogRatings(client, final.rows, await isReviewsSchemaReady(client));
       res.json(serializeAdminCatalogRow(final.rows[0]));
     } catch (e) {
@@ -2026,6 +2117,8 @@ module.exports.MAX_CATALOG_IMAGES_PER_ITEM = MAX_CATALOG_IMAGES_PER_ITEM;
 module.exports.validateHotField = validateHotField;
 module.exports.attachCatalogRatings = attachCatalogRatings;
 module.exports.attachCatalogServicePackages = attachCatalogServicePackages;
+module.exports.attachCatalogCampaignPolicy = attachCatalogCampaignPolicy;
+module.exports.validateCampaignFields = validateCampaignFields;
 // Test-only: queueTodayCache is a 60s in-process TTL cache, deliberately shared
 // across requests within a process. Tests that need a fresh eligibility check
 // (rather than another test's cached value) must clear it first.

--- a/server/routes/catalog/items.js
+++ b/server/routes/catalog/items.js
@@ -2,6 +2,7 @@ const { money, intOrNull, boolish, validateServicePriceRuleForWrite, serviceRule
 const cloudinaryImageUpload = require("../../lib/cloudinaryImageUpload");
 const customerAvailability = require("../../services/public/customerAvailability");
 const { getBangkokNow, computeJobTiming } = require("../../services/jobTiming");
+const servicePackageRepository = require("../../services/packages/servicePackageRepository");
 
 const MAX_CATALOG_IMAGES_PER_ITEM = 4;
 
@@ -85,7 +86,7 @@ const CATALOG_HOT_FIELDS = ["is_hot"];
 // "purchase" = a physical product the customer can buy (e.g. an AC unit),
 // validated like "contact_admin" (no booking ac_type/btu required) — the buy
 // flow collects quantity + delivery/install options at checkout instead.
-const BOOKING_MODES = new Set(["bookable", "contact_admin", "purchase"]);
+const BOOKING_MODES = new Set(["bookable", "contact_admin", "purchase", "service_package"]);
 
 // Allowed values must match the Customer App's canonical lists exactly
 // (customer-app/modules/services.js: acTypes/btuOptions/washVariants) so a
@@ -504,6 +505,61 @@ async function attachCatalogImages(pool, rows, imagesReady) {
   return rows;
 }
 
+async function attachCatalogServicePackages(pool, rows, { customer = false } = {}) {
+  rows.forEach((row) => { row.service_package_variants = []; });
+  if (!rows.length) return rows;
+  const ready = await pool.query(`
+    SELECT COUNT(*)::int AS cnt FROM information_schema.columns
+     WHERE table_schema='public' AND (
+       (table_name='catalog_items' AND column_name IN
+         ('service_bundle_key','service_package_sell_start_at','service_package_sell_end_at','service_package_redeem_until'))
+       OR (table_name='service_packages' AND column_name='catalog_item_id')
+     )
+  `);
+  if (Number(ready.rows?.[0]?.cnt || 0) !== 5) return rows;
+  const ids = rows.map((row) => row.item_id);
+  const parents = await pool.query(
+    `SELECT item_id,service_bundle_key,service_package_sell_start_at,service_package_sell_end_at,service_package_redeem_until
+       FROM public.catalog_items WHERE item_id=ANY($1::bigint[])`, [ids]
+  );
+  const parentById = new Map(parents.rows.map((row) => [String(row.item_id), row]));
+  const variants = await servicePackageRepository.listLinkedPackagesForCatalogItems(pool, ids, { customer });
+  const byItem = new Map();
+  variants.forEach((variant) => {
+    const key = String(variant.catalog_item_id);
+    if (!byItem.has(key)) byItem.set(key, []);
+    byItem.get(key).push({
+      package_key: variant.package_key,
+      package_name: variant.display_name,
+      description: variant.description,
+      service: {
+        service_key: variant.service_key,
+        service_name: variant.service_name,
+        job_type: variant.job_type,
+        ac_type: variant.ac_type,
+        wash_variant: variant.wash_variant,
+        btu_min: variant.btu_min == null ? null : Number(variant.btu_min),
+        btu_max: variant.btu_max == null ? null : Number(variant.btu_max),
+      },
+      unit_duration_minutes: Number(variant.service_unit_duration_minutes),
+      sort_order: Number(variant.sort_order || 0),
+      is_active: Boolean(variant.is_active),
+      is_customer_visible: Boolean(variant.is_customer_visible),
+      tiers: (variant.tiers || []).map((tier) => ({
+        tier_key: tier.tier_key, tier_name: tier.display_name,
+        quantity: Number(tier.service_quantity), fixed_total_price: String(tier.fixed_total_price),
+        sort_order: Number(tier.sort_order || 0), is_active: Boolean(tier.is_active),
+      })),
+    });
+  });
+  rows.forEach((row) => {
+    const parent = parentById.get(String(row.item_id));
+    if (parent) Object.assign(row, parent);
+    row.service_package_variants = byItem.get(String(row.item_id)) || [];
+  });
+  return rows;
+}
+
 // Same migration as catalog_item_reviews; gates whether rating aggregation
 // can take admin-assigned reviews (assigned_item_id, set on originally
 // ambiguous service_type/overall-scoped tracking reviews) into account.
@@ -830,6 +886,12 @@ function serializeCatalogRow(row) {
     short_description: row.short_description || null,
     highlights: Array.isArray(row.highlights) ? row.highlights : [],
     booking_mode: BOOKING_MODES.has(row.booking_mode) ? row.booking_mode : "contact_admin",
+    service_bundle_key: row.booking_mode === "service_package" ? (row.service_bundle_key || null) : null,
+    service_package_sell_start_at: row.booking_mode === "service_package" ? (row.service_package_sell_start_at || null) : null,
+    service_package_sell_end_at: row.booking_mode === "service_package" ? (row.service_package_sell_end_at || null) : null,
+    service_package_redeem_until: row.booking_mode === "service_package" ? (row.service_package_redeem_until || null) : null,
+    service_package_variants: row.booking_mode === "service_package" && Array.isArray(row.service_package_variants)
+      ? row.service_package_variants : [],
     // Needed on the list endpoint so the Store card's "book" button can build a
     // real booking draft without a follow-up detail fetch. booking_service_key is
     // intentionally omitted here: the frontend never uses it for booking, only
@@ -1134,6 +1196,7 @@ module.exports = function createCatalogItemRoutes(deps = {}) {
         params
       );
       await attachCatalogImages(pool, r.rows, imagesReady);
+      await attachCatalogServicePackages(pool, r.rows, { customer });
       await attachCatalogRatings(pool, r.rows, reviewsReady);
       await attachBookingCounts(pool, r.rows, jobsCatalogLinkReady);
       await attachTodayQueueAvailability(pool, r.rows, queueSlotDeps);
@@ -1165,6 +1228,7 @@ module.exports = function createCatalogItemRoutes(deps = {}) {
       const row = r.rows[0];
       if (!row) return res.status(404).json({ error: "ไม่พบรายการนี้" });
       await attachCatalogImages(pool, [row], imagesReady);
+      await attachCatalogServicePackages(pool, [row], { customer: true });
       await attachCatalogRatings(pool, [row], reviewsReady);
       await attachBookingCounts(pool, [row], jobsCatalogLinkReady);
       await attachTodayQueueAvailability(pool, [row], queueSlotDeps);
@@ -1187,6 +1251,7 @@ module.exports = function createCatalogItemRoutes(deps = {}) {
       const select = buildCatalogSelect({ pricingReady, marketplaceReady, autoplayReady, hotReady });
       const r = await pool.query(`${select} ORDER BY ci.item_category, ci.item_name`);
       await attachCatalogImages(pool, r.rows, imagesReady);
+      await attachCatalogServicePackages(pool, r.rows);
       await attachCatalogRatings(pool, r.rows, reviewsReady);
       await attachBookingCounts(pool, r.rows, jobsCatalogLinkReady);
       res.json(r.rows.map(serializeAdminCatalogRow));
@@ -1208,6 +1273,9 @@ module.exports = function createCatalogItemRoutes(deps = {}) {
 
     const marketplaceResult = validateMarketplaceFields(merged);
     if (!marketplaceResult.ok) return res.status(400).json({ error: marketplaceResult.errors.join(", ") });
+    if (marketplaceResult.value.booking_mode === "service_package") {
+      return res.status(400).json({ error: "Use the atomic Store service-package bundle endpoint", code: "SERVICE_PACKAGE_BUNDLE_ENDPOINT_REQUIRED" });
+    }
 
     const hotResult = validateHotField(merged);
     if (!hotResult.ok) return res.status(400).json({ error: hotResult.errors.join(", ") });
@@ -1340,6 +1408,9 @@ module.exports = function createCatalogItemRoutes(deps = {}) {
 
     const marketplaceResult = validateMarketplaceFields(merged);
     if (!marketplaceResult.ok) return res.status(400).json({ error: marketplaceResult.errors.join(", ") });
+    if (marketplaceResult.value.booking_mode === "service_package") {
+      return res.status(400).json({ error: "Use the atomic Store service-package bundle endpoint", code: "SERVICE_PACKAGE_BUNDLE_ENDPOINT_REQUIRED" });
+    }
 
     const hotResult = validateHotField(merged);
     if (!hotResult.ok) return res.status(400).json({ error: hotResult.errors.join(", ") });
@@ -1954,6 +2025,7 @@ module.exports.buildCatalogSelect = buildCatalogSelect;
 module.exports.MAX_CATALOG_IMAGES_PER_ITEM = MAX_CATALOG_IMAGES_PER_ITEM;
 module.exports.validateHotField = validateHotField;
 module.exports.attachCatalogRatings = attachCatalogRatings;
+module.exports.attachCatalogServicePackages = attachCatalogServicePackages;
 // Test-only: queueTodayCache is a 60s in-process TTL cache, deliberately shared
 // across requests within a process. Tests that need a fresh eligibility check
 // (rather than another test's cached value) must clear it first.

--- a/server/routes/public/customerBookings.js
+++ b/server/routes/public/customerBookings.js
@@ -7,6 +7,9 @@ function registerPublicCustomerBookingRoutes(app, options = {}) {
   }
 
   app.post("/public/urgent-dispatch-preflight", service.handlePublicUrgentPreflight);
+  if (options.quoteService && typeof options.quoteService.handle === "function") {
+    app.post("/public/catalog-booking-quote", options.quoteService.handle);
+  }
   app.post("/public/book", service.handlePublicBook);
 }
 

--- a/server/services/booking/adminBookingIdempotency.js
+++ b/server/services/booking/adminBookingIdempotency.js
@@ -1,0 +1,21 @@
+"use strict";
+
+const crypto = require("node:crypto");
+
+function stable(value) {
+  if (Array.isArray(value)) return value.map(stable);
+  if (value && typeof value === "object") return Object.keys(value).sort().reduce((out, key) => {
+    if (key !== "admin_request_key") out[key] = stable(value[key]);
+    return out;
+  }, {});
+  return value;
+}
+
+function validateAdminRequestKey(value) {
+  const key = String(value || "").trim();
+  return /^[A-Za-z0-9_-]{16,128}$/.test(key) ? key : null;
+}
+function requestFingerprint(body) { return crypto.createHash("sha256").update(JSON.stringify(stable(body || {}))).digest("hex"); }
+function bookingToken(key) { return `admin_${crypto.createHash("sha256").update(key).digest("hex").slice(0, 32)}`; }
+
+module.exports = { stable, validateAdminRequestKey, requestFingerprint, bookingToken };

--- a/server/services/booking/adminStorePromotionPolicy.js
+++ b/server/services/booking/adminStorePromotionPolicy.js
@@ -1,0 +1,41 @@
+"use strict";
+
+class AdminStorePromotionPolicyError extends Error {
+  constructor(code, statusCode = 400) {
+    super(code);
+    this.name = "AdminStorePromotionPolicyError";
+    this.code = code;
+    this.statusCode = statusCode;
+  }
+}
+
+function present(value) { return value != null && String(value).trim() !== ""; }
+function positive(value) { return Number(value || 0) > 0; }
+
+function validateAdminStorePromotionRequest(body = {}, { createdBySource = "admin" } = {}) {
+  if (createdBySource !== "admin") return { kind: null };
+  const composite = Array.isArray(body.service_package_groups);
+  const ordinary = !composite && present(body.catalog_item_id);
+  if (!composite && !ordinary) return { kind: null };
+  if (!present(body.admin_request_key)) throw new AdminStorePromotionPolicyError("MISSING_ADMIN_REQUEST_KEY");
+
+  const commonConflict = present(body.promotion_id) || positive(body.override_price)
+    || positive(body.override_duration_min) || (Array.isArray(body.items) && body.items.length > 0);
+  if (commonConflict) throw new AdminStorePromotionPolicyError("STORE_PROMOTION_STACKING_UNSUPPORTED");
+
+  if (composite) {
+    if (present(body.catalog_item_id) || present(body.service_package_key) || present(body.service_package_tier_key)
+        || (Array.isArray(body.services) && body.services.length > 0)
+        || (Array.isArray(body.service_lines) && body.service_lines.length > 0)) {
+      throw new AdminStorePromotionPolicyError("STORE_PROMOTION_STACKING_UNSUPPORTED");
+    }
+    return { kind: "service_package" };
+  }
+
+  const services = Array.isArray(body.services) ? body.services
+    : (Array.isArray(body.service_lines) ? body.service_lines : []);
+  if (services.length > 0) throw new AdminStorePromotionPolicyError("STORE_PROMOTION_STACKING_UNSUPPORTED");
+  return { kind: "bookable" };
+}
+
+module.exports = { AdminStorePromotionPolicyError, validateAdminStorePromotionRequest };

--- a/server/services/booking/bookingTicket.js
+++ b/server/services/booking/bookingTicket.js
@@ -1,35 +1,70 @@
 "use strict";
 
-function text(value, max = 300) { return String(value == null ? "" : value).trim().slice(0, max); }
+const { JOB_STATUS } = require("./bookingStatuses");
+
+function text(value, max = 300) {
+  return String(value == null ? "" : value)
+    .replace(/[\r\n\u2028\u2029]+/g, " ")
+    .trim()
+    .slice(0, max);
+}
 function exactMoney(value) {
   const match = /^(\d+)(?:\.(\d{1,2}))?$/.exec(text(value, 40));
   if (!match) return "0.00";
   return `${match[1]}.${String(match[2] || "").padEnd(2, "0")}`;
 }
 
+const PUBLIC_STATUS = Object.freeze({
+  scheduled: "รอแอดมินยืนยัน",
+  urgent: "กำลังค้นหาช่าง",
+  urgent_fallback: "รอแอดมินช่วยจัดงาน",
+});
+
+function normalizedPhone(value) {
+  return text(value, 40).replace(/\D/g, "").slice(0, 30);
+}
+
+function appointmentIso(value) {
+  const timestamp = new Date(value).getTime();
+  return Number.isFinite(timestamp) ? new Date(timestamp).toISOString() : "";
+}
+
+function publicStatusForJob(job = {}) {
+  if (text(job.public_status, 80)) return text(job.public_status, 80);
+  if (String(job.booking_mode || "").trim().toLowerCase() !== "urgent") return PUBLIC_STATUS.scheduled;
+  return String(job.job_status || "") === JOB_STATUS.URGENT_NO_TECHNICIAN
+    ? PUBLIC_STATUS.urgent_fallback
+    : PUBLIC_STATUS.urgent;
+}
+
 function buildBookingTicket({ job = {}, items = [] } = {}) {
   const allItems = Array.isArray(items) ? items : [];
   const serviceItems = allItems.filter((item) => item.is_service === true);
   const ticketItems = serviceItems.length ? serviceItems : allItems;
-  const components = ticketItems.map((item) => ({
-    label: text(item.item_name, 200), quantity: Math.max(0, Number(item.qty || 0)),
-  })).filter((item) => item.label && Number.isFinite(item.quantity) && item.quantity > 0);
+  const components = ticketItems.map((item) => {
+    const quantity = Number(item.qty || 0);
+    return {
+      label: text(item.item_name, 200),
+      quantity: Number.isInteger(quantity) && quantity > 0 ? quantity : 0,
+    };
+  }).filter((item) => item.label && item.quantity > 0);
   return {
     heading: "CWF BOOKING TICKET",
     booking_code: text(job.booking_code, 40),
     customer_name: text(job.customer_name, 120),
-    customer_phone: text(job.customer_phone, 30),
+    customer_phone: normalizedPhone(job.customer_phone),
     components,
     total_machine_count: components.reduce((sum, item) => sum + item.quantity, 0),
-    appointment_datetime: new Date(job.appointment_datetime).toISOString(),
+    appointment_datetime: appointmentIso(job.appointment_datetime),
     exact_total: exactMoney(job.job_price),
-    public_status: text(job.public_status || "รอแอดมินยืนยัน", 80),
+    public_status: publicStatusForJob(job),
   };
 }
 
 async function loadBookingTicket(db, jobId) {
   const jobResult = await db.query(
-    `SELECT booking_code, customer_name, customer_phone, appointment_datetime, job_price
+    `SELECT booking_code, customer_name, customer_phone, appointment_datetime, job_price,
+            booking_mode, job_status
        FROM public.jobs WHERE job_id=$1 LIMIT 1`, [jobId]
   );
   const job = jobResult.rows[0];
@@ -50,4 +85,11 @@ function formatBookingTicket(ticket) {
   return lines.join("\n");
 }
 
-module.exports = { buildBookingTicket, loadBookingTicket, formatBookingTicket, exactMoney };
+module.exports = {
+  buildBookingTicket,
+  loadBookingTicket,
+  formatBookingTicket,
+  exactMoney,
+  normalizedPhone,
+  publicStatusForJob,
+};

--- a/server/services/booking/bookingTicket.js
+++ b/server/services/booking/bookingTicket.js
@@ -14,6 +14,17 @@ function exactMoney(value) {
   return `${match[1]}.${String(match[2] || "").padEnd(2, "0")}`;
 }
 
+function moneyMinor(value) {
+  const [whole, fraction] = exactMoney(value).split(".");
+  return (BigInt(whole) * 100n) + BigInt(fraction);
+}
+
+function netMoney(base, discount) {
+  const result = moneyMinor(base) - moneyMinor(discount);
+  const safe = result < 0n ? 0n : result;
+  return `${safe / 100n}.${String(safe % 100n).padStart(2, "0")}`;
+}
+
 const PUBLIC_STATUS = Object.freeze({
   scheduled: "รอแอดมินยืนยัน",
   urgent: "กำลังค้นหาช่าง",
@@ -56,16 +67,17 @@ function buildBookingTicket({ job = {}, items = [] } = {}) {
     components,
     total_machine_count: components.reduce((sum, item) => sum + item.quantity, 0),
     appointment_datetime: appointmentIso(job.appointment_datetime),
-    exact_total: exactMoney(job.job_price),
+    exact_total: netMoney(job.job_price, job.applied_discount),
     public_status: publicStatusForJob(job),
   };
 }
 
 async function loadBookingTicket(db, jobId) {
   const jobResult = await db.query(
-    `SELECT booking_code, customer_name, customer_phone, appointment_datetime, job_price,
-            booking_mode, job_status
-       FROM public.jobs WHERE job_id=$1 LIMIT 1`, [jobId]
+    `SELECT j.booking_code, j.customer_name, j.customer_phone, j.appointment_datetime, j.job_price,
+            j.booking_mode, j.job_status,
+            COALESCE((SELECT jp.applied_discount::text FROM public.job_promotions jp WHERE jp.job_id=j.job_id LIMIT 1), '0.00') AS applied_discount
+       FROM public.jobs j WHERE j.job_id=$1 LIMIT 1`, [jobId]
   );
   const job = jobResult.rows[0];
   if (!job) return null;
@@ -90,6 +102,7 @@ module.exports = {
   loadBookingTicket,
   formatBookingTicket,
   exactMoney,
+  netMoney,
   normalizedPhone,
   publicStatusForJob,
 };

--- a/server/services/booking/bookingTicket.js
+++ b/server/services/booking/bookingTicket.js
@@ -1,0 +1,53 @@
+"use strict";
+
+function text(value, max = 300) { return String(value == null ? "" : value).trim().slice(0, max); }
+function exactMoney(value) {
+  const match = /^(\d+)(?:\.(\d{1,2}))?$/.exec(text(value, 40));
+  if (!match) return "0.00";
+  return `${match[1]}.${String(match[2] || "").padEnd(2, "0")}`;
+}
+
+function buildBookingTicket({ job = {}, items = [] } = {}) {
+  const allItems = Array.isArray(items) ? items : [];
+  const serviceItems = allItems.filter((item) => item.is_service === true);
+  const ticketItems = serviceItems.length ? serviceItems : allItems;
+  const components = ticketItems.map((item) => ({
+    label: text(item.item_name, 200), quantity: Math.max(0, Number(item.qty || 0)),
+  })).filter((item) => item.label && Number.isFinite(item.quantity) && item.quantity > 0);
+  return {
+    heading: "CWF BOOKING TICKET",
+    booking_code: text(job.booking_code, 40),
+    customer_name: text(job.customer_name, 120),
+    customer_phone: text(job.customer_phone, 30),
+    components,
+    total_machine_count: components.reduce((sum, item) => sum + item.quantity, 0),
+    appointment_datetime: new Date(job.appointment_datetime).toISOString(),
+    exact_total: exactMoney(job.job_price),
+    public_status: text(job.public_status || "รอแอดมินยืนยัน", 80),
+  };
+}
+
+async function loadBookingTicket(db, jobId) {
+  const jobResult = await db.query(
+    `SELECT booking_code, customer_name, customer_phone, appointment_datetime, job_price
+       FROM public.jobs WHERE job_id=$1 LIMIT 1`, [jobId]
+  );
+  const job = jobResult.rows[0];
+  if (!job) return null;
+  const itemResult = await db.query(
+    `SELECT item_name, qty, is_service FROM public.job_items WHERE job_id=$1 ORDER BY job_item_id`, [jobId]
+  );
+  return buildBookingTicket({ job, items: itemResult.rows });
+}
+
+function formatBookingTicket(ticket) {
+  const lines = [ticket.heading, `รหัสการจอง: ${ticket.booking_code}`, `ชื่อผู้ติดต่อ: ${ticket.customer_name}`,
+    `เบอร์โทร: ${ticket.customer_phone}`, "รายการบริการ:"];
+  ticket.components.forEach((item) => lines.push(`- ${item.label} x ${item.quantity}`));
+  lines.push(`จำนวนรวม: ${ticket.total_machine_count} เครื่อง`, `วันเวลานัด: ${ticket.appointment_datetime}`,
+    `ยอดยืนยันจากระบบ: ${ticket.exact_total} บาท`, `สถานะ: ${ticket.public_status}`,
+    "ผู้ส่งยืนยันว่า LINE บัญชีนี้เป็นผู้ติดต่อสำหรับรายการจองนี้");
+  return lines.join("\n");
+}
+
+module.exports = { buildBookingTicket, loadBookingTicket, formatBookingTicket, exactMoney };

--- a/server/services/booking/catalogBookingPolicy.js
+++ b/server/services/booking/catalogBookingPolicy.js
@@ -11,18 +11,76 @@ class CatalogBookingPolicyError extends Error {
 
 function clean(value) { return String(value == null ? "" : value).trim(); }
 
+function moneyMinor(value) {
+  const match = /^(\d+)(?:\.(\d{1,2}))?$/.exec(clean(value));
+  if (!match) return null;
+  return (BigInt(match[1]) * 100n) + BigInt(String(match[2] || "").padEnd(2, "0"));
+}
+
+function moneyText(minor) {
+  return `${minor / 100n}.${String(minor % 100n).padStart(2, "0")}`;
+}
+
+function dateAllows(now, from, to) {
+  const timestamp = now.getTime();
+  const start = from == null ? null : new Date(from).getTime();
+  const end = to == null ? null : new Date(to).getTime();
+  return Number.isFinite(timestamp)
+    && (start == null || (Number.isFinite(start) && timestamp >= start))
+    && (end == null || (Number.isFinite(end) && timestamp <= end));
+}
+
+function ruleMatches(row, actual, quantity) {
+  if (clean(row.rule_job_type) && clean(row.rule_job_type) !== actual.job_type) return false;
+  if (clean(row.rule_ac_type) && clean(row.rule_ac_type) !== actual.ac_type) return false;
+  if (clean(row.rule_wash_variant) && clean(row.rule_wash_variant) !== actual.wash_variant) return false;
+  if (row.rule_btu_min != null && actual.btu < Number(row.rule_btu_min)) return false;
+  if (row.rule_btu_max != null && actual.btu > Number(row.rule_btu_max)) return false;
+  if (row.rule_machine_min != null && quantity < Number(row.rule_machine_min)) return false;
+  if (row.rule_machine_max != null && quantity > Number(row.rule_machine_max)) return false;
+  return true;
+}
+
+function authoritativePricing(row, actual, quantity, now) {
+  const baseMinor = moneyMinor(row.base_price);
+  const activeRule = row.price_rule_id != null && row.rule_is_active === true
+    && dateAllows(now, row.rule_effective_from, row.rule_effective_to)
+    && ruleMatches(row, actual, quantity);
+  const activeMinor = activeRule ? moneyMinor(row.rule_active_price) : null;
+  const normalMinor = activeRule ? moneyMinor(row.rule_normal_price) : null;
+  const unitMinor = activeMinor != null && activeMinor > 0n ? activeMinor : baseMinor;
+  if (unitMinor == null || unitMinor <= 0n) throw new CatalogBookingPolicyError("CATALOG_PRICE_UNAVAILABLE", 409);
+  return {
+    unit_price: moneyText(unitMinor),
+    exact_total: moneyText(unitMinor * BigInt(quantity)),
+    normal_unit_price: moneyText(normalMinor != null && normalMinor > 0n ? normalMinor : unitMinor),
+    price_rule_id: activeMinor != null && activeMinor > 0n ? Number(row.price_rule_id) : null,
+    price_label: activeMinor != null && activeMinor > 0n ? clean(row.rule_label) || null : null,
+    campaign_name: activeMinor != null && activeMinor > 0n ? clean(row.rule_campaign_name) || null : null,
+    source: activeMinor != null && activeMinor > 0n ? "catalog_price_rule" : "catalog_base_price",
+  };
+}
+
 async function resolveCatalogBookingPolicy(db, input = {}, options = {}) {
   const itemId = Number(input.catalogItemId);
   if (!Number.isSafeInteger(itemId) || itemId <= 0) {
     throw new CatalogBookingPolicyError("CATALOG_ITEM_INVALID", 400);
   }
-  const lock = options.lock === true ? " FOR SHARE" : "";
+  const lock = options.lock === true ? " FOR SHARE OF ci" : "";
   const result = await db.query(
-    `SELECT item_id, item_name, booking_mode, booking_flow_policy,
-            booking_job_type, booking_ac_type, booking_btu, booking_wash_variant,
-            is_active, is_customer_visible
-       FROM public.catalog_items
-      WHERE item_id=$1${lock}`,
+    `SELECT ci.item_id, ci.item_name, ci.booking_mode, ci.booking_flow_policy,
+            ci.job_category AS booking_job_type, ci.booking_ac_type, ci.booking_btu, ci.booking_wash_variant,
+            ci.base_price, ci.price_rule_id, ci.is_active, ci.is_customer_visible,
+            pr.job_type AS rule_job_type, pr.ac_type AS rule_ac_type, pr.wash_variant AS rule_wash_variant,
+            pr.btu_min AS rule_btu_min, pr.btu_max AS rule_btu_max,
+            pr.machine_min AS rule_machine_min, pr.machine_max AS rule_machine_max,
+            pr.normal_price AS rule_normal_price, pr.active_price AS rule_active_price,
+            pr.label AS rule_label, pr.campaign_name AS rule_campaign_name,
+            pr.effective_from AS rule_effective_from, pr.effective_to AS rule_effective_to,
+            pr.is_active AS rule_is_active
+       FROM public.catalog_items ci
+       LEFT JOIN public.customer_service_price_rules pr ON pr.rule_id=ci.price_rule_id
+      WHERE ci.item_id=$1${lock}`,
     [itemId]
   );
   const row = result.rows[0];
@@ -54,7 +112,41 @@ async function resolveCatalogBookingPolicy(db, input = {}, options = {}) {
       || expected.btu !== actual.btu || expected.wash_variant !== actual.wash_variant) {
     throw new CatalogBookingPolicyError("CATALOG_SELECTION_MISMATCH", 409);
   }
-  return { item_id: Number(row.item_id), item_name: clean(row.item_name), booking_flow_policy: policy, ...expected };
+  const quantity = Number(input.machineCount == null ? 1 : input.machineCount);
+  if (!Number.isSafeInteger(quantity) || quantity <= 0) throw new CatalogBookingPolicyError("CATALOG_SELECTION_MISMATCH", 409);
+  return {
+    item_id: Number(row.item_id), item_name: clean(row.item_name), booking_flow_policy: policy,
+    machine_count: quantity, pricing: authoritativePricing(row, actual, quantity, options.now ? options.now() : new Date()),
+    ...expected,
+  };
 }
 
-module.exports = { CatalogBookingPolicyError, resolveCatalogBookingPolicy };
+function buildCatalogBookingItem(booking) {
+  return {
+    item_id: null,
+    item_name: booking.item_name,
+    qty: booking.machine_count,
+    unit_price: booking.pricing.unit_price,
+    line_total: booking.pricing.exact_total,
+    is_service: true,
+    customer_price_rule_id: booking.pricing.price_rule_id,
+    normal_unit_price: booking.pricing.normal_unit_price,
+    customer_price_label: booking.pricing.price_label,
+    customer_campaign_name: booking.pricing.campaign_name,
+    customer_price_source: booking.pricing.source,
+  };
+}
+
+function buildCatalogBookingPayload(booking) {
+  return {
+    job_type: booking.job_type,
+    ac_type: booking.ac_type,
+    btu: booking.btu,
+    machine_count: booking.machine_count,
+    wash_variant: booking.wash_variant,
+    repair_variant: "",
+    admin_override_duration_min: 0,
+  };
+}
+
+module.exports = { CatalogBookingPolicyError, resolveCatalogBookingPolicy, buildCatalogBookingItem, buildCatalogBookingPayload };

--- a/server/services/booking/catalogBookingPolicy.js
+++ b/server/services/booking/catalogBookingPolicy.js
@@ -1,0 +1,60 @@
+"use strict";
+
+class CatalogBookingPolicyError extends Error {
+  constructor(code, statusCode = 409) {
+    super(code);
+    this.name = "CatalogBookingPolicyError";
+    this.code = code;
+    this.statusCode = statusCode;
+  }
+}
+
+function clean(value) { return String(value == null ? "" : value).trim(); }
+
+async function resolveCatalogBookingPolicy(db, input = {}, options = {}) {
+  const itemId = Number(input.catalogItemId);
+  if (!Number.isSafeInteger(itemId) || itemId <= 0) {
+    throw new CatalogBookingPolicyError("CATALOG_ITEM_INVALID", 400);
+  }
+  const lock = options.lock === true ? " FOR SHARE" : "";
+  const result = await db.query(
+    `SELECT item_id, item_name, booking_mode, booking_flow_policy,
+            booking_job_type, booking_ac_type, booking_btu, booking_wash_variant,
+            is_active, is_customer_visible
+       FROM public.catalog_items
+      WHERE item_id=$1${lock}`,
+    [itemId]
+  );
+  const row = result.rows[0];
+  if (!row || row.is_active !== true || (options.identity === "customer" && row.is_customer_visible !== true)) {
+    throw new CatalogBookingPolicyError("CATALOG_ITEM_UNAVAILABLE", 409);
+  }
+  if (clean(row.booking_mode) !== "bookable") {
+    throw new CatalogBookingPolicyError("CATALOG_ITEM_NOT_BOOKABLE", 409);
+  }
+  const mode = clean(input.bookingMode || "scheduled").toLowerCase();
+  const policy = clean(row.booking_flow_policy || "scheduled_only").toLowerCase();
+  if (mode === "urgent" && policy !== "scheduled_and_urgent") {
+    throw new CatalogBookingPolicyError("CATALOG_FLOW_NOT_ALLOWED", 409);
+  }
+  const expected = {
+    job_type: clean(row.booking_job_type),
+    ac_type: clean(row.booking_ac_type),
+    btu: Number(row.booking_btu),
+    wash_variant: clean(row.booking_wash_variant),
+  };
+  const actual = {
+    job_type: clean(input.jobType),
+    ac_type: clean(input.acType),
+    btu: Number(input.btu),
+    wash_variant: clean(input.washVariant),
+  };
+  if (!expected.job_type || !expected.ac_type || !Number.isFinite(expected.btu)
+      || expected.job_type !== actual.job_type || expected.ac_type !== actual.ac_type
+      || expected.btu !== actual.btu || expected.wash_variant !== actual.wash_variant) {
+    throw new CatalogBookingPolicyError("CATALOG_SELECTION_MISMATCH", 409);
+  }
+  return { item_id: Number(row.item_id), item_name: clean(row.item_name), booking_flow_policy: policy, ...expected };
+}
+
+module.exports = { CatalogBookingPolicyError, resolveCatalogBookingPolicy };

--- a/server/services/booking/createBookingJob.js
+++ b/server/services/booking/createBookingJob.js
@@ -4,9 +4,10 @@ const crypto = require("crypto");
 const { JOB_STATUS, ASSIGNMENT_STATUS, OFFER_STATUS } = require("./bookingStatuses");
 const { ensureBookingJobUnits } = require("./bookingJobUnits");
 const { packageRequest, resolvePackageBooking, packageBookingFromSnapshot, compositeBookingFromSnapshots } = require("./servicePackageBooking");
-const { resolveCatalogBookingPolicy } = require("./catalogBookingPolicy");
+const { resolveCatalogBookingPolicy, buildCatalogBookingItem, buildCatalogBookingPayload } = require("./catalogBookingPolicy");
 const { buildBookingTicket, loadBookingTicket } = require("./bookingTicket");
 const adminIdempotency = require("./adminBookingIdempotency");
+const { validateAdminStorePromotionRequest } = require("./adminStorePromotionPolicy");
 
 function safePackagePreview(selection) {
   const line = selection.service_lines[0];
@@ -202,6 +203,12 @@ function createBookingJobService(dependencies = {}) {
     const bm = isUrgentOffer ? "urgent" : rawBm;
     const ttype = (tech_type || (bm === "urgent" ? "partner" : "company")).toString().trim().toLowerCase();
     const mode = isUrgentOffer ? "offer" : rawMode;
+    const createdBySource = req.cwfBookSource === "customer" ? "customer" : "admin";
+    try {
+      validateAdminStorePromotionRequest(body, { createdBySource });
+    } catch (error) {
+      return res.status(Number(error.statusCode || 400)).json({ error: error.code, code: error.code });
+    }
     if (hasPackageRequest) {
       try {
         if (promotion_id) {
@@ -221,7 +228,7 @@ function createBookingJobService(dependencies = {}) {
       try {
         catalogBooking = await resolveCatalogBookingPolicy(pool, {
           catalogItemId: catalog_item_id, bookingMode: bm, jobType: job_type,
-          acType: ac_type, btu, washVariant: wash_variant,
+          acType: ac_type, btu, washVariant: wash_variant, machineCount: machine_count,
         }, { identity: "customer" });
       } catch (error) {
         return res.status(Number(error.statusCode || 409)).json({ error: error.code, code: error.code });
@@ -236,7 +243,6 @@ function createBookingJobService(dependencies = {}) {
       String(allowTimeProposalRaw || "").trim().toLowerCase() === "true" ||
       String(allowTimeProposalRaw || "").trim() === "1"
     );
-    const createdBySource = req.cwfBookSource === "customer" ? "customer" : "admin";
     const rawAdminRequestKey = createdBySource === "admin" && admin_request_key != null ? String(admin_request_key).trim() : "";
     const adminRequestKey = rawAdminRequestKey ? adminIdempotency.validateAdminRequestKey(rawAdminRequestKey) : null;
     if (rawAdminRequestKey && !adminRequestKey) return res.status(400).json({ error: "INVALID_ADMIN_REQUEST_KEY", code: "INVALID_ADMIN_REQUEST_KEY" });
@@ -306,6 +312,7 @@ function createBookingJobService(dependencies = {}) {
       admin_override_duration_min: Math.max(0, coerceNumber(override_duration_min, 0)),
     };
     if (packageBooking) payloadV2 = packageBooking.payload;
+    if (catalogBooking) payloadV2 = buildCatalogBookingPayload(catalogBooking);
 
     // CWF Spec: Always use conservative duration for booking/collision (no parallel/team reduction)
     let duration_min = packageBooking ? packageBooking.durationMin : computeDurationMinMulti(payloadV2, { source: "admin_book_v2", conservative: true });
@@ -318,8 +325,10 @@ function createBookingJobService(dependencies = {}) {
       duration_min = Math.max(1, Math.floor(coerceNumber(override_duration_min, duration_min)));
     }
 
-    const customerPrice = packageBooking ? null : await customerPricingHelpers.resolveCustomerPricingMulti(payloadV2, pool);
-    const standard_price = packageBooking ? Number(packageBooking.fixedTotal) : Number(customerPrice.active_price ?? customerPrice.standard_price ?? 0);
+    const customerPrice = packageBooking || catalogBooking ? null : await customerPricingHelpers.resolveCustomerPricingMulti(payloadV2, pool);
+    let standard_price = packageBooking ? Number(packageBooking.fixedTotal)
+      : catalogBooking ? Number(catalogBooking.pricing.exact_total)
+        : Number(customerPrice.active_price ?? customerPrice.standard_price ?? 0);
 
 
   // Blocker: explicit admin coordinates must be validated at the BACKEND, not just
@@ -406,8 +415,9 @@ function createBookingJobService(dependencies = {}) {
       if (catalogBooking) {
         catalogBooking = await resolveCatalogBookingPolicy(client, {
           catalogItemId: catalogBooking.item_id, bookingMode: bm, jobType: job_type,
-          acType: ac_type, btu, washVariant: wash_variant,
+          acType: ac_type, btu, washVariant: wash_variant, machineCount: machine_count,
         }, { identity: "customer", lock: true });
+        standard_price = Number(catalogBooking.pricing.exact_total);
       }
 
       // Durable, cross-instance idempotency for customer-sourced urgent
@@ -453,7 +463,7 @@ function createBookingJobService(dependencies = {}) {
 
       // promo
       let promo = null;
-      if (!packageBooking && promotion_id) {
+      if (!packageBooking && !catalogBooking && promotion_id) {
         const pr = await client.query(
           `SELECT promo_id, promo_name, promo_type, promo_value
            FROM public.promotions
@@ -464,9 +474,9 @@ function createBookingJobService(dependencies = {}) {
       }
 
       // resolve items
-  const computedItems = packageBooking ? packageBooking.items : [];
+      const computedItems = packageBooking ? packageBooking.items : (catalogBooking ? [buildCatalogBookingItem(catalogBooking)] : []);
 
-  const serviceLineItems = packageBooking ? [] : await customerPricingHelpers.buildCustomerServiceLineItemsFromPayload(
+      const serviceLineItems = packageBooking || catalogBooking ? [] : await customerPricingHelpers.buildCustomerServiceLineItemsFromPayload(
     (payloadV2.services && Array.isArray(payloadV2.services))
       ? payloadV2
       : { ...payloadV2, services: [{
@@ -481,16 +491,16 @@ function createBookingJobService(dependencies = {}) {
     client
   );
 
-  if (!packageBooking && coerceNumber(override_price, 0) > 0) {
+      if (!packageBooking && !catalogBooking && coerceNumber(override_price, 0) > 0) {
     // Customer override price only. Payroll must never use this as technician income.
     computedItems.push({ item_id: null, item_name: `ค่าบริการ (override)`, qty: 1, unit_price: coerceNumber(override_price, 0), line_total: coerceNumber(override_price, 0), is_service: false, customer_price_source: 'manual_override' });
-  } else if (serviceLineItems.length) {
+      } else if (!catalogBooking && serviceLineItems.length) {
     for (const it of serviceLineItems) computedItems.push(it);
-  } else if (standard_price > 0) {
+  } else if (!packageBooking && !catalogBooking && standard_price > 0) {
     computedItems.push({ item_id: null, item_name: `ค่าบริการมาตรฐาน (${payloadV2.job_type || '-'})`, qty: 1, unit_price: Number(standard_price), line_total: Number(standard_price), is_service: false });
   }
 
-      if (!packageBooking && itemIdQty.length) {
+      if (!packageBooking && !catalogBooking && itemIdQty.length) {
         const ids = itemIdQty.map((x) => x.item_id);
         const catR = await client.query(
           `SELECT item_id, item_name, base_price
@@ -927,6 +937,52 @@ function createBookingJobService(dependencies = {}) {
     }
   }
 
+  async function handleAdminCatalogBookingPreview(req, res) {
+    try {
+      const body = req.body || {};
+      const booking = await resolveCatalogBookingPolicy(pool, {
+        catalogItemId: body.catalog_item_id,
+        bookingMode: body.booking_mode,
+        jobType: body.job_type,
+        acType: body.ac_type,
+        btu: body.btu,
+        washVariant: body.wash_variant,
+        machineCount: body.machine_count,
+      }, { identity: "customer" });
+      const timingPayload = {
+        job_type: booking.job_type,
+        ac_type: booking.ac_type,
+        btu: booking.btu,
+        wash_variant: booking.wash_variant,
+        machine_count: booking.machine_count,
+        admin_override_duration_min: 0,
+      };
+      const durationMin = computeDurationMinMulti(timingPayload, { source: "admin_catalog_booking_preview", conservative: true });
+      if (durationMin <= 0) {
+        return res.status(409).json({ error: "CATALOG_DURATION_UNAVAILABLE", code: "CATALOG_DURATION_UNAVAILABLE" });
+      }
+      return res.json({
+        catalog_item_id: booking.item_id,
+        booking_flow_policy: booking.booking_flow_policy,
+        machine_count: booking.machine_count,
+        unit_price: booking.pricing.unit_price,
+        normal_unit_price: booking.pricing.normal_unit_price,
+        exact_total: booking.pricing.exact_total,
+        price_rule_id: booking.pricing.price_rule_id,
+        price_label: booking.pricing.price_label,
+        campaign_name: booking.pricing.campaign_name,
+        price_source: booking.pricing.source,
+        duration_min: durationMin,
+        effective_block_min: effectiveBlockMin(durationMin),
+        travel_buffer_min: TRAVEL_BUFFER_MIN,
+      });
+    } catch (error) {
+      const status = Number(error?.statusCode || 409);
+      const code = error?.code || "CATALOG_ITEM_UNAVAILABLE";
+      return res.status(status >= 400 && status < 500 ? status : 409).json({ error: code, code });
+    }
+  }
+
   async function handleInternalBookFromAi(req, res) {
     const missing = validateInternalBookingPayload(req.body);
     if (missing.length) {
@@ -984,10 +1040,12 @@ function createBookingJobService(dependencies = {}) {
   // Rebuild the incoming service + extra lines with the SAME normalizer used to
   // create a booking, so an identical service payload yields an identical
   // signature (and any material change yields a different one). Read-only.
-  async function buildIncomingBookingLineSignature(db, payloadV2, itemIdQty, standardPrice, packageBooking) {
+  async function buildIncomingBookingLineSignature(db, payloadV2, itemIdQty, standardPrice, packageBooking, catalogBooking) {
     let computed = [];
     let total = Number(standardPrice || 0);
-    const serviceLines = packageBooking ? packageBooking.items : await customerPricingHelpers.buildCustomerServiceLineItemsFromPayload(
+    const serviceLines = packageBooking ? packageBooking.items
+      : catalogBooking ? [buildCatalogBookingItem(catalogBooking)]
+        : await customerPricingHelpers.buildCustomerServiceLineItemsFromPayload(
       (payloadV2.services && Array.isArray(payloadV2.services))
         ? payloadV2
         : {
@@ -1052,6 +1110,8 @@ function createBookingJobService(dependencies = {}) {
     const incomingLng = incoming.gps_longitude == null || String(incoming.gps_longitude).trim() === "" ? null : Number(incoming.gps_longitude);
     if (storedLat !== incomingLat || storedLng !== incomingLng) return false;
     if (Number(jobRow.duration_min || 0) !== Number(incoming.duration_min || 0)) return false;
+    if (incoming.catalog_item_id !== undefined
+        && Number(jobRow.catalog_item_id || 0) !== Number(incoming.catalog_item_id || 0)) return false;
     return true;
   }
 
@@ -1078,7 +1138,7 @@ function createBookingJobService(dependencies = {}) {
     }
     const storedSig = await loadStoredBookingLineSignature(db, jobRow.job_id);
     const incomingSig = await buildIncomingBookingLineSignature(
-      db, incoming.payloadV2, incoming.itemIdQty, incoming.standardPrice, incoming.packageBooking
+      db, incoming.payloadV2, incoming.itemIdQty, incoming.standardPrice, incoming.packageBooking, incoming.catalogBooking
     );
     return storedSig === incomingSig;
   }
@@ -1548,12 +1608,16 @@ function createBookingJobService(dependencies = {}) {
         catalogBooking = await resolveCatalogBookingPolicy(pool, {
           catalogItemId: safeCatalogItemIdForJob, bookingMode: bm,
           jobType: payloadV2.job_type, acType: payloadV2.ac_type,
-          btu: payloadV2.btu, washVariant: payloadV2.wash_variant,
+          btu: payloadV2.btu, washVariant: payloadV2.wash_variant, machineCount: payloadV2.machine_count,
         }, { identity: "customer" });
         safeCatalogItemIdForJob = catalogBooking.item_id;
+        payloadV2 = buildCatalogBookingPayload(catalogBooking);
       } catch (error) {
         return res.status(Number(error.statusCode || 409)).json({ error: error.code, code: error.code });
       }
+    }
+    if (catalogBooking && itemIdQty.length) {
+      return res.status(400).json({ error: "CATALOG_STACKING_UNSUPPORTED", code: "CATALOG_STACKING_UNSUPPORTED" });
     }
     if (bm === "urgent") {
       if (!urgentPublicAdapter.isStrictUrgentCleaningPayload(payloadV2)) {
@@ -1603,10 +1667,11 @@ function createBookingJobService(dependencies = {}) {
         });
       }
     }
-    const customerPrice = packageBooking ? null : await customerPricingHelpers.resolveCustomerPricingMulti(payloadV2, pool);
+    const customerPrice = packageBooking || catalogBooking ? null : await customerPricingHelpers.resolveCustomerPricingMulti(payloadV2, pool);
     const standard_price = packageBooking
       ? packageBooking.fixedTotal
-      : Number(customerPrice.active_price ?? customerPrice.standard_price ?? 0);
+      : catalogBooking ? catalogBooking.pricing.exact_total
+        : Number(customerPrice.active_price ?? customerPrice.standard_price ?? 0);
 
   // ✅ Parse lat/lng from maps_url or address_text (fail-open)
   const parsedLL = parseLatLngFromText(maps_url) || parseLatLngFromText(address_text);
@@ -1638,7 +1703,7 @@ function createBookingJobService(dependencies = {}) {
         await idem.query("BEGIN");
         await idem.query("SELECT pg_advisory_xact_lock(hashtext($1))", [bookingRequestKey]);
         const r = await idem.query(
-          `SELECT job_id, booking_code, booking_token, dispatch_mode, duration_min, job_price,
+          `SELECT job_id, booking_code, booking_token, dispatch_mode, duration_min, job_price, catalog_item_id,
                   appointment_datetime, customer_phone, customer_name, address_text, maps_url,
                   job_zone, job_type, customer_note, allow_time_proposal, gps_latitude, gps_longitude
              FROM public.jobs
@@ -1663,6 +1728,7 @@ function createBookingJobService(dependencies = {}) {
           job_zone, job_type: packageBooking ? payloadV2.job_type : job_type, customer_note, allow_time_proposal: allowTimeProposal,
           gps_latitude: persistedGpsLatitude, gps_longitude: persistedGpsLongitude,
           duration_min: duration_min_v2, payloadV2, itemIdQty, standardPrice: standard_price, packageBooking,
+          catalogBooking, catalog_item_id: catalogBooking ? catalogBooking.item_id : undefined,
         };
         if (!(await scheduledPayloadMatchesExisting(pool, prior, incomingBooking))) {
           // Same key, materially different booking. No mutation, no identifiers/PII.
@@ -1761,7 +1827,7 @@ function createBookingJobService(dependencies = {}) {
         await client.query("SELECT pg_advisory_xact_lock(hashtext($1))", [bookingRequestKey]);
         const existing = await client.query(
           `SELECT job_id, booking_code, booking_token, booking_mode, dispatch_mode,
-                  duration_min, job_price, appointment_datetime, customer_phone, customer_name,
+                  duration_min, job_price, catalog_item_id, appointment_datetime, customer_phone, customer_name,
                   address_text, maps_url, job_zone, job_type, customer_note, allow_time_proposal,
                   gps_latitude, gps_longitude
              FROM public.jobs
@@ -1789,6 +1855,8 @@ function createBookingJobService(dependencies = {}) {
             payloadV2: replayPackageBooking ? replayPackageBooking.payload : payloadV2,
             itemIdQty, standardPrice: replayPackageBooking ? replayPackageBooking.fixedTotal : standard_price,
             packageBooking: replayPackageBooking,
+            catalogBooking: replayPackageBooking ? null : catalogBooking,
+            catalog_item_id: catalogBooking ? catalogBooking.item_id : undefined,
           };
           if (!incomingBooking || !(await scheduledPayloadMatchesExisting(pool, row, incomingBooking))) {
             return res.status(409).json({
@@ -1836,7 +1904,7 @@ function createBookingJobService(dependencies = {}) {
         catalogBooking = await resolveCatalogBookingPolicy(client, {
           catalogItemId: catalogBooking.item_id, bookingMode: bm,
           jobType: payloadV2.job_type, acType: payloadV2.ac_type,
-          btu: payloadV2.btu, washVariant: payloadV2.wash_variant,
+          btu: payloadV2.btu, washVariant: payloadV2.wash_variant, machineCount: payloadV2.machine_count,
         }, { identity: "customer", lock: true });
       }
 
@@ -1856,7 +1924,9 @@ function createBookingJobService(dependencies = {}) {
       }
 
       // 1) ดึงราคา base_price จาก DB
-  const serviceLineItems = packageBooking ? packageBooking.items : await customerPricingHelpers.buildCustomerServiceLineItemsFromPayload(
+  const serviceLineItems = packageBooking ? packageBooking.items
+    : catalogBooking ? [buildCatalogBookingItem(catalogBooking)]
+      : await customerPricingHelpers.buildCustomerServiceLineItemsFromPayload(
     (payloadV2.services && Array.isArray(payloadV2.services))
       ? payloadV2
       : { ...payloadV2, services: [{
@@ -1921,7 +1991,7 @@ function createBookingJobService(dependencies = {}) {
       // - jobs.job_price เก็บ base_total เท่านั้น
       // - ส่วนลดบันทึกแยกที่ job_promotions.applied_discount
       const base_total = packageBooking ? packageBooking.fixedTotal : Number(total || 0);
-      const promoPick = packageBooking ? null : await findBestCustomerPromotion(payloadV2, base_total, client);
+      const promoPick = packageBooking || catalogBooking ? null : await findBestCustomerPromotion(payloadV2, base_total, client);
       const appliedPromo = promoPick?.promo || null;
       const appliedDiscount = Math.min(Number(base_total || 0), Number(promoPick?.discount || 0));
 
@@ -2190,6 +2260,7 @@ function createBookingJobService(dependencies = {}) {
     handleAdminBookV2,
     handleAdminServicePackageList,
     handleAdminServicePackagePreview,
+    handleAdminCatalogBookingPreview,
     handleInternalBookFromAi,
     handlePublicCustomerUrgentBook,
     handlePublicUrgentPreflight,

--- a/server/services/booking/createBookingJob.js
+++ b/server/services/booking/createBookingJob.js
@@ -3,7 +3,7 @@
 const crypto = require("crypto");
 const { JOB_STATUS, ASSIGNMENT_STATUS, OFFER_STATUS } = require("./bookingStatuses");
 const { ensureBookingJobUnits } = require("./bookingJobUnits");
-const { packageRequest, resolvePackageBooking, packageBookingFromSnapshot } = require("./servicePackageBooking");
+const { packageRequest, resolvePackageBooking, packageBookingFromSnapshot, compositeBookingFromSnapshots } = require("./servicePackageBooking");
 
 function safePackagePreview(selection) {
   const line = selection.service_lines[0];
@@ -138,6 +138,7 @@ function createBookingJobService(dependencies = {}) {
   async function handleAdminBookV2(req, res) {
     const body = req.body || {};
     const hasPackageRequest = body.service_package_key != null || body.service_package_tier_key != null
+      || body.service_package_groups != null
       || body.service_package_id != null || body.service_package_tier_id != null;
     let packageBooking = null;
     const {
@@ -419,7 +420,7 @@ function createBookingJobService(dependencies = {}) {
       }
 
       // resolve items
-  const computedItems = packageBooking ? [packageBooking.item] : [];
+  const computedItems = packageBooking ? packageBooking.items : [];
 
   const serviceLineItems = packageBooking ? [] : await customerPricingHelpers.buildCustomerServiceLineItemsFromPayload(
     (payloadV2.services && Array.isArray(payloadV2.services))
@@ -659,7 +660,7 @@ function createBookingJobService(dependencies = {}) {
           it.customer_price_label || null, it.customer_campaign_name || null,
           it.customer_price_source || null,
         ];
-        if (packageBooking) itemParams.push(packageBooking.packageId, packageBooking.tierId, JSON.stringify(packageBooking.snapshot));
+        if (packageBooking) itemParams.push(it.packageId, it.tierId, JSON.stringify(it.snapshot));
         await client.query(
           `INSERT INTO public.job_items
             (job_id, item_id, item_name, qty, unit_price, line_total, assigned_technician_username, is_service,
@@ -934,7 +935,7 @@ function createBookingJobService(dependencies = {}) {
   async function buildIncomingBookingLineSignature(db, payloadV2, itemIdQty, standardPrice, packageBooking) {
     let computed = [];
     let total = Number(standardPrice || 0);
-    const serviceLines = packageBooking ? [packageBooking.item] : await customerPricingHelpers.buildCustomerServiceLineItemsFromPayload(
+    const serviceLines = packageBooking ? packageBooking.items : await customerPricingHelpers.buildCustomerServiceLineItemsFromPayload(
       (payloadV2.services && Array.isArray(payloadV2.services))
         ? payloadV2
         : {
@@ -1007,13 +1008,21 @@ function createBookingJobService(dependencies = {}) {
   async function scheduledPayloadMatchesExisting(db, jobRow, incoming, options = {}) {
     if (!scheduledScalarsMatch(jobRow, incoming, options)) return false;
     if (incoming.packageBooking) {
-      const packageLink = await db.query(
-        `SELECT 1 FROM public.job_items
-          WHERE job_id=$1 AND service_package_id=$2 AND service_package_tier_id=$3
-          LIMIT 1`,
-        [jobRow.job_id, incoming.packageBooking.packageId, incoming.packageBooking.tierId]
-      );
-      if (!packageLink.rows[0]) return false;
+      if (incoming.packageBooking.bundleId) {
+        const packageLinks = await db.query(
+          `SELECT service_package_id::text AS package_id, service_package_tier_id::text AS tier_id
+             FROM public.job_items WHERE job_id=$1 AND service_package_id IS NOT NULL`, [jobRow.job_id]
+        );
+        const actual = packageLinks.rows.map((row) => `${row.package_id}:${row.tier_id}`).sort();
+        const expected = incoming.packageBooking.items.map((item) => `${item.packageId}:${item.tierId}`).sort();
+        if (actual.length !== expected.length || actual.some((value, index) => value !== expected[index])) return false;
+      } else {
+        const packageLink = await db.query(
+          `SELECT 1 FROM public.job_items WHERE job_id=$1 AND service_package_id=$2 AND service_package_tier_id=$3 LIMIT 1`,
+          [jobRow.job_id, incoming.packageBooking.packageId, incoming.packageBooking.tierId]
+        );
+        if (!packageLink.rows[0]) return false;
+      }
     }
     const storedSig = await loadStoredBookingLineSignature(db, jobRow.job_id);
     const incomingSig = await buildIncomingBookingLineSignature(
@@ -1030,11 +1039,14 @@ function createBookingJobService(dependencies = {}) {
           AND service_package_id IS NOT NULL
           AND service_package_tier_id IS NOT NULL
           AND service_package_snapshot IS NOT NULL
-        LIMIT 1`,
+        ORDER BY job_item_id`,
       [jobId]
     );
     const item = result.rows[0];
     if (!item) return null;
+    if (Object.prototype.hasOwnProperty.call(body || {}, "service_package_groups")) {
+      return compositeBookingFromSnapshots({ body, appointmentDatetime, snapshots: result.rows });
+    }
     return packageBookingFromSnapshot({
       body,
       appointmentDatetime,
@@ -1282,6 +1294,7 @@ function createBookingJobService(dependencies = {}) {
       packageRequestBody = { ...(req.body || {}) };
       // Parse before urgent routing so package keys can never reach or alter urgent dispatch.
       hasPackageRequest = service_package_key != null || service_package_tier_key != null
+        || req.body?.service_package_groups != null
         || req.body?.service_package_id != null || req.body?.service_package_tier_id != null;
       if (canonicalBookingMode === "urgent" && hasPackageRequest) {
         return res.status(400).json({ error: "PACKAGE_URGENT_UNSUPPORTED", code: "PACKAGE_URGENT_UNSUPPORTED" });
@@ -1341,7 +1354,7 @@ function createBookingJobService(dependencies = {}) {
       customerSubForJob = null;
     }
     const catalogItemIdForJob = Number(catalog_item_id);
-    const safeCatalogItemIdForJob = Number.isFinite(catalogItemIdForJob) && catalogItemIdForJob > 0 ? catalogItemIdForJob : null;
+    let safeCatalogItemIdForJob = Number.isFinite(catalogItemIdForJob) && catalogItemIdForJob > 0 ? catalogItemIdForJob : null;
 
     // ✅ sanitize items (ไม่เชื่อราคา/ชื่อจากฝั่งลูกค้า)
     const safeItemsIn = Array.isArray(items) ? items : [];
@@ -1469,7 +1482,10 @@ function createBookingJobService(dependencies = {}) {
         appointmentDatetime: appointment_datetime,
         resolver: hasPackageRequest ? createServicePackageResolver(pool) : null,
       });
-      if (packageBooking) payloadV2 = packageBooking.payload;
+      if (packageBooking) {
+        payloadV2 = packageBooking.payload;
+        if (packageBooking.bundleId) safeCatalogItemIdForJob = Number(packageBooking.bundleId);
+      }
     } catch (error) {
       return res.status(Number(error.statusCode || 400)).json({ error: error.code, code: error.code });
     }
@@ -1763,7 +1779,7 @@ function createBookingJobService(dependencies = {}) {
       }
 
       // 1) ดึงราคา base_price จาก DB
-  const serviceLineItems = packageBooking ? [packageBooking.item] : await customerPricingHelpers.buildCustomerServiceLineItemsFromPayload(
+  const serviceLineItems = packageBooking ? packageBooking.items : await customerPricingHelpers.buildCustomerServiceLineItemsFromPayload(
     (payloadV2.services && Array.isArray(payloadV2.services))
       ? payloadV2
       : { ...payloadV2, services: [{
@@ -1983,7 +1999,7 @@ function createBookingJobService(dependencies = {}) {
           : "";
         const packageValues = packageBooking ? ",$14,$15,$16" : "";
         if (packageBooking) {
-          itemParams.push(packageBooking.packageId, packageBooking.tierId, JSON.stringify(packageBooking.snapshot));
+          itemParams.push(it.packageId, it.tierId, JSON.stringify(it.snapshot));
         }
         await client.query(
           `INSERT INTO public.job_items

--- a/server/services/booking/createBookingJob.js
+++ b/server/services/booking/createBookingJob.js
@@ -9,6 +9,7 @@ const { buildBookingTicket, loadBookingTicket, exactMoney } = require("./booking
 const adminIdempotency = require("./adminBookingIdempotency");
 const persistedBookingReplay = require("./persistedBookingReplay");
 const { validateAdminStorePromotionRequest } = require("./adminStorePromotionPolicy");
+const { resolveUrgentCompositePreflight } = require("./urgentCompositePreflight");
 
 function safePackagePreview(selection) {
   const line = selection.service_lines[0];
@@ -218,10 +219,7 @@ function createBookingJobService(dependencies = {}) {
         if (String(existingAdmin.admin_request_fingerprint || "") !== adminRequestFingerprint) {
           return res.status(409).json({ error: "ADMIN_IDEMPOTENCY_KEY_REUSED", code: "ADMIN_IDEMPOTENCY_KEY_REUSED" });
         }
-        return res.json({ success: true, replayed: true, job_id: existingAdmin.job_id,
-          booking_code: existingAdmin.booking_code,
-          booking_mode: existingAdmin.booking_mode || bm,
-          dispatch_mode: existingAdmin.dispatch_mode || mode });
+        return res.json(persistedBookingReplay.adminReplayResponse(existingAdmin, { bookingMode: bm, dispatchMode: mode }));
       }
     }
     try {
@@ -403,7 +401,8 @@ function createBookingJobService(dependencies = {}) {
       if (adminRequestKey) {
         await client.query("SELECT pg_advisory_xact_lock(hashtext($1))", [adminRequestKey]);
         const existingAdmin = await client.query(
-          `SELECT job_id, booking_code, admin_request_fingerprint FROM public.jobs WHERE admin_request_key=$1 LIMIT 1`,
+          `SELECT job_id, booking_code, booking_mode, dispatch_mode, duration_min, job_price,
+                  admin_request_fingerprint FROM public.jobs WHERE admin_request_key=$1 LIMIT 1`,
           [adminRequestKey]
         );
         if (existingAdmin.rows[0]) {
@@ -411,8 +410,7 @@ function createBookingJobService(dependencies = {}) {
             const conflict = new Error("ADMIN_IDEMPOTENCY_KEY_REUSED"); conflict.code = "ADMIN_IDEMPOTENCY_KEY_REUSED"; conflict.statusCode = 409; throw conflict;
           }
           await client.query("COMMIT");
-          return res.json({ success: true, replayed: true, job_id: existingAdmin.rows[0].job_id,
-            booking_code: existingAdmin.rows[0].booking_code, booking_mode: bm, dispatch_mode: mode });
+          return res.json(persistedBookingReplay.adminReplayResponse(existingAdmin.rows[0], { bookingMode: bm, dispatchMode: mode }));
         }
       }
 
@@ -644,7 +642,7 @@ function createBookingJobService(dependencies = {}) {
           (customer_phone || "").toString().trim(),
           String(packageBooking ? payloadV2.job_type : job_type).trim(),
           apptIso,
-          Number(pricing.total || 0),
+          pricing.total_exact,
           String(address_text).trim(),
           (!isUrgentOffer && mode === "forced") ? selectedTech : null,
           isUrgentOffer ? null : selectedTech,
@@ -748,7 +746,7 @@ function createBookingJobService(dependencies = {}) {
           `INSERT INTO public.job_promotions (job_id, promo_id, applied_discount)
            VALUES ($1,$2,$3)
            ON CONFLICT (job_id) DO UPDATE SET promo_id=EXCLUDED.promo_id, applied_discount=EXCLUDED.applied_discount`,
-          [job_id, promo.promo_id, Number(pricing.discount || 0)]
+          [job_id, promo.promo_id, pricing.discount_exact]
         );
       }
 
@@ -852,7 +850,7 @@ function createBookingJobService(dependencies = {}) {
         duration_min,
         effective_block_min: effectiveBlockMin(duration_min),
         standard_price,
-        total: pricing.total,
+        total: pricing.total_exact,
         promo_id: promo?.promo_id || null,
       });
 
@@ -870,6 +868,9 @@ function createBookingJobService(dependencies = {}) {
         subtotal: Number(pricing.subtotal || 0),
         discount: Number(pricing.discount || 0),
         total: Number(pricing.total || 0),
+        subtotal_exact: pricing.subtotal_exact,
+        discount_exact: pricing.discount_exact,
+        total_exact: pricing.total_exact,
         booking_mode: bm,
         dispatch_mode: mode,
         service_zone_code: detectedZoneCode,
@@ -1253,7 +1254,7 @@ function createBookingJobService(dependencies = {}) {
     if (!gps.ok) {
       return { status: 400, error: "ข้อมูล GPS ไม่ถูกต้อง", code: "INVALID_GPS" };
     }
-    const payload = {
+    let payload = {
       job_type: incoming.job_type,
       ac_type: incoming.ac_type,
       btu: Number(incoming.btu || 0),
@@ -1263,7 +1264,15 @@ function createBookingJobService(dependencies = {}) {
       services: incoming.services,
       admin_override_duration_min: 0,
     };
-    const durationMin = computeDurationMinMulti(payload, {
+    const composite = Array.isArray(incoming.service_package_groups)
+      ? await resolveUrgentCompositePreflight({
+          input: incoming,
+          appointmentDatetime: appointment,
+          resolver: createServicePackageResolver(pool),
+        })
+      : null;
+    if (composite) payload = composite.payload;
+    const durationMin = composite?.durationMin || computeDurationMinMulti(payload, {
       source: "public_urgent_preflight",
       conservative: true,
     });
@@ -1319,6 +1328,7 @@ function createBookingJobService(dependencies = {}) {
       } : null,
       nearby_times: preflight.nearby_times,
       duration_min: durationMin,
+      machine_count: composite?.machineCount || Number(payload.machine_count || 0),
       internal: preflight.internal,
     };
   }
@@ -1341,8 +1351,15 @@ function createBookingJobService(dependencies = {}) {
         resolved_zone: result.zone,
         reason: result.reason,
         nearby_times: result.nearby_times,
+        duration_min: result.duration_min,
+        machine_count: result.machine_count,
       });
     } catch (error) {
+      const domainStatus = Number(error?.statusCode || error?.status || 0);
+      if (domainStatus >= 400 && domainStatus < 500) {
+        const code = String(error?.code || "URGENT_PREFLIGHT_REJECTED");
+        return res.status(domainStatus).json({ error: code, code });
+      }
       console.error("[public_urgent_preflight] failed", { message: error?.message });
       return res.status(503).json({
         error: "ระบบตรวจสอบช่างขัดข้องชั่วคราว กรุณาลองอีกครั้ง",
@@ -1546,12 +1563,14 @@ function createBookingJobService(dependencies = {}) {
           return res.status(409).json({ error: "This request key was already used for another booking. Start a new booking.", code: "IDEMPOTENCY_KEY_REUSED" });
         }
         const replayDuration = Number(prior.duration_min || 0);
+        const replayTicket = await loadBookingTicket(pool, prior.job_id);
         return res.json({ success: true, replayed: true, job_id: prior.job_id,
           booking_code: prior.booking_code, token: prior.booking_token,
           booking_mode: prior.booking_mode || bm, dispatch_mode: prior.dispatch_mode || (bm === "urgent" ? "offer" : "normal"),
           duration_min: replayDuration, effective_block_min: effectiveBlockMin(replayDuration),
           travel_buffer_min: TRAVEL_BUFFER_MIN, base_total: Number(prior.job_price || 0),
-          booking_ticket: await loadBookingTicket(pool, prior.job_id) });
+          base_total_exact: exactMoney(prior.job_price), net_total: replayTicket?.exact_total || exactMoney(prior.job_price),
+          booking_ticket: replayTicket });
       }
     }
 
@@ -1608,6 +1627,7 @@ function createBookingJobService(dependencies = {}) {
           booking_mode: bm, dispatch_mode: prior.dispatch_mode || "normal",
           duration_min: replayDuration, effective_block_min: effectiveBlockMin(replayDuration),
           travel_buffer_min: TRAVEL_BUFFER_MIN, base_total: Number(prior.job_price || 0),
+          base_total_exact: exactMoney(prior.job_price), net_total: replayTicket?.exact_total || exactMoney(prior.job_price),
           booking_ticket: replayTicket,
         });
       }
@@ -1786,6 +1806,8 @@ function createBookingJobService(dependencies = {}) {
           effective_block_min: effectiveBlockMin(Number(prior.duration_min || duration_min_v2 || 0)),
           travel_buffer_min: TRAVEL_BUFFER_MIN,
           base_total: Number(prior.job_price || 0),
+          base_total_exact: exactMoney(prior.job_price),
+          net_total: replayTicket?.exact_total || exactMoney(prior.job_price),
           booking_ticket: replayTicket,
         });
       }
@@ -1885,12 +1907,14 @@ function createBookingJobService(dependencies = {}) {
               return res.status(409).json({ error: "This request key was already used for another booking. Start a new booking.", code: "IDEMPOTENCY_KEY_REUSED" });
             }
             const replayDuration = Number(row.duration_min || 0);
+            const replayTicket = await loadBookingTicket(pool, row.job_id);
             return res.json({ success: true, replayed: true, job_id: row.job_id,
               booking_code: row.booking_code, token: row.booking_token, booking_mode: bm,
               dispatch_mode: row.dispatch_mode || (bm === "urgent" ? "offer" : "normal"),
               duration_min: replayDuration, effective_block_min: effectiveBlockMin(replayDuration),
               travel_buffer_min: TRAVEL_BUFFER_MIN, base_total: Number(row.job_price || 0),
-              booking_ticket: await loadBookingTicket(pool, row.job_id) });
+              base_total_exact: exactMoney(row.job_price), net_total: replayTicket?.exact_total || exactMoney(row.job_price),
+              booking_ticket: replayTicket });
           }
           const replayPackageBooking = hasPackageRequest
             ? await historicalPackageBookingForReplay(pool, row.job_id, packageRequestBody, appointment_datetime)
@@ -1925,6 +1949,8 @@ function createBookingJobService(dependencies = {}) {
             effective_block_min: effectiveBlockMin(Number(row.duration_min || duration_min_v2 || 0)),
             travel_buffer_min: TRAVEL_BUFFER_MIN,
             base_total: Number(row.job_price || 0),
+            base_total_exact: exactMoney(row.job_price),
+            net_total: replayTicket?.exact_total || exactMoney(row.job_price),
             booking_ticket: replayTicket,
           });
         }
@@ -2283,6 +2309,8 @@ function createBookingJobService(dependencies = {}) {
           discount: appliedDiscount,
         } : null,
         base_total: Number(base_total || 0),
+        base_total_exact: exactMoney(base_total),
+        net_total: bookingTicket.exact_total,
         booking_ticket: bookingTicket,
       });
     } catch (e) {

--- a/server/services/booking/createBookingJob.js
+++ b/server/services/booking/createBookingJob.js
@@ -4,6 +4,9 @@ const crypto = require("crypto");
 const { JOB_STATUS, ASSIGNMENT_STATUS, OFFER_STATUS } = require("./bookingStatuses");
 const { ensureBookingJobUnits } = require("./bookingJobUnits");
 const { packageRequest, resolvePackageBooking, packageBookingFromSnapshot, compositeBookingFromSnapshots } = require("./servicePackageBooking");
+const { resolveCatalogBookingPolicy } = require("./catalogBookingPolicy");
+const { buildBookingTicket, loadBookingTicket } = require("./bookingTicket");
+const adminIdempotency = require("./adminBookingIdempotency");
 
 function safePackagePreview(selection) {
   const line = selection.service_lines[0];
@@ -168,6 +171,8 @@ function createBookingJobService(dependencies = {}) {
       promotion_id,
       override_price,
       override_duration_min,
+      catalog_item_id,
+      admin_request_key,
     } = body;
 
     // ✅ assign_mode (auto|single|team)
@@ -204,11 +209,22 @@ function createBookingJobService(dependencies = {}) {
           error.code = "PACKAGE_PROMOTION_UNSUPPORTED"; error.statusCode = 400; throw error;
         }
         packageBooking = await resolvePackageBooking({ body, bookingMode: bm, appointmentDatetime: apptIso,
-          resolver: createServicePackageResolver(pool), identity: "admin" });
+          resolver: createServicePackageResolver(pool), identity: Array.isArray(body.service_package_groups) ? "customer" : "admin" });
       } catch (error) {
         const code = String(error?.code || "PACKAGE_UNAVAILABLE").startsWith("PACKAGE_") ? String(error.code) : "PACKAGE_UNAVAILABLE";
         const status = Number(error?.statusCode || error?.status || 409);
         return res.status(status >= 400 && status < 500 ? status : 409).json({ error: code, code });
+      }
+    }
+    let catalogBooking = null;
+    if (!hasPackageRequest && catalog_item_id != null && String(catalog_item_id).trim() !== "") {
+      try {
+        catalogBooking = await resolveCatalogBookingPolicy(pool, {
+          catalogItemId: catalog_item_id, bookingMode: bm, jobType: job_type,
+          acType: ac_type, btu, washVariant: wash_variant,
+        }, { identity: "customer" });
+      } catch (error) {
+        return res.status(Number(error.statusCode || 409)).json({ error: error.code, code: error.code });
       }
     }
     // ✅ HOTFIX: allow_time_proposal may be omitted by older cached frontend/PWA.
@@ -221,6 +237,11 @@ function createBookingJobService(dependencies = {}) {
       String(allowTimeProposalRaw || "").trim() === "1"
     );
     const createdBySource = req.cwfBookSource === "customer" ? "customer" : "admin";
+    const rawAdminRequestKey = createdBySource === "admin" && admin_request_key != null ? String(admin_request_key).trim() : "";
+    const adminRequestKey = rawAdminRequestKey ? adminIdempotency.validateAdminRequestKey(rawAdminRequestKey) : null;
+    if (rawAdminRequestKey && !adminRequestKey) return res.status(400).json({ error: "INVALID_ADMIN_REQUEST_KEY", code: "INVALID_ADMIN_REQUEST_KEY" });
+    const adminRequestFingerprint = adminRequestKey ? adminIdempotency.requestFingerprint(body) : null;
+    const adminBookingToken = adminRequestKey ? adminIdempotency.bookingToken(adminRequestKey) : null;
     // Customer-sourced urgent requests carry a client-generated
     // urgent_request_key; deriving booking_token from it deterministically
     // (instead of a random genToken) lets the dedup check below find a
@@ -355,15 +376,38 @@ function createBookingJobService(dependencies = {}) {
     try {
       await client.query("BEGIN");
 
+      if (adminRequestKey) {
+        await client.query("SELECT pg_advisory_xact_lock(hashtext($1))", [adminRequestKey]);
+        const existingAdmin = await client.query(
+          `SELECT job_id, booking_code, admin_request_fingerprint FROM public.jobs WHERE admin_request_key=$1 LIMIT 1`,
+          [adminRequestKey]
+        );
+        if (existingAdmin.rows[0]) {
+          if (String(existingAdmin.rows[0].admin_request_fingerprint || "") !== adminRequestFingerprint) {
+            const conflict = new Error("ADMIN_IDEMPOTENCY_KEY_REUSED"); conflict.code = "ADMIN_IDEMPOTENCY_KEY_REUSED"; conflict.statusCode = 409; throw conflict;
+          }
+          await client.query("COMMIT");
+          return res.json({ success: true, replayed: true, job_id: existingAdmin.rows[0].job_id,
+            booking_code: existingAdmin.rows[0].booking_code, booking_mode: bm, dispatch_mode: mode });
+        }
+      }
+
       if (packageBooking) {
         const revalidated = await resolvePackageBooking({ body, bookingMode: bm, appointmentDatetime: apptIso,
-          resolver: createServicePackageResolver(client), identity: "admin" });
+          resolver: createServicePackageResolver(client), identity: Array.isArray(body.service_package_groups) ? "customer" : "admin" });
         if (JSON.stringify(revalidated) !== JSON.stringify(packageBooking)) {
           const error = new Error("PACKAGE_UNAVAILABLE");
           error.code = "PACKAGE_UNAVAILABLE"; error.statusCode = 409; throw error;
         }
         packageBooking = revalidated;
         payloadV2 = packageBooking.payload;
+      }
+
+      if (catalogBooking) {
+        catalogBooking = await resolveCatalogBookingPolicy(client, {
+          catalogItemId: catalogBooking.item_id, bookingMode: bm, jobType: job_type,
+          acType: ac_type, btu, washVariant: wash_variant,
+        }, { identity: "customer", lock: true });
       }
 
       // Durable, cross-instance idempotency for customer-sourced urgent
@@ -565,8 +609,9 @@ function createBookingJobService(dependencies = {}) {
          address_text, technician_team, technician_username, job_status,
          booking_token, job_source, dispatch_mode, customer_note,
          maps_url, job_zone, duration_min, booking_mode, admin_override_duration_min,
-         gps_latitude, gps_longitude, service_zone_code, service_zone_source, allow_time_proposal)
-        VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$22,$23,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21)
+         gps_latitude, gps_longitude, service_zone_code, service_zone_source, allow_time_proposal, catalog_item_id,
+         admin_request_key, admin_request_fingerprint)
+        VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$22,$23,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21,$24,$25,$26)
         RETURNING job_id
         `,
         [
@@ -591,8 +636,11 @@ function createBookingJobService(dependencies = {}) {
           detectedZoneCode,
           detectedZoneSource,
           allowTimeProposal,
-          publicBookingToken,
+          publicBookingToken || adminBookingToken,
           createdBySource,
+          packageBooking?.bundleId || catalogBooking?.item_id || null,
+          adminRequestKey,
+          adminRequestFingerprint,
         ]
       );
 
@@ -816,6 +864,9 @@ function createBookingJobService(dependencies = {}) {
       });
     } catch (e) {
       await client.query("ROLLBACK");
+      if (String(e?.code || "").startsWith("ADMIN_IDEMPOTENCY_")) {
+        return res.status(Number(e.statusCode || 409)).json({ error: String(e.code), code: String(e.code) });
+      }
       if (hasPackageRequest) {
         const code = String(e?.code || "PACKAGE_BOOKING_FAILED").startsWith("PACKAGE_") ? String(e.code) : "PACKAGE_BOOKING_FAILED";
         const status = Number(e?.statusCode || e?.status || 500);
@@ -840,6 +891,7 @@ function createBookingJobService(dependencies = {}) {
         `SELECT p.package_key, t.tier_key FROM public.service_packages p
          JOIN public.service_package_tiers t ON t.service_package_id=p.service_package_id
          WHERE p.is_active=TRUE AND t.is_active=TRUE
+           AND p.catalog_item_id IS NULL
            AND (p.sell_start_at IS NULL OR p.sell_start_at <= NOW())
            AND (p.sell_end_at IS NULL OR p.sell_end_at >= NOW())
          ORDER BY p.service_package_id, t.sort_order, t.service_package_tier_id`
@@ -1296,7 +1348,7 @@ function createBookingJobService(dependencies = {}) {
       hasPackageRequest = service_package_key != null || service_package_tier_key != null
         || req.body?.service_package_groups != null
         || req.body?.service_package_id != null || req.body?.service_package_tier_id != null;
-      if (canonicalBookingMode === "urgent" && hasPackageRequest) {
+      if (canonicalBookingMode === "urgent" && hasPackageRequest && !Array.isArray(req.body?.service_package_groups)) {
         return res.status(400).json({ error: "PACKAGE_URGENT_UNSUPPORTED", code: "PACKAGE_URGENT_UNSUPPORTED" });
       }
     } catch (_) {}
@@ -1339,7 +1391,6 @@ function createBookingJobService(dependencies = {}) {
     } catch (error) {
       return res.status(Number(error.statusCode || 400)).json({ error: error.code, code: error.code });
     }
-
     let customerSubForJob = null;
     try {
       const jwtSecretForBook = getJwtSecret();
@@ -1454,12 +1505,14 @@ function createBookingJobService(dependencies = {}) {
           });
         }
         const replayDuration = Number(prior.duration_min || historicalPackageBooking.durationMin || 0);
+        const replayTicket = await loadBookingTicket(pool, prior.job_id);
         return res.json({
           success: true, replayed: true, job_id: prior.job_id,
           booking_code: prior.booking_code, token: prior.booking_token,
           booking_mode: bm, dispatch_mode: prior.dispatch_mode || "normal",
           duration_min: replayDuration, effective_block_min: effectiveBlockMin(replayDuration),
           travel_buffer_min: TRAVEL_BUFFER_MIN, base_total: Number(prior.job_price || 0),
+          booking_ticket: replayTicket,
         });
       }
     }
@@ -1488,6 +1541,19 @@ function createBookingJobService(dependencies = {}) {
       }
     } catch (error) {
       return res.status(Number(error.statusCode || 400)).json({ error: error.code, code: error.code });
+    }
+    let catalogBooking = null;
+    if (!packageBooking && safeCatalogItemIdForJob) {
+      try {
+        catalogBooking = await resolveCatalogBookingPolicy(pool, {
+          catalogItemId: safeCatalogItemIdForJob, bookingMode: bm,
+          jobType: payloadV2.job_type, acType: payloadV2.ac_type,
+          btu: payloadV2.btu, washVariant: payloadV2.wash_variant,
+        }, { identity: "customer" });
+        safeCatalogItemIdForJob = catalogBooking.item_id;
+      } catch (error) {
+        return res.status(Number(error.statusCode || 409)).json({ error: error.code, code: error.code });
+      }
     }
     if (bm === "urgent") {
       if (!urgentPublicAdapter.isStrictUrgentCleaningPayload(payloadV2)) {
@@ -1605,6 +1671,7 @@ function createBookingJobService(dependencies = {}) {
             code: "IDEMPOTENCY_KEY_REUSED",
           });
         }
+        const replayTicket = await loadBookingTicket(pool, prior.job_id);
         return res.json({
           success: true,
           replayed: true,
@@ -1617,6 +1684,7 @@ function createBookingJobService(dependencies = {}) {
           effective_block_min: effectiveBlockMin(Number(prior.duration_min || duration_min_v2 || 0)),
           travel_buffer_min: TRAVEL_BUFFER_MIN,
           base_total: Number(prior.job_price || 0),
+          booking_ticket: replayTicket,
         });
       }
     }
@@ -1728,6 +1796,7 @@ function createBookingJobService(dependencies = {}) {
               code: "IDEMPOTENCY_KEY_REUSED",
             });
           }
+          const replayTicket = await loadBookingTicket(pool, row.job_id);
           return res.json({
             success: true,
             replayed: true,
@@ -1740,6 +1809,7 @@ function createBookingJobService(dependencies = {}) {
             effective_block_min: effectiveBlockMin(Number(row.duration_min || duration_min_v2 || 0)),
             travel_buffer_min: TRAVEL_BUFFER_MIN,
             base_total: Number(row.job_price || 0),
+            booking_ticket: replayTicket,
           });
         }
       }
@@ -1761,6 +1831,13 @@ function createBookingJobService(dependencies = {}) {
         }
         packageBooking = revalidatedPackageBooking;
         payloadV2 = packageBooking.payload;
+      }
+      if (catalogBooking) {
+        catalogBooking = await resolveCatalogBookingPolicy(client, {
+          catalogItemId: catalogBooking.item_id, bookingMode: bm,
+          jobType: payloadV2.job_type, acType: payloadV2.ac_type,
+          btu: payloadV2.btu, washVariant: payloadV2.wash_variant,
+        }, { identity: "customer", lock: true });
       }
 
       let draftReservationTech = null;
@@ -2059,6 +2136,11 @@ function createBookingJobService(dependencies = {}) {
             : "ขณะนี้ยังไม่มีช่างรับงาน คุณสามารถติดตามสถานะหรือติดต่อแอดมินได้",
         }
         : {};
+      const bookingTicket = buildBookingTicket({
+        job: { booking_code, customer_name: String(customer_name).trim(), customer_phone: String(customer_phone || "").trim(),
+          appointment_datetime, job_price: base_total, public_status: bm === "urgent" ? "กำลังค้นหาช่าง" : "รอแอดมินยืนยัน" },
+        items: computedItems,
+      });
       res.json({
         success: true,
         job_id,
@@ -2080,6 +2162,7 @@ function createBookingJobService(dependencies = {}) {
           discount: appliedDiscount,
         } : null,
         base_total: Number(base_total || 0),
+        booking_ticket: bookingTicket,
       });
     } catch (e) {
       await client.query("ROLLBACK");

--- a/server/services/booking/createBookingJob.js
+++ b/server/services/booking/createBookingJob.js
@@ -5,8 +5,9 @@ const { JOB_STATUS, ASSIGNMENT_STATUS, OFFER_STATUS } = require("./bookingStatus
 const { ensureBookingJobUnits } = require("./bookingJobUnits");
 const { packageRequest, resolvePackageBooking, packageBookingFromSnapshot, compositeBookingFromSnapshots } = require("./servicePackageBooking");
 const { resolveCatalogBookingPolicy, buildCatalogBookingItem, buildCatalogBookingPayload } = require("./catalogBookingPolicy");
-const { buildBookingTicket, loadBookingTicket } = require("./bookingTicket");
+const { buildBookingTicket, loadBookingTicket, exactMoney } = require("./bookingTicket");
 const adminIdempotency = require("./adminBookingIdempotency");
+const persistedBookingReplay = require("./persistedBookingReplay");
 const { validateAdminStorePromotionRequest } = require("./adminStorePromotionPolicy");
 
 function safePackagePreview(selection) {
@@ -204,6 +205,25 @@ function createBookingJobService(dependencies = {}) {
     const ttype = (tech_type || (bm === "urgent" ? "partner" : "company")).toString().trim().toLowerCase();
     const mode = isUrgentOffer ? "offer" : rawMode;
     const createdBySource = req.cwfBookSource === "customer" ? "customer" : "admin";
+    const rawAdminRequestKey = createdBySource === "admin" && admin_request_key != null ? String(admin_request_key).trim() : "";
+    const adminRequestKey = rawAdminRequestKey ? adminIdempotency.validateAdminRequestKey(rawAdminRequestKey) : null;
+    if (rawAdminRequestKey && !adminRequestKey) return res.status(400).json({ error: "INVALID_ADMIN_REQUEST_KEY", code: "INVALID_ADMIN_REQUEST_KEY" });
+    const adminRequestFingerprint = adminRequestKey ? adminIdempotency.requestFingerprint(body) : null;
+    const adminBookingToken = adminRequestKey ? adminIdempotency.bookingToken(adminRequestKey) : null;
+    // A committed replay is independent of today's catalog/package/promotion
+    // eligibility. Compare the durable material fingerprint before resolving it.
+    if (adminRequestKey) {
+      const existingAdmin = await persistedBookingReplay.findAdminReplay(pool, adminRequestKey);
+      if (existingAdmin) {
+        if (String(existingAdmin.admin_request_fingerprint || "") !== adminRequestFingerprint) {
+          return res.status(409).json({ error: "ADMIN_IDEMPOTENCY_KEY_REUSED", code: "ADMIN_IDEMPOTENCY_KEY_REUSED" });
+        }
+        return res.json({ success: true, replayed: true, job_id: existingAdmin.job_id,
+          booking_code: existingAdmin.booking_code,
+          booking_mode: existingAdmin.booking_mode || bm,
+          dispatch_mode: existingAdmin.dispatch_mode || mode });
+      }
+    }
     try {
       validateAdminStorePromotionRequest(body, { createdBySource });
     } catch (error) {
@@ -243,11 +263,6 @@ function createBookingJobService(dependencies = {}) {
       String(allowTimeProposalRaw || "").trim().toLowerCase() === "true" ||
       String(allowTimeProposalRaw || "").trim() === "1"
     );
-    const rawAdminRequestKey = createdBySource === "admin" && admin_request_key != null ? String(admin_request_key).trim() : "";
-    const adminRequestKey = rawAdminRequestKey ? adminIdempotency.validateAdminRequestKey(rawAdminRequestKey) : null;
-    if (rawAdminRequestKey && !adminRequestKey) return res.status(400).json({ error: "INVALID_ADMIN_REQUEST_KEY", code: "INVALID_ADMIN_REQUEST_KEY" });
-    const adminRequestFingerprint = adminRequestKey ? adminIdempotency.requestFingerprint(body) : null;
-    const adminBookingToken = adminRequestKey ? adminIdempotency.bookingToken(adminRequestKey) : null;
     // Customer-sourced urgent requests carry a client-generated
     // urgent_request_key; deriving booking_token from it deterministically
     // (instead of a random genToken) lets the dedup check below find a
@@ -1504,6 +1519,7 @@ function createBookingJobService(dependencies = {}) {
       : null;
     const bookingRequestKey = scheduledRequestKey || urgentRequestKey;
     const deterministicToken = scheduledDeterministicToken || urgentDeterministicToken;
+    const publicRequestFingerprint = bookingRequestKey ? adminIdempotency.requestFingerprint(req.body || {}) : null;
     if (deterministicToken) token = deterministicToken;
     const allowAdminScheduleFallback = allow_admin_schedule_fallback === true || String(allow_admin_schedule_fallback || "").trim() === "true";
     const canUseAdminScheduleFallback = bm === "scheduled" && allowAdminScheduleFallback;
@@ -1519,9 +1535,29 @@ function createBookingJobService(dependencies = {}) {
     const persistedGpsLatitude = bm === "urgent" && gps_latitude != null ? Number(gps_latitude) : null;
     const persistedGpsLongitude = bm === "urgent" && gps_longitude != null ? Number(gps_longitude) : null;
 
+    // New bookings persist a canonical request fingerprint. A replay can be
+    // returned before resolving mutable package/catalog/promotion state.
+    if (bookingRequestKey && deterministicToken && publicRequestFingerprint) {
+      const prior = await persistedBookingReplay.findPublicReplay(pool, {
+        requestKey: bookingRequestKey, bookingToken: deterministicToken, bookingMode: bm,
+      });
+      if (prior?.booking_request_fingerprint) {
+        if (String(prior.booking_request_fingerprint) !== publicRequestFingerprint) {
+          return res.status(409).json({ error: "This request key was already used for another booking. Start a new booking.", code: "IDEMPOTENCY_KEY_REUSED" });
+        }
+        const replayDuration = Number(prior.duration_min || 0);
+        return res.json({ success: true, replayed: true, job_id: prior.job_id,
+          booking_code: prior.booking_code, token: prior.booking_token,
+          booking_mode: prior.booking_mode || bm, dispatch_mode: prior.dispatch_mode || (bm === "urgent" ? "offer" : "normal"),
+          duration_min: replayDuration, effective_block_min: effectiveBlockMin(replayDuration),
+          travel_buffer_min: TRAVEL_BUFFER_MIN, base_total: Number(prior.job_price || 0),
+          booking_ticket: await loadBookingTicket(pool, prior.job_id) });
+      }
+    }
+
     // A committed package retry is resolved from immutable booking history before
     // consulting today's package sale/configuration state.
-    if (bm === "scheduled" && hasPackageRequest && deterministicToken) {
+    if (hasPackageRequest && deterministicToken) {
       const idem = await pool.connect();
       let prior = null;
       try {
@@ -1829,7 +1865,7 @@ function createBookingJobService(dependencies = {}) {
           `SELECT job_id, booking_code, booking_token, booking_mode, dispatch_mode,
                   duration_min, job_price, catalog_item_id, appointment_datetime, customer_phone, customer_name,
                   address_text, maps_url, job_zone, job_type, customer_note, allow_time_proposal,
-                  gps_latitude, gps_longitude
+                  gps_latitude, gps_longitude, booking_request_fingerprint
              FROM public.jobs
             WHERE booking_token=$1
               AND job_source='customer'
@@ -1844,6 +1880,18 @@ function createBookingJobService(dependencies = {}) {
           // (no mutation, no identifiers/PII). Same comparison as the pre-flight path.
           const row = existing.rows[0];
           await client.query("COMMIT");
+          if (row.booking_request_fingerprint) {
+            if (String(row.booking_request_fingerprint) !== publicRequestFingerprint) {
+              return res.status(409).json({ error: "This request key was already used for another booking. Start a new booking.", code: "IDEMPOTENCY_KEY_REUSED" });
+            }
+            const replayDuration = Number(row.duration_min || 0);
+            return res.json({ success: true, replayed: true, job_id: row.job_id,
+              booking_code: row.booking_code, token: row.booking_token, booking_mode: bm,
+              dispatch_mode: row.dispatch_mode || (bm === "urgent" ? "offer" : "normal"),
+              duration_min: replayDuration, effective_block_min: effectiveBlockMin(replayDuration),
+              travel_buffer_min: TRAVEL_BUFFER_MIN, base_total: Number(row.job_price || 0),
+              booking_ticket: await loadBookingTicket(pool, row.job_id) });
+          }
           const replayPackageBooking = hasPackageRequest
             ? await historicalPackageBookingForReplay(pool, row.job_id, packageRequestBody, appointment_datetime)
             : null;
@@ -1993,7 +2041,7 @@ function createBookingJobService(dependencies = {}) {
       const base_total = packageBooking ? packageBooking.fixedTotal : Number(total || 0);
       const promoPick = packageBooking || catalogBooking ? null : await findBestCustomerPromotion(payloadV2, base_total, client);
       const appliedPromo = promoPick?.promo || null;
-      const appliedDiscount = Math.min(Number(base_total || 0), Number(promoPick?.discount || 0));
+      const appliedDiscount = exactMoney(Math.min(Number(base_total || 0), Number(promoPick?.discount || 0)).toFixed(2));
 
       // ✅ dispatch_mode:
       // - scheduled (ลูกค้าจองปกติ) => normal (ให้เข้าแอดมิน/คิวตามปกติ)
@@ -2007,8 +2055,9 @@ function createBookingJobService(dependencies = {}) {
         "booking_token", "job_source", "dispatch_mode", "customer_note",
         "maps_url", "job_zone", "duration_min", "booking_mode", "allow_time_proposal",
         "gps_latitude", "gps_longitude", "service_zone_code", "service_zone_source",
+        "booking_request_fingerprint",
       ];
-      const jobInsertValuesSql = ["$1", "$2", "$3", "$4", "$5", "$6", "NULL", "$16", "$11", "$7", "'customer'", "$14", "$8", "$9", "$10", "$12", "$13", "$15", "$17", "$18", "$19", "$20"];
+      const jobInsertValuesSql = ["$1", "$2", "$3", "$4", "$5", "$6", "NULL", "$16", "$11", "$7", "'customer'", "$14", "$8", "$9", "$10", "$12", "$13", "$15", "$17", "$18", "$19", "$20", "$21"];
       const jobInsertParams = [
         String(customer_name).trim(),
         (customer_phone || "").toString().trim(),
@@ -2030,6 +2079,7 @@ function createBookingJobService(dependencies = {}) {
         persistedGpsLongitude,
         publicUrgentZone?.service_zone_code || null,
         publicUrgentZone?.service_zone_source || null,
+        publicRequestFingerprint,
       ];
       if (catalogLinkReady) {
         jobInsertColumns.push("catalog_item_id", "customer_sub");
@@ -2048,13 +2098,13 @@ function createBookingJobService(dependencies = {}) {
       );
 
       // attach promo to job (if any)
-      if(appliedPromo && appliedDiscount > 0){
+      if(appliedPromo && Number(appliedDiscount) > 0){
         try{
           await client.query(
             `INSERT INTO public.job_promotions (job_id, promo_id, applied_discount)
              VALUES ($1,$2,$3)
              ON CONFLICT (job_id) DO UPDATE SET promo_id=EXCLUDED.promo_id, applied_discount=EXCLUDED.applied_discount`,
-            [r.rows[0].job_id, Number(appliedPromo.promo_id), Number(appliedDiscount)]
+            [r.rows[0].job_id, Number(appliedPromo.promo_id), appliedDiscount]
           );
         }catch(e){
           // fail-open: don't break booking
@@ -2208,7 +2258,8 @@ function createBookingJobService(dependencies = {}) {
         : {};
       const bookingTicket = buildBookingTicket({
         job: { booking_code, customer_name: String(customer_name).trim(), customer_phone: String(customer_phone || "").trim(),
-          appointment_datetime, job_price: base_total, public_status: bm === "urgent" ? "กำลังค้นหาช่าง" : "รอแอดมินยืนยัน" },
+          appointment_datetime, job_price: base_total, applied_discount: appliedDiscount,
+          public_status: bm === "urgent" ? "กำลังค้นหาช่าง" : "รอแอดมินยืนยัน" },
         items: computedItems,
       });
       res.json({
@@ -2224,7 +2275,7 @@ function createBookingJobService(dependencies = {}) {
         duration_min: duration_min_v2,
         effective_block_min: effectiveBlockMin(duration_min_v2),
         travel_buffer_min: TRAVEL_BUFFER_MIN,
-        applied_promo: (appliedPromo && appliedDiscount > 0) ? {
+        applied_promo: (appliedPromo && Number(appliedDiscount) > 0) ? {
           promo_id: appliedPromo.promo_id,
           promo_name: appliedPromo.promo_name,
           promo_type: appliedPromo.promo_type,

--- a/server/services/booking/customerCatalogQuote.js
+++ b/server/services/booking/customerCatalogQuote.js
@@ -50,6 +50,7 @@ function createCustomerCatalogQuoteService({ pool, createServicePackageResolver,
     const payload = buildCatalogBookingPayload(booking);
     return {
       kind: "bookable",
+      catalog_item_id: booking.item_id,
       booking_flow_policy: booking.booking_flow_policy,
       fixed_total_price: booking.pricing.exact_total,
       unit_price: booking.pricing.unit_price,

--- a/server/services/booking/customerCatalogQuote.js
+++ b/server/services/booking/customerCatalogQuote.js
@@ -1,0 +1,80 @@
+"use strict";
+
+const { resolvePackageBooking } = require("./servicePackageBooking");
+const { resolveCatalogBookingPolicy, buildCatalogBookingPayload } = require("./catalogBookingPolicy");
+
+function safeCompositeQuote(booking) {
+  return {
+    kind: "service_package",
+    bundle_key: booking.bundleKey,
+    fixed_total_price: booking.fixedTotal,
+    duration_minutes: booking.durationMin,
+    machine_count: booking.payload.machine_count,
+    groups: booking.payload.service_package_groups,
+    services: booking.payload.services || [],
+    components: booking.items.map((item) => ({
+      package_key: item.snapshot.package.key,
+      tier_key: item.snapshot.tier.key,
+      tier_name: item.snapshot.tier.name,
+      quantity: item.snapshot.quantity,
+      fixed_total_price: item.snapshot.fixed_total_price,
+    })),
+  };
+}
+
+function createCustomerCatalogQuoteService({ pool, createServicePackageResolver, computeDurationMinMulti }) {
+  if (!pool || typeof pool.query !== "function") throw new TypeError("pool is required");
+
+  async function quote(input = {}) {
+    const bookingMode = String(input.booking_mode || "scheduled").trim().toLowerCase();
+    if (Array.isArray(input.service_package_groups)) {
+      const booking = await resolvePackageBooking({
+        body: { catalog_item_id: input.catalog_item_id, service_package_groups: input.service_package_groups },
+        bookingMode,
+        appointmentDatetime: input.appointment_datetime || new Date().toISOString(),
+        resolver: createServicePackageResolver(pool),
+        identity: "customer",
+      });
+      return safeCompositeQuote(booking);
+    }
+
+    const booking = await resolveCatalogBookingPolicy(pool, {
+      catalogItemId: input.catalog_item_id,
+      bookingMode,
+      jobType: input.job_type,
+      acType: input.ac_type,
+      btu: input.btu,
+      washVariant: input.wash_variant,
+      machineCount: input.machine_count,
+    }, { identity: "customer" });
+    const payload = buildCatalogBookingPayload(booking);
+    return {
+      kind: "bookable",
+      booking_flow_policy: booking.booking_flow_policy,
+      fixed_total_price: booking.pricing.exact_total,
+      unit_price: booking.pricing.unit_price,
+      normal_unit_price: booking.pricing.normal_unit_price,
+      duration_minutes: Number(computeDurationMinMulti(payload) || 0),
+      machine_count: booking.machine_count,
+      service: payload,
+      price_label: booking.pricing.price_label,
+      campaign_name: booking.pricing.campaign_name,
+    };
+  }
+
+  async function handle(req, res) {
+    try {
+      res.set("Cache-Control", "no-store");
+      return res.json(await quote(req.body || {}));
+    } catch (error) {
+      const status = Number(error?.statusCode || 503);
+      const safeStatus = status >= 400 && status < 500 ? status : 503;
+      const code = safeStatus === 503 ? "CATALOG_QUOTE_UNAVAILABLE" : String(error?.code || "CATALOG_QUOTE_REJECTED");
+      return res.status(safeStatus).json({ error: code, code });
+    }
+  }
+
+  return { quote, handle };
+}
+
+module.exports = { createCustomerCatalogQuoteService, safeCompositeQuote };

--- a/server/services/booking/exactPricing.js
+++ b/server/services/booking/exactPricing.js
@@ -6,25 +6,58 @@ function decimalMinor(value) {
   return (BigInt(match[1]) * 100n) + BigInt(String(match[2] || "").padEnd(2, "0"));
 }
 
-function minorNumber(value) { return Number(value) / 100; }
+function minorText(value) {
+  const minor = BigInt(value);
+  return `${minor / 100n}.${String(minor % 100n).padStart(2, "0")}`;
+}
+
+function decimalRatio(value) {
+  const match = /^(\d+)(?:\.(\d+))?$/.exec(String(value == null ? "" : value).trim());
+  if (!match) return null;
+  const fraction = String(match[2] || "");
+  return {
+    numerator: BigInt(`${match[1]}${fraction}`),
+    denominator: 10n ** BigInt(fraction.length),
+  };
+}
+
+function divideRounded(numerator, denominator) {
+  if (denominator <= 0n) return 0n;
+  return (numerator + (denominator / 2n)) / denominator;
+}
 
 function calcBookingPricing(items, promo) {
   const subtotalMinor = (Array.isArray(items) ? items : []).reduce((sum, item) => {
     const authoritative = decimalMinor(item.line_total);
     if (authoritative != null) return sum + authoritative;
     const quantity = Math.max(0, Number(item.qty || 0));
+    const unitMinor = decimalMinor(item.unit_price);
+    if (Number.isSafeInteger(quantity) && unitMinor != null) return sum + (BigInt(quantity) * unitMinor);
     const unitPrice = Math.max(0, Number(item.unit_price || 0));
     return sum + BigInt(Math.round(quantity * unitPrice * 100));
   }, 0n);
-  const subtotal = minorNumber(subtotalMinor);
-  let discount = 0;
+  let discountMinor = 0n;
   if (promo) {
-    const value = Number(promo.promo_value || 0);
-    if (promo.promo_type === "percent") discount = subtotal * (Math.max(0, value) / 100);
-    if (promo.promo_type === "amount") discount = Math.max(0, value);
+    if (promo.promo_type === "percent") {
+      const ratio = decimalRatio(promo.promo_value);
+      if (ratio) discountMinor = divideRounded(subtotalMinor * ratio.numerator, 100n * ratio.denominator);
+    }
+    if (promo.promo_type === "amount") discountMinor = decimalMinor(promo.promo_value) || 0n;
   }
-  const roundedDiscount = Number(discount.toFixed(2));
-  return { subtotal, discount: roundedDiscount, total: Number(Math.max(0, subtotal - roundedDiscount).toFixed(2)) };
+  const totalMinor = subtotalMinor > discountMinor ? subtotalMinor - discountMinor : 0n;
+  const subtotalExact = minorText(subtotalMinor);
+  const discountExact = minorText(discountMinor);
+  const totalExact = minorText(totalMinor);
+  return {
+    subtotal_exact: subtotalExact,
+    discount_exact: discountExact,
+    total_exact: totalExact,
+    // Legacy numeric fields remain for old callers only. Exact *_exact fields
+    // are the authoritative booking/HTTP/persistence contract.
+    subtotal: Number(subtotalExact),
+    discount: Number(discountExact),
+    total: Number(totalExact),
+  };
 }
 
-module.exports = { decimalMinor, calcBookingPricing };
+module.exports = { decimalMinor, minorText, calcBookingPricing };

--- a/server/services/booking/exactPricing.js
+++ b/server/services/booking/exactPricing.js
@@ -1,0 +1,30 @@
+"use strict";
+
+function decimalMinor(value) {
+  const match = /^(\d+)(?:\.(\d{1,2}))?$/.exec(String(value == null ? "" : value).trim());
+  if (!match) return null;
+  return (BigInt(match[1]) * 100n) + BigInt(String(match[2] || "").padEnd(2, "0"));
+}
+
+function minorNumber(value) { return Number(value) / 100; }
+
+function calcBookingPricing(items, promo) {
+  const subtotalMinor = (Array.isArray(items) ? items : []).reduce((sum, item) => {
+    const authoritative = decimalMinor(item.line_total);
+    if (authoritative != null) return sum + authoritative;
+    const quantity = Math.max(0, Number(item.qty || 0));
+    const unitPrice = Math.max(0, Number(item.unit_price || 0));
+    return sum + BigInt(Math.round(quantity * unitPrice * 100));
+  }, 0n);
+  const subtotal = minorNumber(subtotalMinor);
+  let discount = 0;
+  if (promo) {
+    const value = Number(promo.promo_value || 0);
+    if (promo.promo_type === "percent") discount = subtotal * (Math.max(0, value) / 100);
+    if (promo.promo_type === "amount") discount = Math.max(0, value);
+  }
+  const roundedDiscount = Number(discount.toFixed(2));
+  return { subtotal, discount: roundedDiscount, total: Number(Math.max(0, subtotal - roundedDiscount).toFixed(2)) };
+}
+
+module.exports = { decimalMinor, calcBookingPricing };

--- a/server/services/booking/persistedBookingReplay.js
+++ b/server/services/booking/persistedBookingReplay.js
@@ -1,0 +1,33 @@
+"use strict";
+
+async function findAdminReplay(db, requestKey) {
+  const result = await db.query(
+    `SELECT job_id, booking_code, booking_mode, dispatch_mode, admin_request_fingerprint
+       FROM public.jobs WHERE admin_request_key=$1 LIMIT 1`, [requestKey]
+  );
+  return result.rows[0] || null;
+}
+
+async function findPublicReplay(pool, { requestKey, bookingToken, bookingMode }) {
+  const client = await pool.connect();
+  try {
+    await client.query("BEGIN");
+    await client.query("SELECT pg_advisory_xact_lock(hashtext($1))", [requestKey]);
+    const result = await client.query(
+      `SELECT job_id, booking_code, booking_token, booking_mode, dispatch_mode, duration_min, job_price,
+              booking_request_fingerprint
+         FROM public.jobs
+        WHERE booking_token=$1 AND job_source='customer' AND booking_mode=$2 AND canceled_at IS NULL
+        LIMIT 1`, [bookingToken, bookingMode]
+    );
+    await client.query("COMMIT");
+    return result.rows[0] || null;
+  } catch (error) {
+    try { await client.query("ROLLBACK"); } catch (_) {}
+    throw error;
+  } finally {
+    client.release();
+  }
+}
+
+module.exports = { findAdminReplay, findPublicReplay };

--- a/server/services/booking/persistedBookingReplay.js
+++ b/server/services/booking/persistedBookingReplay.js
@@ -1,8 +1,11 @@
 "use strict";
 
+const { exactMoney } = require("./bookingTicket");
+
 async function findAdminReplay(db, requestKey) {
   const result = await db.query(
-    `SELECT job_id, booking_code, booking_mode, dispatch_mode, admin_request_fingerprint
+    `SELECT job_id, booking_code, booking_mode, dispatch_mode, duration_min, job_price,
+            admin_request_fingerprint
        FROM public.jobs WHERE admin_request_key=$1 LIMIT 1`, [requestKey]
   );
   return result.rows[0] || null;
@@ -30,4 +33,20 @@ async function findPublicReplay(pool, { requestKey, bookingToken, bookingMode })
   }
 }
 
-module.exports = { findAdminReplay, findPublicReplay };
+function adminReplayResponse(row, fallback = {}) {
+  const totalExact = exactMoney(row?.job_price);
+  return {
+    success: true,
+    replayed: true,
+    job_id: row?.job_id,
+    booking_code: row?.booking_code,
+    booking_mode: row?.booking_mode || fallback.bookingMode,
+    dispatch_mode: row?.dispatch_mode || fallback.dispatchMode,
+    duration_min: Number(row?.duration_min || fallback.durationMin || 0),
+    total_exact: totalExact,
+    // Legacy numeric field retained for cached Admin clients.
+    total: Number(totalExact),
+  };
+}
+
+module.exports = { findAdminReplay, findPublicReplay, adminReplayResponse };

--- a/server/services/booking/servicePackageBooking.js
+++ b/server/services/booking/servicePackageBooking.js
@@ -1,5 +1,7 @@
 "use strict";
 
+const { normalizeGroups, parseMoney, formatMoney, allocateUnitMoney } = require("../packages/compositeServicePackage");
+
 const PACKAGE_ERROR_STATUS = Object.freeze({
   PACKAGE_IDENTITY_REQUIRED: 400,
   TIER_IDENTITY_REQUIRED: 400,
@@ -21,6 +23,7 @@ function packageError(code, status = 400) {
 }
 
 function packageRequest(body = {}) {
+  if (Object.prototype.hasOwnProperty.call(body, "service_package_groups")) return { composite: true };
   const hasPackageKey = Object.prototype.hasOwnProperty.call(body, "service_package_key");
   const hasTierKey = Object.prototype.hasOwnProperty.call(body, "service_package_tier_key");
   const packageKey = String(body.service_package_key || "").trim();
@@ -89,6 +92,15 @@ function canonicalizeSelection(selection, body, appointmentDatetime) {
   const unitDuration = Number(line.unit_duration_minutes);
   const fixedTotal = String(selection.fixed_total_price);
   const unitPrice = allocateUnitPrice(fixedTotal, quantity);
+  const item = {
+    item_id: null,
+    item_name: serviceItemName(line, btu),
+    qty: quantity,
+    unit_price: unitPrice,
+    line_total: fixedTotal,
+    is_service: true,
+    customer_price_source: "service_package",
+  };
   return {
     packageId: String(selection.package.id),
     tierId: String(selection.tier.id),
@@ -104,15 +116,8 @@ function canonicalizeSelection(selection, body, appointmentDatetime) {
       repair_variant: "",
       admin_override_duration_min: 0,
     },
-    item: {
-      item_id: null,
-      item_name: serviceItemName(line, btu),
-      qty: quantity,
-      unit_price: unitPrice,
-      line_total: fixedTotal,
-      is_service: true,
-      customer_price_source: "service_package",
-    },
+    item,
+    items: [{ ...item, packageId: String(selection.package.id), tierId: String(selection.tier.id), snapshot: selection.snapshot }],
   };
 }
 
@@ -121,6 +126,10 @@ async function resolvePackageBooking({ body, bookingMode, appointmentDatetime, r
   if (!request) return null;
   if (bookingMode !== "scheduled") throw packageError("PACKAGE_URGENT_UNSUPPORTED", 400);
   try {
+    if (request.composite) {
+      if (!resolver || typeof resolver.resolveComposite !== "function") throw packageError("PACKAGE_UNAVAILABLE", 409);
+      return await resolver.resolveComposite({ body, bookingMode, appointmentDatetime, identity });
+    }
     const selection = await resolver.resolveSelection(request, { identity });
     return canonicalizeSelection(selection, body, appointmentDatetime);
   } catch (error) {
@@ -152,4 +161,56 @@ function packageBookingFromSnapshot({ body, appointmentDatetime, snapshot, packa
   }
 }
 
-module.exports = { packageRequest, canonicalizeSelection, resolvePackageBooking, packageBookingFromSnapshot };
+function compositeBookingFromSnapshots({ body, snapshots }) {
+  let groups;
+  try { groups = normalizeGroups(body); } catch (_) { return null; }
+  if (!groups || !Array.isArray(snapshots) || !snapshots.length) return null;
+  const items = [];
+  const storedGroups = new Map();
+  let total = 0n;
+  let durationMin = 0;
+  let bundleKey = null;
+  let bundleId = null;
+  for (const row of snapshots) {
+    let snapshot = row.service_package_snapshot;
+    if (typeof snapshot === "string") { try { snapshot = JSON.parse(snapshot); } catch (_) { return null; } }
+    if (!snapshot || snapshot.schema_version !== 2) return null;
+    if (String(snapshot.package?.id) !== String(row.service_package_id)
+        || String(snapshot.tier?.id) !== String(row.service_package_tier_id)) return null;
+    if (bundleKey && bundleKey !== snapshot.catalog_item?.key) return null;
+    bundleKey = snapshot.catalog_item?.key; bundleId = String(snapshot.catalog_item?.id || "");
+    const btu = Number(snapshot.taxonomy?.selected_btu); const quantity = Number(snapshot.quantity);
+    if (!bundleKey || !bundleId || !snapshot.package?.key || !Number.isInteger(btu) || !Number.isInteger(quantity) || quantity <= 0) return null;
+    let price;
+    try { price = parseMoney(snapshot.fixed_total_price); } catch (_) { return null; }
+    total += price;
+    durationMin += quantity * Number(snapshot.unit_duration_minutes || 0);
+    const groupKey = `${snapshot.package.key}:${btu}`;
+    storedGroups.set(groupKey, (storedGroups.get(groupKey) || 0) + quantity);
+    items.push({
+      item_id: bundleId, item_name: `${snapshot.package.name} • ${btu} BTU • ${quantity} เครื่อง`, qty: quantity,
+      unit_price: allocateUnitMoney(price, quantity), line_total: snapshot.fixed_total_price,
+      is_service: true, customer_price_source: "service_package",
+      packageId: String(row.service_package_id), tierId: String(row.service_package_tier_id), snapshot,
+    });
+  }
+  const requestedGroups = new Map();
+  groups.forEach((group) => {
+    const key = `${group.packageKey}:${group.btu}`;
+    requestedGroups.set(key, (requestedGroups.get(key) || 0) + group.quantity);
+  });
+  if (storedGroups.size !== requestedGroups.size
+      || [...storedGroups].some(([key, quantity]) => requestedGroups.get(key) !== quantity)) return null;
+  const first = items[0].snapshot;
+  return {
+    bundleId, bundleKey, fixedTotal: formatMoney(total), durationMin, items,
+    payload: {
+      job_type: first.taxonomy.job_type, ac_type: first.taxonomy.ac_type,
+      btu: groups[0].btu, machine_count: groups.reduce((sum, group) => sum + group.quantity, 0),
+      wash_variant: first.taxonomy.wash_variant || "", repair_variant: "", admin_override_duration_min: 0,
+      service_package_groups: groups.map((group) => ({ package_key: group.packageKey, btu: group.btu, quantity: group.quantity })),
+    },
+  };
+}
+
+module.exports = { packageRequest, canonicalizeSelection, resolvePackageBooking, packageBookingFromSnapshot, compositeBookingFromSnapshots };

--- a/server/services/booking/servicePackageBooking.js
+++ b/server/services/booking/servicePackageBooking.js
@@ -124,7 +124,7 @@ function canonicalizeSelection(selection, body, appointmentDatetime) {
 async function resolvePackageBooking({ body, bookingMode, appointmentDatetime, resolver, identity = "customer" }) {
   const request = packageRequest(body);
   if (!request) return null;
-  if (bookingMode !== "scheduled") throw packageError("PACKAGE_URGENT_UNSUPPORTED", 400);
+  if (!request.composite && bookingMode !== "scheduled") throw packageError("PACKAGE_URGENT_UNSUPPORTED", 400);
   try {
     if (request.composite) {
       if (!resolver || typeof resolver.resolveComposite !== "function") throw packageError("PACKAGE_UNAVAILABLE", 409);

--- a/server/services/booking/servicePackageBooking.js
+++ b/server/services/booking/servicePackageBooking.js
@@ -201,6 +201,7 @@ function compositeBookingFromSnapshots({ body, snapshots }) {
   });
   if (storedGroups.size !== requestedGroups.size
       || [...storedGroups].some(([key, quantity]) => requestedGroups.get(key) !== quantity)) return null;
+  if (body.catalog_item_id != null && String(body.catalog_item_id).trim() !== bundleId) return null;
   const first = items[0].snapshot;
   return {
     bundleId, bundleKey, fixedTotal: formatMoney(total), durationMin, items,

--- a/server/services/booking/urgentCompositePreflight.js
+++ b/server/services/booking/urgentCompositePreflight.js
@@ -1,0 +1,30 @@
+"use strict";
+
+const { resolvePackageBooking } = require("./servicePackageBooking");
+
+async function resolveUrgentCompositePreflight({ input, appointmentDatetime, resolver }) {
+  if (!Array.isArray(input?.service_package_groups)) return null;
+  const booking = await resolvePackageBooking({
+    body: {
+      catalog_item_id: input.catalog_item_id,
+      service_package_groups: input.service_package_groups,
+    },
+    bookingMode: "urgent",
+    appointmentDatetime,
+    resolver,
+    identity: "customer",
+  });
+  if (!booking || !Number.isSafeInteger(Number(booking.durationMin)) || Number(booking.durationMin) <= 0) {
+    const error = new Error("INVALID_SERVICE_DURATION");
+    error.code = "INVALID_SERVICE_DURATION";
+    error.statusCode = 400;
+    throw error;
+  }
+  return {
+    payload: booking.payload,
+    durationMin: Number(booking.durationMin),
+    machineCount: Number(booking.payload?.machine_count || 0),
+  };
+}
+
+module.exports = { resolveUrgentCompositePreflight };

--- a/server/services/catalogCampaignPolicy.js
+++ b/server/services/catalogCampaignPolicy.js
@@ -1,0 +1,54 @@
+"use strict";
+
+const PROMOTION_THEMES = new Set(["default", "premium", "limited_time", "new"]);
+const PROMOTION_EFFECTS = new Set(["none", "soft_glow", "shimmer_border", "badge_pulse"]);
+const BOOKING_FLOW_POLICIES = new Set(["scheduled_only", "scheduled_and_urgent"]);
+
+class CatalogCampaignPolicyError extends Error {
+  constructor(code, field) { super(code); this.name = "CatalogCampaignPolicyError"; this.code = code; this.field = field; }
+}
+
+function fail(code, field) { throw new CatalogCampaignPolicyError(code, field); }
+function boundedPlainText(value, field, max) {
+  if (value == null || String(value).trim() === "") return null;
+  const result = String(value).trim();
+  if (result.length > max || /[<>]/.test(result)) fail("INVALID_PROMOTION_TEXT", field);
+  return result;
+}
+function enumValue(value, field, allowed, fallback) {
+  const result = value == null || value === "" ? fallback : String(value).trim();
+  if (!allowed.has(result)) fail("INVALID_CATALOG_CAMPAIGN_POLICY", field);
+  return result;
+}
+function booleanValue(value, field, fallback) {
+  if (value == null || value === "") return fallback;
+  if (typeof value !== "boolean") fail("INVALID_CATALOG_CAMPAIGN_POLICY", field);
+  return value;
+}
+
+function validateCatalogCampaignPolicy(input = {}, { oldClient = false } = {}) {
+  return {
+    promotion_badge_text: boundedPlainText(input.promotion_badge_text, "promotion_badge_text", 80),
+    promotion_theme_preset: enumValue(input.promotion_theme_preset, "promotion_theme_preset", PROMOTION_THEMES, "default"),
+    promotion_effect_preset: enumValue(input.promotion_effect_preset, "promotion_effect_preset", PROMOTION_EFFECTS, "none"),
+    show_sale_countdown: booleanValue(input.show_sale_countdown, "show_sale_countdown", false),
+    promotion_supporting_text: boundedPlainText(input.promotion_supporting_text, "promotion_supporting_text", 200),
+    // Missing values from old clients always fail closed. On PATCH callers merge
+    // the existing row first, so an explicit persisted choice is retained.
+    booking_flow_policy: enumValue(input.booking_flow_policy, "booking_flow_policy", BOOKING_FLOW_POLICIES, "scheduled_only"),
+    old_client_defaulted: oldClient && input.booking_flow_policy == null,
+  };
+}
+
+function safeCatalogCampaignPolicy(row = {}) {
+  let value;
+  try { value = validateCatalogCampaignPolicy(row, { oldClient: true }); }
+  catch (_) { value = validateCatalogCampaignPolicy({}); }
+  delete value.old_client_defaulted;
+  return value;
+}
+
+module.exports = {
+  PROMOTION_THEMES, PROMOTION_EFFECTS, BOOKING_FLOW_POLICIES,
+  CatalogCampaignPolicyError, validateCatalogCampaignPolicy, safeCatalogCampaignPolicy,
+};

--- a/server/services/packages/compositeServicePackage.js
+++ b/server/services/packages/compositeServicePackage.js
@@ -30,8 +30,8 @@ function allocateUnitMoney(totalMinor, quantity) {
 
 function comparePlan(a, b) {
   if (!b) return -1;
-  if (a.total !== b.total) return a.total < b.total ? -1 : 1;
   if (a.components.length !== b.components.length) return a.components.length - b.components.length;
+  if (a.total !== b.total) return a.total < b.total ? -1 : 1;
   const aq = a.components.map((x) => x.quantity).sort((x, y) => y - x);
   const bq = b.components.map((x) => x.quantity).sort((x, y) => y - x);
   for (let i = 0; i < Math.max(aq.length, bq.length); i += 1) {
@@ -59,10 +59,6 @@ function composeTiers(tiers, requestedQuantity) {
   for (let target = 1; target <= quantity; target += 1) {
     for (const tier of usable) {
       if (tier.quantity > target || !best[target - tier.quantity]) continue;
-      // A one-unit tier is an add-on remainder, not an endlessly repeatable way
-      // to undercut the configured multi-unit tiers. Larger tiers remain freely
-      // composable (for example 3+3 for six units).
-      if (tier.quantity === 1 && best[target - tier.quantity].components.some((part) => part.quantity === 1)) continue;
       const candidate = {
         total: best[target - tier.quantity].total + tier.priceMinor,
         components: [...best[target - tier.quantity].components, { tier, quantity: tier.quantity }],
@@ -118,6 +114,7 @@ function buildComponentSnapshot({ bundle, variant, tier, btu, appointmentDatetim
     sell_start_at: bundle.service_package_sell_start_at ? new Date(bundle.service_package_sell_start_at).toISOString() : null,
     sell_end_at: bundle.service_package_sell_end_at ? new Date(bundle.service_package_sell_end_at).toISOString() : null,
     redeem_until: bundle.service_package_redeem_until ? new Date(bundle.service_package_redeem_until).toISOString() : null,
+    booking_flow_policy: bundle.booking_flow_policy === "scheduled_and_urgent" ? "scheduled_and_urgent" : "scheduled_only",
     appointment_datetime: new Date(appointmentDatetime).toISOString(),
   };
 }
@@ -129,7 +126,7 @@ function serviceName(variant, btu, quantity) {
 async function resolveCompositeBooking({ body, bookingMode, appointmentDatetime, repository, db, identity = "customer", now = () => new Date() }) {
   const groups = normalizeGroups(body);
   if (!groups) return null;
-  if (bookingMode !== "scheduled") fail("PACKAGE_URGENT_UNSUPPORTED", 400);
+  if (bookingMode !== "scheduled" && bookingMode !== "urgent") fail("UNKNOWN_BOOKING_MODE", 400);
   const variants = await repository.findLinkedPackagesByKeys(db, groups.map((group) => group.packageKey));
   const byKey = new Map(variants.map((variant) => [variant.package_key, variant]));
   if (byKey.size !== new Set(groups.map((group) => group.packageKey)).size) fail("SERVICE_PACKAGE_NOT_AVAILABLE", 404);
@@ -140,6 +137,7 @@ async function resolveCompositeBooking({ body, bookingMode, appointmentDatetime,
       || bundle.booking_mode !== "service_package" || !inWindow(now(), bundle.service_package_sell_start_at, bundle.service_package_sell_end_at)) {
     fail("SERVICE_PACKAGE_NOT_AVAILABLE", 404);
   }
+  if (bookingMode === "urgent" && bundle.booking_flow_policy !== "scheduled_and_urgent") fail("PACKAGE_FLOW_NOT_ALLOWED", 409);
   if (!inWindow(appointmentDatetime, null, bundle.service_package_redeem_until)) fail("PACKAGE_REDEEM_WINDOW_EXCEEDED");
 
   let total = 0n;

--- a/server/services/packages/compositeServicePackage.js
+++ b/server/services/packages/compositeServicePackage.js
@@ -1,0 +1,189 @@
+"use strict";
+
+class CompositePackageError extends Error {
+  constructor(code, statusCode = 409) {
+    super(code);
+    this.name = "CompositePackageError";
+    this.code = code;
+    this.statusCode = statusCode;
+  }
+}
+
+function fail(code, statusCode) { throw new CompositePackageError(code, statusCode); }
+
+function parseMoney(value) {
+  const match = /^(\d+)\.(\d{2})$/.exec(String(value == null ? "" : value));
+  if (!match) fail("INVALID_PACKAGE_PRICE");
+  return BigInt(match[1]) * 100n + BigInt(match[2]);
+}
+
+function formatMoney(minor) {
+  if (typeof minor !== "bigint" || minor < 0n) fail("INVALID_PACKAGE_PRICE");
+  return `${minor / 100n}.${String(minor % 100n).padStart(2, "0")}`;
+}
+
+function allocateUnitMoney(totalMinor, quantity) {
+  const divisor = BigInt(quantity);
+  const quotient = totalMinor / divisor;
+  return formatMoney(quotient + ((totalMinor % divisor) * 2n >= divisor ? 1n : 0n));
+}
+
+function comparePlan(a, b) {
+  if (!b) return -1;
+  if (a.total !== b.total) return a.total < b.total ? -1 : 1;
+  if (a.components.length !== b.components.length) return a.components.length - b.components.length;
+  const aq = a.components.map((x) => x.quantity).sort((x, y) => y - x);
+  const bq = b.components.map((x) => x.quantity).sort((x, y) => y - x);
+  for (let i = 0; i < Math.max(aq.length, bq.length); i += 1) {
+    if ((aq[i] || 0) !== (bq[i] || 0)) return (bq[i] || 0) - (aq[i] || 0);
+  }
+  return 0;
+}
+
+function composeTiers(tiers, requestedQuantity) {
+  const quantity = Number(requestedQuantity);
+  if (!Number.isSafeInteger(quantity) || quantity <= 0) fail("INVALID_PACKAGE_QUANTITY", 400);
+  const usable = (Array.isArray(tiers) ? tiers : []).filter((tier) => tier.is_active !== false).map((tier) => ({
+    ...tier,
+    quantity: Number(tier.service_quantity),
+    priceMinor: parseMoney(tier.fixed_total_price),
+  })).filter((tier) => Number.isSafeInteger(tier.quantity) && tier.quantity > 0);
+  if (!usable.length) fail("SERVICE_PACKAGE_TIERS_UNAVAILABLE");
+
+  const exact = usable.filter((tier) => tier.quantity === quantity)
+    .sort((a, b) => a.priceMinor === b.priceMinor ? Number(a.sort_order || 0) - Number(b.sort_order || 0) : (a.priceMinor < b.priceMinor ? -1 : 1))[0];
+  if (exact) return { fixed_total_price: formatMoney(exact.priceMinor), components: [{ tier: exact, quantity: exact.quantity }] };
+
+  const best = Array(quantity + 1).fill(null);
+  best[0] = { total: 0n, components: [] };
+  for (let target = 1; target <= quantity; target += 1) {
+    for (const tier of usable) {
+      if (tier.quantity > target || !best[target - tier.quantity]) continue;
+      // A one-unit tier is an add-on remainder, not an endlessly repeatable way
+      // to undercut the configured multi-unit tiers. Larger tiers remain freely
+      // composable (for example 3+3 for six units).
+      if (tier.quantity === 1 && best[target - tier.quantity].components.some((part) => part.quantity === 1)) continue;
+      const candidate = {
+        total: best[target - tier.quantity].total + tier.priceMinor,
+        components: [...best[target - tier.quantity].components, { tier, quantity: tier.quantity }],
+      };
+      if (comparePlan(candidate, best[target]) < 0) best[target] = candidate;
+    }
+  }
+  if (!best[quantity]) fail("SERVICE_PACKAGE_QUANTITY_NOT_COMPOSABLE", 400);
+  best[quantity].components.sort((a, b) => b.quantity - a.quantity || Number(a.tier.sort_order || 0) - Number(b.tier.sort_order || 0));
+  return { fixed_total_price: formatMoney(best[quantity].total), components: best[quantity].components };
+}
+
+function normalizeGroups(body = {}) {
+  if (body.service_package_id != null || body.service_package_tier_id != null || body.catalog_item_id != null) {
+    fail("PACKAGE_IDENTITY_MALFORMED", 400);
+  }
+  if (!Object.prototype.hasOwnProperty.call(body, "service_package_groups")) return null;
+  if (!Array.isArray(body.service_package_groups) || !body.service_package_groups.length) fail("INVALID_PACKAGE_SELECTION", 400);
+  return body.service_package_groups.map((group) => {
+    const packageKey = String(group?.package_key || "").trim();
+    const btu = Number(group?.btu);
+    const quantity = Number(group?.quantity);
+    if (!packageKey || packageKey.length > 128 || !Number.isSafeInteger(btu) || btu <= 0
+        || !Number.isSafeInteger(quantity) || quantity <= 0) fail("INVALID_PACKAGE_SELECTION", 400);
+    return { packageKey, btu, quantity };
+  });
+}
+
+function inWindow(value, start, end) {
+  const at = new Date(value);
+  return Number.isFinite(at.getTime()) && (!start || at >= new Date(start)) && (!end || at <= new Date(end));
+}
+
+function buildComponentSnapshot({ bundle, variant, tier, btu, appointmentDatetime }) {
+  return {
+    schema_version: 2,
+    catalog_item: { id: String(bundle.item_id), key: bundle.service_bundle_key, name: bundle.item_name },
+    package: { id: String(variant.service_package_id), key: variant.package_key, name: variant.display_name },
+    tier: { id: String(tier.service_package_tier_id), key: tier.tier_key, name: tier.display_name },
+    taxonomy: {
+      service_key: variant.service_key,
+      service_name: variant.service_name,
+      job_type: variant.job_type,
+      ac_type: variant.ac_type,
+      wash_variant: variant.wash_variant || null,
+      btu_min: variant.btu_min == null ? null : Number(variant.btu_min),
+      btu_max: variant.btu_max == null ? null : Number(variant.btu_max),
+      selected_btu: btu,
+    },
+    quantity: Number(tier.service_quantity),
+    unit_duration_minutes: Number(variant.service_unit_duration_minutes),
+    fixed_total_price: formatMoney(parseMoney(tier.fixed_total_price)),
+    sell_start_at: bundle.service_package_sell_start_at ? new Date(bundle.service_package_sell_start_at).toISOString() : null,
+    sell_end_at: bundle.service_package_sell_end_at ? new Date(bundle.service_package_sell_end_at).toISOString() : null,
+    redeem_until: bundle.service_package_redeem_until ? new Date(bundle.service_package_redeem_until).toISOString() : null,
+    appointment_datetime: new Date(appointmentDatetime).toISOString(),
+  };
+}
+
+function serviceName(variant, btu, quantity) {
+  return `${variant.display_name} • ${btu} BTU • ${quantity} เครื่อง`;
+}
+
+async function resolveCompositeBooking({ body, bookingMode, appointmentDatetime, repository, db, identity = "customer", now = () => new Date() }) {
+  const groups = normalizeGroups(body);
+  if (!groups) return null;
+  if (bookingMode !== "scheduled") fail("PACKAGE_URGENT_UNSUPPORTED", 400);
+  const variants = await repository.findLinkedPackagesByKeys(db, groups.map((group) => group.packageKey));
+  const byKey = new Map(variants.map((variant) => [variant.package_key, variant]));
+  if (byKey.size !== new Set(groups.map((group) => group.packageKey)).size) fail("SERVICE_PACKAGE_NOT_AVAILABLE", 404);
+  const bundleIds = new Set(variants.map((variant) => String(variant.catalog_item_id || "")));
+  if (bundleIds.size !== 1 || bundleIds.has("")) fail("PACKAGE_PARENT_MISMATCH", 400);
+  const bundle = variants[0];
+  if (!bundle.catalog_is_active || (identity === "customer" && !bundle.catalog_is_customer_visible)
+      || bundle.booking_mode !== "service_package" || !inWindow(now(), bundle.service_package_sell_start_at, bundle.service_package_sell_end_at)) {
+    fail("SERVICE_PACKAGE_NOT_AVAILABLE", 404);
+  }
+  if (!inWindow(appointmentDatetime, null, bundle.service_package_redeem_until)) fail("PACKAGE_REDEEM_WINDOW_EXCEEDED");
+
+  let total = 0n;
+  let durationMin = 0;
+  let machineCount = 0;
+  const items = [];
+  const payloadGroups = [];
+  const services = [];
+  for (const group of groups) {
+    const variant = byKey.get(group.packageKey);
+    if (!variant.is_active || (identity === "customer" && !variant.is_customer_visible)) fail("SERVICE_PACKAGE_NOT_AVAILABLE", 404);
+    if ((variant.btu_min != null && group.btu < Number(variant.btu_min))
+        || (variant.btu_max != null && group.btu > Number(variant.btu_max))) fail("PACKAGE_BTU_MISMATCH", 400);
+    const plan = composeTiers(variant.tiers, group.quantity);
+    total += parseMoney(plan.fixed_total_price);
+    durationMin += group.quantity * Number(variant.service_unit_duration_minutes);
+    machineCount += group.quantity;
+    payloadGroups.push({ package_key: group.packageKey, btu: group.btu, quantity: group.quantity });
+    services.push({ job_type: variant.job_type, ac_type: variant.ac_type, btu: group.btu,
+      machine_count: group.quantity, wash_variant: variant.wash_variant || "", repair_variant: "" });
+    for (const component of plan.components) {
+      const snapshot = buildComponentSnapshot({ bundle, variant, tier: component.tier, btu: group.btu, appointmentDatetime });
+      items.push({
+        item_id: String(bundle.item_id), item_name: serviceName(variant, group.btu, component.quantity),
+        qty: component.quantity, unit_price: allocateUnitMoney(parseMoney(component.tier.fixed_total_price), component.quantity),
+        line_total: snapshot.fixed_total_price, is_service: true, customer_price_source: "service_package",
+        packageId: String(variant.service_package_id), tierId: String(component.tier.service_package_tier_id), snapshot,
+      });
+    }
+  }
+  const first = variants[0];
+  return {
+    bundleId: String(bundle.item_id), bundleKey: bundle.service_bundle_key,
+    fixedTotal: formatMoney(total), durationMin, items,
+    payload: {
+      job_type: first.job_type, ac_type: first.ac_type, btu: groups[0].btu, machine_count: machineCount,
+      wash_variant: first.wash_variant || "", repair_variant: "", admin_override_duration_min: 0,
+      service_package_groups: payloadGroups,
+      services,
+    },
+  };
+}
+
+module.exports = {
+  CompositePackageError, parseMoney, formatMoney, allocateUnitMoney, composeTiers, normalizeGroups,
+  buildComponentSnapshot, resolveCompositeBooking,
+};

--- a/server/services/packages/compositeServicePackage.js
+++ b/server/services/packages/compositeServicePackage.js
@@ -9,6 +9,10 @@ class CompositePackageError extends Error {
   }
 }
 
+// Keep public quantity expansion within the booking domain's safe upper bound.
+// This check must run before allocating the dynamic-programming table.
+const MAX_COMPOSITE_PACKAGE_QUANTITY = 99;
+
 function fail(code, statusCode) { throw new CompositePackageError(code, statusCode); }
 
 function parseMoney(value) {
@@ -30,8 +34,8 @@ function allocateUnitMoney(totalMinor, quantity) {
 
 function comparePlan(a, b) {
   if (!b) return -1;
-  if (a.components.length !== b.components.length) return a.components.length - b.components.length;
   if (a.total !== b.total) return a.total < b.total ? -1 : 1;
+  if (a.components.length !== b.components.length) return a.components.length - b.components.length;
   const aq = a.components.map((x) => x.quantity).sort((x, y) => y - x);
   const bq = b.components.map((x) => x.quantity).sort((x, y) => y - x);
   for (let i = 0; i < Math.max(aq.length, bq.length); i += 1) {
@@ -42,7 +46,9 @@ function comparePlan(a, b) {
 
 function composeTiers(tiers, requestedQuantity) {
   const quantity = Number(requestedQuantity);
-  if (!Number.isSafeInteger(quantity) || quantity <= 0) fail("INVALID_PACKAGE_QUANTITY", 400);
+  if (!Number.isSafeInteger(quantity) || quantity <= 0 || quantity > MAX_COMPOSITE_PACKAGE_QUANTITY) {
+    fail("INVALID_PACKAGE_QUANTITY", 400);
+  }
   const usable = (Array.isArray(tiers) ? tiers : []).filter((tier) => tier.is_active !== false).map((tier) => ({
     ...tier,
     quantity: Number(tier.service_quantity),
@@ -72,19 +78,25 @@ function composeTiers(tiers, requestedQuantity) {
 }
 
 function normalizeGroups(body = {}) {
-  if (body.service_package_id != null || body.service_package_tier_id != null || body.catalog_item_id != null) {
+  if (body.service_package_id != null || body.service_package_tier_id != null) {
     fail("PACKAGE_IDENTITY_MALFORMED", 400);
   }
   if (!Object.prototype.hasOwnProperty.call(body, "service_package_groups")) return null;
   if (!Array.isArray(body.service_package_groups) || !body.service_package_groups.length) fail("INVALID_PACKAGE_SELECTION", 400);
-  return body.service_package_groups.map((group) => {
+  let totalQuantity = 0;
+  const groups = body.service_package_groups.map((group) => {
     const packageKey = String(group?.package_key || "").trim();
     const btu = Number(group?.btu);
     const quantity = Number(group?.quantity);
     if (!packageKey || packageKey.length > 128 || !Number.isSafeInteger(btu) || btu <= 0
-        || !Number.isSafeInteger(quantity) || quantity <= 0) fail("INVALID_PACKAGE_SELECTION", 400);
+        || !Number.isSafeInteger(quantity) || quantity <= 0 || quantity > MAX_COMPOSITE_PACKAGE_QUANTITY) {
+      fail("INVALID_PACKAGE_SELECTION", 400);
+    }
+    totalQuantity += quantity;
     return { packageKey, btu, quantity };
   });
+  if (totalQuantity > MAX_COMPOSITE_PACKAGE_QUANTITY) fail("INVALID_PACKAGE_SELECTION", 400);
+  return groups;
 }
 
 function inWindow(value, start, end) {
@@ -131,8 +143,11 @@ async function resolveCompositeBooking({ body, bookingMode, appointmentDatetime,
   const byKey = new Map(variants.map((variant) => [variant.package_key, variant]));
   if (byKey.size !== new Set(groups.map((group) => group.packageKey)).size) fail("SERVICE_PACKAGE_NOT_AVAILABLE", 404);
   const bundleIds = new Set(variants.map((variant) => String(variant.catalog_item_id || "")));
-  if (bundleIds.size !== 1 || bundleIds.has("")) fail("PACKAGE_PARENT_MISMATCH", 400);
+  if (bundleIds.size !== 1 || bundleIds.has("")) fail("PACKAGE_IDENTITY_MALFORMED", 400);
   const bundle = variants[0];
+  if (body.catalog_item_id != null && String(body.catalog_item_id).trim() !== String(bundle.catalog_item_id)) {
+    fail("PACKAGE_IDENTITY_MALFORMED", 400);
+  }
   if (!bundle.catalog_is_active || (identity === "customer" && !bundle.catalog_is_customer_visible)
       || bundle.booking_mode !== "service_package" || !inWindow(now(), bundle.service_package_sell_start_at, bundle.service_package_sell_end_at)) {
     fail("SERVICE_PACKAGE_NOT_AVAILABLE", 404);
@@ -183,5 +198,5 @@ async function resolveCompositeBooking({ body, bookingMode, appointmentDatetime,
 
 module.exports = {
   CompositePackageError, parseMoney, formatMoney, allocateUnitMoney, composeTiers, normalizeGroups,
-  buildComponentSnapshot, resolveCompositeBooking,
+  buildComponentSnapshot, resolveCompositeBooking, MAX_COMPOSITE_PACKAGE_QUANTITY,
 };

--- a/server/services/packages/servicePackageCatalogService.js
+++ b/server/services/packages/servicePackageCatalogService.js
@@ -126,7 +126,7 @@ function dto(row, at) {
     sell_start_at: row.sell_start_at, sell_end_at: row.sell_end_at, redeem_until: row.redeem_until,
     is_active: row.is_active, is_customer_visible: row.is_customer_visible, lifecycle_status: lifecycle(row, at),
     tiers: (row.tiers || []).map((tier) => ({ tier_key: tier.tier_key, display_name: tier.display_name,
-      service_quantity: Number(tier.service_quantity), fixed_total_price: Number(tier.fixed_total_price).toFixed(2),
+      service_quantity: Number(tier.service_quantity), fixed_total_price: String(tier.fixed_total_price),
       sort_order: Number(tier.sort_order), is_active: tier.is_active })) };
 }
 
@@ -143,6 +143,7 @@ function createServicePackageCatalogService({ pool, packageRepository = reposito
       if (packageKey) {
         packageRow = await packageRepository.findPackageByKeyForUpdate(client, packageKey);
         if (!packageRow) fail("PACKAGE_NOT_FOUND", "Service package was not found", 404);
+        if (packageRow.catalog_item_id != null) fail("LINKED_PACKAGE_REQUIRES_BUNDLE_ENDPOINT", "Linked variants must be edited through their Store parent", 409);
         existingTiers = await packageRepository.listTiersForUpdate(client, packageRow.service_package_id);
         packageRow = await packageRepository.updatePackage(client, packageRow.service_package_id, value);
       } else {

--- a/server/services/packages/servicePackageCatalogService.js
+++ b/server/services/packages/servicePackageCatalogService.js
@@ -3,9 +3,7 @@
 const crypto = require("node:crypto");
 const repository = require("./servicePackageRepository");
 const { normalizeServiceType, normalizeAcType, normalizeWashVariantLabel, normalizeWashKey } = require("../../normalizers");
-
-const JOB_TYPES = new Set(["wash", "repair", "install"].map(normalizeServiceType));
-const AC_TYPES = new Set(["wall", "cassette", "floor", "ceiling"].map(normalizeAcType));
+const { JOB_TYPE_VALUES, AC_TYPE_VALUES, WASH_VARIANT_VALUES } = require("./servicePackageTaxonomy");
 const PG_INTEGER_MIN = -2147483648;
 const PG_INTEGER_MAX = 2147483647;
 const MAX_FIXED_TOTAL_CENTS = 999999999999n;
@@ -71,9 +69,10 @@ function validate(input) {
   }
   const jobType = normalizeServiceType(text(input.job_type, "job_type", 80));
   const acType = normalizeAcType(text(input.ac_type, "ac_type", 80));
-  if (!JOB_TYPES.has(jobType) || !AC_TYPES.has(acType)) fail("INVALID_SERVICE_CONSTRAINTS", "Unsupported job_type or ac_type");
+  if (!JOB_TYPE_VALUES.has(jobType) || !AC_TYPE_VALUES.has(acType)) fail("INVALID_SERVICE_CONSTRAINTS", "Unsupported job_type or ac_type");
   let washVariant = optionalText(input.wash_variant, 100);
   if (washVariant) washVariant = normalizeWashVariantLabel(washVariant);
+  if (washVariant && !WASH_VARIANT_VALUES.has(washVariant)) fail("INVALID_SERVICE_CONSTRAINTS", "Unsupported wash_variant");
   if (jobType === normalizeServiceType("wash") && acType === normalizeAcType("wall") && !normalizeWashKey(washVariant)) {
     fail("INVALID_SERVICE_CONSTRAINTS", "Wall cleaning packages require a supported wash_variant");
   }

--- a/server/services/packages/servicePackageRepository.js
+++ b/server/services/packages/servicePackageRepository.js
@@ -5,6 +5,16 @@ function requireDb(db) {
   return db;
 }
 
+async function queryUnlinkedPackages(db, sql, params) {
+  try { return await requireDb(db).query(sql, params); }
+  catch (error) {
+    if (error?.code !== "42703") throw error;
+    return requireDb(db).query(sql
+      .replace(/\s+AND p\.catalog_item_id IS NULL/, "")
+      .replace(/\s+WHERE p\.catalog_item_id IS NULL/, ""), params);
+  }
+}
+
 async function findPackageById(db, packageId) {
   const result = await requireDb(db).query(
     "SELECT * FROM public.service_packages WHERE service_package_id=$1",
@@ -33,7 +43,7 @@ async function findTier(db, { packageId, tierId, tierKey }) {
 }
 
 async function listCustomerVisiblePackages(db, { at = new Date() } = {}) {
-  const result = await requireDb(db).query(
+  const result = await queryUnlinkedPackages(db,
     `SELECT p.*, COALESCE(jsonb_agg(
        to_jsonb(t) || jsonb_build_object('fixed_total_price', t.fixed_total_price::text)
        ORDER BY t.sort_order, t.service_package_tier_id
@@ -42,6 +52,7 @@ async function listCustomerVisiblePackages(db, { at = new Date() } = {}) {
      LEFT JOIN public.service_package_tiers t
        ON t.service_package_id=p.service_package_id AND t.is_active=TRUE
      WHERE p.is_active=TRUE AND p.is_customer_visible=TRUE
+       AND p.catalog_item_id IS NULL
        AND (p.sell_start_at IS NULL OR p.sell_start_at <= $1)
        AND (p.sell_end_at IS NULL OR p.sell_end_at >= $1)
      GROUP BY p.service_package_id
@@ -51,14 +62,65 @@ async function listCustomerVisiblePackages(db, { at = new Date() } = {}) {
   return result.rows;
 }
 
-async function listCatalogPackages(db) {
+async function findLinkedPackagesByKeys(db, packageKeys) {
+  if (!Array.isArray(packageKeys) || !packageKeys.length) return [];
   const result = await requireDb(db).query(
+    `SELECT p.*, ci.item_id, ci.item_name, ci.service_bundle_key, ci.booking_mode,
+            ci.is_active AS catalog_is_active,
+            ci.is_customer_visible AS catalog_is_customer_visible,
+            ci.service_package_sell_start_at, ci.service_package_sell_end_at,
+            ci.service_package_redeem_until,
+            COALESCE(jsonb_agg(
+              to_jsonb(t) || jsonb_build_object('fixed_total_price', t.fixed_total_price::text)
+              ORDER BY t.sort_order, t.service_package_tier_id
+            ) FILTER (WHERE t.service_package_tier_id IS NOT NULL), '[]'::jsonb) AS tiers
+       FROM public.service_packages p
+       JOIN public.catalog_items ci ON ci.item_id=p.catalog_item_id
+       LEFT JOIN public.service_package_tiers t ON t.service_package_id=p.service_package_id
+      WHERE p.package_key = ANY($1::text[])
+      GROUP BY p.service_package_id, ci.item_id`,
+    [packageKeys]
+  );
+  return result.rows;
+}
+
+async function listLinkedPackagesForCatalogItems(db, itemIds, { customer = false, at = new Date() } = {}) {
+  if (!Array.isArray(itemIds) || !itemIds.length) return [];
+  const params = [itemIds];
+  let customerSql = "";
+  if (customer) {
+    params.push(at);
+    customerSql = `AND p.is_active=TRUE AND p.is_customer_visible=TRUE
+      AND ci.is_active=TRUE AND ci.is_customer_visible=TRUE
+      AND (ci.service_package_sell_start_at IS NULL OR ci.service_package_sell_start_at <= $2)
+      AND (ci.service_package_sell_end_at IS NULL OR ci.service_package_sell_end_at >= $2)`;
+  }
+  const result = await requireDb(db).query(
+    `SELECT p.*, COALESCE(jsonb_agg(
+       to_jsonb(t) || jsonb_build_object('fixed_total_price', t.fixed_total_price::text)
+       ORDER BY t.sort_order, t.service_package_tier_id
+     ) FILTER (WHERE t.service_package_tier_id IS NOT NULL), '[]'::jsonb) AS tiers
+       FROM public.service_packages p
+       JOIN public.catalog_items ci ON ci.item_id=p.catalog_item_id
+       LEFT JOIN public.service_package_tiers t ON t.service_package_id=p.service_package_id
+        ${customer ? "AND t.is_active=TRUE" : ""}
+      WHERE p.catalog_item_id = ANY($1::bigint[]) ${customerSql}
+      GROUP BY p.service_package_id
+      ORDER BY p.catalog_item_id, p.sort_order, p.service_package_id`,
+    params
+  );
+  return result.rows;
+}
+
+async function listCatalogPackages(db) {
+  const result = await queryUnlinkedPackages(db,
     `SELECT p.*, COALESCE(jsonb_agg(
        to_jsonb(t) || jsonb_build_object('fixed_total_price', t.fixed_total_price::text)
        ORDER BY t.sort_order, t.service_package_tier_id
      ) FILTER (WHERE t.service_package_tier_id IS NOT NULL), '[]'::jsonb) AS tiers
      FROM public.service_packages p
      LEFT JOIN public.service_package_tiers t ON t.service_package_id=p.service_package_id
+     WHERE p.catalog_item_id IS NULL
      GROUP BY p.service_package_id
      ORDER BY p.created_at DESC, p.service_package_id DESC`
   );
@@ -87,12 +149,12 @@ async function insertPackage(db, value) {
     `INSERT INTO public.service_packages
        (package_key, display_name, description, service_key, service_name, job_type, ac_type,
         wash_variant, btu_min, btu_max, service_unit_duration_minutes, sell_start_at, sell_end_at,
-        redeem_until, is_active, is_customer_visible)
-     VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16) RETURNING *`,
+        redeem_until, is_active, is_customer_visible, catalog_item_id, sort_order)
+     VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18) RETURNING *`,
     [value.package_key, value.display_name, value.description, value.service_key, value.service_name,
       value.job_type, value.ac_type, value.wash_variant, value.btu_min, value.btu_max,
       value.service_unit_duration_minutes, value.sell_start_at, value.sell_end_at, value.redeem_until,
-      value.is_active, value.is_customer_visible]
+      value.is_active, value.is_customer_visible, value.catalog_item_id || null, Number(value.sort_order || 0)]
   );
   return result.rows[0];
 }
@@ -102,12 +164,13 @@ async function updatePackage(db, packageId, value) {
     `UPDATE public.service_packages SET display_name=$2, description=$3, service_key=$4,
        service_name=$5, job_type=$6, ac_type=$7, wash_variant=$8, btu_min=$9, btu_max=$10,
        service_unit_duration_minutes=$11, sell_start_at=$12, sell_end_at=$13, redeem_until=$14,
-       is_active=$15, is_customer_visible=$16, updated_at=NOW()
+       is_active=$15, is_customer_visible=$16, catalog_item_id=COALESCE($17,catalog_item_id),
+       sort_order=$18, updated_at=NOW()
      WHERE service_package_id=$1 RETURNING *`,
     [packageId, value.display_name, value.description, value.service_key, value.service_name,
       value.job_type, value.ac_type, value.wash_variant, value.btu_min, value.btu_max,
       value.service_unit_duration_minutes, value.sell_start_at, value.sell_end_at, value.redeem_until,
-      value.is_active, value.is_customer_visible]
+      value.is_active, value.is_customer_visible, value.catalog_item_id || null, Number(value.sort_order || 0)]
   );
   return result.rows[0];
 }
@@ -144,5 +207,5 @@ async function deactivateTiers(db, packageId, keepTierIds) {
 module.exports = {
   findPackageById, findPackageByKey, findTier, listCustomerVisiblePackages, listCatalogPackages,
   findPackageByKeyForUpdate, listTiersForUpdate, insertPackage, updatePackage, insertTier,
-  updateTier, deactivateTiers,
+  updateTier, deactivateTiers, findLinkedPackagesByKeys, listLinkedPackagesForCatalogItems,
 };

--- a/server/services/packages/servicePackageRepository.js
+++ b/server/services/packages/servicePackageRepository.js
@@ -69,7 +69,7 @@ async function findLinkedPackagesByKeys(db, packageKeys) {
             ci.is_active AS catalog_is_active,
             ci.is_customer_visible AS catalog_is_customer_visible,
             ci.service_package_sell_start_at, ci.service_package_sell_end_at,
-            ci.service_package_redeem_until,
+            ci.service_package_redeem_until, ci.booking_flow_policy,
             COALESCE(jsonb_agg(
               to_jsonb(t) || jsonb_build_object('fixed_total_price', t.fixed_total_price::text)
               ORDER BY t.sort_order, t.service_package_tier_id

--- a/server/services/packages/servicePackageResolver.js
+++ b/server/services/packages/servicePackageResolver.js
@@ -2,6 +2,7 @@
 
 const repository = require("./servicePackageRepository");
 const { normalizeServiceType, normalizeAcType, normalizeWashVariantLabel, normalizeWashKey } = require("../../normalizers");
+const { resolveCompositeBooking } = require("./compositeServicePackage");
 
 const SUPPORTED_JOB_TYPES = new Set(["wash", "repair", "install"].map(normalizeServiceType));
 const SUPPORTED_AC_TYPES = new Set(["wall", "cassette", "floor", "ceiling"].map(normalizeAcType));
@@ -123,6 +124,9 @@ function createServicePackageResolver({ db, packageRepository = repository, now 
     },
     readSnapshot,
     listCustomerVisible(options) { return packageRepository.listCustomerVisiblePackages(db, options); },
+    resolveComposite(input) {
+      return resolveCompositeBooking({ ...input, repository: packageRepository, db, now });
+    },
   };
 }
 

--- a/server/services/packages/servicePackageResolver.js
+++ b/server/services/packages/servicePackageResolver.js
@@ -3,9 +3,7 @@
 const repository = require("./servicePackageRepository");
 const { normalizeServiceType, normalizeAcType, normalizeWashVariantLabel, normalizeWashKey } = require("../../normalizers");
 const { resolveCompositeBooking } = require("./compositeServicePackage");
-
-const SUPPORTED_JOB_TYPES = new Set(["wash", "repair", "install"].map(normalizeServiceType));
-const SUPPORTED_AC_TYPES = new Set(["wall", "cassette", "floor", "ceiling"].map(normalizeAcType));
+const { JOB_TYPE_VALUES, AC_TYPE_VALUES, WASH_VARIANT_VALUES } = require("./servicePackageTaxonomy");
 
 class ServicePackageResolutionError extends Error {
   constructor(code, message) { super(message); this.name = "ServicePackageResolutionError"; this.code = code; }
@@ -37,7 +35,7 @@ function serviceConstraints(packageRow) {
   const washVariant = packageRow.wash_variant == null ? null : normalizeWashVariantLabel(packageRow.wash_variant);
   const btuMin = positiveIntegerOrNull(packageRow.btu_min, "btu_min");
   const btuMax = positiveIntegerOrNull(packageRow.btu_max, "btu_max");
-  if (!SUPPORTED_JOB_TYPES.has(jobType) || !SUPPORTED_AC_TYPES.has(acType)
+  if (!JOB_TYPE_VALUES.has(jobType) || !AC_TYPE_VALUES.has(acType) || (washVariant && !WASH_VARIANT_VALUES.has(washVariant))
       || (btuMin != null && btuMax != null && btuMax < btuMin)) {
     fail("INVALID_SERVICE_CONSTRAINTS", "Package service constraints are invalid");
   }

--- a/server/services/packages/servicePackageTaxonomy.js
+++ b/server/services/packages/servicePackageTaxonomy.js
@@ -1,0 +1,60 @@
+"use strict";
+
+const { normalizeServiceType, normalizeAcType, normalizeWashVariantLabel } = require("../../normalizers");
+
+// This is the existing booking taxonomy expressed once as a shared server
+// contract. Store package configuration consumes these values; individual
+// campaigns never define or hard-code their own service taxonomy.
+const JOB_TYPES = Object.freeze([
+  Object.freeze({ key: "wash", value: normalizeServiceType("wash"), label: "ล้าง" }),
+  Object.freeze({ key: "repair", value: normalizeServiceType("repair"), label: "ซ่อม" }),
+  Object.freeze({ key: "install", value: normalizeServiceType("install"), label: "ติดตั้ง" }),
+]);
+
+const AC_TYPES = Object.freeze([
+  Object.freeze({ key: "wall", value: normalizeAcType("wall"), label: "แอร์ผนัง" }),
+  Object.freeze({ key: "cassette", value: normalizeAcType("cassette"), label: "แอร์สี่ทิศทาง" }),
+  Object.freeze({ key: "floor", value: normalizeAcType("floor"), label: "แอร์แขวน" }),
+  Object.freeze({ key: "ceiling", value: normalizeAcType("ceiling"), label: "แอร์เปลือยใต้ฝ้า" }),
+]);
+
+const WASH_VARIANTS = Object.freeze([
+  Object.freeze({ key: "normal", value: normalizeWashVariantLabel("normal"), label: "ล้างปกติ" }),
+  Object.freeze({ key: "premium", value: normalizeWashVariantLabel("premium"), label: "ล้างพรีเมียม" }),
+  Object.freeze({ key: "coil", value: normalizeWashVariantLabel("coil"), label: "ล้างแบบแขวนคอยล์" }),
+  Object.freeze({ key: "overhaul", value: normalizeWashVariantLabel("overhaul"), label: "ตัดล้างใหญ่" }),
+]);
+
+const JOB_TYPE_VALUES = new Set(JOB_TYPES.map((entry) => entry.value));
+const AC_TYPE_VALUES = new Set(AC_TYPES.map((entry) => entry.value));
+const WASH_VARIANT_VALUES = new Set(WASH_VARIANTS.map((entry) => entry.value));
+
+function publicTaxonomy() {
+  return {
+    job_types: JOB_TYPES.map((entry) => ({ ...entry })),
+    ac_types: AC_TYPES.map((entry) => ({ ...entry })),
+    wash_variants: WASH_VARIANTS.map((entry) => ({ ...entry })),
+  };
+}
+
+function canonicalServiceIdentity(input = {}) {
+  const jobValue = normalizeServiceType(input.job_type);
+  const acValue = normalizeAcType(input.ac_type);
+  const washValue = input.wash_variant ? normalizeWashVariantLabel(input.wash_variant) : null;
+  const job = JOB_TYPES.find((entry) => entry.value === jobValue);
+  const ac = AC_TYPES.find((entry) => entry.value === acValue);
+  const wash = washValue ? WASH_VARIANTS.find((entry) => entry.value === washValue) : null;
+  if (!job || !ac || (washValue && !wash)) return null;
+  return {
+    job_type: job.value,
+    ac_type: ac.value,
+    wash_variant: wash?.value || null,
+    service_key: [job.key, ac.key, wash?.key].filter(Boolean).join("-"),
+    service_name: [job.label, ac.label, wash?.label].filter(Boolean).join(" • "),
+  };
+}
+
+module.exports = {
+  JOB_TYPES, AC_TYPES, WASH_VARIANTS, JOB_TYPE_VALUES, AC_TYPE_VALUES, WASH_VARIANT_VALUES,
+  publicTaxonomy, canonicalServiceIdentity,
+};

--- a/server/services/packages/servicePackageTaxonomy.js
+++ b/server/services/packages/servicePackageTaxonomy.js
@@ -1,29 +1,14 @@
 "use strict";
 
 const { normalizeServiceType, normalizeAcType, normalizeWashVariantLabel } = require("../../normalizers");
+const { supportedServiceTaxonomy } = require("../../customerPricing");
 
-// This is the existing booking taxonomy expressed once as a shared server
-// contract. Store package configuration consumes these values; individual
-// campaigns never define or hard-code their own service taxonomy.
-const JOB_TYPES = Object.freeze([
-  Object.freeze({ key: "wash", value: normalizeServiceType("wash"), label: "ล้าง" }),
-  Object.freeze({ key: "repair", value: normalizeServiceType("repair"), label: "ซ่อม" }),
-  Object.freeze({ key: "install", value: normalizeServiceType("install"), label: "ติดตั้ง" }),
-]);
-
-const AC_TYPES = Object.freeze([
-  Object.freeze({ key: "wall", value: normalizeAcType("wall"), label: "แอร์ผนัง" }),
-  Object.freeze({ key: "cassette", value: normalizeAcType("cassette"), label: "แอร์สี่ทิศทาง" }),
-  Object.freeze({ key: "floor", value: normalizeAcType("floor"), label: "แอร์แขวน" }),
-  Object.freeze({ key: "ceiling", value: normalizeAcType("ceiling"), label: "แอร์เปลือยใต้ฝ้า" }),
-]);
-
-const WASH_VARIANTS = Object.freeze([
-  Object.freeze({ key: "normal", value: normalizeWashVariantLabel("normal"), label: "ล้างปกติ" }),
-  Object.freeze({ key: "premium", value: normalizeWashVariantLabel("premium"), label: "ล้างพรีเมียม" }),
-  Object.freeze({ key: "coil", value: normalizeWashVariantLabel("coil"), label: "ล้างแบบแขวนคอยล์" }),
-  Object.freeze({ key: "overhaul", value: normalizeWashVariantLabel("overhaul"), label: "ตัดล้างใหญ่" }),
-]);
+// Store packages reuse the canonical customer price-book taxonomy. Campaigns
+// therefore contain configuration only and cannot introduce private variants.
+const canonical = supportedServiceTaxonomy();
+const JOB_TYPES = Object.freeze(canonical.job_types.map(Object.freeze));
+const AC_TYPES = Object.freeze(canonical.ac_types.map(Object.freeze));
+const WASH_VARIANTS = Object.freeze(canonical.wash_variants.map(Object.freeze));
 
 const JOB_TYPE_VALUES = new Set(JOB_TYPES.map((entry) => entry.value));
 const AC_TYPE_VALUES = new Set(AC_TYPES.map((entry) => entry.value));

--- a/server/services/packages/storeServicePackageCatalogService.js
+++ b/server/services/packages/storeServicePackageCatalogService.js
@@ -1,0 +1,214 @@
+"use strict";
+
+const crypto = require("node:crypto");
+const repository = require("./servicePackageRepository");
+const { validate: validatePackage } = require("./servicePackageCatalogService");
+
+class StoreServicePackageCatalogError extends Error {
+  constructor(code, message, status = 400) {
+    super(message);
+    this.name = "StoreServicePackageCatalogError";
+    this.code = code;
+    this.status = status;
+  }
+}
+
+function fail(code, message, status) { throw new StoreServicePackageCatalogError(code, message, status); }
+function requiredText(value, field, max = 300) {
+  const text = String(value == null ? "" : value).trim();
+  if (!text || text.length > max) fail("INVALID_BUNDLE", `${field} is required and must not exceed ${max} characters`);
+  return text;
+}
+function optionalText(value, max) {
+  if (value == null || String(value).trim() === "") return null;
+  const text = String(value).trim();
+  if (text.length > max) fail("INVALID_BUNDLE", `Text must not exceed ${max} characters`);
+  return text;
+}
+function boolean(value, field) {
+  if (typeof value !== "boolean") fail("INVALID_BUNDLE", `${field} must be boolean`);
+  return value;
+}
+function instant(value, field) {
+  if (value == null || value === "") return null;
+  if (typeof value !== "string" || !Number.isFinite(Date.parse(value))) fail("INVALID_BUNDLE", `${field} must be an ISO date-time`);
+  return new Date(value).toISOString();
+}
+function generatedKey(prefix) { return `${prefix}-${crypto.randomUUID().replace(/-/g, "").slice(0, 16)}`; }
+
+function validate(input) {
+  if (!input || typeof input !== "object" || Array.isArray(input)) fail("INVALID_BUNDLE", "Bundle payload is required");
+  if (Object.prototype.hasOwnProperty.call(input, "service_bundle_key")) fail("IMMUTABLE_KEY", "service_bundle_key is server-controlled");
+  const sellStart = instant(input.sell_start_at, "sell_start_at");
+  const sellEnd = instant(input.sell_end_at, "sell_end_at");
+  const redeemUntil = instant(input.redeem_until, "redeem_until");
+  if (sellStart && sellEnd && sellEnd < sellStart) fail("INVALID_SELL_WINDOW", "sell_end_at must not precede sell_start_at");
+  if (redeemUntil && sellEnd && redeemUntil < sellEnd) fail("INVALID_REDEEM_WINDOW", "redeem_until must not precede sell_end_at");
+  if (!Array.isArray(input.variants) || !input.variants.length) fail("INVALID_VARIANTS", "At least one variant is required");
+  const variants = input.variants.map((raw, index) => {
+    const packageKey = raw?.package_key == null ? null : requiredText(raw.package_key, "package_key", 128);
+    const packageInput = { ...raw };
+    delete packageInput.package_key;
+    delete packageInput.packageKey;
+    const value = validatePackage({
+      ...packageInput,
+      sell_start_at: null,
+      sell_end_at: null,
+      redeem_until: null,
+    });
+    return { ...value, package_key: packageKey, sort_order: Number.isInteger(Number(raw.sort_order)) ? Number(raw.sort_order) : index };
+  });
+  const keys = variants.map((variant) => variant.package_key).filter(Boolean);
+  if (keys.length !== new Set(keys).size) fail("INVALID_VARIANTS", "Duplicate package_key values are not allowed");
+  for (let i = 0; i < variants.length; i += 1) {
+    for (let j = i + 1; j < variants.length; j += 1) {
+      const a = variants[i]; const b = variants[j];
+      if (!a.is_active || !b.is_active || a.job_type !== b.job_type || a.ac_type !== b.ac_type || a.wash_variant !== b.wash_variant) continue;
+      const aMin = a.btu_min == null ? -Infinity : a.btu_min; const aMax = a.btu_max == null ? Infinity : a.btu_max;
+      const bMin = b.btu_min == null ? -Infinity : b.btu_min; const bMax = b.btu_max == null ? Infinity : b.btu_max;
+      if (Math.max(aMin, bMin) <= Math.min(aMax, bMax)) fail("OVERLAPPING_VARIANT_RANGE", "Active variants with the same taxonomy must not overlap BTU ranges");
+    }
+  }
+  return {
+    item_name: requiredText(input.item_name, "item_name"),
+    short_description: optionalText(input.short_description, 300),
+    long_description: optionalText(input.long_description, 5000),
+    highlights: Array.isArray(input.highlights) ? input.highlights.map((x) => String(x).trim()).filter(Boolean).slice(0, 20) : [],
+    service_conditions: optionalText(input.service_conditions, 3000),
+    is_active: boolean(input.is_active, "is_active"),
+    is_customer_visible: boolean(input.is_customer_visible, "is_customer_visible"),
+    is_featured: input.is_featured == null ? false : boolean(input.is_featured, "is_featured"),
+    is_autoplay_enabled: input.is_autoplay_enabled == null ? true : boolean(input.is_autoplay_enabled, "is_autoplay_enabled"),
+    sell_start_at: sellStart, sell_end_at: sellEnd, redeem_until: redeemUntil, variants,
+  };
+}
+
+function variantDto(row) {
+  return {
+    package_key: row.package_key, display_name: row.display_name, description: row.description,
+    service_key: row.service_key, service_name: row.service_name, job_type: row.job_type,
+    ac_type: row.ac_type, wash_variant: row.wash_variant, btu_min: row.btu_min, btu_max: row.btu_max,
+    service_unit_duration_minutes: Number(row.service_unit_duration_minutes), sort_order: Number(row.sort_order || 0),
+    is_active: Boolean(row.is_active), is_customer_visible: Boolean(row.is_customer_visible),
+    tiers: (row.tiers || []).map((tier) => ({
+      tier_key: tier.tier_key, display_name: tier.display_name, service_quantity: Number(tier.service_quantity),
+      fixed_total_price: String(tier.fixed_total_price), sort_order: Number(tier.sort_order), is_active: Boolean(tier.is_active),
+    })),
+  };
+}
+
+async function loadBundle(db, bundleKey, { lock = false } = {}) {
+  const result = await db.query(
+    `SELECT * FROM public.catalog_items WHERE service_bundle_key=$1${lock ? " FOR UPDATE" : ""}`,
+    [bundleKey]
+  );
+  return result.rows[0] || null;
+}
+
+async function listBundles(db) {
+  const result = await db.query("SELECT * FROM public.catalog_items WHERE booking_mode='service_package' ORDER BY item_id DESC");
+  const rows = result.rows;
+  const variants = await repository.listLinkedPackagesForCatalogItems(db, rows.map((row) => row.item_id));
+  const byItem = new Map();
+  variants.forEach((variant) => {
+    const key = String(variant.catalog_item_id);
+    if (!byItem.has(key)) byItem.set(key, []);
+    byItem.get(key).push(variantDto(variant));
+  });
+  return rows.map((row) => ({
+    service_bundle_key: row.service_bundle_key, item_id: String(row.item_id), item_name: row.item_name,
+    short_description: row.short_description, long_description: row.long_description,
+    highlights: Array.isArray(row.highlights) ? row.highlights : [], service_conditions: row.service_conditions,
+    booking_mode: row.booking_mode, sell_start_at: row.service_package_sell_start_at,
+    sell_end_at: row.service_package_sell_end_at, redeem_until: row.service_package_redeem_until,
+    is_active: Boolean(row.is_active), is_customer_visible: Boolean(row.is_customer_visible),
+    is_featured: Boolean(row.is_featured), is_autoplay_enabled: Boolean(row.is_autoplay_enabled),
+    variants: byItem.get(String(row.item_id)) || [],
+  }));
+}
+
+function createStoreServicePackageCatalogService({ pool, packageRepository = repository }) {
+  async function save(input, bundleKey = null) {
+    const value = validate(input);
+    const client = await pool.connect();
+    try {
+      await client.query("BEGIN");
+      let parent = bundleKey ? await loadBundle(client, bundleKey, { lock: true }) : null;
+      if (bundleKey && !parent) fail("BUNDLE_NOT_FOUND", "Store service-package bundle was not found", 404);
+      if (!parent) {
+        const inserted = await client.query(
+          `INSERT INTO public.catalog_items
+            (item_name,item_category,base_price,unit_label,job_category,ac_type,is_active,is_customer_visible,
+             short_description,long_description,highlights,service_conditions,booking_mode,is_featured,is_autoplay_enabled,
+             service_bundle_key,service_package_sell_start_at,service_package_sell_end_at,service_package_redeem_until)
+           VALUES ($1,'service',0,'package',$2,$3,$4,$5,$6,$7,$8,$9,'service_package',$10,$11,$12,$13,$14,$15)
+           RETURNING *`,
+          [value.item_name, value.variants[0].job_type, value.variants[0].ac_type, value.is_active, value.is_customer_visible,
+            value.short_description, value.long_description, JSON.stringify(value.highlights), value.service_conditions,
+            value.is_featured, value.is_autoplay_enabled, generatedKey("bundle"), value.sell_start_at, value.sell_end_at, value.redeem_until]
+        );
+        parent = inserted.rows[0];
+      } else {
+        const updated = await client.query(
+          `UPDATE public.catalog_items SET item_name=$2,job_category=$3,ac_type=$4,is_active=$5,is_customer_visible=$6,
+             short_description=$7,long_description=$8,highlights=$9,service_conditions=$10,is_featured=$11,
+             is_autoplay_enabled=$12,service_package_sell_start_at=$13,service_package_sell_end_at=$14,
+             service_package_redeem_until=$15,updated_at=NOW() WHERE item_id=$1 RETURNING *`,
+          [parent.item_id, value.item_name, value.variants[0].job_type, value.variants[0].ac_type, value.is_active,
+            value.is_customer_visible, value.short_description, value.long_description, JSON.stringify(value.highlights),
+            value.service_conditions, value.is_featured, value.is_autoplay_enabled, value.sell_start_at, value.sell_end_at, value.redeem_until]
+        );
+        parent = updated.rows[0];
+      }
+
+      const existingResult = await client.query("SELECT * FROM public.service_packages WHERE catalog_item_id=$1 FOR UPDATE", [parent.item_id]);
+      const existingByKey = new Map(existingResult.rows.map((row) => [row.package_key, row]));
+      const keptPackageIds = [];
+      for (const variant of value.variants) {
+        let packageRow;
+        let existingTiers = [];
+        if (variant.package_key) {
+          const existing = existingByKey.get(variant.package_key);
+          if (!existing) fail("INVALID_PACKAGE_KEY", "package_key does not belong to this bundle");
+          existingTiers = await packageRepository.listTiersForUpdate(client, existing.service_package_id);
+          packageRow = await packageRepository.updatePackage(client, existing.service_package_id, {
+            ...variant, catalog_item_id: parent.item_id, sort_order: variant.sort_order,
+          });
+        } else {
+          packageRow = await packageRepository.insertPackage(client, {
+            ...variant, package_key: generatedKey("pkg"), catalog_item_id: parent.item_id,
+            sort_order: variant.sort_order, sell_start_at: null, sell_end_at: null, redeem_until: null,
+          });
+        }
+        keptPackageIds.push(packageRow.service_package_id);
+        const existingTiersByKey = new Map(existingTiers.map((tier) => [tier.tier_key, tier]));
+        const keptTierIds = [];
+        for (const tier of variant.tiers) {
+          let saved;
+          if (tier.tier_key) {
+            const existing = existingTiersByKey.get(tier.tier_key);
+            if (!existing) fail("INVALID_TIER_KEY", "tier_key does not belong to this variant");
+            saved = await packageRepository.updateTier(client, existing.service_package_tier_id, tier);
+          } else {
+            saved = await packageRepository.insertTier(client, packageRow.service_package_id, { ...tier, tier_key: generatedKey("tier") });
+          }
+          keptTierIds.push(saved.service_package_tier_id);
+        }
+        if (variant.package_key) await packageRepository.deactivateTiers(client, packageRow.service_package_id, keptTierIds);
+      }
+      await client.query(
+        `UPDATE public.service_packages SET is_active=FALSE,is_customer_visible=FALSE,updated_at=NOW()
+          WHERE catalog_item_id=$1 AND NOT (service_package_id = ANY($2::bigint[]))`,
+        [parent.item_id, keptPackageIds]
+      );
+      await client.query("COMMIT");
+      return (await listBundles(client)).find((row) => row.service_bundle_key === parent.service_bundle_key);
+    } catch (error) {
+      await client.query("ROLLBACK").catch(() => {});
+      throw error;
+    } finally { client.release(); }
+  }
+  return { list: () => listBundles(pool), create: (input) => save(input), update: (key, input) => save(input, requiredText(key, "service_bundle_key", 128)) };
+}
+
+module.exports = { StoreServicePackageCatalogError, validate, createStoreServicePackageCatalogService };

--- a/server/services/packages/storeServicePackageCatalogService.js
+++ b/server/services/packages/storeServicePackageCatalogService.js
@@ -145,7 +145,7 @@ async function listBundles(db) {
 function createStoreServicePackageCatalogService({ pool, packageRepository = repository }) {
   async function quote(input = {}) {
     const booking = await resolveCompositeBooking({
-      body: { service_package_groups: input.service_package_groups },
+      body: { catalog_item_id: input.catalog_item_id, service_package_groups: input.service_package_groups },
       bookingMode: String(input.booking_mode || "scheduled"),
       appointmentDatetime: input.appointment_datetime,
       repository: packageRepository, db: pool, identity: "customer",

--- a/server/services/packages/storeServicePackageCatalogService.js
+++ b/server/services/packages/storeServicePackageCatalogService.js
@@ -3,6 +3,9 @@
 const crypto = require("node:crypto");
 const repository = require("./servicePackageRepository");
 const { validate: validatePackage } = require("./servicePackageCatalogService");
+const { publicTaxonomy, canonicalServiceIdentity } = require("./servicePackageTaxonomy");
+const { validateCatalogCampaignPolicy } = require("../catalogCampaignPolicy");
+const { resolveCompositeBooking } = require("./compositeServicePackage");
 
 class StoreServicePackageCatalogError extends Error {
   constructor(code, message, status = 400) {
@@ -42,16 +45,22 @@ function validate(input) {
   const sellStart = instant(input.sell_start_at, "sell_start_at");
   const sellEnd = instant(input.sell_end_at, "sell_end_at");
   const redeemUntil = instant(input.redeem_until, "redeem_until");
+  let campaign;
+  try { campaign = validateCatalogCampaignPolicy(input); }
+  catch (error) { fail(error.code || "INVALID_CATALOG_CAMPAIGN_POLICY", error.field || "Invalid campaign setting"); }
   if (sellStart && sellEnd && sellEnd < sellStart) fail("INVALID_SELL_WINDOW", "sell_end_at must not precede sell_start_at");
   if (redeemUntil && sellEnd && redeemUntil < sellEnd) fail("INVALID_REDEEM_WINDOW", "redeem_until must not precede sell_end_at");
   if (!Array.isArray(input.variants) || !input.variants.length) fail("INVALID_VARIANTS", "At least one variant is required");
   const variants = input.variants.map((raw, index) => {
     const packageKey = raw?.package_key == null ? null : requiredText(raw.package_key, "package_key", 128);
+    const identity = canonicalServiceIdentity(raw);
+    if (!identity) fail("INVALID_SERVICE_CONSTRAINTS", "Variant taxonomy must use a supported Admin option");
     const packageInput = { ...raw };
     delete packageInput.package_key;
     delete packageInput.packageKey;
     const value = validatePackage({
       ...packageInput,
+      ...identity,
       sell_start_at: null,
       sell_end_at: null,
       redeem_until: null,
@@ -79,7 +88,7 @@ function validate(input) {
     is_customer_visible: boolean(input.is_customer_visible, "is_customer_visible"),
     is_featured: input.is_featured == null ? false : boolean(input.is_featured, "is_featured"),
     is_autoplay_enabled: input.is_autoplay_enabled == null ? true : boolean(input.is_autoplay_enabled, "is_autoplay_enabled"),
-    sell_start_at: sellStart, sell_end_at: sellEnd, redeem_until: redeemUntil, variants,
+    sell_start_at: sellStart, sell_end_at: sellEnd, redeem_until: redeemUntil, ...campaign, variants,
   };
 }
 
@@ -123,11 +132,39 @@ async function listBundles(db) {
     sell_end_at: row.service_package_sell_end_at, redeem_until: row.service_package_redeem_until,
     is_active: Boolean(row.is_active), is_customer_visible: Boolean(row.is_customer_visible),
     is_featured: Boolean(row.is_featured), is_autoplay_enabled: Boolean(row.is_autoplay_enabled),
+    promotion_badge_text: row.promotion_badge_text || null,
+    promotion_theme_preset: row.promotion_theme_preset || "default",
+    promotion_effect_preset: row.promotion_effect_preset || "none",
+    show_sale_countdown: Boolean(row.show_sale_countdown),
+    promotion_supporting_text: row.promotion_supporting_text || null,
+    booking_flow_policy: row.booking_flow_policy || "scheduled_only",
     variants: byItem.get(String(row.item_id)) || [],
   }));
 }
 
 function createStoreServicePackageCatalogService({ pool, packageRepository = repository }) {
+  async function quote(input = {}) {
+    const booking = await resolveCompositeBooking({
+      body: { service_package_groups: input.service_package_groups },
+      bookingMode: String(input.booking_mode || "scheduled"),
+      appointmentDatetime: input.appointment_datetime,
+      repository: packageRepository, db: pool, identity: "customer",
+    });
+    return {
+      bundle_key: booking.bundleKey,
+      fixed_total_price: booking.fixedTotal,
+      duration_minutes: booking.durationMin,
+      machine_count: booking.payload.machine_count,
+      groups: booking.payload.service_package_groups,
+      components: booking.items.map((item) => ({
+        package_key: item.snapshot.package.key,
+        tier_key: item.snapshot.tier.key,
+        tier_name: item.snapshot.tier.name,
+        quantity: item.snapshot.quantity,
+        fixed_total_price: item.snapshot.fixed_total_price,
+      })),
+    };
+  }
   async function save(input, bundleKey = null) {
     const value = validate(input);
     const client = await pool.connect();
@@ -140,12 +177,15 @@ function createStoreServicePackageCatalogService({ pool, packageRepository = rep
           `INSERT INTO public.catalog_items
             (item_name,item_category,base_price,unit_label,job_category,ac_type,is_active,is_customer_visible,
              short_description,long_description,highlights,service_conditions,booking_mode,is_featured,is_autoplay_enabled,
-             service_bundle_key,service_package_sell_start_at,service_package_sell_end_at,service_package_redeem_until)
-           VALUES ($1,'service',0,'package',$2,$3,$4,$5,$6,$7,$8,$9,'service_package',$10,$11,$12,$13,$14,$15)
+             service_bundle_key,service_package_sell_start_at,service_package_sell_end_at,service_package_redeem_until,
+             promotion_badge_text,promotion_theme_preset,promotion_effect_preset,show_sale_countdown,promotion_supporting_text,booking_flow_policy)
+           VALUES ($1,'service',0,'package',$2,$3,$4,$5,$6,$7,$8,$9,'service_package',$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21)
            RETURNING *`,
           [value.item_name, value.variants[0].job_type, value.variants[0].ac_type, value.is_active, value.is_customer_visible,
             value.short_description, value.long_description, JSON.stringify(value.highlights), value.service_conditions,
-            value.is_featured, value.is_autoplay_enabled, generatedKey("bundle"), value.sell_start_at, value.sell_end_at, value.redeem_until]
+            value.is_featured, value.is_autoplay_enabled, generatedKey("bundle"), value.sell_start_at, value.sell_end_at, value.redeem_until,
+            value.promotion_badge_text, value.promotion_theme_preset, value.promotion_effect_preset, value.show_sale_countdown,
+            value.promotion_supporting_text, value.booking_flow_policy]
         );
         parent = inserted.rows[0];
       } else {
@@ -153,10 +193,14 @@ function createStoreServicePackageCatalogService({ pool, packageRepository = rep
           `UPDATE public.catalog_items SET item_name=$2,job_category=$3,ac_type=$4,is_active=$5,is_customer_visible=$6,
              short_description=$7,long_description=$8,highlights=$9,service_conditions=$10,is_featured=$11,
              is_autoplay_enabled=$12,service_package_sell_start_at=$13,service_package_sell_end_at=$14,
-             service_package_redeem_until=$15,updated_at=NOW() WHERE item_id=$1 RETURNING *`,
+             service_package_redeem_until=$15,promotion_badge_text=$16,promotion_theme_preset=$17,
+             promotion_effect_preset=$18,show_sale_countdown=$19,promotion_supporting_text=$20,booking_flow_policy=$21,
+             updated_at=NOW() WHERE item_id=$1 RETURNING *`,
           [parent.item_id, value.item_name, value.variants[0].job_type, value.variants[0].ac_type, value.is_active,
             value.is_customer_visible, value.short_description, value.long_description, JSON.stringify(value.highlights),
-            value.service_conditions, value.is_featured, value.is_autoplay_enabled, value.sell_start_at, value.sell_end_at, value.redeem_until]
+            value.service_conditions, value.is_featured, value.is_autoplay_enabled, value.sell_start_at, value.sell_end_at, value.redeem_until,
+            value.promotion_badge_text, value.promotion_theme_preset, value.promotion_effect_preset, value.show_sale_countdown,
+            value.promotion_supporting_text, value.booking_flow_policy]
         );
         parent = updated.rows[0];
       }
@@ -208,7 +252,13 @@ function createStoreServicePackageCatalogService({ pool, packageRepository = rep
       throw error;
     } finally { client.release(); }
   }
-  return { list: () => listBundles(pool), create: (input) => save(input), update: (key, input) => save(input, requiredText(key, "service_bundle_key", 128)) };
+  return {
+    list: () => listBundles(pool),
+    taxonomy: () => publicTaxonomy(),
+    quote,
+    create: (input) => save(input),
+    update: (key, input) => save(input, requiredText(key, "service_bundle_key", 128)),
+  };
 }
 
 module.exports = { StoreServicePackageCatalogError, validate, createStoreServicePackageCatalogService };

--- a/server/services/urgentPublicAdapter.js
+++ b/server/services/urgentPublicAdapter.js
@@ -66,6 +66,12 @@ function sanitizeCustomerUrgentBody(body) {
   const services = Array.isArray(src.services) && src.services.length
     ? src.services.slice(0, 10).map(sanitizeCustomerServiceLine)
     : null;
+  const servicePackageGroups = Array.isArray(src.service_package_groups) && src.service_package_groups.length
+    ? src.service_package_groups.slice(0, 50).map((group) => ({
+      package_key: String(group?.package_key || "").trim(),
+      btu: coerceNumber(group?.btu, 0),
+      quantity: coerceNumber(group?.quantity, 0),
+    })) : undefined;
   return {
     customer_name: String(src.customer_name || "").trim(),
     customer_phone: String(src.customer_phone || "").trim(),
@@ -86,6 +92,9 @@ function sanitizeCustomerUrgentBody(body) {
     services,
     client_app: "customer_app_v2",
     urgent_request_key: String(src.urgent_request_key || "").trim(),
+    ...(Number.isSafeInteger(Number(src.catalog_item_id)) && Number(src.catalog_item_id) > 0
+      ? { catalog_item_id: Number(src.catalog_item_id) } : {}),
+    ...(servicePackageGroups ? { service_package_groups: servicePackageGroups } : {}),
   };
 }
 

--- a/test/adminBookingIdempotency.test.js
+++ b/test/adminBookingIdempotency.test.js
@@ -1,0 +1,13 @@
+"use strict";
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const idem = require("../server/services/booking/adminBookingIdempotency");
+
+test("Admin request fingerprint is bounded, stable and changes with material package selection", () => {
+  const key = "admin_test_request_123456";
+  assert.equal(idem.validateAdminRequestKey(key), key);
+  assert.equal(idem.requestFingerprint({ b: 2, a: 1, admin_request_key: key }), idem.requestFingerprint({ a: 1, b: 2 }));
+  assert.notEqual(idem.requestFingerprint({ service_package_groups: [{ package_key: "a", quantity: 2 }] }),
+    idem.requestFingerprint({ service_package_groups: [{ package_key: "a", quantity: 3 }] }));
+  assert.match(idem.bookingToken(key), /^admin_[a-f0-9]{32}$/);
+});

--- a/test/adminServicePackageBooking.test.js
+++ b/test/adminServicePackageBooking.test.js
@@ -51,7 +51,7 @@ test("Admin package rejects missing BTU, ordinary lines, extras, promotion, and 
   const admin = source.slice(source.indexOf("async function handleAdminBookV2"), source.indexOf("async function handleAdminServicePackageList"));
   assert.match(admin, /PACKAGE_PROMOTION_UNSUPPORTED/);
   assert.match(admin, /service_package_snapshot/);
-  assert.match(admin, /resolvePackageBooking[\s\S]*createServicePackageResolver\(client\)[\s\S]*identity: "admin"/);
+  assert.match(admin, /resolvePackageBooking[\s\S]*createServicePackageResolver\(client\)[\s\S]*Array\.isArray\(body\.service_package_groups\) \? "customer" : "admin"/);
   assert.match(admin, /ROLLBACK/);
   assert.match(admin, /if \(hasPackageRequest\)[\s\S]*json\(\{ error: code, code \}\)/);
 });

--- a/test/adminStoreCatalogServicePackages.test.js
+++ b/test/adminStoreCatalogServicePackages.test.js
@@ -13,7 +13,7 @@ test("new flow offers immutable ordinary or Service Package type while ordinary 
   assert.match(js, /รายการบริการปกติ/);
   assert.match(js, /โปรโมชั่นแพ็กเกจ/);
   assert.match(js, /new_ordinary_item[\s\S]*openCatalogModalForNew/);
-  assert.match(js, /new_package_item[\s\S]*openPackageModal/);
+  assert.match(js, /new_package_item[\s\S]*openBundleModal/);
   assert.match(js, /savedItem = await apiFetch\("\/admin\/catalog\/items", \{ method: "POST", body: JSON\.stringify\(payload\) \}\)/);
 });
 
@@ -38,16 +38,14 @@ test("same Admin page renders full package history lifecycle statuses and uses c
   assert.match(html, /id="package_catalog_list"/);
   for (const status of ["แบบร่าง", "ปิดใช้งาน", "ซ่อนจากลูกค้า", "ยังไม่ถึงวันขาย", "กำลังเปิดขาย", "ปิดการขายแล้ว", "หมดเขตใช้สิทธิ์"]) assert.match(js, new RegExp(status));
   for (const statusKey of ["draft", "disabled", "hidden", "upcoming", "on-sale", "sale-ended", "redeem-ended"]) assert.match(js, new RegExp(`(?:^|[" ])${statusKey}(?:[":]|$)`));
-  assert.match(html, /admin-store-catalog\.js\?v=20260808_service_packages_th_v1/);
-  assert.match(html, /admin-store-catalog\.css\?v=20260808_service_packages_responsive_v2/);
+  assert.match(html, /admin-store-catalog\.js\?v=20260809_store_service_package_bundles_v1/);
+  assert.match(html, /admin-store-catalog\.css\?v=20260809_store_service_package_bundles_v1/);
 });
 
-test("package controls keep server enum values while showing Thai labels", () => {
-  for (const pair of [["wash", "ล้าง"], ["repair", "ซ่อม"], ["install", "ติดตั้ง"], ["wall", "ติดผนัง"], ["cassette", "สี่ทิศทาง"], ["floor", "ตั้งพื้น/แขวน"], ["ceiling", "ฝังในฝ้า"], ["normal", "ล้างธรรมดา"], ["premium", "ล้างพรีเมียม"], ["coil", "ล้างคอยล์"], ["overhaul", "ตัดล้าง"]]) {
-    assert.match(js, new RegExp(`value="${pair[0]}"[^>]*>${pair[1]}`));
-  }
-  const payload = js.match(/function packagePayload\(\)[\s\S]*?\r?\n}\r?\n/)[0];
-  for (const field of ["job_type", "ac_type", "wash_variant", "tier_key"]) assert.match(payload, new RegExp(field));
-  assert.match(js, /packageJobTypeLabel\(item\.job_type\)/);
-  assert.match(js, /packageAcTypeLabel\(item\.ac_type\)/);
+test("bundle controls keep taxonomy and stable keys in the atomic JSON contract", () => {
+  const save = js.match(/async function saveBundle\(\)[\s\S]*?\r?\n}\r?\n/)[0];
+  assert.match(save, /service-package-bundles/);
+  assert.match(js, /package_key\/tier_key/);
+  for (const field of ["job_type", "ac_type", "wash_variant", "tier_key", "fixed_total_price"]) assert.match(js, new RegExp(field));
+  assert.match(js, /loadCatalogItems\(\)/);
 });

--- a/test/adminStoreCatalogServicePackages.test.js
+++ b/test/adminStoreCatalogServicePackages.test.js
@@ -38,8 +38,8 @@ test("same Admin page renders full package history lifecycle statuses and uses c
   assert.match(html, /id="package_catalog_list"/);
   for (const status of ["แบบร่าง", "ปิดใช้งาน", "ซ่อนจากลูกค้า", "ยังไม่ถึงวันขาย", "กำลังเปิดขาย", "ปิดการขายแล้ว", "หมดเขตใช้สิทธิ์"]) assert.match(js, new RegExp(status));
   for (const statusKey of ["draft", "disabled", "hidden", "upcoming", "on-sale", "sale-ended", "redeem-ended"]) assert.match(js, new RegExp(`(?:^|[" ])${statusKey}(?:[":]|$)`));
-  assert.match(html, /admin-store-catalog\.js\?v=20260809_issue267_admin_builder_v2/);
-  assert.match(html, /admin-store-catalog\.css\?v=20260809_issue267_admin_builder_v2/);
+  assert.match(html, /admin-store-catalog\.js\?v=20260809_issue267_merchandising_v3/);
+  assert.match(html, /admin-store-catalog\.css\?v=20260809_issue267_merchandising_v3/);
 });
 
 test("bundle builder uses canonical taxonomy and preserves stable keys without product-specific JSON defaults", () => {

--- a/test/adminStoreCatalogServicePackages.test.js
+++ b/test/adminStoreCatalogServicePackages.test.js
@@ -38,14 +38,21 @@ test("same Admin page renders full package history lifecycle statuses and uses c
   assert.match(html, /id="package_catalog_list"/);
   for (const status of ["แบบร่าง", "ปิดใช้งาน", "ซ่อนจากลูกค้า", "ยังไม่ถึงวันขาย", "กำลังเปิดขาย", "ปิดการขายแล้ว", "หมดเขตใช้สิทธิ์"]) assert.match(js, new RegExp(status));
   for (const statusKey of ["draft", "disabled", "hidden", "upcoming", "on-sale", "sale-ended", "redeem-ended"]) assert.match(js, new RegExp(`(?:^|[" ])${statusKey}(?:[":]|$)`));
-  assert.match(html, /admin-store-catalog\.js\?v=20260809_store_service_package_bundles_v1/);
-  assert.match(html, /admin-store-catalog\.css\?v=20260809_store_service_package_bundles_v1/);
+  assert.match(html, /admin-store-catalog\.js\?v=20260809_issue267_admin_builder_v2/);
+  assert.match(html, /admin-store-catalog\.css\?v=20260809_issue267_admin_builder_v2/);
 });
 
-test("bundle controls keep taxonomy and stable keys in the atomic JSON contract", () => {
+test("bundle builder uses canonical taxonomy and preserves stable keys without product-specific JSON defaults", () => {
   const save = js.match(/async function saveBundle\(\)[\s\S]*?\r?\n}\r?\n/)[0];
   assert.match(save, /service-package-bundles/);
-  assert.match(js, /package_key\/tier_key/);
+  assert.match(js, /service-package-bundles\/taxonomy/);
+  assert.match(js, /data-bundle-action="variant-(?:up|down|archive)"/);
+  assert.match(js, /data-bundle-action="tier-(?:add|up|down|archive)"/);
+  assert.match(js, /variant\.package_key/);
+  assert.match(js, /tier\.tier_key/);
   for (const field of ["job_type", "ac_type", "wash_variant", "tier_key", "fixed_total_price"]) assert.match(js, new RegExp(field));
+  const fresh = js.match(/function newBundleVariant\(\)[\s\S]*?\r?\n}/)[0];
+  assert.doesNotMatch(fresh, /wall|premium|12000|18000|699|service_quantity:\s*1/);
+  assert.doesNotMatch(js, /id="bm_variants"/);
   assert.match(js, /loadCatalogItems\(\)/);
 });

--- a/test/adminStoreCatalogUi.test.js
+++ b/test/adminStoreCatalogUi.test.js
@@ -176,8 +176,8 @@ test("admin-store-catalog.css defines the page-local responsive modal contract",
 });
 
 test("admin-store-catalog.html cache versions stay coherent with unchanged JavaScript", () => {
-  assert.match(catalogHtmlSource, /admin-store-catalog\.css\?v=20260808_service_packages_responsive_v2/);
-  assert.match(catalogHtmlSource, /admin-store-catalog\.js\?v=20260808_service_packages_th_v1/);
+  assert.match(catalogHtmlSource, /admin-store-catalog\.css\?v=20260809_store_service_package_bundles_v1/);
+  assert.match(catalogHtmlSource, /admin-store-catalog\.js\?v=20260809_store_service_package_bundles_v1/);
 });
 
 test("openCatalogModalForEdit populates cm_effective_from and cm_effective_to from raw pricing fields with fallback", () => {
@@ -387,8 +387,8 @@ test("gallery delete and set-primary actions ask for confirmation only on delete
 });
 
 test("admin-store-catalog.html keeps CSS cache and bumps JS cache for pricing safety", () => {
-  assert.match(catalogHtmlSource, /admin-store-catalog\.css\?v=20260808_service_packages_responsive_v2/);
-  assert.match(catalogHtmlSource, /admin-store-catalog\.js\?v=20260808_service_packages_th_v1/);
+  assert.match(catalogHtmlSource, /admin-store-catalog\.css\?v=20260809_store_service_package_bundles_v1/);
+  assert.match(catalogHtmlSource, /admin-store-catalog\.js\?v=20260809_store_service_package_bundles_v1/);
 });
 
 test("the item_category field is a service/product dropdown, not free text", () => {

--- a/test/adminStoreCatalogUi.test.js
+++ b/test/adminStoreCatalogUi.test.js
@@ -176,8 +176,8 @@ test("admin-store-catalog.css defines the page-local responsive modal contract",
 });
 
 test("admin-store-catalog.html cache versions stay coherent with unchanged JavaScript", () => {
-  assert.match(catalogHtmlSource, /admin-store-catalog\.css\?v=20260809_issue267_admin_builder_v2/);
-  assert.match(catalogHtmlSource, /admin-store-catalog\.js\?v=20260809_issue267_admin_builder_v2/);
+  assert.match(catalogHtmlSource, /admin-store-catalog\.css\?v=20260809_issue267_merchandising_v3/);
+  assert.match(catalogHtmlSource, /admin-store-catalog\.js\?v=20260809_issue267_merchandising_v3/);
 });
 
 test("openCatalogModalForEdit populates cm_effective_from and cm_effective_to from raw pricing fields with fallback", () => {
@@ -387,8 +387,8 @@ test("gallery delete and set-primary actions ask for confirmation only on delete
 });
 
 test("admin-store-catalog.html keeps CSS cache and bumps JS cache for pricing safety", () => {
-  assert.match(catalogHtmlSource, /admin-store-catalog\.css\?v=20260809_issue267_admin_builder_v2/);
-  assert.match(catalogHtmlSource, /admin-store-catalog\.js\?v=20260809_issue267_admin_builder_v2/);
+  assert.match(catalogHtmlSource, /admin-store-catalog\.css\?v=20260809_issue267_merchandising_v3/);
+  assert.match(catalogHtmlSource, /admin-store-catalog\.js\?v=20260809_issue267_merchandising_v3/);
 });
 
 test("the item_category field is a service/product dropdown, not free text", () => {

--- a/test/adminStoreCatalogUi.test.js
+++ b/test/adminStoreCatalogUi.test.js
@@ -176,8 +176,8 @@ test("admin-store-catalog.css defines the page-local responsive modal contract",
 });
 
 test("admin-store-catalog.html cache versions stay coherent with unchanged JavaScript", () => {
-  assert.match(catalogHtmlSource, /admin-store-catalog\.css\?v=20260809_store_service_package_bundles_v1/);
-  assert.match(catalogHtmlSource, /admin-store-catalog\.js\?v=20260809_store_service_package_bundles_v1/);
+  assert.match(catalogHtmlSource, /admin-store-catalog\.css\?v=20260809_issue267_admin_builder_v2/);
+  assert.match(catalogHtmlSource, /admin-store-catalog\.js\?v=20260809_issue267_admin_builder_v2/);
 });
 
 test("openCatalogModalForEdit populates cm_effective_from and cm_effective_to from raw pricing fields with fallback", () => {
@@ -387,8 +387,8 @@ test("gallery delete and set-primary actions ask for confirmation only on delete
 });
 
 test("admin-store-catalog.html keeps CSS cache and bumps JS cache for pricing safety", () => {
-  assert.match(catalogHtmlSource, /admin-store-catalog\.css\?v=20260809_store_service_package_bundles_v1/);
-  assert.match(catalogHtmlSource, /admin-store-catalog\.js\?v=20260809_store_service_package_bundles_v1/);
+  assert.match(catalogHtmlSource, /admin-store-catalog\.css\?v=20260809_issue267_admin_builder_v2/);
+  assert.match(catalogHtmlSource, /admin-store-catalog\.js\?v=20260809_issue267_admin_builder_v2/);
 });
 
 test("the item_category field is a service/product dropdown, not free text", () => {

--- a/test/adminStorePromotionBookingUi.test.js
+++ b/test/adminStorePromotionBookingUi.test.js
@@ -37,4 +37,13 @@ test("Admin Add Job selects Store parents, quotes arbitrary mixed groups and ret
   assert.match(policy, /ci\.job_category AS booking_job_type/);
   assert.match(policy, /exact_total/);
   assert.match(guard, /STORE_PROMOTION_STACKING_UNSUPPORTED/);
+  assert.match(booking, /pricing\.total_exact/);
+  assert.match(booking, /total_exact: pricing\.total_exact/);
+  assert.match(js, /state\.exact_total = String\(quote\.exact_total/);
+  assert.match(js, /state\.exact_total \|\| fmtMoney/);
+});
+
+test("Admin Add Job runtime uses the deploy-safe Issue 267 v8 asset URL", () => {
+  assert.match(html, /admin-add-v2\.js\?v=20260809_issue267_catalog_flow_v8/);
+  assert.doesNotMatch(html, /admin-add-v2\.js\?v=20260809_issue267_catalog_flow_v2/);
 });

--- a/test/adminStorePromotionBookingUi.test.js
+++ b/test/adminStorePromotionBookingUi.test.js
@@ -17,6 +17,8 @@ test("Admin Add Job selects Store parents, quotes arbitrary mixed groups and ret
   assert.match(js, /\/admin\/catalog\/service-package-bundles\/quote/);
   assert.match(js, /service_package_groups = selectedBundleGroups/);
   assert.match(js, /catalog_item_id: state\.selected_store_catalog_item_id/);
+  assert.match(js, /el\("job_type"\)\.value = item\.job_category \|\| ""/);
+  assert.doesNotMatch(js, /el\("job_type"\)\.value = item\.booking_job_type/);
   assert.match(js, /admin_request_key/);
   assert.doesNotMatch(js, /data-admin-bundle-quantity[^\n]+max=/);
   assert.match(booking, /AND p\.catalog_item_id IS NULL/);

--- a/test/adminStorePromotionBookingUi.test.js
+++ b/test/adminStorePromotionBookingUi.test.js
@@ -6,6 +6,9 @@ const fs = require("node:fs");
 const html = fs.readFileSync("admin-add-v2.html", "utf8");
 const js = fs.readFileSync("admin-add-v2.js", "utf8");
 const booking = fs.readFileSync("server/services/booking/createBookingJob.js", "utf8");
+const policy = fs.readFileSync("server/services/booking/catalogBookingPolicy.js", "utf8");
+const guard = fs.readFileSync("server/services/booking/adminStorePromotionPolicy.js", "utf8");
+const routes = fs.readFileSync("server/routes/admin/adminBookings.js", "utf8");
 
 test("Admin Add Job selects Store parents, quotes arbitrary mixed groups and retains ordinary catalog identity", () => {
   assert.match(html, /store_bookable_item_id/);
@@ -18,4 +21,18 @@ test("Admin Add Job selects Store parents, quotes arbitrary mixed groups and ret
   assert.doesNotMatch(js, /data-admin-bundle-quantity[^\n]+max=/);
   assert.match(booking, /AND p\.catalog_item_id IS NULL/);
   assert.match(booking, /ADMIN_IDEMPOTENCY_KEY_REUSED/);
+  assert.match(routes, /\/admin\/catalog-booking-preview/);
+  assert.match(js, /\/admin\/catalog-booking-preview/);
+  assert.match(js, /applySelectedStoreFlowPolicy/);
+  assert.match(js, /urgent\.disabled = !!blocked/);
+  assert.match(js, /state\.service_lines = \[\]/);
+  assert.match(js, /state\.selected_items = \[\]/);
+  assert.match(js, /if \(state\.selected_store_catalog_item_id\)[\s\S]*?delete payload\.services/);
+  assert.match(booking, /validateAdminStorePromotionRequest/);
+  assert.match(booking, /buildCatalogBookingItem/);
+  assert.match(booking, /buildCatalogBookingPayload/);
+  assert.match(booking, /CATALOG_STACKING_UNSUPPORTED/);
+  assert.match(policy, /ci\.job_category AS booking_job_type/);
+  assert.match(policy, /exact_total/);
+  assert.match(guard, /STORE_PROMOTION_STACKING_UNSUPPORTED/);
 });

--- a/test/adminStorePromotionBookingUi.test.js
+++ b/test/adminStorePromotionBookingUi.test.js
@@ -1,0 +1,21 @@
+"use strict";
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+
+const html = fs.readFileSync("admin-add-v2.html", "utf8");
+const js = fs.readFileSync("admin-add-v2.js", "utf8");
+const booking = fs.readFileSync("server/services/booking/createBookingJob.js", "utf8");
+
+test("Admin Add Job selects Store parents, quotes arbitrary mixed groups and retains ordinary catalog identity", () => {
+  assert.match(html, /store_bookable_item_id/);
+  assert.match(html, /store_service_bundle_key/);
+  assert.match(js, /data-admin-bundle-quantity/);
+  assert.match(js, /\/admin\/catalog\/service-package-bundles\/quote/);
+  assert.match(js, /service_package_groups = selectedBundleGroups/);
+  assert.match(js, /catalog_item_id: state\.selected_store_catalog_item_id/);
+  assert.match(js, /admin_request_key/);
+  assert.doesNotMatch(js, /data-admin-bundle-quantity[^\n]+max=/);
+  assert.match(booking, /AND p\.catalog_item_id IS NULL/);
+  assert.match(booking, /ADMIN_IDEMPOTENCY_KEY_REUSED/);
+});

--- a/test/adminStorePromotionPolicy.test.js
+++ b/test/adminStorePromotionPolicy.test.js
@@ -1,0 +1,34 @@
+"use strict";
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const { validateAdminStorePromotionRequest } = require("../server/services/booking/adminStorePromotionPolicy");
+
+const key = "admin_store_request_123456";
+
+test("manual and legacy Admin booking contracts remain unchanged", () => {
+  assert.deepEqual(validateAdminStorePromotionRequest({ services: [{ job_type: "wash" }] }), { kind: null });
+  assert.deepEqual(validateAdminStorePromotionRequest({ catalog_item_id: 41 }, { createdBySource: "customer" }), { kind: null });
+});
+
+test("ordinary Store promotion requires idempotency and rejects unsupported stacking", () => {
+  assert.throws(() => validateAdminStorePromotionRequest({ catalog_item_id: 41 }), /MISSING_ADMIN_REQUEST_KEY/);
+  assert.deepEqual(validateAdminStorePromotionRequest({ catalog_item_id: 41, admin_request_key: key }), { kind: "bookable" });
+  for (const conflict of [
+    { promotion_id: 7 }, { override_price: "1.00" }, { override_duration_min: 10 },
+    { items: [{ item_id: 2, qty: 1 }] }, { services: [{}] }, { service_lines: [{}] },
+  ]) {
+    assert.throws(() => validateAdminStorePromotionRequest({ catalog_item_id: 41, admin_request_key: key, ...conflict }), /STORE_PROMOTION_STACKING_UNSUPPORTED/);
+  }
+});
+
+test("composed Store package accepts only its authoritative groups", () => {
+  assert.deepEqual(validateAdminStorePromotionRequest({ service_package_groups: [{ package_key: "group", quantity: 2 }],
+    admin_request_key: key }), { kind: "service_package" });
+  for (const conflict of [
+    { catalog_item_id: 41 }, { service_package_key: "legacy" }, { service_package_tier_key: "tier" },
+    { services: [{}] }, { service_lines: [{}] }, { promotion_id: 7 }, { override_price: 1 }, { items: [{}] },
+  ]) {
+    assert.throws(() => validateAdminStorePromotionRequest({ service_package_groups: [], admin_request_key: key, ...conflict }), /STORE_PROMOTION_STACKING_UNSUPPORTED/);
+  }
+});

--- a/test/bookingTicket.test.js
+++ b/test/bookingTicket.test.js
@@ -1,0 +1,18 @@
+"use strict";
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const { buildBookingTicket, formatBookingTicket } = require("../server/services/booking/bookingTicket");
+
+test("booking ticket exposes only safe server-confirmed public fields", () => {
+  const ticket = buildBookingTicket({ job: { job_id: 91, booking_code: "CWF-TEST-91", booking_token: "secret-token",
+    customer_name: "TEST Customer", customer_phone: "0000000000", appointment_datetime: "2026-08-10T09:00:00+07:00",
+    job_price: "5198.00", address_text: "secret address" }, items: [
+      { item_name: "TEST Cassette Care", qty: 7, service_package_id: 22, service_package_snapshot: { secret: true } },
+    ] });
+  assert.equal(ticket.exact_total, "5198.00");
+  assert.equal(ticket.total_machine_count, 7);
+  const serialized = JSON.stringify(ticket);
+  assert.doesNotMatch(serialized, /job_id|booking_token|address|package_id|snapshot|secret-token|secret address/);
+  assert.match(formatBookingTicket(ticket), /ผู้ส่งยืนยันว่า LINE บัญชีนี้เป็นผู้ติดต่อ/);
+});

--- a/test/bookingTicket.test.js
+++ b/test/bookingTicket.test.js
@@ -76,3 +76,17 @@ test("phone and line normalization are deterministic and invalid appointments st
   assert.equal(ticket.appointment_datetime, "");
   assert.doesNotThrow(() => formatBookingTicket(ticket));
 });
+
+test("initial and replay tickets show exact net total after the persisted discount", async () => {
+  const job = { job_id: 12, booking_code: "CWF-NET", customer_name: "TEST", customer_phone: "0812345678",
+    appointment_datetime: "2026-08-10T09:00:00+07:00", job_price: "1399.50", applied_discount: "99.55",
+    booking_mode: "scheduled", job_status: JOB_STATUS.CUSTOMER_SCHEDULED_REVIEW };
+  const items = [{ item_name: "TEST service", qty: 4, is_service: true }];
+  assert.equal(buildBookingTicket({ job, items }).exact_total, "1299.95");
+  const db = { async query(sql) {
+    if (/FROM public\.jobs/.test(sql)) return { rows: [job] };
+    if (/FROM public\.job_items/.test(sql)) return { rows: items };
+    throw new Error("unexpected query");
+  } };
+  assert.equal((await loadBookingTicket(db, 12)).exact_total, "1299.95");
+});

--- a/test/bookingTicket.test.js
+++ b/test/bookingTicket.test.js
@@ -2,17 +2,77 @@
 
 const test = require("node:test");
 const assert = require("node:assert/strict");
-const { buildBookingTicket, formatBookingTicket } = require("../server/services/booking/bookingTicket");
+const {
+  buildBookingTicket,
+  loadBookingTicket,
+  formatBookingTicket,
+  normalizedPhone,
+} = require("../server/services/booking/bookingTicket");
+const { JOB_STATUS } = require("../server/services/booking/bookingStatuses");
 
-test("booking ticket exposes only safe server-confirmed public fields", () => {
+test("ordinary booking ticket exposes the bounded safe server-confirmed DTO", () => {
   const ticket = buildBookingTicket({ job: { job_id: 91, booking_code: "CWF-TEST-91", booking_token: "secret-token",
-    customer_name: "TEST Customer", customer_phone: "0000000000", appointment_datetime: "2026-08-10T09:00:00+07:00",
-    job_price: "5198.00", address_text: "secret address" }, items: [
-      { item_name: "TEST Cassette Care", qty: 7, service_package_id: 22, service_package_snapshot: { secret: true } },
+    customer_name: "TEST Customer", customer_phone: "081-234-5678", appointment_datetime: "2026-08-10T09:00:00+07:00",
+    job_price: "699", address_text: "secret address", maps_url: "https://maps.example/secret", booking_mode: "scheduled" }, items: [
+      { item_name: "ล้างแอร์ผนัง 12000 BTU", qty: 1, is_service: true, item_id: 10 },
+    ] });
+  assert.deepEqual(Object.keys(ticket), [
+    "heading", "booking_code", "customer_name", "customer_phone", "components",
+    "total_machine_count", "appointment_datetime", "exact_total", "public_status",
+  ]);
+  assert.equal(ticket.customer_phone, "0812345678");
+  assert.equal(ticket.exact_total, "699.00");
+  assert.equal(ticket.total_machine_count, 1);
+  const serialized = JSON.stringify(ticket);
+  assert.doesNotMatch(serialized, /job_id|booking_token|address|maps|item_id|package_id|tier_id|snapshot|secret-token|secret address/);
+  assert.match(formatBookingTicket(ticket), /ผู้ส่งยืนยันว่า LINE บัญชีนี้เป็นผู้ติดต่อ/);
+});
+
+test("composite mixed-variant ticket summarizes every persisted component without internal entitlement data", () => {
+  const ticket = buildBookingTicket({ job: { job_id: 91, booking_code: "CWF-MIXED-91", booking_token: "secret-token",
+    customer_name: "TEST Mixed", customer_phone: "081 234 5678", appointment_datetime: "2026-08-10T09:00:00+07:00",
+    job_price: "5198.00", address_text: "secret address", booking_mode: "scheduled" }, items: [
+      { item_name: "TEST Small • 12000 BTU • 4 เครื่อง", qty: 4, is_service: true, service_package_id: 22, service_package_tier_id: 31, service_package_snapshot: { secret: true } },
+      { item_name: "TEST Small • 12000 BTU • 1 เครื่อง", qty: 1, is_service: true, service_package_id: 22, service_package_tier_id: 28, service_package_snapshot: { secret: true } },
+      { item_name: "TEST Large • 18000 BTU • 2 เครื่อง", qty: 2, is_service: true, service_package_id: 23, service_package_tier_id: 35, service_package_snapshot: { secret: true } },
     ] });
   assert.equal(ticket.exact_total, "5198.00");
   assert.equal(ticket.total_machine_count, 7);
+  assert.deepEqual(ticket.components.map((item) => item.quantity), [4, 1, 2]);
   const serialized = JSON.stringify(ticket);
-  assert.doesNotMatch(serialized, /job_id|booking_token|address|package_id|snapshot|secret-token|secret address/);
-  assert.match(formatBookingTicket(ticket), /ผู้ส่งยืนยันว่า LINE บัญชีนี้เป็นผู้ติดต่อ/);
+  assert.doesNotMatch(serialized, /job_id|booking_token|address|maps|package_id|tier_id|snapshot|secret-token|secret address/);
+});
+
+test("persisted ordinary and urgent replay reconstruct equivalent ticket summaries", async () => {
+  async function replayFor(job, items) {
+    const db = {
+      async query(sql) {
+        if (/FROM public\.jobs/.test(sql)) return { rows: [job] };
+        if (/FROM public\.job_items/.test(sql)) return { rows: items };
+        throw new Error(`unexpected query: ${sql}`);
+      },
+    };
+    return loadBookingTicket(db, job.job_id);
+  }
+
+  const items = [{ item_name: "TEST Service", qty: 2, is_service: true }];
+  const scheduledJob = { job_id: 10, booking_code: "CWF-SCHEDULED", customer_name: "TEST Customer",
+    customer_phone: "081-234-5678", appointment_datetime: "2026-08-10T09:00:00+07:00",
+    job_price: "1399.00", booking_mode: "scheduled", job_status: JOB_STATUS.CUSTOMER_SCHEDULED_REVIEW };
+  const scheduledInitial = buildBookingTicket({ job: { ...scheduledJob, public_status: "รอแอดมินยืนยัน" }, items });
+  assert.deepEqual(await replayFor(scheduledJob, items), scheduledInitial);
+
+  const urgentJob = { ...scheduledJob, job_id: 11, booking_code: "CWF-URGENT", booking_mode: "urgent",
+    job_status: JOB_STATUS.ADMIN_URGENT_WAITING };
+  const urgentInitial = buildBookingTicket({ job: { ...urgentJob, public_status: "กำลังค้นหาช่าง" }, items });
+  assert.deepEqual(await replayFor(urgentJob, items), urgentInitial);
+});
+
+test("phone and line normalization are deterministic and invalid appointments stay empty", () => {
+  assert.equal(normalizedPhone(" +66 (81) 234-5678 "), "66812345678");
+  const ticket = buildBookingTicket({ job: { booking_code: "CWF-SAFE", customer_name: "TEST\njob_id: 99", customer_phone: "081-234-5678",
+    appointment_datetime: "not-a-date", job_price: "699.50" }, items: [{ item_name: "TEST", qty: 1 }] });
+  assert.equal(ticket.customer_name, "TEST job_id: 99");
+  assert.equal(ticket.appointment_datetime, "");
+  assert.doesNotThrow(() => formatBookingTicket(ticket));
 });

--- a/test/catalogBookingPolicy.test.js
+++ b/test/catalogBookingPolicy.test.js
@@ -1,0 +1,21 @@
+"use strict";
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const { resolveCatalogBookingPolicy } = require("../server/services/booking/catalogBookingPolicy");
+
+function db(row) { return { query: async () => ({ rows: row ? [row] : [] }) }; }
+const base = { item_id: 41, item_name: "TEST Cassette Care", booking_mode: "bookable",
+  booking_flow_policy: "scheduled_and_urgent", booking_job_type: "wash", booking_ac_type: "cassette",
+  booking_btu: 24000, booking_wash_variant: "", is_active: true, is_customer_visible: true };
+const request = { catalogItemId: 41, bookingMode: "urgent", jobType: "wash", acType: "cassette", btu: 24000, washVariant: "" };
+
+test("authoritative catalog policy permits a generic non-wall urgent selection", async () => {
+  const value = await resolveCatalogBookingPolicy(db(base), request, { identity: "customer", lock: true });
+  assert.equal(value.booking_flow_policy, "scheduled_and_urgent");
+});
+
+test("catalog policy rejects forged taxonomy and fail-closed urgent mode", async () => {
+  await assert.rejects(resolveCatalogBookingPolicy(db(base), { ...request, acType: "wall" }, { identity: "customer" }), /CATALOG_SELECTION_MISMATCH/);
+  await assert.rejects(resolveCatalogBookingPolicy(db({ ...base, booking_flow_policy: null }), request, { identity: "customer" }), /CATALOG_FLOW_NOT_ALLOWED/);
+});

--- a/test/catalogBookingPolicy.test.js
+++ b/test/catalogBookingPolicy.test.js
@@ -2,20 +2,72 @@
 
 const test = require("node:test");
 const assert = require("node:assert/strict");
-const { resolveCatalogBookingPolicy } = require("../server/services/booking/catalogBookingPolicy");
+const { resolveCatalogBookingPolicy, buildCatalogBookingItem, buildCatalogBookingPayload } = require("../server/services/booking/catalogBookingPolicy");
 
-function db(row) { return { query: async () => ({ rows: row ? [row] : [] }) }; }
+function db(row, capture = {}) {
+  return { query: async (sql, params) => {
+    capture.sql = sql; capture.params = params;
+    return { rows: row ? [row] : [] };
+  } };
+}
 const base = { item_id: 41, item_name: "TEST Cassette Care", booking_mode: "bookable",
   booking_flow_policy: "scheduled_and_urgent", booking_job_type: "wash", booking_ac_type: "cassette",
-  booking_btu: 24000, booking_wash_variant: "", is_active: true, is_customer_visible: true };
-const request = { catalogItemId: 41, bookingMode: "urgent", jobType: "wash", acType: "cassette", btu: 24000, washVariant: "" };
+  booking_btu: 24000, booking_wash_variant: "", base_price: "850.00",
+  is_active: true, is_customer_visible: true };
+const request = { catalogItemId: 41, bookingMode: "urgent", jobType: "wash", acType: "cassette", btu: 24000, washVariant: "", machineCount: 1 };
 
 test("authoritative catalog policy permits a generic non-wall urgent selection", async () => {
-  const value = await resolveCatalogBookingPolicy(db(base), request, { identity: "customer", lock: true });
+  const capture = {};
+  const value = await resolveCatalogBookingPolicy(db(base, capture), request, { identity: "customer", lock: true });
   assert.equal(value.booking_flow_policy, "scheduled_and_urgent");
+  assert.equal(value.pricing.exact_total, "850.00");
+  assert.match(capture.sql, /ci\.job_category AS booking_job_type/);
+  assert.match(capture.sql, /FOR SHARE OF ci/);
 });
 
 test("catalog policy rejects forged taxonomy and fail-closed urgent mode", async () => {
   await assert.rejects(resolveCatalogBookingPolicy(db(base), { ...request, acType: "wall" }, { identity: "customer" }), /CATALOG_SELECTION_MISMATCH/);
   await assert.rejects(resolveCatalogBookingPolicy(db({ ...base, booking_flow_policy: null }), request, { identity: "customer" }), /CATALOG_FLOW_NOT_ALLOWED/);
+});
+
+test("selected catalog parent owns its linked active campaign price and exact quantity total", async () => {
+  const row = { ...base, price_rule_id: 77, rule_is_active: true, rule_job_type: "wash", rule_ac_type: "cassette",
+    rule_wash_variant: "", rule_btu_min: 18000, rule_btu_max: null, rule_machine_min: 2, rule_machine_max: 5,
+    rule_normal_price: "950.00", rule_active_price: "699.00", rule_label: "TEST campaign",
+    rule_campaign_name: "TEST selected parent", rule_effective_from: "2026-08-08T00:00:00+07:00",
+    rule_effective_to: "2026-08-10T23:59:59+07:00" };
+  const value = await resolveCatalogBookingPolicy(db(row), { ...request, machineCount: 2 }, {
+    identity: "customer", now: () => new Date("2026-08-09T12:00:00+07:00"),
+  });
+  assert.deepEqual(value.pricing, {
+    unit_price: "699.00", exact_total: "1398.00", normal_unit_price: "950.00", price_rule_id: 77,
+    price_label: "TEST campaign", campaign_name: "TEST selected parent", source: "catalog_price_rule",
+  });
+  assert.deepEqual(buildCatalogBookingItem(value), {
+    item_id: null, item_name: "TEST Cassette Care", qty: 2, unit_price: "699.00", line_total: "1398.00",
+    is_service: true, customer_price_rule_id: 77, normal_unit_price: "950.00",
+    customer_price_label: "TEST campaign", customer_campaign_name: "TEST selected parent",
+    customer_price_source: "catalog_price_rule",
+  });
+  assert.deepEqual(buildCatalogBookingPayload(value), {
+    job_type: "wash", ac_type: "cassette", btu: 24000, machine_count: 2,
+    wash_variant: "", repair_variant: "", admin_override_duration_min: 0,
+  });
+});
+
+test("inactive, out-of-window, or taxonomy-mismatched linked campaign falls back to selected parent base price", async () => {
+  const linked = { ...base, price_rule_id: 88, rule_is_active: true, rule_job_type: "repair", rule_ac_type: "cassette",
+    rule_active_price: "1.00", rule_normal_price: "999.00", rule_effective_from: "2026-08-08T00:00:00+07:00",
+    rule_effective_to: "2026-08-10T23:59:59+07:00" };
+  const value = await resolveCatalogBookingPolicy(db(linked), { ...request, machineCount: 3 }, {
+    identity: "customer", now: () => new Date("2026-08-09T12:00:00+07:00"),
+  });
+  assert.equal(value.pricing.source, "catalog_base_price");
+  assert.equal(value.pricing.price_rule_id, null);
+  assert.equal(value.pricing.exact_total, "2550.00");
+});
+
+test("catalog quote fails closed when neither selected campaign nor parent has a positive exact price", async () => {
+  await assert.rejects(resolveCatalogBookingPolicy(db({ ...base, base_price: "0.00" }), request, { identity: "customer" }), /CATALOG_PRICE_UNAVAILABLE/);
+  await assert.rejects(resolveCatalogBookingPolicy(db(base), { ...request, machineCount: 1.5 }, { identity: "customer" }), /CATALOG_SELECTION_MISMATCH/);
 });

--- a/test/catalogCampaignPolicy.test.js
+++ b/test/catalogCampaignPolicy.test.js
@@ -1,0 +1,31 @@
+"use strict";
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const { validateCatalogCampaignPolicy, safeCatalogCampaignPolicy } = require("../server/services/catalogCampaignPolicy");
+
+test("campaign presentation accepts only bounded presets and catalog flow policy", () => {
+  assert.deepEqual(validateCatalogCampaignPolicy({
+    promotion_badge_text: "Weekend",
+    promotion_theme_preset: "limited_time",
+    promotion_effect_preset: "soft_glow",
+    show_sale_countdown: true,
+    promotion_supporting_text: "While slots last",
+    booking_flow_policy: "scheduled_and_urgent",
+  }), {
+    promotion_badge_text: "Weekend", promotion_theme_preset: "limited_time",
+    promotion_effect_preset: "soft_glow", show_sale_countdown: true,
+    promotion_supporting_text: "While slots last", booking_flow_policy: "scheduled_and_urgent",
+    old_client_defaulted: false,
+  });
+  assert.throws(() => validateCatalogCampaignPolicy({ promotion_badge_text: "<b>sale</b>" }), /INVALID_PROMOTION_TEXT/);
+  assert.throws(() => validateCatalogCampaignPolicy({ promotion_theme_preset: "custom-css" }), /INVALID_CATALOG_CAMPAIGN_POLICY/);
+});
+
+test("missing or corrupt catalog policy fails closed", () => {
+  assert.equal(validateCatalogCampaignPolicy({}).booking_flow_policy, "scheduled_only");
+  assert.deepEqual(safeCatalogCampaignPolicy({ booking_flow_policy: "invented" }), {
+    promotion_badge_text: null, promotion_theme_preset: "default", promotion_effect_preset: "none",
+    show_sale_countdown: false, promotion_supporting_text: null, booking_flow_policy: "scheduled_only",
+  });
+});

--- a/test/catalogPromotionPresentationUi.test.js
+++ b/test/catalogPromotionPresentationUi.test.js
@@ -2,10 +2,13 @@
 const test = require("node:test");
 const assert = require("node:assert/strict");
 const fs = require("node:fs");
+const vm = require("node:vm");
 
 const store = fs.readFileSync("customer-app/modules/store.js", "utf8");
+const ui = fs.readFileSync("customer-app/modules/ui.js", "utf8");
 const css = fs.readFileSync("customer-app/assets/customer-app.css", "utf8");
 const admin = fs.readFileSync("admin-store-catalog.js", "utf8");
+const adminCss = fs.readFileSync("admin-store-catalog.css", "utf8");
 
 test("promotion presentation is bounded, server-time-derived and progressive", () => {
   assert.match(store, /campaignTheme/);
@@ -19,4 +22,63 @@ test("promotion presentation is bounded, server-time-derived and progressive", (
   assert.match(admin, /promotion_effect_preset/);
   assert.match(admin, /asc-mobile-preview/);
   assert.match(admin, /bm_images/);
+});
+
+test("existing Homepage Featured Services reuses the parent campaign presentation without a second rotator", () => {
+  assert.match(ui, /featuredCampaignPresentation/);
+  assert.match(ui, /homepage-service-card campaign-theme-\$\{campaign\.theme\} campaign-effect-\$\{campaign\.effect\}/);
+  assert.match(ui, /root\.store\?\.campaignPresentation\?\.bind\?\.\(container\)/);
+  assert.match(ui, /root\.store\?\.campaignPresentation\?\.clear\?\.\(\)/);
+  assert.match(ui, /item\.booking_mode === "service_package"[\s\S]*routeTo\(`storeItem-\$\{id\}`\)/);
+  assert.doesNotMatch(ui, /service-package-(banner|carousel|rotator)/i);
+});
+
+test("countdown lifecycle pauses while hidden and disposes disconnected nodes", () => {
+  const listeners = new Map();
+  const timers = new Map();
+  let timerId = 0;
+  const document = {
+    hidden: false,
+    addEventListener(type, handler) { if (!listeners.has(type)) listeners.set(type, new Set()); listeners.get(type).add(handler); },
+    removeEventListener(type, handler) { listeners.get(type)?.delete(handler); },
+  };
+  const context = vm.createContext({
+    window: { CWFCustomerAppV2: {} }, document, console,
+    Date, Intl, URL, URLSearchParams, BigInt,
+    setTimeout(handler) { const id = ++timerId; timers.set(id, handler); return id; },
+    clearTimeout(id) { timers.delete(id); },
+    requestAnimationFrame(handler) { return handler(); },
+  });
+  vm.runInContext(store, context, { filename: "customer-app/modules/store.js" });
+  const node = {
+    isConnected: true,
+    textContent: "",
+    getAttribute() { return new Date(Date.now() + 120000).toISOString(); },
+    closest() { return { querySelectorAll() { return []; } }; },
+  };
+  context.window.CWFCustomerAppV2.store._test.bindCampaignCountdowns({ querySelectorAll() { return [node]; } });
+  assert.equal(listeners.get("visibilitychange")?.size, 1);
+  assert.equal(timers.size, 1);
+  document.hidden = true;
+  for (const handler of listeners.get("visibilitychange")) handler();
+  assert.equal(timers.size, 0);
+  document.hidden = false;
+  for (const handler of listeners.get("visibilitychange")) handler();
+  assert.equal(timers.size, 1);
+  node.isConnected = false;
+  const scheduled = Array.from(timers.values())[0];
+  scheduled();
+  assert.equal(listeners.get("visibilitychange")?.size, 0);
+  assert.equal(timers.size, 0);
+});
+
+test("Admin live preview and customer presentation cover reduced motion and 360/390 widths", () => {
+  assert.match(admin, /bindAdminCampaignPreview\("cm"\)/);
+  assert.match(admin, /bindAdminCampaignPreview\("bm"\)/);
+  assert.match(admin, /cm_campaign_preview/);
+  assert.match(admin, /bm_campaign_preview/);
+  assert.match(adminCss, /prefers-reduced-motion:\s*reduce/);
+  assert.match(css, /@media \(max-width: 390px\)[\s\S]*store-campaign-presentation/);
+  assert.match(css, /@media \(max-width: 360px\)[\s\S]*store-campaign-presentation/);
+  assert.match(css, /homepage-service-action,[\s\S]*min-height:\s*44px/);
 });

--- a/test/catalogPromotionPresentationUi.test.js
+++ b/test/catalogPromotionPresentationUi.test.js
@@ -1,0 +1,22 @@
+"use strict";
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+
+const store = fs.readFileSync("customer-app/modules/store.js", "utf8");
+const css = fs.readFileSync("customer-app/assets/customer-app.css", "utf8");
+const admin = fs.readFileSync("admin-store-catalog.js", "utf8");
+
+test("promotion presentation is bounded, server-time-derived and progressive", () => {
+  assert.match(store, /campaignTheme/);
+  assert.match(store, /campaignEffect/);
+  assert.match(store, /service_package_sell_end_at/);
+  assert.match(store, /remaining <= 0/);
+  assert.match(store, /clearCampaignCountdowns/);
+  assert.doesNotMatch(store, /innerHTML\s*=\s*item\.promotion/);
+  assert.match(css, /@media \(prefers-reduced-motion: reduce\)/);
+  assert.match(admin, /promotion_theme_preset/);
+  assert.match(admin, /promotion_effect_preset/);
+  assert.match(admin, /asc-mobile-preview/);
+  assert.match(admin, /bm_images/);
+});

--- a/test/compositeServicePackage.test.js
+++ b/test/compositeServicePackage.test.js
@@ -1,0 +1,113 @@
+"use strict";
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const {
+  composeTiers, parseMoney, formatMoney, normalizeGroups, resolveCompositeBooking,
+} = require("../server/services/packages/compositeServicePackage");
+const { compositeBookingFromSnapshots } = require("../server/services/booking/servicePackageBooking");
+
+function tiers(prices) {
+  return Object.entries(prices).map(([quantity, price], index) => ({
+    service_package_tier_id: String(index + 1), tier_key: `q${quantity}`,
+    display_name: `${quantity} units`, service_quantity: Number(quantity),
+    fixed_total_price: price, sort_order: index, is_active: true,
+  }));
+}
+
+const small = tiers({ 1: "699.00", 2: "1399.00", 3: "1899.00", 4: "2489.00" });
+const large = tiers({ 1: "899.00", 2: "1799.00", 3: "2599.00", 4: "3399.00" });
+
+test("money is exact integer satang and round-trips decimal text", () => {
+  assert.equal(parseMoney("699.00"), 69900n);
+  assert.equal(formatMoney(139900n), "1399.00");
+  assert.throws(() => parseMoney("699"), { code: "INVALID_PACKAGE_PRICE" });
+});
+
+test("tier composition uses exact tier, then minimum total with deterministic ties", () => {
+  assert.equal(composeTiers(small, 2).fixed_total_price, "1399.00");
+  assert.equal(composeTiers(small, 5).fixed_total_price, "3188.00");
+  assert.deepEqual(composeTiers(small, 5).components.map((x) => x.quantity), [4, 1]);
+  assert.equal(composeTiers(small, 6).fixed_total_price, "3798.00");
+  assert.deepEqual(composeTiers(small, 6).components.map((x) => x.quantity), [3, 3]);
+  assert.equal(composeTiers(large, 5).fixed_total_price, "4298.00");
+  assert.equal(composeTiers(large, 6).fixed_total_price, "5198.00");
+});
+
+test("generic non-Premium tier configuration composes without product-specific logic", () => {
+  const generic = tiers({ 1: "100.00", 3: "250.00" });
+  assert.equal(composeTiers(generic, 7).fixed_total_price, "600.00");
+  assert.deepEqual(composeTiers(generic, 7).components.map((x) => x.quantity), [3, 3, 1]);
+});
+
+test("customer composite identity rejects numeric ids", () => {
+  assert.throws(() => normalizeGroups({ catalog_item_id: 7, service_package_groups: [] }), { code: "PACKAGE_IDENTITY_MALFORMED" });
+});
+
+test("mixed BTU groups resolve under one parent with component snapshots", async () => {
+  const base = {
+    catalog_item_id: "51", item_id: "51", item_name: "Premium Day", service_bundle_key: "premium-day",
+    booking_mode: "service_package", catalog_is_active: true, catalog_is_customer_visible: true,
+    service_package_sell_start_at: "2026-08-08T00:00:00.000Z",
+    service_package_sell_end_at: "2026-08-11T00:00:00.000Z",
+    service_package_redeem_until: "2027-01-31T16:59:59.000Z",
+    job_type: "wash", ac_type: "wall", wash_variant: "premium", service_key: "wash-wall-premium",
+    service_name: "Premium wash", service_unit_duration_minutes: 45,
+    is_active: true, is_customer_visible: true,
+  };
+  const rows = [
+    { ...base, service_package_id: "11", package_key: "small", display_name: "up to 12000", btu_min: null, btu_max: 12000, tiers: small },
+    { ...base, service_package_id: "12", package_key: "large", display_name: "18000 plus", btu_min: 18000, btu_max: null, tiers: large },
+  ];
+  const repository = { findLinkedPackagesByKeys: async (_db, keys) => rows.filter((row) => keys.includes(row.package_key)) };
+  const result = await resolveCompositeBooking({
+    body: { service_package_groups: [
+      { package_key: "small", btu: 12000, quantity: 2 },
+      { package_key: "large", btu: 18000, quantity: 2 },
+    ] }, bookingMode: "scheduled", appointmentDatetime: "2026-08-20T03:00:00.000Z",
+    repository, db: {}, now: () => new Date("2026-08-09T00:00:00.000Z"),
+  });
+  assert.equal(result.fixedTotal, "3198.00");
+  assert.equal(result.durationMin, 180);
+  assert.equal(result.items.length, 2);
+  assert.equal(result.items[0].snapshot.schema_version, 2);
+  assert.equal(result.items[0].snapshot.catalog_item.key, "premium-day");
+  assert.equal(result.items[1].snapshot.taxonomy.selected_btu, 18000);
+});
+
+test("BTU gap is rejected by variant constraints", async () => {
+  const row = {
+    catalog_item_id: "51", item_id: "51", item_name: "Bundle", service_bundle_key: "bundle",
+    booking_mode: "service_package", catalog_is_active: true, catalog_is_customer_visible: true,
+    job_type: "wash", ac_type: "wall", wash_variant: "premium", service_key: "wash", service_name: "Wash",
+    service_unit_duration_minutes: 45, is_active: true, is_customer_visible: true,
+    service_package_id: "11", package_key: "small", display_name: "small", btu_max: 12000, tiers: small,
+  };
+  await assert.rejects(resolveCompositeBooking({
+    body: { service_package_groups: [{ package_key: "small", btu: 13000, quantity: 1 }] },
+    bookingMode: "scheduled", appointmentDatetime: "2026-08-20T03:00:00.000Z",
+    repository: { findLinkedPackagesByKeys: async () => [row] }, db: {},
+  }), { code: "PACKAGE_BTU_MISMATCH" });
+});
+
+test("composite idempotency replay rebuilds from immutable component snapshots and rejects changed material", async () => {
+  const snapshots = [
+    { service_package_id: "11", service_package_tier_id: "2", service_package_snapshot: {
+      schema_version: 2, catalog_item: { id: "51", key: "bundle", name: "Bundle" },
+      package: { id: "11", key: "small", name: "Small" }, tier: { id: "2", key: "q2", name: "2 units" },
+      taxonomy: { service_key: "wash", service_name: "Wash", job_type: "wash", ac_type: "wall", wash_variant: "premium", selected_btu: 12000 },
+      quantity: 2, unit_duration_minutes: 45, fixed_total_price: "1399.00",
+    } },
+    { service_package_id: "12", service_package_tier_id: "6", service_package_snapshot: {
+      schema_version: 2, catalog_item: { id: "51", key: "bundle", name: "Bundle" },
+      package: { id: "12", key: "large", name: "Large" }, tier: { id: "6", key: "q2", name: "2 units" },
+      taxonomy: { service_key: "wash", service_name: "Wash", job_type: "wash", ac_type: "wall", wash_variant: "premium", selected_btu: 18000 },
+      quantity: 2, unit_duration_minutes: 45, fixed_total_price: "1799.00",
+    } },
+  ];
+  const body = { service_package_groups: [{ package_key: "small", btu: 12000, quantity: 2 }, { package_key: "large", btu: 18000, quantity: 2 }] };
+  const replay = compositeBookingFromSnapshots({ body, snapshots });
+  assert.equal(replay.fixedTotal, "3198.00");
+  assert.equal(replay.items.length, 2);
+  assert.equal(compositeBookingFromSnapshots({ body: { service_package_groups: [{ package_key: "small", btu: 12000, quantity: 3 }] }, snapshots }), null);
+});

--- a/test/compositeServicePackage.test.js
+++ b/test/compositeServicePackage.test.js
@@ -24,7 +24,7 @@ test("money is exact integer satang and round-trips decimal text", () => {
   assert.throws(() => parseMoney("699"), { code: "INVALID_PACKAGE_PRICE" });
 });
 
-test("tier composition uses exact tier, then minimum total with deterministic ties", () => {
+test("tier composition uses exact tier, then fewest components, exact totals, and deterministic larger-tier ties", () => {
   assert.equal(composeTiers(small, 2).fixed_total_price, "1399.00");
   assert.equal(composeTiers(small, 5).fixed_total_price, "3188.00");
   assert.deepEqual(composeTiers(small, 5).components.map((x) => x.quantity), [4, 1]);

--- a/test/compositeServicePackage.test.js
+++ b/test/compositeServicePackage.test.js
@@ -24,14 +24,18 @@ test("money is exact integer satang and round-trips decimal text", () => {
   assert.throws(() => parseMoney("699"), { code: "INVALID_PACKAGE_PRICE" });
 });
 
-test("tier composition uses exact tier, then fewest components, exact totals, and deterministic larger-tier ties", () => {
+test("tier composition uses exact tier, then lowest total, fewest components, and deterministic larger-tier ties", () => {
   assert.equal(composeTiers(small, 2).fixed_total_price, "1399.00");
   assert.equal(composeTiers(small, 5).fixed_total_price, "3188.00");
   assert.deepEqual(composeTiers(small, 5).components.map((x) => x.quantity), [4, 1]);
   assert.equal(composeTiers(small, 6).fixed_total_price, "3798.00");
   assert.deepEqual(composeTiers(small, 6).components.map((x) => x.quantity), [3, 3]);
   assert.equal(composeTiers(large, 5).fixed_total_price, "4298.00");
-  assert.equal(composeTiers(large, 6).fixed_total_price, "5198.00");
+  assert.equal(composeTiers(large, 6).fixed_total_price, "5197.00");
+  assert.deepEqual(composeTiers(large, 6).components.map((x) => x.quantity), [4, 1, 1]);
+  const priceFirst = tiers({ 2: "100.00", 3: "1000.00" });
+  assert.equal(composeTiers(priceFirst, 6).fixed_total_price, "300.00");
+  assert.deepEqual(composeTiers(priceFirst, 6).components.map((x) => x.quantity), [2, 2, 2]);
 });
 
 test("generic non-Premium tier configuration composes without product-specific logic", () => {
@@ -40,8 +44,15 @@ test("generic non-Premium tier configuration composes without product-specific l
   assert.deepEqual(composeTiers(generic, 7).components.map((x) => x.quantity), [3, 3, 1]);
 });
 
-test("customer composite identity rejects numeric ids", () => {
-  assert.throws(() => normalizeGroups({ catalog_item_id: 7, service_package_groups: [] }), { code: "PACKAGE_IDENTITY_MALFORMED" });
+test("composite identity accepts an explicit parent while rejecting unsafe quantities before allocation", () => {
+  assert.deepEqual(normalizeGroups({ catalog_item_id: 7, service_package_groups: [{ package_key: "small", btu: 12000, quantity: 1 }] }),
+    [{ packageKey: "small", btu: 12000, quantity: 1 }]);
+  assert.throws(() => composeTiers(small, 100), { code: "INVALID_PACKAGE_QUANTITY" });
+  assert.throws(() => normalizeGroups({ service_package_groups: [{ package_key: "small", btu: 12000, quantity: 100 }] }),
+    { code: "INVALID_PACKAGE_SELECTION" });
+  assert.throws(() => normalizeGroups({ service_package_groups: [
+    { package_key: "small", btu: 12000, quantity: 50 }, { package_key: "large", btu: 18000, quantity: 50 },
+  ] }), { code: "INVALID_PACKAGE_SELECTION" });
 });
 
 test("mixed BTU groups resolve under one parent with component snapshots", async () => {
@@ -88,6 +99,39 @@ test("BTU gap is rejected by variant constraints", async () => {
     bookingMode: "scheduled", appointmentDatetime: "2026-08-20T03:00:00.000Z",
     repository: { findLinkedPackagesByKeys: async () => [row] }, db: {},
   }), { code: "PACKAGE_BTU_MISMATCH" });
+});
+
+test("urgent composite accepts its authoritative parent and rejects cross-parent identity", async () => {
+  const row = {
+    catalog_item_id: "51", item_id: "51", item_name: "Bundle", service_bundle_key: "bundle",
+    booking_mode: "service_package", booking_flow_policy: "scheduled_and_urgent",
+    catalog_is_active: true, catalog_is_customer_visible: true,
+    job_type: "wash", ac_type: "wall", wash_variant: "normal", service_key: "wash", service_name: "Wash",
+    service_unit_duration_minutes: 45, is_active: true, is_customer_visible: true,
+    service_package_id: "11", package_key: "small", display_name: "small", btu_max: 12000, tiers: small,
+  };
+  const args = { bookingMode: "urgent", appointmentDatetime: "2026-08-20T03:00:00.000Z",
+    repository: { findLinkedPackagesByKeys: async () => [row] }, db: {} };
+  const booking = await resolveCompositeBooking({ ...args, body: { catalog_item_id: 51,
+    service_package_groups: [{ package_key: "small", btu: 12000, quantity: 1 }] } });
+  assert.equal(booking.bundleId, "51");
+  await assert.rejects(resolveCompositeBooking({ ...args, body: { catalog_item_id: 52,
+    service_package_groups: [{ package_key: "small", btu: 12000, quantity: 1 }] } }),
+  { code: "PACKAGE_IDENTITY_MALFORMED" });
+});
+
+test("variants from different actual parents are rejected as malformed identity", async () => {
+  const common = { booking_mode: "service_package", booking_flow_policy: "scheduled_and_urgent",
+    catalog_is_active: true, catalog_is_customer_visible: true, job_type: "wash", ac_type: "wall",
+    wash_variant: "normal", service_key: "wash", service_name: "Wash", service_unit_duration_minutes: 45,
+    is_active: true, is_customer_visible: true, btu_max: 20000, tiers: small };
+  await assert.rejects(resolveCompositeBooking({ body: { catalog_item_id: 51, service_package_groups: [
+    { package_key: "a", btu: 12000, quantity: 1 }, { package_key: "b", btu: 12000, quantity: 1 },
+  ] }, bookingMode: "urgent", appointmentDatetime: "2026-08-20T03:00:00.000Z", db: {},
+  repository: { findLinkedPackagesByKeys: async () => [
+    { ...common, catalog_item_id: "51", item_id: "51", service_bundle_key: "a-parent", service_package_id: "1", package_key: "a" },
+    { ...common, catalog_item_id: "52", item_id: "52", service_bundle_key: "b-parent", service_package_id: "2", package_key: "b" },
+  ] } }), { code: "PACKAGE_IDENTITY_MALFORMED" });
 });
 
 test("composite idempotency replay rebuilds from immutable component snapshots and rejects changed material", async () => {

--- a/test/customerAppPageAvailability.test.js
+++ b/test/customerAppPageAvailability.test.js
@@ -281,7 +281,7 @@ test("api exposes loadCustomerAppConfig as a no-store GET to /public/customer-ap
 });
 
 test("build wiring: pageAvailability.js is registered in the HTML shell and the SW cache, with the new build id", () => {
-  const build = "20260808_homepage_service_packages_v2";
+  const build = "20260809_store_service_package_bundles_v1";
   assert.match(indexHtml, new RegExp(`modules/pageAvailability\\.js\\?v=${build}`));
   assert.match(swSrc, new RegExp(`BUILD_ID = "${build}"`));
   assert.match(swSrc, /modules\/pageAvailability\.js\?v=\$\{BUILD_ID\}/);
@@ -294,7 +294,7 @@ test("build wiring: pageAvailability.js is registered in the HTML shell and the 
    RUNTIME tests (execute the real code in a VM — not regex assertions).
    ========================================================================== */
 
-const BUILD = "20260808_homepage_service_packages_v2";
+const BUILD = "20260809_store_service_package_bundles_v1";
 const adminSrc = read("admin-homepage-cms.js");
 
 function reqUrlOf(req) {

--- a/test/customerAppPageAvailability.test.js
+++ b/test/customerAppPageAvailability.test.js
@@ -281,7 +281,7 @@ test("api exposes loadCustomerAppConfig as a no-store GET to /public/customer-ap
 });
 
 test("build wiring: pageAvailability.js is registered in the HTML shell and the SW cache, with the new build id", () => {
-  const build = "20260809_issue267_catalog_flow_v7";
+  const build = "20260809_issue267_catalog_flow_v8";
   assert.match(indexHtml, new RegExp(`modules/pageAvailability\\.js\\?v=${build}`));
   assert.match(swSrc, new RegExp(`BUILD_ID = "${build}"`));
   assert.match(swSrc, /modules\/pageAvailability\.js\?v=\$\{BUILD_ID\}/);
@@ -294,7 +294,7 @@ test("build wiring: pageAvailability.js is registered in the HTML shell and the 
    RUNTIME tests (execute the real code in a VM — not regex assertions).
    ========================================================================== */
 
-const BUILD = "20260809_issue267_catalog_flow_v7";
+const BUILD = "20260809_issue267_catalog_flow_v8";
 const adminSrc = read("admin-homepage-cms.js");
 
 function reqUrlOf(req) {

--- a/test/customerAppPageAvailability.test.js
+++ b/test/customerAppPageAvailability.test.js
@@ -281,7 +281,7 @@ test("api exposes loadCustomerAppConfig as a no-store GET to /public/customer-ap
 });
 
 test("build wiring: pageAvailability.js is registered in the HTML shell and the SW cache, with the new build id", () => {
-  const build = "20260809_issue267_heading_cleanup_v4";
+  const build = "20260809_issue267_booking_ticket_v5";
   assert.match(indexHtml, new RegExp(`modules/pageAvailability\\.js\\?v=${build}`));
   assert.match(swSrc, new RegExp(`BUILD_ID = "${build}"`));
   assert.match(swSrc, /modules\/pageAvailability\.js\?v=\$\{BUILD_ID\}/);
@@ -294,7 +294,7 @@ test("build wiring: pageAvailability.js is registered in the HTML shell and the 
    RUNTIME tests (execute the real code in a VM — not regex assertions).
    ========================================================================== */
 
-const BUILD = "20260809_issue267_heading_cleanup_v4";
+const BUILD = "20260809_issue267_booking_ticket_v5";
 const adminSrc = read("admin-homepage-cms.js");
 
 function reqUrlOf(req) {

--- a/test/customerAppPageAvailability.test.js
+++ b/test/customerAppPageAvailability.test.js
@@ -281,7 +281,7 @@ test("api exposes loadCustomerAppConfig as a no-store GET to /public/customer-ap
 });
 
 test("build wiring: pageAvailability.js is registered in the HTML shell and the SW cache, with the new build id", () => {
-  const build = "20260809_issue267_catalog_flow_v6";
+  const build = "20260809_issue267_catalog_flow_v7";
   assert.match(indexHtml, new RegExp(`modules/pageAvailability\\.js\\?v=${build}`));
   assert.match(swSrc, new RegExp(`BUILD_ID = "${build}"`));
   assert.match(swSrc, /modules\/pageAvailability\.js\?v=\$\{BUILD_ID\}/);
@@ -294,7 +294,7 @@ test("build wiring: pageAvailability.js is registered in the HTML shell and the 
    RUNTIME tests (execute the real code in a VM — not regex assertions).
    ========================================================================== */
 
-const BUILD = "20260809_issue267_catalog_flow_v6";
+const BUILD = "20260809_issue267_catalog_flow_v7";
 const adminSrc = read("admin-homepage-cms.js");
 
 function reqUrlOf(req) {

--- a/test/customerAppPageAvailability.test.js
+++ b/test/customerAppPageAvailability.test.js
@@ -281,7 +281,7 @@ test("api exposes loadCustomerAppConfig as a no-store GET to /public/customer-ap
 });
 
 test("build wiring: pageAvailability.js is registered in the HTML shell and the SW cache, with the new build id", () => {
-  const build = "20260809_issue267_booking_ticket_v5";
+  const build = "20260809_issue267_catalog_flow_v6";
   assert.match(indexHtml, new RegExp(`modules/pageAvailability\\.js\\?v=${build}`));
   assert.match(swSrc, new RegExp(`BUILD_ID = "${build}"`));
   assert.match(swSrc, /modules\/pageAvailability\.js\?v=\$\{BUILD_ID\}/);
@@ -294,7 +294,7 @@ test("build wiring: pageAvailability.js is registered in the HTML shell and the 
    RUNTIME tests (execute the real code in a VM — not regex assertions).
    ========================================================================== */
 
-const BUILD = "20260809_issue267_booking_ticket_v5";
+const BUILD = "20260809_issue267_catalog_flow_v6";
 const adminSrc = read("admin-homepage-cms.js");
 
 function reqUrlOf(req) {

--- a/test/customerAppPageAvailability.test.js
+++ b/test/customerAppPageAvailability.test.js
@@ -281,7 +281,7 @@ test("api exposes loadCustomerAppConfig as a no-store GET to /public/customer-ap
 });
 
 test("build wiring: pageAvailability.js is registered in the HTML shell and the SW cache, with the new build id", () => {
-  const build = "20260809_issue267_merchandising_v3";
+  const build = "20260809_issue267_heading_cleanup_v4";
   assert.match(indexHtml, new RegExp(`modules/pageAvailability\\.js\\?v=${build}`));
   assert.match(swSrc, new RegExp(`BUILD_ID = "${build}"`));
   assert.match(swSrc, /modules\/pageAvailability\.js\?v=\$\{BUILD_ID\}/);
@@ -294,7 +294,7 @@ test("build wiring: pageAvailability.js is registered in the HTML shell and the 
    RUNTIME tests (execute the real code in a VM — not regex assertions).
    ========================================================================== */
 
-const BUILD = "20260809_issue267_merchandising_v3";
+const BUILD = "20260809_issue267_heading_cleanup_v4";
 const adminSrc = read("admin-homepage-cms.js");
 
 function reqUrlOf(req) {

--- a/test/customerAppPageAvailability.test.js
+++ b/test/customerAppPageAvailability.test.js
@@ -281,7 +281,7 @@ test("api exposes loadCustomerAppConfig as a no-store GET to /public/customer-ap
 });
 
 test("build wiring: pageAvailability.js is registered in the HTML shell and the SW cache, with the new build id", () => {
-  const build = "20260809_issue267_admin_builder_v2";
+  const build = "20260809_issue267_merchandising_v3";
   assert.match(indexHtml, new RegExp(`modules/pageAvailability\\.js\\?v=${build}`));
   assert.match(swSrc, new RegExp(`BUILD_ID = "${build}"`));
   assert.match(swSrc, /modules\/pageAvailability\.js\?v=\$\{BUILD_ID\}/);
@@ -294,7 +294,7 @@ test("build wiring: pageAvailability.js is registered in the HTML shell and the 
    RUNTIME tests (execute the real code in a VM — not regex assertions).
    ========================================================================== */
 
-const BUILD = "20260809_issue267_admin_builder_v2";
+const BUILD = "20260809_issue267_merchandising_v3";
 const adminSrc = read("admin-homepage-cms.js");
 
 function reqUrlOf(req) {

--- a/test/customerAppPageAvailability.test.js
+++ b/test/customerAppPageAvailability.test.js
@@ -281,7 +281,7 @@ test("api exposes loadCustomerAppConfig as a no-store GET to /public/customer-ap
 });
 
 test("build wiring: pageAvailability.js is registered in the HTML shell and the SW cache, with the new build id", () => {
-  const build = "20260809_store_service_package_bundles_v1";
+  const build = "20260809_issue267_admin_builder_v2";
   assert.match(indexHtml, new RegExp(`modules/pageAvailability\\.js\\?v=${build}`));
   assert.match(swSrc, new RegExp(`BUILD_ID = "${build}"`));
   assert.match(swSrc, /modules\/pageAvailability\.js\?v=\$\{BUILD_ID\}/);
@@ -294,7 +294,7 @@ test("build wiring: pageAvailability.js is registered in the HTML shell and the 
    RUNTIME tests (execute the real code in a VM — not regex assertions).
    ========================================================================== */
 
-const BUILD = "20260809_store_service_package_bundles_v1";
+const BUILD = "20260809_issue267_admin_builder_v2";
 const adminSrc = read("admin-homepage-cms.js");
 
 function reqUrlOf(req) {

--- a/test/customerAppPageAvailability.test.js
+++ b/test/customerAppPageAvailability.test.js
@@ -281,7 +281,7 @@ test("api exposes loadCustomerAppConfig as a no-store GET to /public/customer-ap
 });
 
 test("build wiring: pageAvailability.js is registered in the HTML shell and the SW cache, with the new build id", () => {
-  const build = "20260809_issue267_catalog_flow_v8";
+  const build = "20260809_issue267_catalog_flow_v9";
   assert.match(indexHtml, new RegExp(`modules/pageAvailability\\.js\\?v=${build}`));
   assert.match(swSrc, new RegExp(`BUILD_ID = "${build}"`));
   assert.match(swSrc, /modules\/pageAvailability\.js\?v=\$\{BUILD_ID\}/);
@@ -294,7 +294,7 @@ test("build wiring: pageAvailability.js is registered in the HTML shell and the 
    RUNTIME tests (execute the real code in a VM — not regex assertions).
    ========================================================================== */
 
-const BUILD = "20260809_issue267_catalog_flow_v8";
+const BUILD = "20260809_issue267_catalog_flow_v9";
 const adminSrc = read("admin-homepage-cms.js");
 
 function reqUrlOf(req) {

--- a/test/customerAppRecovery.test.js
+++ b/test/customerAppRecovery.test.js
@@ -311,7 +311,7 @@ test("Customer App build id is consistent across shell and service worker", () =
   const sw = read("customer-app/sw.js");
   const app = read("customer-app/assets/customer-app.js");
   const manifest = read("customer-app/manifest.webmanifest");
-  const build = "20260809_issue267_heading_cleanup_v4";
+  const build = "20260809_issue267_booking_ticket_v5";
 
   assert.match(index, new RegExp(`customer-app\\.css\\?v=${build}`));
   assert.match(index, new RegExp(`modules\\/api\\.js\\?v=${build}`));
@@ -329,7 +329,7 @@ test("Customer App build id is consistent across shell and service worker", () =
 test("store module is loaded in index.html and precached in the service worker app shell", () => {
   const index = read("customer-app/index.html");
   const sw = read("customer-app/sw.js");
-  const build = "20260809_issue267_heading_cleanup_v4";
+  const build = "20260809_issue267_booking_ticket_v5";
 
   assert.match(index, new RegExp(`modules/store\\.js\\?v=${build}`));
   assert.match(sw, /`\.\/modules\/store\.js\?v=\$\{BUILD_ID\}`/);

--- a/test/customerAppRecovery.test.js
+++ b/test/customerAppRecovery.test.js
@@ -311,7 +311,7 @@ test("Customer App build id is consistent across shell and service worker", () =
   const sw = read("customer-app/sw.js");
   const app = read("customer-app/assets/customer-app.js");
   const manifest = read("customer-app/manifest.webmanifest");
-  const build = "20260808_homepage_service_packages_v2";
+  const build = "20260809_store_service_package_bundles_v1";
 
   assert.match(index, new RegExp(`customer-app\\.css\\?v=${build}`));
   assert.match(index, new RegExp(`modules\\/api\\.js\\?v=${build}`));
@@ -329,7 +329,7 @@ test("Customer App build id is consistent across shell and service worker", () =
 test("store module is loaded in index.html and precached in the service worker app shell", () => {
   const index = read("customer-app/index.html");
   const sw = read("customer-app/sw.js");
-  const build = "20260808_homepage_service_packages_v2";
+  const build = "20260809_store_service_package_bundles_v1";
 
   assert.match(index, new RegExp(`modules/store\\.js\\?v=${build}`));
   assert.match(sw, /`\.\/modules\/store\.js\?v=\$\{BUILD_ID\}`/);

--- a/test/customerAppRecovery.test.js
+++ b/test/customerAppRecovery.test.js
@@ -311,7 +311,7 @@ test("Customer App build id is consistent across shell and service worker", () =
   const sw = read("customer-app/sw.js");
   const app = read("customer-app/assets/customer-app.js");
   const manifest = read("customer-app/manifest.webmanifest");
-  const build = "20260809_issue267_admin_builder_v2";
+  const build = "20260809_issue267_merchandising_v3";
 
   assert.match(index, new RegExp(`customer-app\\.css\\?v=${build}`));
   assert.match(index, new RegExp(`modules\\/api\\.js\\?v=${build}`));
@@ -329,7 +329,7 @@ test("Customer App build id is consistent across shell and service worker", () =
 test("store module is loaded in index.html and precached in the service worker app shell", () => {
   const index = read("customer-app/index.html");
   const sw = read("customer-app/sw.js");
-  const build = "20260809_issue267_admin_builder_v2";
+  const build = "20260809_issue267_merchandising_v3";
 
   assert.match(index, new RegExp(`modules/store\\.js\\?v=${build}`));
   assert.match(sw, /`\.\/modules\/store\.js\?v=\$\{BUILD_ID\}`/);

--- a/test/customerAppRecovery.test.js
+++ b/test/customerAppRecovery.test.js
@@ -124,10 +124,34 @@ class FakeButton {
   }
   getAttribute(name) { return this.attrs[name] || ""; }
   hasAttribute(name) { return Object.prototype.hasOwnProperty.call(this.attrs, name); }
+  setAttribute(name, value) { this.attrs[name] = String(value); }
+  removeAttribute(name) { delete this.attrs[name]; }
   addEventListener(type, listener) { this.listeners[type] = listener; }
   async click() {
     if (this.listeners.click) await this.listeners.click({ preventDefault() {} });
   }
+}
+
+function stubOrdinaryCatalogQuotes(root, items) {
+  root.api.quoteCatalogBooking = async ({ catalog_item_id, booking_mode }) => {
+    const item = items.find((candidate) => Number(candidate.item_id) === Number(catalog_item_id));
+    const mapped = root.services.catalogItemToCommerceDraft(item);
+    assert.ok(mapped, "test fixture must map to an ordinary booking draft");
+    const total = Number(item.display_price || item.base_price || 0).toFixed(2);
+    return {
+      kind: "bookable",
+      catalog_item_id: Number(item.item_id),
+      booking_mode,
+      fixed_total_price: total,
+      unit_price: total,
+      normal_unit_price: total,
+      duration_minutes: 45,
+      machine_count: 1,
+      price_label: "Server quote",
+      campaign_name: "",
+      service: { ...mapped.draft },
+    };
+  };
 }
 
 class HomeContainer {
@@ -311,7 +335,7 @@ test("Customer App build id is consistent across shell and service worker", () =
   const sw = read("customer-app/sw.js");
   const app = read("customer-app/assets/customer-app.js");
   const manifest = read("customer-app/manifest.webmanifest");
-  const build = "20260809_issue267_catalog_flow_v7";
+  const build = "20260809_issue267_catalog_flow_v8";
 
   assert.match(index, new RegExp(`customer-app\\.css\\?v=${build}`));
   assert.match(index, new RegExp(`modules\\/api\\.js\\?v=${build}`));
@@ -329,7 +353,7 @@ test("Customer App build id is consistent across shell and service worker", () =
 test("store module is loaded in index.html and precached in the service worker app shell", () => {
   const index = read("customer-app/index.html");
   const sw = read("customer-app/sw.js");
-  const build = "20260809_issue267_catalog_flow_v7";
+  const build = "20260809_issue267_catalog_flow_v8";
 
   assert.match(index, new RegExp(`modules/store\\.js\\?v=${build}`));
   assert.match(sw, /`\.\/modules\/store\.js\?v=\$\{BUILD_ID\}`/);
@@ -2277,12 +2301,14 @@ test("product detail escapes hostile text in description, highlight, and image a
 test("clicking a bookable card's book button prefills the real scheduled draft from the catalog item's booking fields", async () => {
   const context = makeContext();
   const root = loadCustomerFrontend(context);
-  root.api.loadCatalogItems = async () => [
+  const items = [
     {
       item_id: 1, item_name: "ล้างแอร์แขวนพรีเมียม", item_category: "ล้างแอร์", base_price: 900, unit_label: "เครื่อง",
       booking_mode: "bookable", booking_ac_type: "แขวน", booking_btu: 18000, booking_wash_variant: "ล้างพรีเมียม",
     },
   ];
+  root.api.loadCatalogItems = async () => items;
+  stubOrdinaryCatalogQuotes(root, items);
 
   const container = new FakeMount();
   root.store.render(container);
@@ -2655,6 +2681,7 @@ test("BTU/spec variant selector routes to the sibling's own detail URL on select
   let listCalls = 0;
   root.api.loadCatalogItem = async (id) => { detailCalls += 1; return itemsById.get(String(id)); };
   root.api.loadCatalogItems = async () => { listCalls += 1; return items; };
+  stubOrdinaryCatalogQuotes(root, items);
 
   const container = new FakeMount();
   root.store.renderDetail(container);
@@ -2836,6 +2863,7 @@ test("legacy rows with no booking_wash_variant resolve ล้างปกติ/
   const itemsById = new Map(items.map((it) => [String(it.item_id), it]));
   root.api.loadCatalogItem = async (id) => itemsById.get(String(id));
   root.api.loadCatalogItems = async () => items;
+  stubOrdinaryCatalogQuotes(root, items);
 
   const container = new FakeMount();
   root.store.renderDetail(container);
@@ -3122,6 +3150,7 @@ test("store funnel analytics: cwf_store_begin_booking and cwf_store_contact_admi
     { item_id: 302, item_name: "ติดตั้งแอร์ใหม่", booking_mode: "contact", display_price: 0, base_price: 0 },
   ];
   root.api.loadCatalogItems = async () => items;
+  stubOrdinaryCatalogQuotes(root, items);
 
   const container = new FakeMount();
   root.store.render(container);

--- a/test/customerAppRecovery.test.js
+++ b/test/customerAppRecovery.test.js
@@ -335,7 +335,7 @@ test("Customer App build id is consistent across shell and service worker", () =
   const sw = read("customer-app/sw.js");
   const app = read("customer-app/assets/customer-app.js");
   const manifest = read("customer-app/manifest.webmanifest");
-  const build = "20260809_issue267_catalog_flow_v8";
+  const build = "20260809_issue267_catalog_flow_v9";
 
   assert.match(index, new RegExp(`customer-app\\.css\\?v=${build}`));
   assert.match(index, new RegExp(`modules\\/api\\.js\\?v=${build}`));
@@ -353,7 +353,7 @@ test("Customer App build id is consistent across shell and service worker", () =
 test("store module is loaded in index.html and precached in the service worker app shell", () => {
   const index = read("customer-app/index.html");
   const sw = read("customer-app/sw.js");
-  const build = "20260809_issue267_catalog_flow_v8";
+  const build = "20260809_issue267_catalog_flow_v9";
 
   assert.match(index, new RegExp(`modules/store\\.js\\?v=${build}`));
   assert.match(sw, /`\.\/modules\/store\.js\?v=\$\{BUILD_ID\}`/);

--- a/test/customerAppRecovery.test.js
+++ b/test/customerAppRecovery.test.js
@@ -311,7 +311,7 @@ test("Customer App build id is consistent across shell and service worker", () =
   const sw = read("customer-app/sw.js");
   const app = read("customer-app/assets/customer-app.js");
   const manifest = read("customer-app/manifest.webmanifest");
-  const build = "20260809_issue267_catalog_flow_v6";
+  const build = "20260809_issue267_catalog_flow_v7";
 
   assert.match(index, new RegExp(`customer-app\\.css\\?v=${build}`));
   assert.match(index, new RegExp(`modules\\/api\\.js\\?v=${build}`));
@@ -329,7 +329,7 @@ test("Customer App build id is consistent across shell and service worker", () =
 test("store module is loaded in index.html and precached in the service worker app shell", () => {
   const index = read("customer-app/index.html");
   const sw = read("customer-app/sw.js");
-  const build = "20260809_issue267_catalog_flow_v6";
+  const build = "20260809_issue267_catalog_flow_v7";
 
   assert.match(index, new RegExp(`modules/store\\.js\\?v=${build}`));
   assert.match(sw, /`\.\/modules\/store\.js\?v=\$\{BUILD_ID\}`/);

--- a/test/customerAppRecovery.test.js
+++ b/test/customerAppRecovery.test.js
@@ -311,7 +311,7 @@ test("Customer App build id is consistent across shell and service worker", () =
   const sw = read("customer-app/sw.js");
   const app = read("customer-app/assets/customer-app.js");
   const manifest = read("customer-app/manifest.webmanifest");
-  const build = "20260809_store_service_package_bundles_v1";
+  const build = "20260809_issue267_admin_builder_v2";
 
   assert.match(index, new RegExp(`customer-app\\.css\\?v=${build}`));
   assert.match(index, new RegExp(`modules\\/api\\.js\\?v=${build}`));
@@ -329,7 +329,7 @@ test("Customer App build id is consistent across shell and service worker", () =
 test("store module is loaded in index.html and precached in the service worker app shell", () => {
   const index = read("customer-app/index.html");
   const sw = read("customer-app/sw.js");
-  const build = "20260809_store_service_package_bundles_v1";
+  const build = "20260809_issue267_admin_builder_v2";
 
   assert.match(index, new RegExp(`modules/store\\.js\\?v=${build}`));
   assert.match(sw, /`\.\/modules\/store\.js\?v=\$\{BUILD_ID\}`/);

--- a/test/customerAppRecovery.test.js
+++ b/test/customerAppRecovery.test.js
@@ -311,7 +311,7 @@ test("Customer App build id is consistent across shell and service worker", () =
   const sw = read("customer-app/sw.js");
   const app = read("customer-app/assets/customer-app.js");
   const manifest = read("customer-app/manifest.webmanifest");
-  const build = "20260809_issue267_merchandising_v3";
+  const build = "20260809_issue267_heading_cleanup_v4";
 
   assert.match(index, new RegExp(`customer-app\\.css\\?v=${build}`));
   assert.match(index, new RegExp(`modules\\/api\\.js\\?v=${build}`));
@@ -329,7 +329,7 @@ test("Customer App build id is consistent across shell and service worker", () =
 test("store module is loaded in index.html and precached in the service worker app shell", () => {
   const index = read("customer-app/index.html");
   const sw = read("customer-app/sw.js");
-  const build = "20260809_issue267_merchandising_v3";
+  const build = "20260809_issue267_heading_cleanup_v4";
 
   assert.match(index, new RegExp(`modules/store\\.js\\?v=${build}`));
   assert.match(sw, /`\.\/modules\/store\.js\?v=\$\{BUILD_ID\}`/);

--- a/test/customerAppRecovery.test.js
+++ b/test/customerAppRecovery.test.js
@@ -311,7 +311,7 @@ test("Customer App build id is consistent across shell and service worker", () =
   const sw = read("customer-app/sw.js");
   const app = read("customer-app/assets/customer-app.js");
   const manifest = read("customer-app/manifest.webmanifest");
-  const build = "20260809_issue267_booking_ticket_v5";
+  const build = "20260809_issue267_catalog_flow_v6";
 
   assert.match(index, new RegExp(`customer-app\\.css\\?v=${build}`));
   assert.match(index, new RegExp(`modules\\/api\\.js\\?v=${build}`));
@@ -329,7 +329,7 @@ test("Customer App build id is consistent across shell and service worker", () =
 test("store module is loaded in index.html and precached in the service worker app shell", () => {
   const index = read("customer-app/index.html");
   const sw = read("customer-app/sw.js");
-  const build = "20260809_issue267_booking_ticket_v5";
+  const build = "20260809_issue267_catalog_flow_v6";
 
   assert.match(index, new RegExp(`modules/store\\.js\\?v=${build}`));
   assert.match(sw, /`\.\/modules\/store\.js\?v=\$\{BUILD_ID\}`/);

--- a/test/customerAppStorePayment.test.js
+++ b/test/customerAppStorePayment.test.js
@@ -58,7 +58,7 @@ test("store falls back to the LINE hand-off when payment is unconfigured or the 
 test("payment step styles exist and the Customer App payment build id is bumped", () => {
   assert.match(cssSrc, /\.pay-method-btn/);
   assert.match(cssSrc, /\.pay-qr-img/);
-  assert.match(read("customer-app/index.html"), /modules\/store\.js\?v=20260809_issue267_booking_ticket_v5/);
-  assert.match(read("customer-app/sw.js"), /BUILD_ID = "20260809_issue267_booking_ticket_v5"/);
+  assert.match(read("customer-app/index.html"), /modules\/store\.js\?v=20260809_issue267_catalog_flow_v6/);
+  assert.match(read("customer-app/sw.js"), /BUILD_ID = "20260809_issue267_catalog_flow_v6"/);
   assert.match(storeSrc, /payment-security 20260705 loaded/);
 });

--- a/test/customerAppStorePayment.test.js
+++ b/test/customerAppStorePayment.test.js
@@ -58,7 +58,7 @@ test("store falls back to the LINE hand-off when payment is unconfigured or the 
 test("payment step styles exist and the Customer App payment build id is bumped", () => {
   assert.match(cssSrc, /\.pay-method-btn/);
   assert.match(cssSrc, /\.pay-qr-img/);
-  assert.match(read("customer-app/index.html"), /modules\/store\.js\?v=20260809_store_service_package_bundles_v1/);
-  assert.match(read("customer-app/sw.js"), /BUILD_ID = "20260809_store_service_package_bundles_v1"/);
+  assert.match(read("customer-app/index.html"), /modules\/store\.js\?v=20260809_issue267_admin_builder_v2/);
+  assert.match(read("customer-app/sw.js"), /BUILD_ID = "20260809_issue267_admin_builder_v2"/);
   assert.match(storeSrc, /payment-security 20260705 loaded/);
 });

--- a/test/customerAppStorePayment.test.js
+++ b/test/customerAppStorePayment.test.js
@@ -58,7 +58,7 @@ test("store falls back to the LINE hand-off when payment is unconfigured or the 
 test("payment step styles exist and the Customer App payment build id is bumped", () => {
   assert.match(cssSrc, /\.pay-method-btn/);
   assert.match(cssSrc, /\.pay-qr-img/);
-  assert.match(read("customer-app/index.html"), /modules\/store\.js\?v=20260809_issue267_heading_cleanup_v4/);
-  assert.match(read("customer-app/sw.js"), /BUILD_ID = "20260809_issue267_heading_cleanup_v4"/);
+  assert.match(read("customer-app/index.html"), /modules\/store\.js\?v=20260809_issue267_booking_ticket_v5/);
+  assert.match(read("customer-app/sw.js"), /BUILD_ID = "20260809_issue267_booking_ticket_v5"/);
   assert.match(storeSrc, /payment-security 20260705 loaded/);
 });

--- a/test/customerAppStorePayment.test.js
+++ b/test/customerAppStorePayment.test.js
@@ -58,7 +58,7 @@ test("store falls back to the LINE hand-off when payment is unconfigured or the 
 test("payment step styles exist and the Customer App payment build id is bumped", () => {
   assert.match(cssSrc, /\.pay-method-btn/);
   assert.match(cssSrc, /\.pay-qr-img/);
-  assert.match(read("customer-app/index.html"), /modules\/store\.js\?v=20260809_issue267_merchandising_v3/);
-  assert.match(read("customer-app/sw.js"), /BUILD_ID = "20260809_issue267_merchandising_v3"/);
+  assert.match(read("customer-app/index.html"), /modules\/store\.js\?v=20260809_issue267_heading_cleanup_v4/);
+  assert.match(read("customer-app/sw.js"), /BUILD_ID = "20260809_issue267_heading_cleanup_v4"/);
   assert.match(storeSrc, /payment-security 20260705 loaded/);
 });

--- a/test/customerAppStorePayment.test.js
+++ b/test/customerAppStorePayment.test.js
@@ -58,7 +58,7 @@ test("store falls back to the LINE hand-off when payment is unconfigured or the 
 test("payment step styles exist and the Customer App payment build id is bumped", () => {
   assert.match(cssSrc, /\.pay-method-btn/);
   assert.match(cssSrc, /\.pay-qr-img/);
-  assert.match(read("customer-app/index.html"), /modules\/store\.js\?v=20260809_issue267_catalog_flow_v6/);
-  assert.match(read("customer-app/sw.js"), /BUILD_ID = "20260809_issue267_catalog_flow_v6"/);
+  assert.match(read("customer-app/index.html"), /modules\/store\.js\?v=20260809_issue267_catalog_flow_v7/);
+  assert.match(read("customer-app/sw.js"), /BUILD_ID = "20260809_issue267_catalog_flow_v7"/);
   assert.match(storeSrc, /payment-security 20260705 loaded/);
 });

--- a/test/customerAppStorePayment.test.js
+++ b/test/customerAppStorePayment.test.js
@@ -58,7 +58,7 @@ test("store falls back to the LINE hand-off when payment is unconfigured or the 
 test("payment step styles exist and the Customer App payment build id is bumped", () => {
   assert.match(cssSrc, /\.pay-method-btn/);
   assert.match(cssSrc, /\.pay-qr-img/);
-  assert.match(read("customer-app/index.html"), /modules\/store\.js\?v=20260809_issue267_catalog_flow_v7/);
-  assert.match(read("customer-app/sw.js"), /BUILD_ID = "20260809_issue267_catalog_flow_v7"/);
+  assert.match(read("customer-app/index.html"), /modules\/store\.js\?v=20260809_issue267_catalog_flow_v8/);
+  assert.match(read("customer-app/sw.js"), /BUILD_ID = "20260809_issue267_catalog_flow_v8"/);
   assert.match(storeSrc, /payment-security 20260705 loaded/);
 });

--- a/test/customerAppStorePayment.test.js
+++ b/test/customerAppStorePayment.test.js
@@ -58,7 +58,7 @@ test("store falls back to the LINE hand-off when payment is unconfigured or the 
 test("payment step styles exist and the Customer App payment build id is bumped", () => {
   assert.match(cssSrc, /\.pay-method-btn/);
   assert.match(cssSrc, /\.pay-qr-img/);
-  assert.match(read("customer-app/index.html"), /modules\/store\.js\?v=20260728_urgent_dispatch_preflight_v2/);
-  assert.match(read("customer-app/sw.js"), /BUILD_ID = "20260728_urgent_dispatch_preflight_v2"/);
+  assert.match(read("customer-app/index.html"), /modules\/store\.js\?v=20260809_store_service_package_bundles_v1/);
+  assert.match(read("customer-app/sw.js"), /BUILD_ID = "20260809_store_service_package_bundles_v1"/);
   assert.match(storeSrc, /payment-security 20260705 loaded/);
 });

--- a/test/customerAppStorePayment.test.js
+++ b/test/customerAppStorePayment.test.js
@@ -58,7 +58,7 @@ test("store falls back to the LINE hand-off when payment is unconfigured or the 
 test("payment step styles exist and the Customer App payment build id is bumped", () => {
   assert.match(cssSrc, /\.pay-method-btn/);
   assert.match(cssSrc, /\.pay-qr-img/);
-  assert.match(read("customer-app/index.html"), /modules\/store\.js\?v=20260809_issue267_catalog_flow_v8/);
-  assert.match(read("customer-app/sw.js"), /BUILD_ID = "20260809_issue267_catalog_flow_v8"/);
+  assert.match(read("customer-app/index.html"), /modules\/store\.js\?v=20260809_issue267_catalog_flow_v9/);
+  assert.match(read("customer-app/sw.js"), /BUILD_ID = "20260809_issue267_catalog_flow_v9"/);
   assert.match(storeSrc, /payment-security 20260705 loaded/);
 });

--- a/test/customerAppStorePayment.test.js
+++ b/test/customerAppStorePayment.test.js
@@ -58,7 +58,7 @@ test("store falls back to the LINE hand-off when payment is unconfigured or the 
 test("payment step styles exist and the Customer App payment build id is bumped", () => {
   assert.match(cssSrc, /\.pay-method-btn/);
   assert.match(cssSrc, /\.pay-qr-img/);
-  assert.match(read("customer-app/index.html"), /modules\/store\.js\?v=20260809_issue267_admin_builder_v2/);
-  assert.match(read("customer-app/sw.js"), /BUILD_ID = "20260809_issue267_admin_builder_v2"/);
+  assert.match(read("customer-app/index.html"), /modules\/store\.js\?v=20260809_issue267_merchandising_v3/);
+  assert.match(read("customer-app/sw.js"), /BUILD_ID = "20260809_issue267_merchandising_v3"/);
   assert.match(storeSrc, /payment-security 20260705 loaded/);
 });

--- a/test/customerBookingAdminNotifications.test.js
+++ b/test/customerBookingAdminNotifications.test.js
@@ -312,10 +312,10 @@ test("admin/customer frontend cache versions are bumped for booking notification
   assert.doesNotMatch(adminReviewHtml, /admin-review-v2\.js\?v=20260707_customer_booking_notify_v2/);
   assert.match(adminReviewHtml, /admin-review-ai-intake\.js\?v=ai-booking-intake-customer-cards-v11-admin-alert-gate/);
   assert.doesNotMatch(adminReviewHtml, /admin-review-ai-intake\.js\?v=ai-booking-intake-customer-cards-v10/);
-  assert.match(customerIndex, /bookingScheduled\.js\?v=20260808_homepage_service_packages_v2/);
-  assert.match(customerIndex, /state\.js\?v=20260808_homepage_service_packages_v2/);
-  assert.match(customerSw, /const BUILD_ID = "20260808_homepage_service_packages_v2"/);
-  assert.match(customerManifest, /20260808_homepage_service_packages_v2/);
+  assert.match(customerIndex, /bookingScheduled\.js\?v=20260809_store_service_package_bundles_v1/);
+  assert.match(customerIndex, /state\.js\?v=20260809_store_service_package_bundles_v1/);
+  assert.match(customerSw, /const BUILD_ID = "20260809_store_service_package_bundles_v1"/);
+  assert.match(customerManifest, /20260809_store_service_package_bundles_v1/);
 });
 
 test("behavior: review queue only includes customer urgent waiting rows while preserving review statuses", () => {

--- a/test/customerBookingAdminNotifications.test.js
+++ b/test/customerBookingAdminNotifications.test.js
@@ -312,10 +312,10 @@ test("admin/customer frontend cache versions are bumped for booking notification
   assert.doesNotMatch(adminReviewHtml, /admin-review-v2\.js\?v=20260707_customer_booking_notify_v2/);
   assert.match(adminReviewHtml, /admin-review-ai-intake\.js\?v=ai-booking-intake-customer-cards-v11-admin-alert-gate/);
   assert.doesNotMatch(adminReviewHtml, /admin-review-ai-intake\.js\?v=ai-booking-intake-customer-cards-v10/);
-  assert.match(customerIndex, /bookingScheduled\.js\?v=20260809_issue267_heading_cleanup_v4/);
-  assert.match(customerIndex, /state\.js\?v=20260809_issue267_heading_cleanup_v4/);
-  assert.match(customerSw, /const BUILD_ID = "20260809_issue267_heading_cleanup_v4"/);
-  assert.match(customerManifest, /20260809_issue267_heading_cleanup_v4/);
+  assert.match(customerIndex, /bookingScheduled\.js\?v=20260809_issue267_booking_ticket_v5/);
+  assert.match(customerIndex, /state\.js\?v=20260809_issue267_booking_ticket_v5/);
+  assert.match(customerSw, /const BUILD_ID = "20260809_issue267_booking_ticket_v5"/);
+  assert.match(customerManifest, /20260809_issue267_booking_ticket_v5/);
 });
 
 test("behavior: review queue only includes customer urgent waiting rows while preserving review statuses", () => {

--- a/test/customerBookingAdminNotifications.test.js
+++ b/test/customerBookingAdminNotifications.test.js
@@ -312,10 +312,10 @@ test("admin/customer frontend cache versions are bumped for booking notification
   assert.doesNotMatch(adminReviewHtml, /admin-review-v2\.js\?v=20260707_customer_booking_notify_v2/);
   assert.match(adminReviewHtml, /admin-review-ai-intake\.js\?v=ai-booking-intake-customer-cards-v11-admin-alert-gate/);
   assert.doesNotMatch(adminReviewHtml, /admin-review-ai-intake\.js\?v=ai-booking-intake-customer-cards-v10/);
-  assert.match(customerIndex, /bookingScheduled\.js\?v=20260809_issue267_booking_ticket_v5/);
-  assert.match(customerIndex, /state\.js\?v=20260809_issue267_booking_ticket_v5/);
-  assert.match(customerSw, /const BUILD_ID = "20260809_issue267_booking_ticket_v5"/);
-  assert.match(customerManifest, /20260809_issue267_booking_ticket_v5/);
+  assert.match(customerIndex, /bookingScheduled\.js\?v=20260809_issue267_catalog_flow_v6/);
+  assert.match(customerIndex, /state\.js\?v=20260809_issue267_catalog_flow_v6/);
+  assert.match(customerSw, /const BUILD_ID = "20260809_issue267_catalog_flow_v6"/);
+  assert.match(customerManifest, /20260809_issue267_catalog_flow_v6/);
 });
 
 test("behavior: review queue only includes customer urgent waiting rows while preserving review statuses", () => {

--- a/test/customerBookingAdminNotifications.test.js
+++ b/test/customerBookingAdminNotifications.test.js
@@ -312,10 +312,10 @@ test("admin/customer frontend cache versions are bumped for booking notification
   assert.doesNotMatch(adminReviewHtml, /admin-review-v2\.js\?v=20260707_customer_booking_notify_v2/);
   assert.match(adminReviewHtml, /admin-review-ai-intake\.js\?v=ai-booking-intake-customer-cards-v11-admin-alert-gate/);
   assert.doesNotMatch(adminReviewHtml, /admin-review-ai-intake\.js\?v=ai-booking-intake-customer-cards-v10/);
-  assert.match(customerIndex, /bookingScheduled\.js\?v=20260809_issue267_catalog_flow_v6/);
-  assert.match(customerIndex, /state\.js\?v=20260809_issue267_catalog_flow_v6/);
-  assert.match(customerSw, /const BUILD_ID = "20260809_issue267_catalog_flow_v6"/);
-  assert.match(customerManifest, /20260809_issue267_catalog_flow_v6/);
+  assert.match(customerIndex, /bookingScheduled\.js\?v=20260809_issue267_catalog_flow_v7/);
+  assert.match(customerIndex, /state\.js\?v=20260809_issue267_catalog_flow_v7/);
+  assert.match(customerSw, /const BUILD_ID = "20260809_issue267_catalog_flow_v7"/);
+  assert.match(customerManifest, /20260809_issue267_catalog_flow_v7/);
 });
 
 test("behavior: review queue only includes customer urgent waiting rows while preserving review statuses", () => {

--- a/test/customerBookingAdminNotifications.test.js
+++ b/test/customerBookingAdminNotifications.test.js
@@ -312,10 +312,10 @@ test("admin/customer frontend cache versions are bumped for booking notification
   assert.doesNotMatch(adminReviewHtml, /admin-review-v2\.js\?v=20260707_customer_booking_notify_v2/);
   assert.match(adminReviewHtml, /admin-review-ai-intake\.js\?v=ai-booking-intake-customer-cards-v11-admin-alert-gate/);
   assert.doesNotMatch(adminReviewHtml, /admin-review-ai-intake\.js\?v=ai-booking-intake-customer-cards-v10/);
-  assert.match(customerIndex, /bookingScheduled\.js\?v=20260809_issue267_catalog_flow_v8/);
-  assert.match(customerIndex, /state\.js\?v=20260809_issue267_catalog_flow_v8/);
-  assert.match(customerSw, /const BUILD_ID = "20260809_issue267_catalog_flow_v8"/);
-  assert.match(customerManifest, /20260809_issue267_catalog_flow_v8/);
+  assert.match(customerIndex, /bookingScheduled\.js\?v=20260809_issue267_catalog_flow_v9/);
+  assert.match(customerIndex, /state\.js\?v=20260809_issue267_catalog_flow_v9/);
+  assert.match(customerSw, /const BUILD_ID = "20260809_issue267_catalog_flow_v9"/);
+  assert.match(customerManifest, /20260809_issue267_catalog_flow_v9/);
 });
 
 test("behavior: review queue only includes customer urgent waiting rows while preserving review statuses", () => {

--- a/test/customerBookingAdminNotifications.test.js
+++ b/test/customerBookingAdminNotifications.test.js
@@ -312,10 +312,10 @@ test("admin/customer frontend cache versions are bumped for booking notification
   assert.doesNotMatch(adminReviewHtml, /admin-review-v2\.js\?v=20260707_customer_booking_notify_v2/);
   assert.match(adminReviewHtml, /admin-review-ai-intake\.js\?v=ai-booking-intake-customer-cards-v11-admin-alert-gate/);
   assert.doesNotMatch(adminReviewHtml, /admin-review-ai-intake\.js\?v=ai-booking-intake-customer-cards-v10/);
-  assert.match(customerIndex, /bookingScheduled\.js\?v=20260809_issue267_admin_builder_v2/);
-  assert.match(customerIndex, /state\.js\?v=20260809_issue267_admin_builder_v2/);
-  assert.match(customerSw, /const BUILD_ID = "20260809_issue267_admin_builder_v2"/);
-  assert.match(customerManifest, /20260809_issue267_admin_builder_v2/);
+  assert.match(customerIndex, /bookingScheduled\.js\?v=20260809_issue267_merchandising_v3/);
+  assert.match(customerIndex, /state\.js\?v=20260809_issue267_merchandising_v3/);
+  assert.match(customerSw, /const BUILD_ID = "20260809_issue267_merchandising_v3"/);
+  assert.match(customerManifest, /20260809_issue267_merchandising_v3/);
 });
 
 test("behavior: review queue only includes customer urgent waiting rows while preserving review statuses", () => {

--- a/test/customerBookingAdminNotifications.test.js
+++ b/test/customerBookingAdminNotifications.test.js
@@ -312,10 +312,10 @@ test("admin/customer frontend cache versions are bumped for booking notification
   assert.doesNotMatch(adminReviewHtml, /admin-review-v2\.js\?v=20260707_customer_booking_notify_v2/);
   assert.match(adminReviewHtml, /admin-review-ai-intake\.js\?v=ai-booking-intake-customer-cards-v11-admin-alert-gate/);
   assert.doesNotMatch(adminReviewHtml, /admin-review-ai-intake\.js\?v=ai-booking-intake-customer-cards-v10/);
-  assert.match(customerIndex, /bookingScheduled\.js\?v=20260809_issue267_merchandising_v3/);
-  assert.match(customerIndex, /state\.js\?v=20260809_issue267_merchandising_v3/);
-  assert.match(customerSw, /const BUILD_ID = "20260809_issue267_merchandising_v3"/);
-  assert.match(customerManifest, /20260809_issue267_merchandising_v3/);
+  assert.match(customerIndex, /bookingScheduled\.js\?v=20260809_issue267_heading_cleanup_v4/);
+  assert.match(customerIndex, /state\.js\?v=20260809_issue267_heading_cleanup_v4/);
+  assert.match(customerSw, /const BUILD_ID = "20260809_issue267_heading_cleanup_v4"/);
+  assert.match(customerManifest, /20260809_issue267_heading_cleanup_v4/);
 });
 
 test("behavior: review queue only includes customer urgent waiting rows while preserving review statuses", () => {

--- a/test/customerBookingAdminNotifications.test.js
+++ b/test/customerBookingAdminNotifications.test.js
@@ -312,10 +312,10 @@ test("admin/customer frontend cache versions are bumped for booking notification
   assert.doesNotMatch(adminReviewHtml, /admin-review-v2\.js\?v=20260707_customer_booking_notify_v2/);
   assert.match(adminReviewHtml, /admin-review-ai-intake\.js\?v=ai-booking-intake-customer-cards-v11-admin-alert-gate/);
   assert.doesNotMatch(adminReviewHtml, /admin-review-ai-intake\.js\?v=ai-booking-intake-customer-cards-v10/);
-  assert.match(customerIndex, /bookingScheduled\.js\?v=20260809_store_service_package_bundles_v1/);
-  assert.match(customerIndex, /state\.js\?v=20260809_store_service_package_bundles_v1/);
-  assert.match(customerSw, /const BUILD_ID = "20260809_store_service_package_bundles_v1"/);
-  assert.match(customerManifest, /20260809_store_service_package_bundles_v1/);
+  assert.match(customerIndex, /bookingScheduled\.js\?v=20260809_issue267_admin_builder_v2/);
+  assert.match(customerIndex, /state\.js\?v=20260809_issue267_admin_builder_v2/);
+  assert.match(customerSw, /const BUILD_ID = "20260809_issue267_admin_builder_v2"/);
+  assert.match(customerManifest, /20260809_issue267_admin_builder_v2/);
 });
 
 test("behavior: review queue only includes customer urgent waiting rows while preserving review statuses", () => {

--- a/test/customerBookingAdminNotifications.test.js
+++ b/test/customerBookingAdminNotifications.test.js
@@ -312,10 +312,10 @@ test("admin/customer frontend cache versions are bumped for booking notification
   assert.doesNotMatch(adminReviewHtml, /admin-review-v2\.js\?v=20260707_customer_booking_notify_v2/);
   assert.match(adminReviewHtml, /admin-review-ai-intake\.js\?v=ai-booking-intake-customer-cards-v11-admin-alert-gate/);
   assert.doesNotMatch(adminReviewHtml, /admin-review-ai-intake\.js\?v=ai-booking-intake-customer-cards-v10/);
-  assert.match(customerIndex, /bookingScheduled\.js\?v=20260809_issue267_catalog_flow_v7/);
-  assert.match(customerIndex, /state\.js\?v=20260809_issue267_catalog_flow_v7/);
-  assert.match(customerSw, /const BUILD_ID = "20260809_issue267_catalog_flow_v7"/);
-  assert.match(customerManifest, /20260809_issue267_catalog_flow_v7/);
+  assert.match(customerIndex, /bookingScheduled\.js\?v=20260809_issue267_catalog_flow_v8/);
+  assert.match(customerIndex, /state\.js\?v=20260809_issue267_catalog_flow_v8/);
+  assert.match(customerSw, /const BUILD_ID = "20260809_issue267_catalog_flow_v8"/);
+  assert.match(customerManifest, /20260809_issue267_catalog_flow_v8/);
 });
 
 test("behavior: review queue only includes customer urgent waiting rows while preserving review statuses", () => {

--- a/test/customerBookingKillSwitch.test.js
+++ b/test/customerBookingKillSwitch.test.js
@@ -89,7 +89,7 @@ test("scheduled idempotency is payload-bound and checked before the availability
   // Reusing a key with a different payload is a 409, never a silent old-job return.
   assert.match(bookHandler, /code: "IDEMPOTENCY_KEY_REUSED"/);
   // Both the pre-flight and the in-transaction race path use the SAME full match.
-  assert.equal((bookHandler.match(/scheduledPayloadMatchesExisting\(pool, /g) || []).length, 2);
+  assert.equal((bookHandler.match(/scheduledPayloadMatchesExisting\(pool, /g) || []).length, 3);
 });
 
 test("idempotency payload comparison covers every canonical material field", () => {

--- a/test/customerBookingMutationCharacterization.test.js
+++ b/test/customerBookingMutationCharacterization.test.js
@@ -623,6 +623,9 @@ dbTest("real PostgreSQL: scheduled retry replays the same job without duplicate 
   assert.equal(replay.statusCode, 200);
   assert.equal(replay.body.replayed, true);
   assert.equal(replay.body.job_id, first.body.job_id);
+  assert.deepEqual(replay.body.booking_ticket, first.body.booking_ticket);
+  assert.equal(first.body.booking_ticket.customer_phone, body.customer_phone.replace(/\D/g, ""));
+  assert.doesNotMatch(JSON.stringify(first.body.booking_ticket), /job_id|booking_token|package_id|tier_id|snapshot|address|maps/i);
   assert.equal(Number((await pool.query(`SELECT COUNT(*) FROM public.jobs`)).rows[0].count), 1);
   assert.equal(Number((await pool.query(`SELECT COUNT(*) FROM public.job_items`)).rows[0].count), 1);
 });
@@ -686,6 +689,9 @@ dbTest("real PostgreSQL: public urgent creates one offer set and notifies only a
   assert.equal(Object.hasOwn(first.body, "offers_count"), false);
   assert.equal(replay.body.replayed, true);
   assert.equal(replay.body.booking_code, first.body.booking_code);
+  assert.deepEqual(replay.body.booking_ticket, first.body.booking_ticket);
+  assert.equal(first.body.booking_ticket.public_status, "กำลังค้นหาช่าง");
+  assert.doesNotMatch(JSON.stringify(first.body.booking_ticket), /job_id|booking_token|package_id|tier_id|snapshot|address|maps/i);
   assert.equal(Number((await pool.query(`SELECT COUNT(*) FROM public.jobs`)).rows[0].count), 1);
   assert.equal(Number((await pool.query(`SELECT COUNT(*) FROM public.job_offers`)).rows[0].count), 2);
   assert.equal(Number((await pool.query(`SELECT COUNT(*) FROM public.job_assignments`)).rows[0].count), 0);

--- a/test/customerBookingMutationCharacterization.test.js
+++ b/test/customerBookingMutationCharacterization.test.js
@@ -22,6 +22,7 @@ const { loadCustomerScheduledLoadMap } = require("../server/services/public/cust
 const { registerPublicCustomerBookingRoutes } = require("../server/routes/public/customerBookings");
 const { registerAdminBookingRoutes } = require("../server/routes/admin/adminBookings");
 const urgentPublicAdapterBase = require("../server/services/urgentPublicAdapter");
+const { resolveCatalogBookingPolicy, buildCatalogBookingItem } = require("../server/services/booking/catalogBookingPolicy");
 
 const REPO_ROOT = path.resolve(__dirname, "..");
 
@@ -72,6 +73,7 @@ test("public/admin/internal routes and urgent alias preserve registration and no
     async handleAdminBookV2(req, res) { calls.push(["admin", req.body]); return res.json({ ok: true }); },
     async handleAdminServicePackageList(_req, res) { return res.json({ service_packages: [] }); },
     async handleAdminServicePackagePreview(_req, res) { return res.json({}); },
+    async handleAdminCatalogBookingPreview(_req, res) { return res.json({}); },
     async handleInternalBookFromAi(req, res) { calls.push(["internal", req.body]); return res.json({ ok: true }); },
   };
   const requireAdminSession = () => {};
@@ -85,20 +87,22 @@ test("public/admin/internal routes and urgent alias preserve registration and no
     "/admin/book_v2",
     "/admin/service-packages",
     "/admin/service-packages/preview",
+    "/admin/catalog-booking-preview",
     "/admin/urgent_broadcast_v2",
     "/internal/book_from_ai",
   ]);
   assert.equal(registrations[2].handlers[0], requireAdminSession);
   assert.equal(registrations[5].handlers[0], requireAdminSession);
-  assert.equal(registrations[6].handlers[0], requireInternalApiKeyOnly);
+  assert.equal(registrations[6].handlers[0], requireAdminSession);
+  assert.equal(registrations[7].handlers[0], requireInternalApiKeyOnly);
 
   const res = responseHarness();
-  await registrations[5].handlers.at(-1)({ body: { customer_name: "Alias" } }, res);
+  await registrations[6].handlers.at(-1)({ body: { customer_name: "Alias" } }, res);
   assert.equal(calls.at(-1)[0], "admin");
   assert.equal(calls.at(-1)[1].booking_mode, "urgent");
   assert.equal(calls.at(-1)[1].dispatch_mode, "offer");
 
-  await registrations[6].handlers.at(-1)({ body: { customer_name: "AI" } }, res);
+  await registrations[7].handlers.at(-1)({ body: { customer_name: "AI" } }, res);
   assert.equal(calls.at(-1)[0], "internal");
 });
 
@@ -195,7 +199,7 @@ test.before(async () => {
     DROP TABLE IF EXISTS public.technician_special_slots_v2, public.technician_workdays_v2,
       public.technician_monthly_work_calendar, public.technician_service_matrix,
       public.job_updates_v2, public.job_units, public.job_promotions, public.job_offers, public.job_assignments,
-      public.job_team_members, public.job_items, public.catalog_items,
+      public.job_team_members, public.job_items, public.catalog_items, public.customer_service_price_rules,
       public.technician_profiles, public.users, public.jobs CASCADE
   `);
   await pool.query(`
@@ -231,6 +235,9 @@ test.before(async () => {
       ,approved_by_admin TEXT
       ,approved_at TIMESTAMPTZ
       ,cancel_reason TEXT
+      ,catalog_item_id BIGINT
+      ,admin_request_key TEXT
+      ,admin_request_fingerprint TEXT
     )
   `);
   await pool.query(`
@@ -275,7 +282,18 @@ test.before(async () => {
     )
   `);
   await pool.query(`CREATE TABLE public.job_updates_v2 (update_id BIGSERIAL PRIMARY KEY, job_id BIGINT, action TEXT, payload_json JSONB)`);
-  await pool.query(`CREATE TABLE public.catalog_items (item_id BIGSERIAL PRIMARY KEY, item_name TEXT, base_price NUMERIC, is_active BOOLEAN, is_customer_visible BOOLEAN)`);
+  await pool.query(`CREATE TABLE public.customer_service_price_rules (
+    rule_id BIGSERIAL PRIMARY KEY, job_type TEXT, ac_type TEXT, wash_variant TEXT,
+    btu_min INT, btu_max INT, machine_min INT, machine_max INT,
+    normal_price NUMERIC(12,2), active_price NUMERIC(12,2), label TEXT, campaign_name TEXT,
+    effective_from TIMESTAMPTZ, effective_to TIMESTAMPTZ, is_active BOOLEAN
+  )`);
+  await pool.query(`CREATE TABLE public.catalog_items (
+    item_id BIGSERIAL PRIMARY KEY, item_name TEXT, base_price NUMERIC(12,2),
+    job_category TEXT, booking_mode TEXT, booking_flow_policy TEXT,
+    booking_ac_type TEXT, booking_btu INT, booking_wash_variant TEXT,
+    price_rule_id BIGINT, is_active BOOLEAN, is_customer_visible BOOLEAN
+  )`);
   await pool.query(`CREATE TABLE public.users (username TEXT PRIMARY KEY, role TEXT)`);
   await pool.query(`
     CREATE TABLE public.technician_profiles (
@@ -318,7 +336,7 @@ test.after(async () => {
     DROP TABLE IF EXISTS public.technician_special_slots_v2, public.technician_workdays_v2,
       public.technician_monthly_work_calendar, public.technician_service_matrix,
       public.job_updates_v2, public.job_units, public.job_promotions, public.job_offers, public.job_assignments,
-      public.job_team_members, public.job_items, public.catalog_items,
+      public.job_team_members, public.job_items, public.catalog_items, public.customer_service_price_rules,
       public.technician_profiles, public.users, public.jobs CASCADE
   `);
   await pool.end();
@@ -329,7 +347,7 @@ test.beforeEach(async () => {
   await pool.query(`TRUNCATE public.technician_special_slots_v2, public.technician_workdays_v2,
     public.technician_monthly_work_calendar, public.technician_service_matrix,
     public.job_updates_v2, public.job_units, public.job_promotions, public.job_offers, public.job_assignments,
-    public.job_team_members, public.job_items, public.catalog_items,
+    public.job_team_members, public.job_items, public.catalog_items, public.customer_service_price_rules,
     public.technician_profiles, public.users, public.jobs RESTART IDENTITY CASCADE`);
 });
 
@@ -339,6 +357,42 @@ function dbTest(name, fn) {
     return fn(t);
   });
 }
+
+dbTest("real PostgreSQL: selected catalog policy locks its parent and preserves exact campaign price", async () => {
+  const rule = await pool.query(
+    `INSERT INTO public.customer_service_price_rules
+      (job_type,ac_type,wash_variant,btu_min,btu_max,machine_min,machine_max,normal_price,active_price,label,campaign_name,effective_from,effective_to,is_active)
+     VALUES ('wash','cassette','',18000,NULL,1,NULL,950.00,699.00,'TEST exact','TEST selected catalog','2000-01-01','2099-12-31',TRUE)
+     RETURNING rule_id`
+  );
+  const item = await pool.query(
+    `INSERT INTO public.catalog_items
+      (item_name,base_price,job_category,booking_mode,booking_flow_policy,booking_ac_type,booking_btu,booking_wash_variant,price_rule_id,is_active,is_customer_visible)
+     VALUES ('TEST Catalog Cassette',850.00,'wash','bookable','scheduled_and_urgent','cassette',24000,'',$1,TRUE,TRUE)
+     RETURNING item_id`,
+    [rule.rows[0].rule_id]
+  );
+  const client = await pool.connect();
+  try {
+    await client.query("BEGIN");
+    const resolved = await resolveCatalogBookingPolicy(client, {
+      catalogItemId: item.rows[0].item_id, bookingMode: "urgent", jobType: "wash",
+      acType: "cassette", btu: 24000, washVariant: "", machineCount: 2,
+    }, { identity: "customer", lock: true });
+    assert.equal(resolved.pricing.unit_price, "699.00");
+    assert.equal(resolved.pricing.exact_total, "1398.00");
+    assert.equal(typeof resolved.pricing.exact_total, "string");
+    assert.deepEqual(buildCatalogBookingItem(resolved), {
+      item_id: null, item_name: "TEST Catalog Cassette", qty: 2, unit_price: "699.00", line_total: "1398.00",
+      is_service: true, customer_price_rule_id: Number(rule.rows[0].rule_id), normal_unit_price: "950.00",
+      customer_price_label: "TEST exact", customer_campaign_name: "TEST selected catalog",
+      customer_price_source: "catalog_price_rule",
+    });
+    await client.query("ROLLBACK");
+  } finally {
+    client.release();
+  }
+});
 
 function makeDependencies(overrides = {}) {
   let bookingCodeSequence = 0;

--- a/test/customerBookingMutationCharacterization.test.js
+++ b/test/customerBookingMutationCharacterization.test.js
@@ -23,6 +23,8 @@ const { registerPublicCustomerBookingRoutes } = require("../server/routes/public
 const { registerAdminBookingRoutes } = require("../server/routes/admin/adminBookings");
 const urgentPublicAdapterBase = require("../server/services/urgentPublicAdapter");
 const { resolveCatalogBookingPolicy, buildCatalogBookingItem } = require("../server/services/booking/catalogBookingPolicy");
+const { calcBookingPricing } = require("../server/services/booking/exactPricing");
+const { createServicePackageResolver } = require("../server/services/packages/servicePackageResolver");
 
 const REPO_ROOT = path.resolve(__dirname, "..");
 
@@ -199,7 +201,8 @@ test.before(async () => {
     DROP TABLE IF EXISTS public.technician_special_slots_v2, public.technician_workdays_v2,
       public.technician_monthly_work_calendar, public.technician_service_matrix,
       public.job_updates_v2, public.job_units, public.job_promotions, public.job_offers, public.job_assignments,
-      public.job_team_members, public.job_items, public.catalog_items, public.customer_service_price_rules,
+      public.job_team_members, public.job_items, public.service_package_tiers, public.service_packages,
+      public.catalog_items, public.customer_service_price_rules,
       public.technician_profiles, public.users, public.jobs CASCADE
   `);
   await pool.query(`
@@ -255,7 +258,10 @@ test.before(async () => {
       normal_unit_price NUMERIC,
       customer_price_label TEXT,
       customer_campaign_name TEXT,
-      customer_price_source TEXT
+      customer_price_source TEXT,
+      service_package_id BIGINT,
+      service_package_tier_id BIGINT,
+      service_package_snapshot JSONB
     )
   `);
   await pool.query(`CREATE TABLE public.job_team_members (job_id BIGINT, username TEXT, is_primary BOOLEAN, UNIQUE(job_id, username))`);
@@ -292,7 +298,21 @@ test.before(async () => {
     item_id BIGSERIAL PRIMARY KEY, item_name TEXT, base_price NUMERIC(12,2),
     job_category TEXT, booking_mode TEXT, booking_flow_policy TEXT,
     booking_ac_type TEXT, booking_btu INT, booking_wash_variant TEXT,
-    price_rule_id BIGINT, is_active BOOLEAN, is_customer_visible BOOLEAN
+    price_rule_id BIGINT, is_active BOOLEAN, is_customer_visible BOOLEAN,
+    service_bundle_key TEXT, service_package_sell_start_at TIMESTAMPTZ,
+    service_package_sell_end_at TIMESTAMPTZ, service_package_redeem_until TIMESTAMPTZ
+  )`);
+  await pool.query(`CREATE TABLE public.service_packages (
+    service_package_id BIGSERIAL PRIMARY KEY, package_key TEXT UNIQUE, display_name TEXT,
+    description TEXT, service_key TEXT, service_name TEXT, job_type TEXT, ac_type TEXT,
+    wash_variant TEXT, btu_min INT, btu_max INT, service_unit_duration_minutes INT,
+    sell_start_at TIMESTAMPTZ, sell_end_at TIMESTAMPTZ, redeem_until TIMESTAMPTZ,
+    is_active BOOLEAN, is_customer_visible BOOLEAN, catalog_item_id BIGINT, sort_order INT DEFAULT 0
+  )`);
+  await pool.query(`CREATE TABLE public.service_package_tiers (
+    service_package_tier_id BIGSERIAL PRIMARY KEY, service_package_id BIGINT,
+    tier_key TEXT, display_name TEXT, service_quantity INT, fixed_total_price NUMERIC(12,2),
+    sort_order INT DEFAULT 0, is_active BOOLEAN
   )`);
   await pool.query(`CREATE TABLE public.users (username TEXT PRIMARY KEY, role TEXT)`);
   await pool.query(`
@@ -336,7 +356,8 @@ test.after(async () => {
     DROP TABLE IF EXISTS public.technician_special_slots_v2, public.technician_workdays_v2,
       public.technician_monthly_work_calendar, public.technician_service_matrix,
       public.job_updates_v2, public.job_units, public.job_promotions, public.job_offers, public.job_assignments,
-      public.job_team_members, public.job_items, public.catalog_items, public.customer_service_price_rules,
+      public.job_team_members, public.job_items, public.service_package_tiers, public.service_packages,
+      public.catalog_items, public.customer_service_price_rules,
       public.technician_profiles, public.users, public.jobs CASCADE
   `);
   await pool.end();
@@ -347,7 +368,8 @@ test.beforeEach(async () => {
   await pool.query(`TRUNCATE public.technician_special_slots_v2, public.technician_workdays_v2,
     public.technician_monthly_work_calendar, public.technician_service_matrix,
     public.job_updates_v2, public.job_units, public.job_promotions, public.job_offers, public.job_assignments,
-    public.job_team_members, public.job_items, public.catalog_items, public.customer_service_price_rules,
+    public.job_team_members, public.job_items, public.service_package_tiers, public.service_packages,
+    public.catalog_items, public.customer_service_price_rules,
     public.technician_profiles, public.users, public.jobs RESTART IDENTITY CASCADE`);
 });
 
@@ -415,10 +437,7 @@ function makeDependencies(overrides = {}) {
     parseLatLngFromText: () => null,
     resolveMapsUrlToLatLng: async () => null,
     expireTechnicianAcceptStatuses: async () => {},
-    calcPricing: (items) => {
-      const subtotal = items.reduce((sum, item) => sum + Number(item.line_total || 0), 0);
-      return { subtotal, discount: 0, total: subtotal };
-    },
+    calcPricing: calcBookingPricing,
     rankTechniciansForServiceZone: (rows) => rows,
     buildOffMapForDate: async () => new Map(),
     isTechOffOnDate: () => false,
@@ -445,6 +464,7 @@ function makeDependencies(overrides = {}) {
     },
     publicCustomerAvailabilityDeps: () => ({}),
     findBestCustomerPromotion: async () => ({ promo: null, discount: 0 }),
+    createServicePackageResolver: (db) => createServicePackageResolver({ db }),
     availabilityEngine: {
       buildCriteriaList: (payload) => [{ job: "wash", ac: payload.ac_type || "wall", wash: payload.wash_variant || "normal" }],
       validateCriteriaList: () => true,
@@ -473,6 +493,69 @@ function makeDependencies(overrides = {}) {
     ...overrides,
   };
 }
+
+dbTest("real PostgreSQL: Admin package exact total persists through transaction, HTTP response, and replay", async () => {
+  const parent = await pool.query(
+    `INSERT INTO public.catalog_items
+      (item_name,base_price,job_category,booking_mode,booking_flow_policy,is_active,is_customer_visible,
+       service_bundle_key,service_package_sell_start_at,service_package_sell_end_at,service_package_redeem_until)
+     VALUES ('TEST Exact Bundle',0.00,'wash','service_package','scheduled_and_urgent',TRUE,TRUE,
+       'test-exact-bundle','2026-08-01','2026-08-31','2027-01-31') RETURNING item_id`
+  );
+  const packageRow = await pool.query(
+    `INSERT INTO public.service_packages
+      (package_key,display_name,service_key,service_name,job_type,ac_type,wash_variant,btu_min,btu_max,
+       service_unit_duration_minutes,is_active,is_customer_visible,catalog_item_id,sort_order)
+     VALUES ('test-exact-q4','TEST Exact Variant','test-exact-service','TEST Exact Service','wash','wall','premium',
+       NULL,12000,45,TRUE,TRUE,$1,0) RETURNING service_package_id`,
+    [parent.rows[0].item_id]
+  );
+  await pool.query(
+    `INSERT INTO public.service_package_tiers
+      (service_package_id,tier_key,display_name,service_quantity,fixed_total_price,sort_order,is_active)
+     VALUES ($1,'test-q4','TEST 4 units',4,1399.50,0,TRUE)`,
+    [packageRow.rows[0].service_package_id]
+  );
+
+  const service = createBookingJobService(makeDependencies());
+  const request = {
+    customer_name: "TEST Admin Exact",
+    customer_phone: "0812345678",
+    appointment_datetime: "2026-08-20T10:00:00+07:00",
+    address_text: "TEST isolated PostgreSQL",
+    booking_mode: "scheduled",
+    dispatch_mode: "normal",
+    assign_mode: "single",
+    technician_username: "tech-exact",
+    tech_type: "company",
+    admin_request_key: "admin-exact-package-q4-0001",
+    service_package_groups: [{ package_key: "test-exact-q4", btu: 12000, quantity: 4 }],
+  };
+  const initial = await invoke(service.handleAdminBookV2, request);
+  const replay = await invoke(service.handleAdminBookV2, request);
+
+  assert.equal(initial.statusCode, 200);
+  assert.equal(initial.body.total_exact, "1399.50");
+  assert.equal(initial.body.subtotal_exact, "1399.50");
+  assert.equal(initial.body.discount_exact, "0.00");
+  assert.equal(replay.statusCode, 200);
+  assert.equal(replay.body.replayed, true);
+  assert.equal(replay.body.job_id, initial.body.job_id);
+  assert.equal(replay.body.booking_code, initial.body.booking_code);
+  assert.equal(replay.body.total_exact, "1399.50");
+
+  const jobs = await pool.query("SELECT job_price::text AS total FROM public.jobs WHERE admin_request_key=$1", [request.admin_request_key]);
+  const lines = await pool.query(
+    `SELECT qty::int AS quantity, line_total::text AS total, service_package_snapshot
+       FROM public.job_items WHERE job_id=$1`,
+    [initial.body.job_id]
+  );
+  assert.deepEqual(jobs.rows, [{ total: "1399.50" }]);
+  assert.equal(lines.rows.length, 1);
+  assert.equal(lines.rows[0].quantity, 4);
+  assert.equal(lines.rows[0].total, "1399.50");
+  assert.equal(lines.rows[0].service_package_snapshot.fixed_total_price, "1399.50");
+});
 
 async function seedTechnicians() {
   await pool.query(`INSERT INTO public.users (username, role) VALUES ('tech-a','technician'),('tech-b','technician')`);
@@ -608,7 +691,7 @@ dbTest("real PostgreSQL: public scheduled success preserves response, status, it
   assert.deepEqual(Object.keys(result.body), [
     "success", "job_id", "booking_code", "token", "booking_mode", "dispatch_mode",
     "offers_count", "urgent_offer_enabled", "duration_min", "effective_block_min",
-    "travel_buffer_min", "applied_promo", "base_total",
+    "travel_buffer_min", "applied_promo", "base_total", "base_total_exact", "net_total", "booking_ticket",
   ]);
   assert.equal(result.body.booking_mode, "scheduled");
   assert.equal(result.body.base_total, 600);

--- a/test/customerBookingPendingApproval.test.js
+++ b/test/customerBookingPendingApproval.test.js
@@ -128,7 +128,7 @@ test("Admin Add and Queue no longer call public forced availability", () => {
 });
 
 test("changed Admin booking scripts have one shared cache-bust build", () => {
-  assert.match(read("admin-add-v2.html"), /admin-add-v2\.js\?v=20260807_admin_service_packages_v1/);
+  assert.match(read("admin-add-v2.html"), /admin-add-v2\.js\?v=20260809_issue267_catalog_flow_v2/);
   assert.match(read("admin-queue-v2.html"), /admin-queue-v2\.js\?v=20260719_customer_booking_pr3_v1/);
   assert.match(read("admin-review-v2.html"), /admin-review-v2\.js\?v=20260726_urgent_preferred_time_gps_v1/);
 });

--- a/test/customerBookingPendingApproval.test.js
+++ b/test/customerBookingPendingApproval.test.js
@@ -128,7 +128,7 @@ test("Admin Add and Queue no longer call public forced availability", () => {
 });
 
 test("changed Admin booking scripts have one shared cache-bust build", () => {
-  assert.match(read("admin-add-v2.html"), /admin-add-v2\.js\?v=20260809_issue267_catalog_flow_v2/);
+  assert.match(read("admin-add-v2.html"), /admin-add-v2\.js\?v=20260809_issue267_catalog_flow_v8/);
   assert.match(read("admin-queue-v2.html"), /admin-queue-v2\.js\?v=20260719_customer_booking_pr3_v1/);
   assert.match(read("admin-review-v2.html"), /admin-review-v2\.js\?v=20260726_urgent_preferred_time_gps_v1/);
 });

--- a/test/customerBookingPendingApproval.test.js
+++ b/test/customerBookingPendingApproval.test.js
@@ -128,9 +128,7 @@ test("Admin Add and Queue no longer call public forced availability", () => {
 });
 
 test("changed Admin booking scripts have one shared cache-bust build", () => {
-  const pr3Build = "20260719_customer_booking_pr3_v1";
-  for (const page of ["admin-add-v2", "admin-queue-v2"]) {
-    assert.match(read(`${page}.html`), new RegExp(`${page}\\.js\\?v=${pr3Build}`));
-  }
+  assert.match(read("admin-add-v2.html"), /admin-add-v2\.js\?v=20260807_admin_service_packages_v1/);
+  assert.match(read("admin-queue-v2.html"), /admin-queue-v2\.js\?v=20260719_customer_booking_pr3_v1/);
   assert.match(read("admin-review-v2.html"), /admin-review-v2\.js\?v=20260726_urgent_preferred_time_gps_v1/);
 });

--- a/test/customerBookingProductionCopy.test.js
+++ b/test/customerBookingProductionCopy.test.js
@@ -5,7 +5,7 @@ const path = require("node:path");
 const vm = require("node:vm");
 
 const ROOT = path.resolve(__dirname, "..");
-const BUILD = "20260808_homepage_service_packages_v2";
+const BUILD = "20260809_store_service_package_bundles_v1";
 
 function read(relativePath) {
   return fs.readFileSync(path.join(ROOT, relativePath), "utf8");

--- a/test/customerBookingProductionCopy.test.js
+++ b/test/customerBookingProductionCopy.test.js
@@ -5,7 +5,7 @@ const path = require("node:path");
 const vm = require("node:vm");
 
 const ROOT = path.resolve(__dirname, "..");
-const BUILD = "20260809_issue267_booking_ticket_v5";
+const BUILD = "20260809_issue267_catalog_flow_v6";
 
 function read(relativePath) {
   return fs.readFileSync(path.join(ROOT, relativePath), "utf8");

--- a/test/customerBookingProductionCopy.test.js
+++ b/test/customerBookingProductionCopy.test.js
@@ -5,7 +5,7 @@ const path = require("node:path");
 const vm = require("node:vm");
 
 const ROOT = path.resolve(__dirname, "..");
-const BUILD = "20260809_issue267_heading_cleanup_v4";
+const BUILD = "20260809_issue267_booking_ticket_v5";
 
 function read(relativePath) {
   return fs.readFileSync(path.join(ROOT, relativePath), "utf8");

--- a/test/customerBookingProductionCopy.test.js
+++ b/test/customerBookingProductionCopy.test.js
@@ -5,7 +5,7 @@ const path = require("node:path");
 const vm = require("node:vm");
 
 const ROOT = path.resolve(__dirname, "..");
-const BUILD = "20260809_issue267_admin_builder_v2";
+const BUILD = "20260809_issue267_merchandising_v3";
 
 function read(relativePath) {
   return fs.readFileSync(path.join(ROOT, relativePath), "utf8");

--- a/test/customerBookingProductionCopy.test.js
+++ b/test/customerBookingProductionCopy.test.js
@@ -5,7 +5,7 @@ const path = require("node:path");
 const vm = require("node:vm");
 
 const ROOT = path.resolve(__dirname, "..");
-const BUILD = "20260809_issue267_catalog_flow_v8";
+const BUILD = "20260809_issue267_catalog_flow_v9";
 
 function read(relativePath) {
   return fs.readFileSync(path.join(ROOT, relativePath), "utf8");

--- a/test/customerBookingProductionCopy.test.js
+++ b/test/customerBookingProductionCopy.test.js
@@ -5,7 +5,7 @@ const path = require("node:path");
 const vm = require("node:vm");
 
 const ROOT = path.resolve(__dirname, "..");
-const BUILD = "20260809_store_service_package_bundles_v1";
+const BUILD = "20260809_issue267_admin_builder_v2";
 
 function read(relativePath) {
   return fs.readFileSync(path.join(ROOT, relativePath), "utf8");

--- a/test/customerBookingProductionCopy.test.js
+++ b/test/customerBookingProductionCopy.test.js
@@ -5,7 +5,7 @@ const path = require("node:path");
 const vm = require("node:vm");
 
 const ROOT = path.resolve(__dirname, "..");
-const BUILD = "20260809_issue267_catalog_flow_v7";
+const BUILD = "20260809_issue267_catalog_flow_v8";
 
 function read(relativePath) {
   return fs.readFileSync(path.join(ROOT, relativePath), "utf8");

--- a/test/customerBookingProductionCopy.test.js
+++ b/test/customerBookingProductionCopy.test.js
@@ -5,7 +5,7 @@ const path = require("node:path");
 const vm = require("node:vm");
 
 const ROOT = path.resolve(__dirname, "..");
-const BUILD = "20260809_issue267_catalog_flow_v6";
+const BUILD = "20260809_issue267_catalog_flow_v7";
 
 function read(relativePath) {
   return fs.readFileSync(path.join(ROOT, relativePath), "utf8");

--- a/test/customerBookingProductionCopy.test.js
+++ b/test/customerBookingProductionCopy.test.js
@@ -5,7 +5,7 @@ const path = require("node:path");
 const vm = require("node:vm");
 
 const ROOT = path.resolve(__dirname, "..");
-const BUILD = "20260809_issue267_merchandising_v3";
+const BUILD = "20260809_issue267_heading_cleanup_v4";
 
 function read(relativePath) {
   return fs.readFileSync(path.join(ROOT, relativePath), "utf8");

--- a/test/customerBookingTicketUi.test.js
+++ b/test/customerBookingTicketUi.test.js
@@ -3,21 +3,113 @@
 const test = require("node:test");
 const assert = require("node:assert/strict");
 const fs = require("node:fs");
+const vm = require("node:vm");
 
+const ticketModule = fs.readFileSync("customer-app/modules/bookingTicket.js", "utf8");
 const scheduled = fs.readFileSync("customer-app/modules/bookingScheduled.js", "utf8");
 const urgent = fs.readFileSync("customer-app/modules/bookingUrgent.js", "utf8");
 const css = fs.readFileSync("customer-app/assets/customer-app.css", "utf8");
+const index = fs.readFileSync("customer-app/index.html", "utf8");
+const sw = fs.readFileSync("customer-app/sw.js", "utf8");
 
-test("scheduled and urgent success screens use only server ticket DTO and explicit LINE handoff", () => {
+function loadTicketModule({ secure = true, writeText = async () => {} } = {}) {
+  const writes = [];
+  const navigator = {
+    clipboard: writeText === null ? undefined : {
+      async writeText(value) {
+        writes.push(value);
+        return writeText(value);
+      },
+    },
+  };
+  const window = { CWFCustomerAppV2: {}, isSecureContext: secure };
+  vm.runInNewContext(ticketModule, { window, navigator }, { filename: "bookingTicket.js" });
+  return { api: window.CWFCustomerAppV2.bookingTicket, writes };
+}
+
+function safeTicket(overrides = {}) {
+  return {
+    heading: "untrusted heading is ignored",
+    booking_code: "CWF-TEST-267",
+    customer_name: "TEST Customer\nสถานะ: forged",
+    customer_phone: "0812345678",
+    components: [
+      { label: "TEST Small 12000 BTU", quantity: 2, package_id: 7, snapshot: { secret: true } },
+      { label: "TEST Large 18000 BTU", quantity: 2, tier_id: 8 },
+    ],
+    total_machine_count: 4,
+    appointment_datetime: "2026-08-10T02:00:00.000Z",
+    exact_total: "3198.00",
+    public_status: "รอแอดมินยืนยัน",
+    job_id: 99,
+    booking_token: "secret-token",
+    address_text: "secret address",
+    maps_url: "https://maps.example/secret",
+    ...overrides,
+  };
+}
+
+test("shared formatter uses only the safe server ticket DTO for ordinary/composite/mixed bookings", () => {
+  const { api } = loadTicketModule();
+  const text = api.formatText(safeTicket());
+  assert.equal(api.lineUrl, "https://lin.ee/fG1Oq7y");
+  assert.match(text, /^CWF BOOKING TICKET\n/);
+  assert.match(text, /รหัสการจอง: CWF-TEST-267/);
+  assert.match(text, /ชื่อผู้ติดต่อ: TEST Customer สถานะ: forged\n/);
+  assert.match(text, /TEST Small 12000 BTU x 2/);
+  assert.match(text, /TEST Large 18000 BTU x 2/);
+  assert.match(text, /จำนวนรวม: 4 เครื่อง/);
+  assert.match(text, /ยอดยืนยันจากระบบ: 3198\.00 บาท/);
+  assert.match(text, /ผู้ส่งยืนยันว่า LINE บัญชีนี้เป็นผู้ติดต่อ/);
+  assert.doesNotMatch(text, /untrusted heading|job_id|booking_token|package_id|tier_id|snapshot|secret-token|secret address|maps\.example/);
+});
+
+test("clipboard success and unsupported/denied/insecure fallbacks are deterministic", async () => {
+  const expected = loadTicketModule().api.formatText(safeTicket());
+
+  const success = loadTicketModule();
+  const successResult = await success.api.copyText(expected);
+  assert.equal(successResult.status, "copied");
+  assert.equal(successResult.error, "");
+  assert.deepEqual(success.writes, [expected]);
+
+  const unsupported = loadTicketModule({ writeText: null });
+  assert.equal((await unsupported.api.copyText(expected)).status, "manual");
+  assert.deepEqual(unsupported.writes, []);
+
+  const denied = loadTicketModule({ writeText: async () => { throw new Error("permission denied"); } });
+  assert.equal((await denied.api.copyText(expected)).status, "manual");
+  assert.equal(denied.writes.length, 1);
+
+  const insecure = loadTicketModule({ secure: false });
+  assert.equal((await insecure.api.copyText(expected)).status, "manual");
+  assert.deepEqual(insecure.writes, []);
+});
+
+test("scheduled and urgent success actions cannot call booking APIs and reveal LINE only after copy", () => {
   for (const source of [scheduled, urgent]) {
-    assert.match(source, /result(?:\?|\.)?\.booking_ticket|result\.booking_ticket/);
+    assert.match(source, /root\.bookingTicket\?\.formatText\?\./);
     assert.match(source, /คัดลอก Ticket ส่งให้แอดมิน/);
     assert.match(source, /Ticket มีชื่อและเบอร์โทร/);
-    assert.match(source, /https:\/\/lin\.ee\/fG1Oq7y/);
-    assert.match(source, /navigator\.clipboard\?\.writeText/);
+    assert.match(source, /copied \? '<a class="primary-btn" href="https:\/\/lin\.ee\/fG1Oq7y"/);
     assert.match(source, /readonly/);
     assert.match(source, /aria-live="polite"/);
-    assert.doesNotMatch(source, /ticket[^\n]*(?:job_id|booking_token|address_text|maps_url|snapshot)/i);
+    const start = source.indexOf('action === "copy-booking-ticket"');
+    assert.ok(start >= 0);
+    const block = source.slice(start, start + 1800);
+    assert.match(block, /root\.bookingTicket\.copyText/);
+    assert.doesNotMatch(block, /submitScheduledBooking|submitUrgentRequest|\/public\/book|root\.api/);
   }
+  assert.doesNotMatch(ticketModule, /root\.api|fetch\(|XMLHttpRequest|booking_token|job_id|address_text|maps_url|snapshot/);
+});
+
+test("ticket handoff keeps tracking/new-booking actions, 44px controls, mobile layout, and PWA wiring", () => {
+  assert.match(scheduled, /data-action="track-created"/);
+  assert.match(scheduled, /data-action="new-cleaning-booking"/);
+  assert.match(urgent, /data-urgent-action="track-created"/);
   assert.match(css, /\.booking-ticket-handoff[\s\S]*min-height:\s*44px/);
+  assert.match(css, /@media \(max-width:\s*390px\)[\s\S]*\.booking-ticket-handoff/);
+  assert.match(css, /@media \(max-width:\s*360px\)[\s\S]*\.booking-ticket-handoff/);
+  assert.match(index, /modules\/bookingTicket\.js\?v=/);
+  assert.match(sw, /modules\/bookingTicket\.js\?v=\$\{BUILD_ID\}/);
 });

--- a/test/customerBookingTicketUi.test.js
+++ b/test/customerBookingTicketUi.test.js
@@ -11,6 +11,8 @@ const urgent = fs.readFileSync("customer-app/modules/bookingUrgent.js", "utf8");
 const css = fs.readFileSync("customer-app/assets/customer-app.css", "utf8");
 const index = fs.readFileSync("customer-app/index.html", "utf8");
 const sw = fs.readFileSync("customer-app/sw.js", "utf8");
+const manifest = fs.readFileSync("customer-app/manifest.webmanifest", "utf8");
+const appEntry = fs.readFileSync("customer-app/assets/customer-app.js", "utf8");
 
 function loadTicketModule({ secure = true, writeText = async () => {} } = {}) {
   const writes = [];
@@ -86,12 +88,25 @@ test("clipboard success and unsupported/denied/insecure fallbacks are determinis
   assert.deepEqual(insecure.writes, []);
 });
 
-test("scheduled and urgent success actions cannot call booking APIs and reveal LINE only after copy", () => {
+test("success and replay use one server-confirmed exact net total without browser discount math", () => {
+  const { api } = loadTicketModule();
+  const initial = { base_total: 1399.5, base_total_exact: "1399.50", net_total: "1299.95",
+    booking_ticket: safeTicket({ exact_total: "1299.95" }) };
+  const replay = { ...initial, replayed: true };
+  assert.equal(api.confirmedNetTotal(initial), "1299.95");
+  assert.equal(api.confirmedNetTotal(replay), "1299.95");
+  assert.equal(api.confirmedNetTotal({ base_total: 1399.5, booking_ticket: safeTicket({ exact_total: "1299.95" }) }), "1299.95");
+  assert.doesNotMatch(scheduled, /formatBaht\(result\.base_total\)/);
+  assert.match(scheduled, /confirmedNetTotal\?\.\(result\)/);
+});
+
+test("scheduled and urgent success actions cannot call booking APIs and keep LINE available during manual fallback", () => {
   for (const source of [scheduled, urgent]) {
     assert.match(source, /root\.bookingTicket\?\.formatText\?\./);
     assert.match(source, /คัดลอก Ticket ส่งให้แอดมิน/);
     assert.match(source, /Ticket มีชื่อและเบอร์โทร/);
-    assert.match(source, /copied \? '<a class="primary-btn" href="https:\/\/lin\.ee\/fG1Oq7y"/);
+    assert.match(source, /<a class="primary-btn" href="https:\/\/lin\.ee\/fG1Oq7y"/);
+    assert.doesNotMatch(source, /copied \? '<a class="primary-btn" href="https:\/\/lin\.ee\/fG1Oq7y"/);
     assert.match(source, /readonly/);
     assert.match(source, /aria-live="polite"/);
     const start = source.indexOf('action === "copy-booking-ticket"');
@@ -112,4 +127,8 @@ test("ticket handoff keeps tracking/new-booking actions, 44px controls, mobile l
   assert.match(css, /@media \(max-width:\s*360px\)[\s\S]*\.booking-ticket-handoff/);
   assert.match(index, /modules\/bookingTicket\.js\?v=/);
   assert.match(sw, /modules\/bookingTicket\.js\?v=\$\{BUILD_ID\}/);
+  for (const source of [index, sw, manifest, appEntry]) {
+    assert.match(source, /20260809_issue267_catalog_flow_v8/);
+    assert.doesNotMatch(source, /20260809_issue267_catalog_flow_v7/);
+  }
 });

--- a/test/customerBookingTicketUi.test.js
+++ b/test/customerBookingTicketUi.test.js
@@ -51,6 +51,149 @@ function safeTicket(overrides = {}) {
   };
 }
 
+function escapeHtml(value) {
+  return String(value ?? "")
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#039;");
+}
+
+function moduleWithTicketState(source, status, error = "") {
+  const initial = 'let ticketCopyState = { status: "idle", error: "" };';
+  assert.equal(source.includes(initial), true, "ticket state initializer must stay testable");
+  return source.replace(
+    initial,
+    `let ticketCopyState = { status: ${JSON.stringify(status)}, error: ${JSON.stringify(error)} };`
+  );
+}
+
+function renderScheduledTicketState(status, error = "") {
+  const { api } = loadTicketModule();
+  const root = {
+    state: {
+      draft: {
+        scheduled: {
+          date: "2026-08-10",
+          selectedSlot: { date: "2026-08-10", start: "09:00", end: "09:45" },
+        },
+      },
+      scheduledSubmit: {
+        result: {
+          booking_code: "CWF-TEST-267",
+          token: "public-tracking-key",
+          duration_min: 45,
+          net_total: "3198.00",
+          booking_ticket: safeTicket(),
+        },
+      },
+      scheduledPreview: { pricing: { data: null }, package: { data: null } },
+    },
+    bookingTicket: api,
+    utils: { escapeHtml },
+    services: { normalizeServiceLines: () => [], bookableBtuOptions: [] },
+    availability: { bangkokTodayYmd: () => "2026-08-09" },
+  };
+  const window = { CWFCustomerAppV2: root };
+  vm.runInNewContext(moduleWithTicketState(scheduled, status, error), { window, console }, {
+    filename: "bookingScheduled.js",
+  });
+  return root.bookingScheduled._test.renderSuccess();
+}
+
+function renderUrgentTicketState(status, error = "") {
+  const { api } = loadTicketModule();
+  const serviceLine = {
+    line_id: "line-1",
+    job_type: "wash",
+    ac_type: "wall",
+    btu: 12000,
+    machine_count: 1,
+    wash_variant: "standard",
+    repair_variant: "",
+  };
+  const services = {
+    normalizeServiceLine(input = {}) {
+      return { ...serviceLine, ...input, line_id: input.line_id || serviceLine.line_id };
+    },
+    normalizeCompositeServiceLine(input = {}) {
+      return services.normalizeServiceLine(input);
+    },
+    normalizeServiceLines(source = {}) {
+      return (source.services || [serviceLine]).map((line) => services.normalizeServiceLine(line));
+    },
+    serviceLabel: () => "TEST wall wash 12000 BTU",
+    payloadFromServiceLines: () => null,
+    payloadFromCompositeServiceLines: () => null,
+  };
+  const root = {
+    state: {
+      draft: {
+        urgent: {
+          date: "2026-08-10",
+          time: "09:00",
+          services: [serviceLine],
+          service_package_groups: [],
+        },
+      },
+      urgentFlow: {
+        result: {
+          booking_code: "CWF-TEST-267",
+          token: "public-tracking-key",
+          net_total: "3198.00",
+          booking_ticket: safeTicket(),
+        },
+        liveStatus: { can_cancel: false },
+        liveStatusError: "",
+      },
+      updateDraft(scope, patch) {
+        Object.assign(this.draft[scope], patch);
+      },
+      setUrgentFlow(patch) {
+        Object.assign(this.urgentFlow, patch);
+      },
+    },
+    bookingTicket: api,
+    utils: { escapeHtml },
+    services,
+    customerCopy: {
+      urgentSubmittedView: () => ({
+        state: "terminal",
+        cardClass: "is-success",
+        mark: "OK",
+        kicker: "TEST",
+        title: "TEST submitted",
+        boxClass: "is-success",
+        message: "TEST confirmed",
+        detail: "TEST detail",
+        statusLabel: "TEST status",
+        showAdminContact: false,
+      }),
+    },
+  };
+  const window = { CWFCustomerAppV2: root };
+  vm.runInNewContext(moduleWithTicketState(urgent, status, error), { window, console }, {
+    filename: "bookingUrgent.js",
+  });
+  return root.bookingUrgent._test.renderSubmitted(root.customerCopy.urgentSubmittedView());
+}
+
+function assertTicketState(html, status, textareaId) {
+  if (status === "idle" || status === "copying") {
+    assert.doesNotMatch(html, /href="https:\/\/lin\.ee\/fG1Oq7y"/);
+    assert.doesNotMatch(html, new RegExp(`id="${textareaId}"`));
+    return;
+  }
+  assert.match(html, /href="https:\/\/lin\.ee\/fG1Oq7y"/);
+  if (status === "manual") {
+    assert.match(html, new RegExp(`<textarea id="${textareaId}"[^>]*readonly`));
+    assert.match(html, /CWF BOOKING TICKET/);
+  } else {
+    assert.doesNotMatch(html, new RegExp(`id="${textareaId}"`));
+  }
+}
+
 test("shared formatter uses only the safe server ticket DTO for ordinary/composite/mixed bookings", () => {
   const { api } = loadTicketModule();
   const text = api.formatText(safeTicket());
@@ -100,13 +243,40 @@ test("success and replay use one server-confirmed exact net total without browse
   assert.match(scheduled, /confirmedNetTotal\?\.\(result\)/);
 });
 
-test("scheduled and urgent success actions cannot call booking APIs and keep LINE available during manual fallback", () => {
+test("scheduled and urgent render LINE only after the copy attempt", () => {
+  for (const [renderState, textareaId] of [
+    [renderScheduledTicketState, "booking-ticket-manual"],
+    [renderUrgentTicketState, "urgent-ticket-manual"],
+  ]) {
+    for (const status of ["idle", "copying", "copied", "manual"]) {
+      const error = status === "manual" ? "Copy failed" : "";
+      assertTicketState(renderState(status, error), status, textareaId);
+    }
+  }
+});
+
+test("clipboard unavailable, thrown, and rejected attempts expose manual Ticket plus LINE", async () => {
+  const expected = loadTicketModule().api.formatText(safeTicket());
+  const cases = [
+    loadTicketModule({ writeText: null }),
+    loadTicketModule({ writeText: () => { throw new Error("clipboard threw"); } }),
+    loadTicketModule({ writeText: async () => Promise.reject(new Error("clipboard rejected")) }),
+  ];
+  for (const clipboard of cases) {
+    const result = await clipboard.api.copyText(expected);
+    assert.equal(result.status, "manual");
+    assertTicketState(renderScheduledTicketState(result.status, result.error), "manual", "booking-ticket-manual");
+    assertTicketState(renderUrgentTicketState(result.status, result.error), "manual", "urgent-ticket-manual");
+  }
+});
+
+test("scheduled and urgent Ticket actions cannot call booking APIs", () => {
   for (const source of [scheduled, urgent]) {
     assert.match(source, /root\.bookingTicket\?\.formatText\?\./);
     assert.match(source, /คัดลอก Ticket ส่งให้แอดมิน/);
     assert.match(source, /Ticket มีชื่อและเบอร์โทร/);
-    assert.match(source, /<a class="primary-btn" href="https:\/\/lin\.ee\/fG1Oq7y"/);
-    assert.doesNotMatch(source, /copied \? '<a class="primary-btn" href="https:\/\/lin\.ee\/fG1Oq7y"/);
+    assert.match(source, /const showLineHandoff = copied \|\| manual;/);
+    assert.match(source, /showLineHandoff \? '<a class="primary-btn" href="https:\/\/lin\.ee\/fG1Oq7y"/);
     assert.match(source, /readonly/);
     assert.match(source, /aria-live="polite"/);
     const start = source.indexOf('action === "copy-booking-ticket"');
@@ -119,16 +289,21 @@ test("scheduled and urgent success actions cannot call booking APIs and keep LIN
 });
 
 test("ticket handoff keeps tracking/new-booking actions, 44px controls, mobile layout, and PWA wiring", () => {
-  assert.match(scheduled, /data-action="track-created"/);
-  assert.match(scheduled, /data-action="new-cleaning-booking"/);
-  assert.match(urgent, /data-urgent-action="track-created"/);
+  const scheduledCopied = renderScheduledTicketState("copied");
+  const urgentCopied = renderUrgentTicketState("copied");
+  assert.match(scheduledCopied, /CWF-TEST-267/);
+  assert.match(scheduledCopied, /data-action="track-created"/);
+  assert.match(scheduledCopied, /data-action="new-cleaning-booking"/);
+  assert.match(urgentCopied, /CWF-TEST-267/);
+  assert.match(urgentCopied, /data-urgent-action="track-created"/);
+  assert.match(urgentCopied, /data-urgent-action="new-request"/);
   assert.match(css, /\.booking-ticket-handoff[\s\S]*min-height:\s*44px/);
   assert.match(css, /@media \(max-width:\s*390px\)[\s\S]*\.booking-ticket-handoff/);
   assert.match(css, /@media \(max-width:\s*360px\)[\s\S]*\.booking-ticket-handoff/);
   assert.match(index, /modules\/bookingTicket\.js\?v=/);
   assert.match(sw, /modules\/bookingTicket\.js\?v=\$\{BUILD_ID\}/);
   for (const source of [index, sw, manifest, appEntry]) {
-    assert.match(source, /20260809_issue267_catalog_flow_v8/);
-    assert.doesNotMatch(source, /20260809_issue267_catalog_flow_v7/);
+    assert.match(source, /20260809_issue267_catalog_flow_v9/);
+    assert.doesNotMatch(source, /20260809_issue267_catalog_flow_v8/);
   }
 });

--- a/test/customerBookingTicketUi.test.js
+++ b/test/customerBookingTicketUi.test.js
@@ -1,0 +1,23 @@
+"use strict";
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+
+const scheduled = fs.readFileSync("customer-app/modules/bookingScheduled.js", "utf8");
+const urgent = fs.readFileSync("customer-app/modules/bookingUrgent.js", "utf8");
+const css = fs.readFileSync("customer-app/assets/customer-app.css", "utf8");
+
+test("scheduled and urgent success screens use only server ticket DTO and explicit LINE handoff", () => {
+  for (const source of [scheduled, urgent]) {
+    assert.match(source, /result(?:\?|\.)?\.booking_ticket|result\.booking_ticket/);
+    assert.match(source, /คัดลอก Ticket ส่งให้แอดมิน/);
+    assert.match(source, /Ticket มีชื่อและเบอร์โทร/);
+    assert.match(source, /https:\/\/lin\.ee\/fG1Oq7y/);
+    assert.match(source, /navigator\.clipboard\?\.writeText/);
+    assert.match(source, /readonly/);
+    assert.match(source, /aria-live="polite"/);
+    assert.doesNotMatch(source, /ticket[^\n]*(?:job_id|booking_token|address_text|maps_url|snapshot)/i);
+  }
+  assert.match(css, /\.booking-ticket-handoff[\s\S]*min-height:\s*44px/);
+});

--- a/test/customerCatalogQuote.test.js
+++ b/test/customerCatalogQuote.test.js
@@ -1,0 +1,40 @@
+"use strict";
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const { createCustomerCatalogQuoteService } = require("../server/services/booking/customerCatalogQuote");
+
+test("ordinary Store quote uses the catalog policy and returns a customer-safe exact DTO", async () => {
+  const pool = { async query() { return { rows: [{
+    item_id: 9, item_name: "TEST campaign", booking_mode: "bookable", booking_flow_policy: "scheduled_only",
+    booking_job_type: "wash", booking_ac_type: "wall", booking_btu: 12000, booking_wash_variant: "normal",
+    base_price: "699.00", is_active: true, is_customer_visible: true,
+  }] }; } };
+  const service = createCustomerCatalogQuoteService({ pool, createServicePackageResolver: () => ({}), computeDurationMinMulti: () => 45 });
+  const quote = await service.quote({ catalog_item_id: 9, booking_mode: "scheduled", job_type: "wash",
+    ac_type: "wall", btu: 12000, wash_variant: "normal", machine_count: 2 });
+  assert.equal(quote.fixed_total_price, "1398.00");
+  assert.equal(typeof quote.fixed_total_price, "string");
+  assert.equal(quote.duration_minutes, 45);
+  assert.doesNotMatch(JSON.stringify(quote), /item_id|job_id|snapshot|token|address|maps/i);
+});
+
+test("composite quote strips internal ids and snapshots", async () => {
+  const resolved = { bundleKey: "bundle", fixedTotal: "1399.50", durationMin: 90,
+    payload: { machine_count: 2, service_package_groups: [{ package_key: "small", btu: 12000, quantity: 2 }], services: [] },
+    items: [{ snapshot: { package: { id: "secret", key: "small" }, tier: { id: "secret", key: "q2", name: "Two" }, quantity: 2, fixed_total_price: "1399.50" } }] };
+  const service = createCustomerCatalogQuoteService({ pool: { query() {} },
+    createServicePackageResolver: () => ({ resolveComposite: async () => resolved }), computeDurationMinMulti: () => 0 });
+  const quote = await service.quote({ catalog_item_id: 9, service_package_groups: [{ package_key: "small", btu: 12000, quantity: 2 }] });
+  assert.equal(quote.fixed_total_price, "1399.50");
+  assert.doesNotMatch(JSON.stringify(quote), /"id"|snapshot|secret/);
+});
+
+test("Customer Store waits for server quotes, handles stale/error state, and never verifies a browser tier calculation", () => {
+  const store = fs.readFileSync("customer-app/modules/store.js", "utf8");
+  assert.match(store, /await root\.api\.quoteCatalogBooking/);
+  assert.match(store, /requestId !== bundleQuoteRequestId/);
+  assert.match(store, /ไม่สามารถยืนยันราคาและสิทธิ์ได้ กรุณาลองใหม่/);
+  assert.doesNotMatch(store, /verified:\s*true[\s\S]{0,160}composeBundleTiers/);
+});

--- a/test/customerCatalogQuote.test.js
+++ b/test/customerCatalogQuote.test.js
@@ -16,8 +16,9 @@ test("ordinary Store quote uses the catalog policy and returns a customer-safe e
     ac_type: "wall", btu: 12000, wash_variant: "normal", machine_count: 2 });
   assert.equal(quote.fixed_total_price, "1398.00");
   assert.equal(typeof quote.fixed_total_price, "string");
+  assert.equal(quote.catalog_item_id, 9);
   assert.equal(quote.duration_minutes, 45);
-  assert.doesNotMatch(JSON.stringify(quote), /item_id|job_id|snapshot|token|address|maps/i);
+  assert.doesNotMatch(JSON.stringify(quote), /job_id|package_id|tier_id|snapshot|token|address|maps/i);
 });
 
 test("composite quote strips internal ids and snapshots", async () => {
@@ -37,4 +38,6 @@ test("Customer Store waits for server quotes, handles stale/error state, and nev
   assert.match(store, /requestId !== bundleQuoteRequestId/);
   assert.match(store, /ไม่สามารถยืนยันราคาและสิทธิ์ได้ กรุณาลองใหม่/);
   assert.doesNotMatch(store, /verified:\s*true[\s\S]{0,160}composeBundleTiers/);
+  assert.match(store, /catalogQuoteToCommerceDraft\(item, quote, scope\)/);
+  assert.match(store, /ordinaryQuotesInFlight\.has\(requestKey\)/);
 });

--- a/test/customerHistoryClaim.test.js
+++ b/test/customerHistoryClaim.test.js
@@ -845,7 +845,7 @@ test("Customer History search and preview keep 360px and 390px width contracts",
 });
 
 test("Customer App cache version is bumped consistently", () => {
-  const expected = "20260809_issue267_booking_ticket_v5";
+  const expected = "20260809_issue267_catalog_flow_v6";
   for (const file of [
     "customer-app/index.html",
     "customer-app/sw.js",

--- a/test/customerHistoryClaim.test.js
+++ b/test/customerHistoryClaim.test.js
@@ -845,7 +845,7 @@ test("Customer History search and preview keep 360px and 390px width contracts",
 });
 
 test("Customer App cache version is bumped consistently", () => {
-  const expected = "20260809_issue267_merchandising_v3";
+  const expected = "20260809_issue267_heading_cleanup_v4";
   for (const file of [
     "customer-app/index.html",
     "customer-app/sw.js",

--- a/test/customerHistoryClaim.test.js
+++ b/test/customerHistoryClaim.test.js
@@ -845,7 +845,7 @@ test("Customer History search and preview keep 360px and 390px width contracts",
 });
 
 test("Customer App cache version is bumped consistently", () => {
-  const expected = "20260809_issue267_admin_builder_v2";
+  const expected = "20260809_issue267_merchandising_v3";
   for (const file of [
     "customer-app/index.html",
     "customer-app/sw.js",

--- a/test/customerHistoryClaim.test.js
+++ b/test/customerHistoryClaim.test.js
@@ -845,7 +845,7 @@ test("Customer History search and preview keep 360px and 390px width contracts",
 });
 
 test("Customer App cache version is bumped consistently", () => {
-  const expected = "20260809_issue267_catalog_flow_v6";
+  const expected = "20260809_issue267_catalog_flow_v7";
   for (const file of [
     "customer-app/index.html",
     "customer-app/sw.js",

--- a/test/customerHistoryClaim.test.js
+++ b/test/customerHistoryClaim.test.js
@@ -845,7 +845,7 @@ test("Customer History search and preview keep 360px and 390px width contracts",
 });
 
 test("Customer App cache version is bumped consistently", () => {
-  const expected = "20260728_urgent_dispatch_preflight_v2";
+  const expected = "20260809_store_service_package_bundles_v1";
   for (const file of [
     "customer-app/index.html",
     "customer-app/sw.js",

--- a/test/customerHistoryClaim.test.js
+++ b/test/customerHistoryClaim.test.js
@@ -845,7 +845,7 @@ test("Customer History search and preview keep 360px and 390px width contracts",
 });
 
 test("Customer App cache version is bumped consistently", () => {
-  const expected = "20260809_issue267_catalog_flow_v7";
+  const expected = "20260809_issue267_catalog_flow_v8";
   for (const file of [
     "customer-app/index.html",
     "customer-app/sw.js",

--- a/test/customerHistoryClaim.test.js
+++ b/test/customerHistoryClaim.test.js
@@ -845,7 +845,7 @@ test("Customer History search and preview keep 360px and 390px width contracts",
 });
 
 test("Customer App cache version is bumped consistently", () => {
-  const expected = "20260809_issue267_heading_cleanup_v4";
+  const expected = "20260809_issue267_booking_ticket_v5";
   for (const file of [
     "customer-app/index.html",
     "customer-app/sw.js",

--- a/test/customerHistoryClaim.test.js
+++ b/test/customerHistoryClaim.test.js
@@ -845,7 +845,7 @@ test("Customer History search and preview keep 360px and 390px width contracts",
 });
 
 test("Customer App cache version is bumped consistently", () => {
-  const expected = "20260809_store_service_package_bundles_v1";
+  const expected = "20260809_issue267_admin_builder_v2";
   for (const file of [
     "customer-app/index.html",
     "customer-app/sw.js",

--- a/test/customerHistoryClaim.test.js
+++ b/test/customerHistoryClaim.test.js
@@ -845,7 +845,7 @@ test("Customer History search and preview keep 360px and 390px width contracts",
 });
 
 test("Customer App cache version is bumped consistently", () => {
-  const expected = "20260809_issue267_catalog_flow_v8";
+  const expected = "20260809_issue267_catalog_flow_v9";
   for (const file of [
     "customer-app/index.html",
     "customer-app/sw.js",

--- a/test/customerHomepageFeaturedRotation.test.js
+++ b/test/customerHomepageFeaturedRotation.test.js
@@ -418,6 +418,6 @@ test("compact CSS and cache build remain consistent with six-card rotation", () 
   assert.match(css, /\.homepage-featured-page\s*\{[^}]*grid-area:\s*1\s*\/\s*1/s);
   assert.match(css, /transition:\s*opacity 350ms/);
   assert.match(css, /prefers-reduced-motion:\s*reduce/);
-  const build = "20260809_issue267_merchandising_v3";
+  const build = "20260809_issue267_heading_cleanup_v4";
   for (const source of [html, sw, boot, manifest]) assert.match(source, new RegExp(build));
 });

--- a/test/customerHomepageFeaturedRotation.test.js
+++ b/test/customerHomepageFeaturedRotation.test.js
@@ -418,6 +418,6 @@ test("compact CSS and cache build remain consistent with six-card rotation", () 
   assert.match(css, /\.homepage-featured-page\s*\{[^}]*grid-area:\s*1\s*\/\s*1/s);
   assert.match(css, /transition:\s*opacity 350ms/);
   assert.match(css, /prefers-reduced-motion:\s*reduce/);
-  const build = "20260809_issue267_catalog_flow_v7";
+  const build = "20260809_issue267_catalog_flow_v8";
   for (const source of [html, sw, boot, manifest]) assert.match(source, new RegExp(build));
 });

--- a/test/customerHomepageFeaturedRotation.test.js
+++ b/test/customerHomepageFeaturedRotation.test.js
@@ -418,6 +418,6 @@ test("compact CSS and cache build remain consistent with six-card rotation", () 
   assert.match(css, /\.homepage-featured-page\s*\{[^}]*grid-area:\s*1\s*\/\s*1/s);
   assert.match(css, /transition:\s*opacity 350ms/);
   assert.match(css, /prefers-reduced-motion:\s*reduce/);
-  const build = "20260809_store_service_package_bundles_v1";
+  const build = "20260809_issue267_admin_builder_v2";
   for (const source of [html, sw, boot, manifest]) assert.match(source, new RegExp(build));
 });

--- a/test/customerHomepageFeaturedRotation.test.js
+++ b/test/customerHomepageFeaturedRotation.test.js
@@ -418,6 +418,6 @@ test("compact CSS and cache build remain consistent with six-card rotation", () 
   assert.match(css, /\.homepage-featured-page\s*\{[^}]*grid-area:\s*1\s*\/\s*1/s);
   assert.match(css, /transition:\s*opacity 350ms/);
   assert.match(css, /prefers-reduced-motion:\s*reduce/);
-  const build = "20260809_issue267_booking_ticket_v5";
+  const build = "20260809_issue267_catalog_flow_v6";
   for (const source of [html, sw, boot, manifest]) assert.match(source, new RegExp(build));
 });

--- a/test/customerHomepageFeaturedRotation.test.js
+++ b/test/customerHomepageFeaturedRotation.test.js
@@ -418,6 +418,6 @@ test("compact CSS and cache build remain consistent with six-card rotation", () 
   assert.match(css, /\.homepage-featured-page\s*\{[^}]*grid-area:\s*1\s*\/\s*1/s);
   assert.match(css, /transition:\s*opacity 350ms/);
   assert.match(css, /prefers-reduced-motion:\s*reduce/);
-  const build = "20260808_homepage_service_packages_v2";
+  const build = "20260809_store_service_package_bundles_v1";
   for (const source of [html, sw, boot, manifest]) assert.match(source, new RegExp(build));
 });

--- a/test/customerHomepageFeaturedRotation.test.js
+++ b/test/customerHomepageFeaturedRotation.test.js
@@ -418,6 +418,6 @@ test("compact CSS and cache build remain consistent with six-card rotation", () 
   assert.match(css, /\.homepage-featured-page\s*\{[^}]*grid-area:\s*1\s*\/\s*1/s);
   assert.match(css, /transition:\s*opacity 350ms/);
   assert.match(css, /prefers-reduced-motion:\s*reduce/);
-  const build = "20260809_issue267_heading_cleanup_v4";
+  const build = "20260809_issue267_booking_ticket_v5";
   for (const source of [html, sw, boot, manifest]) assert.match(source, new RegExp(build));
 });

--- a/test/customerHomepageFeaturedRotation.test.js
+++ b/test/customerHomepageFeaturedRotation.test.js
@@ -418,6 +418,6 @@ test("compact CSS and cache build remain consistent with six-card rotation", () 
   assert.match(css, /\.homepage-featured-page\s*\{[^}]*grid-area:\s*1\s*\/\s*1/s);
   assert.match(css, /transition:\s*opacity 350ms/);
   assert.match(css, /prefers-reduced-motion:\s*reduce/);
-  const build = "20260809_issue267_catalog_flow_v8";
+  const build = "20260809_issue267_catalog_flow_v9";
   for (const source of [html, sw, boot, manifest]) assert.match(source, new RegExp(build));
 });

--- a/test/customerHomepageFeaturedRotation.test.js
+++ b/test/customerHomepageFeaturedRotation.test.js
@@ -255,7 +255,7 @@ test("render contract exposes exactly one active six-card page and accessible in
   assert.equal((html.match(/aria-hidden="true"/g) || []).length, 2);
   assert.equal((html.match(/data-featured-dot="/g) || []).length, 3);
   assert.equal((html.match(/aria-selected="true"/g) || []).length, 1);
-  assert.equal((html.match(/class="homepage-service-card"/g) || []).length, 18);
+  assert.equal((html.match(/class="homepage-service-card(?:\s[^"]*)?"/g) || []).length, 18);
   assert.match(html, /data-featured-page="1"[\s\S]*?data-home-featured-detail="7"/);
   assert.match(html, /data-featured-page="2"[\s\S]*?data-home-featured-detail="13"/);
   assert.doesNotMatch(html, /homepage-featured-page[\s\S]*grid-template-columns[^]*repeat\(4/);
@@ -418,6 +418,6 @@ test("compact CSS and cache build remain consistent with six-card rotation", () 
   assert.match(css, /\.homepage-featured-page\s*\{[^}]*grid-area:\s*1\s*\/\s*1/s);
   assert.match(css, /transition:\s*opacity 350ms/);
   assert.match(css, /prefers-reduced-motion:\s*reduce/);
-  const build = "20260809_issue267_admin_builder_v2";
+  const build = "20260809_issue267_merchandising_v3";
   for (const source of [html, sw, boot, manifest]) assert.match(source, new RegExp(build));
 });

--- a/test/customerHomepageFeaturedRotation.test.js
+++ b/test/customerHomepageFeaturedRotation.test.js
@@ -418,6 +418,6 @@ test("compact CSS and cache build remain consistent with six-card rotation", () 
   assert.match(css, /\.homepage-featured-page\s*\{[^}]*grid-area:\s*1\s*\/\s*1/s);
   assert.match(css, /transition:\s*opacity 350ms/);
   assert.match(css, /prefers-reduced-motion:\s*reduce/);
-  const build = "20260809_issue267_catalog_flow_v6";
+  const build = "20260809_issue267_catalog_flow_v7";
   for (const source of [html, sw, boot, manifest]) assert.match(source, new RegExp(build));
 });

--- a/test/customerLegacyUiRetirement.test.js
+++ b/test/customerLegacyUiRetirement.test.js
@@ -77,7 +77,7 @@ test("featured manual mode preserves configured order, removes duplicates, and n
 test("homepage renders a single compact page without timer controls when the pool has six items", () => {
   const app = loadHomepage(Array.from({ length: 6 }, (_, index) => catalogItem(index + 1, { is_featured: index < 2 })));
   const html = app.ui._test.renderHomepageFeaturedServices({ featured_mode: "auto", featured_limit: 6 });
-  assert.equal((html.match(/class="homepage-service-card"/g) || []).length, 6);
+  assert.equal((html.match(/class="homepage-service-card(?:\s[^"]*)?"/g) || []).length, 6);
   assert.match(html, /homepage-featured-grid/);
   assert.match(html, /data-featured-page-count="1"/);
   assert.doesNotMatch(html, /data-featured-dot|aria-hidden="true"/);

--- a/test/customerOrdinaryCatalogQuoteFlow.test.js
+++ b/test/customerOrdinaryCatalogQuoteFlow.test.js
@@ -1,0 +1,114 @@
+"use strict";
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const vm = require("node:vm");
+
+const servicesSource = fs.readFileSync("customer-app/modules/services.js", "utf8");
+const storeSource = fs.readFileSync("customer-app/modules/store.js", "utf8");
+
+function item(id) {
+  return {
+    item_id: id,
+    item_name: `TEST Catalog ${id}`,
+    booking_mode: "bookable",
+    booking_ac_type: "ผนัง",
+    booking_btu: 12000,
+    booking_wash_variant: "ล้างธรรมดา",
+    job_category: "ล้าง",
+    base_price: "999.00",
+  };
+}
+
+function quote(id, total = "1399.50", campaign = "TEST Campaign") {
+  return {
+    kind: "bookable",
+    catalog_item_id: id,
+    fixed_total_price: total,
+    unit_price: total,
+    normal_unit_price: "1599.50",
+    duration_minutes: 45,
+    machine_count: 1,
+    price_label: "TEST price",
+    campaign_name: campaign,
+    service: { job_type: "ล้าง", ac_type: "ผนัง", btu: 12000, wash_variant: "ล้างธรรมดา", machine_count: 1 },
+  };
+}
+
+function harness(quoteCatalogBooking) {
+  const state = {
+    currentRoute: "store",
+    draft: { scheduled: {}, urgent: {} },
+    scheduledPreview: { pricing: null },
+    urgentFlow: {},
+    updateDraft(scope, patch) { Object.assign(this.draft[scope], patch); },
+    setScheduledPreview(name, value) { this.scheduledPreview[name] = value; },
+    setUrgentFlow(patch) { Object.assign(this.urgentFlow, patch); },
+    setScheduledWizard() {},
+    setScheduledSubmit() {},
+  };
+  const root = {
+    state,
+    api: { quoteCatalogBooking },
+    utils: {
+      routeTo(route) { state.currentRoute = route; },
+      formatBaht(value) { return String(value); },
+      escapeHtml(value) { return String(value); },
+      icon() { return ""; },
+    },
+  };
+  const window = { CWFCustomerAppV2: root, scrollY: 0, pageYOffset: 0 };
+  const document = { visibilityState: "visible", createElement() { return { setAttribute() {}, className: "", textContent: "" }; } };
+  vm.runInNewContext(servicesSource, { window, document, console, Date, Math, BigInt, Intl, Set }, { filename: "services.js" });
+  vm.runInNewContext(storeSource, { window, document, console, Date, Math, BigInt, Intl, Set, clearInterval, setInterval, clearTimeout, setTimeout }, { filename: "store.js" });
+  const status = { textContent: "", setAttribute() {} };
+  const buttons = [{ disabled: false, setAttribute() {}, removeAttribute() {} }];
+  const container = {
+    querySelector(selector) { return selector === "[data-catalog-quote-status]" ? status : null; },
+    querySelectorAll() { return buttons; },
+    prepend() {},
+  };
+  return { root, state, status, buttons, begin: root.store._test.beginOrdinaryBooking, container };
+}
+
+test("ordinary Store quote drives the visible scheduled draft, exact price, duration and campaign", async () => {
+  const flow = harness(async () => quote(7));
+  assert.equal(await flow.begin(flow.container, item(7), "scheduled", "test"), true);
+  assert.equal(flow.state.currentRoute, "scheduled");
+  assert.equal(flow.state.draft.scheduled.catalog_item_id, 7);
+  assert.equal(flow.state.draft.scheduled.catalog_booking_quote.fixed_total_price, "1399.50");
+  assert.equal(flow.state.draft.scheduled.catalog_booking_quote.duration_min, 45);
+  assert.equal(flow.state.scheduledPreview.pricing.data.active_price, "1399.50");
+  assert.equal(flow.state.scheduledPreview.pricing.data.promo.promo_name, "TEST Campaign");
+  assert.equal(flow.buttons[0].disabled, false);
+});
+
+test("ordinary quote ignores stale out-of-order responses and suppresses duplicate submit", async () => {
+  const pending = [];
+  const flow = harness((payload) => new Promise((resolve) => pending.push({ payload, resolve })));
+  const first = flow.begin(flow.container, item(7), "scheduled", "test");
+  const duplicate = flow.begin(flow.container, item(7), "scheduled", "test");
+  assert.equal(await duplicate, false);
+  assert.equal(pending.length, 1);
+
+  const second = flow.begin(flow.container, item(8), "scheduled", "test");
+  assert.equal(pending.length, 2);
+  pending[1].resolve(quote(8, "899.00", "NEW Campaign"));
+  assert.equal(await second, true);
+  pending[0].resolve(quote(7));
+  assert.equal(await first, false);
+  assert.equal(flow.state.draft.scheduled.catalog_item_id, 8);
+  assert.equal(flow.state.draft.scheduled.catalog_booking_quote.fixed_total_price, "899.00");
+});
+
+test("ordinary quote 4xx/409/5xx/network failure stays retryable without routing or a verified draft", async () => {
+  for (const status of [400, 409, 503, 0]) {
+    const flow = harness(async () => { const error = new Error("quote failed"); error.status = status; throw error; });
+    assert.equal(await flow.begin(flow.container, item(status || 9), "urgent", "test"), false);
+    assert.equal(flow.state.currentRoute, "store");
+    assert.equal(flow.state.draft.urgent.catalog_booking_quote, undefined);
+    assert.match(flow.status.textContent, /ลองใหม่/);
+    assert.equal(flow.buttons[0].disabled, false);
+  }
+});

--- a/test/customerPricingSafety.test.js
+++ b/test/customerPricingSafety.test.js
@@ -532,5 +532,5 @@ test("admin UI source exposes safety warnings and cache-busted assets", () => {
   assert.match(catalogJs, /ราคาสินค้าเท่านั้น ไม่ใช้คำนวณค่าบริการ/);
   assert.match(catalogJs, /modalPricingRisk/);
   assert.match(promoHtml, /admin-promotions-v2\.js\?v=20260708_price_rule_safety_v2/);
-  assert.match(catalogHtml, /admin-store-catalog\.js\?v=20260808_service_packages_th_v1/);
+  assert.match(catalogHtml, /admin-store-catalog\.js\?v=20260809_store_service_package_bundles_v1/);
 });

--- a/test/customerPricingSafety.test.js
+++ b/test/customerPricingSafety.test.js
@@ -532,5 +532,5 @@ test("admin UI source exposes safety warnings and cache-busted assets", () => {
   assert.match(catalogJs, /ราคาสินค้าเท่านั้น ไม่ใช้คำนวณค่าบริการ/);
   assert.match(catalogJs, /modalPricingRisk/);
   assert.match(promoHtml, /admin-promotions-v2\.js\?v=20260708_price_rule_safety_v2/);
-  assert.match(catalogHtml, /admin-store-catalog\.js\?v=20260809_issue267_admin_builder_v2/);
+  assert.match(catalogHtml, /admin-store-catalog\.js\?v=20260809_issue267_merchandising_v3/);
 });

--- a/test/customerPricingSafety.test.js
+++ b/test/customerPricingSafety.test.js
@@ -532,5 +532,5 @@ test("admin UI source exposes safety warnings and cache-busted assets", () => {
   assert.match(catalogJs, /ราคาสินค้าเท่านั้น ไม่ใช้คำนวณค่าบริการ/);
   assert.match(catalogJs, /modalPricingRisk/);
   assert.match(promoHtml, /admin-promotions-v2\.js\?v=20260708_price_rule_safety_v2/);
-  assert.match(catalogHtml, /admin-store-catalog\.js\?v=20260809_store_service_package_bundles_v1/);
+  assert.match(catalogHtml, /admin-store-catalog\.js\?v=20260809_issue267_admin_builder_v2/);
 });

--- a/test/customerRouteHeadings.test.js
+++ b/test/customerRouteHeadings.test.js
@@ -6,6 +6,8 @@ const vm = require("node:vm");
 
 const ROOT = path.resolve(__dirname, "..");
 const UI_SOURCE = fs.readFileSync(path.join(ROOT, "customer-app/modules/ui.js"), "utf8");
+const CUSTOMER_INDEX = fs.readFileSync(path.join(ROOT, "customer-app/index.html"), "utf8");
+const ROUTER_SOURCE = fs.readFileSync(path.join(ROOT, "customer-app/modules/router.js"), "utf8");
 
 function escapeHtml(value) {
   return String(value == null ? "" : value)
@@ -80,7 +82,7 @@ test("Customer App UI module has no startup debug logging", () => {
   assert.doesNotMatch(UI_SOURCE, /\bconsole\.(?:debug|info|log)\s*\(/);
 });
 
-test("routes keep semantic headings while four redundant mobile rows are visually hidden", () => {
+test("only the four requested routes replace the redundant visible row with a no-layout accessible name", () => {
   const { app } = loadUi({
     utils: {
       iconSlot() { throw new Error("page heading must not request an icon slot"); },
@@ -105,13 +107,65 @@ test("routes keep semantic headings while four redundant mobile rows are visuall
 
     assert.equal(container.insertions.length, 1, `${route} heading should not be injected twice`);
     const html = container.insertions[0];
-    assert.match(html, /<header class="route-page-heading(?: is-accessible-only)?"/);
     assert.match(html, new RegExp(`data-page-icon-heading="${page}"`));
-    assert.match(html, new RegExp(`<h2 class="route-page-heading__title">${label}</h2>`));
-    const hidden = ["home", "store", "storeItem", "storeItem-42", "scheduled", "tracking"].includes(route);
-    assert.equal(/is-accessible-only/.test(html), hidden, `${route} standalone visibility`);
+    const accessibleOnly = ["home", "store", "scheduled", "tracking"].includes(route);
+    if (accessibleOnly) {
+      assert.match(html, new RegExp(`<h2 class="route-accessible-page-name"[^>]*>${label}</h2>`));
+      assert.doesNotMatch(html, /<header class="route-page-heading"/);
+    } else {
+      assert.match(html, /<header class="route-page-heading"/);
+      assert.match(html, new RegExp(`<h2 class="route-page-heading__title">${label}</h2>`));
+      assert.doesNotMatch(html, /route-accessible-page-name/);
+    }
     assert.doesNotMatch(html, /<svg\b|<img\b|cwf-icon-slot|data-(?:cwf-)?icon-slot/i);
   }
+});
+
+test("document title and all bottom navigation labels remain present", () => {
+  assert.match(CUSTOMER_INDEX, /<title>CWF Customer Service<\/title>/);
+  for (const [route, label] of [
+    ["home", "หน้าแรก"],
+    ["store", "ร้านค้า"],
+    ["booking", "จองบริการ"],
+    ["tracking", "ติดตามงาน"],
+    ["profile", "บัญชี"],
+  ]) {
+    assert.match(CUSTOMER_INDEX, new RegExp(`data-route="${route}"[^>]*>[\\s\\S]*?data-nav-label>${label}<\\/span>`));
+  }
+});
+
+test("router still maps Store detail to Store and exposes one active nav item", () => {
+  const navItems = ["home", "store", "booking", "tracking", "profile"].map((route) => {
+    const attributes = new Map([["data-route", route]]);
+    const classes = new Set();
+    return {
+      route,
+      attributes,
+      classes,
+      getAttribute(name) { return attributes.get(name) || null; },
+      setAttribute(name, value) { attributes.set(name, value); },
+      removeAttribute(name) { attributes.delete(name); },
+      classList: { toggle(name, enabled) { enabled ? classes.add(name) : classes.delete(name); } },
+    };
+  });
+  const app = {};
+  const document = {
+    addEventListener() {},
+    querySelectorAll(selector) {
+      assert.equal(selector, ".nav-item[data-route]");
+      return navItems;
+    },
+  };
+  const window = { CWFCustomerAppV2: app, addEventListener() {} };
+  vm.runInNewContext(ROUTER_SOURCE, { window, document, history: {} }, { filename: "router.js" });
+
+  app.router.updateNav("storeItem-42");
+  assert.deepEqual(navItems.filter((item) => item.classes.has("is-active")).map((item) => item.route), ["store"]);
+  assert.deepEqual(navItems.filter((item) => item.attributes.get("aria-current") === "page").map((item) => item.route), ["store"]);
+
+  app.router.updateNav("tracking");
+  assert.deepEqual(navItems.filter((item) => item.classes.has("is-active")).map((item) => item.route), ["tracking"]);
+  assert.deepEqual(navItems.filter((item) => item.attributes.get("aria-current") === "page").map((item) => item.route), ["tracking"]);
 });
 
 test("applyRouteIcons keeps profile slots, action decoration, and page-header binding", () => {
@@ -176,8 +230,8 @@ test("route heading layout stays aligned and mobile overflow guards remain activ
   assert.match(css, /\.route-page-heading__title\s*\{[^}]*max-width:\s*100%;[^}]*overflow-wrap:\s*anywhere;/s);
   assert.match(css, /\.booking-wizard-page\s*\{[^}]*padding:\s*12px 16px 20px;/s);
   assert.match(css, /\.booking-wizard-page > \.route-page-heading\s*\{[^}]*margin:\s*0;/s);
-  assert.match(css, /\.route-page-heading ~ \.page-header-mount:empty\s*\{\s*display:\s*none;/);
-  assert.match(css, /\.route-page-heading\.is-accessible-only\s*\{[^}]*position:\s*absolute;[^}]*width:\s*1px;[^}]*height:\s*1px;/s);
+  assert.match(css, /\.page-header-mount:empty\s*\{\s*display:\s*none;/);
+  assert.match(css, /\.route-accessible-page-name\s*\{[^}]*position:\s*absolute;[^}]*width:\s*1px;[^}]*height:\s*1px;[^}]*padding:\s*0;[^}]*margin:\s*-1px;[^}]*animation:\s*none\s*!important;/s);
   assert.match(css, /html\s*\{[^}]*overflow-x:\s*hidden;/s);
   assert.match(css, /body\s*\{[^}]*overflow-x:\s*hidden;/s);
   assert.doesNotMatch(css, /\.page-icon-heading/);

--- a/test/customerRouteHeadings.test.js
+++ b/test/customerRouteHeadings.test.js
@@ -80,7 +80,7 @@ test("Customer App UI module has no startup debug logging", () => {
   assert.doesNotMatch(UI_SOURCE, /\bconsole\.(?:debug|info|log)\s*\(/);
 });
 
-test("all Customer App routes render one semantic text-only page heading", () => {
+test("routes keep semantic headings while four redundant mobile rows are visually hidden", () => {
   const { app } = loadUi({
     utils: {
       iconSlot() { throw new Error("page heading must not request an icon slot"); },
@@ -105,9 +105,11 @@ test("all Customer App routes render one semantic text-only page heading", () =>
 
     assert.equal(container.insertions.length, 1, `${route} heading should not be injected twice`);
     const html = container.insertions[0];
-    assert.match(html, /<header class="route-page-heading"/);
+    assert.match(html, /<header class="route-page-heading(?: is-accessible-only)?"/);
     assert.match(html, new RegExp(`data-page-icon-heading="${page}"`));
     assert.match(html, new RegExp(`<h2 class="route-page-heading__title">${label}</h2>`));
+    const hidden = ["home", "store", "storeItem", "storeItem-42", "scheduled", "tracking"].includes(route);
+    assert.equal(/is-accessible-only/.test(html), hidden, `${route} standalone visibility`);
     assert.doesNotMatch(html, /<svg\b|<img\b|cwf-icon-slot|data-(?:cwf-)?icon-slot/i);
   }
 });
@@ -175,6 +177,7 @@ test("route heading layout stays aligned and mobile overflow guards remain activ
   assert.match(css, /\.booking-wizard-page\s*\{[^}]*padding:\s*12px 16px 20px;/s);
   assert.match(css, /\.booking-wizard-page > \.route-page-heading\s*\{[^}]*margin:\s*0;/s);
   assert.match(css, /\.route-page-heading ~ \.page-header-mount:empty\s*\{\s*display:\s*none;/);
+  assert.match(css, /\.route-page-heading\.is-accessible-only\s*\{[^}]*position:\s*absolute;[^}]*width:\s*1px;[^}]*height:\s*1px;/s);
   assert.match(css, /html\s*\{[^}]*overflow-x:\s*hidden;/s);
   assert.match(css, /body\s*\{[^}]*overflow-x:\s*hidden;/s);
   assert.doesNotMatch(css, /\.page-icon-heading/);

--- a/test/customerSameDayTiming.test.js
+++ b/test/customerSameDayTiming.test.js
@@ -161,7 +161,7 @@ test("customer app disables availability HTTP cache and refreshes same-day slots
 });
 
 test("customer app build and service worker cache IDs changed", () => {
-  const id = "20260809_issue267_merchandising_v3";
+  const id = "20260809_issue267_heading_cleanup_v4";
   for (const file of [
     "customer-app/index.html",
     "customer-app/sw.js",

--- a/test/customerSameDayTiming.test.js
+++ b/test/customerSameDayTiming.test.js
@@ -161,7 +161,7 @@ test("customer app disables availability HTTP cache and refreshes same-day slots
 });
 
 test("customer app build and service worker cache IDs changed", () => {
-  const id = "20260809_store_service_package_bundles_v1";
+  const id = "20260809_issue267_admin_builder_v2";
   for (const file of [
     "customer-app/index.html",
     "customer-app/sw.js",

--- a/test/customerSameDayTiming.test.js
+++ b/test/customerSameDayTiming.test.js
@@ -161,7 +161,7 @@ test("customer app disables availability HTTP cache and refreshes same-day slots
 });
 
 test("customer app build and service worker cache IDs changed", () => {
-  const id = "20260809_issue267_catalog_flow_v7";
+  const id = "20260809_issue267_catalog_flow_v8";
   for (const file of [
     "customer-app/index.html",
     "customer-app/sw.js",

--- a/test/customerSameDayTiming.test.js
+++ b/test/customerSameDayTiming.test.js
@@ -161,7 +161,7 @@ test("customer app disables availability HTTP cache and refreshes same-day slots
 });
 
 test("customer app build and service worker cache IDs changed", () => {
-  const id = "20260809_issue267_admin_builder_v2";
+  const id = "20260809_issue267_merchandising_v3";
   for (const file of [
     "customer-app/index.html",
     "customer-app/sw.js",

--- a/test/customerSameDayTiming.test.js
+++ b/test/customerSameDayTiming.test.js
@@ -161,7 +161,7 @@ test("customer app disables availability HTTP cache and refreshes same-day slots
 });
 
 test("customer app build and service worker cache IDs changed", () => {
-  const id = "20260809_issue267_heading_cleanup_v4";
+  const id = "20260809_issue267_booking_ticket_v5";
   for (const file of [
     "customer-app/index.html",
     "customer-app/sw.js",

--- a/test/customerSameDayTiming.test.js
+++ b/test/customerSameDayTiming.test.js
@@ -161,7 +161,7 @@ test("customer app disables availability HTTP cache and refreshes same-day slots
 });
 
 test("customer app build and service worker cache IDs changed", () => {
-  const id = "20260728_urgent_dispatch_preflight_v2";
+  const id = "20260809_store_service_package_bundles_v1";
   for (const file of [
     "customer-app/index.html",
     "customer-app/sw.js",

--- a/test/customerSameDayTiming.test.js
+++ b/test/customerSameDayTiming.test.js
@@ -161,7 +161,7 @@ test("customer app disables availability HTTP cache and refreshes same-day slots
 });
 
 test("customer app build and service worker cache IDs changed", () => {
-  const id = "20260809_issue267_catalog_flow_v6";
+  const id = "20260809_issue267_catalog_flow_v7";
   for (const file of [
     "customer-app/index.html",
     "customer-app/sw.js",

--- a/test/customerSameDayTiming.test.js
+++ b/test/customerSameDayTiming.test.js
@@ -161,7 +161,7 @@ test("customer app disables availability HTTP cache and refreshes same-day slots
 });
 
 test("customer app build and service worker cache IDs changed", () => {
-  const id = "20260809_issue267_booking_ticket_v5";
+  const id = "20260809_issue267_catalog_flow_v6";
   for (const file of [
     "customer-app/index.html",
     "customer-app/sw.js",

--- a/test/customerSameDayTiming.test.js
+++ b/test/customerSameDayTiming.test.js
@@ -161,7 +161,7 @@ test("customer app disables availability HTTP cache and refreshes same-day slots
 });
 
 test("customer app build and service worker cache IDs changed", () => {
-  const id = "20260809_issue267_catalog_flow_v8";
+  const id = "20260809_issue267_catalog_flow_v9";
   for (const file of [
     "customer-app/index.html",
     "customer-app/sw.js",

--- a/test/customerServicePackageBooking.test.js
+++ b/test/customerServicePackageBooking.test.js
@@ -11,6 +11,7 @@ const {
   packageBookingFromSnapshot,
 } = require("../server/services/booking/servicePackageBooking");
 const { createBookingJobService } = require("../server/services/booking/createBookingJob");
+const adminIdempotency = require("../server/services/booking/adminBookingIdempotency");
 
 function responseHarness() {
   return {
@@ -266,7 +267,7 @@ test("advisory-locked committed package replay bypasses unavailable current reso
     async connect() { return client; },
     async query(sql) {
       calls.push(sql);
-      if (/FROM public\.jobs WHERE job_id=\$1/.test(sql)) return { rows: [prior] };
+      if (/FROM public\.jobs(?: j)? WHERE (?:j\.)?job_id=\$1/.test(sql)) return { rows: [prior] };
       if (/service_package_snapshot/.test(sql)) return { rows: [{
         service_package_id: "41", service_package_tier_id: "73",
         service_package_snapshot: historical.snapshot,
@@ -308,6 +309,38 @@ test("advisory-locked committed package replay bypasses unavailable current reso
   assert.equal(changed.body.code, "IDEMPOTENCY_KEY_REUSED");
   assert.equal(resolverCalls, 0);
   assert.equal(calls.some((sql) => /\bINSERT\b|\bUPDATE\b|\bDELETE\b/.test(sql)), false);
+});
+
+test("ordinary Store replay uses its persisted fingerprint before a disabled catalog or promotion is resolved", async () => {
+  const request = scheduledRequest({ customer_phone: "0812345678", job_type: "wash", ac_type: "wall", btu: 12000,
+    wash_variant: "normal", machine_count: 1, catalog_item_id: 77 });
+  const prior = { job_id: "777", booking_code: "CWF777", booking_token: "stored", booking_mode: "scheduled",
+    dispatch_mode: "normal", duration_min: 45, job_price: "699.00",
+    booking_request_fingerprint: adminIdempotency.requestFingerprint(request) };
+  const calls = [];
+  const client = { async query(sql) { calls.push(sql); return /FROM public\.jobs/.test(sql) ? { rows: [prior] } : { rows: [] }; }, release() {} };
+  const pool = {
+    async connect() { return client; },
+    async query(sql) {
+      calls.push(sql);
+      if (/FROM public\.jobs j/.test(sql)) return { rows: [{ ...prior, customer_name: "Package customer",
+        customer_phone: "0812345678", appointment_datetime: request.appointment_datetime,
+        applied_discount: "0.00", job_status: "customer_scheduled_review" }] };
+      if (/FROM public\.job_items/.test(sql)) return { rows: [{ item_name: "TEST Store service", qty: 1, is_service: true }] };
+      throw new Error(`unexpected query: ${sql}`);
+    },
+  };
+  const service = bookingService({ pool, effectiveBlockMin: (value) => value });
+  const replay = await invoke(service.handlePublicBook, request);
+  assert.equal(replay.statusCode, 200);
+  assert.equal(replay.body.replayed, true);
+  assert.equal(replay.body.booking_ticket.exact_total, "699.00");
+  assert.equal(calls.some((sql) => /catalog_items|customer_service_price_rules|promotions_v2/.test(sql)), false);
+  assert.equal(calls.some((sql) => /\bINSERT\b|\bUPDATE\b|\bDELETE\b/.test(sql)), false);
+
+  const changed = await invoke(service.handlePublicBook, { ...request, machine_count: 2 });
+  assert.equal(changed.statusCode, 409);
+  assert.equal(changed.body.code, "IDEMPOTENCY_KEY_REUSED");
 });
 
 test("mixed ordinary lines and urgent package booking are rejected", async () => {

--- a/test/customerServicePackageBooking.test.js
+++ b/test/customerServicePackageBooking.test.js
@@ -292,6 +292,10 @@ test("advisory-locked committed package replay bypasses unavailable current reso
   assert.equal(result.body.replayed, true);
   assert.equal(result.body.job_id, "501");
   assert.equal(result.body.base_total, 1399.5);
+  assert.equal(result.body.booking_ticket.booking_code, "CWF501");
+  assert.equal(result.body.booking_ticket.exact_total, "1399.50");
+  assert.equal(result.body.booking_ticket.total_machine_count, 2);
+  assert.doesNotMatch(JSON.stringify(result.body.booking_ticket), /job_id|booking_token|package_id|tier_id|snapshot|address|maps/i);
   assert.equal(resolverCalls, 0);
   assert.ok(calls.some((sql) => /pg_advisory_xact_lock/.test(sql)));
   assert.equal(calls.some((sql) => /\bINSERT\b|\bUPDATE\b|\bDELETE\b/.test(sql)), false);

--- a/test/customerServicePackageBooking.test.js
+++ b/test/customerServicePackageBooking.test.js
@@ -106,7 +106,7 @@ test("Admin ordinary validation remains callable while package requests use the 
   const adminEnd = source.indexOf("\n  async function ", adminStart + 1);
   const adminSource = source.slice(adminStart, adminEnd);
   assert.match(adminSource, /hasPackageRequest/);
-  assert.match(adminSource, /identity: "admin"/);
+  assert.match(adminSource, /identity: Array\.isArray\(body\.service_package_groups\) \? "customer" : "admin"/);
 
   const result = await invoke(bookingService().handleAdminBookV2, scheduledRequest());
   assert.equal(result.statusCode, 400);
@@ -266,11 +266,13 @@ test("advisory-locked committed package replay bypasses unavailable current reso
     async connect() { return client; },
     async query(sql) {
       calls.push(sql);
+      if (/FROM public\.jobs WHERE job_id=\$1/.test(sql)) return { rows: [prior] };
       if (/service_package_snapshot/.test(sql)) return { rows: [{
         service_package_id: "41", service_package_tier_id: "73",
         service_package_snapshot: historical.snapshot,
       }] };
       if (/SELECT 1 FROM public\.job_items/.test(sql)) return { rows: [{ "?column?": 1 }] };
+      if (/SELECT item_name, qty, is_service/.test(sql)) return { rows: [{ ...canonical.item, is_service: true }] };
       if (/SELECT item_name, qty, line_total/.test(sql)) return { rows: [canonical.item] };
       throw new Error(`unexpected query: ${sql}`);
     },

--- a/test/customerServicePackageBooking.test.js
+++ b/test/customerServicePackageBooking.test.js
@@ -333,10 +333,10 @@ test("booking mutation keeps package linkage, snapshot, price, promotion bypass,
   const units = source.indexOf("ensureCanonicalBookingJobUnits(job_id, client)", itemInsert);
   const commit = source.indexOf('await client.query("COMMIT")', units);
   assert.ok(begin >= 0 && revalidate > begin && itemInsert > revalidate && units > itemInsert && commit > units);
-  assert.match(source, /const promoPick = packageBooking \? null : await findBestCustomerPromotion/);
+  assert.match(source, /const promoPick = packageBooking \|\| catalogBooking \? null : await findBestCustomerPromotion/);
   assert.match(source, /packageBooking \? packageBooking\.fixedTotal : Number\(total \|\| 0\)/);
   assert.match(source, /pg_advisory_xact_lock/);
-  assert.match(source, /packageBooking \? packageBooking\.items : await customerPricingHelpers/);
+  assert.match(source, /packageBooking \? packageBooking\.items[\s\S]*?catalogBooking \? \[buildCatalogBookingItem\(catalogBooking\)\]/);
 });
 
 test("package replay ordering uses persisted history before current resolution and locked revalidation", () => {

--- a/test/customerServicePackageBooking.test.js
+++ b/test/customerServicePackageBooking.test.js
@@ -330,7 +330,7 @@ test("booking mutation keeps package linkage, snapshot, price, promotion bypass,
   assert.match(source, /const promoPick = packageBooking \? null : await findBestCustomerPromotion/);
   assert.match(source, /packageBooking \? packageBooking\.fixedTotal : Number\(total \|\| 0\)/);
   assert.match(source, /pg_advisory_xact_lock/);
-  assert.match(source, /packageBooking \? \[packageBooking\.item\] : await customerPricingHelpers/);
+  assert.match(source, /packageBooking \? packageBooking\.items : await customerPricingHelpers/);
 });
 
 test("package replay ordering uses persisted history before current resolution and locked revalidation", () => {

--- a/test/customerServicePackageBooking.test.js
+++ b/test/customerServicePackageBooking.test.js
@@ -293,6 +293,8 @@ test("advisory-locked committed package replay bypasses unavailable current reso
   assert.equal(result.body.replayed, true);
   assert.equal(result.body.job_id, "501");
   assert.equal(result.body.base_total, 1399.5);
+  assert.equal(result.body.base_total_exact, "1399.50");
+  assert.equal(result.body.net_total, "1399.50");
   assert.equal(result.body.booking_ticket.booking_code, "CWF501");
   assert.equal(result.body.booking_ticket.exact_total, "1399.50");
   assert.equal(result.body.booking_ticket.total_machine_count, 2);
@@ -335,6 +337,7 @@ test("ordinary Store replay uses its persisted fingerprint before a disabled cat
   assert.equal(replay.statusCode, 200);
   assert.equal(replay.body.replayed, true);
   assert.equal(replay.body.booking_ticket.exact_total, "699.00");
+  assert.equal(replay.body.net_total, "699.00");
   assert.equal(calls.some((sql) => /catalog_items|customer_service_price_rules|promotions_v2/.test(sql)), false);
   assert.equal(calls.some((sql) => /\bINSERT\b|\bUPDATE\b|\bDELETE\b/.test(sql)), false);
 

--- a/test/customerServicePackageUi.test.js
+++ b/test/customerServicePackageUi.test.js
@@ -109,6 +109,28 @@ test("package payload contains only keys and actual BTU while availability is se
   assert.equal("services" in query, false);
 });
 
+test("composite Store selection submits only stable package keys, BTU, quantity, and keeps duplicate-submit key", () => {
+  const root = loadBooking();
+  const previewData = { package_name: "Bundle", fixed_total_price: "3198.00", duration_min: 180,
+    redeem_until: "2027-01-31T16:59:59.000Z", groups: [], payload: { services: [
+      { job_type: "wash", ac_type: "wall", btu: 12000, machine_count: 2, wash_variant: "premium", repair_variant: "" },
+      { job_type: "wash", ac_type: "wall", btu: 18000, machine_count: 2, wash_variant: "premium", repair_variant: "" },
+    ] } };
+  root.state.updateDraft("scheduled", { customer_name: "TEST", customer_phone: "0812345678", address_text: "TEST",
+    selectedSlot: { date: root.state.draft.scheduled.date, start: "09:00" },
+    service_package_groups: [{ package_key: "small", btu: 12000, quantity: 2 }, { package_key: "large", btu: 18000, quantity: 2 }],
+    service_package_bundle_preview: previewData, services: [] });
+  root.state.setScheduledPreview("package", { status: "success", data: previewData, error: "", verified: true });
+  const payload = root.bookingScheduled._test.buildSubmitPayload();
+  assert.equal(payload.service_package_groups.length, 2);
+  assert.deepEqual(JSON.parse(JSON.stringify(payload.service_package_groups)), [
+    { package_key: "small", btu: 12000, quantity: 2 }, { package_key: "large", btu: 18000, quantity: 2 },
+  ]);
+  assert.match(payload.scheduled_request_key, /^[A-Za-z0-9_-]{16,128}$/);
+  for (const forbidden of ["catalog_item_id", "fixed_total_price", "duration_min", "snapshot", "service_package_id"]) assert.equal(forbidden in payload, false);
+  assert.equal(root.bookingScheduled._test.validateServiceStep(), "");
+});
+
 test("ordinary payload remains ordinary and package horizon is isolated", () => {
   const root = loadBooking();
   const ordinaryMax = root.bookingScheduled._test.maxBookingDate();
@@ -168,7 +190,7 @@ test("build id is coordinated and service worker privacy/network behavior remain
   const app = read("customer-app/assets/customer-app.js");
   const manifest = read("customer-app/manifest.webmanifest");
   const build = sw.match(/BUILD_ID = "([^"]+)"/)[1];
-  assert.equal(build, "20260808_homepage_service_packages_v2");
+  assert.equal(build, "20260809_store_service_package_bundles_v1");
   assert.match(index, new RegExp(build));
   assert.match(app, new RegExp(`BUILD_ID = "${build}"`));
   assert.match(manifest, new RegExp(`index\\.html\\?v=${build}#home`));

--- a/test/customerServicePackageUi.test.js
+++ b/test/customerServicePackageUi.test.js
@@ -118,6 +118,7 @@ test("composite Store selection submits only stable package keys, BTU, quantity,
     ] } };
   root.state.updateDraft("scheduled", { customer_name: "TEST", customer_phone: "0812345678", address_text: "TEST",
     selectedSlot: { date: root.state.draft.scheduled.date, start: "09:00" },
+    catalog_item_id: 51,
     service_package_groups: [{ package_key: "small", btu: 12000, quantity: 2 }, { package_key: "large", btu: 18000, quantity: 2 }],
     service_package_bundle_preview: previewData, services: [] });
   root.state.setScheduledPreview("package", { status: "success", data: previewData, error: "", verified: true });
@@ -127,7 +128,8 @@ test("composite Store selection submits only stable package keys, BTU, quantity,
     { package_key: "small", btu: 12000, quantity: 2 }, { package_key: "large", btu: 18000, quantity: 2 },
   ]);
   assert.match(payload.scheduled_request_key, /^[A-Za-z0-9_-]{16,128}$/);
-  for (const forbidden of ["catalog_item_id", "fixed_total_price", "duration_min", "snapshot", "service_package_id"]) assert.equal(forbidden in payload, false);
+  assert.equal(payload.catalog_item_id, 51);
+  for (const forbidden of ["fixed_total_price", "duration_min", "snapshot", "service_package_id"]) assert.equal(forbidden in payload, false);
   assert.equal(root.bookingScheduled._test.validateServiceStep(), "");
 });
 
@@ -190,7 +192,7 @@ test("build id is coordinated and service worker privacy/network behavior remain
   const app = read("customer-app/assets/customer-app.js");
   const manifest = read("customer-app/manifest.webmanifest");
   const build = sw.match(/BUILD_ID = "([^"]+)"/)[1];
-  assert.equal(build, "20260809_issue267_catalog_flow_v6");
+  assert.equal(build, "20260809_issue267_catalog_flow_v7");
   assert.match(index, new RegExp(build));
   assert.match(app, new RegExp(`BUILD_ID = "${build}"`));
   assert.match(manifest, new RegExp(`index\\.html\\?v=${build}#home`));

--- a/test/customerServicePackageUi.test.js
+++ b/test/customerServicePackageUi.test.js
@@ -190,7 +190,7 @@ test("build id is coordinated and service worker privacy/network behavior remain
   const app = read("customer-app/assets/customer-app.js");
   const manifest = read("customer-app/manifest.webmanifest");
   const build = sw.match(/BUILD_ID = "([^"]+)"/)[1];
-  assert.equal(build, "20260809_issue267_admin_builder_v2");
+  assert.equal(build, "20260809_issue267_merchandising_v3");
   assert.match(index, new RegExp(build));
   assert.match(app, new RegExp(`BUILD_ID = "${build}"`));
   assert.match(manifest, new RegExp(`index\\.html\\?v=${build}#home`));

--- a/test/customerServicePackageUi.test.js
+++ b/test/customerServicePackageUi.test.js
@@ -192,7 +192,7 @@ test("build id is coordinated and service worker privacy/network behavior remain
   const app = read("customer-app/assets/customer-app.js");
   const manifest = read("customer-app/manifest.webmanifest");
   const build = sw.match(/BUILD_ID = "([^"]+)"/)[1];
-  assert.equal(build, "20260809_issue267_catalog_flow_v8");
+  assert.equal(build, "20260809_issue267_catalog_flow_v9");
   assert.match(index, new RegExp(build));
   assert.match(app, new RegExp(`BUILD_ID = "${build}"`));
   assert.match(manifest, new RegExp(`index\\.html\\?v=${build}#home`));

--- a/test/customerServicePackageUi.test.js
+++ b/test/customerServicePackageUi.test.js
@@ -192,7 +192,7 @@ test("build id is coordinated and service worker privacy/network behavior remain
   const app = read("customer-app/assets/customer-app.js");
   const manifest = read("customer-app/manifest.webmanifest");
   const build = sw.match(/BUILD_ID = "([^"]+)"/)[1];
-  assert.equal(build, "20260809_issue267_catalog_flow_v7");
+  assert.equal(build, "20260809_issue267_catalog_flow_v8");
   assert.match(index, new RegExp(build));
   assert.match(app, new RegExp(`BUILD_ID = "${build}"`));
   assert.match(manifest, new RegExp(`index\\.html\\?v=${build}#home`));

--- a/test/customerServicePackageUi.test.js
+++ b/test/customerServicePackageUi.test.js
@@ -190,7 +190,7 @@ test("build id is coordinated and service worker privacy/network behavior remain
   const app = read("customer-app/assets/customer-app.js");
   const manifest = read("customer-app/manifest.webmanifest");
   const build = sw.match(/BUILD_ID = "([^"]+)"/)[1];
-  assert.equal(build, "20260809_issue267_heading_cleanup_v4");
+  assert.equal(build, "20260809_issue267_booking_ticket_v5");
   assert.match(index, new RegExp(build));
   assert.match(app, new RegExp(`BUILD_ID = "${build}"`));
   assert.match(manifest, new RegExp(`index\\.html\\?v=${build}#home`));

--- a/test/customerServicePackageUi.test.js
+++ b/test/customerServicePackageUi.test.js
@@ -190,7 +190,7 @@ test("build id is coordinated and service worker privacy/network behavior remain
   const app = read("customer-app/assets/customer-app.js");
   const manifest = read("customer-app/manifest.webmanifest");
   const build = sw.match(/BUILD_ID = "([^"]+)"/)[1];
-  assert.equal(build, "20260809_issue267_merchandising_v3");
+  assert.equal(build, "20260809_issue267_heading_cleanup_v4");
   assert.match(index, new RegExp(build));
   assert.match(app, new RegExp(`BUILD_ID = "${build}"`));
   assert.match(manifest, new RegExp(`index\\.html\\?v=${build}#home`));

--- a/test/customerServicePackageUi.test.js
+++ b/test/customerServicePackageUi.test.js
@@ -190,7 +190,7 @@ test("build id is coordinated and service worker privacy/network behavior remain
   const app = read("customer-app/assets/customer-app.js");
   const manifest = read("customer-app/manifest.webmanifest");
   const build = sw.match(/BUILD_ID = "([^"]+)"/)[1];
-  assert.equal(build, "20260809_issue267_booking_ticket_v5");
+  assert.equal(build, "20260809_issue267_catalog_flow_v6");
   assert.match(index, new RegExp(build));
   assert.match(app, new RegExp(`BUILD_ID = "${build}"`));
   assert.match(manifest, new RegExp(`index\\.html\\?v=${build}#home`));

--- a/test/customerServicePackageUi.test.js
+++ b/test/customerServicePackageUi.test.js
@@ -190,7 +190,7 @@ test("build id is coordinated and service worker privacy/network behavior remain
   const app = read("customer-app/assets/customer-app.js");
   const manifest = read("customer-app/manifest.webmanifest");
   const build = sw.match(/BUILD_ID = "([^"]+)"/)[1];
-  assert.equal(build, "20260809_store_service_package_bundles_v1");
+  assert.equal(build, "20260809_issue267_admin_builder_v2");
   assert.match(index, new RegExp(build));
   assert.match(app, new RegExp(`BUILD_ID = "${build}"`));
   assert.match(manifest, new RegExp(`index\\.html\\?v=${build}#home`));

--- a/test/customerSmartAdvisor.test.js
+++ b/test/customerSmartAdvisor.test.js
@@ -1174,7 +1174,7 @@ test("Home places built-in advisor after Quick Actions and before Featured Servi
 });
 
 test("advisor module is loaded before ui.js and precached under the shared build id", () => {
-  const build = "20260809_issue267_booking_ticket_v5";
+  const build = "20260809_issue267_catalog_flow_v6";
   assert.ok(INDEX_SOURCE.indexOf(`modules/advisor.js?v=${build}`) < INDEX_SOURCE.indexOf(`modules/ui.js?v=${build}`));
   assert.match(SW_SOURCE, new RegExp(`BUILD_ID = "${build}"`));
   assert.match(SW_SOURCE, /modules\/advisor\.js\?v=\$\{BUILD_ID\}/);

--- a/test/customerSmartAdvisor.test.js
+++ b/test/customerSmartAdvisor.test.js
@@ -1174,7 +1174,7 @@ test("Home places built-in advisor after Quick Actions and before Featured Servi
 });
 
 test("advisor module is loaded before ui.js and precached under the shared build id", () => {
-  const build = "20260809_issue267_catalog_flow_v6";
+  const build = "20260809_issue267_catalog_flow_v7";
   assert.ok(INDEX_SOURCE.indexOf(`modules/advisor.js?v=${build}`) < INDEX_SOURCE.indexOf(`modules/ui.js?v=${build}`));
   assert.match(SW_SOURCE, new RegExp(`BUILD_ID = "${build}"`));
   assert.match(SW_SOURCE, /modules\/advisor\.js\?v=\$\{BUILD_ID\}/);

--- a/test/customerSmartAdvisor.test.js
+++ b/test/customerSmartAdvisor.test.js
@@ -1174,7 +1174,7 @@ test("Home places built-in advisor after Quick Actions and before Featured Servi
 });
 
 test("advisor module is loaded before ui.js and precached under the shared build id", () => {
-  const build = "20260809_issue267_merchandising_v3";
+  const build = "20260809_issue267_heading_cleanup_v4";
   assert.ok(INDEX_SOURCE.indexOf(`modules/advisor.js?v=${build}`) < INDEX_SOURCE.indexOf(`modules/ui.js?v=${build}`));
   assert.match(SW_SOURCE, new RegExp(`BUILD_ID = "${build}"`));
   assert.match(SW_SOURCE, /modules\/advisor\.js\?v=\$\{BUILD_ID\}/);

--- a/test/customerSmartAdvisor.test.js
+++ b/test/customerSmartAdvisor.test.js
@@ -1174,7 +1174,7 @@ test("Home places built-in advisor after Quick Actions and before Featured Servi
 });
 
 test("advisor module is loaded before ui.js and precached under the shared build id", () => {
-  const build = "20260809_issue267_catalog_flow_v8";
+  const build = "20260809_issue267_catalog_flow_v9";
   assert.ok(INDEX_SOURCE.indexOf(`modules/advisor.js?v=${build}`) < INDEX_SOURCE.indexOf(`modules/ui.js?v=${build}`));
   assert.match(SW_SOURCE, new RegExp(`BUILD_ID = "${build}"`));
   assert.match(SW_SOURCE, /modules\/advisor\.js\?v=\$\{BUILD_ID\}/);

--- a/test/customerSmartAdvisor.test.js
+++ b/test/customerSmartAdvisor.test.js
@@ -1174,7 +1174,7 @@ test("Home places built-in advisor after Quick Actions and before Featured Servi
 });
 
 test("advisor module is loaded before ui.js and precached under the shared build id", () => {
-  const build = "20260809_issue267_admin_builder_v2";
+  const build = "20260809_issue267_merchandising_v3";
   assert.ok(INDEX_SOURCE.indexOf(`modules/advisor.js?v=${build}`) < INDEX_SOURCE.indexOf(`modules/ui.js?v=${build}`));
   assert.match(SW_SOURCE, new RegExp(`BUILD_ID = "${build}"`));
   assert.match(SW_SOURCE, /modules\/advisor\.js\?v=\$\{BUILD_ID\}/);

--- a/test/customerSmartAdvisor.test.js
+++ b/test/customerSmartAdvisor.test.js
@@ -1174,7 +1174,7 @@ test("Home places built-in advisor after Quick Actions and before Featured Servi
 });
 
 test("advisor module is loaded before ui.js and precached under the shared build id", () => {
-  const build = "20260809_issue267_heading_cleanup_v4";
+  const build = "20260809_issue267_booking_ticket_v5";
   assert.ok(INDEX_SOURCE.indexOf(`modules/advisor.js?v=${build}`) < INDEX_SOURCE.indexOf(`modules/ui.js?v=${build}`));
   assert.match(SW_SOURCE, new RegExp(`BUILD_ID = "${build}"`));
   assert.match(SW_SOURCE, /modules\/advisor\.js\?v=\$\{BUILD_ID\}/);

--- a/test/customerSmartAdvisor.test.js
+++ b/test/customerSmartAdvisor.test.js
@@ -1174,7 +1174,7 @@ test("Home places built-in advisor after Quick Actions and before Featured Servi
 });
 
 test("advisor module is loaded before ui.js and precached under the shared build id", () => {
-  const build = "20260809_store_service_package_bundles_v1";
+  const build = "20260809_issue267_admin_builder_v2";
   assert.ok(INDEX_SOURCE.indexOf(`modules/advisor.js?v=${build}`) < INDEX_SOURCE.indexOf(`modules/ui.js?v=${build}`));
   assert.match(SW_SOURCE, new RegExp(`BUILD_ID = "${build}"`));
   assert.match(SW_SOURCE, /modules\/advisor\.js\?v=\$\{BUILD_ID\}/);

--- a/test/customerSmartAdvisor.test.js
+++ b/test/customerSmartAdvisor.test.js
@@ -1174,7 +1174,7 @@ test("Home places built-in advisor after Quick Actions and before Featured Servi
 });
 
 test("advisor module is loaded before ui.js and precached under the shared build id", () => {
-  const build = "20260728_urgent_dispatch_preflight_v2";
+  const build = "20260809_store_service_package_bundles_v1";
   assert.ok(INDEX_SOURCE.indexOf(`modules/advisor.js?v=${build}`) < INDEX_SOURCE.indexOf(`modules/ui.js?v=${build}`));
   assert.match(SW_SOURCE, new RegExp(`BUILD_ID = "${build}"`));
   assert.match(SW_SOURCE, /modules\/advisor\.js\?v=\$\{BUILD_ID\}/);

--- a/test/customerSmartAdvisor.test.js
+++ b/test/customerSmartAdvisor.test.js
@@ -1174,7 +1174,7 @@ test("Home places built-in advisor after Quick Actions and before Featured Servi
 });
 
 test("advisor module is loaded before ui.js and precached under the shared build id", () => {
-  const build = "20260809_issue267_catalog_flow_v7";
+  const build = "20260809_issue267_catalog_flow_v8";
   assert.ok(INDEX_SOURCE.indexOf(`modules/advisor.js?v=${build}`) < INDEX_SOURCE.indexOf(`modules/ui.js?v=${build}`));
   assert.match(SW_SOURCE, new RegExp(`BUILD_ID = "${build}"`));
   assert.match(SW_SOURCE, /modules\/advisor\.js\?v=\$\{BUILD_ID\}/);

--- a/test/customerStoreServicePackageBundleUi.test.js
+++ b/test/customerStoreServicePackageBundleUi.test.js
@@ -12,7 +12,9 @@ const admin = fs.readFileSync("admin-store-catalog.js", "utf8");
 test("Store renders one parent configurator with arbitrary nested variants and quantities beyond four", () => {
   assert.match(store, /service_package_variants\.map/);
   assert.match(store, /data-bundle-package/);
-  assert.match(store, /Array\.from\(\{ length: 11 \}/);
+  assert.match(store, /data-bundle-quantity[^>]*type="number"[^>]*min="0"/);
+  assert.doesNotMatch(store, /data-bundle-quantity[\s\S]{0,200}max=/);
+  assert.doesNotMatch(store, /tier\.quantity === 1[\s\S]{0,120}prior\.components/);
   assert.match(store, /service_package_groups: result\.groups/);
   assert.doesNotMatch(store, /Premium Day|premium-day/);
 });

--- a/test/customerStoreServicePackageBundleUi.test.js
+++ b/test/customerStoreServicePackageBundleUi.test.js
@@ -1,0 +1,32 @@
+"use strict";
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+
+const store = fs.readFileSync("customer-app/modules/store.js", "utf8");
+const scheduled = fs.readFileSync("customer-app/modules/bookingScheduled.js", "utf8");
+const css = fs.readFileSync("customer-app/assets/customer-app.css", "utf8");
+const admin = fs.readFileSync("admin-store-catalog.js", "utf8");
+
+test("Store renders one parent configurator with arbitrary nested variants and quantities beyond four", () => {
+  assert.match(store, /service_package_variants\.map/);
+  assert.match(store, /data-bundle-package/);
+  assert.match(store, /Array\.from\(\{ length: 11 \}/);
+  assert.match(store, /service_package_groups: result\.groups/);
+  assert.doesNotMatch(store, /Premium Day|premium-day/);
+});
+
+test("mobile 360 and 390 layouts collapse each bundle row without a fixed-width overflow", () => {
+  assert.match(css, /@media \(max-width: 480px\)[^{]*\{[^}]*\.store-bundle-row/);
+  assert.match(css, /grid-template-columns: 1fr 1fr/);
+  for (const viewport of [360, 390]) assert.ok(viewport <= 480);
+  assert.doesNotMatch(css.match(/\.store-bundle-row \{[^}]+\}/)?.[0] || "", /width:\s*[4-9]\d{2}px/);
+});
+
+test("scheduled flow and Admin use the composite contract instead of standalone package seeding", () => {
+  assert.match(scheduled, /service_package_groups/);
+  assert.match(admin, /\/admin\/catalog\/service-package-bundles/);
+  assert.match(admin, /บันทึกสินค้าและแพ็กเกจ/);
+  assert.match(admin, /loadCatalogItems\(\)/);
+});

--- a/test/customerStoreServicePackageBundleUi.test.js
+++ b/test/customerStoreServicePackageBundleUi.test.js
@@ -41,3 +41,11 @@ test("Store grid binds urgent actions with policy and runtime availability gates
   assert.match(grid, /urgentBookingAvailable/);
   assert.doesNotMatch(detail, /querySelectorAll\("\[data-store-urgent\]"\)/);
 });
+
+test("sale expiry gates actions independently from countdown presentation", () => {
+  assert.match(store, /data-campaign-sale-end/);
+  assert.match(store, /querySelectorAll\("\[data-campaign-sale-end\]"\)/);
+  assert.match(store, /querySelector\("\[data-campaign-countdown\]"\)/);
+  assert.match(store, /button\.disabled = true/);
+  assert.match(store, /Math\.min\(60000, Math\.max\(1, remaining\)\)/);
+});

--- a/test/customerStoreServicePackageBundleUi.test.js
+++ b/test/customerStoreServicePackageBundleUi.test.js
@@ -32,3 +32,12 @@ test("scheduled flow and Admin use the composite contract instead of standalone 
   assert.match(admin, /บันทึกสินค้าและแพ็กเกจ/);
   assert.match(admin, /loadCatalogItems\(\)/);
 });
+
+test("Store grid binds urgent actions with policy and runtime availability gates", () => {
+  const grid = store.slice(store.indexOf("function bindGridActions"), store.indexOf("function patchGrid"));
+  const detail = store.slice(store.indexOf("function bindDetailBody"), store.indexOf("function openDetail"));
+  assert.match(grid, /querySelectorAll\("\[data-store-urgent\]"\)/);
+  assert.match(grid, /allowsUrgentBooking\(item\)/);
+  assert.match(grid, /urgentBookingAvailable/);
+  assert.doesNotMatch(detail, /querySelectorAll\("\[data-store-urgent\]"\)/);
+});

--- a/test/customerTrackingFullReadUi.test.js
+++ b/test/customerTrackingFullReadUi.test.js
@@ -1191,7 +1191,7 @@ test("tracking UI exposes loading, not-found, rate-limit and offline states", ()
 });
 
 test("tracking assets share the full-read cache build id", () => {
-  const build = "20260809_issue267_catalog_flow_v7";
+  const build = "20260809_issue267_catalog_flow_v8";
   for (const file of [
     "customer-app/index.html",
     "customer-app/sw.js",

--- a/test/customerTrackingFullReadUi.test.js
+++ b/test/customerTrackingFullReadUi.test.js
@@ -1191,7 +1191,7 @@ test("tracking UI exposes loading, not-found, rate-limit and offline states", ()
 });
 
 test("tracking assets share the full-read cache build id", () => {
-  const build = "20260809_issue267_admin_builder_v2";
+  const build = "20260809_issue267_merchandising_v3";
   for (const file of [
     "customer-app/index.html",
     "customer-app/sw.js",

--- a/test/customerTrackingFullReadUi.test.js
+++ b/test/customerTrackingFullReadUi.test.js
@@ -1191,7 +1191,7 @@ test("tracking UI exposes loading, not-found, rate-limit and offline states", ()
 });
 
 test("tracking assets share the full-read cache build id", () => {
-  const build = "20260809_issue267_catalog_flow_v6";
+  const build = "20260809_issue267_catalog_flow_v7";
   for (const file of [
     "customer-app/index.html",
     "customer-app/sw.js",

--- a/test/customerTrackingFullReadUi.test.js
+++ b/test/customerTrackingFullReadUi.test.js
@@ -355,7 +355,7 @@ test("completed cleaning renders one prominent donut with date elapsed time and 
   const html = app.tracking._test.renderPassport(completedHealthPayload());
   assert.equal((html.match(/data-unit-cleanliness/g) || []).length, 1);
   assert.match(html, /class="cleanliness-ring"/);
-  assert.match(html, />100%<|>99%</);
+  assert.match(html, />\d{1,3}%</);
   assert.match(html, /ประมาณการความสะอาดจากงานนี้/);
   assert.match(html, /วันที่ล้างของงานนี้/);
   assert.match(html, /ผ่านมาแล้ว/);
@@ -1191,7 +1191,7 @@ test("tracking UI exposes loading, not-found, rate-limit and offline states", ()
 });
 
 test("tracking assets share the full-read cache build id", () => {
-  const build = "20260728_urgent_dispatch_preflight_v2";
+  const build = "20260809_store_service_package_bundles_v1";
   for (const file of [
     "customer-app/index.html",
     "customer-app/sw.js",

--- a/test/customerTrackingFullReadUi.test.js
+++ b/test/customerTrackingFullReadUi.test.js
@@ -1191,7 +1191,7 @@ test("tracking UI exposes loading, not-found, rate-limit and offline states", ()
 });
 
 test("tracking assets share the full-read cache build id", () => {
-  const build = "20260809_store_service_package_bundles_v1";
+  const build = "20260809_issue267_admin_builder_v2";
   for (const file of [
     "customer-app/index.html",
     "customer-app/sw.js",

--- a/test/customerTrackingFullReadUi.test.js
+++ b/test/customerTrackingFullReadUi.test.js
@@ -1191,7 +1191,7 @@ test("tracking UI exposes loading, not-found, rate-limit and offline states", ()
 });
 
 test("tracking assets share the full-read cache build id", () => {
-  const build = "20260809_issue267_heading_cleanup_v4";
+  const build = "20260809_issue267_booking_ticket_v5";
   for (const file of [
     "customer-app/index.html",
     "customer-app/sw.js",

--- a/test/customerTrackingFullReadUi.test.js
+++ b/test/customerTrackingFullReadUi.test.js
@@ -1191,7 +1191,7 @@ test("tracking UI exposes loading, not-found, rate-limit and offline states", ()
 });
 
 test("tracking assets share the full-read cache build id", () => {
-  const build = "20260809_issue267_catalog_flow_v8";
+  const build = "20260809_issue267_catalog_flow_v9";
   for (const file of [
     "customer-app/index.html",
     "customer-app/sw.js",

--- a/test/customerTrackingFullReadUi.test.js
+++ b/test/customerTrackingFullReadUi.test.js
@@ -1191,7 +1191,7 @@ test("tracking UI exposes loading, not-found, rate-limit and offline states", ()
 });
 
 test("tracking assets share the full-read cache build id", () => {
-  const build = "20260809_issue267_booking_ticket_v5";
+  const build = "20260809_issue267_catalog_flow_v6";
   for (const file of [
     "customer-app/index.html",
     "customer-app/sw.js",

--- a/test/customerTrackingFullReadUi.test.js
+++ b/test/customerTrackingFullReadUi.test.js
@@ -1191,7 +1191,7 @@ test("tracking UI exposes loading, not-found, rate-limit and offline states", ()
 });
 
 test("tracking assets share the full-read cache build id", () => {
-  const build = "20260809_issue267_merchandising_v3";
+  const build = "20260809_issue267_heading_cleanup_v4";
   for (const file of [
     "customer-app/index.html",
     "customer-app/sw.js",

--- a/test/customerUrgentDirectAutoOffer.test.js
+++ b/test/customerUrgentDirectAutoOffer.test.js
@@ -152,10 +152,14 @@ test("public urgent preflight serializes only safe dispatch fields and never can
   assert.equal(reply.statusCode, 200);
   assert.deepEqual(Object.keys(reply.body).sort(), [
     "can_dispatch",
+    "duration_min",
+    "machine_count",
     "nearby_times",
     "reason",
     "resolved_zone",
   ]);
+  assert.equal(reply.body.duration_min, 60);
+  assert.equal(reply.body.machine_count, 1);
   assert.equal(reply.body.can_dispatch, false);
   assert.equal(reply.body.reason, "time_unavailable");
   assert.equal(reply.body.resolved_zone.service_zone_code, "A");

--- a/test/exactBookingPricing.test.js
+++ b/test/exactBookingPricing.test.js
@@ -1,0 +1,11 @@
+"use strict";
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const { calcBookingPricing } = require("../server/services/booking/exactPricing");
+
+test("authoritative package line total is not recomputed from rounded unit price", () => {
+  assert.deepEqual(calcBookingPricing([{ qty: 4, unit_price: "349.88", line_total: "1399.50" }]), {
+    subtotal: 1399.5, discount: 0, total: 1399.5,
+  });
+});

--- a/test/exactBookingPricing.test.js
+++ b/test/exactBookingPricing.test.js
@@ -3,9 +3,44 @@
 const test = require("node:test");
 const assert = require("node:assert/strict");
 const { calcBookingPricing } = require("../server/services/booking/exactPricing");
+const { createBookingJobService } = require("../server/services/booking/createBookingJob");
+const adminIdempotency = require("../server/services/booking/adminBookingIdempotency");
 
 test("authoritative package line total is not recomputed from rounded unit price", () => {
   assert.deepEqual(calcBookingPricing([{ qty: 4, unit_price: "349.88", line_total: "1399.50" }]), {
+    subtotal_exact: "1399.50", discount_exact: "0.00", total_exact: "1399.50",
     subtotal: 1399.5, discount: 0, total: 1399.5,
   });
+});
+
+test("percent and amount discounts stay in integer minor units and preserve textual scale", () => {
+  assert.deepEqual(calcBookingPricing([{ qty: 1, line_total: "1399.50" }], {
+    promo_type: "percent", promo_value: "10.00",
+  }), {
+    subtotal_exact: "1399.50", discount_exact: "139.95", total_exact: "1259.55",
+    subtotal: 1399.5, discount: 139.95, total: 1259.55,
+  });
+  assert.equal(calcBookingPricing([{ qty: 4, unit_price: "349.88" }]).total_exact, "1399.52");
+});
+
+test("Admin HTTP idempotent replay returns the persisted two-decimal total as authoritative text", async () => {
+  const body = {
+    customer_name: "TEST Admin Customer", job_type: "ล้าง", appointment_datetime: "2026-08-20T10:00:00+07:00",
+    address_text: "TEST address", booking_mode: "scheduled", admin_request_key: "admin_exact_139950_test",
+  };
+  const fingerprint = adminIdempotency.requestFingerprint(body);
+  const service = createBookingJobService({
+    pool: { async query() { return { rows: [{ job_id: 41, booking_code: "CWFTEST41", booking_mode: "scheduled",
+      dispatch_mode: "normal", duration_min: 180, job_price: "1399.50", admin_request_fingerprint: fingerprint }] }; } },
+    isServiceZoneFilterEnabled: () => false,
+    isCustomerScheduledBookingEnabled: () => true,
+    normalizeAppointmentDatetime: (value) => value,
+  });
+  const response = { statusCode: 200, status(code) { this.statusCode = code; return this; }, json(value) { this.body = value; return value; } };
+  await service.handleAdminBookV2({ body }, response);
+  assert.equal(response.statusCode, 200);
+  assert.equal(response.body.replayed, true);
+  assert.equal(response.body.total_exact, "1399.50");
+  assert.equal(response.body.total, 1399.5);
+  assert.equal(response.body.duration_min, 180);
 });

--- a/test/homepageCms.test.js
+++ b/test/homepageCms.test.js
@@ -305,7 +305,7 @@ test("customer homepage has no admin control, bottom nav is fixed five-tab, and 
   const sw = read("customer-app/sw.js");
   const app = read("customer-app/assets/customer-app.js");
   const manifest = read("customer-app/manifest.webmanifest");
-  const build = "20260808_homepage_service_packages_v2";
+  const build = "20260809_store_service_package_bundles_v1";
 
   assert.doesNotMatch(index + ui, /โหมดแอดมิน|openCms|localStorage\.getItem\('cwfHomeCmsDemo'/);
   assert.match(index, /data-route="store"[\s\S]*ร้านค้า/);

--- a/test/homepageCms.test.js
+++ b/test/homepageCms.test.js
@@ -305,7 +305,7 @@ test("customer homepage has no admin control, bottom nav is fixed five-tab, and 
   const sw = read("customer-app/sw.js");
   const app = read("customer-app/assets/customer-app.js");
   const manifest = read("customer-app/manifest.webmanifest");
-  const build = "20260809_issue267_catalog_flow_v8";
+  const build = "20260809_issue267_catalog_flow_v9";
 
   assert.doesNotMatch(index + ui, /โหมดแอดมิน|openCms|localStorage\.getItem\('cwfHomeCmsDemo'/);
   assert.match(index, /data-route="store"[\s\S]*ร้านค้า/);

--- a/test/homepageCms.test.js
+++ b/test/homepageCms.test.js
@@ -305,7 +305,7 @@ test("customer homepage has no admin control, bottom nav is fixed five-tab, and 
   const sw = read("customer-app/sw.js");
   const app = read("customer-app/assets/customer-app.js");
   const manifest = read("customer-app/manifest.webmanifest");
-  const build = "20260809_issue267_catalog_flow_v6";
+  const build = "20260809_issue267_catalog_flow_v7";
 
   assert.doesNotMatch(index + ui, /โหมดแอดมิน|openCms|localStorage\.getItem\('cwfHomeCmsDemo'/);
   assert.match(index, /data-route="store"[\s\S]*ร้านค้า/);

--- a/test/homepageCms.test.js
+++ b/test/homepageCms.test.js
@@ -305,7 +305,7 @@ test("customer homepage has no admin control, bottom nav is fixed five-tab, and 
   const sw = read("customer-app/sw.js");
   const app = read("customer-app/assets/customer-app.js");
   const manifest = read("customer-app/manifest.webmanifest");
-  const build = "20260809_issue267_heading_cleanup_v4";
+  const build = "20260809_issue267_booking_ticket_v5";
 
   assert.doesNotMatch(index + ui, /โหมดแอดมิน|openCms|localStorage\.getItem\('cwfHomeCmsDemo'/);
   assert.match(index, /data-route="store"[\s\S]*ร้านค้า/);

--- a/test/homepageCms.test.js
+++ b/test/homepageCms.test.js
@@ -305,7 +305,7 @@ test("customer homepage has no admin control, bottom nav is fixed five-tab, and 
   const sw = read("customer-app/sw.js");
   const app = read("customer-app/assets/customer-app.js");
   const manifest = read("customer-app/manifest.webmanifest");
-  const build = "20260809_issue267_admin_builder_v2";
+  const build = "20260809_issue267_merchandising_v3";
 
   assert.doesNotMatch(index + ui, /โหมดแอดมิน|openCms|localStorage\.getItem\('cwfHomeCmsDemo'/);
   assert.match(index, /data-route="store"[\s\S]*ร้านค้า/);

--- a/test/homepageCms.test.js
+++ b/test/homepageCms.test.js
@@ -305,7 +305,7 @@ test("customer homepage has no admin control, bottom nav is fixed five-tab, and 
   const sw = read("customer-app/sw.js");
   const app = read("customer-app/assets/customer-app.js");
   const manifest = read("customer-app/manifest.webmanifest");
-  const build = "20260809_issue267_booking_ticket_v5";
+  const build = "20260809_issue267_catalog_flow_v6";
 
   assert.doesNotMatch(index + ui, /โหมดแอดมิน|openCms|localStorage\.getItem\('cwfHomeCmsDemo'/);
   assert.match(index, /data-route="store"[\s\S]*ร้านค้า/);

--- a/test/homepageCms.test.js
+++ b/test/homepageCms.test.js
@@ -305,7 +305,7 @@ test("customer homepage has no admin control, bottom nav is fixed five-tab, and 
   const sw = read("customer-app/sw.js");
   const app = read("customer-app/assets/customer-app.js");
   const manifest = read("customer-app/manifest.webmanifest");
-  const build = "20260809_issue267_merchandising_v3";
+  const build = "20260809_issue267_heading_cleanup_v4";
 
   assert.doesNotMatch(index + ui, /โหมดแอดมิน|openCms|localStorage\.getItem\('cwfHomeCmsDemo'/);
   assert.match(index, /data-route="store"[\s\S]*ร้านค้า/);

--- a/test/homepageCms.test.js
+++ b/test/homepageCms.test.js
@@ -305,7 +305,7 @@ test("customer homepage has no admin control, bottom nav is fixed five-tab, and 
   const sw = read("customer-app/sw.js");
   const app = read("customer-app/assets/customer-app.js");
   const manifest = read("customer-app/manifest.webmanifest");
-  const build = "20260809_issue267_catalog_flow_v7";
+  const build = "20260809_issue267_catalog_flow_v8";
 
   assert.doesNotMatch(index + ui, /โหมดแอดมิน|openCms|localStorage\.getItem\('cwfHomeCmsDemo'/);
   assert.match(index, /data-route="store"[\s\S]*ร้านค้า/);

--- a/test/homepageCms.test.js
+++ b/test/homepageCms.test.js
@@ -305,7 +305,7 @@ test("customer homepage has no admin control, bottom nav is fixed five-tab, and 
   const sw = read("customer-app/sw.js");
   const app = read("customer-app/assets/customer-app.js");
   const manifest = read("customer-app/manifest.webmanifest");
-  const build = "20260809_store_service_package_bundles_v1";
+  const build = "20260809_issue267_admin_builder_v2";
 
   assert.doesNotMatch(index + ui, /โหมดแอดมิน|openCms|localStorage\.getItem\('cwfHomeCmsDemo'/);
   assert.match(index, /data-route="store"[\s\S]*ร้านค้า/);

--- a/test/jobLocationRoundtrip.test.js
+++ b/test/jobLocationRoundtrip.test.js
@@ -216,13 +216,13 @@ test("Test 14: check-in 500 m + accuracy policy is unchanged", () => {
 
 test("Test 15: PWA + admin cache build IDs are bumped consistently", () => {
   const BUILD = "20260712_job_location_roundtrip_v1";
-  const PR3_ADMIN_BUILD = "20260719_customer_booking_pr3_v1";
+  const ADMIN_ADD_BUILD = "20260807_admin_service_packages_v1";
   const URGENT_REVIEW_BUILD = "20260726_urgent_preferred_time_gps_v1";
   assert.match(read("app.js"), new RegExp(`__CWF_TECH_APP_VERSION__ = "${BUILD}"`));
   assert.match(read("sw.js"), new RegExp(`CWF_TECH_BUILD_ID = "${BUILD}"`));
   assert.match(read("cwf-pwa.js"), new RegExp(`VERSION = '${BUILD}'`));
   assert.match(read("tech.html"), new RegExp(`app\\.js\\?v=${BUILD}`));
-  assert.match(read("admin-add-v2.html"), new RegExp(`admin-add-v2\\.js\\?v=${PR3_ADMIN_BUILD}`));
+  assert.match(read("admin-add-v2.html"), new RegExp(`admin-add-v2\\.js\\?v=${ADMIN_ADD_BUILD}`));
   assert.match(read("admin-job-view-v2.html"), new RegExp(`admin-job-view-v2\\.js\\?v=${BUILD}`));
   assert.match(read("admin-review-v2.html"), new RegExp(`admin-review-v2\\.js\\?v=${URGENT_REVIEW_BUILD}`));
 });

--- a/test/jobLocationRoundtrip.test.js
+++ b/test/jobLocationRoundtrip.test.js
@@ -216,7 +216,7 @@ test("Test 14: check-in 500 m + accuracy policy is unchanged", () => {
 
 test("Test 15: PWA + admin cache build IDs are bumped consistently", () => {
   const BUILD = "20260712_job_location_roundtrip_v1";
-  const ADMIN_ADD_BUILD = "20260809_issue267_catalog_flow_v2";
+  const ADMIN_ADD_BUILD = "20260809_issue267_catalog_flow_v8";
   const URGENT_REVIEW_BUILD = "20260726_urgent_preferred_time_gps_v1";
   assert.match(read("app.js"), new RegExp(`__CWF_TECH_APP_VERSION__ = "${BUILD}"`));
   assert.match(read("sw.js"), new RegExp(`CWF_TECH_BUILD_ID = "${BUILD}"`));

--- a/test/jobLocationRoundtrip.test.js
+++ b/test/jobLocationRoundtrip.test.js
@@ -216,7 +216,7 @@ test("Test 14: check-in 500 m + accuracy policy is unchanged", () => {
 
 test("Test 15: PWA + admin cache build IDs are bumped consistently", () => {
   const BUILD = "20260712_job_location_roundtrip_v1";
-  const ADMIN_ADD_BUILD = "20260807_admin_service_packages_v1";
+  const ADMIN_ADD_BUILD = "20260809_issue267_catalog_flow_v2";
   const URGENT_REVIEW_BUILD = "20260726_urgent_preferred_time_gps_v1";
   assert.match(read("app.js"), new RegExp(`__CWF_TECH_APP_VERSION__ = "${BUILD}"`));
   assert.match(read("sw.js"), new RegExp(`CWF_TECH_BUILD_ID = "${BUILD}"`));

--- a/test/storeServicePackageBundlesMigration.test.js
+++ b/test/storeServicePackageBundlesMigration.test.js
@@ -1,0 +1,34 @@
+"use strict";
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const sql = fs.readFileSync("migrations/20260809_store_service_package_bundles.sql", "utf8");
+const runner = require("../scripts/run-store-service-package-bundles-migration");
+const rollback = fs.readFileSync("migrations/20260809_store_service_package_bundles.rollback.sql", "utf8");
+
+test("bundle migration links variants to Store parent and widens booking mode", () => {
+  assert.match(sql, /service_package/);
+  assert.match(sql, /ADD COLUMN IF NOT EXISTS catalog_item_id BIGINT/);
+  assert.match(sql, /REFERENCES public\.catalog_items\(item_id\) ON DELETE RESTRICT/);
+  assert.match(sql, /service_bundle_key TEXT/);
+  assert.match(sql, /service_package_sell_start_at TIMESTAMPTZ/);
+  assert.match(sql, /service_package_redeem_until TIMESTAMPTZ/);
+  assert.doesNotMatch(sql.split("\n").filter((line) => !line.trim().startsWith("--")).join("\n"), /\b(?:DELETE FROM|TRUNCATE|DROP TABLE|DROP COLUMN)\b/i);
+});
+
+test("migration runner is advisory locked, verified, and redacts credentials", () => {
+  assert.equal(runner.MIGRATION_RELATIVE_PATH, "migrations/20260809_store_service_package_bundles.sql");
+  assert.match(runner.safeErrorMessage(new Error("postgres://u:p@host/db password=oops")), /REDACTED_DATABASE_URL/);
+  assert.doesNotMatch(runner.safeErrorMessage(new Error("password=oops")), /oops/);
+  const source = fs.readFileSync("scripts/run-store-service-package-bundles-migration.js", "utf8");
+  assert.match(source, /pg_advisory_lock/);
+  assert.match(source, /query\("BEGIN"\)[\s\S]*verifySchema[\s\S]*query\("COMMIT"\)/);
+  assert.match(source, /query\("ROLLBACK"\)/);
+});
+
+test("pre-data rollback restores the former booking-mode contract", () => {
+  assert.match(rollback, /DROP COLUMN IF EXISTS catalog_item_id/);
+  assert.match(rollback, /CHECK \(booking_mode IN \('bookable', 'contact_admin', 'purchase'\)\)/);
+  assert.match(rollback, /PRE-DATA ROLLBACK ONLY/);
+});

--- a/test/storeServicePackageBundlesMigration.test.js
+++ b/test/storeServicePackageBundlesMigration.test.js
@@ -14,6 +14,12 @@ test("bundle migration links variants to Store parent and widens booking mode", 
   assert.match(sql, /service_bundle_key TEXT/);
   assert.match(sql, /service_package_sell_start_at TIMESTAMPTZ/);
   assert.match(sql, /service_package_redeem_until TIMESTAMPTZ/);
+  assert.match(sql, /promotion_theme_preset TEXT NOT NULL DEFAULT 'default'/);
+  assert.match(sql, /promotion_effect_preset TEXT NOT NULL DEFAULT 'none'/);
+  assert.match(sql, /booking_flow_policy TEXT NOT NULL DEFAULT 'scheduled_only'/);
+  assert.match(sql, /scheduled_and_urgent/);
+  assert.match(sql, /admin_request_key VARCHAR\(128\)/);
+  assert.match(sql, /CREATE UNIQUE INDEX IF NOT EXISTS uq_jobs_admin_request_key/);
   assert.doesNotMatch(sql.split("\n").filter((line) => !line.trim().startsWith("--")).join("\n"), /\b(?:DELETE FROM|TRUNCATE|DROP TABLE|DROP COLUMN)\b/i);
 });
 
@@ -29,6 +35,9 @@ test("migration runner is advisory locked, verified, and redacts credentials", (
 
 test("pre-data rollback restores the former booking-mode contract", () => {
   assert.match(rollback, /DROP COLUMN IF EXISTS catalog_item_id/);
+  assert.match(rollback, /DROP COLUMN IF EXISTS booking_flow_policy/);
+  assert.match(rollback, /DROP COLUMN IF EXISTS promotion_theme_preset/);
+  assert.match(rollback, /DROP COLUMN IF EXISTS admin_request_key/);
   assert.match(rollback, /CHECK \(booking_mode IN \('bookable', 'contact_admin', 'purchase'\)\)/);
   assert.match(rollback, /PRE-DATA ROLLBACK ONLY/);
 });

--- a/test/storeServicePackageBundlesMigration.test.js
+++ b/test/storeServicePackageBundlesMigration.test.js
@@ -19,6 +19,7 @@ test("bundle migration links variants to Store parent and widens booking mode", 
   assert.match(sql, /booking_flow_policy TEXT NOT NULL DEFAULT 'scheduled_only'/);
   assert.match(sql, /scheduled_and_urgent/);
   assert.match(sql, /admin_request_key VARCHAR\(128\)/);
+  assert.match(sql, /booking_request_fingerprint CHAR\(64\)/);
   assert.match(sql, /CREATE UNIQUE INDEX IF NOT EXISTS uq_jobs_admin_request_key/);
   assert.doesNotMatch(sql.split("\n").filter((line) => !line.trim().startsWith("--")).join("\n"), /\b(?:DELETE FROM|TRUNCATE|DROP TABLE|DROP COLUMN)\b/i);
 });
@@ -38,6 +39,7 @@ test("pre-data rollback restores the former booking-mode contract", () => {
   assert.match(rollback, /DROP COLUMN IF EXISTS booking_flow_policy/);
   assert.match(rollback, /DROP COLUMN IF EXISTS promotion_theme_preset/);
   assert.match(rollback, /DROP COLUMN IF EXISTS admin_request_key/);
+  assert.match(rollback, /DROP COLUMN IF EXISTS booking_request_fingerprint/);
   assert.match(rollback, /CHECK \(booking_mode IN \('bookable', 'contact_admin', 'purchase'\)\)/);
   assert.match(rollback, /PRE-DATA ROLLBACK ONLY/);
 });

--- a/test/storeServicePackageBundlesPostgres.test.js
+++ b/test/storeServicePackageBundlesPostgres.test.js
@@ -66,5 +66,39 @@ integration("isolated PostgreSQL atomically persists one parent, two variants, e
     assert.equal(resolved.fixedTotal, "3198.00");
     assert.equal(resolved.items.length, 2);
     assert.ok(resolved.items.every((item) => item.snapshot.schema_version === 2 && item.snapshot.catalog_item.key === created.service_bundle_key));
+
+    // Generic configurability proof: a second campaign uses another supported
+    // AC type, no wall-wash variant, and non-1..4 tier quantities. It goes
+    // through the same Admin service and needs no seed SQL or product constant.
+    const generic = await service.create({
+      item_name: "TEST Cassette Care", short_description: "Configured entirely through Admin contract",
+      long_description: "Reusable Store package", highlights: ["Gallery-ready parent"], service_conditions: "TEST only",
+      sell_start_at: "2026-08-01T00:00:00+07:00", sell_end_at: "2026-08-31T23:59:59+07:00",
+      redeem_until: "2026-09-30T23:59:59+07:00", is_active: true, is_customer_visible: true,
+      is_featured: false, is_autoplay_enabled: false,
+      variants: [{
+        display_name: "Cassette maintenance", description: "Four-way cassette",
+        job_type: "wash", ac_type: "cassette", wash_variant: null, btu_min: 15000, btu_max: 60000,
+        service_unit_duration_minutes: 70, sort_order: 0, is_active: true, is_customer_visible: true,
+        tiers: [
+          { display_name: "2 units", service_quantity: 2, fixed_total_price: "2800.00", sort_order: 0, is_active: true },
+          { display_name: "5 units", service_quantity: 5, fixed_total_price: "6500.00", sort_order: 1, is_active: true },
+          { display_name: "7 units", service_quantity: 7, fixed_total_price: "8750.00", sort_order: 2, is_active: true },
+        ],
+      }],
+    });
+    assert.notEqual(generic.service_bundle_key, created.service_bundle_key);
+    assert.equal(generic.variants[0].ac_type, "สี่ทิศทาง");
+    assert.equal(generic.variants[0].wash_variant, null);
+    assert.deepEqual(generic.variants[0].tiers.map((tier) => tier.service_quantity), [2, 5, 7]);
+    assert.ok(generic.variants[0].tiers.every((tier) => typeof tier.fixed_total_price === "string"));
+    const genericRow = (await pool.query("SELECT * FROM catalog_items WHERE service_bundle_key=$1", [generic.service_bundle_key])).rows[0];
+    genericRow.images = [{ image_id: "TEST-image", image_url: "https://example.invalid/test-cassette.webp", is_primary: true }];
+    await catalogRoutes.attachCatalogServicePackages(pool, [genericRow], { customer: true });
+    const genericDto = catalogRoutes.serializeCatalogDetailRow(genericRow);
+    assert.equal(genericDto.service_package_variants[0].service.ac_type, "สี่ทิศทาง");
+    assert.equal(genericDto.images.length, 1);
+    assert.equal(genericDto.images[0].image_url, genericRow.images[0].image_url);
+    assert.equal(genericDto.images[0].is_primary, true);
   } finally { await pool.end(); }
 });

--- a/test/storeServicePackageBundlesPostgres.test.js
+++ b/test/storeServicePackageBundlesPostgres.test.js
@@ -1,0 +1,70 @@
+"use strict";
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const { Pool } = require("pg");
+const { createStoreServicePackageCatalogService } = require("../server/services/packages/storeServicePackageCatalogService");
+const { createServicePackageResolver } = require("../server/services/packages/servicePackageResolver");
+const catalogRoutes = require("../server/routes/catalog/items");
+
+const url = process.env.CWF_ISSUE267_TEST_DATABASE_URL;
+const integration = url ? test : test.skip;
+
+function variant(name, min, max, prices) {
+  return {
+    display_name: name, service_key: "wash-wall-premium", service_name: "Premium wash",
+    job_type: "wash", ac_type: "wall", wash_variant: "premium", btu_min: min, btu_max: max,
+    service_unit_duration_minutes: 45, is_active: true, is_customer_visible: true,
+    tiers: prices.map((price, index) => ({ display_name: `${index + 1} units`, service_quantity: index + 1,
+      fixed_total_price: price, sort_order: index, is_active: true })),
+  };
+}
+
+integration("isolated PostgreSQL atomically persists one parent, two variants, eight exact tiers, and composite snapshots", async () => {
+  const pool = new Pool({ connectionString: url, ssl: false });
+  try {
+    await pool.query("TRUNCATE service_package_tiers, service_packages, catalog_items RESTART IDENTITY CASCADE");
+    const service = createStoreServicePackageCatalogService({ pool });
+    const created = await service.create({
+      item_name: "TEST Premium Day", short_description: "TEST composite bundle",
+      sell_start_at: "2026-08-08T00:00:00+07:00", sell_end_at: "2026-08-10T23:59:59+07:00",
+      redeem_until: "2027-01-31T23:59:59+07:00", is_active: true, is_customer_visible: true,
+      variants: [
+        variant("TEST up to 12000", null, 12000, ["699.00", "1399.00", "1899.00", "2489.00"]),
+        variant("TEST 18000 plus", 18000, null, ["899.00", "1799.00", "2599.00", "3399.00"]),
+      ],
+    });
+    assert.equal(created.variants.length, 2);
+    assert.equal(created.variants.flatMap((entry) => entry.tiers).length, 8);
+    assert.ok(created.variants.flatMap((entry) => entry.tiers).every((tier) => typeof tier.fixed_total_price === "string" && /^\d+\.\d{2}$/.test(tier.fixed_total_price)));
+    const identitiesBefore = await pool.query("SELECT package_key,service_package_id::text AS id FROM service_packages ORDER BY package_key");
+    const updated = await service.update(created.service_bundle_key, {
+      item_name: "TEST Premium Day updated", short_description: "TEST composite bundle",
+      sell_start_at: "2026-08-08T00:00:00+07:00", sell_end_at: "2026-08-10T23:59:59+07:00",
+      redeem_until: "2027-01-31T23:59:59+07:00", is_active: true, is_customer_visible: true,
+      variants: created.variants.map((entry) => ({ ...entry, tiers: entry.tiers })),
+    });
+    const identitiesAfter = await pool.query("SELECT package_key,service_package_id::text AS id FROM service_packages ORDER BY package_key");
+    assert.deepEqual(identitiesAfter.rows, identitiesBefore.rows);
+    assert.equal(updated.item_name, "TEST Premium Day updated");
+    const counts = await pool.query(`SELECT
+      (SELECT COUNT(*)::int FROM catalog_items WHERE booking_mode='service_package') AS parents,
+      (SELECT COUNT(*)::int FROM service_packages WHERE catalog_item_id IS NOT NULL) AS variants,
+      (SELECT COUNT(*)::int FROM service_package_tiers) AS tiers`);
+    assert.deepEqual(counts.rows[0], { parents: 1, variants: 2, tiers: 8 });
+    const publicRowResult = await pool.query("SELECT * FROM catalog_items WHERE service_bundle_key=$1", [created.service_bundle_key]);
+    await catalogRoutes.attachCatalogServicePackages(pool, publicRowResult.rows, { customer: true });
+    const publicDto = catalogRoutes.serializeCatalogDetailRow(publicRowResult.rows[0]);
+    assert.equal(publicDto.booking_mode, "service_package");
+    assert.equal(publicDto.service_package_variants.length, 2);
+    assert.equal(publicDto.service_package_variants.flatMap((entry) => entry.tiers).length, 8);
+    assert.ok(publicDto.service_package_variants.flatMap((entry) => entry.tiers).every((tier) => typeof tier.fixed_total_price === "string"));
+    const groups = updated.variants.map((entry, index) => ({ package_key: entry.package_key, btu: index ? 18000 : 12000, quantity: 2 }));
+    const resolved = await createServicePackageResolver({ db: pool, now: () => new Date("2026-08-09T00:00:00Z") }).resolveComposite({
+      body: { service_package_groups: groups }, bookingMode: "scheduled", appointmentDatetime: "2026-08-20T03:00:00Z", identity: "customer",
+    });
+    assert.equal(resolved.fixedTotal, "3198.00");
+    assert.equal(resolved.items.length, 2);
+    assert.ok(resolved.items.every((item) => item.snapshot.schema_version === 2 && item.snapshot.catalog_item.key === created.service_bundle_key));
+  } finally { await pool.end(); }
+});

--- a/test/storeServicePackageCatalogValidation.test.js
+++ b/test/storeServicePackageCatalogValidation.test.js
@@ -2,6 +2,8 @@
 
 const test = require("node:test");
 const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
 const { validate } = require("../server/services/packages/storeServicePackageCatalogService");
 
 function variant(overrides = {}) {
@@ -58,4 +60,10 @@ test("canonical Admin taxonomy accepts a non-wall package and derives service id
 test("unknown free-text taxonomy is rejected before persistence", () => {
   assert.throws(() => validate(bundle({ variants: [variant({ ac_type: "invented-ac-type" })] })),
     { code: "INVALID_SERVICE_CONSTRAINTS" });
+});
+
+test("bundle taxonomy reuses the canonical price-book contract without campaign defaults", () => {
+  const source = fs.readFileSync(path.join(__dirname, "../server/services/packages/servicePackageTaxonomy.js"), "utf8");
+  assert.match(source, /supportedServiceTaxonomy/);
+  assert.doesNotMatch(source, /Premium Day|["']wall["']|["']premium["']|12000|18000|699\.00/);
 });

--- a/test/storeServicePackageCatalogValidation.test.js
+++ b/test/storeServicePackageCatalogValidation.test.js
@@ -41,3 +41,21 @@ test("BTU gap and a non-Premium configuration are accepted", () => {
   assert.equal(result.item_name, "Maintenance Club");
   assert.equal(result.variants[1].tiers[0].fixed_total_price, "2500.00");
 });
+
+test("canonical Admin taxonomy accepts a non-wall package and derives service identity", () => {
+  const result = validate(bundle({ item_name: "Cassette Club", variants: [variant({
+    display_name: "Cassette seven", job_type: "wash", ac_type: "cassette", wash_variant: null,
+    btu_min: 15000, btu_max: 60000, service_unit_duration_minutes: 70,
+    tiers: [{ display_name: "7 units", service_quantity: 7, fixed_total_price: "8750.00", sort_order: 0, is_active: true }],
+  })] }));
+  assert.equal(result.variants[0].job_type, "ล้าง");
+  assert.equal(result.variants[0].ac_type, "สี่ทิศทาง");
+  assert.equal(result.variants[0].wash_variant, null);
+  assert.equal(result.variants[0].service_key, "wash-cassette");
+  assert.equal(result.variants[0].tiers[0].service_quantity, 7);
+});
+
+test("unknown free-text taxonomy is rejected before persistence", () => {
+  assert.throws(() => validate(bundle({ variants: [variant({ ac_type: "invented-ac-type" })] })),
+    { code: "INVALID_SERVICE_CONSTRAINTS" });
+});

--- a/test/storeServicePackageCatalogValidation.test.js
+++ b/test/storeServicePackageCatalogValidation.test.js
@@ -1,0 +1,43 @@
+"use strict";
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const { validate } = require("../server/services/packages/storeServicePackageCatalogService");
+
+function variant(overrides = {}) {
+  return {
+    display_name: "Small", service_key: "wash-wall-premium", service_name: "Premium wash",
+    job_type: "wash", ac_type: "wall", wash_variant: "premium", btu_min: null, btu_max: 12000,
+    service_unit_duration_minutes: 45, is_active: true, is_customer_visible: true,
+    tiers: [{ display_name: "1 unit", service_quantity: 1, fixed_total_price: "699.00", sort_order: 0, is_active: true }],
+    ...overrides,
+  };
+}
+function bundle(overrides = {}) {
+  return { item_name: "Premium Day", is_active: true, is_customer_visible: true,
+    sell_start_at: "2026-08-08T00:00:00+07:00", sell_end_at: "2026-08-10T23:59:59+07:00",
+    redeem_until: "2027-01-31T23:59:59+07:00", variants: [variant()], ...overrides };
+}
+
+test("bundle validation keeps parent windows authoritative and price text exact", () => {
+  const result = validate(bundle());
+  assert.equal(result.variants[0].fixed_total_price, undefined);
+  assert.equal(result.variants[0].tiers[0].fixed_total_price, "699.00");
+  assert.equal(result.variants[0].sell_start_at, null);
+  assert.equal(result.sell_start_at, "2026-08-07T17:00:00.000Z");
+});
+
+test("active same-taxonomy BTU ranges may not overlap", () => {
+  assert.throws(() => validate(bundle({ variants: [variant(), variant({ display_name: "Overlap", btu_min: 12000, btu_max: 18000 })] })),
+    { code: "OVERLAPPING_VARIANT_RANGE" });
+});
+
+test("BTU gap and a non-Premium configuration are accepted", () => {
+  const result = validate(bundle({ item_name: "Maintenance Club", variants: [
+    variant({ display_name: "Compact", wash_variant: "normal" }),
+    variant({ display_name: "Large", wash_variant: "normal", btu_min: 18000, btu_max: null,
+      tiers: [{ display_name: "3 visits", service_quantity: 3, fixed_total_price: "2500.00", is_active: true }] }),
+  ] }));
+  assert.equal(result.item_name, "Maintenance Club");
+  assert.equal(result.variants[1].tiers[0].fixed_total_price, "2500.00");
+});

--- a/test/urgentCompositePreflight.test.js
+++ b/test/urgentCompositePreflight.test.js
@@ -1,0 +1,68 @@
+"use strict";
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const { resolveUrgentCompositePreflight } = require("../server/services/booking/urgentCompositePreflight");
+const { resolveCompositeBooking } = require("../server/services/packages/compositeServicePackage");
+
+const row = {
+  catalog_item_id: "51", item_id: "51", item_name: "TEST reusable bundle", service_bundle_key: "test-bundle",
+  booking_mode: "service_package", booking_flow_policy: "scheduled_and_urgent",
+  catalog_is_active: true, catalog_is_customer_visible: true,
+  service_package_sell_start_at: "2026-08-01T00:00:00.000Z",
+  service_package_sell_end_at: "2026-08-31T23:59:59.000Z",
+  service_package_redeem_until: "2027-01-31T16:59:59.000Z",
+  job_type: "ล้าง", ac_type: "ผนัง", wash_variant: "ล้างพรีเมียม",
+  service_key: "test-wash", service_name: "TEST Wash", service_unit_duration_minutes: 45,
+  is_active: true, is_customer_visible: true, service_package_id: "11", package_key: "test-variant",
+  display_name: "TEST variant", btu_max: 12000,
+  tiers: [1, 2, 3, 4].map((quantity) => ({
+    service_package_tier_id: String(quantity), tier_key: `q${quantity}`, display_name: `${quantity} units`,
+    service_quantity: quantity, fixed_total_price: `${quantity * 700}.00`, sort_order: quantity, is_active: true,
+  })),
+};
+
+function resolver() {
+  return {
+    resolveComposite(input) {
+      return resolveCompositeBooking({
+        ...input,
+        repository: { findLinkedPackagesByKeys: async () => [row] },
+        db: {},
+        now: () => new Date("2026-08-09T00:00:00.000Z"),
+      });
+    },
+  };
+}
+
+async function preflight(quantity) {
+  return resolveUrgentCompositePreflight({
+    input: { catalog_item_id: 51, service_package_groups: [{ package_key: "test-variant", btu: 12000, quantity }] },
+    appointmentDatetime: "2026-08-20T03:00:00.000Z",
+    resolver: resolver(),
+  });
+}
+
+test("urgent composite preflight uses the final package resolver for 20 and 99 machines", async () => {
+  for (const quantity of [20, 99]) {
+    const result = await preflight(quantity);
+    assert.equal(result.machineCount, quantity);
+    assert.equal(result.durationMin, quantity * 45);
+    assert.equal(result.payload.machine_count, quantity);
+    assert.equal(result.payload.services[0].machine_count, quantity);
+    assert.equal(result.payload.service_package_groups[0].quantity, quantity);
+  }
+});
+
+test("urgent composite preflight safely rejects quantities above the shared 99-machine domain", async () => {
+  await assert.rejects(preflight(100), { code: "INVALID_PACKAGE_SELECTION" });
+});
+
+test("urgent UI review, preflight fingerprint and submit retain the authoritative groups and duration", () => {
+  const source = fs.readFileSync("customer-app/modules/bookingUrgent.js", "utf8");
+  assert.match(source, /payloadFromCompositeServiceLines\(services\(\)\)/);
+  assert.match(source, /service_package_groups: Array\.isArray\(draft\(\)\.service_package_groups\)/);
+  assert.match(source, /Number\(result\?\.duration_min\) !== Number\(bundlePreview\(\)\?\.duration_min\)/);
+  assert.match(source, /preview\.groups \|\| \[\]/);
+});

--- a/test/urgentProductionHotfix.test.js
+++ b/test/urgentProductionHotfix.test.js
@@ -34,10 +34,9 @@ test("customer urgent zero-target commits job/items into admin review without ch
   assert.match(noTargets, /dispatch_mode='offer'/);
   assert.match(noTargets, /throw err;/, "Admin Add zero-target path must still throw NO_URGENT_OFFER_TARGETS");
 
-  const response = section(handler, "return res.json({", "} catch (e)");
-  assert.match(response, /offers_count: urgentPushTargets\.length/);
-  assert.match(response, /phase: "admin_review"/);
-  assert.match(response, /admin_review: true/);
+  assert.match(handler, /offers_count: urgentPushTargets\.length/);
+  assert.match(handler, /phase: "admin_review"/);
+  assert.match(handler, /admin_review: true/);
 });
 
 test("public urgent adapter sanitizes into direct-offer creation and public urgent status is read-only", () => {


### PR DESCRIPTION
Promotes the merged Issue #267 / PR #269 Store service-package bundle booking flow from `main` into `staging/home-server-test`.

Source:
- Issue #267
- Merged PR #269
- Reviewed implementation head `686d8b881d2859adcdc9c17bec48c8fbe54a35a4`
- Main merge commit `e2498c9366424fb11c81cca1a3d9785be31dd18d`
- Staging base at creation `ac3ffdcd268f29afe25d72805db33d08c9963c50`

Business outcome to verify on Staging:
- Premium Day service-package bundles appear with authoritative server price, duration and campaign data.
- Scheduled and Urgent booking preserve exact totals and package identity through final booking/replay.
- Urgent composite quantities 20–99 use the same resolver as final booking.
- Ticket handoff hides LINE before copy attempt, then supports copied/manual states without duplicate booking submission.
- Customer PWA updates consistently to `20260809_issue267_catalog_flow_v9`; Admin remains on its reviewed v8 runtime.

Deployment and data impact:
- This promotion includes the reviewed Issue #267 migration and application changes on Staging.
- No Production deployment, Production migration, Production data change or Production configuration change is authorized by this PR.
- PostgreSQL integration coverage that was skipped locally must be observed in an environment with isolated PostgreSQL support.

Gate:
- This PR is intentionally Draft.
- Review conflict/mergeability and the full compare before approval.
- Merging this PR is the Staging deployment event and requires separate owner approval.
- Stop after Staging deploy and verification; do not promote to Production without explicit owner approval.