### PR TITLE
Promotion: main -> staging/home-server-test (legacy package controls)

### DIFF
--- a/admin-store-catalog.html
+++ b/admin-store-catalog.html
@@ -84,6 +84,6 @@
   </div>
 
   <script src="/admin-v2-common.js?v=20260622_admin_menu_catalog_entry"></script>
-  <script src="/admin-store-catalog.js?v=20260809_issue267_merchandising_v3"></script>
+  <script src="/admin-store-catalog.js?v=20260809_issue267_merchandising_v4"></script>
 </body>
 </html>

--- a/admin-store-catalog.js
+++ b/admin-store-catalog.js
@@ -11,6 +11,7 @@ let galleryUploadQueue = [];
 let galleryPickNotice = "";
 let deleteModalItemId = null;
 let servicePackages = [];
+let standaloneServicePackages = [];
 let editingPackageKey = null;
 let packageTierDrafts = [];
 const BOOKING_MODES = ["bookable", "contact_admin", "purchase", "service_package"];
@@ -1480,7 +1481,7 @@ function updatePackageTierDraft(event) {
 function openPackageModal(packageKey = null) {
   ensurePackageModal();
   editingPackageKey = packageKey;
-  const item = packageKey ? servicePackages.find((p) => p.package_key === packageKey) : null;
+  const item = packageKey ? standaloneServicePackages.find((p) => p.package_key === packageKey) : null;
   el("package_modal_title").textContent = item ? `แก้ไข ${item.display_name}` : "สร้างโปรโมชั่นแพ็กเกจใหม่";
   el("pm_key_field").classList.toggle("hidden", !item);
   el("pm_package_key").value = item?.package_key || "";
@@ -1525,22 +1526,41 @@ async function saveServicePackage() {
 
 function renderServicePackages() {
   const box = el("package_catalog_list");
-  box.innerHTML = servicePackages.length ? servicePackages.map((item) => `<div class="asc-item-card">
+  const bundleCards = servicePackages.map((item) => `<div class="asc-item-card">
     <div class="asc-item-main"><div class="asc-item-title">${escapeHtml(item.item_name)} <span class="asc-badge asc-package-badge">Store service package</span></div>
       <div class="asc-item-meta">${item.variants.length} BTU variants · ${item.variants.reduce((sum, variant) => sum + variant.tiers.length, 0)} tiers</div>
       <div class="asc-item-meta">รหัสสินค้าแม่: ${escapeHtml(item.service_bundle_key)}</div>
       <div class="asc-badges"><span class="asc-badge">${item.is_active ? "เปิดใช้งาน" : "แบบร่าง"}</span><span class="asc-badge">${item.is_customer_visible ? "แสดงใน Store" : "ซ่อน"}</span></div></div>
-    <div class="asc-item-actions"><button class="secondary btn-small" data-edit-bundle="${escapeHtml(item.service_bundle_key)}" type="button">แก้ไข</button></div></div>`).join("") : `<div class="asc-empty">ยังไม่มี Store service package</div>`;
+    <div class="asc-item-actions"><button class="secondary btn-small" data-edit-bundle="${escapeHtml(item.service_bundle_key)}" type="button">แก้ไข</button></div></div>`).join("");
+  const standaloneCards = standaloneServicePackages.map((item) => `<div class="asc-item-card">
+    <div class="asc-item-main"><div class="asc-item-title">${escapeHtml(item.display_name)} <span class="asc-badge asc-package-badge">Legacy standalone package</span></div>
+      <div class="asc-item-meta">${item.tiers.length} tiers · รหัสแพ็กเกจ: ${escapeHtml(item.package_key)}</div>
+      <div class="asc-badges"><span class="asc-badge">${packageLifecycleLabel(item.lifecycle_status)}</span><span class="asc-badge">${item.is_active ? "เปิดใช้งาน" : "ปิดใช้งาน"}</span><span class="asc-badge">${item.is_customer_visible ? "แสดงต่อลูกค้า" : "ซ่อนจากลูกค้า"}</span></div></div>
+    <div class="asc-item-actions"><button class="secondary btn-small" data-edit-package="${escapeHtml(item.package_key)}" type="button">แก้ไข</button></div></div>`).join("");
+  box.innerHTML = bundleCards + standaloneCards || `<div class="asc-empty">ยังไม่มี Store service package</div>`;
 }
 
 async function loadServicePackages() {
   const box = el("package_catalog_list"); box.innerHTML = `<div class="asc-loading">กำลังโหลดโปรโมชั่น...</div>`;
-  try { const result = await apiFetch("/admin/catalog/service-package-bundles"); servicePackages = Array.isArray(result?.bundles) ? result.bundles : []; renderServicePackages(); }
+  try {
+    const [bundleResult, standaloneResult] = await Promise.all([
+      apiFetch("/admin/catalog/service-package-bundles"),
+      apiFetch("/admin/service-packages/catalog"),
+    ]);
+    servicePackages = Array.isArray(bundleResult?.bundles) ? bundleResult.bundles : [];
+    standaloneServicePackages = Array.isArray(standaloneResult) ? standaloneResult : [];
+    renderServicePackages();
+  }
   catch (_error) { box.innerHTML = `<div class="asc-error">ไม่สามารถโหลดโปรโมชั่นแพ็กเกจได้ โปรดลองอีกครั้ง</div>`; }
 }
 
 function bindServicePackageActions() {
-  el("package_catalog_list").addEventListener("click", (event) => { const button = event.target.closest("[data-edit-bundle]"); if (button) openBundleModal(button.dataset.editBundle); });
+  el("package_catalog_list").addEventListener("click", (event) => {
+    const bundleButton = event.target.closest("[data-edit-bundle]");
+    if (bundleButton) return openBundleModal(bundleButton.dataset.editBundle);
+    const packageButton = event.target.closest("[data-edit-package]");
+    if (packageButton) openPackageModal(packageButton.dataset.editPackage);
+  });
 }
 
 /* ---------- Review moderation ---------- */

--- a/test/adminStoreCatalogServicePackages.test.js
+++ b/test/adminStoreCatalogServicePackages.test.js
@@ -36,9 +36,13 @@ test("package tier editor is repeatable, supports inactive tiers and preserves f
 
 test("same Admin page renders full package history lifecycle statuses and uses cache-busted assets", () => {
   assert.match(html, /id="package_catalog_list"/);
+  assert.match(js, /\/admin\/service-packages\/catalog/);
+  assert.match(js, /standaloneServicePackages/);
+  assert.match(js, /data-edit-package/);
+  assert.match(js, /Legacy standalone package/);
   for (const status of ["แบบร่าง", "ปิดใช้งาน", "ซ่อนจากลูกค้า", "ยังไม่ถึงวันขาย", "กำลังเปิดขาย", "ปิดการขายแล้ว", "หมดเขตใช้สิทธิ์"]) assert.match(js, new RegExp(status));
   for (const statusKey of ["draft", "disabled", "hidden", "upcoming", "on-sale", "sale-ended", "redeem-ended"]) assert.match(js, new RegExp(`(?:^|[" ])${statusKey}(?:[":]|$)`));
-  assert.match(html, /admin-store-catalog\.js\?v=20260809_issue267_merchandising_v3/);
+  assert.match(html, /admin-store-catalog\.js\?v=20260809_issue267_merchandising_v4/);
   assert.match(html, /admin-store-catalog\.css\?v=20260809_issue267_merchandising_v3/);
 });
 

--- a/test/adminStoreCatalogUi.test.js
+++ b/test/adminStoreCatalogUi.test.js
@@ -177,7 +177,7 @@ test("admin-store-catalog.css defines the page-local responsive modal contract",
 
 test("admin-store-catalog.html cache versions stay coherent with unchanged JavaScript", () => {
   assert.match(catalogHtmlSource, /admin-store-catalog\.css\?v=20260809_issue267_merchandising_v3/);
-  assert.match(catalogHtmlSource, /admin-store-catalog\.js\?v=20260809_issue267_merchandising_v3/);
+  assert.match(catalogHtmlSource, /admin-store-catalog\.js\?v=20260809_issue267_merchandising_v4/);
 });
 
 test("openCatalogModalForEdit populates cm_effective_from and cm_effective_to from raw pricing fields with fallback", () => {
@@ -388,7 +388,7 @@ test("gallery delete and set-primary actions ask for confirmation only on delete
 
 test("admin-store-catalog.html keeps CSS cache and bumps JS cache for pricing safety", () => {
   assert.match(catalogHtmlSource, /admin-store-catalog\.css\?v=20260809_issue267_merchandising_v3/);
-  assert.match(catalogHtmlSource, /admin-store-catalog\.js\?v=20260809_issue267_merchandising_v3/);
+  assert.match(catalogHtmlSource, /admin-store-catalog\.js\?v=20260809_issue267_merchandising_v4/);
 });
 
 test("the item_category field is a service/product dropdown, not free text", () => {

--- a/test/customerPricingSafety.test.js
+++ b/test/customerPricingSafety.test.js
@@ -532,5 +532,5 @@ test("admin UI source exposes safety warnings and cache-busted assets", () => {
   assert.match(catalogJs, /ราคาสินค้าเท่านั้น ไม่ใช้คำนวณค่าบริการ/);
   assert.match(catalogJs, /modalPricingRisk/);
   assert.match(promoHtml, /admin-promotions-v2\.js\?v=20260708_price_rule_safety_v2/);
-  assert.match(catalogHtml, /admin-store-catalog\.js\?v=20260809_issue267_merchandising_v3/);
+  assert.match(catalogHtml, /admin-store-catalog\.js\?v=20260809_issue267_merchandising_v4/);
 });


### PR DESCRIPTION
## Promotion scope

Promotes the Admin-only legacy package management restoration from PR #277 to `staging/home-server-test`.

- Enables hiding the two stale `TEST Premium Day` standalone packages through the existing Admin modal.
- Includes no server, database, migration, Customer App, or Production changes.
- Full suite: 1,527 passed, 58 skipped, 0 failed.

Staging only; Production remains unchanged.