### PR TITLE
Promotion: main -> staging/home-server-test (Admin bundle quote stability)

### DIFF
--- a/admin-add-v2.html
+++ b/admin-add-v2.html
@@ -608,7 +608,7 @@
   </div>
 
   <script src="admin-v2-common.js?v=20260428_allpages_ui1"></script>
-  <script src="admin-add-v2.js?v=20260809_issue267_catalog_flow_v8"></script>
+  <script src="admin-add-v2.js?v=20260809_issue267_catalog_flow_v9"></script>
   <script src="admin-add-ai-intake-prefill.js?v=line-ai-prefill-real-v8"></script>
 </body>
 </html>

--- a/admin-add-v2.js
+++ b/admin-add-v2.js
@@ -31,6 +31,7 @@ let state = {
   service_bundles: [],
   service_bundle_quote: null,
   service_bundle_quote_fingerprint: "",
+  service_bundle_quote_request_id: 0,
   selected_store_catalog_item_id: null,
   admin_request_key: "",
   admin_request_fingerprint: "",
@@ -1430,28 +1431,39 @@ function renderServiceBundleGroups() {
 }
 
 async function previewServiceBundle() {
+  const requestId = ++state.service_bundle_quote_request_id;
   state.service_bundle_quote = null;
   state.service_bundle_quote_fingerprint = "";
   state.exact_total = "";
+  state.standard_price = 0;
+  state.normal_price = 0;
+  state.duration_min = 0;
+  state.effective_block_min = 0;
   const groups = selectedBundleGroups();
   const panel = el("store_service_bundle_quote");
   if (!bundleSelected() || !groups.length) { if (panel) panel.textContent = "Select at least one quantity"; return; }
+  const fingerprint = bundleFingerprint();
+  if (panel) panel.textContent = "Loading package price and duration...";
+  const submit = el("btnSubmit"); if (submit) submit.disabled = true;
   const appointment = localDatetimeToBangkokISO(String(el("appointment_datetime")?.value || "").trim()) || new Date(Date.now() + 86400000).toISOString();
   const quote = await apiFetch("/admin/catalog/service-package-bundles/quote", { method: "POST", body: JSON.stringify({
     catalog_item_id: state.selected_store_catalog_item_id,
     service_package_groups: groups, booking_mode: String(el("booking_mode")?.value || "scheduled"), appointment_datetime: appointment,
   }) });
+  if (requestId !== state.service_bundle_quote_request_id || fingerprint !== bundleFingerprint()) return;
   state.service_bundle_quote = quote;
-  state.service_bundle_quote_fingerprint = bundleFingerprint();
+  state.service_bundle_quote_fingerprint = fingerprint;
   state.exact_total = String(quote.fixed_total_price || "");
   state.standard_price = Number(state.exact_total); state.normal_price = state.standard_price;
   state.duration_min = Number(quote.duration_minutes); state.effective_block_min = state.duration_min + Number(state.travel_buffer_min || 30);
   if (panel) panel.textContent = `${quote.machine_count} units | ${quote.fixed_total_price} | ${quote.duration_minutes} min | ${(quote.components || []).map((x) => `${x.tier_name} x ${x.quantity}`).join(", ")}`;
-  updateTotalPreview();
+  if (submit) submit.disabled = false;
+  await refreshPreview();
 }
 
 function invalidateServicePackagePreview({ loading = false } = {}) {
   state.service_package_preview_request_id += 1;
+  state.service_bundle_quote_request_id += 1;
   state.service_package_preview = null;
   state.service_package_preview_selection = null;
   state.service_bundle_quote = null;
@@ -1469,8 +1481,9 @@ function invalidateServicePackagePreview({ loading = false } = {}) {
   if (btuWrap) btuWrap.style.display = "none";
   const panel = el("service_package_preview");
   if (panel) {
-    panel.style.display = packageSelected() ? "" : "none";
-    panel.textContent = packageSelected()
+    const legacySelected = !!String(el("service_package_key")?.value || "").trim();
+    panel.style.display = legacySelected ? "" : "none";
+    panel.textContent = legacySelected
       ? (loading ? "Loading package price and duration..." : "Package price and duration unavailable")
       : "";
   }

--- a/test/adminStorePromotionBookingUi.test.js
+++ b/test/adminStorePromotionBookingUi.test.js
@@ -43,7 +43,20 @@ test("Admin Add Job selects Store parents, quotes arbitrary mixed groups and ret
   assert.match(js, /state\.exact_total \|\| fmtMoney/);
 });
 
-test("Admin Add Job runtime uses the deploy-safe Issue 267 v8 asset URL", () => {
-  assert.match(html, /admin-add-v2\.js\?v=20260809_issue267_catalog_flow_v8/);
+test("Admin Add Job runtime uses the deploy-safe Issue 267 v9 asset URL", () => {
+  assert.match(html, /admin-add-v2\.js\?v=20260809_issue267_catalog_flow_v9/);
   assert.doesNotMatch(html, /admin-add-v2\.js\?v=20260809_issue267_catalog_flow_v2/);
+});
+
+test("Admin Store bundle quote ignores stale responses and refreshes the authoritative summary", () => {
+  const preview = js.match(/async function previewServiceBundle\(\)[\s\S]*?\n}\n/)[0];
+  const invalidate = js.match(/function invalidateServicePackagePreview\([\s\S]*?\n}\n/)[0];
+  assert.match(js, /service_bundle_quote_request_id: 0/);
+  assert.match(preview, /const requestId = \+\+state\.service_bundle_quote_request_id/);
+  assert.match(preview, /requestId !== state\.service_bundle_quote_request_id \|\| fingerprint !== bundleFingerprint\(\)/);
+  assert.match(preview, /state\.service_bundle_quote_fingerprint = fingerprint/);
+  assert.match(preview, /await refreshPreview\(\)/);
+  assert.match(invalidate, /state\.service_bundle_quote_request_id \+= 1/);
+  assert.match(invalidate, /const legacySelected =/);
+  assert.match(invalidate, /panel\.style\.display = legacySelected/);
 });

--- a/test/customerBookingPendingApproval.test.js
+++ b/test/customerBookingPendingApproval.test.js
@@ -128,7 +128,7 @@ test("Admin Add and Queue no longer call public forced availability", () => {
 });
 
 test("changed Admin booking scripts have one shared cache-bust build", () => {
-  assert.match(read("admin-add-v2.html"), /admin-add-v2\.js\?v=20260809_issue267_catalog_flow_v8/);
+  assert.match(read("admin-add-v2.html"), /admin-add-v2\.js\?v=20260809_issue267_catalog_flow_v9/);
   assert.match(read("admin-queue-v2.html"), /admin-queue-v2\.js\?v=20260719_customer_booking_pr3_v1/);
   assert.match(read("admin-review-v2.html"), /admin-review-v2\.js\?v=20260726_urgent_preferred_time_gps_v1/);
 });

--- a/test/jobLocationRoundtrip.test.js
+++ b/test/jobLocationRoundtrip.test.js
@@ -216,7 +216,7 @@ test("Test 14: check-in 500 m + accuracy policy is unchanged", () => {
 
 test("Test 15: PWA + admin cache build IDs are bumped consistently", () => {
   const BUILD = "20260712_job_location_roundtrip_v1";
-  const ADMIN_ADD_BUILD = "20260809_issue267_catalog_flow_v8";
+  const ADMIN_ADD_BUILD = "20260809_issue267_catalog_flow_v9";
   const URGENT_REVIEW_BUILD = "20260726_urgent_preferred_time_gps_v1";
   assert.match(read("app.js"), new RegExp(`__CWF_TECH_APP_VERSION__ = "${BUILD}"`));
   assert.match(read("sw.js"), new RegExp(`CWF_TECH_BUILD_ID = "${BUILD}"`));


### PR DESCRIPTION
## Promotion scope

Promotes the Admin Booking on Behalf quote-race fix from PR #279 to `staging/home-server-test`.

- Latest mixed-group response wins.
- Authoritative price/duration summary refreshes from the server quote.
- Admin Add Job asset cache advances to v9.
- Full suite: 1,528 passed, 58 skipped, 0 failed.

Staging only; Production remains unchanged.