### PR TITLE
Promote PR #308 Admin Add Thai UI and slot technician picker to CWF home staging

### DIFF
--- a/admin-add-v2.html
+++ b/admin-add-v2.html
@@ -187,6 +187,91 @@
     #btnSubmit{background:#0b4bb3 !important;color:#ffffff !important;border:1px solid rgba(255,204,0,0.55) !important;font-weight:900 !important}
     #btnSubmit:active{background:#0b1b3a !important}
 
+    /* ===============================
+       Slot technician picker (mobile-safe bottom sheet)
+       Scope: หน้าเพิ่มงาน Admin เท่านั้น (#slot_modal_overlay)
+       - ความสูงถูกจำกัดตาม viewport จริงบนมือถือ (dvh + vh fallback)
+       - หัวข้อ/ปุ่มยืนยันอยู่กับที่ • รายชื่อช่างเลื่อนได้ในกล่องของตัวเอง
+       =============================== */
+    #slot_modal_overlay{align-items:flex-end}
+    #slot_modal_overlay .team-sheet.slot-sheet{
+      display:flex;
+      flex-direction:column;
+      max-height:88vh;            /* fallback สำหรับเบราว์เซอร์เก่า */
+      max-height:88dvh;           /* Android/iOS: กันแถบที่อยู่บังท้ายชีต */
+      overflow:hidden;
+      padding-bottom:calc(16px + env(safe-area-inset-bottom));
+    }
+    #slot_modal_overlay .slot-sheet-head{flex:0 0 auto}
+    #slot_modal_overlay .slot-sheet-head h3{margin:0}
+    #slot_modal_overlay .slot-sheet-head p{margin:6px 0 0}
+    #slot_modal_overlay #slot_modal_body{
+      flex:1 1 auto;
+      min-height:0;               /* จำเป็นสำหรับ flex child ที่ต้องเลื่อน */
+      overflow-y:auto;
+      overflow-x:hidden;
+      -webkit-overflow-scrolling:touch;
+      overscroll-behavior:contain;
+      margin-top:12px;
+      padding-right:2px;
+    }
+    #slot_modal_overlay .slot-sheet .sheet-actions{
+      flex:0 0 auto;
+      margin-top:12px;
+      padding-top:10px;
+      border-top:1px solid rgba(15,23,42,0.08);
+      background:#fff;
+    }
+    /* ค้นหาช่างในสล็อต */
+    #slot_modal_overlay .slot-tech-search{
+      width:100%;
+      padding:10px 12px;
+      border-radius:14px;
+      border:1px solid rgba(11,75,179,0.22);
+      background:#fff;
+      font-size:16px;             /* กัน iOS zoom ตอนโฟกัส */
+      font-weight:700;
+      color:#0b1b3a;
+    }
+    #slot_modal_overlay .slot-tech-count{margin-top:8px}
+    #slot_modal_overlay .slot-tech-list{
+      display:flex;
+      flex-wrap:wrap;
+      gap:8px;
+      margin-top:10px;
+    }
+    /* กันกฎรวม `.team-sheet button{width:100%}` ไม่ให้ยืดชิปช่างเต็มบรรทัด */
+    #slot_modal_overlay .slot-sheet .slot-tech-list button{
+      width:auto;
+      max-width:100%;
+      min-height:40px;
+      padding:8px 12px;
+      border-radius:999px;
+      font-size:13px;
+      font-weight:900;
+      text-align:left;
+      overflow-wrap:anywhere;
+    }
+    #slot_modal_overlay .slot-tech-row{
+      display:inline-flex;
+      align-items:center;
+      gap:6px;
+      border:1px solid rgba(11,75,179,0.22);
+      background:#ffffff;
+      color:#0b1b3a;
+      box-shadow:0 6px 14px rgba(2,6,23,0.06);
+    }
+    #slot_modal_overlay .slot-tech-row.active{
+      background:#0b4bb3;
+      color:#ffffff;
+      border-color:rgba(255,204,0,0.75);
+    }
+    #slot_modal_overlay .slot-tech-empty{
+      padding:10px 2px;
+      color:rgba(15,23,42,0.72);
+      font-size:13px;
+    }
+
     /* เมนู/ออกจากระบบ/Debug ใช้จาก admin-v2-common.js (เมนูบาร์ด้านบนแบบเดียวกันทุกหน้า) */
   </style>
 </head>
@@ -208,7 +293,7 @@
           <input id="customer_phone" placeholder="0xx-xxx-xxxx">
           <input id="customer_id" type="hidden">
           <div class="line" style="margin-top:8px;flex-wrap:wrap;align-items:center;">
-            <button id="btnUseLatestCustomerData" class="secondary" type="button" style="display:none;width:auto;">Use latest customer data</button>
+            <button id="btnUseLatestCustomerData" class="secondary" type="button" style="display:none;width:auto;">ใช้ข้อมูลลูกค้าล่าสุด</button>
             <div id="customer_lookup_hint" class="muted2 grow">กรอกเบอร์ลูกค้าเก่าแล้วออกจากช่องนี้ ระบบจะค้นหาข้อมูลล่าสุดให้ก่อน โดยยังไม่เติมค่าให้อัตโนมัติ</div>
           </div>
           <div id="customer_location_candidates" class="customer-location-candidates"></div>
@@ -229,7 +314,7 @@
       <div style="margin-top:10px;border:1px solid rgba(11,75,179,.16);background:#f8fbff;border-radius:16px;padding:10px">
         <label>โซนงาน</label>
         <select id="service_zone_code" style="width:100%;margin-top:6px">
-          <option value="">Auto / ระบบเลือกจากที่อยู่</option>
+          <option value="">อัตโนมัติ / ระบบเลือกจากที่อยู่</option>
         </select>
         <input id="service_zone_source" type="hidden" value="">
         <div id="service_zone_hint" class="muted2" style="margin-top:7px">ระบบจะเลือกโซนจากเขต/อำเภอในที่อยู่</div>
@@ -237,11 +322,11 @@
       <label style="margin-top:10px">หมายเหตุ</label>
       <div class="grid2" style="margin-top:10px">
         <div>
-          <label>Latitude</label>
+          <label>ละติจูด</label>
           <input id="gps_latitude" placeholder="เช่น 13.7" />
         </div>
         <div>
-          <label>Longitude</label>
+          <label>ลองจิจูด</label>
           <input id="gps_longitude" placeholder="เช่น 100.5" />
         </div>
       </div>
@@ -250,7 +335,7 @@
     </div>
 
     <div class="card section-card">
-      <b>2) รายละเอียดบริการ (Flow เหมือนลูกค้า)</b>
+      <b>2) รายละเอียดบริการ (ขั้นตอนเดียวกับฝั่งลูกค้า)</b>
       <label style="margin-top:10px">ประเภทงาน *</label>
       <select id="job_type">
         <option value="">-- เลือก --</option>
@@ -282,7 +367,7 @@
         <div>
           <label>จำนวนเครื่อง</label>
           <div class="mc-row">
-            <div class="stepper" aria-label="machine count">
+            <div class="stepper" aria-label="จำนวนเครื่อง">
               <button id="mc_minus" class="btn-round" type="button" title="ลด">−</button>
               <input id="machine_count" class="stepper-input" type="number" min="1" max="20" step="1" value="1" inputmode="numeric">
               <button id="mc_plus" class="btn-round" type="button" title="เพิ่ม">+</button>
@@ -295,17 +380,17 @@
       </div>
 <!-- MULTI-SERVICE (หลายรายการในใบงานเดียว) -->
 <div id="service_package_box" class="card card-lite" style="margin-top:12px">
-  <b>Service Package (optional)</b>
-  <div class="muted2 mini">Choose a Store package parent for mixed BTU/arbitrary quantities, or a legacy standalone package. Totals and rules come from the server.</div>
-  <div style="margin-top:10px"><label>Ordinary Store service (optional)</label><select id="store_bookable_item_id"><option value="">Use manual service fields</option></select></div>
-  <div style="margin-top:10px"><label>Store service-package item</label><select id="store_service_bundle_key"><option value="">No Store package</option></select></div>
+  <b>แพ็กเกจบริการ (ถ้ามี)</b>
+  <div class="muted2 mini">เลือกแพ็กเกจหลักจากร้านค้าเมื่อต้องผสม BTU หรือกำหนดจำนวนเครื่องเอง หรือเลือกแพ็กเกจเดี่ยวของระบบเดิม • ยอดรวมและเงื่อนไขทั้งหมดคำนวณจากเซิร์ฟเวอร์</div>
+  <div style="margin-top:10px"><label>บริการร้านค้าแบบปกติ (ถ้ามี)</label><select id="store_bookable_item_id"><option value="">กรอกรายละเอียดบริการเอง</option></select></div>
+  <div style="margin-top:10px"><label>รายการแพ็กเกจบริการของร้านค้า</label><select id="store_service_bundle_key"><option value="">ไม่ใช้แพ็กเกจร้านค้า</option></select></div>
   <div id="store_service_bundle_groups" style="display:none;margin-top:10px"></div>
   <div class="grid2" style="margin-top:10px">
-    <div><label>Legacy standalone package</label><select id="service_package_key"><option value="">No legacy package</option></select></div>
-    <div><label>Tier</label><select id="service_package_tier_key" disabled><option value="">Select tier</option></select></div>
+    <div><label>แพ็กเกจเดี่ยว (ระบบเดิม)</label><select id="service_package_key"><option value="">ไม่ใช้แพ็กเกจระบบเดิม</option></select></div>
+    <div><label>ตัวเลือกราคา/จำนวนเครื่อง</label><select id="service_package_tier_key" disabled><option value="">เลือกตัวเลือกราคา/จำนวนเครื่อง</option></select></div>
   </div>
   <div id="service_package_btu_wrap" style="display:none;margin-top:10px">
-    <label>Actual BTU *</label><select id="service_package_btu"><option value="">Select actual BTU</option></select>
+    <label>BTU จริง *</label><select id="service_package_btu"><option value="">เลือก BTU จริง</option></select>
   </div>
   <div id="service_package_preview" class="muted2" style="display:none;margin-top:10px"></div>
 </div>
@@ -343,12 +428,12 @@
         </div>
         <div class="grid2" style="margin-top:10px">
           <div>
-            <label>Override ราคา (กรณีพิเศษเท่านั้น)</label>
+            <label>ราคาพิเศษแทนราคาระบบ (กรณีพิเศษเท่านั้น)</label>
             <input id="override_price" type="number" min="0" step="1" placeholder="0 = ใช้ราคาจากสมุดราคา">
-            <div class="muted2 mini">ราคา Override ใช้เฉพาะกรณีพิเศษของงานนั้น ๆ ไม่ใช่ราคาหลักของระบบ</div>
+            <div class="muted2 mini">ราคาพิเศษใช้เฉพาะกรณีพิเศษของงานนั้น ๆ ไม่ใช่ราคาหลักของระบบ</div>
           </div>
           <div>
-            <label id="override_duration_label">Override เวลา (นาที)</label>
+            <label id="override_duration_label">เวลาพิเศษแทนเวลาระบบ (นาที)</label>
             <input id="override_duration_min" type="number" min="0" step="1" placeholder="0 = คิดตามกติกา">
           </div>
         </div>
@@ -427,7 +512,7 @@
               <option value="single">เลือกช่างคนเดียว</option>
               <option value="team">เลือกทีมช่าง</option>
             </select>
-            <div id="assign_mode_ui_help" class="muted2 mini" style="margin-top:6px">ทีม = เลือกช่างร่วมหลายคน (validation ยังห้ามชนคิวเหมือนเดิม)</div>
+            <div id="assign_mode_ui_help" class="muted2 mini" style="margin-top:6px">ทีม = เลือกช่างร่วมหลายคน (ระบบยังตรวจสอบไม่ให้ชนคิวเหมือนเดิม)</div>
           </div>
 
           <div id="appt_date_wrap">
@@ -435,7 +520,7 @@
             <input id="appt_date" type="date">
           </div>
           <button class="secondary" type="button" id="btnLoadSlots" style="margin-top:8px;width:100%">โหลดคิวว่าง</button>
-          <div id="debug_hint" class="muted2 mini" style="margin-top:8px">🐞 Debug = มุมขวาบน (ใส่รหัสก่อนเปิด) • ไม่แสดงในหน้าเพื่อไม่รก</div>
+          <div id="debug_hint" class="muted2 mini" style="margin-top:8px">🐞 โหมดตรวจสอบระบบ = ปุ่มมุมขวาบน (ใส่รหัสก่อนเปิด) • ไม่แสดงในหน้าเพื่อไม่ให้รก</div>
 
           <!-- Slots appear directly under the load button (no scrolling confusion) -->
           <div id="slots_wrap" style="margin-top:10px">
@@ -456,17 +541,17 @@
           <!-- dispatch_mode kept hidden for backward compatibility; derived from booking_mode_ui -->
           <!-- booking_mode (scheduled/urgent) kept hidden for backward compatibility; derived from booking_mode_ui -->
           <select id="booking_mode" style="display:none">
-            <option value="scheduled">scheduled</option>
-            <option value="urgent">urgent</option>
+            <option value="scheduled">จองล่วงหน้า</option>
+            <option value="urgent">งานด่วน</option>
           </select>
           <select id="dispatch_mode" style="display:none">
-            <option value="forced">forced (ล็อคช่าง)</option>
-            <option value="offer">offer (ยิงข้อเสนอ)</option>
+            <option value="forced">ล็อกช่าง</option>
+            <option value="offer">ส่งข้อเสนอให้ช่าง</option>
           </select>
           <!-- Reduced clutter (kept elements for backward compatibility with JS) -->
           <div class="pill" style="margin-top:10px; display:none">
             <b style="color:#0b1b3a">หมายเหตุ:</b>
-            <span class="muted2 mini">โหมดจองกำหนดการส่งงานอัตโนมัติ • ไม่ต้องเลือก dispatch ซ้ำ</span>
+            <span class="muted2 mini">โหมดจองกำหนดการส่งงานอัตโนมัติ • ไม่ต้องเลือกโหมดส่งงานซ้ำ</span>
           </div>
 
           <div id="assign_summary" class="pill" style="margin-top:12px;display:none;justify-content:space-between;gap:10px">
@@ -498,7 +583,8 @@
               <label>ทีมช่าง • เลือกหลายคน</label>
               <div class="team-help">พิมพ์ค้นหา แล้วแตะเพื่อเพิ่มเป็นทีม • ไม่ต้องเลือกช่างหลัก</div>
               <div class="team-picker">
-                <input id="team_search" class="team-search" placeholder="ค้นหาช่างร่วม..." autocomplete="off">
+                <input id="team_search" class="team-search" placeholder="ค้นหาช่างร่วม (ชื่อ หรือ ชื่อผู้ใช้)..." autocomplete="off">
+                <div class="muted2 mini" id="team_suggest_count" style="margin-top:8px"></div>
                 <div class="team-suggest" id="team_suggest"></div>
                 <div class="team-divider"></div>
                 <div class="team-selected-title">เลือกแล้ว</div>
@@ -525,11 +611,13 @@
 
       <!-- Slot Quick Pick Modal (แตะสล็อตแล้วเลือกช่าง/เดี่ยว/ทีมได้ทันที) -->
       <div id="slot_modal_overlay" class="team-sheet-overlay">
-        <div class="team-sheet" role="dialog" aria-modal="true" style="max-width:560px">
-          <h3 id="slot_modal_title">เลือกช่างในสล็อต</h3>
-          <p id="slot_modal_sub" class="muted2" style="margin-top:6px">-</p>
-          <div id="slot_modal_body" style="margin-top:12px"></div>
-          <div class="sheet-actions" style="margin-top:14px">
+        <div class="team-sheet slot-sheet" role="dialog" aria-modal="true" aria-labelledby="slot_modal_title" style="max-width:560px">
+          <div class="slot-sheet-head">
+            <h3 id="slot_modal_title">เลือกช่างในสล็อต</h3>
+            <p id="slot_modal_sub" class="muted2">-</p>
+          </div>
+          <div id="slot_modal_body"></div>
+          <div class="sheet-actions">
             <button id="slot_modal_confirm" class="btn-primary" type="button">ยืนยัน</button>
             <button id="slot_modal_close" class="btn-close" type="button">ปิด</button>
           </div>
@@ -568,7 +656,7 @@
         <b>✅ ข้อความยืนยันนัด (คัดลอกส่งลูกค้า)</b>
         <div class="lang-toggle" role="tablist" aria-label="ภาษา">
           <button type="button" class="lang-btn active" id="btnLangTH" aria-selected="true">ไทย</button>
-          <button type="button" class="lang-btn" id="btnLangEN" aria-selected="false">English</button>
+          <button type="button" class="lang-btn" id="btnLangEN" aria-selected="false">ภาษาอังกฤษ</button>
         </div>
       </div>
       <div class="muted2 mini" style="margin-top:6px">เลือกภาษา แล้วกดคัดลอกส่งใน LINE/WhatsApp ได้ทันที</div>
@@ -589,7 +677,7 @@
           <div></div>
           <div class="lang-toggle" role="tablist" aria-label="ภาษา">
             <button type="button" class="lang-btn active" id="btnLangTHModal" aria-selected="true">ไทย</button>
-            <button type="button" class="lang-btn" id="btnLangENModal" aria-selected="false">English</button>
+            <button type="button" class="lang-btn" id="btnLangENModal" aria-selected="false">ภาษาอังกฤษ</button>
           </div>
         </div>
         <textarea id="summary_modal_text" rows="10" style="margin-top:12px; width:100%; min-height:220px; max-height:52vh; resize:vertical;" readonly></textarea>
@@ -608,7 +696,7 @@
   </div>
 
   <script src="admin-v2-common.js?v=20260428_allpages_ui1"></script>
-  <script src="admin-add-v2.js?v=20260809_issue267_catalog_flow_v9"></script>
+  <script src="admin-add-v2.js?v=20260820_issue307_admin_add_thai_slot_v1"></script>
   <script src="admin-add-ai-intake-prefill.js?v=line-ai-prefill-real-v8"></script>
 </body>
 </html>

--- a/admin-add-v2.js
+++ b/admin-add-v2.js
@@ -210,8 +210,8 @@ async function loadServiceZones(){
     const sel = el('service_zone_code');
     if(sel){
       const cur = sel.value || '';
-      sel.innerHTML = `<option value="">Auto / ระบบเลือกจากที่อยู่</option>` + state.service_zones.map(z => (
-        `<option value="${z.zone_code}">Zone ${z.zone_code} - ${z.zone_label}</option>`
+      sel.innerHTML = `<option value="">อัตโนมัติ / ระบบเลือกจากที่อยู่</option>` + state.service_zones.map(z => (
+        `<option value="${z.zone_code}">โซน ${z.zone_code} - ${z.zone_label}</option>`
       )).join('');
       sel.value = cur;
     }
@@ -239,7 +239,7 @@ async function detectAdminServiceZone(){
         const z = state.detected_service_zone;
         const matched = [z.matched_area, z.matched_district].filter(Boolean).join(' / ');
         const sourceLabel = z.service_zone_source === 'maps_coordinate' ? 'จาก GPS/แผนที่' : (z.service_zone_source === 'area_alias_detect' ? 'จากย่าน/ตำบล' : (override ? 'เลือกเอง' : 'จากที่อยู่'));
-        hint.textContent = `${override ? 'เลือกเอง' : 'ระบบเลือกให้'}: Zone ${z.service_zone_code} - ${z.service_zone_label}${matched ? ` • ${matched}` : ''} (${sourceLabel})`;
+        hint.textContent = `${override ? 'เลือกเอง' : 'ระบบเลือกให้'}: โซน ${z.service_zone_code} - ${z.service_zone_label}${matched ? ` • ${matched}` : ''} (${sourceLabel})`;
         hint.style.color = '#0b4bb3';
       }else{
         hint.textContent = 'ระบบยังหาโซนไม่ได้ กรุณาเลือกโซนเอง หรือใส่เขต/อำเภอเพิ่ม';
@@ -313,10 +313,10 @@ function renderCustomerLookupUI(result){
     `;
   }
   if (result.source === "customer_profiles") {
-    hint.textContent = 'พบข้อมูลจาก customer_profiles • กด "Use latest customer data" เพื่อเติมชื่อ/เบอร์/ที่อยู่/แผนที่ล่าสุด';
+    hint.textContent = 'พบข้อมูลจากโปรไฟล์ลูกค้า • กด "ใช้ข้อมูลลูกค้าล่าสุด" เพื่อเติมชื่อ/เบอร์/ที่อยู่/แผนที่ล่าสุด';
     return;
   }
-  hint.textContent = 'ไม่พบใน customer_profiles • พบข้อมูล fallback จาก latest job แทน กด "Use latest customer data" เพื่อใช้ข้อมูลล่าสุดจากใบงานเก่า';
+  hint.textContent = 'ไม่พบในโปรไฟล์ลูกค้า • ใช้ข้อมูลสำรองจากใบงานล่าสุดแทน กด "ใช้ข้อมูลลูกค้าล่าสุด" เพื่อใช้ข้อมูลล่าสุดจากใบงานเก่า';
 }
 
 async function lookupLatestCustomerDataByPhone(){
@@ -359,7 +359,7 @@ function applyLatestCustomerData(){
   try { el("maps_url").dispatchEvent(new Event("input", { bubbles: true })); } catch(e){}
   try { el("job_zone").dispatchEvent(new Event("input", { bubbles: true })); } catch(e){}
   try { detectAdminServiceZone(); } catch(e){}
-  showToast(data.source === "customer_profiles" ? "เติมข้อมูลจาก customer_profiles แล้ว" : "เติมข้อมูลจาก latest job แล้ว", "success");
+  showToast(data.source === "customer_profiles" ? "เติมข้อมูลจากโปรไฟล์ลูกค้าแล้ว" : "เติมข้อมูลจากใบงานล่าสุดแล้ว", "success");
 }
 
 function applyCustomerLocationCandidate(index){
@@ -409,7 +409,7 @@ function dbgRender(){
 
   // Hint
   const hint = el('debug_panel_hint');
-  if (hint) hint.textContent = 'on';
+  if (hint) hint.textContent = 'เปิด';
 
   // Content
   const setPre = (id, obj) => {
@@ -473,31 +473,31 @@ function dbgBind(){
       const enabled = !!ev.target.checked;
       const r = await apiFetch('/admin/debug_toggle_backend', { method:'POST', body: JSON.stringify({ enable: enabled ? '1':'0' }) });
       const st = el('dbg_backend_status');
-      if(st) st.textContent = (r && r.enabled) ? 'ON' : 'OFF';
-      showToast('ตั้งค่า Logging แล้ว', 'success');
+      if(st) st.textContent = (r && r.enabled) ? 'เปิด' : 'ปิด';
+      showToast('ตั้งค่าการเก็บบันทึกระบบแล้ว', 'success');
     } catch(e){
-      showToast('ตั้งค่า Logging ไม่สำเร็จ', 'error');
+      showToast('ตั้งค่าการเก็บบันทึกระบบไม่สำเร็จ', 'error');
     }
   });
 
   // Init status label (best-effort)
   try {
     const st = el('dbg_backend_status');
-    if (st) st.textContent = 'OFF';
+    if (st) st.textContent = 'ปิด';
   } catch(e) {}
 }
 function bindDebugToggle(){
   const btn = el('btnBug');
   if(!btn) return;
   // keep icon stable, show state via tooltip
-  try{ btn.title = DEBUG_ENABLED ? 'Debug: On' : 'Debug: Off'; }catch(e){}
+  try{ btn.title = DEBUG_ENABLED ? 'โหมดตรวจสอบระบบ: เปิด' : 'โหมดตรวจสอบระบบ: ปิด'; }catch(e){}
   btn.addEventListener('click', () => {
     try {
       // Require PIN 1549 whenever opening the panel (prevents accidental tap)
       const panel = el('debugFloat');
       const isOpen = !!(panel && panel.style.display !== 'none' && panel.style.display !== '');
       if (!DEBUG_ENABLED || !isOpen) {
-        const pin = (prompt('ใส่รหัสเพื่อเปิด Debug Panel') || '').trim();
+        const pin = (prompt('ใส่รหัสเพื่อเปิดแผงตรวจสอบระบบ') || '').trim();
         if (pin !== '1549') { showToast('รหัสไม่ถูกต้อง', 'error'); return; }
         try { localStorage.setItem('cwf_debug_unlocked', '1'); } catch(e) {}
         try { localStorage.setItem('cwf_debug', '1'); } catch(e) {}
@@ -507,7 +507,7 @@ function bindDebugToggle(){
         DEBUG_ENABLED = false;
         try { localStorage.removeItem('cwf_debug'); } catch(e) {}
       }
-      try{ btn.title = DEBUG_ENABLED ? 'Debug: On' : 'Debug: Off'; }catch(e){}
+      try{ btn.title = DEBUG_ENABLED ? 'โหมดตรวจสอบระบบ: เปิด' : 'โหมดตรวจสอบระบบ: ปิด'; }catch(e){}
       // Ensure floating panel becomes visible immediately
       if (panel) panel.style.display = DEBUG_ENABLED ? 'block' : 'none';
       if (DEBUG_ENABLED) {
@@ -517,7 +517,7 @@ function bindDebugToggle(){
         dbgRender();
       }
     } catch(e){
-      showToast('สลับ Debug ไม่สำเร็จ', 'error');
+      showToast('สลับโหมดตรวจสอบระบบไม่สำเร็จ', 'error');
     }
   });
 }
@@ -635,6 +635,30 @@ function techDisplay(username){
   if(!u) return "";
   const t = (state.techMap && state.techMap[u]) || (state.techs||[]).find(x=>x.username===u);
   return (t && t.display_name) ? t.display_name : u;
+}
+
+// Pure helper for the in-slot technician picker.
+// Contract (Issue 307): the list must contain EVERY technician the availability API
+// reported as free for the selected slot, each exactly once, in API order.
+// Filtering is only ever done by an explicit admin search query - there is no
+// hidden cap, no .slice() truncation and no re-ordering that could hide someone.
+// `total` always reports the full available count so the UI can say so out loud.
+function buildSlotTechnicianList(ids, query, displayFn){
+  const seen = new Set();
+  const all = [];
+  for (const raw of (Array.isArray(ids) ? ids : [])) {
+    const username = String(raw == null ? '' : raw).trim();
+    if (!username || seen.has(username)) continue;
+    seen.add(username);
+    let label = username;
+    try { label = String((typeof displayFn === 'function' ? displayFn(username) : username) || username); } catch(e) { label = username; }
+    all.push({ username, label });
+  }
+  const q = String(query == null ? '' : query).trim().toLowerCase();
+  const items = q
+    ? all.filter(t => t.username.toLowerCase().includes(q) || t.label.toLowerCase().includes(q))
+    : all;
+  return { total: all.length, items };
 }
 
 function renderTechSelect(allowedIds=null){
@@ -865,17 +889,28 @@ function renderTeamPicker(allowedIds=null){
   const q = (searchEl.value||"").trim().toLowerCase();
   state.teamPicker.primary = '';
 
-  // Suggestions: top 30 matches that are not selected
-  const suggestions = techList
-    .filter(t=>{
-      const key = (t.username||"").toLowerCase();
-      return (!q || key.includes(q)) && !state.teamPicker.selected.has(t.username);
-    })
-    .slice(0, 30);
+  // Suggestions: EVERY not-yet-selected technician that matches the search box.
+  // Issue 307: no fixed cap here - a hidden 30-entry cap used to drop valid
+  // technicians silently. Search (username or display name) is the only filter,
+  // and the count line below states how many are hidden by that search.
+  const selectable = techList.filter(t=>!state.teamPicker.selected.has(t.username));
+  const suggestions = selectable.filter(t=>{
+    if(!q) return true;
+    const key = (t.username||"").toLowerCase();
+    const name = String(t.display_name || t.full_name || t.username || "").toLowerCase();
+    return key.includes(q) || name.includes(q);
+  });
 
   suggestBox.innerHTML = suggestions.map(t=>{
     return `<button type="button" class="team-chip team-chip-add" data-u="${t.username}">+ ${escapeHtml(t.display_name || t.full_name || t.username)}</button>`;
-  }).join("") || `<div class="team-empty">ไม่พบช่าง</div>`;
+  }).join("") || `<div class="team-empty">ไม่พบช่างที่ตรงกับคำค้นหา</div>`;
+
+  const countBox = document.getElementById("team_suggest_count");
+  if(countBox){
+    countBox.textContent = (suggestions.length === selectable.length)
+      ? `เลือกเพิ่มได้ทั้งหมด ${selectable.length} คน (แสดงครบทุกคน)`
+      : `แสดง ${suggestions.length} จาก ${selectable.length} คน • ล้างช่องค้นหาเพื่อดูครบทุกคน`;
+  }
 
   // Selected chips: all selected technicians are team members (no Primary UI).
   const selected = Array.from(state.teamPicker.selected).filter(Boolean);
@@ -1423,9 +1458,9 @@ function renderServiceBundleGroups() {
   wrap.style.display = "";
   wrap.innerHTML = (bundle.variants || []).filter((variant) => variant.is_active !== false).map((variant) => `
     <div class="grid3" data-admin-bundle-group="${escapeHtml(variant.package_key)}" style="margin-top:8px">
-      <div><label>${escapeHtml(variant.display_name)}</label><div class="muted2 mini">BTU ${variant.btu_min ?? "any"}-${variant.btu_max ?? "any"}</div></div>
-      <div><label>Actual BTU</label><input type="number" min="1" step="1" data-admin-bundle-btu value="${escapeHtml(variant.btu_min || variant.btu_max || "")}"></div>
-      <div><label>Quantity</label><input type="number" min="0" step="1" value="0" data-admin-bundle-quantity></div>
+      <div><label>${escapeHtml(variant.display_name)}</label><div class="muted2 mini">BTU ${variant.btu_min ?? "ไม่จำกัด"}-${variant.btu_max ?? "ไม่จำกัด"}</div></div>
+      <div><label>BTU จริง</label><input type="number" min="1" step="1" data-admin-bundle-btu value="${escapeHtml(variant.btu_min || variant.btu_max || "")}"></div>
+      <div><label>จำนวนเครื่อง</label><input type="number" min="0" step="1" value="0" data-admin-bundle-quantity></div>
     </div>`).join("") + '<div id="store_service_bundle_quote" class="muted2" style="margin-top:8px"></div>';
   wrap.querySelectorAll("input").forEach((input) => input.addEventListener("change", () => previewServiceBundle().catch((e) => showToast(e.message, "error"))));
 }
@@ -1441,9 +1476,9 @@ async function previewServiceBundle() {
   state.effective_block_min = 0;
   const groups = selectedBundleGroups();
   const panel = el("store_service_bundle_quote");
-  if (!bundleSelected() || !groups.length) { if (panel) panel.textContent = "Select at least one quantity"; return; }
+  if (!bundleSelected() || !groups.length) { if (panel) panel.textContent = "กรุณาระบุจำนวนเครื่องอย่างน้อย 1 รายการ"; return; }
   const fingerprint = bundleFingerprint();
-  if (panel) panel.textContent = "Loading package price and duration...";
+  if (panel) panel.textContent = "กำลังโหลดราคาและเวลาของแพ็กเกจ...";
   const submit = el("btnSubmit"); if (submit) submit.disabled = true;
   const appointment = localDatetimeToBangkokISO(String(el("appointment_datetime")?.value || "").trim()) || new Date(Date.now() + 86400000).toISOString();
   const quote = await apiFetch("/admin/catalog/service-package-bundles/quote", { method: "POST", body: JSON.stringify({
@@ -1456,7 +1491,7 @@ async function previewServiceBundle() {
   state.exact_total = String(quote.fixed_total_price || "");
   state.standard_price = Number(state.exact_total); state.normal_price = state.standard_price;
   state.duration_min = Number(quote.duration_minutes); state.effective_block_min = state.duration_min + Number(state.travel_buffer_min || 30);
-  if (panel) panel.textContent = `${quote.machine_count} units | ${quote.fixed_total_price} | ${quote.duration_minutes} min | ${(quote.components || []).map((x) => `${x.tier_name} x ${x.quantity}`).join(", ")}`;
+  if (panel) panel.textContent = `จำนวน ${quote.machine_count} เครื่อง | ราคารวม ${quote.fixed_total_price} บาท | ใช้เวลา ${quote.duration_minutes} นาที | ${(quote.components || []).map((x) => `${x.tier_name} x ${x.quantity}`).join(", ")}`;
   if (submit) submit.disabled = false;
   await refreshPreview();
 }
@@ -1484,7 +1519,7 @@ function invalidateServicePackagePreview({ loading = false } = {}) {
     const legacySelected = !!String(el("service_package_key")?.value || "").trim();
     panel.style.display = legacySelected ? "" : "none";
     panel.textContent = legacySelected
-      ? (loading ? "Loading package price and duration..." : "Package price and duration unavailable")
+      ? (loading ? "กำลังโหลดราคาและเวลาของแพ็กเกจ..." : "ยังไม่มีราคาและเวลาของแพ็กเกจนี้")
       : "";
   }
   ["pv_duration", "pv_block", "pv_price", "pv_normal_price", "pv_line_total"].forEach((id) => {
@@ -1507,7 +1542,7 @@ function setPackageControlsLocked(locked, { allowQuantity = false } = {}) {
 
 function renderPackageBtuOptions(constraints = {}) {
   const select = el("service_package_btu");
-  select.innerHTML = '<option value="">Select actual BTU</option>';
+  select.innerHTML = '<option value="">เลือก BTU จริง</option>';
   BTU_OPTIONS.filter((value) => (constraints.btu_min == null || value >= constraints.btu_min)
     && (constraints.btu_max == null || value <= constraints.btu_max)).forEach((value) => {
     const option = document.createElement("option"); option.value = String(value); option.textContent = `${value.toLocaleString()} BTU`; select.appendChild(option);
@@ -1537,7 +1572,7 @@ async function previewServicePackage() {
   renderPackageBtuOptions(c);
   el("service_package_btu_wrap").style.display = "";
   const panel = el("service_package_preview"); panel.style.display = "";
-  panel.textContent = `${preview.package_name} / ${preview.tier_name} | ${preview.service.service_name} | quantity ${preview.quantity} | duration ${preview.duration_minutes} min | fixed total ${preview.fixed_total_price} | BTU ${c.btu_min || "any"}-${c.btu_max || "any"} | redeem by ${preview.redeem_until || "no limit"}`;
+  panel.textContent = `${preview.package_name} / ${preview.tier_name} | ${preview.service.service_name} | จำนวน ${preview.quantity} เครื่อง | ใช้เวลา ${preview.duration_minutes} นาที | ราคาเหมารวม ${preview.fixed_total_price} บาท | BTU ${c.btu_min || "ไม่จำกัด"}-${c.btu_max || "ไม่จำกัด"} | ใช้สิทธิ์ได้ถึง ${preview.redeem_until || "ไม่มีกำหนด"}`;
   state.exact_total = String(preview.fixed_total_price || "");
   state.standard_price = Number(state.exact_total); state.normal_price = state.standard_price;
   state.duration_min = Number(preview.duration_minutes); state.effective_block_min = state.duration_min + Number(state.travel_buffer_min || 30);
@@ -1619,7 +1654,7 @@ async function refreshPreview() {
       if (el("pv_normal_price")) el("pv_normal_price").textContent = fmtMoney(state.normal_price);
       if (el("pv_price_source")) {
         const campaign = state.campaign_name || state.customer_price_label || "-";
-        el("pv_price_source").textContent = `แคมเปญที่ใช้: ${campaign} • แหล่งราคา: Store catalog`;
+        el("pv_price_source").textContent = `แคมเปญที่ใช้: ${campaign} • แหล่งราคา: แคตตาล็อกร้านค้า`;
       }
       if (el("pv_line_total")) el("pv_line_total").textContent = state.exact_total || fmtMoney(state.standard_price);
       updateTotalPreview();
@@ -1669,8 +1704,8 @@ async function refreshPreview() {
     if (el("pv_price_source")) {
       const overridePrice = Math.max(0, Number(el("override_price")?.value || 0));
       const src = overridePrice > 0
-        ? "Override"
-        : (state.customer_price_source === "customer_service_price_rules" ? "Service Price Book" : "Fallback");
+        ? "ราคาพิเศษที่แอดมินกรอกเอง"
+        : (state.customer_price_source === "customer_service_price_rules" ? "สมุดราคาบริการ" : "ราคาสำรองของระบบ");
       const campaign = state.campaign_name || state.customer_price_label || "-";
       el("pv_price_source").textContent = `แคมเปญที่ใช้: ${campaign} • แหล่งราคา: ${src}`;
     }
@@ -1724,8 +1759,8 @@ function updateTotalPreview() {
   const srcBox = el("pv_price_source");
   if (srcBox && state.duration_min > 0) {
     const src = overridePrice > 0
-      ? "Override"
-      : (state.customer_price_source === "customer_service_price_rules" ? "Service Price Book" : "Fallback");
+      ? "ราคาพิเศษที่แอดมินกรอกเอง"
+      : (state.customer_price_source === "customer_service_price_rules" ? "สมุดราคาบริการ" : "ราคาสำรองของระบบ");
     const campaign = state.campaign_name || state.customer_price_label || "-";
     srcBox.textContent = `แคมเปญที่ใช้: ${campaign} • แหล่งราคา: ${src}`;
   }
@@ -1887,7 +1922,7 @@ async function loadAvailability() {
     const redeemDate = String(state.service_package_preview.redeem_until).slice(0, 10);
     if (selectedDate && selectedDate > redeemDate) {
       state.available_slots = []; state.slots_loaded = false; renderSlots();
-      showToast("Selected date is after the package redemption deadline", "error"); return;
+      showToast("วันที่เลือกเลยกำหนดใช้สิทธิ์ของแพ็กเกจแล้ว", "error"); return;
     }
   }
   if (!canLoadAvailability()) {
@@ -2413,7 +2448,7 @@ function renderSlots() {
       <div class="muted2 mini" style="margin-top:8px">* ระบบจะเพิ่มสลอตให้ช่าง 1 คนก่อน (เลือกช่างได้) แล้วค่อยโหลดคิวใหม่</div>
     
       ${DEBUG_ENABLED && DBG.intervals && Array.isArray(DBG.intervals.reasons) && DBG.intervals.reasons.length ? `
-      <div class="muted2 mini" style="margin-top:10px">เหตุผล (debug):</div>
+      <div class="muted2 mini" style="margin-top:10px">เหตุผล (โหมดตรวจสอบระบบ):</div>
       <ul class="muted2 mini" style="margin-top:6px;padding-left:18px">
         ${DBG.intervals.reasons.map(r=>`<li><b>${String(r.code||'')}</b>: ${String(r.message||'')}</li>`).join('')}
       </ul>
@@ -2610,7 +2645,7 @@ function updateAssignSummary(){
   }
   if(mode === 'single'){
     const u = (state.confirmed_tech_username || (el('technician_username_select')?.value || el('technician_username')?.value || '')).trim();
-    t.textContent = u ? `เลือกเดี่ยว • ${techDisplay(u)} • username: ${u}` : 'เลือกเดี่ยว • กรุณาเลือกช่างก่อนบันทึก';
+    t.textContent = u ? `เลือกเดี่ยว • ${techDisplay(u)} • ชื่อผู้ใช้: ${u}` : 'เลือกเดี่ยว • กรุณาเลือกช่างก่อนบันทึก';
     return;
   }
   t.textContent = 'ยังไม่ได้เลือกช่าง • ระบบจะเลือกช่างว่างให้';
@@ -2657,11 +2692,17 @@ function openSlotModal(slot){
 
   const date = el('appt_date')?.value || '';
   const ids = Array.isArray(slot?.available_tech_ids) ? slot.available_tech_ids : [];
+  // Full, de-duplicated count of technicians the API reported as free for this slot.
+  // Every one of them must stay reachable in the picker below.
+  const availableTechTotal = buildSlotTechnicianList(ids, '', techDisplay).total;
+  // Search box state lives here so re-rendering the list (on pick/toggle) never
+  // wipes what the admin typed and never steals focus from the mobile keyboard.
+  let techQuery = '';
   syncModesFromUI();
     const dispatchMode = (el('dispatch_mode')?.value || 'normal').toString();
 
   if(title) title.textContent = 'เลือกช่างในสล็อตนี้';
-  sub.textContent = `${date} • เริ่ม ${picked} (ช่วง ${slotStart} - ${slotEnd}) • ว่าง ${ids.length} ช่าง`;
+  sub.textContent = `${date} • เริ่ม ${picked} (ช่วง ${slotStart} - ${slotEnd}) • ช่างที่ว่างในสล็อตนี้ ${availableTechTotal} คน`;
 
   // Offer mode: choose time only (no manual technician picking)
   if(dispatchMode === 'offer'){
@@ -2693,7 +2734,7 @@ function openSlotModal(slot){
         const reasonDiv = document.createElement('div');
         reasonDiv.className = 'muted2 mini';
         reasonDiv.style.marginTop = '10px';
-        reasonDiv.innerHTML = '<b>เหตุผล (Debug)</b>:<br>' + reasons.map(r=>`• ${String(r.code||'')}: ${String(r.message||'')}`).join('<br>');
+        reasonDiv.innerHTML = '<b>เหตุผล (โหมดตรวจสอบระบบ)</b>:<br>' + reasons.map(r=>`• ${String(r.code||'')}: ${String(r.message||'')}`).join('<br>');
         wrap.appendChild(reasonDiv);
       }
     }catch(e){}
@@ -2704,7 +2745,7 @@ function openSlotModal(slot){
           const v = clampHHMM(t.value, slotStart, slotEnd);
           t.value = v;
           try{ selectSlot(v, slot); }catch(e){}
-          sub.textContent = `${date} • เริ่ม ${v} (ช่วง ${slotStart} - ${slotEnd}) • ว่าง ${ids.length} ช่าง`;
+          sub.textContent = `${date} • เริ่ม ${v} (ช่วง ${slotStart} - ${slotEnd}) • ช่างที่ว่างในสล็อตนี้ ${availableTechTotal} คน`;
         });
       }
       const btn = body.querySelector('#slotm_confirm_offer');
@@ -2751,59 +2792,118 @@ function openSlotModal(slot){
       return;
     }
 
-    if(mode === 'team'){
-      const selected = new Set(Array.from(state.teamPicker.selected || []));
-      state.teamPicker.primary = '';
-      body.innerHTML = timeSeg + modeInfo + `
-        <div>
-          <label>ทีมช่าง</label>
-          <div id="slotm_team" style="display:flex;flex-wrap:wrap;gap:8px"></div>
-          <div class="muted2 mini" style="margin-top:6px">แตะเพื่อเลือก/ยกเลิกช่างในทีม • ไม่ต้องเลือกช่างหลัก</div>
+    // Shared, scrollable, searchable technician picker (single / auto / team).
+    // The hidden <select id="slotm_single"> stays the authoritative value holder for
+    // auto/single so the existing change-handler and confirm contract are unchanged.
+    const pickerShell = (pickMode)=>`
+      <div class="card-lite" style="padding:12px;border-radius:16px">
+        <b style="color:#0b1b3a">ช่างที่ว่างในสล็อตนี้</b>
+        <div class="muted2 mini" style="margin-top:4px">
+          ${pickMode === 'team'
+            ? 'แตะเพื่อเลือก/ยกเลิกช่างในทีม • ไม่ต้องเลือกช่างหลัก'
+            : (pickMode === 'single'
+              ? 'โหมดเดี่ยว: แตะเลือกช่าง 1 คน แล้วกด “ยืนยัน”'
+              : 'แตะเลือกช่าง 1 คน หรือไม่เลือกเพื่อให้ระบบเลือกช่างว่างให้')}
         </div>
-      `;
+        <div class="muted2 mini" style="margin-top:4px">รายชื่อนี้คือช่างที่ว่างจริงในสล็อตนี้เท่านั้น • ช่างที่ติดคิว วันหยุด หรือประเภทการจ้างไม่ตรง จะไม่ถูกแสดงว่าว่าง</div>
+        <input type="search" id="slotm_tech_search" class="slot-tech-search" style="margin-top:10px"
+          placeholder="ค้นหาช่าง (ชื่อ หรือ ชื่อผู้ใช้)" autocomplete="off" value="${escapeHtml(techQuery)}">
+        <div class="muted2 mini slot-tech-count" id="slotm_tech_count"></div>
+        <div class="slot-tech-list" id="slotm_tech_list"></div>
+        ${pickMode === 'team' ? '' : '<select id="slotm_single" style="display:none"></select>'}
+      </div>
+    `;
 
-      const wrap = body.querySelector('#slotm_team');
-      for(const u of ids){
-        const b = document.createElement('button');
-        b.type = 'button';
-        const active = selected.has(u);
-        b.className = `chip ${active ? 'active' : ''}`;
-        b.textContent = techDisplay(u);
-        b.addEventListener('click', ()=>{
-          if(selected.has(u)) selected.delete(u); else selected.add(u);
-          state.teamPicker.selected = new Set(Array.from(selected));
-          state.teamPicker.primary = '';
-          const leg = el('technician_username_select');
-          if(leg) leg.value = '';
-          const hid = el('technician_username');
-          if(hid) hid.value = '';
-          getTeamMembersForPayload();
-          renderTeamPicker(ids);
-          renderSlots();
-          try { renderWashAssign(); } catch(e){}
-          updateAssignSummary();
-          renderBody();
-        });
-        wrap.appendChild(b);
+    // Repaints ONLY the list, so the search box keeps its value, focus and caret.
+    const renderTechList = ()=>{
+      const listBox = body.querySelector('#slotm_tech_list');
+      const countBox = body.querySelector('#slotm_tech_count');
+      if(!listBox) return;
+      const listMode = (el('assign_mode')?.value || 'auto').toString();
+      const result = buildSlotTechnicianList(ids, techQuery, techDisplay);
+      const teamSelected = (listMode === 'team') ? new Set(getTeamListForAssign()) : null;
+      const currentSingle = (body.querySelector('#slotm_single')?.value || '').trim();
+
+      listBox.innerHTML = '';
+      if(!result.items.length){
+        const empty = document.createElement('div');
+        empty.className = 'slot-tech-empty';
+        empty.textContent = 'ไม่พบช่างที่ตรงกับคำค้นหา • ลองพิมพ์ชื่อหรือชื่อผู้ใช้บางส่วน';
+        listBox.appendChild(empty);
+      }else{
+        for(const t of result.items){
+          const b = document.createElement('button');
+          b.type = 'button';
+          b.setAttribute('data-slot-tech', t.username);
+          const active = teamSelected ? teamSelected.has(t.username) : (currentSingle === t.username);
+          b.className = `chip slot-tech-row ${active ? 'active' : ''}`;
+          b.setAttribute('aria-pressed', active ? 'true' : 'false');
+          b.textContent = (t.label === t.username) ? t.username : `${t.label} (${t.username})`;
+          b.addEventListener('click', ()=>{ pickTech(t.username); });
+          listBox.appendChild(b);
+        }
       }
+      if(countBox){
+        countBox.textContent = (result.items.length === result.total)
+          ? `ช่างที่ว่างในสล็อตนี้ทั้งหมด ${result.total} คน (แสดงครบทุกคน)`
+          : `แสดง ${result.items.length} จากช่างที่ว่างในสล็อตนี้ ${result.total} คน • ล้างช่องค้นหาเพื่อดูครบทุกคน`;
+      }
+    };
 
+    const pickTech = (username)=>{
+      const pickMode = (el('assign_mode')?.value || 'auto').toString();
+      if(pickMode === 'team'){
+        const selected = new Set(getTeamListForAssign());
+        if(selected.has(username)) selected.delete(username); else selected.add(username);
+        state.teamPicker.selected = new Set(Array.from(selected));
+        state.teamPicker.primary = '';
+        const leg = el('technician_username_select');
+        if(leg) leg.value = '';
+        const hid = el('technician_username');
+        if(hid) hid.value = '';
+        getTeamMembersForPayload();
+        renderTeamPicker(ids);
+        renderSlots();
+        try { renderWashAssign(); } catch(e){}
+        updateAssignSummary();
+        renderTechList();
+        return;
+      }
+      const selEl = body.querySelector('#slotm_single');
+      if(!selEl) return;
+      // Tapping the already-selected technician clears the choice.
+      selEl.value = (selEl.value === username) ? '' : username;
+      try { selEl.dispatchEvent(new Event('change')); } catch(e) {}
+      renderTechList();
+    };
+
+    const bindTechSearch = ()=>{
+      const searchEl = body.querySelector('#slotm_tech_search');
+      if(!searchEl) return;
+      searchEl.addEventListener('input', ()=>{
+        techQuery = searchEl.value || '';
+        renderTechList();
+      });
+    };
+
+    if(mode === 'team'){
+      state.teamPicker.primary = '';
+      body.innerHTML = timeSeg + modeInfo + pickerShell('team');
+      bindTechSearch();
+      renderTechList();
       bindTimePicker();
       return;
     }
 
     const cur = (el('technician_username_select')?.value || '').trim();
-    // In real production use, the admin chooses assignment mode/technician in the main form.
-    // The slot modal should only be for picking the start time (and showing who is free),
-    // not forcing a second technician selection step.
+    // Options mirror the visible list one-for-one (every available id, exactly once),
+    // so the submitted payload can only ever be a technician the admin actually saw.
+    const optionsHtml = buildSlotTechnicianList(ids, '', techDisplay).items
+      .map(t=>`<option value="${escapeHtml(t.username)}">${escapeHtml(t.label)} (${escapeHtml(t.username)})</option>`).join('');
     if(mode === 'auto'){
-      body.innerHTML = timeSeg + modeInfo + `
-        <label>ช่าง (ว่างในสล็อตนี้)</label>
-        <select id="slotm_single" class="grow"></select>
-        <div class="muted2 mini" style="margin-top:6px">ไม่เลือก = ระบบเลือกช่างว่าง</div>
-      `;
+      body.innerHTML = timeSeg + modeInfo + pickerShell('auto');
       const selEl = body.querySelector('#slotm_single');
-      selEl.innerHTML = `<option value="">-- ไม่เลือก (ระบบเลือกช่างว่าง) --</option>`
-        + ids.map(u=>`<option value="${escapeHtml(u)}">${escapeHtml(techDisplay(u))} (${escapeHtml(u)})</option>`).join('');
+      selEl.innerHTML = `<option value="">-- ไม่เลือก (ระบบเลือกช่างว่าง) --</option>` + optionsHtml;
       if(cur && ids.includes(cur)) selEl.value = cur;
       selEl.addEventListener('change', ()=>{
         const v = (selEl.value||'').trim();
@@ -2824,21 +2924,17 @@ function openSlotModal(slot){
         try { renderWashAssign(); } catch(e){}
         updateAssignSummary();
       });
-    } else if(mode === 'single'){
+    } else {
       // Production UX: allow selecting the technician right inside the slot modal.
       // This avoids relying on a hidden/empty main dropdown and prevents "เลือกช่าง A แต่ไปลง B".
       const ok = !!cur && ids.includes(cur);
-      body.innerHTML = timeSeg + modeInfo + `
-        <label>ช่าง (ว่างในสล็อตนี้)</label>
-        <select id="slotm_single" class="grow"></select>
-        <div id="slotm_single_hint" class="muted2 mini" style="margin-top:6px">โหมดเดี่ยว: ต้องเลือกช่าง 1 คน แล้วกด “ยืนยัน”</div>
+      body.innerHTML = timeSeg + modeInfo + pickerShell('single') + `
         <div id="slotm_single_warn" style="display:none;margin-top:10px;padding:10px 12px;border-radius:14px;background:#fee2e2;color:#7f1d1d;font-weight:700">
           โหมดเดี่ยว: กรุณาเลือกช่าง แล้วกด “ยืนยัน”
         </div>
       `;
       const selEl = body.querySelector('#slotm_single');
-      selEl.innerHTML = `<option value="">-- เลือกช่าง --</option>`
-        + ids.map(u=>`<option value="${escapeHtml(u)}">${escapeHtml(techDisplay(u))} (${escapeHtml(u)})</option>`).join('');
+      selEl.innerHTML = `<option value="">-- เลือกช่าง --</option>` + optionsHtml;
       if(ok) selEl.value = cur;
       // keep main fields in sync for payload
       selEl.addEventListener('change', ()=>{
@@ -2847,15 +2943,13 @@ function openSlotModal(slot){
         if(el('technician_username')) el('technician_username').value = v;
         state.confirmed_tech_username = '';
         state.confirmed_tech_label = '';
-        body.querySelector('#slotm_single_warn').style.display = v ? 'none' : 'block';
+        const warn = body.querySelector('#slotm_single_warn');
+        if(warn) warn.style.display = v ? 'none' : 'block';
       });
-    } else {
-      // team: the team selection happens in the main form; modal is only for time picking.
-      body.innerHTML = timeSeg + modeInfo + `
-        <div class="muted2 mini" style="margin-top:2px">โหมดทีม: เลือกทีมได้ที่หน้าหลัก (ไม่ต้องเลือกซ้ำในสล็อต)</div>
-      `;
     }
 
+    bindTechSearch();
+    renderTechList();
     bindModeButtons();
     bindTimePicker();
   };
@@ -2868,7 +2962,7 @@ function openSlotModal(slot){
       const v = clampHHMM(t.value, slotStart, slotEnd);
       t.value = v;
       try{ selectSlot(v, slot); }catch(e){}
-      sub.textContent = `${date} • เริ่ม ${v} (ช่วง ${slotStart} - ${slotEnd}) • ว่าง ${ids.length} ช่าง`;
+      sub.textContent = `${date} • เริ่ม ${v} (ช่วง ${slotStart} - ${slotEnd}) • ช่างที่ว่างในสล็อตนี้ ${availableTechTotal} คน`;
       try { renderWashAssign(); } catch(e){}
       try { updateAssignSummary(); } catch(e){}
     });
@@ -3043,7 +3137,7 @@ async function submitBooking() {
     return;
   }
   if (packageSelected() && !packagePreviewIsFresh()) {
-    showToast("Wait for the selected package tier price and duration before booking", "error");
+    showToast("กรุณารอราคาและเวลาของตัวเลือกแพ็กเกจที่เลือกก่อนบันทึกงาน", "error");
     el("btnSubmit").disabled = true;
     return;
   }
@@ -3144,7 +3238,7 @@ async function submitBooking() {
   if (packageSelected()) {
     if (bundleSelected()) {
       if (!packagePreviewIsFresh()) {
-        showToast("Select Store package quantities and wait for the server quote", "error");
+        showToast("กรุณาระบุจำนวนเครื่องของแพ็กเกจร้านค้า แล้วรอให้เซิร์ฟเวอร์คำนวณราคาก่อน", "error");
         el("btnSubmit").disabled = false; return;
       }
       payload.service_package_groups = selectedBundleGroups();
@@ -3159,11 +3253,11 @@ async function submitBooking() {
     const preview = state.service_package_preview;
     const actualBtu = Number(el("service_package_btu")?.value || 0);
     if (!packagePreviewIsFresh() || !actualBtu) {
-      showToast("Select a package tier and actual BTU before booking", "error");
+      showToast("กรุณาเลือกตัวเลือกราคา/จำนวนเครื่อง และ BTU จริง ก่อนบันทึกงาน", "error");
       el("btnSubmit").disabled = false; return;
     }
     if (preview.redeem_until && new Date(payload.appointment_datetime) > new Date(preview.redeem_until)) {
-      showToast("The appointment is after this package redemption deadline", "error");
+      showToast("วันเวลานัดหมายเลยกำหนดใช้สิทธิ์ของแพ็กเกจนี้แล้ว", "error");
       el("btnSubmit").disabled = false; return;
     }
     payload.service_package_key = el("service_package_key").value;
@@ -3226,7 +3320,7 @@ async function submitBooking() {
       const validPair = latRaw && lngRaw && Number.isFinite(la) && Number.isFinite(ln)
         && Math.abs(la) <= 90 && Math.abs(ln) <= 180 && !(la === 0 && ln === 0);
       if (!validPair) {
-        showToast('พิกัดหน้างานไม่ถูกต้อง กรุณากรอก Lat และ Lng ให้ครบทั้งคู่และถูกต้อง (ไม่ใช่ 0,0) หรือเว้นว่างทั้งคู่', 'error');
+        showToast('พิกัดหน้างานไม่ถูกต้อง กรุณากรอกละติจูดและลองจิจูดให้ครบทั้งคู่และถูกต้อง (ไม่ใช่ 0,0) หรือเว้นว่างทั้งคู่', 'error');
         el("btnSubmit").disabled = false;
         return;
       }
@@ -3335,7 +3429,7 @@ function wireEvents() {
     }
     el("store_service_bundle_key").value = "";
     el("service_package_key").value = "";
-    el("service_package_tier_key").innerHTML = '<option value="">Select tier</option>';
+    el("service_package_tier_key").innerHTML = '<option value="">เลือกตัวเลือกราคา/จำนวนเครื่อง</option>';
     el("service_package_tier_key").disabled = true;
     renderServiceBundleGroups();
     invalidateServicePackagePreview();
@@ -3362,7 +3456,7 @@ function wireEvents() {
       state.selected_store_catalog_item_id = bundle ? Number(bundle.item_id) : null;
       if (el("store_bookable_item_id")) el("store_bookable_item_id").value = "";
       el("service_package_key").value = "";
-      el("service_package_tier_key").innerHTML = '<option value="">Select tier</option>';
+      el("service_package_tier_key").innerHTML = '<option value="">เลือกตัวเลือกราคา/จำนวนเครื่อง</option>';
       el("service_package_tier_key").disabled = true;
     }
     state.admin_request_key = "";
@@ -3375,7 +3469,7 @@ function wireEvents() {
   el("service_package_key")?.addEventListener("change", async () => {
     const key = String(el("service_package_key").value || "");
     const tier = el("service_package_tier_key");
-    tier.innerHTML = '<option value="">Select tier</option>';
+    tier.innerHTML = '<option value="">เลือกตัวเลือกราคา/จำนวนเครื่อง</option>';
     const pkg = state.service_packages.find((item) => item.package_key === key);
     if (pkg) {
       state.selected_store_catalog_item_id = null;
@@ -3414,7 +3508,7 @@ function wireEvents() {
       else lab.textContent = 'เวลารายการนี้ (นาที) (ไม่ใส่ = 60 นาทีโดยประมาณ)';
       return;
     }
-    lab.textContent = 'Override เวลา (นาที)';
+    lab.textContent = 'เวลาพิเศษแทนเวลาระบบ (นาที)';
   };
 
   // build variant when job type changes
@@ -3483,12 +3577,12 @@ function wireEvents() {
   try {
     el('btnLangTH')?.addEventListener('click', ()=> setSummaryLang('th','card'));
     el('btnLangEN')?.addEventListener('click', ()=>{
-      if(!state.summary_texts.en){ showToast('English version not available', 'error'); return; }
+      if(!state.summary_texts.en){ showToast('ยังไม่มีข้อความฉบับภาษาอังกฤษ', 'error'); return; }
       setSummaryLang('en','card');
     });
     el('btnLangTHModal')?.addEventListener('click', ()=> setSummaryLang('th','modal'));
     el('btnLangENModal')?.addEventListener('click', ()=>{
-      if(!state.summary_texts.en){ showToast('English version not available', 'error'); return; }
+      if(!state.summary_texts.en){ showToast('ยังไม่มีข้อความฉบับภาษาอังกฤษ', 'error'); return; }
       setSummaryLang('en','modal');
     });
   } catch(e){}
@@ -3647,7 +3741,7 @@ function _pickUsernameForSpecialSlot(){
 
   const top = techs.slice(0, 12);
   const lines = top.map((t,i)=>`${i+1}) ${t.display_name || t.full_name || t.username} (${t.username})`).join("\n");
-  const pick = prompt(`เลือกช่างสำหรับสลอตพิเศษ (พิมพ์เลข)\n\n${lines}\n\nหรือพิมพ์ username ตรงๆ`, "1");
+  const pick = prompt(`เลือกช่างสำหรับสลอตพิเศษ (พิมพ์เลข)\n\n${lines}\n\nหรือพิมพ์ชื่อผู้ใช้ของช่างตรง ๆ`, "1");
   if(!pick) return null;
   const n = Number(pick);
   if(Number.isFinite(n) && n >= 1 && n <= top.length) return String(top[n-1].username).trim();

--- a/test/adminAddJobThaiUiAndSlotPicker.test.js
+++ b/test/adminAddJobThaiUiAndSlotPicker.test.js
@@ -1,0 +1,362 @@
+"use strict";
+
+// Issue 307 - Admin Add Job must be Thai-only, and the in-slot technician picker
+// must stay scrollable on small Android screens while still exposing EVERY
+// technician the availability API reported as free for that slot.
+//
+// These tests are UI-contract tests only. They never touch availability
+// eligibility, collision, day-off, employment-type or scheduling rules.
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const vm = require("node:vm");
+
+const ROOT = path.join(__dirname, "..");
+const html = fs.readFileSync(path.join(ROOT, "admin-add-v2.html"), "utf8");
+const js = fs.readFileSync(path.join(ROOT, "admin-add-v2.js"), "utf8");
+
+// ---------------------------------------------------------------------------
+// helpers
+// ---------------------------------------------------------------------------
+
+function sliceFunction(source, signature, nextSignature) {
+  const start = source.indexOf(signature);
+  assert.notEqual(start, -1, `could not find ${signature}`);
+  const end = nextSignature ? source.indexOf(nextSignature, start) : -1;
+  assert.notEqual(end, 0, `could not find ${nextSignature}`);
+  return end === -1 ? source.slice(start) : source.slice(start, end);
+}
+
+// Runs the real, pure buildSlotTechnicianList() out of the shipped runtime file
+// so the parity guarantees below are proven against production code, not a copy.
+function loadSlotTechnicianListApi() {
+  const fnSource = sliceFunction(js, "function buildSlotTechnicianList(", "function renderTechSelect(");
+  const context = {};
+  vm.runInNewContext(`${fnSource}\n;__api = { buildSlotTechnicianList };`, context);
+  return context.__api;
+}
+
+// Text that is allowed to stay non-Thai anywhere on this page: protocol values,
+// API payload keys, route names, brand names and units. Everything else that is
+// user-visible has to be Thai.
+const TECHNICAL_ALLOWLIST = [
+  "BTU", "LINE", "WhatsApp", "CWF", "GPS", "CMS",
+  "scheduled", "urgent", "forced", "offer", "assign", "auto", "single", "team",
+  "admin-add-v2.js", "admin-add-v2.html", "style.css", "admin-v2-common.js",
+  "https://maps...", "0xx-xxx-xxxx",
+];
+
+// ---------------------------------------------------------------------------
+// 1) Thai-only Admin UI
+// ---------------------------------------------------------------------------
+
+test("Issue 307: the confirmed English Admin Add Job strings are gone from the markup", () => {
+  const forbidden = [
+    "Use latest customer data",
+    "Auto / ระบบเลือกจากที่อยู่",
+    ">Latitude<",
+    ">Longitude<",
+    "Service Package (optional)",
+    "Choose a Store package parent",
+    "Ordinary Store service (optional)",
+    "Use manual service fields",
+    "Store service-package item",
+    "No Store package",
+    "Legacy standalone package",
+    "No legacy package",
+    ">Tier<",
+    "Select tier",
+    "Actual BTU *",
+    "Select actual BTU",
+    ">scheduled<",
+    ">urgent<",
+    "forced (ล็อคช่าง)",
+    "offer (ยิงข้อเสนอ)",
+    ">English<",
+    'aria-label="machine count"',
+    "Override ราคา",
+    "Override เวลา",
+  ];
+  for (const needle of forbidden) {
+    assert.equal(html.includes(needle), false, `admin-add-v2.html still ships English UI text: ${needle}`);
+  }
+});
+
+test("Issue 307: the confirmed English runtime messages are gone from the script", () => {
+  const forbidden = [
+    "Select at least one quantity",
+    "Loading package price and duration...",
+    "Package price and duration unavailable",
+    "Selected date is after the package redemption deadline",
+    "Wait for the selected package tier price and duration before booking",
+    "Select Store package quantities and wait for the server quote",
+    "Select a package tier and actual BTU before booking",
+    "The appointment is after this package redemption deadline",
+    "Select actual BTU",
+    "Select tier",
+    "English version not available",
+    "Use latest customer data",
+    "แหล่งราคา: Store catalog",
+    "Service Price Book",
+    "Debug: On",
+    "Debug: Off",
+    "redeem by",
+    "no limit",
+    "fixed total",
+    "<label>Quantity</label>",
+    "<label>Actual BTU</label>",
+    "Override เวลา (นาที)",
+  ];
+  for (const needle of forbidden) {
+    assert.equal(js.includes(needle), false, `admin-add-v2.js still ships English UI text: ${needle}`);
+  }
+});
+
+test("Issue 307: the Thai replacements are actually present", () => {
+  for (const needle of [
+    "ใช้ข้อมูลลูกค้าล่าสุด",
+    "อัตโนมัติ / ระบบเลือกจากที่อยู่",
+    ">ละติจูด<",
+    ">ลองจิจูด<",
+    "แพ็กเกจบริการ (ถ้ามี)",
+    "บริการร้านค้าแบบปกติ (ถ้ามี)",
+    "กรอกรายละเอียดบริการเอง",
+    "รายการแพ็กเกจบริการของร้านค้า",
+    "ไม่ใช้แพ็กเกจร้านค้า",
+    "แพ็กเกจเดี่ยว (ระบบเดิม)",
+    "ไม่ใช้แพ็กเกจระบบเดิม",
+    "ตัวเลือกราคา/จำนวนเครื่อง",
+    "BTU จริง *",
+    "เลือก BTU จริง",
+    ">ภาษาอังกฤษ<",
+    "ราคาพิเศษแทนราคาระบบ",
+    "เวลาพิเศษแทนเวลาระบบ (นาที)",
+  ]) {
+    assert.equal(html.includes(needle), true, `admin-add-v2.html is missing the Thai text: ${needle}`);
+  }
+  for (const needle of [
+    "กรุณาระบุจำนวนเครื่องอย่างน้อย 1 รายการ",
+    "กำลังโหลดราคาและเวลาของแพ็กเกจ...",
+    "ยังไม่มีราคาและเวลาของแพ็กเกจนี้",
+    "วันที่เลือกเลยกำหนดใช้สิทธิ์ของแพ็กเกจแล้ว",
+    "กรุณารอราคาและเวลาของตัวเลือกแพ็กเกจที่เลือกก่อนบันทึกงาน",
+    "กรุณาระบุจำนวนเครื่องของแพ็กเกจร้านค้า แล้วรอให้เซิร์ฟเวอร์คำนวณราคาก่อน",
+    "กรุณาเลือกตัวเลือกราคา/จำนวนเครื่อง และ BTU จริง ก่อนบันทึกงาน",
+    "วันเวลานัดหมายเลยกำหนดใช้สิทธิ์ของแพ็กเกจนี้แล้ว",
+    "ยังไม่มีข้อความฉบับภาษาอังกฤษ",
+    "แหล่งราคา: แคตตาล็อกร้านค้า",
+    "สมุดราคาบริการ",
+    "โหมดตรวจสอบระบบ: เปิด",
+  ]) {
+    assert.equal(js.includes(needle), true, `admin-add-v2.js is missing the Thai text: ${needle}`);
+  }
+});
+
+test("Issue 307: option values, payload keys and route names stay English contracts", () => {
+  // Translating the labels must not have touched anything the backend reads.
+  for (const contract of [
+    'value="scheduled"', 'value="urgent"', 'value="forced"', 'value="offer"',
+    'value="assign"', 'value="auto"', 'value="single"', 'value="team"',
+    'id="technician_username_select"', 'id="technician_username"',
+    'id="team_members_csv"', 'id="assign_mode"', 'id="booking_mode"', 'id="dispatch_mode"',
+  ]) {
+    assert.equal(html.includes(contract), true, `admin-add-v2.html lost a stable contract: ${contract}`);
+  }
+  assert.match(js, /\/admin\/availability_by_tech_v2/);
+  assert.match(js, /\/admin\/book_v2/);
+  assert.match(js, /assign_mode:/);
+  assert.match(js, /technician_username:/);
+  assert.match(js, /team_members:/);
+  // The English customer confirmation feature itself is preserved.
+  assert.match(js, /\/jobs\/\$\{r\.job_id\}\/summary\?lang=en/);
+  assert.match(js, /summary_texts/);
+  assert.equal(TECHNICAL_ALLOWLIST.length > 0, true);
+});
+
+// ---------------------------------------------------------------------------
+// 2) Technician-list parity - no silent truncation
+// ---------------------------------------------------------------------------
+
+test("Issue 307: every available technician is listed exactly once, first/middle/last included", () => {
+  const { buildSlotTechnicianList } = loadSlotTechnicianListApi();
+  const ids = Array.from({ length: 40 }, (_, i) => `tech${String(i + 1).padStart(2, "0")}`);
+  const display = (u) => `ช่าง ${u.slice(4)}`;
+
+  const result = buildSlotTechnicianList(ids, "", display);
+  assert.equal(result.total, 40);
+  assert.equal(result.items.length, 40, "the picker must not drop any available technician");
+
+  // NOTE: the helper runs in a vm realm, so compare by value, not by Array identity.
+  const rendered = result.items.map((t) => t.username);
+  assert.equal(rendered.join(","), ids.join(","), "order and membership must mirror the API response exactly");
+  assert.equal(new Set(rendered).size, 40, "each technician must be rendered exactly once");
+  assert.equal(rendered.includes(ids[0]), true, "first entry must stay reachable");
+  assert.equal(rendered.includes(ids[19]), true, "middle entry must stay reachable");
+  assert.equal(rendered.includes(ids[39]), true, "last entry must stay reachable");
+});
+
+test("Issue 307: search reaches a late entry by username and by display name", () => {
+  const { buildSlotTechnicianList } = loadSlotTechnicianListApi();
+  const ids = Array.from({ length: 40 }, (_, i) => `tech${String(i + 1).padStart(2, "0")}`);
+  const display = (u) => (u === "tech40" ? "สมชาย ปลายคิว" : `ช่าง ${u.slice(4)}`);
+
+  const byUsername = buildSlotTechnicianList(ids, "tech40", display);
+  assert.equal(byUsername.total, 40, "total must always report the full available count");
+  assert.equal(byUsername.items.map((t) => t.username).join(","), "tech40");
+
+  const byName = buildSlotTechnicianList(ids, "ปลายคิว", display);
+  assert.equal(byName.items.map((t) => t.username).join(","), "tech40");
+
+  const noMatch = buildSlotTechnicianList(ids, "ไม่มีคนนี้", display);
+  assert.equal(noMatch.items.length, 0);
+  assert.equal(noMatch.total, 40);
+});
+
+test("Issue 307: duplicate or blank ids are normalised without hiding a real technician", () => {
+  const { buildSlotTechnicianList } = loadSlotTechnicianListApi();
+  const result = buildSlotTechnicianList(["a", " a ", "", null, "b", "c"], "", (u) => u);
+  assert.equal(result.items.map((t) => t.username).join(","), "a,b,c");
+  assert.equal(result.total, 3);
+});
+
+test("Issue 307: no hidden slice caps remain in the technician renderers", () => {
+  const teamPicker = sliceFunction(js, "function renderTeamPicker(", "function getTeamListForAssign(");
+  assert.doesNotMatch(teamPicker, /\.slice\(\s*0\s*,\s*\d+\s*\)/, "renderTeamPicker must not cap suggestions");
+  assert.match(teamPicker, /suggestions\.length === selectable\.length/, "the UI must state when a search is hiding entries");
+  assert.match(teamPicker, /name\.includes\(q\)/, "team search must also match the display name");
+
+  const slotModal = sliceFunction(js, "function openSlotModal(", "function bindMachineCountStepper(");
+  assert.doesNotMatch(slotModal, /\.slice\(\s*0\s*,\s*\d+\s*\)/, "the slot picker must not cap the technician list");
+  assert.match(slotModal, /buildSlotTechnicianList\(ids, techQuery, techDisplay\)/);
+  assert.match(slotModal, /buildSlotTechnicianList\(ids, '', techDisplay\)/);
+  assert.match(slotModal, /ช่างที่ว่างในสล็อตนี้ทั้งหมด \$\{result\.total\} คน \(แสดงครบทุกคน\)/);
+  assert.match(slotModal, /รายชื่อนี้คือช่างที่ว่างจริงในสล็อตนี้เท่านั้น/);
+});
+
+// ---------------------------------------------------------------------------
+// 3) Selection / payload integrity
+// ---------------------------------------------------------------------------
+
+test("Issue 307: the slot picker keeps the authoritative selection fields in sync", () => {
+  const slotModal = sliceFunction(js, "function openSlotModal(", "function bindMachineCountStepper(");
+
+  // auto: picking a technician is authoritative and confirms immediately.
+  assert.match(slotModal, /state\.confirmed_tech_username = v;\s*\n\s*state\.confirmed_tech_label = techDisplay\(v\);/);
+  // single: picking is NOT a confirmation - the admin must press ยืนยัน.
+  assert.match(slotModal, /state\.confirmed_tech_username = '';\s*\n\s*state\.confirmed_tech_label = '';\s*\n\s*const warn = body\.querySelector\('#slotm_single_warn'\)/);
+  // team: picking clears the single-technician fields and rewrites the CSV payload.
+  assert.match(slotModal, /state\.teamPicker\.selected = new Set\(Array\.from\(selected\)\);/);
+  assert.match(slotModal, /getTeamMembersForPayload\(\);/);
+  // the confirm button remains the only place that promotes auto -> single.
+  assert.match(slotModal, /switchAssignModeToSingleForManualTech\(\);/);
+  // the visible list drives the same hidden <select> the confirm handler reads.
+  assert.match(slotModal, /selEl\.dispatchEvent\(new Event\('change'\)\)/);
+  assert.match(slotModal, /const sel = body\.querySelector\('#slotm_single'\);/);
+});
+
+test("Issue 307: changing time or slot still clears a technician who is not free there", () => {
+  const selectSlot = sliceFunction(js, "function selectSlot(", "// =============================\n// Slot Quick Pick Modal");
+  assert.match(selectSlot, /if\(u && !ids\.includes\(u\)\)/);
+  assert.match(selectSlot, /สล็อตนี้ไม่มีช่างที่เลือก/);
+  assert.match(selectSlot, /const bad = team\.filter\(u=>u && !ids\.includes\(u\)\)/);
+  assert.match(selectSlot, /สล็อตนี้ไม่ว่างครบทีม/);
+  // The modal re-runs selectSlot for the picked start time before rendering.
+  const slotModal = sliceFunction(js, "function openSlotModal(", "function bindMachineCountStepper(");
+  assert.match(slotModal, /try\{ selectSlot\(picked, slot\); \}catch\(e\)\{\}/);
+  assert.match(slotModal, /try\{ selectSlot\(v, slot\); \}catch\(e\)\{\}/);
+});
+
+test("Issue 307: availability inputs and eligibility rules are untouched", () => {
+  // The renderer still consumes exactly what the API returned for the slot.
+  assert.match(js, /const ids = Array\.isArray\(slot\?\.available_tech_ids\) \? slot\.available_tech_ids : \[\]/);
+  // The availability request itself is byte-for-byte the same contract as before.
+  const loadAvailability = sliceFunction(js, "async function loadAvailability(", "function getConstraintTechs(");
+  assert.match(loadAvailability, /qs\.set\('forced','1'\)/);
+  assert.match(loadAvailability, /qs\.set\('aggregate','1'\)/);
+  assert.match(loadAvailability, /\/admin\/availability_by_tech_v2\?\$\{qs\.toString\(\)\}/);
+  assert.match(loadAvailability, /const forced = true;/);
+});
+
+// ---------------------------------------------------------------------------
+// 4) Mobile-safe bottom sheet
+// ---------------------------------------------------------------------------
+
+test("Issue 307: the slot sheet is a viewport-bounded flex column with a scrolling body", () => {
+  const style = html.slice(html.indexOf("<style>"), html.indexOf("</style>"));
+
+  assert.match(style, /#slot_modal_overlay \.team-sheet\.slot-sheet\{[\s\S]*?display:flex/);
+  assert.match(style, /#slot_modal_overlay \.team-sheet\.slot-sheet\{[\s\S]*?flex-direction:column/);
+  // dvh for real Android viewports, with a vh fallback declared first.
+  assert.match(style, /max-height:88vh;[\s\S]*?max-height:88dvh;/);
+  assert.match(style, /padding-bottom:calc\(16px \+ env\(safe-area-inset-bottom\)\)/);
+
+  assert.match(style, /#slot_modal_overlay #slot_modal_body\{[\s\S]*?overflow-y:auto/);
+  assert.match(style, /#slot_modal_overlay #slot_modal_body\{[\s\S]*?min-height:0/);
+  assert.match(style, /#slot_modal_overlay #slot_modal_body\{[\s\S]*?-webkit-overflow-scrolling:touch/);
+  assert.match(style, /#slot_modal_overlay #slot_modal_body\{[\s\S]*?overscroll-behavior:contain/);
+
+  // header and footer must not scroll away
+  assert.match(style, /#slot_modal_overlay \.slot-sheet-head\{flex:0 0 auto\}/);
+  assert.match(style, /#slot_modal_overlay \.slot-sheet \.sheet-actions\{[\s\S]*?flex:0 0 auto/);
+
+  // the broad `.team-sheet button{width:100%}` rule must not stretch technician chips
+  assert.match(style, /#slot_modal_overlay \.slot-sheet \.slot-tech-list button\{[\s\S]*?width:auto/);
+  // 16px keeps iOS/Android from zooming the page when the search field is focused
+  assert.match(style, /\.slot-tech-search\{[\s\S]*?font-size:16px/);
+});
+
+test("Issue 307: the slot modal markup has a fixed head, a scroll body and reachable actions", () => {
+  const modal = html.slice(html.indexOf('id="slot_modal_overlay"'), html.indexOf('id="slot_modal_overlay"') + 900);
+  assert.match(modal, /class="team-sheet slot-sheet"/);
+  assert.match(modal, /<div class="slot-sheet-head">[\s\S]*?id="slot_modal_title"[\s\S]*?id="slot_modal_sub"[\s\S]*?<\/div>/);
+  assert.match(modal, /<div id="slot_modal_body"><\/div>/);
+  assert.match(modal, /<div class="sheet-actions">[\s\S]*?id="slot_modal_confirm"[\s\S]*?id="slot_modal_close"/);
+  assert.match(modal, /aria-labelledby="slot_modal_title"/);
+});
+
+test("Issue 307: the scoped CSS cannot regress other pages' team sheets", () => {
+  const style = html.slice(html.indexOf("<style>"), html.indexOf("</style>"));
+  const slotRules = style.split("\n").filter((line) => line.trim().startsWith("#slot_modal_overlay"));
+  assert.equal(slotRules.length > 0, true);
+  // Every slot-sheet rule is scoped to this page's modal id; nothing bare-selects .team-sheet.
+  for (const line of slotRules) {
+    assert.match(line.trim(), /^#slot_modal_overlay\b/);
+  }
+  const css = fs.readFileSync(path.join(ROOT, "style.css"), "utf8");
+  assert.match(css, /\.team-sheet\{/, "shared style.css team-sheet base rule is left alone");
+});
+
+test("Issue 307: the in-slot search box exists for both single and team assignment", () => {
+  const slotModal = sliceFunction(js, "function openSlotModal(", "function bindMachineCountStepper(");
+  assert.match(slotModal, /id="slotm_tech_search"/);
+  assert.match(slotModal, /placeholder="ค้นหาช่าง \(ชื่อ หรือ ชื่อผู้ใช้\)"/);
+  assert.match(slotModal, /pickerShell\('team'\)/);
+  assert.match(slotModal, /pickerShell\('auto'\)/);
+  assert.match(slotModal, /pickerShell\('single'\)/);
+  // Typing only repaints the list, so the mobile keyboard never loses the field.
+  // The handler body is asserted exactly: a full renderBody() here would blow the
+  // search box (and the caret) away on every keystroke and strand the last entries.
+  const inputHandler = slotModal.match(/searchEl\.addEventListener\('input', \(\)=>\{([\s\S]*?)\n {6}\}\);/);
+  assert.notEqual(inputHandler, null, "the in-slot search box must have an input handler");
+  assert.match(inputHandler[1], /techQuery = searchEl\.value \|\| '';/);
+  assert.match(inputHandler[1], /renderTechList\(\);/);
+  assert.doesNotMatch(inputHandler[1], /renderBody\(\)/);
+  // Picking a technician also repaints the list only - never the whole body.
+  const pickHandler = sliceFunction(slotModal, "const pickTech = (username)=>{", "const bindTechSearch = ()=>{");
+  assert.doesNotMatch(pickHandler, /renderBody\(\)/);
+  assert.match(pickHandler, /renderTechList\(\);/);
+  // the main-form team picker has a search box and a live count too
+  assert.match(html, /id="team_search"[^>]*placeholder="ค้นหาช่างร่วม \(ชื่อ หรือ ชื่อผู้ใช้\)\.\.\."/);
+  assert.match(html, /id="team_suggest_count"/);
+});
+
+// ---------------------------------------------------------------------------
+// 5) Cache-bust contract
+// ---------------------------------------------------------------------------
+
+test("Issue 307: admin-add-v2.js ships a new cache-busting build id", () => {
+  assert.match(html, /admin-add-v2\.js\?v=20260820_issue307_admin_add_thai_slot_v1/);
+  assert.doesNotMatch(html, /admin-add-v2\.js\?v=20260809_issue267_catalog_flow_v9/);
+});

--- a/test/adminServicePackageBooking.test.js
+++ b/test/adminServicePackageBooking.test.js
@@ -65,7 +65,8 @@ test("Admin package UI sends stable keys and canonical availability inputs witho
   assert.match(js, /payload\.service_package_key/);
   assert.match(js, /delete payload\.services/);
   assert.match(js, /payload\.promotion_id = null/);
-  assert.match(js, /Selected date is after the package redemption deadline/);
+  // Issue 307: the Admin Add Job UI is Thai-only; the guard itself is unchanged.
+  assert.match(js, /วันที่เลือกเลยกำหนดใช้สิทธิ์ของแพ็กเกจแล้ว/);
 });
 
 test("Admin package tier changes invalidate stale preview authority until the matching preview succeeds", () => {

--- a/test/adminStorePromotionBookingUi.test.js
+++ b/test/adminStorePromotionBookingUi.test.js
@@ -43,8 +43,9 @@ test("Admin Add Job selects Store parents, quotes arbitrary mixed groups and ret
   assert.match(js, /state\.exact_total \|\| fmtMoney/);
 });
 
-test("Admin Add Job runtime uses the deploy-safe Issue 267 v9 asset URL", () => {
-  assert.match(html, /admin-add-v2\.js\?v=20260809_issue267_catalog_flow_v9/);
+test("Admin Add Job runtime uses the deploy-safe Issue 307 asset URL", () => {
+  assert.match(html, /admin-add-v2\.js\?v=20260820_issue307_admin_add_thai_slot_v1/);
+  assert.doesNotMatch(html, /admin-add-v2\.js\?v=20260809_issue267_catalog_flow_v9/);
   assert.doesNotMatch(html, /admin-add-v2\.js\?v=20260809_issue267_catalog_flow_v2/);
 });
 

--- a/test/customerBookingPendingApproval.test.js
+++ b/test/customerBookingPendingApproval.test.js
@@ -128,7 +128,7 @@ test("Admin Add and Queue no longer call public forced availability", () => {
 });
 
 test("changed Admin booking scripts have one shared cache-bust build", () => {
-  assert.match(read("admin-add-v2.html"), /admin-add-v2\.js\?v=20260809_issue267_catalog_flow_v9/);
+  assert.match(read("admin-add-v2.html"), /admin-add-v2\.js\?v=20260820_issue307_admin_add_thai_slot_v1/);
   assert.match(read("admin-queue-v2.html"), /admin-queue-v2\.js\?v=20260719_customer_booking_pr3_v1/);
   assert.match(read("admin-review-v2.html"), /admin-review-service-editor\.js\?v=20260819_admin_structured_services_v1/);
   assert.match(read("admin-review-v2.html"), /admin-review-v2\.js\?v=20260819_admin_structured_services_v1/);

--- a/test/jobLocationRoundtrip.test.js
+++ b/test/jobLocationRoundtrip.test.js
@@ -216,7 +216,7 @@ test("Test 14: check-in 500 m + accuracy policy is unchanged", () => {
 
 test("Test 15: PWA + admin cache build IDs are bumped consistently", () => {
   const BUILD = "20260712_job_location_roundtrip_v1";
-  const ADMIN_ADD_BUILD = "20260809_issue267_catalog_flow_v9";
+  const ADMIN_ADD_BUILD = "20260820_issue307_admin_add_thai_slot_v1";
   const URGENT_REVIEW_BUILD = "20260726_urgent_preferred_time_gps_v1";
   assert.match(read("app.js"), new RegExp(`__CWF_TECH_APP_VERSION__ = "${BUILD}"`));
   assert.match(read("sw.js"), new RegExp(`CWF_TECH_BUILD_ID = "${BUILD}"`));


### PR DESCRIPTION
Manual replacement for the failed `CWF Home Release Promotion` automation after PR #308 was merged to `main`.

## Source

- Implementation Issue: #307
- Merged implementation PR: #308
- Main merge commit: `f3d07b0e4ffb231c742a236cc1904eed755e228c`
- Target: `staging/home-server-test`
- Staging head before promotion: `c48390231009dbe959baa70fc9cb528fdd8699e8`

## Scope

This promotion contains the reviewed seven-file Admin Add Job change only:

- Translate Admin Add Job user-facing interface text to Thai.
- Make the selected-slot technician modal viewport-bounded and internally scrollable on mobile.
- Add Thai technician search for auto/single/team assignment.
- Remove the silent 30-technician UI cap while preserving server availability rules.
- Preserve stable booking/dispatch values, selection payloads, pricing, backend scheduling rules and DB state.
- Add focused Issue #307 regressions and synchronized Admin Add cache-bust assertions.

No backend availability policy, database, migration, auth, pricing, customer app, technician app or shared `style.css` change is included.

## Review evidence

- Controller reviewed the exact PR #308 diff and scope before merge.
- Issue #307 focused regression: 16/16 passed.
- Full branch suite added 16 passing tests with no branch-only regression; the one full-suite failure reproduced on the base and is unrelated to this change.
- Mobile QA was reported at 360×640 and 390×844 with 40 available technicians.
- Current `staging...main` file comparison contains only the seven reviewed paths.

## Gate

This PR is intentionally Draft.

Merging this PR is the Staging deployment event. Do not merge until the owner explicitly approves Staging deployment. After deployment, verify `test-app.cwf-air.com` with:

1. automatic technician assignment,
2. single technician assignment using ช่างอาร์ม,
3. team assignment,
4. urgent/offer flow.

No Production promotion or deployment is authorized by this PR.