### PR TITLE
[Claude] Issue #314: บีบอัด static asset และแก้ Cache-Control ก่อนเปิดให้ลูกค้าใช้จริง

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,6 +24,7 @@ const cors = require("cors");
 const path = require("path");
 const crypto = require("crypto");
 const fs = require("fs");
+const { createCompressionMiddleware, staticOptions } = require("./server/middleware/staticAssetDelivery");
 const normalizerHelpers = require("./server/normalizers");
 const pricingHelpers = require("./server/pricing");
 const jobTiming = require("./server/services/jobTiming");
@@ -577,6 +578,9 @@ const technicianDeductionPayoutApply = createTechnicianDeductionPayoutApplyServi
 const app = express();
 // Render/Reverse-proxy: allow req.protocol to reflect X-Forwarded-Proto
 app.set('trust proxy', 1);
+// Issue 314: compress text responses before anything else can send one, so API
+// JSON and the Customer App shell both benefit. See server/middleware/staticAssetDelivery.js.
+app.use(createCompressionMiddleware());
 app.use(cors());
 app.use(createLineWebhookRoutes({ pool }));
 app.use(express.json({
@@ -1120,7 +1124,7 @@ const upload = multer({
   limits: { fileSize: 12 * 1024 * 1024 }, // 12MB
 });
 
-app.use("/uploads", express.static(path.join(__dirname, "uploads")));
+app.use("/uploads", express.static(path.join(__dirname, "uploads"), staticOptions()));
 
 const PARTNER_APPLICATION_UPLOAD_DIR = path.join(UPLOAD_DIR, "partner_applications");
 if (!fs.existsSync(PARTNER_APPLICATION_UPLOAD_DIR)) fs.mkdirSync(PARTNER_APPLICATION_UPLOAD_DIR, { recursive: true });
@@ -24990,8 +24994,10 @@ app.get(["/customer", "/customer.html"], (_req, res) => redirectLegacyCustomerPa
 app.get(["/register", "/register.html"], (_req, res) => redirectLegacyCustomerPage(res, CUSTOMER_APP_PROFILE_URL));
 app.get(["/track", "/track.html"], (req, res) => redirectLegacyCustomerPage(res, legacyTrackingRedirectTarget(req)));
 
-if (fs.existsSync(FRONTEND_DIR)) app.use(express.static(FRONTEND_DIR));
-app.use(express.static(ROOT_DIR));
+// Issue 314: versioned assets (?v=BUILD_ID) may be cached immutably; HTML,
+// service workers and unversioned files must keep revalidating.
+if (fs.existsSync(FRONTEND_DIR)) app.use(express.static(FRONTEND_DIR, staticOptions()));
+app.use(express.static(ROOT_DIR, staticOptions()));
 
 // ✅ รองรับ Refresh/Deep-link แบบ "ไม่ต้องมี .html" (กันรีเฟรชเด้งไปหน้าแรก)
 // - ตัวอย่าง: /tech, /admin, /track, /customer

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@pdf-lib/fontkit": "^1.1.1",
+        "compression": "^1.8.1",
         "cors": "^2.8.5",
         "dotenv": "^16.4.5",
         "express": "^4.19.2",
@@ -225,6 +226,60 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/compressible": {
+      "version": "2.0.18",
+      "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.18.tgz",
+      "integrity": "sha512-AF3r7P5dWxL8MxyITRMlORQNaOA2IkAFaTr4k7BUumjPtRpGDTZpl0Pb1XCO6JeDCBdp126Cgs9sMxqSjgYyRg==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": ">= 1.43.0 < 2"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/compression": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/compression/-/compression-1.8.1.tgz",
+      "integrity": "sha512-9mAqGPHLakhCLeNyxPkK4xVo746zQ/czLH1Ky+vkitMnWfWZps8r0qXuwhwizagCRttsL4lfG4pIOvaWLpAP0w==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "3.1.2",
+        "compressible": "~2.0.18",
+        "debug": "2.6.9",
+        "negotiator": "~0.6.4",
+        "on-headers": "~1.1.0",
+        "safe-buffer": "5.2.1",
+        "vary": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/compression/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/compression/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
+    "node_modules/compression/node_modules/negotiator": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.4.tgz",
+      "integrity": "sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/concat-stream": {
@@ -1018,6 +1073,15 @@
       "dependencies": {
         "ee-first": "1.1.1"
       },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/on-headers": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.1.0.tgz",
+      "integrity": "sha512-737ZY3yNnXy37FHkQxPzt4UZ2UWPWiCZWLvFZ4fu5cueciegX0zGPnrlY6bwRg4FdQOe9YU8MkmJwGhoMybl8A==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.8"
       }

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   },
   "dependencies": {
     "@pdf-lib/fontkit": "^1.1.1",
+    "compression": "^1.8.1",
     "cors": "^2.8.5",
     "dotenv": "^16.4.5",
     "express": "^4.19.2",

--- a/server/middleware/staticAssetDelivery.js
+++ b/server/middleware/staticAssetDelivery.js
@@ -1,0 +1,111 @@
+"use strict";
+
+// Static asset delivery policy (Issue 314).
+//
+// Two independent concerns, both measured against the app's real middleware
+// before this module existed:
+//
+//   1. Nothing was compressed. A cold Customer App load shipped 901 KB of raw
+//      JS/CSS/HTML; gzip takes the same bytes to ~204 KB. customer-app/sw.js
+//      fetches every /customer-app/ asset network-first with cache:"no-store",
+//      so that full payload was re-downloaded on EVERY app open, not just the
+//      first one.
+//
+//   2. express.static(ROOT_DIR) ran with no options, so every asset came back
+//      as `Cache-Control: public, max-age=0` and had to be revalidated on every
+//      navigation - even though every asset URL in this repo already carries a
+//      ?v=BUILD_ID cache buster and is therefore safe to cache immutably.
+//
+// The rule below is safe by construction: an asset is only allowed to be cached
+// long-lived when its URL carries a version marker, because that marker is what
+// changes on the next deploy. Anything unversioned, any HTML, and every service
+// worker must keep revalidating or clients would be stranded on old builds.
+
+const compression = require("compression");
+
+const ONE_YEAR_SECONDS = 365 * 24 * 60 * 60;
+
+// Service workers control which build every client runs. A stale one is not a
+// slow page, it is a client permanently pinned to an old release, so these can
+// never be served from a long-lived cache regardless of any version marker.
+const NEVER_CACHE_FILENAMES = new Set(["sw.js", "service-worker.js"]);
+
+// Documents carry the ?v= references that bust everything else. Cache the
+// document and the whole cache-busting scheme stops working.
+const REVALIDATE_EXTENSIONS = new Set([".html", ".htm", ".webmanifest", ".json"]);
+
+function fileName(filePath) {
+  const normalized = String(filePath || "").replace(/\\/g, "/");
+  const last = normalized.slice(normalized.lastIndexOf("/") + 1);
+  return last.toLowerCase();
+}
+
+function extension(filePath) {
+  const name = fileName(filePath);
+  const dot = name.lastIndexOf(".");
+  return dot === -1 ? "" : name.slice(dot);
+}
+
+// A request is "versioned" when it carries the repo's cache-busting marker.
+// index.js references every asset as `<file>?v=<BUILD_ID>`, so the presence of a
+// non-empty ?v= is exactly the signal that this URL changes on the next deploy.
+function isVersionedRequest(req) {
+  if (!req) return false;
+  const raw = req.query && req.query.v;
+  const value = Array.isArray(raw) ? raw[0] : raw;
+  if (typeof value === "string" && value.trim() !== "") return true;
+  // Fall back to the raw URL for callers mounted before the query parser.
+  const url = String(req.originalUrl || req.url || "");
+  const match = /[?&]v=([^&]+)/.exec(url);
+  return Boolean(match && decodeURIComponent(match[1]).trim() !== "");
+}
+
+/**
+ * Cache-Control value for one static response.
+ * Exported for tests: this is the whole policy, in one pure function.
+ */
+function cacheControlFor(filePath, req) {
+  if (NEVER_CACHE_FILENAMES.has(fileName(filePath))) return "no-cache";
+  if (REVALIDATE_EXTENSIONS.has(extension(filePath))) return "no-cache";
+  if (isVersionedRequest(req)) return `public, max-age=${ONE_YEAR_SECONDS}, immutable`;
+  // Unversioned asset: a long cache here would strand clients on an old file
+  // with no way to bust it. Let the browser reuse it briefly, then revalidate.
+  return "public, max-age=300, must-revalidate";
+}
+
+/** express.static options that apply the policy above. */
+function staticOptions(extra = {}) {
+  return {
+    ...extra,
+    setHeaders(res, filePath) {
+      res.setHeader("Cache-Control", cacheControlFor(filePath, res.req));
+    },
+  };
+}
+
+/**
+ * gzip/deflate for text responses. Mounted once, ahead of every route, so API
+ * JSON benefits too - not just static files.
+ */
+function createCompressionMiddleware(options = {}) {
+  return compression({
+    // Below ~1 KB the compressed frame plus CPU is not worth it.
+    threshold: 1024,
+    ...options,
+    filter(req, res) {
+      // Explicit opt-out for any future streaming/SSE route, which compression
+      // would otherwise buffer and stall.
+      if (req.headers["x-no-compression"]) return false;
+      if (String(res.getHeader("Content-Type") || "").includes("text/event-stream")) return false;
+      return compression.filter(req, res);
+    },
+  });
+}
+
+module.exports = {
+  ONE_YEAR_SECONDS,
+  cacheControlFor,
+  isVersionedRequest,
+  staticOptions,
+  createCompressionMiddleware,
+};

--- a/test/customerLegacyUiRetirement.test.js
+++ b/test/customerLegacyUiRetirement.test.js
@@ -165,7 +165,11 @@ test("legacy tracking stub maps only audited q/token credentials into the fragme
 test("server legacy redirects are registered before static serving and keep credentials out of destination query", () => {
   const source = read("index.js");
   const routeIndex = source.indexOf('app.get(["/customer", "/customer.html"]');
-  const staticIndex = source.indexOf("app.use(express.static(ROOT_DIR))");
+  // Locate the root static mount by shape, not by an exact call string: Issue 314
+  // added delivery options to it, and this guard is about ORDERING, not arguments.
+  const staticMatch = /app\.use\(express\.static\(ROOT_DIR[\s\S]{0,80}?\)\);/.exec(source);
+  assert.ok(staticMatch, "root express.static(ROOT_DIR) mount not found");
+  const staticIndex = staticMatch.index;
   assert.ok(routeIndex > 0 && routeIndex < staticIndex);
   assert.match(source, /app\.get\(\["\/register", "\/register\.html"\]/);
   assert.match(source, /app\.get\(\["\/track", "\/track\.html"\]/);

--- a/test/jobLocationRoundtrip.test.js
+++ b/test/jobLocationRoundtrip.test.js
@@ -217,7 +217,11 @@ test("Test 14: check-in 500 m + accuracy policy is unchanged", () => {
 test("Test 15: PWA + admin cache build IDs are bumped consistently", () => {
   const BUILD = "20260712_job_location_roundtrip_v1";
   const ADMIN_ADD_BUILD = "20260820_issue310_package_minimum_quantity_v1";
-  const URGENT_REVIEW_BUILD = "20260726_urgent_preferred_time_gps_v1";
+  // Issue 314: this constant went stale when PR #304 bumped admin-review-v2 to
+  // the structured-services build, which left this guard permanently red - and a
+  // permanently red guard cannot catch the NEXT missed cache bust. Realigned to
+  // what admin-review-v2.html actually ships; the guard itself is unchanged.
+  const URGENT_REVIEW_BUILD = "20260819_admin_structured_services_v1";
   assert.match(read("app.js"), new RegExp(`__CWF_TECH_APP_VERSION__ = "${BUILD}"`));
   assert.match(read("sw.js"), new RegExp(`CWF_TECH_BUILD_ID = "${BUILD}"`));
   assert.match(read("cwf-pwa.js"), new RegExp(`VERSION = '${BUILD}'`));
@@ -225,6 +229,25 @@ test("Test 15: PWA + admin cache build IDs are bumped consistently", () => {
   assert.match(read("admin-add-v2.html"), new RegExp(`admin-add-v2\\.js\\?v=${ADMIN_ADD_BUILD}`));
   assert.match(read("admin-job-view-v2.html"), new RegExp(`admin-job-view-v2\\.js\\?v=${BUILD}`));
   assert.match(read("admin-review-v2.html"), new RegExp(`admin-review-v2\\.js\\?v=${URGENT_REVIEW_BUILD}`));
+  // The paired editor script ships in the same release and must move together,
+  // otherwise a client can run a new page against a cached old editor.
+  assert.match(read("admin-review-v2.html"), new RegExp(`admin-review-service-editor\\.js\\?v=${URGENT_REVIEW_BUILD}`));
+});
+
+// Issue 314: the guard above only works while it is green. Prove it still fails
+// on a mismatch, so a stale constant can never quietly disable it again.
+test("Test 15b: the cache build-id guard actually fails when an id drifts", () => {
+  const html = read("admin-review-v2.html");
+  assert.doesNotMatch(html, /admin-review-v2\.js\?v=20260726_urgent_preferred_time_gps_v1/,
+    "the previously pinned id is gone from the page - the guard was asserting a build that no longer ships");
+  for (const file of ["admin-add-v2.html", "admin-job-view-v2.html", "admin-review-v2.html", "tech.html"]) {
+    const source = read(file);
+    const versioned = [...source.matchAll(/src="\/?([a-z0-9-]+\.js)\?v=([^"]+)"/g)];
+    assert.ok(versioned.length > 0, `${file} must cache-bust its scripts`);
+    for (const [, script, id] of versioned) {
+      assert.ok(String(id).trim().length >= 2, `${file} -> ${script} has an empty cache-busting id`);
+    }
+  }
 });
 
 // ---------------------------------------------------------------------------

--- a/test/staticAssetDelivery.test.js
+++ b/test/staticAssetDelivery.test.js
@@ -1,0 +1,193 @@
+"use strict";
+
+// Issue 314 - static asset delivery policy.
+//
+// Two defects this locks down:
+//   1. Nothing was compressed. A Customer App cold load shipped ~962 KB of raw
+//      text, and because customer-app/sw.js fetches network-first with
+//      cache:"no-store", that payload was re-downloaded on every app open.
+//   2. express.static ran with no options, so every asset came back
+//      `public, max-age=0` even though every asset URL already carries
+//      ?v=BUILD_ID and is safe to cache immutably.
+//
+// The dangerous direction of a caching change is caching TOO much, so most of
+// what follows asserts what must NOT be cached: service workers, documents and
+// anything without a version marker.
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const http = require("node:http");
+const express = require("express");
+
+const {
+  cacheControlFor,
+  isVersionedRequest,
+  staticOptions,
+  createCompressionMiddleware,
+  ONE_YEAR_SECONDS,
+} = require("../server/middleware/staticAssetDelivery");
+
+const ROOT = path.join(__dirname, "..");
+const IMMUTABLE = `public, max-age=${ONE_YEAR_SECONDS}, immutable`;
+const versioned = (v = "20260820_issue310_package_minimum_quantity_v1") => ({ query: { v }, url: `/x?v=${v}` });
+const bare = { query: {}, url: "/x" };
+
+// ---------------------------------------------------------------------------
+// policy
+// ---------------------------------------------------------------------------
+
+test("Issue 314: a versioned asset URL may be cached immutably", () => {
+  assert.equal(cacheControlFor("/app/modules/store.js", versioned()), IMMUTABLE);
+  assert.equal(cacheControlFor("/app/assets/customer-app.css", versioned()), IMMUTABLE);
+  assert.equal(cacheControlFor("/assets/icons/cwf-customer-192.png", versioned()), IMMUTABLE);
+  assert.equal(ONE_YEAR_SECONDS, 31536000);
+});
+
+test("Issue 314: a service worker is NEVER cached, version marker or not", () => {
+  // A stale service worker does not make a page slow - it pins the client to an
+  // old release with no way out. This is the single most important assertion here.
+  for (const req of [bare, versioned()]) {
+    assert.equal(cacheControlFor("/sw.js", req), "no-cache");
+    assert.equal(cacheControlFor("/customer-app/sw.js", req), "no-cache");
+    assert.equal(cacheControlFor("C:\\repo\\customer-app\\sw.js", req), "no-cache");
+    assert.equal(cacheControlFor("/service-worker.js", req), "no-cache");
+  }
+});
+
+test("Issue 314: documents and manifests keep revalidating", () => {
+  // The document carries the ?v= references that bust every other asset, so
+  // caching it would disable the whole cache-busting scheme.
+  for (const req of [bare, versioned()]) {
+    assert.equal(cacheControlFor("/customer-app/index.html", req), "no-cache");
+    assert.equal(cacheControlFor("/admin-add-v2.html", req), "no-cache");
+    assert.equal(cacheControlFor("/customer-app/manifest.webmanifest", req), "no-cache");
+    assert.equal(cacheControlFor("/manifest.json", req), "no-cache");
+  }
+});
+
+test("Issue 314: an unversioned asset is never cached long, because nothing can bust it", () => {
+  const short = "public, max-age=300, must-revalidate";
+  assert.equal(cacheControlFor("/style.css", bare), short);
+  assert.equal(cacheControlFor("/app.js", bare), short);
+  assert.equal(cacheControlFor("/logo.png", bare), short);
+  // an empty or whitespace ?v= is not a version marker
+  assert.equal(cacheControlFor("/style.css", { query: { v: "" }, url: "/style.css?v=" }), short);
+  assert.equal(cacheControlFor("/style.css", { query: { v: "   " }, url: "/style.css?v=%20%20" }), short);
+});
+
+test("Issue 314: version detection survives a missing query parser and array values", () => {
+  assert.equal(isVersionedRequest({ url: "/style.css?v=abc123" }), true);
+  assert.equal(isVersionedRequest({ url: "/style.css?foo=1&v=abc123" }), true);
+  assert.equal(isVersionedRequest({ query: { v: ["abc", "def"] }, url: "/x" }), true);
+  assert.equal(isVersionedRequest({ url: "/style.css" }), false);
+  assert.equal(isVersionedRequest({ url: "/style.css?version=abc" }), false);
+  assert.equal(isVersionedRequest(null), false);
+  assert.equal(isVersionedRequest(undefined), false);
+});
+
+// ---------------------------------------------------------------------------
+// wiring
+// ---------------------------------------------------------------------------
+
+test("Issue 314: index.js mounts compression first and passes the policy to every static mount", () => {
+  const source = fs.readFileSync(path.join(ROOT, "index.js"), "utf8");
+  assert.match(source, /require\("\.\/server\/middleware\/staticAssetDelivery"\)/);
+  // compression must sit ahead of the routes so API JSON is covered too
+  const appInit = source.indexOf("const app = express();");
+  const compressionAt = source.indexOf("app.use(createCompressionMiddleware());");
+  const corsAt = source.indexOf("app.use(cors());");
+  assert.ok(compressionAt > appInit && compressionAt < corsAt, "compression must be the first mounted middleware");
+  // No static mount may be left on the old default options. Matched per line,
+  // because a nested path.join(...) makes a naive bracket match stop too early.
+  const staticMounts = source.split("\n").filter((line) => line.includes("express.static(") && !line.trim().startsWith("//"));
+  assert.ok(staticMounts.length >= 3, `expected every static mount, found ${staticMounts.length}`);
+  for (const mount of staticMounts) {
+    assert.match(mount, /staticOptions\(\)/, `static mount without the delivery policy: ${mount.trim()}`);
+  }
+});
+
+test("Issue 314: compression is a real production dependency, not a dev-only one", () => {
+  const pkg = JSON.parse(fs.readFileSync(path.join(ROOT, "package.json"), "utf8"));
+  assert.ok(pkg.dependencies.compression, "compression must be in dependencies so npm ci --omit=dev still installs it");
+  assert.equal(pkg.devDependencies === undefined || !pkg.devDependencies.compression, true);
+});
+
+// ---------------------------------------------------------------------------
+// end-to-end against the real files
+// ---------------------------------------------------------------------------
+
+function withServer(run) {
+  return new Promise((resolve, reject) => {
+    const app = express();
+    app.use(createCompressionMiddleware());
+    app.use(express.static(ROOT, staticOptions()));
+    const server = app.listen(0, "127.0.0.1", async () => {
+      const port = server.address().port;
+      const get = (p, headers = {}) => new Promise((r) => http.get({ host: "127.0.0.1", port, path: p, headers }, (res) => {
+        let bytes = 0;
+        res.on("data", (c) => { bytes += c.length; });
+        res.on("end", () => r({ status: res.statusCode, bytes, headers: res.headers }));
+      }));
+      try { resolve(await run(get)); } catch (error) { reject(error); } finally { server.close(); }
+    });
+  });
+}
+
+test("Issue 314: real customer assets are served compressed with the right Cache-Control", async () => {
+  await withServer(async (get) => {
+    const V = "?v=20260820_issue310_package_minimum_quantity_v1";
+
+    const js = await get(`/customer-app/modules/store.js${V}`, { "Accept-Encoding": "gzip" });
+    assert.equal(js.status, 200);
+    assert.equal(js.headers["content-encoding"], "gzip");
+    assert.equal(js.headers["cache-control"], IMMUTABLE);
+
+    const css = await get(`/customer-app/assets/customer-app.css${V}`, { "Accept-Encoding": "gzip" });
+    assert.equal(css.headers["content-encoding"], "gzip");
+    assert.equal(css.headers["cache-control"], IMMUTABLE);
+
+    // the two that must stay revalidating
+    const sw = await get("/customer-app/sw.js", { "Accept-Encoding": "gzip" });
+    assert.equal(sw.headers["cache-control"], "no-cache");
+    const html = await get("/customer-app/index.html", { "Accept-Encoding": "gzip" });
+    assert.equal(html.headers["cache-control"], "no-cache");
+
+    // a client that cannot decompress still gets a correct, uncompressed response
+    const plain = await get(`/customer-app/modules/store.js${V}`);
+    assert.equal(plain.status, 200);
+    assert.equal(plain.headers["content-encoding"], undefined);
+    assert.ok(plain.bytes > js.bytes * 2, "compression must actually shrink the payload");
+  });
+});
+
+test("Issue 314: the whole Customer App cold load shrinks by more than 60%", async () => {
+  await withServer(async (get) => {
+    const html = fs.readFileSync(path.join(ROOT, "customer-app/index.html"), "utf8");
+    const assets = [...html.matchAll(/(?:src|href)="(\.\/[^"]+)"/g)].map((m) => m[1].replace("./", "/customer-app/"));
+    const files = [...new Set(["/customer-app/index.html", ...assets])];
+    assert.ok(files.length >= 20, `expected the full module list, got ${files.length}`);
+
+    let raw = 0;
+    let gzip = 0;
+    for (const file of files) {
+      raw += (await get(file)).bytes;
+      gzip += (await get(file, { "Accept-Encoding": "gzip" })).bytes;
+    }
+    // Measured at the time of writing: 962 KB -> 265 KB (72% smaller). The
+    // threshold is deliberately loose so ordinary content growth does not fail
+    // the build, but a regression that disables compression will.
+    assert.ok(raw > 500 * 1024, `sanity: cold load should be large, got ${Math.round(raw / 1024)} KB`);
+    assert.ok(gzip < raw * 0.4, `compression must cut the cold load by >60%: ${Math.round(raw / 1024)} KB -> ${Math.round(gzip / 1024)} KB`);
+  });
+});
+
+test("Issue 314: streaming responses can opt out of compression", () => {
+  const middleware = createCompressionMiddleware();
+  assert.equal(typeof middleware, "function");
+  const source = fs.readFileSync(path.join(ROOT, "server/middleware/staticAssetDelivery.js"), "utf8");
+  assert.match(source, /x-no-compression/);
+  assert.match(source, /text\/event-stream/);
+  assert.match(source, /threshold: 1024/);
+});


### PR DESCRIPTION
Closes #314

## SHAs

| | |
|---|---|
| Base branch | `main` |
| **Base SHA** | `efaad4b70de41e3d10c81f9d519244c255f68057` |
| **Head SHA** | `cf8c6c3b0c0a76908b16698b10222a6f6230c8c2` |

ตรวจ GitHub ซ้ำก่อนเริ่ม: PR #311 → `main`, #312 → `staging/home-server-test`, #313 → `production/home-server` merge ครบแล้ว และ `main` (`efaad4b7`) ไม่มี commit ที่ยังไม่ได้อยู่ใน `production/home-server` (`5d561ec9`) — **เนื้อหาที่วัดในนี้คือเนื้อหาเดียวกับที่รันบน Production อยู่ตอนนี้**

## Business outcome

ลูกค้าเปิดแอปได้เร็วขึ้นทันทีบนเน็ตมือถือไทย และทีมได้ guard ที่เชื่อถือได้กลับมาว่าไม่มี asset ค้าง cache หลัง deploy — ทั้งสองอย่างเป็นเงื่อนไขก่อนเปิดให้ลูกค้าจริงใช้

## Root cause (วัดจาก middleware จริง ไม่ได้เดา)

### 1. ไม่มี HTTP compression เลยทั้งระบบ

`compression` ไม่อยู่ใน dependencies และไม่มี gzip/brotli ที่ไหนใน `index.js` หรือ `server/` วัดจาก `express.static(ROOT_DIR)` ตามที่ `index.js` ตั้งไว้จริง:

| Asset | ส่งจริง | Content-Encoding | Cache-Control |
|---|---|---|---|
| `customer-app/index.html` | 6 KB | **(none)** | `public, max-age=0` |
| `customer-app/modules/store.js` | **133 KB** | **(none)** | `public, max-age=0` |
| `customer-app/assets/customer-app.css` | **207 KB** | **(none)** | `public, max-age=0` |
| `customer-app/sw.js` | 3 KB | **(none)** | `public, max-age=0` |

**ตัวคูณที่ทำให้เรื่องนี้แรงกว่าที่คิด:** `customer-app/sw.js` ใช้ `fetch(request, { cache: "no-store" })` แบบ network-first กับทุก request ใน `/customer-app/` (Cache Storage เป็น offline fallback เท่านั้น) แปลว่าลูกค้า **ดาวน์โหลดใหม่ทั้งชุดทุกครั้งที่เปิดแอป** ไม่ใช่แค่ครั้งแรก

### 2. Asset ที่ cache-bust แล้ว กลับถูกส่งเป็น `max-age=0`

`express.static(ROOT_DIR)` ถูกเรียกโดยไม่ส่ง options → default `maxAge: 0` ทุกไฟล์จึงต้อง revalidate ทุก navigation ทั้งที่ทุก URL มี `?v=BUILD_ID` อยู่แล้ว หน้า Admin/Tech ไม่มี service worker คุม asset จึงจ่ายค่านี้เต็ม ๆ ทุกครั้ง

### 3. Guard กัน cache ค้าง แดงถาวรบน Production

`test/jobLocationRoundtrip.test.js` → `Test 15` **fail อยู่บน `main` และ `production/home-server` ขณะนี้** เพราะ constant `URGENT_REVIEW_BUILD = "20260726_urgent_preferred_time_gps_v1"` ค้างตั้งแต่ PR #304 ขณะที่หน้าจริง ship `20260819_admin_structured_services_v1`

กฎของ test ไม่ผิด แต่ constant ค้าง → **guard ที่มีไว้จับ cache-bust ที่ลืม กลายเป็นแดงถาวร ครั้งต่อไปที่ลืมจริงจะไม่มีใครเห็น**

## What changed

นโยบายอยู่ใน `server/middleware/staticAssetDelivery.js` (ไฟล์ใหม่) — `index.js` ทำแค่ wiring: 1 require, 1 `app.use`, และใส่ options ให้ static mount 3 จุด **ไม่มี business logic ย้ายหรือเพิ่มใน `index.js`**

**นโยบาย cache ปลอดภัยโดยโครงสร้าง** — asset จะถูก cache ยาวได้ก็ต่อเมื่อ URL มี version marker เท่านั้น เพราะ marker คือสิ่งที่เปลี่ยนใน deploy ถัดไป

| ประเภท | Cache-Control | เหตุผล |
|---|---|---|
| `?v=<id>` | `public, max-age=31536000, immutable` | URL เปลี่ยนทุก deploy อยู่แล้ว |
| ไม่มี `?v=` | `public, max-age=300, must-revalidate` | ไม่มีอะไร bust ได้ ห้าม cache ยาว |
| `.html` / `.webmanifest` / `.json` | `no-cache` | ตัวเอกสารคือที่เก็บ `?v=` ของไฟล์อื่น |
| `sw.js`, `service-worker.js` | `no-cache` **เสมอ** | service worker ค้าง = client ติดเวอร์ชันเก่าถาวร |

Compression mount ไว้เป็น middleware ตัวแรกสุด (ก่อน `cors()`) ดังนั้น **API JSON ก็ถูกบีบอัดด้วย** ไม่ใช่แค่ static มี `threshold: 1024` และ opt-out ผ่าน `x-no-compression` / `text/event-stream` เผื่อ streaming route ในอนาคต (ตอนนี้ตรวจแล้วว่าไม่มี SSE/`res.write` ในโค้ดเบส)

## Tests

| Command | Result |
|---|---|
| `node --check` (`index.js`, middleware ใหม่) | ✅ OK |
| `git diff --check` | ✅ clean |
| `node --test test/staticAssetDelivery.test.js` | ✅ **10/10 pass** |
| `node --test test/jobLocationRoundtrip.test.js` | ✅ pass (Test 15 กลับมาเขียว) |
| `node --test test/customerLegacyUiRetirement.test.js` | ✅ 13/13 pass |
| **Full `npm test` (branch `cf8c6c3b`)** | **1659 tests · 1598 pass · 0 fail · 61 skipped** |
| **Full `npm test` (base `efaad4b7`)** | **1648 tests · 1586 pass · 1 fail · 61 skipped** |

**Base-vs-Branch: +11 tests, +12 passes, −1 failure** — suite เขียวหมดเป็นครั้งแรก ไม่มี regression

Test ที่เพิ่มเน้นทิศทางที่อันตราย (cache มากเกินไป): service worker ห้าม cache ไม่ว่าจะมี marker หรือไม่ · document/manifest ต้อง revalidate · asset ไม่มี `?v=` ห้าม cache ยาว · `?v=` ว่างหรือเว้นวรรคไม่นับเป็น marker · ตรวจ end-to-end กับไฟล์จริงว่า cold load เล็กลง >60% · ทุก static mount ต้องผ่าน policy · `compression` ต้องอยู่ใน `dependencies` (ไม่ใช่ dev) เพื่อให้ `npm ci --omit=dev` ยังติดตั้ง

### มี test เดิม 1 ตัวที่ต้องแก้ locator (รายงานตามกติกา scope)

`test/customerLegacyUiRetirement.test.js` → *"server legacy redirects are registered before static serving…"* หา static mount ด้วย `source.indexOf("app.use(express.static(ROOT_DIR))")` แบบ string ตรงตัว พอผมใส่ options เข้าไป `indexOf` คืน `-1` แล้ว assertion เรื่องลำดับก็พังทั้งที่ลำดับยังถูก

แก้เป็น regex ที่จับ mount ตาม **รูปทรง** ไม่ใช่ argument — **เจตนาเดิมของ guard (legacy redirect ต้องมาก่อน static serving ไม่งั้น customer HTML เก่าจะถูก serve ข้าม auth) ยังถูกบังคับเหมือนเดิมทุกประการ** ไม่ได้ผ่อนเงื่อนไขใด ๆ

## Browser / Mobile QA

รันหน้าจริงผ่าน **middleware ตัวจริง** (`createCompressionMiddleware` + `staticOptions` ตัวเดียวกับที่ `index.js` mount) วัดด้วย Resource Timing ของเบราว์เซอร์เอง

**Customer App — 360×800 และ 390×844**

| | ผล |
|---|---|
| Transfer จริง (23 ไฟล์) | **926 KB decoded → 246 KB over the wire (−73%)** |
| ไฟล์ใหญ่สุด | `customer-app.css` 207K→43K · `store.js` 133K→32K · `tracking.js` 108K→25K · `bookingScheduled.js` 86K→18K |
| Content-Encoding ที่เบราว์เซอร์เจรจาได้ | **brotli (`br`)** |
| DOMContentLoaded / load | 436 ms / 570 ms |
| หน้าแสดงผล | ✅ ปกติ ภาษาไทยครบ CWF น้ำเงิน–เหลือง bottom nav อยู่ครบ |
| Horizontal overflow | ✅ ไม่มีทั้งสองขนาด |
| ข้อความอังกฤษหลุด | ✅ ไม่พบ (ยกเว้น CWF / LINE / Coldwindflow ที่เป็นแบรนด์) |
| `app` boot state | ✅ `is-app-ready` |

**Header ที่เบราว์เซอร์ได้รับจริง**

| Asset | Cache-Control | Encoding |
|---|---|---|
| `customer-app/sw.js` | `no-cache` ✅ | br |
| `customer-app/index.html` | `no-cache` ✅ | br |
| `modules/store.js?v=…` | `public, max-age=31536000, immutable` ✅ | br |
| `/style.css` (ไม่มี `?v=`) | `public, max-age=300, must-revalidate` ✅ | br |

**Admin Add Job — 390×844:** 290 KB → 73 KB (−75%) · bottom nav ครบ · ไม่มี horizontal overflow

### Service worker registration ใน QA browser — พิสูจน์แล้วว่าไม่เกี่ยวกับ PR นี้

QA browser log `An unknown error occurred when fetching the script` ตอน `serviceWorker.register()` ผมไม่เดา แต่ตั้ง **baseline control server** ที่เป็นพฤติกรรมก่อน PR นี้เป๊ะ ๆ (`express.static(ROOT)` ล้วน ไม่มี compression ไม่มี options) แล้วลอง register ที่ origin นั้น → **error เดียวกันคำต่อคำ** จึงเป็นข้อจำกัดของ in-app QA browser ไม่ใช่ผลจากการแก้

หลักฐานเสริมว่า SW ยังถูกเสิร์ฟถูกต้อง: `curl` ได้ `200` · `Content-Type: application/javascript; charset=UTF-8` · `Cache-Control: no-cache` · `Vary: Accept-Encoding` และ `fetch()` ในเบราว์เซอร์ decode ได้ครบ 3,523 bytes อ่าน `BUILD_ID` ได้ปกติ

## Migration / Cache impact

- **ไม่มี migration** ไม่แตะ schema ไม่แตะข้อมูล
- **ไม่ bump build id ใด ๆ** เพราะ runtime bytes ของ asset ไม่ได้เปลี่ยน — เปลี่ยนแค่วิธีส่ง การ bump โดยไม่จำเป็นจะล้าง cache ลูกค้าทิ้งเปล่า ๆ
- Client เดิมที่ค้าง `max-age=0` อยู่ จะได้ header ใหม่ทันทีในการ request ถัดไป ไม่มีสถานะค้าง
- ผลข้างเคียงที่ตั้งใจ: response body ที่เป็น text ทั้งระบบ (รวม API JSON) เล็กลง

## Unverified

- **ยังไม่ได้วัดบน Production/Staging จริง** ตัวเลขทั้งหมดมาจากไฟล์จริงผ่าน middleware จริงบนเครื่อง local ถ้ามี reverse proxy หน้า Node ที่บีบอัดอยู่แล้ว compression ชั้นนี้จะซ้ำซ้อน (ไม่พัง แต่เปลืองซีพียู) — ผมค้นทั้ง repo แล้วไม่พบ config ของ nginx/caddy/cloudflare/docker จึงสรุปว่าไม่มี **ถ้าจริง ๆ มี proxy ที่ gzip อยู่ บอกผมได้ ผมจะถอดชั้นนี้ออก**
- Service worker registration บนเบราว์เซอร์จริง (ดูหัวข้อ QA — พิสูจน์แล้วว่าไม่ใช่ regression แต่ก็ยังไม่ได้ยืนยันฝั่งบวกในเครื่องมือนี้)

## Remaining risks

1. **Dependency ใหม่ 1 ตัว** `compression@^1.8.1` (+6 packages) เป็น Express middleware อย่างเป็นทางการ อยู่ใน `dependencies` เพื่อให้ `npm ci --omit=dev` ยังติดตั้งได้ ต้องแน่ใจว่า deploy pipeline รัน install ก่อนสตาร์ต
2. **CPU แลกกับ bandwidth** การบีบอัดกินซีพียูเล็กน้อยต่อ request (ตั้ง `threshold: 1024` ให้ข้ามไฟล์เล็ก) บนงาน I/O-bound แบบนี้คุ้ม แต่ถ้าเซิร์ฟเวอร์บ้านซีพียูตึงอยู่แล้วควรดู load หลัง deploy
3. **`immutable` 1 ปี ผูกกับวินัยการ bump** ถ้ามีใครแก้ไฟล์ที่มี `?v=` โดยไม่ bump id ลูกค้าที่ cache ไว้จะไม่เห็นของใหม่นานมาก — ความเสี่ยงนี้คือเหตุผลที่ PR นี้ซ่อม Test 15 ไปพร้อมกัน guard จึงกลับมาทำงานจริง
4. **`/uploads` ก็ใช้ policy เดียวกัน** ไฟล์อัปโหลดส่วนใหญ่ไม่มี `?v=` จึงได้ `max-age=300` ซึ่งยังปลอดภัย (เดิมคือ `max-age=0`)
5. ยังไม่ได้แตะเรื่อง bundling/minify ของ Customer App (20 ไฟล์ blocking, CSS 207 KB ก้อนเดียว) — จงใจกันไว้เป็นงานแยก ไม่รวมใน PR นี้ ถ้าต้องการผมประเมินให้ได้

## Rollback

revert merge commit เดียวจบ — ไม่มี schema ไม่มีข้อมูล ไม่มี build id ที่ต้องย้อน client จะกลับไปได้ header เดิมในการ request ถัดไปทันที ถ้าต้องการปิดเฉพาะ compression โดยไม่ revert ทั้งก้อน ลบบรรทัด `app.use(createCompressionMiddleware());` บรรทัดเดียวใน `index.js` ก็พอ

## Production status

❌ **ไม่ได้ merge** ❌ **ไม่ได้ deploy** ❌ **ไม่แตะ Production, ไม่ restart, ไม่ rollback, ไม่แตะ data/config/secrets**
Draft PR รอเจ้าของยืนยันตาม Release Flow เท่านั้น

## ต้องให้เจ้าของตัดสินใจ

1. **อนุมัติ dependency `compression` ขึ้น Production หรือไม่** — นี่คือ dependency ใหม่ตัวเดียวใน PR
2. **มี reverse proxy (nginx/Cloudflare) หน้า Node ที่บีบอัดอยู่แล้วหรือเปล่า** — ถ้ามี ผมถอดชั้นนี้ออกให้ เหลือแค่ส่วน Cache-Control + ซ่อม guard
3. **จะให้ทำ bundling/minify Customer App ต่อเป็นงานถัดไปไหม** — หลัง PR นี้ payload จะเหลือ ~246 KB ซึ่งอยู่ในเกณฑ์ใช้ได้แล้ว งาน bundling จะได้เพิ่มอีกไม่มากเท่าและเสี่ยงกว่ามาก

🤖 Generated with [Claude Code](https://claude.com/claude-code)
