### PR TITLE
Fix Premium Day composite booking persistence

### DIFF
--- a/server/services/packages/compositeServicePackage.js
+++ b/server/services/packages/compositeServicePackage.js
@@ -1,5 +1,11 @@
 "use strict";
 
+const {
+  normalizeServiceType,
+  normalizeAcType,
+  normalizeWashVariantLabel,
+} = require("../../normalizers");
+
 class CompositePackageError extends Error {
   constructor(code, statusCode = 409) {
     super(code);
@@ -132,7 +138,21 @@ function buildComponentSnapshot({ bundle, variant, tier, btu, appointmentDatetim
 }
 
 function serviceName(variant, btu, quantity) {
-  return `${variant.display_name} • ${btu} BTU • ${quantity} เครื่อง`;
+  const jobType = normalizeServiceType(variant.job_type);
+  const acType = normalizeAcType(variant.ac_type);
+  const parts = [];
+  if (jobType === "ล้าง") {
+    parts.push(`ล้างแอร์${acType}`.trim());
+    if (acType === "ผนัง") parts.push(normalizeWashVariantLabel(variant.wash_variant));
+  } else if (jobType === "ซ่อม") {
+    parts.push(`ซ่อมแอร์${acType}`.trim());
+  } else if (jobType === "ติดตั้ง") {
+    parts.push(`ติดตั้งแอร์${acType}`.trim());
+  } else {
+    parts.push(jobType);
+  }
+  parts.push(`${btu} BTU`, `${quantity} เครื่อง`);
+  return parts.filter(Boolean).join(" • ");
 }
 
 async function resolveCompositeBooking({ body, bookingMode, appointmentDatetime, repository, db, identity = "customer", now = () => new Date() }) {

--- a/test/compositeServicePackage.test.js
+++ b/test/compositeServicePackage.test.js
@@ -6,6 +6,7 @@ const {
   composeTiers, parseMoney, formatMoney, normalizeGroups, resolveCompositeBooking,
 } = require("../server/services/packages/compositeServicePackage");
 const { compositeBookingFromSnapshots } = require("../server/services/booking/servicePackageBooking");
+const { parseCanonicalServiceItem } = require("../server/services/booking/bookingJobUnits");
 
 function tiers(prices) {
   return Object.entries(prices).map(([quantity, price], index) => ({
@@ -84,6 +85,14 @@ test("mixed BTU groups resolve under one parent with component snapshots", async
   assert.equal(result.items[0].snapshot.schema_version, 2);
   assert.equal(result.items[0].snapshot.catalog_item.key, "premium-day");
   assert.equal(result.items[1].snapshot.taxonomy.selected_btu, 18000);
+  assert.deepEqual(parseCanonicalServiceItem(result.items[0]), {
+    job_type: "ล้าง", ac_type: "ผนัง", wash_variant: "ล้างพรีเมียม",
+    repair_variant: "", btu: 12000, machine_count: 2,
+  });
+  assert.deepEqual(parseCanonicalServiceItem(result.items[1]), {
+    job_type: "ล้าง", ac_type: "ผนัง", wash_variant: "ล้างพรีเมียม",
+    repair_variant: "", btu: 18000, machine_count: 2,
+  });
 });
 
 test("BTU gap is rejected by variant constraints", async () => {


### PR DESCRIPTION
## Root cause
Composite package rows persisted `variant.display_name` as the service item name (for example `ไม่เกิน 12,000 BTU`). The canonical `job_units` builder requires the item name to contain the actual job type, AC type, wash variant, BTU, and quantity. It therefore rejected the row with `PENDING_SERVICE_CRITERIA_DRIFT`, which the public package route sanitized to `PACKAGE_BOOKING_FAILED`.

## Fix
Generate composite service item names from authoritative package taxonomy, for example:
`ล้างแอร์ผนัง • ล้างพรีเมียม • 9000 BTU • 1 เครื่อง`

## Validation
- Production quote and availability succeeded before the fix; the mutation reproduced HTTP 500 with no job persisted
- Added regression coverage that feeds both small and large composite rows into the real `parseCanonicalServiceItem`
- 52 related tests: 30 passed, 22 PostgreSQL-dependent skips, 0 failed
- syntax and `git diff --check` passed

No schema, migration, payment, auth, or unrelated changes.