### PR TITLE
fix(issue-267): make Store bundle migration deploy-safe

### DIFF
--- a/migrations/.deploy-approved.tsv
+++ b/migrations/.deploy-approved.tsv
@@ -1,0 +1,1 @@
+2df5a42eb7f3679c9933cb8f23369c3a7f0efdab83ec4442d95ffe3269646414	20260809_store_service_package_bundles.sql	expand

--- a/migrations/20260809_store_service_package_bundles.sql
+++ b/migrations/20260809_store_service_package_bundles.sql
@@ -1,11 +1,11 @@
 -- Store service-package bundles. A catalog item owns presentation/media and
 -- sale/redeem windows; linked service_packages are selectable BTU variants.
 -- Existing unlinked service packages remain valid and keep their own windows.
-
-ALTER TABLE public.catalog_items DROP CONSTRAINT IF EXISTS catalog_items_booking_mode_check;
-ALTER TABLE public.catalog_items
-  ADD CONSTRAINT catalog_items_booking_mode_check
-  CHECK (booking_mode IN ('bookable', 'contact_admin', 'purchase', 'service_package'));
+--
+-- Bundle parents keep the existing stored booking_mode='contact_admin'. The
+-- application exposes the bounded virtual mode 'service_package' whenever a
+-- non-null service_bundle_key is present. This keeps the migration additive and
+-- compatible with the deploy controller's expand-only lane.
 
 ALTER TABLE public.catalog_items ADD COLUMN IF NOT EXISTS service_bundle_key TEXT;
 ALTER TABLE public.catalog_items ADD COLUMN IF NOT EXISTS service_package_sell_start_at TIMESTAMPTZ;

--- a/migrations/rollback/20260809_store_service_package_bundles.sql
+++ b/migrations/rollback/20260809_store_service_package_bundles.sql
@@ -24,6 +24,3 @@ ALTER TABLE public.catalog_items DROP COLUMN IF EXISTS service_package_redeem_un
 ALTER TABLE public.catalog_items DROP COLUMN IF EXISTS service_package_sell_end_at;
 ALTER TABLE public.catalog_items DROP COLUMN IF EXISTS service_package_sell_start_at;
 ALTER TABLE public.catalog_items DROP COLUMN IF EXISTS service_bundle_key;
-ALTER TABLE public.catalog_items DROP CONSTRAINT IF EXISTS catalog_items_booking_mode_check;
-ALTER TABLE public.catalog_items ADD CONSTRAINT catalog_items_booking_mode_check
-  CHECK (booking_mode IN ('bookable', 'contact_admin', 'purchase'));

--- a/scripts/run-store-service-package-bundles-migration.js
+++ b/scripts/run-store-service-package-bundles-migration.js
@@ -39,12 +39,11 @@ async function verifySchema(client) {
       EXISTS (SELECT 1 FROM pg_indexes WHERE schemaname='public' AND indexname='uq_jobs_admin_request_key') AS admin_request_unique,
       EXISTS (SELECT 1 FROM pg_constraint WHERE conname='service_packages_catalog_item_fk') AS parent_fk,
       EXISTS (SELECT 1 FROM pg_constraint WHERE conname='catalog_items_promotion_theme_check') AS presentation_check,
-      EXISTS (SELECT 1 FROM pg_constraint WHERE conname='catalog_items_booking_flow_policy_check') AS flow_policy_check,
-      COALESCE((SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conname='catalog_items_booking_mode_check' LIMIT 1),'') AS booking_mode_def
+      EXISTS (SELECT 1 FROM pg_constraint WHERE conname='catalog_items_booking_flow_policy_check') AS flow_policy_check
   `);
   const row = result.rows[0] || {};
   if (!row.linked || !row.parent_key || !row.presentation || !row.flow_policy || !row.admin_request_key || !row.booking_request_fingerprint || !row.admin_request_unique || !row.parent_fk
-      || !row.presentation_check || !row.flow_policy_check || !/service_package/.test(row.booking_mode_def)) {
+      || !row.presentation_check || !row.flow_policy_check) {
     throw new Error("store service-package bundle schema verification failed");
   }
 }

--- a/server/routes/catalog/items.js
+++ b/server/routes/catalog/items.js
@@ -883,6 +883,11 @@ function serializeCatalogRow(row) {
     ? orderedGalleryRows.map(serializeCatalogImage)
     : (row.image_url ? [{ image_id: null, image_url: row.image_url, alt_text: null, sort_order: 0, is_primary: true }] : []);
 
+  const isServicePackageBundle = Boolean(row.service_bundle_key);
+  const publicBookingMode = isServicePackageBundle
+    ? "service_package"
+    : (BOOKING_MODES.has(row.booking_mode) ? row.booking_mode : "contact_admin");
+
   return {
     item_id: row.item_id,
     item_name: row.item_name,
@@ -916,12 +921,12 @@ function serializeCatalogRow(row) {
     images,
     short_description: row.short_description || null,
     highlights: Array.isArray(row.highlights) ? row.highlights : [],
-    booking_mode: BOOKING_MODES.has(row.booking_mode) ? row.booking_mode : "contact_admin",
-    service_bundle_key: row.booking_mode === "service_package" ? (row.service_bundle_key || null) : null,
-    service_package_sell_start_at: row.booking_mode === "service_package" ? (row.service_package_sell_start_at || null) : null,
-    service_package_sell_end_at: row.booking_mode === "service_package" ? (row.service_package_sell_end_at || null) : null,
-    service_package_redeem_until: row.booking_mode === "service_package" ? (row.service_package_redeem_until || null) : null,
-    service_package_variants: row.booking_mode === "service_package" && Array.isArray(row.service_package_variants)
+    booking_mode: publicBookingMode,
+    service_bundle_key: isServicePackageBundle ? row.service_bundle_key : null,
+    service_package_sell_start_at: isServicePackageBundle ? (row.service_package_sell_start_at || null) : null,
+    service_package_sell_end_at: isServicePackageBundle ? (row.service_package_sell_end_at || null) : null,
+    service_package_redeem_until: isServicePackageBundle ? (row.service_package_redeem_until || null) : null,
+    service_package_variants: isServicePackageBundle && Array.isArray(row.service_package_variants)
       ? row.service_package_variants : [],
     // Needed on the list endpoint so the Store card's "book" button can build a
     // real booking draft without a follow-up detail fetch. booking_service_key is
@@ -960,7 +965,7 @@ function serializeCatalogDetailRow(row) {
     ...base,
     long_description: row.long_description || null,
     service_conditions: row.service_conditions || null,
-    booking_service_key: row.booking_mode === "bookable" ? (row.booking_service_key || null) : null,
+    booking_service_key: base.booking_mode === "bookable" ? (row.booking_service_key || null) : null,
   };
 }
 

--- a/server/services/packages/servicePackageRepository.js
+++ b/server/services/packages/servicePackageRepository.js
@@ -65,7 +65,8 @@ async function listCustomerVisiblePackages(db, { at = new Date() } = {}) {
 async function findLinkedPackagesByKeys(db, packageKeys) {
   if (!Array.isArray(packageKeys) || !packageKeys.length) return [];
   const result = await requireDb(db).query(
-    `SELECT p.*, ci.item_id, ci.item_name, ci.service_bundle_key, ci.booking_mode,
+    `SELECT p.*, ci.item_id, ci.item_name, ci.service_bundle_key,
+            CASE WHEN ci.service_bundle_key IS NOT NULL THEN 'service_package' ELSE ci.booking_mode END AS booking_mode,
             ci.is_active AS catalog_is_active,
             ci.is_customer_visible AS catalog_is_customer_visible,
             ci.service_package_sell_start_at, ci.service_package_sell_end_at,

--- a/server/services/packages/storeServicePackageCatalogService.js
+++ b/server/services/packages/storeServicePackageCatalogService.js
@@ -115,7 +115,7 @@ async function loadBundle(db, bundleKey, { lock = false } = {}) {
 }
 
 async function listBundles(db) {
-  const result = await db.query("SELECT * FROM public.catalog_items WHERE booking_mode='service_package' ORDER BY item_id DESC");
+  const result = await db.query("SELECT * FROM public.catalog_items WHERE service_bundle_key IS NOT NULL ORDER BY item_id DESC");
   const rows = result.rows;
   const variants = await repository.listLinkedPackagesForCatalogItems(db, rows.map((row) => row.item_id));
   const byItem = new Map();
@@ -128,7 +128,7 @@ async function listBundles(db) {
     service_bundle_key: row.service_bundle_key, item_id: String(row.item_id), item_name: row.item_name,
     short_description: row.short_description, long_description: row.long_description,
     highlights: Array.isArray(row.highlights) ? row.highlights : [], service_conditions: row.service_conditions,
-    booking_mode: row.booking_mode, sell_start_at: row.service_package_sell_start_at,
+    booking_mode: "service_package", sell_start_at: row.service_package_sell_start_at,
     sell_end_at: row.service_package_sell_end_at, redeem_until: row.service_package_redeem_until,
     is_active: Boolean(row.is_active), is_customer_visible: Boolean(row.is_customer_visible),
     is_featured: Boolean(row.is_featured), is_autoplay_enabled: Boolean(row.is_autoplay_enabled),
@@ -179,7 +179,7 @@ function createStoreServicePackageCatalogService({ pool, packageRepository = rep
              short_description,long_description,highlights,service_conditions,booking_mode,is_featured,is_autoplay_enabled,
              service_bundle_key,service_package_sell_start_at,service_package_sell_end_at,service_package_redeem_until,
              promotion_badge_text,promotion_theme_preset,promotion_effect_preset,show_sale_countdown,promotion_supporting_text,booking_flow_policy)
-           VALUES ($1,'service',0,'package',$2,$3,$4,$5,$6,$7,$8,$9,'service_package',$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21)
+           VALUES ($1,'service',0,'package',$2,$3,$4,$5,$6,$7,$8,$9,'contact_admin',$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21)
            RETURNING *`,
           [value.item_name, value.variants[0].job_type, value.variants[0].ac_type, value.is_active, value.is_customer_visible,
             value.short_description, value.long_description, JSON.stringify(value.highlights), value.service_conditions,

--- a/test/storeServicePackageBundlesMigration.test.js
+++ b/test/storeServicePackageBundlesMigration.test.js
@@ -2,12 +2,20 @@
 
 const test = require("node:test");
 const assert = require("node:assert/strict");
+const crypto = require("node:crypto");
 const fs = require("node:fs");
-const sql = fs.readFileSync("migrations/20260809_store_service_package_bundles.sql", "utf8");
+const migrationName = "20260809_store_service_package_bundles.sql";
+const migrationPath = `migrations/${migrationName}`;
+const rollbackPath = "migrations/rollback/20260809_store_service_package_bundles.sql";
+const sql = fs.readFileSync(migrationPath, "utf8");
 const runner = require("../scripts/run-store-service-package-bundles-migration");
-const rollback = fs.readFileSync("migrations/20260809_store_service_package_bundles.rollback.sql", "utf8");
+const rollback = fs.readFileSync(rollbackPath, "utf8");
+const approvals = fs.readFileSync("migrations/.deploy-approved.tsv", "utf8");
+const catalogRoutes = require("../server/routes/catalog/items");
+const packageRepository = require("../server/services/packages/servicePackageRepository");
 
-test("bundle migration links variants to Store parent and widens booking mode", () => {
+test("bundle migration links variants to Store parent through additive schema", () => {
+  const executableSql = sql.split("\n").filter((line) => !line.trim().startsWith("--")).join("\n");
   assert.match(sql, /service_package/);
   assert.match(sql, /ADD COLUMN IF NOT EXISTS catalog_item_id BIGINT/);
   assert.match(sql, /REFERENCES public\.catalog_items\(item_id\) ON DELETE RESTRICT/);
@@ -21,7 +29,40 @@ test("bundle migration links variants to Store parent and widens booking mode", 
   assert.match(sql, /admin_request_key VARCHAR\(128\)/);
   assert.match(sql, /booking_request_fingerprint CHAR\(64\)/);
   assert.match(sql, /CREATE UNIQUE INDEX IF NOT EXISTS uq_jobs_admin_request_key/);
-  assert.doesNotMatch(sql.split("\n").filter((line) => !line.trim().startsWith("--")).join("\n"), /\b(?:DELETE FROM|TRUNCATE|DROP TABLE|DROP COLUMN)\b/i);
+  assert.doesNotMatch(executableSql, /\b(?:DELETE FROM|TRUNCATE|DROP TABLE|DROP COLUMN)\b/i);
+  assert.doesNotMatch(executableSql, /DROP\s+CONSTRAINT|booking_mode_check/i);
+});
+
+test("deploy catalog approves only the forward expand migration by exact SHA", () => {
+  const hash = crypto.createHash("sha256").update(fs.readFileSync(migrationPath)).digest("hex");
+  const entries = approvals.split(/\r?\n/).map((line) => line.trim()).filter(Boolean);
+  assert.deepEqual(entries, [`${hash}\t${migrationName}\texpand`]);
+  const rootRollbackFiles = fs.readdirSync("migrations", { withFileTypes: true })
+    .filter((entry) => entry.isFile() && /\.rollback\.sql$/i.test(entry.name));
+  assert.deepEqual(rootRollbackFiles, []);
+  assert.equal(fs.existsSync("migrations/20260809_store_service_package_bundles.rollback.sql"), false);
+});
+
+test("bundle discriminator stays fail-closed in storage and virtual at API boundaries", async () => {
+  const serviceSource = fs.readFileSync("server/services/packages/storeServicePackageCatalogService.js", "utf8");
+  assert.match(serviceSource, /VALUES \([\s\S]*'contact_admin'/);
+  assert.doesNotMatch(serviceSource, /VALUES \([\s\S]*'service_package'/);
+
+  const dto = catalogRoutes.serializeCatalogRow({
+    item_id: 1, item_name: "TEST bundle", item_category: "service",
+    booking_mode: "contact_admin", service_bundle_key: "test-bundle",
+    service_package_variants: [], is_active: true, is_customer_visible: true,
+    highlights: [], images: [],
+  });
+  assert.equal(dto.booking_mode, "service_package");
+  assert.equal(dto.service_bundle_key, "test-bundle");
+
+  let capturedSql = "";
+  await packageRepository.findLinkedPackagesByKeys({ query: async (statement) => {
+    capturedSql = statement;
+    return { rows: [] };
+  } }, ["test-package"]);
+  assert.match(capturedSql, /CASE WHEN ci\.service_bundle_key IS NOT NULL THEN 'service_package'/);
 });
 
 test("migration runner is advisory locked, verified, and redacts credentials", () => {
@@ -34,12 +75,12 @@ test("migration runner is advisory locked, verified, and redacts credentials", (
   assert.match(source, /query\("ROLLBACK"\)/);
 });
 
-test("pre-data rollback restores the former booking-mode contract", () => {
+test("pre-data rollback removes only the additive bundle schema", () => {
   assert.match(rollback, /DROP COLUMN IF EXISTS catalog_item_id/);
   assert.match(rollback, /DROP COLUMN IF EXISTS booking_flow_policy/);
   assert.match(rollback, /DROP COLUMN IF EXISTS promotion_theme_preset/);
   assert.match(rollback, /DROP COLUMN IF EXISTS admin_request_key/);
   assert.match(rollback, /DROP COLUMN IF EXISTS booking_request_fingerprint/);
-  assert.match(rollback, /CHECK \(booking_mode IN \('bookable', 'contact_admin', 'purchase'\)\)/);
   assert.match(rollback, /PRE-DATA ROLLBACK ONLY/);
+  assert.doesNotMatch(rollback, /booking_mode_check/);
 });

--- a/test/storeServicePackageBundlesPostgres.test.js
+++ b/test/storeServicePackageBundlesPostgres.test.js
@@ -48,11 +48,12 @@ integration("isolated PostgreSQL atomically persists one parent, two variants, e
     assert.deepEqual(identitiesAfter.rows, identitiesBefore.rows);
     assert.equal(updated.item_name, "TEST Premium Day updated");
     const counts = await pool.query(`SELECT
-      (SELECT COUNT(*)::int FROM catalog_items WHERE booking_mode='service_package') AS parents,
+      (SELECT COUNT(*)::int FROM catalog_items WHERE service_bundle_key IS NOT NULL) AS parents,
       (SELECT COUNT(*)::int FROM service_packages WHERE catalog_item_id IS NOT NULL) AS variants,
       (SELECT COUNT(*)::int FROM service_package_tiers) AS tiers`);
     assert.deepEqual(counts.rows[0], { parents: 1, variants: 2, tiers: 8 });
     const publicRowResult = await pool.query("SELECT * FROM catalog_items WHERE service_bundle_key=$1", [created.service_bundle_key]);
+    assert.equal(publicRowResult.rows[0].booking_mode, "contact_admin");
     await catalogRoutes.attachCatalogServicePackages(pool, publicRowResult.rows, { customer: true });
     const publicDto = catalogRoutes.serializeCatalogDetailRow(publicRowResult.rows[0]);
     assert.equal(publicDto.booking_mode, "service_package");


### PR DESCRIPTION
## Why

Staging run [#31316673408](https://github.com/coldwindflow/cwf-services-system/actions/runs/31316673408) failed safely before applying Issue #267's migration. The deploy controller rejected a root rollback file as pending and the forward migration's destructive booking-mode constraint replacement. Automatic rollback succeeded; Production was untouched.

## Fix

- keep bundle parents stored as fail-closed `booking_mode='contact_admin'`
- expose virtual `booking_mode='service_package'` only at bounded API/service boundaries when `service_bundle_key` exists
- keep the forward migration additive
- move the pre-data rollback under `migrations/rollback/`
- approve only the exact forward SHA (`2df5a42eb7f3679c9933cb8f23369c3a7f0efdab83ec4442d95ffe3269646414`) as `expand`

## Verification

- focused related suite: 151 passed
- full suite: 1,526 passed, 58 skipped (PostgreSQL integration DB unavailable)
- deploy-policy simulation: exact SHA, expand-only, zero destructive patterns, zero root rollback files
- `git diff --check`: clean

Closes no issue until Staging deploy and smoke verification pass.

Issue: #267