### PR TITLE
Remove temporary package booking diagnostics

### DIFF
--- a/server/services/booking/createBookingJob.js
+++ b/server/services/booking/createBookingJob.js
@@ -1881,14 +1881,11 @@ function createBookingJobService(dependencies = {}) {
     }
 
     const client = await pool.connect();
-    let packageMutationStage = "begin";
     try {
       await client.query("BEGIN");
 
       if (bookingRequestKey && deterministicToken) {
-        packageMutationStage = "idempotency_lock";
         await client.query("SELECT pg_advisory_xact_lock(hashtext($1))", [bookingRequestKey]);
-        packageMutationStage = "idempotency_lookup";
         const existing = await client.query(
           `SELECT job_id, booking_code, booking_token, booking_mode, dispatch_mode,
                   duration_min, job_price, catalog_item_id, appointment_datetime, customer_phone, customer_name,
@@ -1965,7 +1962,6 @@ function createBookingJobService(dependencies = {}) {
       // Only a genuinely new mutation depends on current package state. The
       // advisory-lock replay above must win if another request just committed.
       if (packageBooking) {
-        packageMutationStage = "package_revalidation";
         const revalidatedPackageBooking = await resolvePackageBooking({
           body: packageRequestBody,
           bookingMode: bm,
@@ -1991,7 +1987,6 @@ function createBookingJobService(dependencies = {}) {
 
       let draftReservationTech = null;
       if (bm === "scheduled") {
-        packageMutationStage = "technician_reservation";
         const startIso = normalizeAppointmentDatetime(appointment_datetime);
         draftReservationTech = await customerAvailability.reservePublicCustomerTechnician(
           publicCustomerAvailabilityDeps(client),
@@ -2082,8 +2077,6 @@ function createBookingJobService(dependencies = {}) {
       //   approval also finalizes scheduled reservations as forced)
       // - urgent (ยิงงานด่วน)      => offer  (ไป flow offer)
       const dispatchMode = (bm === 'urgent') ? 'offer' : 'forced';
-
-      packageMutationStage = "job_schema_check";
       const catalogLinkReady = await isJobsCatalogLinkSchemaReady();
       const jobInsertColumns = [
         "customer_name", "customer_phone", "job_type", "appointment_datetime", "job_price",
@@ -2122,8 +2115,6 @@ function createBookingJobService(dependencies = {}) {
         jobInsertParams.push(safeCatalogItemIdForJob, customerSubForJob);
         jobInsertValuesSql.push(`$${jobInsertParams.length - 1}`, `$${jobInsertParams.length}`);
       }
-
-      packageMutationStage = "job_insert";
       const r = await client.query(
         `
         INSERT INTO public.jobs
@@ -2151,10 +2142,7 @@ function createBookingJobService(dependencies = {}) {
 
       const job_id = r.rows[0].job_id;
       // ✅ booking_code (สุ่ม ไม่เรียง)
-      packageMutationStage = "booking_code";
       const booking_code = await generateUniqueBookingCode(client);
-
-      packageMutationStage = "booking_code_update";
       await client.query(`UPDATE public.jobs SET booking_code=$1 WHERE job_id=$2`, [booking_code, job_id]);
 
       // CREATE_URGENT_OFFERS_V2
@@ -2215,7 +2203,6 @@ function createBookingJobService(dependencies = {}) {
 
       // 3) บันทึกรายการ (ถ้ามี)
       for (const it of computedItems) {
-        packageMutationStage = "job_item_insert";
         const itemParams = [
           job_id,
           it.item_id || null,
@@ -2246,10 +2233,7 @@ function createBookingJobService(dependencies = {}) {
           itemParams
         );
       }
-
-      packageMutationStage = "job_units";
       await ensureCanonicalBookingJobUnits(job_id, client);
-      packageMutationStage = "job_evidence_update";
       await client.query(`UPDATE public.jobs SET per_unit_evidence_enabled=TRUE WHERE job_id=$1`, [job_id]);
 
       if (bm === "urgent" && typeof logJobUpdate === "function") {
@@ -2263,7 +2247,6 @@ function createBookingJobService(dependencies = {}) {
           payload: { dispatch_mode: "offer" },
         }, client);
       }
-      packageMutationStage = "commit";
       await client.query("COMMIT");
 
       if (bm === "urgent" && urgentPushTargets.length && typeof _notifyUrgentOffer === "function") {
@@ -2335,19 +2318,10 @@ function createBookingJobService(dependencies = {}) {
       if (hasPackageRequest) {
         const knownPackageCode = String(e?.code || "").startsWith("PACKAGE_") ? e.code : "PACKAGE_BOOKING_FAILED";
         const statusCode = Number(e?.statusCode || e?.status || 500);
-        const diagnosticDbCode = /^[0-9A-Z]{5}$/.test(String(e?.code || "")) ? String(e.code) : null;
-        const diagnosticConstraint = /^[A-Za-z0-9_]{1,128}$/.test(String(e?.constraint || "")) ? String(e.constraint) : null;
-        const diagnosticColumn = /^[A-Za-z0-9_]{1,128}$/.test(String(e?.column || "")) ? String(e.column) : null;
-        console.error("[public_book] package mutation failed", { stage: packageMutationStage, error: e });
+        console.error(e);
         return res.status(statusCode >= 400 && statusCode < 600 ? statusCode : 500).json({
           error: knownPackageCode,
           code: knownPackageCode,
-          ...(knownPackageCode === "PACKAGE_BOOKING_FAILED" ? {
-            diagnostic_stage: packageMutationStage,
-            ...(diagnosticDbCode ? { diagnostic_db_code: diagnosticDbCode } : {}),
-            ...(diagnosticConstraint ? { diagnostic_constraint: diagnosticConstraint } : {}),
-            ...(diagnosticColumn ? { diagnostic_column: diagnosticColumn } : {}),
-          } : {}),
         });
       }
       const statusCode = Number(e?.statusCode || e?.status || 500);


### PR DESCRIPTION
Removes the temporary public diagnostic stage/SQLSTATE fields after confirming and fixing the Production jobs_dispatch_mode_check failure. Keeps the scheduled forced-mode fix and server-side error logging.