### PR TITLE
Fix customer scheduled booking dispatch constraint

### DIFF
--- a/server/services/booking/createBookingJob.js
+++ b/server/services/booking/createBookingJob.js
@@ -2078,9 +2078,10 @@ function createBookingJobService(dependencies = {}) {
       const appliedDiscount = exactMoney(Math.min(Number(base_total || 0), Number(promoPick?.discount || 0)).toFixed(2));
 
       // ✅ dispatch_mode:
-      // - scheduled (ลูกค้าจองปกติ) => normal (ให้เข้าแอดมิน/คิวตามปกติ)
+      // - scheduled => forced (Production constraint permits offer|forced;
+      //   approval also finalizes scheduled reservations as forced)
       // - urgent (ยิงงานด่วน)      => offer  (ไป flow offer)
-      const dispatchMode = (bm === 'urgent') ? 'offer' : 'normal';
+      const dispatchMode = (bm === 'urgent') ? 'offer' : 'forced';
 
       packageMutationStage = "job_schema_check";
       const catalogLinkReady = await isJobsCatalogLinkSchemaReady();

--- a/test/customerBookingMutationCharacterization.test.js
+++ b/test/customerBookingMutationCharacterization.test.js
@@ -694,6 +694,7 @@ dbTest("real PostgreSQL: public scheduled success preserves response, status, it
     "travel_buffer_min", "applied_promo", "base_total", "base_total_exact", "net_total", "booking_ticket",
   ]);
   assert.equal(result.body.booking_mode, "scheduled");
+  assert.equal(result.body.dispatch_mode, "forced");
   assert.equal(result.body.base_total, 600);
   assert.equal(Object.hasOwn(result.body, "technician_username"), false);
   assert.equal(Object.hasOwn(result.body, "technician"), false);
@@ -701,6 +702,7 @@ dbTest("real PostgreSQL: public scheduled success preserves response, status, it
   const job = (await pool.query(`SELECT * FROM public.jobs`)).rows[0];
   const items = (await pool.query(`SELECT item_name, qty::int, line_total::int FROM public.job_items ORDER BY item_name`)).rows;
   assert.equal(job.job_status, JOB_STATUS.CUSTOMER_SCHEDULED_REVIEW);
+  assert.equal(job.dispatch_mode, "forced");
   assert.equal(job.technician_username, "tech-a");
   assert.equal(Number(job.job_price), 600);
   assert.deepEqual(items, [{ item_name: "ล้างแอร์ผนัง • ล้างธรรมดา • 12000 BTU • 1 เครื่อง", qty: 1, line_total: 600 }]);

--- a/test/customerServicePackageBooking.test.js
+++ b/test/customerServicePackageBooking.test.js
@@ -375,6 +375,13 @@ test("booking mutation keeps package linkage, snapshot, price, promotion bypass,
   assert.match(source, /packageBooking \? packageBooking\.items[\s\S]*?catalogBooking \? \[buildCatalogBookingItem\(catalogBooking\)\]/);
 });
 
+test("public scheduled reservation uses the Production-accepted forced dispatch mode", () => {
+  const source = fs.readFileSync(path.join(__dirname, "../server/services/booking/createBookingJob.js"), "utf8");
+  const handler = source.slice(source.indexOf("async function handlePublicBook"));
+  assert.match(handler, /const dispatchMode = \(bm === 'urgent'\) \? 'offer' : 'forced';/);
+  assert.doesNotMatch(handler, /const dispatchMode = \(bm === 'urgent'\) \? 'offer' : 'normal';/);
+});
+
 test("package replay ordering uses persisted history before current resolution and locked revalidation", () => {
   const source = fs.readFileSync(path.join(__dirname, "../server/services/booking/createBookingJob.js"), "utf8");
   const handler = source.indexOf("async function handlePublicBook");


### PR DESCRIPTION
Production rejects dispatch_mode=normal via jobs_dispatch_mode_check. Persist customer scheduled reservations as forced, matching the existing approval transition and Production's offer|forced constraint. Adds regression assertions. Local targeted tests: 31 passed, 22 PostgreSQL tests skipped because no local DB, 0 failed.