### PR TITLE
Promote scheduled runtime switch to staging

### DIFF
--- a/index.js
+++ b/index.js
@@ -50,6 +50,7 @@ const customerAvailability = require("./server/services/public/customerAvailabil
 const { registerPublicCustomerAvailabilityRoutes } = require("./server/routes/public/customerAvailability");
 const { registerAdminAvailabilityRoutes } = require("./server/routes/admin/adminAvailability");
 const { createBookingJobService } = require("./server/services/booking/createBookingJob");
+const scheduledCapability = require("./server/services/booking/scheduledCapability");
 const { createCustomerCatalogQuoteService } = require("./server/services/booking/customerCatalogQuote");
 const { calcBookingPricing } = require("./server/services/booking/exactPricing");
 const { pendingCustomerScheduledReservationSql } = require("./server/services/booking/bookingStatuses");
@@ -143,13 +144,9 @@ const FLAG_SHOW_TECH_PHONE_ON_TRACKING = envBool("SHOW_TECH_PHONE_ON_TRACKING", 
 const ENABLE_AVAILABILITY_V2 = envBool("ENABLE_AVAILABILITY_V2", true);
 // ✅ Safe toggle: urgent offer flow (public booking + offers)
 const ENABLE_URGENT_FLOW = envBool("ENABLE_URGENT_FLOW", true);
-// 🔒 Customer App booking kill switches — FAIL CLOSED by design: customer
-// self-booking stays OFF until the operator explicitly enables each lane in
-// the environment. When off, /public/book answers 503 with a machine-readable
-// code + LINE contact URL so the app can hand the customer to a human without
-// ever creating a job (no job = no duplicate risk). Admin booking flows are
-// NOT affected by these flags.
-const ENABLE_CUSTOMER_SCHEDULED_BOOKING = envBool("ENABLE_CUSTOMER_SCHEDULED_BOOKING", false);
+// Customer scheduled booking is controlled by the published Admin runtime
+// switch (page_availability.scheduled). It is read for every request, needs no
+// ENV or restart, and fails closed if the published configuration is unavailable.
 const ENABLE_CUSTOMER_URGENT_BOOKING = envBool("ENABLE_CUSTOMER_URGENT_BOOKING", false);
 const CWF_LINE_CONTACT_URL = String(process.env.CWF_LINE_CONTACT_URL || "https://lin.ee/fG1Oq7y").trim();
 // Rate limits for the public tracking lookups (per client IP, per minute).
@@ -14123,10 +14120,10 @@ const bookingJobService = createBookingJobService({
   createServicePackageResolver: (db) => createServicePackageResolver({ db }),
   availabilityEngine: customerAvailability,
   urgentDispatchService,
+  resolveCustomerScheduledCapability: () => scheduledCapability.resolveScheduledCapability(pool),
   resolveCustomerUrgentCapability: () => urgentCapability.resolveUrgentCapability(pool),
   logJobUpdate,
   isServiceZoneFilterEnabled: () => ENABLE_SERVICE_ZONE_FILTER,
-  isCustomerScheduledBookingEnabled: () => ENABLE_CUSTOMER_SCHEDULED_BOOKING,
   lineContactUrl: CWF_LINE_CONTACT_URL,
   travelBufferMin: TRAVEL_BUFFER_MIN,
   getInvalidJobSiteCoordinatesMessage: () => INVALID_JOB_SITE_COORDINATES_MSG,

--- a/server/services/booking/createBookingJob.js
+++ b/server/services/booking/createBookingJob.js
@@ -62,13 +62,13 @@ function createBookingJobService(dependencies = {}) {
   } = dependencies;
 
   const ENABLE_SERVICE_ZONE_FILTER = Boolean(dependencies.isServiceZoneFilterEnabled());
-  const ENABLE_CUSTOMER_SCHEDULED_BOOKING = Boolean(dependencies.isCustomerScheduledBookingEnabled());
   const CWF_LINE_CONTACT_URL = dependencies.lineContactUrl;
   const TRAVEL_BUFFER_MIN = dependencies.travelBufferMin;
   const getInvalidJobSiteCoordinatesMessage = dependencies.getInvalidJobSiteCoordinatesMessage;
   const _refreshTechnicianIncomePreviewForJob = dependencies.refreshTechnicianIncomePreviewForJob;
   const _notifyUrgentOffer = dependencies.notifyUrgentOffer;
   const _notifyDirectJobAssigned = dependencies.notifyDirectJobAssigned;
+  const resolveCustomerScheduledCapability = dependencies.resolveCustomerScheduledCapability;
   const resolveCustomerUrgentCapability = dependencies.resolveCustomerUrgentCapability;
   const urgentDispatchService = dependencies.urgentDispatchService;
   const logJobUpdate = dependencies.logJobUpdate;
@@ -1444,6 +1444,9 @@ function createBookingJobService(dependencies = {}) {
         return res.status(400).json({ error: "PACKAGE_URGENT_UNSUPPORTED", code: "PACKAGE_URGENT_UNSUPPORTED" });
       }
     } catch (_) {}
+    const scheduledCapability = canonicalBookingMode === "scheduled"
+      ? await resolveCustomerScheduledCapability()
+      : null;
     const urgentCapability = canonicalBookingMode === "urgent"
       ? await resolveCustomerUrgentCapability()
       : null;
@@ -1454,7 +1457,7 @@ function createBookingJobService(dependencies = {}) {
         line_url: CWF_LINE_CONTACT_URL,
       });
     }
-    if (canonicalBookingMode === "scheduled" && !ENABLE_CUSTOMER_SCHEDULED_BOOKING) {
+    if (canonicalBookingMode === "scheduled" && scheduledCapability?.enabled !== true) {
       return res.status(503).json({
         error: "ระบบจองคิวออนไลน์ปิดให้บริการชั่วคราว กรุณาติดต่อแอดมินทาง LINE",
         code: "SCHEDULED_BOOKING_DISABLED",

--- a/server/services/booking/scheduledCapability.js
+++ b/server/services/booking/scheduledCapability.js
@@ -1,0 +1,38 @@
+"use strict";
+
+const CONFIG_KEY = "customer_homepage_v1";
+
+async function resolveScheduledCapability(pool) {
+  if (!pool || typeof pool.query !== "function") {
+    return { enabled: false, degraded: true };
+  }
+  try {
+    const result = await pool.query(
+      `SELECT published_config
+         FROM public.homepage_cms_configs
+        WHERE config_key=$1
+        LIMIT 1`,
+      [CONFIG_KEY]
+    );
+    const config = result.rows?.[0]?.published_config;
+    const raw = config && typeof config === "object" && !Array.isArray(config)
+      ? config.page_availability
+      : null;
+    const enabled = Boolean(
+      raw
+      && typeof raw === "object"
+      && !Array.isArray(raw)
+      && raw.scheduled === true
+    );
+    return { enabled, degraded: false };
+  } catch (_) {
+    // Public booking is transactional. If the published runtime switch cannot
+    // be read, fail closed without exposing storage details or needing a restart.
+    return { enabled: false, degraded: true };
+  }
+}
+
+module.exports = {
+  CONFIG_KEY,
+  resolveScheduledCapability,
+};

--- a/test/customerBookingKillSwitch.test.js
+++ b/test/customerBookingKillSwitch.test.js
@@ -10,13 +10,17 @@ const indexSrc = fs.readFileSync(path.join(REPO_ROOT, "index.js"), "utf8");
 const bookingServiceSrc = fs.readFileSync(path.join(REPO_ROOT, "server", "services", "booking", "createBookingJob.js"), "utf8");
 const scheduledSrc = fs.readFileSync(path.join(REPO_ROOT, "customer-app", "modules", "bookingScheduled.js"), "utf8");
 const urgentSrc = fs.readFileSync(path.join(REPO_ROOT, "customer-app", "modules", "bookingUrgent.js"), "utf8");
+const scheduledCapabilitySrc = fs.readFileSync(path.join(REPO_ROOT, "server", "services", "booking", "scheduledCapability.js"), "utf8");
 const urgentCapabilitySrc = fs.readFileSync(path.join(REPO_ROOT, "server", "services", "urgent", "capability.js"), "utf8");
 
 // The /public/book source (handler body only) for gate-ordering assertions.
 const bookHandler = bookingServiceSrc.slice(bookingServiceSrc.indexOf("async function handlePublicBook"));
 
-test("scheduled keeps its existing ENV switch while urgent uses the persisted CMS runtime switch", () => {
-  assert.match(indexSrc, /const ENABLE_CUSTOMER_SCHEDULED_BOOKING = envBool\("ENABLE_CUSTOMER_SCHEDULED_BOOKING", false\);/);
+test("scheduled and urgent use persisted CMS runtime switches without ENV", () => {
+  assert.doesNotMatch(indexSrc, /ENABLE_CUSTOMER_SCHEDULED_BOOKING/);
+  assert.match(scheduledCapabilitySrc, /published_config[\s\S]*page_availability/);
+  assert.match(scheduledCapabilitySrc, /raw\.scheduled === true/);
+  assert.doesNotMatch(scheduledCapabilitySrc, /process\.env|ENABLE_/);
   assert.match(urgentCapabilitySrc, /published_config[\s\S]*page_availability/);
   assert.match(urgentCapabilitySrc, /raw\.urgent === true/);
   assert.doesNotMatch(bookingServiceSrc, /ENABLE_CUSTOMER_URGENT_BOOKING|ENABLE_URGENT_FLOW/);
@@ -31,8 +35,9 @@ test("the kill-switch gate keys off the canonical booking_mode, NOT the attacker
   // The whole gate block must not mention client_app — it is not a boundary.
   assert.doesNotMatch(gate, /client_app|clientApp/);
   assert.match(gate, /await resolveCustomerUrgentCapability\(\)/);
+  assert.match(gate, /await resolveCustomerScheduledCapability\(\)/);
   assert.match(gate, /canonicalBookingMode === "urgent" && urgentCapability\?\.enabled !== true/);
-  assert.match(gate, /canonicalBookingMode === "scheduled" && !ENABLE_CUSTOMER_SCHEDULED_BOOKING/);
+  assert.match(gate, /canonicalBookingMode === "scheduled" && scheduledCapability\?\.enabled !== true/);
   assert.match(gate, /status\(503\)/);
   assert.match(gate, /line_url: CWF_LINE_CONTACT_URL/);
 });
@@ -121,9 +126,13 @@ test("legacy customer.html is redirect-only and contains no booking implementati
   assert.doesNotMatch(customerHtml, /scheduled_request_key|\/public\/book|sessionStorage|booking form/i);
 });
 
-test("scheduled keeps its existing single gate and urgent ENV is not wired into customer booking", () => {
-  assert.equal((indexSrc.match(/ENABLE_CUSTOMER_SCHEDULED_BOOKING/g) || []).length, 3);
-  const bookingWiring = indexSrc.slice(indexSrc.indexOf("createBookingJobService({"), indexSrc.indexOf("registerAdminBookingRoutes"));
+test("scheduled has one persisted runtime resolver and urgent ENV is not wired into customer booking", () => {
+  assert.equal((indexSrc.match(/resolveCustomerScheduledCapability/g) || []).length, 1);
+  const wiringStart = indexSrc.indexOf("const bookingJobService = createBookingJobService({");
+  const wiringEnd = indexSrc.indexOf("\n});", wiringStart);
+  assert.ok(wiringStart >= 0 && wiringEnd > wiringStart, "booking service wiring not found");
+  const bookingWiring = indexSrc.slice(wiringStart, wiringEnd);
+  assert.match(bookingWiring, /resolveCustomerScheduledCapability/);
   assert.doesNotMatch(bookingWiring, /ENABLE_CUSTOMER_URGENT_BOOKING|ENABLE_URGENT_FLOW/);
 });
 

--- a/test/customerBookingMutationCharacterization.test.js
+++ b/test/customerBookingMutationCharacterization.test.js
@@ -483,7 +483,7 @@ function makeDependencies(overrides = {}) {
     resolveCustomerUrgentCapability: async () => ({ enabled: true, degraded: false }),
     logJobUpdate: async () => {},
     isServiceZoneFilterEnabled: () => false,
-    isCustomerScheduledBookingEnabled: () => true,
+    resolveCustomerScheduledCapability: async () => ({ enabled: true, degraded: false }),
     lineContactUrl: "https://lin.ee/test",
     travelBufferMin: 30,
     getInvalidJobSiteCoordinatesMessage: () => "พิกัดหน้างานไม่ถูกต้อง",

--- a/test/customerScheduledRuntimeCapability.test.js
+++ b/test/customerScheduledRuntimeCapability.test.js
@@ -1,0 +1,79 @@
+"use strict";
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const { resolveScheduledCapability } = require("../server/services/booking/scheduledCapability");
+const { createBookingJobService } = require("../server/services/booking/createBookingJob");
+
+test("published page_availability.scheduled is read on every request without ENV or restart", async () => {
+  let scheduled = false;
+  let reads = 0;
+  const pool = {
+    async query() {
+      reads += 1;
+      return { rows: [{ published_config: { page_availability: { scheduled } } }] };
+    },
+  };
+
+  assert.equal((await resolveScheduledCapability(pool)).enabled, false);
+  scheduled = true;
+  assert.equal((await resolveScheduledCapability(pool)).enabled, true);
+  scheduled = false;
+  assert.equal((await resolveScheduledCapability(pool)).enabled, false);
+  assert.equal(reads, 3);
+});
+
+test("scheduled capability opens only for an explicitly published boolean true", async () => {
+  const cases = [
+    { label: "true", rows: [{ published_config: { page_availability: { scheduled: true } } }], enabled: true },
+    { label: "false", rows: [{ published_config: { page_availability: { scheduled: false } } }], enabled: false },
+    { label: "no row", rows: [], enabled: false },
+    { label: "missing published", rows: [{ published_config: null }], enabled: false },
+    { label: "missing page availability", rows: [{ published_config: {} }], enabled: false },
+    { label: "missing scheduled", rows: [{ published_config: { page_availability: { home: true } } }], enabled: false },
+    { label: "null", rows: [{ published_config: { page_availability: { scheduled: null } } }], enabled: false },
+    { label: "string", rows: [{ published_config: { page_availability: { scheduled: "true" } } }], enabled: false },
+    { label: "number", rows: [{ published_config: { page_availability: { scheduled: 1 } } }], enabled: false },
+    { label: "array", rows: [{ published_config: { page_availability: [] } }], enabled: false },
+  ];
+
+  for (const scenario of cases) {
+    const result = await resolveScheduledCapability({ query: async () => ({ rows: scenario.rows }) });
+    assert.equal(result.enabled, scenario.enabled, scenario.label);
+  }
+  assert.equal((await resolveScheduledCapability(null)).enabled, false);
+  assert.equal((await resolveScheduledCapability({ query: async () => { throw new Error("db down"); } })).enabled, false);
+});
+
+test("closed scheduled runtime switch rejects before booking mutation and reopens immediately", async () => {
+  let enabled = false;
+  let connects = 0;
+  const service = createBookingJobService({
+    pool: { async connect() { connects += 1; throw new Error("must not connect"); } },
+    isServiceZoneFilterEnabled: () => false,
+    resolveCustomerScheduledCapability: async () => ({ enabled }),
+    resolveCustomerUrgentCapability: async () => ({ enabled: false }),
+    lineContactUrl: "https://lin.ee/test",
+  });
+  const invoke = async () => {
+    const reply = { statusCode: 200, body: null };
+    const res = {
+      status(code) { reply.statusCode = code; return this; },
+      json(value) { reply.body = value; return value; },
+    };
+    await service.handlePublicBook({ body: { booking_mode: "scheduled" } }, res);
+    return reply;
+  };
+
+  const closed = await invoke();
+  assert.equal(closed.statusCode, 503);
+  assert.equal(closed.body.code, "SCHEDULED_BOOKING_DISABLED");
+  assert.equal(connects, 0);
+
+  enabled = true;
+  const opened = await invoke();
+  assert.equal(opened.statusCode, 400);
+  assert.notEqual(opened.body.code, "SCHEDULED_BOOKING_DISABLED");
+  assert.equal(connects, 0);
+});

--- a/test/customerServicePackageBooking.test.js
+++ b/test/customerServicePackageBooking.test.js
@@ -36,7 +36,7 @@ function bookingService(overrides = {}) {
   return createBookingJobService({
     pool: { async connect() { return emptyClient; } },
     isServiceZoneFilterEnabled: () => false,
-    isCustomerScheduledBookingEnabled: () => true,
+    resolveCustomerScheduledCapability: async () => ({ enabled: true, degraded: false }),
     genToken: () => "test-booking-token",
     createServicePackageResolver: () => ({
       async resolveSelection() {

--- a/test/customerUrgentDirectAutoOffer.test.js
+++ b/test/customerUrgentDirectAutoOffer.test.js
@@ -64,7 +64,7 @@ test("closed authoritative urgent switch rejects before database mutation and ig
     pool: { async connect() { connects += 1; throw new Error("must not connect"); } },
     urgentPublicAdapter,
     isServiceZoneFilterEnabled: () => false,
-    isCustomerScheduledBookingEnabled: () => true,
+    resolveCustomerScheduledCapability: async () => ({ enabled: true, degraded: false }),
     resolveCustomerUrgentCapability: async () => ({ enabled }),
   });
   const invoke = async (body) => {
@@ -92,7 +92,7 @@ test("public urgent preflight serializes only safe dispatch fields and never can
     urgentPublicAdapter,
     resolveCustomerUrgentCapability: async () => ({ enabled: true }),
     isServiceZoneFilterEnabled: () => true,
-    isCustomerScheduledBookingEnabled: () => true,
+    resolveCustomerScheduledCapability: async () => ({ enabled: true, degraded: false }),
     computeDurationMinMulti: () => 60,
     effectiveBlockMin: (duration) => Number(duration) + 30,
     detectServiceZoneFromText: async () => ({

--- a/test/customerUrgentPreferredTimeGps.test.js
+++ b/test/customerUrgentPreferredTimeGps.test.js
@@ -357,7 +357,7 @@ function backendValidationService() {
     },
     urgentPublicAdapter,
     isServiceZoneFilterEnabled: () => false,
-    isCustomerScheduledBookingEnabled: () => true,
+    resolveCustomerScheduledCapability: async () => ({ enabled: true, degraded: false }),
     resolveCustomerUrgentCapability: async () => ({ enabled: true, degraded: false }),
   });
   return { service, touched: () => databaseTouched };

--- a/test/e2e/run-booking-e2e.js
+++ b/test/e2e/run-booking-e2e.js
@@ -204,7 +204,6 @@ function bootApp(port, extraEnv = {}) {
       // PostgreSQL cluster, which intentionally has TLS disabled.
       NODE_OPTIONS: `--require=${path.join(__dirname, "local-postgres-preload.js")}`,
       CWF_E2E_NOW_BANGKOK: "2026-07-28T07:30:00+07:00",
-      ENABLE_CUSTOMER_SCHEDULED_BOOKING: "true",
       // Customer urgent must ignore this legacy ENV and use the persisted CMS switch.
       ENABLE_CUSTOMER_URGENT_BOOKING: "false",
       ...extraEnv,
@@ -400,7 +399,8 @@ async function apiBook(base, payload) {
   return { status: res.status, body };
 }
 
-async function publishUrgentSwitch(base, adminSession, enabled) {
+async function publishBookingSwitch(base, adminSession, lane, enabled) {
+  assert(["scheduled", "urgent"].includes(lane), `unsupported booking lane: ${lane}`);
   const headers = {
     "content-type": "application/json",
     cookie: `cwf_session=${adminSession}`,
@@ -412,7 +412,7 @@ async function publishUrgentSwitch(base, adminSession, enabled) {
   const config = JSON.parse(JSON.stringify(current.draft_config));
   config.page_availability = {
     ...(config.page_availability || {}),
-    urgent: enabled === true,
+    [lane]: enabled === true,
   };
   const saved = await fetch(`${base}/admin/homepage-cms/draft`, {
     method: "PUT",
@@ -428,9 +428,12 @@ async function publishUrgentSwitch(base, adminSession, enabled) {
   });
   const publishedBody = await published.json();
   assert(published.status === 200 && publishedBody?.ok === true, `admin CMS publish failed: ${published.status}`);
-  assert(publishedBody.published_config?.page_availability?.urgent === (enabled === true),
-    "admin CMS publish did not persist the requested urgent switch");
+  assert(publishedBody.published_config?.page_availability?.[lane] === (enabled === true),
+    `admin CMS publish did not persist the requested ${lane} switch`);
 }
+
+const publishUrgentSwitch = (base, adminSession, enabled) => publishBookingSwitch(base, adminSession, "urgent", enabled);
+const publishScheduledSwitch = (base, adminSession, enabled) => publishBookingSwitch(base, adminSession, "scheduled", enabled);
 
 function scheduledPayload(ymd, start, overrides = {}) {
   return {
@@ -458,10 +461,10 @@ async function main() {
   pool = new Pool({ ...PG, database: DB_NAME, max: 5 });
   await assertCoreSchema();
 
-  log("booting app A (booking enabled) + app B (booking disabled)...");
+  log("booting app A + app B (booking lanes controlled by persisted CMS)...");
   bootApp(PORT_A, {});
   if (process.env.E2E_API_ONLY !== "1") {
-    bootApp(PORT_B, { ENABLE_CUSTOMER_SCHEDULED_BOOKING: "false", ENABLE_CUSTOMER_URGENT_BOOKING: "false" });
+    bootApp(PORT_B, { ENABLE_CUSTOMER_URGENT_BOOKING: "false" });
   }
   await waitForReady(BASE_A);
   if (process.env.E2E_API_ONLY !== "1") await waitForReady(BASE_B);
@@ -509,6 +512,7 @@ async function main() {
     return token;
   }
   const adminSession = await seedAdminSession();
+  await publishScheduledSwitch(BASE_A, adminSession, true);
   if (process.env.E2E_API_ONLY !== "1") {
     await publishUrgentSwitch(BASE_A, adminSession, true);
   }
@@ -1559,6 +1563,7 @@ async function main() {
     // Urgent is controlled solely by the persisted CMS switch. Both test
     // servers share that row, so an ENV-disabled server is not an urgent-off
     // fixture. Exercise the real authenticated publish path instead.
+    await publishScheduledSwitch(BASE_A, adminSession, false);
     await publishUrgentSwitch(BASE_A, adminSession, false);
     const before = await jobCountWhere("TRUE");
     const forgedApps = ["admin_console", "internal", "", "customer_app_v2", "cwf_admin"];
@@ -1590,6 +1595,7 @@ async function main() {
       `unknown booking_mode must 400 on the open instance too, got ${bogusOpen.status}`);
     const after = await jobCountWhere("TRUE");
     assert(after === before, `bypass probes leaked ${after - before} job(s)`);
+    await publishScheduledSwitch(BASE_A, adminSession, true);
     await publishUrgentSwitch(BASE_A, adminSession, true);
   });
 

--- a/test/exactBookingPricing.test.js
+++ b/test/exactBookingPricing.test.js
@@ -33,7 +33,7 @@ test("Admin HTTP idempotent replay returns the persisted two-decimal total as au
     pool: { async query() { return { rows: [{ job_id: 41, booking_code: "CWFTEST41", booking_mode: "scheduled",
       dispatch_mode: "normal", duration_min: 180, job_price: "1399.50", admin_request_fingerprint: fingerprint }] }; } },
     isServiceZoneFilterEnabled: () => false,
-    isCustomerScheduledBookingEnabled: () => true,
+    resolveCustomerScheduledCapability: async () => ({ enabled: true, degraded: false }),
     normalizeAppointmentDatetime: (value) => value,
   });
   const response = { statusCode: 200, status(code) { this.statusCode = code; return this; }, json(value) { this.body = value; return value; } };


### PR DESCRIPTION
Promote `main` after PR #286 to Staging.

Includes removal of the scheduled-booking ENV dependency in favor of the published Admin runtime switch.

Validation before promotion:
- PR #286 remote diff matches the tested local tree exactly (11 files, +161/-29)
- 185 related tests: 163 passed, 22 PostgreSQL-dependent skips, 0 failed
- syntax and whitespace checks passed