### PR TITLE
Promote PR #283 bundle booking modal to CWF home staging

### DIFF
--- a/customer-app/assets/customer-app.css
+++ b/customer-app/assets/customer-app.css
@@ -7342,13 +7342,35 @@ body.has-advisor-sheet { overflow: hidden; }
 .has-package-selection .ordinary-service-controls,
 .has-package-selection [data-action="add-line"],
 .has-package-selection .service-line-review-list { display: none; }
-.store-bundle-config { margin: 16px 0; padding: 16px; border: 1px solid var(--line, #dfe6ee); border-radius: 16px; background: #fff; }
-.store-bundle-config h3 { margin: 0 0 4px; }
-.store-bundle-row { display: grid; grid-template-columns: minmax(140px, 1fr) minmax(120px, .7fr) minmax(110px, .55fr); gap: 12px; align-items: end; padding: 14px 0; border-bottom: 1px solid var(--line, #e5e7eb); }
-.store-bundle-row > div { display: grid; gap: 4px; }
-.store-bundle-row label { display: grid; gap: 5px; font-size: 13px; }
-.store-bundle-live-total { margin-top: 14px; font-weight: 700; }
-@media (max-width: 480px) { .store-bundle-row { grid-template-columns: 1fr 1fr; } .store-bundle-row > div { grid-column: 1 / -1; } }
+.store-bundle-sheet { width: auto; max-width: 456px; max-height: min(88vh, 720px); min-width: 0; overflow-x: hidden; }
+.store-bundle-sheet > h2 { padding-right: 42px; overflow-wrap: anywhere; }
+.store-bundle-config { display: grid; gap: 12px; min-width: 0; margin: 0; }
+.store-bundle-config > .muted { margin: 0; font-size: 13px; }
+.store-bundle-row { display: grid; grid-template-columns: minmax(0, .8fr) minmax(0, 1.2fr); gap: 10px 12px; min-width: 0; padding: 13px 0; border-bottom: 1px solid var(--line, #e5e7eb); }
+.store-bundle-package { display: grid; grid-column: 1 / -1; gap: 3px; min-width: 0; }
+.store-bundle-package strong,
+.store-bundle-package small { overflow-wrap: anywhere; }
+.store-bundle-package small { color: var(--muted); line-height: 1.45; }
+.store-bundle-btu,
+.store-bundle-quantity { display: grid; align-content: start; gap: 5px; min-width: 0; font-size: 13px; }
+.store-bundle-btu .select { width: 100%; min-width: 0; }
+.store-bundle-stepper { display: grid; grid-template-columns: 40px minmax(0, 1fr) 40px; gap: 5px; min-width: 0; }
+.store-bundle-stepper .qty-btn { width: 40px; height: 42px; }
+.store-bundle-stepper .input { width: 100%; min-width: 0; height: 42px; padding-inline: 4px; text-align: center; }
+.store-bundle-row-error { min-height: 16px; color: var(--danger); font-size: 11px; font-weight: 700; line-height: 1.35; }
+.store-bundle-live-summary { display: grid; gap: 7px; padding: 12px; border-radius: 14px; background: var(--bg-2); }
+.store-bundle-live-summary > div { display: flex; justify-content: space-between; gap: 12px; min-width: 0; font-size: 13px; }
+.store-bundle-live-summary span { color: var(--muted); }
+.store-bundle-live-summary strong { color: var(--ink); text-align: right; overflow-wrap: anywhere; }
+.store-bundle-live-summary [data-bundle-price] { color: var(--blue); font-size: 17px; }
+.store-bundle-live-summary p { margin: 2px 0 0; font-size: 12px; line-height: 1.45; }
+.store-bundle-error { min-height: 18px; margin: 0; }
+.store-bundle-confirm { width: 100%; min-width: 0; }
+@media (max-width: 480px) {
+  .store-bundle-sheet { right: 10px; bottom: max(8px, env(safe-area-inset-bottom)); left: 10px; max-width: none; padding: 18px 14px 14px; border-radius: 20px; }
+  .store-bundle-row { grid-template-columns: minmax(0, 1fr); }
+  .store-bundle-package { grid-column: 1; }
+}
 
 /* Catalog-configured promotion presentation: bounded server presets only. */
 .store-campaign-presentation { display:flex; flex-wrap:wrap; align-items:center; gap:8px; padding:10px 14px 0; }

--- a/customer-app/assets/customer-app.js
+++ b/customer-app/assets/customer-app.js
@@ -3,7 +3,7 @@
 
   const App = window.CWFCustomerAppV2;
   const BOOT_TIMEOUT_MS = 3500;
-  const BUILD_ID = "20260809_issue267_catalog_flow_v9";
+  const BUILD_ID = "20260819_issue282_bundle_sheet_v1";
 
   function withTimeout(promise, timeoutMs) {
     return Promise.race([

--- a/customer-app/index.html
+++ b/customer-app/index.html
@@ -21,10 +21,10 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Noto+Sans+Thai:wght@400;500;600;700;800;900&display=swap" media="print" onload="this.media='all'">
   <noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Noto+Sans+Thai:wght@400;500;600;700;800;900&display=swap"></noscript>
-  <link rel="manifest" href="./manifest.webmanifest?v=20260809_issue267_catalog_flow_v9">
+  <link rel="manifest" href="./manifest.webmanifest?v=20260819_issue282_bundle_sheet_v1">
   <link rel="icon" type="image/png" sizes="192x192" href="./assets/icons/cwf-customer-192.png">
   <link rel="apple-touch-icon" sizes="180x180" href="./assets/icons/cwf-customer-180.png">
-  <link rel="stylesheet" href="./assets/customer-app.css?v=20260809_issue267_catalog_flow_v9">
+  <link rel="stylesheet" href="./assets/customer-app.css?v=20260819_issue282_bundle_sheet_v1">
 </head>
 <body class="is-app-booting">
   <div class="app-shell" data-app-shell>
@@ -62,26 +62,26 @@
     </nav>
   </div>
 
-  <script src="./modules/iconRegistry.js?v=20260809_issue267_catalog_flow_v9"></script>
-  <script src="./modules/state.js?v=20260809_issue267_catalog_flow_v9"></script>
-  <script src="./modules/utils.js?v=20260809_issue267_catalog_flow_v9"></script>
-  <script src="./modules/customerCopy.js?v=20260809_issue267_catalog_flow_v9"></script>
-  <script src="./modules/analytics.js?v=20260809_issue267_catalog_flow_v9"></script>
-  <script src="./modules/api.js?v=20260809_issue267_catalog_flow_v9"></script>
-  <script src="./modules/pageAvailability.js?v=20260809_issue267_catalog_flow_v9"></script>
-  <script src="./modules/services.js?v=20260809_issue267_catalog_flow_v9"></script>
-  <script src="./modules/advisor.js?v=20260809_issue267_catalog_flow_v9"></script>
-  <script src="./modules/ui.js?v=20260809_issue267_catalog_flow_v9"></script>
-  <script src="./modules/store.js?v=20260809_issue267_catalog_flow_v9"></script>
-  <script src="./modules/auth.js?v=20260809_issue267_catalog_flow_v9"></script>
-  <script src="./modules/pricing.js?v=20260809_issue267_catalog_flow_v9"></script>
-  <script src="./modules/availability.js?v=20260809_issue267_catalog_flow_v9"></script>
-  <script src="./modules/bookingTicket.js?v=20260809_issue267_catalog_flow_v9"></script>
-  <script src="./modules/bookingScheduled.js?v=20260809_issue267_catalog_flow_v9"></script>
-  <script src="./modules/bookingUrgent.js?v=20260809_issue267_catalog_flow_v9"></script>
-  <script src="./modules/tracking.js?v=20260809_issue267_catalog_flow_v9"></script>
-  <script src="./modules/profile.js?v=20260809_issue267_catalog_flow_v9"></script>
-  <script src="./modules/router.js?v=20260809_issue267_catalog_flow_v9"></script>
-  <script src="./assets/customer-app.js?v=20260809_issue267_catalog_flow_v9"></script>
+  <script src="./modules/iconRegistry.js?v=20260819_issue282_bundle_sheet_v1"></script>
+  <script src="./modules/state.js?v=20260819_issue282_bundle_sheet_v1"></script>
+  <script src="./modules/utils.js?v=20260819_issue282_bundle_sheet_v1"></script>
+  <script src="./modules/customerCopy.js?v=20260819_issue282_bundle_sheet_v1"></script>
+  <script src="./modules/analytics.js?v=20260819_issue282_bundle_sheet_v1"></script>
+  <script src="./modules/api.js?v=20260819_issue282_bundle_sheet_v1"></script>
+  <script src="./modules/pageAvailability.js?v=20260819_issue282_bundle_sheet_v1"></script>
+  <script src="./modules/services.js?v=20260819_issue282_bundle_sheet_v1"></script>
+  <script src="./modules/advisor.js?v=20260819_issue282_bundle_sheet_v1"></script>
+  <script src="./modules/ui.js?v=20260819_issue282_bundle_sheet_v1"></script>
+  <script src="./modules/store.js?v=20260819_issue282_bundle_sheet_v1"></script>
+  <script src="./modules/auth.js?v=20260819_issue282_bundle_sheet_v1"></script>
+  <script src="./modules/pricing.js?v=20260819_issue282_bundle_sheet_v1"></script>
+  <script src="./modules/availability.js?v=20260819_issue282_bundle_sheet_v1"></script>
+  <script src="./modules/bookingTicket.js?v=20260819_issue282_bundle_sheet_v1"></script>
+  <script src="./modules/bookingScheduled.js?v=20260819_issue282_bundle_sheet_v1"></script>
+  <script src="./modules/bookingUrgent.js?v=20260819_issue282_bundle_sheet_v1"></script>
+  <script src="./modules/tracking.js?v=20260819_issue282_bundle_sheet_v1"></script>
+  <script src="./modules/profile.js?v=20260819_issue282_bundle_sheet_v1"></script>
+  <script src="./modules/router.js?v=20260819_issue282_bundle_sheet_v1"></script>
+  <script src="./assets/customer-app.js?v=20260819_issue282_bundle_sheet_v1"></script>
 </body>
 </html>

--- a/customer-app/manifest.webmanifest
+++ b/customer-app/manifest.webmanifest
@@ -2,7 +2,7 @@
   "name": "CWF Customer Service",
   "short_name": "CWF Service",
   "description": "แอปลูกค้า Coldwindflow สำหรับเลือกบริการ จองคิว และติดตามงาน",
-  "start_url": "/customer-app/index.html?v=20260809_issue267_catalog_flow_v9#home",
+  "start_url": "/customer-app/index.html?v=20260819_issue282_bundle_sheet_v1#home",
   "scope": "/customer-app/",
   "id": "/customer-app/",
   "display": "standalone",

--- a/customer-app/modules/store.js
+++ b/customer-app/modules/store.js
@@ -133,17 +133,32 @@
 
   function renderBundleConfigurator(item) {
     if (!isServicePackageBundle(item)) return "";
-    return `<section class="store-bundle-config" data-store-bundle-config><h3>เลือก BTU และจำนวนเครื่อง</h3><p class="muted">รวมแอร์หลายขนาดในงานเดียวได้ และเลือกมากกว่า 4 เครื่องได้</p>${item.service_package_variants.map((variant) => {
+    return `<section class="store-bundle-config" data-store-bundle-config><p class="muted">รวมแอร์หลายขนาดในงานเดียวได้ และเลือกมากกว่า 4 เครื่องได้</p>${item.service_package_variants.map((variant, index) => {
       const options = bundleBtuOptions(variant);
-      return `<div class="store-bundle-row" data-bundle-package="${root.utils.escapeHtml(variant.package_key)}"><div><strong>${root.utils.escapeHtml(variant.package_name)}</strong>${variant.description ? `<small>${root.utils.escapeHtml(variant.description)}</small>` : ""}</div><label>BTU<select class="select" data-bundle-btu>${options.map((option) => `<option value="${option.btu}">${root.utils.escapeHtml(option.label || `${option.btu} BTU`)}</option>`).join("")}</select></label><label>จำนวน<input class="input" data-bundle-quantity type="number" min="0" step="1" inputmode="numeric" value="0" aria-label="จำนวนเครื่องสำหรับ ${root.utils.escapeHtml(variant.package_name)}"></label></div>`;
-    }).join("")}<div class="store-bundle-live-total" data-bundle-total>เลือกอย่างน้อย 1 เครื่อง</div><div class="inline-error" data-bundle-error aria-live="polite"></div></section>`;
+      const quantityId = `bundle-quantity-${index}`;
+      const errorId = `bundle-quantity-error-${index}`;
+      return `<div class="store-bundle-row" data-bundle-package="${root.utils.escapeHtml(variant.package_key)}"><div class="store-bundle-package"><strong>${root.utils.escapeHtml(variant.package_name)}</strong>${variant.description ? `<small>${root.utils.escapeHtml(variant.description)}</small>` : ""}</div><label class="store-bundle-btu">BTU<select class="select" data-bundle-btu>${options.map((option) => `<option value="${option.btu}">${root.utils.escapeHtml(option.label || `${option.btu} BTU`)}</option>`).join("")}</select></label><div class="store-bundle-quantity"><span>จำนวน</span><div class="store-bundle-stepper" role="group" aria-label="จำนวนเครื่องสำหรับ ${root.utils.escapeHtml(variant.package_name)}"><button class="qty-btn" type="button" data-bundle-dec aria-label="ลดจำนวน ${root.utils.escapeHtml(variant.package_name)}" aria-controls="${quantityId}">−</button><input class="input" id="${quantityId}" data-bundle-quantity type="number" min="0" max="99" step="1" inputmode="numeric" value="0" aria-describedby="${errorId}" aria-label="จำนวนเครื่องสำหรับ ${root.utils.escapeHtml(variant.package_name)}"><button class="qty-btn" type="button" data-bundle-inc aria-label="เพิ่มจำนวน ${root.utils.escapeHtml(variant.package_name)}" aria-controls="${quantityId}">+</button></div><small class="store-bundle-row-error" id="${errorId}" data-bundle-row-error aria-live="polite"></small></div></div>`;
+    }).join("")}<div class="store-bundle-live-summary" data-bundle-summary aria-live="polite"><div><span>จำนวนเครื่อง</span><strong data-bundle-count>0 เครื่อง</strong></div><div><span>ราคาที่ระบบยืนยัน</span><strong data-bundle-price>—</strong></div><div data-bundle-duration-row hidden><span>ระยะเวลาโดยประมาณ</span><strong data-bundle-duration></strong></div><p data-bundle-quote-status>เลือกอย่างน้อย 1 เครื่องเพื่อดูราคา</p></div><div class="inline-error store-bundle-error" data-bundle-error aria-live="polite"></div></section>`;
+  }
+
+  function parseBundleQuantity(value) {
+    const text = String(value == null ? "" : value).trim();
+    if (!/^\d+$/.test(text)) throw new Error("กรอกจำนวนเป็นเลขจำนวนเต็ม 0 ถึง 99");
+    const quantity = Number(text);
+    if (!Number.isSafeInteger(quantity) || quantity < 0 || quantity > 99) throw new Error("จำนวนเครื่องต้องอยู่ระหว่าง 0 ถึง 99");
+    return quantity;
+  }
+
+  function clampBundleQuantity(value, change) {
+    const parsed = Number(value);
+    const current = Number.isSafeInteger(parsed) ? parsed : 0;
+    return Math.min(99, Math.max(0, current + change));
   }
 
   function collectBundleDraft(container, item) {
     const groups = [];
     container.querySelectorAll("[data-bundle-package]").forEach((row) => {
-      const quantity = Number(row.querySelector("[data-bundle-quantity]")?.value || 0);
-      if (!Number.isSafeInteger(quantity) || quantity < 0 || quantity > 99) throw new Error("จำนวนเครื่องต้องเป็นจำนวนเต็มระหว่าง 0 ถึง 99");
+      const quantity = parseBundleQuantity(row.querySelector("[data-bundle-quantity]")?.value);
       if (!quantity) return;
       const packageKey = row.getAttribute("data-bundle-package");
       const variant = item.service_package_variants.find((entry) => entry.package_key === packageKey);
@@ -157,34 +172,176 @@
   }
 
   let bundleQuoteRequestId = 0;
-  async function beginBundleBooking(container, item, scope = "scheduled") {
-    const errorBox = container.querySelector("[data-bundle-error]");
-    const requestId = ++bundleQuoteRequestId;
-    try {
-      const result = collectBundleDraft(container, item);
-      if (errorBox) errorBox.textContent = "กำลังตรวจสอบราคาและสิทธิ์จากระบบ...";
-      const quote = await root.api.quoteCatalogBooking({
-        catalog_item_id: Number(item.item_id), service_package_groups: result.groups, booking_mode: scope,
-      });
-      if (requestId !== bundleQuoteRequestId || String(root.state.storeDetail?.data?.item_id) !== String(item.item_id)) return;
-      const preview = { package_name: item.item_name, groups: quote.groups, components: quote.components,
-        fixed_total_price: quote.fixed_total_price, duration_min: quote.duration_minutes,
-        redeem_until: item.service_package_redeem_until, payload: { services: quote.services }, server_verified: true };
-      const common = { catalog_item_id: Number(item.item_id), service_package_key: "", service_package_tier_key: "", service_package_btu: "",
-        service_package_groups: result.groups, service_package_bundle_preview: preview,
-        services: quote.services, selectedSlot: null };
-      root.state.updateDraft(scope, scope === "urgent" ? { ...common, urgent_request_key: "" } : { ...common, scheduled_request_key: "" });
-      if (scope === "scheduled") {
-        root.state.setScheduledPreview("package", { status: "success", data: preview, error: "", verified: true });
-        root.state.setScheduledPreview("pricing", { status: "idle", data: null, error: "" });
-      }
-      if (errorBox) errorBox.textContent = "";
-      root.utils.routeTo(scope);
-    } catch (error) {
-      if (requestId !== bundleQuoteRequestId) return;
-      if (scope === "scheduled") root.state.setScheduledPreview("package", { status: "error", data: null, error: "ไม่สามารถยืนยันแพ็กเกจได้ กรุณาลองใหม่", verified: false });
-      if (errorBox) errorBox.textContent = "ไม่สามารถยืนยันราคาและสิทธิ์ได้ กรุณาลองใหม่";
+  let activeBundleSheetCleanup = null;
+
+  function bundleSelectionSignature(groups) {
+    return JSON.stringify(groups.map((group) => ({ package_key: group.package_key, btu: group.btu, quantity: group.quantity })));
+  }
+
+  function continueBundleBooking(item, result, quote, scope = "scheduled") {
+    const preview = { package_name: item.item_name, groups: quote.groups, components: quote.components,
+      fixed_total_price: quote.fixed_total_price, duration_min: quote.duration_minutes,
+      redeem_until: item.service_package_redeem_until, payload: { services: quote.services }, server_verified: true };
+    const common = { catalog_item_id: Number(item.item_id), service_package_key: "", service_package_tier_key: "", service_package_btu: "",
+      service_package_groups: result.groups, service_package_bundle_preview: preview,
+      services: quote.services, selectedSlot: null };
+    root.state.updateDraft(scope, scope === "urgent" ? { ...common, urgent_request_key: "" } : { ...common, scheduled_request_key: "" });
+    if (scope === "scheduled") {
+      root.state.setScheduledPreview("package", { status: "success", data: preview, error: "", verified: true });
+      root.state.setScheduledPreview("pricing", { status: "idle", data: null, error: "" });
     }
+    root.utils.routeTo(scope);
+  }
+
+  function bundleSheetHtml(item, scope) {
+    const titleId = `bundle-sheet-title-${scope}`;
+    return `
+      <div class="contact-sheet-backdrop" data-bundle-close></div>
+      <section class="contact-sheet store-bundle-sheet" role="dialog" aria-modal="true" aria-labelledby="${titleId}">
+        <button class="contact-sheet-close" type="button" data-bundle-close aria-label="ปิด">×</button>
+        <span class="section-kicker">${scope === "urgent" ? "จองแพ็กเกจด่วน" : "จองแพ็กเกจ"}</span>
+        <h2 id="${titleId}">${root.utils.escapeHtml(item.item_name || "แพ็กเกจบริการ")}</h2>
+        ${renderBundleConfigurator(item)}
+        <button class="primary-btn store-bundle-confirm" type="button" data-bundle-confirm disabled>${scope === "urgent" ? "ดำเนินการจองด่วน" : "ยืนยันและเลือกวันเวลา"}</button>
+      </section>
+    `;
+  }
+
+  function clearBundleSheet() {
+    if (activeBundleSheetCleanup) activeBundleSheetCleanup({ restoreFocus: false });
+  }
+
+  function openBundleConfigurator(container, item, scope = "scheduled", trigger = null) {
+    clearBundleSheet();
+    let mount = container.querySelector("[data-contact-sheet-mount]");
+    if (!mount) { mount = document.createElement("div"); mount.setAttribute("data-contact-sheet-mount", ""); container.appendChild(mount); }
+    mount.innerHTML = bundleSheetHtml(item, scope);
+    document.body.classList.add("has-contact-sheet");
+    const sheet = mount.querySelector(".store-bundle-sheet");
+    const confirm = mount.querySelector("[data-bundle-confirm]");
+    const count = mount.querySelector("[data-bundle-count]");
+    const price = mount.querySelector("[data-bundle-price]");
+    const duration = mount.querySelector("[data-bundle-duration]");
+    const durationRow = mount.querySelector("[data-bundle-duration-row]");
+    const status = mount.querySelector("[data-bundle-quote-status]");
+    const errorBox = mount.querySelector("[data-bundle-error]");
+    let quoteTimer = null;
+    let verifiedQuote = null;
+    let verifiedSignature = "";
+    let closed = false;
+
+    const setSummary = (machineCount, state, quote = null) => {
+      if (count) count.textContent = `${machineCount} เครื่อง`;
+      if (price) price.textContent = state === "loading" ? "กำลังตรวจสอบ..." : (quote ? root.utils.formatBaht(quote.fixed_total_price) : "—");
+      const minutes = Number(quote?.duration_minutes);
+      if (durationRow) durationRow.hidden = !(Number.isFinite(minutes) && minutes > 0);
+      if (duration) duration.textContent = Number.isFinite(minutes) && minutes > 0 ? `${minutes} นาที` : "";
+      if (status) status.textContent = state === "loading" ? "กำลังขอราคาล่าสุดจากระบบ..."
+        : state === "success" ? "ราคานี้ยืนยันจากระบบแล้ว"
+          : state === "error" ? "ขอราคาไม่สำเร็จ กรุณาลองแก้จำนวนหรือ BTU อีกครั้ง"
+            : "เลือกอย่างน้อย 1 เครื่องเพื่อดูราคา";
+    };
+
+    const setQuantityErrors = () => {
+      let firstError = "";
+      mount.querySelectorAll("[data-bundle-package]").forEach((row) => {
+        const input = row.querySelector("[data-bundle-quantity]");
+        const error = row.querySelector("[data-bundle-row-error]");
+        let message = "";
+        try { parseBundleQuantity(input?.value); } catch (cause) { message = cause.message; }
+        if (input) input.setAttribute("aria-invalid", message ? "true" : "false");
+        if (error) error.textContent = message;
+        if (!firstError && message) firstError = message;
+      });
+      return firstError;
+    };
+
+    const refreshQuote = () => {
+      if (quoteTimer) { clearTimeout(quoteTimer); quoteTimer = null; }
+      ++bundleQuoteRequestId;
+      verifiedQuote = null;
+      verifiedSignature = "";
+      if (confirm) confirm.disabled = true;
+      if (errorBox) errorBox.textContent = "";
+      const rowError = setQuantityErrors();
+      const machineCount = Array.from(mount.querySelectorAll("[data-bundle-quantity]")).reduce((sum, input) => {
+        try { return sum + parseBundleQuantity(input.value); } catch (_error) { return sum; }
+      }, 0);
+      let result;
+      try {
+        if (rowError) throw new Error(rowError);
+        result = collectBundleDraft(mount, item);
+      } catch (cause) {
+        if (errorBox) errorBox.textContent = cause.message;
+        setSummary(machineCount, "empty");
+        return;
+      }
+      const signature = bundleSelectionSignature(result.groups);
+      const requestId = bundleQuoteRequestId;
+      setSummary(machineCount, "loading");
+      quoteTimer = setTimeout(async () => {
+        quoteTimer = null;
+        try {
+          const quote = await root.api.quoteCatalogBooking({
+            catalog_item_id: Number(item.item_id), service_package_groups: result.groups, booking_mode: scope,
+          });
+          if (closed || requestId !== bundleQuoteRequestId || String(root.state.storeDetail?.data?.item_id) !== String(item.item_id)) return;
+          if (!quote || !Number.isFinite(Number(quote.fixed_total_price))) throw new Error("INVALID_BUNDLE_QUOTE");
+          verifiedQuote = quote;
+          verifiedSignature = signature;
+          setSummary(machineCount, "success", quote);
+          if (confirm) confirm.disabled = false;
+        } catch (_error) {
+          if (closed || requestId !== bundleQuoteRequestId) return;
+          setSummary(machineCount, "error");
+          if (errorBox) errorBox.textContent = "ไม่สามารถยืนยันราคาและสิทธิ์ได้ กรุณาลองใหม่";
+          if (confirm) confirm.disabled = true;
+        }
+      }, 300);
+    };
+
+    const close = ({ restoreFocus = true } = {}) => {
+      if (closed) return;
+      closed = true;
+      ++bundleQuoteRequestId;
+      if (quoteTimer) clearTimeout(quoteTimer);
+      document.removeEventListener("keydown", onKeydown);
+      mount.innerHTML = "";
+      document.body.classList.remove("has-contact-sheet");
+      if (activeBundleSheetCleanup === close) activeBundleSheetCleanup = null;
+      if (restoreFocus) trigger?.focus?.({ preventScroll: true });
+    };
+    const onKeydown = (event) => {
+      if (event.key === "Escape") close();
+    };
+    activeBundleSheetCleanup = close;
+    document.addEventListener("keydown", onKeydown);
+    mount.querySelectorAll("[data-bundle-close]").forEach((button) => button.addEventListener("click", () => close(), { once: true }));
+    mount.querySelectorAll("[data-bundle-quantity]").forEach((input) => input.addEventListener("input", refreshQuote));
+    mount.querySelectorAll("[data-bundle-btu]").forEach((select) => select.addEventListener("change", refreshQuote));
+    mount.querySelectorAll("[data-bundle-dec], [data-bundle-inc]").forEach((button) => {
+      button.addEventListener("click", () => {
+        const row = button.closest("[data-bundle-package]");
+        const input = row?.querySelector("[data-bundle-quantity]");
+        if (!input) return;
+        input.value = String(clampBundleQuantity(input.value, button.hasAttribute("data-bundle-inc") ? 1 : -1));
+        refreshQuote();
+      });
+    });
+    confirm?.addEventListener("click", () => {
+      if (confirm.disabled || !verifiedQuote) return;
+      try {
+        const result = collectBundleDraft(mount, item);
+        if (bundleSelectionSignature(result.groups) !== verifiedSignature) { refreshQuote(); return; }
+        confirm.disabled = true;
+        close({ restoreFocus: false });
+        continueBundleBooking(item, result, verifiedQuote, scope);
+      } catch (cause) {
+        if (errorBox) errorBox.textContent = cause.message;
+        refreshQuote();
+      }
+    });
+    requestAnimationFrame(() => sheet?.querySelector(".contact-sheet-close")?.focus());
   }
 
   async function beginOrdinaryBooking(container, item, scope, source) {
@@ -1722,7 +1879,6 @@
       ${renderPromoInfo(item)}
       ${renderVariantSelector(item, siblings)}
       ${item.short_description ? `<div class="store-detail-section store-detail-summary"><p>${root.utils.escapeHtml(item.short_description)}</p></div>` : ""}
-      ${renderBundleConfigurator(item)}
       <div class="store-detail-inline-cta">${ctaButton}</div>
       <div class="store-detail-accordion-group">
         ${renderAccordionSection("จุดเด่นของบริการ", highlights.length ? `
@@ -1806,7 +1962,7 @@
       bookButton.addEventListener("click", async () => {
         const item = root.state.storeDetail?.data;
         if (!item) return;
-        if (isServicePackageBundle(item)) { beginBundleBooking(container, item); return; }
+        if (isServicePackageBundle(item)) { openBundleConfigurator(container, item, "scheduled", bookButton); return; }
         if (!root.services.catalogItemToCommerceDraft(item)) {
           trackItemEvent("cwf_store_contact_admin", item, { source: "store_detail" });
           root.ui.openContactSheet(container, { title: item?.item_name || "รายการนี้" });
@@ -1815,26 +1971,12 @@
         await beginOrdinaryBooking(container, item, "scheduled", "store_detail");
       });
     });
-    container.querySelectorAll("[data-bundle-quantity], [data-bundle-btu]").forEach((control) => {
-      control.addEventListener("change", () => {
-        const item = root.state.storeDetail?.data;
-        const total = container.querySelector("[data-bundle-total]");
-        const error = container.querySelector("[data-bundle-error]");
-        if (error) error.textContent = "";
-        try {
-          const result = collectBundleDraft(container, item);
-          if (total) total.textContent = `รวม ${result.groups.reduce((sum, group) => sum + group.quantity, 0)} เครื่อง · ระบบจะยืนยันราคาเมื่อกดจอง`;
-        } catch (cause) {
-          if (total) total.textContent = cause.message;
-        }
-      });
-    });
     container.querySelectorAll("[data-store-detail-urgent]").forEach((bookButton) => {
       bookButton.addEventListener("click", async () => {
         if (bookButton.disabled) return;
         const item = root.state.storeDetail?.data;
         if (!item || !allowsUrgentBooking(item)) return;
-        if (isServicePackageBundle(item)) { beginBundleBooking(container, item, "urgent"); return; }
+        if (isServicePackageBundle(item)) { openBundleConfigurator(container, item, "urgent", bookButton); return; }
         await beginOrdinaryBooking(container, item, "urgent", "store_detail");
       });
     });
@@ -2360,10 +2502,12 @@
   store.render.onLeave = () => {
     clearCardAutoplay();
     clearCampaignCountdowns();
+    clearBundleSheet();
   };
   store.renderDetail.onLeave = () => {
     clearDetailAutoplay();
     clearCampaignCountdowns();
+    clearBundleSheet();
   };
 
   // Shared presentation renderer/lifecycle for both Store and the existing
@@ -2378,7 +2522,8 @@
   };
 
   store._test = { loadDetail, loadReviewsList, loadEligibility, detailItemId, renderDetailBody, renderReviewsSectionBody,
-    composeBundleTiers, renderBundleConfigurator, collectBundleDraft, beginOrdinaryBooking,
+    composeBundleTiers, renderBundleConfigurator, parseBundleQuantity, clampBundleQuantity, collectBundleDraft,
+    bundleSelectionSignature, beginOrdinaryBooking,
     bindCampaignCountdowns, clearCampaignCountdowns };
 
   root.store = store;

--- a/customer-app/sw.js
+++ b/customer-app/sw.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const BUILD_ID = "20260809_issue267_catalog_flow_v9";
+const BUILD_ID = "20260819_issue282_bundle_sheet_v1";
 const CACHE_NAME = `cwf-customer-app-v2-${BUILD_ID}`;
 const APP_SHELL = [
   `./index.html?v=${BUILD_ID}`,

--- a/test/customerAppPageAvailability.test.js
+++ b/test/customerAppPageAvailability.test.js
@@ -281,7 +281,7 @@ test("api exposes loadCustomerAppConfig as a no-store GET to /public/customer-ap
 });
 
 test("build wiring: pageAvailability.js is registered in the HTML shell and the SW cache, with the new build id", () => {
-  const build = "20260809_issue267_catalog_flow_v9";
+  const build = "20260819_issue282_bundle_sheet_v1";
   assert.match(indexHtml, new RegExp(`modules/pageAvailability\\.js\\?v=${build}`));
   assert.match(swSrc, new RegExp(`BUILD_ID = "${build}"`));
   assert.match(swSrc, /modules\/pageAvailability\.js\?v=\$\{BUILD_ID\}/);
@@ -294,7 +294,7 @@ test("build wiring: pageAvailability.js is registered in the HTML shell and the 
    RUNTIME tests (execute the real code in a VM — not regex assertions).
    ========================================================================== */
 
-const BUILD = "20260809_issue267_catalog_flow_v9";
+const BUILD = "20260819_issue282_bundle_sheet_v1";
 const adminSrc = read("admin-homepage-cms.js");
 
 function reqUrlOf(req) {

--- a/test/customerAppRecovery.test.js
+++ b/test/customerAppRecovery.test.js
@@ -335,7 +335,7 @@ test("Customer App build id is consistent across shell and service worker", () =
   const sw = read("customer-app/sw.js");
   const app = read("customer-app/assets/customer-app.js");
   const manifest = read("customer-app/manifest.webmanifest");
-  const build = "20260809_issue267_catalog_flow_v9";
+  const build = "20260819_issue282_bundle_sheet_v1";
 
   assert.match(index, new RegExp(`customer-app\\.css\\?v=${build}`));
   assert.match(index, new RegExp(`modules\\/api\\.js\\?v=${build}`));
@@ -353,7 +353,7 @@ test("Customer App build id is consistent across shell and service worker", () =
 test("store module is loaded in index.html and precached in the service worker app shell", () => {
   const index = read("customer-app/index.html");
   const sw = read("customer-app/sw.js");
-  const build = "20260809_issue267_catalog_flow_v9";
+  const build = "20260819_issue282_bundle_sheet_v1";
 
   assert.match(index, new RegExp(`modules/store\\.js\\?v=${build}`));
   assert.match(sw, /`\.\/modules\/store\.js\?v=\$\{BUILD_ID\}`/);

--- a/test/customerAppStorePayment.test.js
+++ b/test/customerAppStorePayment.test.js
@@ -58,7 +58,7 @@ test("store falls back to the LINE hand-off when payment is unconfigured or the 
 test("payment step styles exist and the Customer App payment build id is bumped", () => {
   assert.match(cssSrc, /\.pay-method-btn/);
   assert.match(cssSrc, /\.pay-qr-img/);
-  assert.match(read("customer-app/index.html"), /modules\/store\.js\?v=20260809_issue267_catalog_flow_v9/);
-  assert.match(read("customer-app/sw.js"), /BUILD_ID = "20260809_issue267_catalog_flow_v9"/);
+  assert.match(read("customer-app/index.html"), /modules\/store\.js\?v=20260819_issue282_bundle_sheet_v1/);
+  assert.match(read("customer-app/sw.js"), /BUILD_ID = "20260819_issue282_bundle_sheet_v1"/);
   assert.match(storeSrc, /payment-security 20260705 loaded/);
 });

--- a/test/customerBookingAdminNotifications.test.js
+++ b/test/customerBookingAdminNotifications.test.js
@@ -312,10 +312,10 @@ test("admin/customer frontend cache versions are bumped for booking notification
   assert.doesNotMatch(adminReviewHtml, /admin-review-v2\.js\?v=20260707_customer_booking_notify_v2/);
   assert.match(adminReviewHtml, /admin-review-ai-intake\.js\?v=ai-booking-intake-customer-cards-v11-admin-alert-gate/);
   assert.doesNotMatch(adminReviewHtml, /admin-review-ai-intake\.js\?v=ai-booking-intake-customer-cards-v10/);
-  assert.match(customerIndex, /bookingScheduled\.js\?v=20260809_issue267_catalog_flow_v9/);
-  assert.match(customerIndex, /state\.js\?v=20260809_issue267_catalog_flow_v9/);
-  assert.match(customerSw, /const BUILD_ID = "20260809_issue267_catalog_flow_v9"/);
-  assert.match(customerManifest, /20260809_issue267_catalog_flow_v9/);
+  assert.match(customerIndex, /bookingScheduled\.js\?v=20260819_issue282_bundle_sheet_v1/);
+  assert.match(customerIndex, /state\.js\?v=20260819_issue282_bundle_sheet_v1/);
+  assert.match(customerSw, /const BUILD_ID = "20260819_issue282_bundle_sheet_v1"/);
+  assert.match(customerManifest, /20260819_issue282_bundle_sheet_v1/);
 });
 
 test("behavior: review queue only includes customer urgent waiting rows while preserving review statuses", () => {

--- a/test/customerBookingProductionCopy.test.js
+++ b/test/customerBookingProductionCopy.test.js
@@ -5,7 +5,7 @@ const path = require("node:path");
 const vm = require("node:vm");
 
 const ROOT = path.resolve(__dirname, "..");
-const BUILD = "20260809_issue267_catalog_flow_v9";
+const BUILD = "20260819_issue282_bundle_sheet_v1";
 
 function read(relativePath) {
   return fs.readFileSync(path.join(ROOT, relativePath), "utf8");

--- a/test/customerBookingTicketUi.test.js
+++ b/test/customerBookingTicketUi.test.js
@@ -303,7 +303,7 @@ test("ticket handoff keeps tracking/new-booking actions, 44px controls, mobile l
   assert.match(index, /modules\/bookingTicket\.js\?v=/);
   assert.match(sw, /modules\/bookingTicket\.js\?v=\$\{BUILD_ID\}/);
   for (const source of [index, sw, manifest, appEntry]) {
-    assert.match(source, /20260809_issue267_catalog_flow_v9/);
+    assert.match(source, /20260819_issue282_bundle_sheet_v1/);
     assert.doesNotMatch(source, /20260809_issue267_catalog_flow_v8/);
   }
 });

--- a/test/customerHistoryClaim.test.js
+++ b/test/customerHistoryClaim.test.js
@@ -845,7 +845,7 @@ test("Customer History search and preview keep 360px and 390px width contracts",
 });
 
 test("Customer App cache version is bumped consistently", () => {
-  const expected = "20260809_issue267_catalog_flow_v9";
+  const expected = "20260819_issue282_bundle_sheet_v1";
   for (const file of [
     "customer-app/index.html",
     "customer-app/sw.js",

--- a/test/customerHomepageFeaturedRotation.test.js
+++ b/test/customerHomepageFeaturedRotation.test.js
@@ -418,6 +418,6 @@ test("compact CSS and cache build remain consistent with six-card rotation", () 
   assert.match(css, /\.homepage-featured-page\s*\{[^}]*grid-area:\s*1\s*\/\s*1/s);
   assert.match(css, /transition:\s*opacity 350ms/);
   assert.match(css, /prefers-reduced-motion:\s*reduce/);
-  const build = "20260809_issue267_catalog_flow_v9";
+  const build = "20260819_issue282_bundle_sheet_v1";
   for (const source of [html, sw, boot, manifest]) assert.match(source, new RegExp(build));
 });

--- a/test/customerSameDayTiming.test.js
+++ b/test/customerSameDayTiming.test.js
@@ -161,7 +161,7 @@ test("customer app disables availability HTTP cache and refreshes same-day slots
 });
 
 test("customer app build and service worker cache IDs changed", () => {
-  const id = "20260809_issue267_catalog_flow_v9";
+  const id = "20260819_issue282_bundle_sheet_v1";
   for (const file of [
     "customer-app/index.html",
     "customer-app/sw.js",

--- a/test/customerServicePackageUi.test.js
+++ b/test/customerServicePackageUi.test.js
@@ -192,7 +192,7 @@ test("build id is coordinated and service worker privacy/network behavior remain
   const app = read("customer-app/assets/customer-app.js");
   const manifest = read("customer-app/manifest.webmanifest");
   const build = sw.match(/BUILD_ID = "([^"]+)"/)[1];
-  assert.equal(build, "20260809_issue267_catalog_flow_v9");
+  assert.equal(build, "20260819_issue282_bundle_sheet_v1");
   assert.match(index, new RegExp(build));
   assert.match(app, new RegExp(`BUILD_ID = "${build}"`));
   assert.match(manifest, new RegExp(`index\\.html\\?v=${build}#home`));

--- a/test/customerSmartAdvisor.test.js
+++ b/test/customerSmartAdvisor.test.js
@@ -1174,7 +1174,7 @@ test("Home places built-in advisor after Quick Actions and before Featured Servi
 });
 
 test("advisor module is loaded before ui.js and precached under the shared build id", () => {
-  const build = "20260809_issue267_catalog_flow_v9";
+  const build = "20260819_issue282_bundle_sheet_v1";
   assert.ok(INDEX_SOURCE.indexOf(`modules/advisor.js?v=${build}`) < INDEX_SOURCE.indexOf(`modules/ui.js?v=${build}`));
   assert.match(SW_SOURCE, new RegExp(`BUILD_ID = "${build}"`));
   assert.match(SW_SOURCE, /modules\/advisor\.js\?v=\$\{BUILD_ID\}/);

--- a/test/customerStoreServicePackageBundleUi.test.js
+++ b/test/customerStoreServicePackageBundleUi.test.js
@@ -3,25 +3,78 @@
 const test = require("node:test");
 const assert = require("node:assert/strict");
 const fs = require("node:fs");
+const vm = require("node:vm");
 
 const store = fs.readFileSync("customer-app/modules/store.js", "utf8");
 const scheduled = fs.readFileSync("customer-app/modules/bookingScheduled.js", "utf8");
 const css = fs.readFileSync("customer-app/assets/customer-app.css", "utf8");
 const admin = fs.readFileSync("admin-store-catalog.js", "utf8");
 
-test("Store renders one parent configurator with arbitrary nested variants and quantities beyond four", () => {
+function storeTestApi() {
+  const context = { window: { CWFCustomerAppV2: {} }, console: { info() {} } };
+  vm.runInNewContext(store, context);
+  return context.window.CWFCustomerAppV2.store._test;
+}
+
+test("bundle configurator is modal-only and keeps the composite parent payload", () => {
   assert.match(store, /service_package_variants\.map/);
   assert.match(store, /data-bundle-package/);
-  assert.match(store, /data-bundle-quantity[^>]*type="number"[^>]*min="0"/);
-  assert.doesNotMatch(store, /data-bundle-quantity[\s\S]{0,200}max=/);
+  assert.match(store, /data-bundle-quantity[^>]*type="number"[^>]*min="0"[^>]*max="99"[^>]*step="1"/);
   assert.doesNotMatch(store, /tier\.quantity === 1[\s\S]{0,120}prior\.components/);
   assert.match(store, /service_package_groups: result\.groups/);
   assert.doesNotMatch(store, /Premium Day|premium-day/);
+  const detail = store.slice(store.indexOf("function renderDetailContent"), store.indexOf("function renderDetailBody"));
+  assert.doesNotMatch(detail, /renderBundleConfigurator/);
 });
 
-test("mobile 360 and 390 layouts collapse each bundle row without a fixed-width overflow", () => {
-  assert.match(css, /@media \(max-width: 480px\)[^{]*\{[^}]*\.store-bundle-row/);
-  assert.match(css, /grid-template-columns: 1fr 1fr/);
+test("detail booking CTAs open the same scheduled or urgent bundle sheet", () => {
+  const detail = store.slice(store.indexOf("function bindDetailBody"), store.indexOf("function openDetail"));
+  assert.match(detail, /openBundleConfigurator\(container, item, "scheduled", bookButton\)/);
+  assert.match(detail, /openBundleConfigurator\(container, item, "urgent", bookButton\)/);
+  assert.match(store, /booking_mode: scope/);
+});
+
+test("bundle quantities support accessible minus, typed input, plus, and strict bounds", () => {
+  assert.match(store, /data-bundle-dec[^>]*aria-label="ลดจำนวน/);
+  assert.match(store, /data-bundle-inc[^>]*aria-label="เพิ่มจำนวน/);
+  assert.match(store, /data-bundle-quantity type="number" min="0" max="99" step="1" inputmode="numeric"/);
+  assert.match(store, /addEventListener\("input", refreshQuote\)/);
+  assert.match(store, /data-bundle-row-error[^>]*aria-live="polite"/);
+  const api = storeTestApi();
+  assert.equal(api.parseBundleQuantity("0"), 0);
+  assert.equal(api.parseBundleQuantity("99"), 99);
+  assert.throws(() => api.parseBundleQuantity("1.5"), /จำนวนเต็ม/);
+  assert.throws(() => api.parseBundleQuantity("100"), /0 ถึง 99/);
+  assert.equal(api.clampBundleQuantity("0", -1), 0);
+  assert.equal(api.clampBundleQuantity("99", 1), 99);
+  assert.equal(api.clampBundleQuantity("invalid", 1), 1);
+});
+
+test("live quote is debounced, authoritative, stale-safe, and gates confirmation", () => {
+  assert.match(store, /setTimeout\(async \(\) =>[\s\S]*root\.api\.quoteCatalogBooking/);
+  assert.match(store, /\}, 300\)/);
+  assert.match(store, /requestId !== bundleQuoteRequestId/);
+  assert.match(store, /verifiedSignature = signature/);
+  assert.match(store, /root\.utils\.formatBaht\(quote\.fixed_total_price\)/);
+  assert.match(store, /quote\?\.duration_minutes/);
+  assert.match(store, /data-bundle-confirm disabled/);
+  assert.match(store, /verifiedQuote = null[\s\S]*confirm\) confirm\.disabled = true/);
+  assert.match(store, /verifiedQuote = quote[\s\S]*confirm\) confirm\.disabled = false/);
+  assert.doesNotMatch(store, /composeBundleTiers\([^)]*\)[\s\S]{0,200}data-bundle-price/);
+});
+
+test("bundle sheet closes from backdrop, close button, Escape, and restores focus", () => {
+  assert.match(store, /contact-sheet-backdrop" data-bundle-close/);
+  assert.match(store, /contact-sheet-close[^>]*data-bundle-close/);
+  assert.match(store, /event\.key === "Escape"/);
+  assert.match(store, /trigger\?\.focus\?\.\(\{ preventScroll: true \}\)/);
+  assert.match(store, /document\.body\.classList\.remove\("has-contact-sheet"\)/);
+});
+
+test("mobile 360 and 390 layouts collapse rows without horizontal overflow", () => {
+  assert.match(css, /\.store-bundle-sheet \{[^}]*overflow-x: hidden/);
+  assert.match(css, /\.store-bundle-stepper \{[^}]*grid-template-columns: 40px minmax\(0, 1fr\) 40px/);
+  assert.match(css, /@media \(max-width: 480px\)[\s\S]*?\.store-bundle-row \{ grid-template-columns: minmax\(0, 1fr\); \}/);
   for (const viewport of [360, 390]) assert.ok(viewport <= 480);
   assert.doesNotMatch(css.match(/\.store-bundle-row \{[^}]+\}/)?.[0] || "", /width:\s*[4-9]\d{2}px/);
 });

--- a/test/customerTrackingFullReadUi.test.js
+++ b/test/customerTrackingFullReadUi.test.js
@@ -1191,7 +1191,7 @@ test("tracking UI exposes loading, not-found, rate-limit and offline states", ()
 });
 
 test("tracking assets share the full-read cache build id", () => {
-  const build = "20260809_issue267_catalog_flow_v9";
+  const build = "20260819_issue282_bundle_sheet_v1";
   for (const file of [
     "customer-app/index.html",
     "customer-app/sw.js",

--- a/test/homepageCms.test.js
+++ b/test/homepageCms.test.js
@@ -305,7 +305,7 @@ test("customer homepage has no admin control, bottom nav is fixed five-tab, and 
   const sw = read("customer-app/sw.js");
   const app = read("customer-app/assets/customer-app.js");
   const manifest = read("customer-app/manifest.webmanifest");
-  const build = "20260809_issue267_catalog_flow_v9";
+  const build = "20260819_issue282_bundle_sheet_v1";
 
   assert.doesNotMatch(index + ui, /โหมดแอดมิน|openCms|localStorage\.getItem\('cwfHomeCmsDemo'/);
   assert.match(index, /data-route="store"[\s\S]*ร้านค้า/);


### PR DESCRIPTION
Owner-approved release for merged PR #283 / Issue #282.

Source:
- main head: `ce3dc614f1f28838d41875ef7d9dd605d1a88c77`
- staging base before promotion: `62a001ec90570f45e52facef1172ef8599365641`

Scope:
- Customer Store bundle configurator moves from inline detail content into a modal/bottom sheet.
- Quantity supports minus, editable numeric input, and plus.
- Live summary uses the existing server-authoritative quote endpoint with stale-response protection.
- Customer App PWA build ID is synchronized.
- No server pricing/resolver, DB migration, auth, payment, Production data/config, or booking kill-switch change.

Review evidence:
- Controller reviewed exact PR #283 diff and head.
- Focused + quote/composite/recovery: 133 passed, 0 failed.
- Worker affected regression group: 311 passed, 0 failed.
- Syntax and git diff checks passed.

Merging this PR is the Staging deployment event. Verify the Staging deployment log, health, Customer App build ID `20260819_issue282_bundle_sheet_v1`, and Store modal before Production promotion.