### PR TITLE
[Claude] Issue #316: ให้ลูกค้าปักหมุดตำแหน่งบ้านได้ในการจองล่วงหน้าด้วย ไม่ใช่เฉพาะงานด่วน

### DIFF
--- a/customer-app/assets/customer-app.css
+++ b/customer-app/assets/customer-app.css
@@ -528,6 +528,37 @@ p { margin: 0; }
 .secondary-btn:active:not([disabled]) { transform: scale(0.98); background: var(--soft-blue-2); }
 .secondary-btn[disabled] { color: var(--muted-2); background: #f1f5fa; border-color: var(--line); cursor: not-allowed; }
 
+/* Location pin (Issue 316) — shared by the scheduled and urgent booking flows. */
+.booking-pin-hint { margin: 0 0 8px; font-size: 12.5px; line-height: 1.5; }
+.booking-pin-saved {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  margin-top: 8px;
+  padding: 10px 12px;
+  border: 1px solid var(--line);
+  border-radius: 12px;
+  background: var(--bg-2);
+  color: var(--ink);
+  font-size: 13px;
+  font-weight: 700;
+}
+.booking-pin-saved span { min-width: 0; overflow-wrap: anywhere; }
+.link-btn {
+  flex: none;
+  min-height: 44px;
+  padding: 0 6px;
+  border: 0;
+  background: none;
+  color: var(--blue);
+  font-size: 13px;
+  font-weight: 700;
+  text-decoration: underline;
+  cursor: pointer;
+}
+.link-btn:active { opacity: 0.7; }
+
 .action-btn { width: 100%; }
 
 .disabled-btn {

--- a/customer-app/assets/customer-app.js
+++ b/customer-app/assets/customer-app.js
@@ -3,7 +3,7 @@
 
   const App = window.CWFCustomerAppV2;
   const BOOT_TIMEOUT_MS = 3500;
-  const BUILD_ID = "20260820_issue310_package_minimum_quantity_v1";
+  const BUILD_ID = "20260821_issue316_scheduled_location_pin_v1";
 
   function withTimeout(promise, timeoutMs) {
     return Promise.race([

--- a/customer-app/index.html
+++ b/customer-app/index.html
@@ -21,10 +21,10 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Noto+Sans+Thai:wght@400;500;600;700;800;900&display=swap" media="print" onload="this.media='all'">
   <noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Noto+Sans+Thai:wght@400;500;600;700;800;900&display=swap"></noscript>
-  <link rel="manifest" href="./manifest.webmanifest?v=20260820_issue310_package_minimum_quantity_v1">
+  <link rel="manifest" href="./manifest.webmanifest?v=20260821_issue316_scheduled_location_pin_v1">
   <link rel="icon" type="image/png" sizes="192x192" href="./assets/icons/cwf-customer-192.png">
   <link rel="apple-touch-icon" sizes="180x180" href="./assets/icons/cwf-customer-180.png">
-  <link rel="stylesheet" href="./assets/customer-app.css?v=20260820_issue310_package_minimum_quantity_v1">
+  <link rel="stylesheet" href="./assets/customer-app.css?v=20260821_issue316_scheduled_location_pin_v1">
 </head>
 <body class="is-app-booting">
   <div class="app-shell" data-app-shell>
@@ -62,26 +62,26 @@
     </nav>
   </div>
 
-  <script src="./modules/iconRegistry.js?v=20260820_issue310_package_minimum_quantity_v1"></script>
-  <script src="./modules/state.js?v=20260820_issue310_package_minimum_quantity_v1"></script>
-  <script src="./modules/utils.js?v=20260820_issue310_package_minimum_quantity_v1"></script>
-  <script src="./modules/customerCopy.js?v=20260820_issue310_package_minimum_quantity_v1"></script>
-  <script src="./modules/analytics.js?v=20260820_issue310_package_minimum_quantity_v1"></script>
-  <script src="./modules/api.js?v=20260820_issue310_package_minimum_quantity_v1"></script>
-  <script src="./modules/pageAvailability.js?v=20260820_issue310_package_minimum_quantity_v1"></script>
-  <script src="./modules/services.js?v=20260820_issue310_package_minimum_quantity_v1"></script>
-  <script src="./modules/advisor.js?v=20260820_issue310_package_minimum_quantity_v1"></script>
-  <script src="./modules/ui.js?v=20260820_issue310_package_minimum_quantity_v1"></script>
-  <script src="./modules/store.js?v=20260820_issue310_package_minimum_quantity_v1"></script>
-  <script src="./modules/auth.js?v=20260820_issue310_package_minimum_quantity_v1"></script>
-  <script src="./modules/pricing.js?v=20260820_issue310_package_minimum_quantity_v1"></script>
-  <script src="./modules/availability.js?v=20260820_issue310_package_minimum_quantity_v1"></script>
-  <script src="./modules/bookingTicket.js?v=20260820_issue310_package_minimum_quantity_v1"></script>
-  <script src="./modules/bookingScheduled.js?v=20260820_issue310_package_minimum_quantity_v1"></script>
-  <script src="./modules/bookingUrgent.js?v=20260820_issue310_package_minimum_quantity_v1"></script>
-  <script src="./modules/tracking.js?v=20260820_issue310_package_minimum_quantity_v1"></script>
-  <script src="./modules/profile.js?v=20260820_issue310_package_minimum_quantity_v1"></script>
-  <script src="./modules/router.js?v=20260820_issue310_package_minimum_quantity_v1"></script>
-  <script src="./assets/customer-app.js?v=20260820_issue310_package_minimum_quantity_v1"></script>
+  <script src="./modules/iconRegistry.js?v=20260821_issue316_scheduled_location_pin_v1"></script>
+  <script src="./modules/state.js?v=20260821_issue316_scheduled_location_pin_v1"></script>
+  <script src="./modules/utils.js?v=20260821_issue316_scheduled_location_pin_v1"></script>
+  <script src="./modules/customerCopy.js?v=20260821_issue316_scheduled_location_pin_v1"></script>
+  <script src="./modules/analytics.js?v=20260821_issue316_scheduled_location_pin_v1"></script>
+  <script src="./modules/api.js?v=20260821_issue316_scheduled_location_pin_v1"></script>
+  <script src="./modules/pageAvailability.js?v=20260821_issue316_scheduled_location_pin_v1"></script>
+  <script src="./modules/services.js?v=20260821_issue316_scheduled_location_pin_v1"></script>
+  <script src="./modules/advisor.js?v=20260821_issue316_scheduled_location_pin_v1"></script>
+  <script src="./modules/ui.js?v=20260821_issue316_scheduled_location_pin_v1"></script>
+  <script src="./modules/store.js?v=20260821_issue316_scheduled_location_pin_v1"></script>
+  <script src="./modules/auth.js?v=20260821_issue316_scheduled_location_pin_v1"></script>
+  <script src="./modules/pricing.js?v=20260821_issue316_scheduled_location_pin_v1"></script>
+  <script src="./modules/availability.js?v=20260821_issue316_scheduled_location_pin_v1"></script>
+  <script src="./modules/bookingTicket.js?v=20260821_issue316_scheduled_location_pin_v1"></script>
+  <script src="./modules/bookingScheduled.js?v=20260821_issue316_scheduled_location_pin_v1"></script>
+  <script src="./modules/bookingUrgent.js?v=20260821_issue316_scheduled_location_pin_v1"></script>
+  <script src="./modules/tracking.js?v=20260821_issue316_scheduled_location_pin_v1"></script>
+  <script src="./modules/profile.js?v=20260821_issue316_scheduled_location_pin_v1"></script>
+  <script src="./modules/router.js?v=20260821_issue316_scheduled_location_pin_v1"></script>
+  <script src="./assets/customer-app.js?v=20260821_issue316_scheduled_location_pin_v1"></script>
 </body>
 </html>

--- a/customer-app/manifest.webmanifest
+++ b/customer-app/manifest.webmanifest
@@ -2,7 +2,7 @@
   "name": "CWF Customer Service",
   "short_name": "CWF Service",
   "description": "แอปลูกค้า Coldwindflow สำหรับเลือกบริการ จองคิว และติดตามงาน",
-  "start_url": "/customer-app/index.html?v=20260820_issue310_package_minimum_quantity_v1#home",
+  "start_url": "/customer-app/index.html?v=20260821_issue316_scheduled_location_pin_v1#home",
   "scope": "/customer-app/",
   "id": "/customer-app/",
   "display": "standalone",

--- a/customer-app/modules/bookingScheduled.js
+++ b/customer-app/modules/bookingScheduled.js
@@ -77,6 +77,82 @@
     return Math.max(1, Math.min(STEP_MAX, Number(root.state.scheduledWizard?.step || 1)));
   }
 
+  // --- Location pin (Issue 316) -------------------------------------------
+  // Same rules the server enforces for every customer booking: both values or
+  // neither, finite, in range, and never (0,0). The UI is a convenience; the
+  // server rejects a broken pair regardless of what the client sends.
+  function normalizePin(source) {
+    const rawLatitude = source?.gps_latitude;
+    const rawLongitude = source?.gps_longitude;
+    const latProvided = rawLatitude !== undefined && rawLatitude !== null && String(rawLatitude).trim() !== "";
+    const lngProvided = rawLongitude !== undefined && rawLongitude !== null && String(rawLongitude).trim() !== "";
+    if (!latProvided || !lngProvided) return null;
+    const latitude = Number(rawLatitude);
+    const longitude = Number(rawLongitude);
+    if (!Number.isFinite(latitude) || !Number.isFinite(longitude)) return null;
+    if (latitude < -90 || latitude > 90 || longitude < -180 || longitude > 180) return null;
+    if (latitude === 0 && longitude === 0) return null;
+    return { latitude, longitude };
+  }
+
+  function hasLocationPin(source) {
+    return normalizePin(source) !== null;
+  }
+
+  function formatPin(source) {
+    const pin = normalizePin(source);
+    if (!pin) return "";
+    return `${pin.latitude.toFixed(5)}, ${pin.longitude.toFixed(5)}`;
+  }
+
+  function clearLocationPin() {
+    root.state.updateDraft("scheduled", { gps_latitude: null, gps_longitude: null });
+    root.state.setScheduledWizard({ locationStatus: "idle", locationMessage: "ลบหมุดแล้ว ช่างจะใช้ที่อยู่และลิงก์แผนที่แทน" });
+  }
+
+  function requestCurrentLocation() {
+    if (!navigator.geolocation || typeof navigator.geolocation.getCurrentPosition !== "function") {
+      root.state.setScheduledWizard({
+        locationStatus: "error",
+        locationMessage: "เบราว์เซอร์นี้ไม่รองรับการอ่านตำแหน่ง กรุณาวางลิงก์ Google Maps เอง",
+      });
+      return Promise.resolve(false);
+    }
+    root.state.setScheduledWizard({ locationStatus: "loading", locationMessage: "กำลังอ่านตำแหน่งปัจจุบัน..." });
+    return new Promise((resolve) => {
+      navigator.geolocation.getCurrentPosition(
+        (position) => {
+          const pin = normalizePin({
+            gps_latitude: position?.coords?.latitude,
+            gps_longitude: position?.coords?.longitude,
+          });
+          if (!pin) {
+            root.state.setScheduledWizard({ locationStatus: "error", locationMessage: "อ่านตำแหน่งไม่สำเร็จ กรุณาลองอีกครั้ง" });
+            resolve(false);
+            return;
+          }
+          root.state.updateDraft("scheduled", {
+            gps_latitude: pin.latitude,
+            gps_longitude: pin.longitude,
+            maps_url: `https://www.google.com/maps?q=${pin.latitude},${pin.longitude}`,
+          });
+          root.state.setScheduledWizard({ locationStatus: "success", locationMessage: "ปักหมุดตำแหน่งสำเร็จ ช่างจะนำทางมาที่จุดนี้" });
+          resolve(true);
+        },
+        (error) => {
+          const message = Number(error?.code) === 1
+            ? "คุณปฏิเสธสิทธิ์ตำแหน่ง กรุณาอนุญาตสิทธิ์หรือวางลิงก์ Google Maps เอง"
+            : Number(error?.code) === 3
+              ? "อ่านตำแหน่งหมดเวลา กรุณาลองอีกครั้ง"
+              : "อ่านตำแหน่งไม่สำเร็จ กรุณาลองอีกครั้ง";
+          root.state.setScheduledWizard({ locationStatus: "error", locationMessage: message });
+          resolve(false);
+        },
+        { enableHighAccuracy: false, timeout: 10000, maximumAge: 0 }
+      );
+    });
+  }
+
   function finalPrice() {
     if (hasPackageSelection()) return packagePreview()?.fixed_total_price ?? null;
     const data = root.state.scheduledPreview.pricing.data;
@@ -250,6 +326,7 @@
   function renderStepContactLocation() {
     const d = draft();
     const saved = root.state.savedAddress();
+    const wizard = root.state.scheduledWizard || {};
     return `
       <section class="card booking-wizard-card" data-booking-step="2">
         <div class="section-head">
@@ -271,8 +348,20 @@
             <textarea id="scheduled-address" class="textarea" rows="4" data-scheduled-field="address_text" placeholder="บ้าน/คอนโด อาคาร ชั้น ห้อง ซอย ถนน และจุดนัดพบ">${root.utils.escapeHtml(d.address_text || "")}</textarea>
           </div>
           <div class="field field-wide">
-            <label for="scheduled-map">ลิงก์ Google Maps</label>
+            <label for="scheduled-map">ปักหมุดตำแหน่งบ้าน</label>
+            <p class="muted booking-pin-hint">ปักหมุดให้ช่างหาบ้านเจอแม่นยำ โดยเฉพาะซอยลึก หมู่บ้าน หรือคอนโด • หรือจะวางลิงก์ Google Maps เองก็ได้</p>
             <input id="scheduled-map" class="input" type="url" inputmode="url" value="${root.utils.escapeHtml(d.maps_url || "")}" data-scheduled-field="maps_url" placeholder="https://maps.app.goo.gl/...">
+            <button class="secondary-btn" type="button" data-scheduled-action="use-location" ${wizard.locationStatus === "loading" ? "disabled" : ""}>
+              ${wizard.locationStatus === "loading" ? "กำลังอ่านตำแหน่ง..." : (hasLocationPin(d) ? "ปักหมุดใหม่" : "ใช้ตำแหน่งปัจจุบัน")}
+            </button>
+            ${hasLocationPin(d) ? `
+              <div class="booking-pin-saved" data-scheduled-pin>
+                <span>📍 ปักหมุดแล้ว (${root.utils.escapeHtml(formatPin(d))})</span>
+                <button class="link-btn" type="button" data-scheduled-action="clear-location">ลบหมุด</button>
+              </div>` : ""}
+            ${wizard.locationMessage
+              ? `<small class="${wizard.locationStatus === "success" ? "muted" : "danger-text"}" role="status">${root.utils.escapeHtml(wizard.locationMessage)}</small>`
+              : ""}
           </div>
           <div class="field">
             <label for="scheduled-zone">พื้นที่ / เขต</label>
@@ -793,7 +882,7 @@
         <div class="data-row"><strong>ระยะเวลา</strong><span class="muted">${root.utils.escapeHtml(pricing.duration_min || "-")} นาที</span></div>
         <div class="data-row"><strong>ผู้ติดต่อ</strong><span class="muted">${root.utils.escapeHtml(d.customer_name || "-")} · ${root.utils.escapeHtml(d.customer_phone || "-")}</span></div>
         <div class="data-row"><strong>ที่อยู่</strong><span class="muted">${root.utils.escapeHtml(d.address_text || "-")}</span></div>
-        <div class="data-row"><strong>แผนที่</strong><span class="muted">${map ? "แนบลิงก์ Google Maps แล้ว" : "ไม่มีลิงก์แผนที่"}</span></div>
+        <div class="data-row"><strong>แผนที่</strong><span class="muted">${hasLocationPin(d) ? `ปักหมุดแล้ว (${root.utils.escapeHtml(formatPin(d))})` : (map ? "แนบลิงก์ Google Maps แล้ว" : "ไม่มีลิงก์แผนที่")}</span></div>
         <div class="data-row"><strong>พื้นที่</strong><span class="muted">${root.utils.escapeHtml(d.job_zone || "-")}</span></div>
         <div class="data-row"><strong>หมายเหตุ</strong><span class="muted">${root.utils.escapeHtml(d.customer_note || "-")}</span></div>
         <div class="data-row"><strong>วันและเวลา</strong><span class="muted">${root.utils.escapeHtml(d.date || "-")} · ${root.utils.escapeHtml(selected.start || "-")}-${root.utils.escapeHtml(selected.end || "-")} น.</span></div>
@@ -928,6 +1017,10 @@
       appointment_datetime: appointmentDatetime(),
       address_text: String(d.address_text || "").trim(),
       maps_url: String(d.maps_url || "").trim(),
+      // Issue 316: send the pin only when it is a complete, valid pair. A half
+      // pair is omitted entirely rather than sent as a partial the server has
+      // to reject.
+      ...(normalizePin(d) ? { gps_latitude: normalizePin(d).latitude, gps_longitude: normalizePin(d).longitude } : {}),
       customer_note: String(d.customer_note || "").trim(),
       booking_mode: "scheduled",
       client_app: "customer_app_v2",
@@ -1294,10 +1387,28 @@
       const eventName = input.tagName === "SELECT" ? "change" : "input";
       input.addEventListener(eventName, () => {
         const field = input.getAttribute("data-scheduled-field");
-        root.state.updateDraft("scheduled", { [field]: input.value });
+        const patch = { [field]: input.value };
+        // Issue 316: a hand-edited map link no longer matches the pinned
+        // coordinate, so drop the pin rather than send the technician to a
+        // point the customer has just overridden.
+        if (field === "maps_url" && hasLocationPin(draft())) {
+          patch.gps_latitude = null;
+          patch.gps_longitude = null;
+        }
+        root.state.updateDraft("scheduled", patch);
         root.state.setScheduledWizard({ error: "" });
       });
       if (eventName === "input") input.addEventListener("change", () => root.state.persistScheduledDraft());
+    });
+
+    container.querySelectorAll("[data-scheduled-action]").forEach((button) => {
+      button.addEventListener("click", async () => {
+        const action = button.getAttribute("data-scheduled-action");
+        if (action === "use-location") await requestCurrentLocation();
+        if (action === "clear-location") clearLocationPin();
+        root.state.persistScheduledDraft();
+        paint(container);
+      });
     });
 
     container.querySelectorAll("[data-calendar-month]").forEach((button) => {

--- a/customer-app/modules/state.js
+++ b/customer-app/modules/state.js
@@ -85,6 +85,11 @@
       customer_phone: "",
       address_text: "",
       maps_url: "",
+      // Issue 316: scheduled bookings can pin the site the same way urgent can.
+      // The technician navigates by coordinate first, so this is what gets them
+      // to the right soi/building instead of a free-text address.
+      gps_latitude: null,
+      gps_longitude: null,
       customer_note: "",
       job_zone: "",
       service_package_key: "",
@@ -189,6 +194,9 @@
       step: 1,
       maxStep: MAX_SCHEDULED_STEP,
       error: "",
+      // Issue 316: location-pin request state, mirroring the urgent flow.
+      locationStatus: "idle",
+      locationMessage: "",
     },
     scheduledPreview: {
       packages: { status: "idle", items: [], error: "" },
@@ -240,7 +248,7 @@
     },
     resetScheduledDraft() {
       this.draft.scheduled = defaultScheduledDraft();
-      this.scheduledWizard = { step: 1, maxStep: MAX_SCHEDULED_STEP, error: "" };
+      this.scheduledWizard = { step: 1, maxStep: MAX_SCHEDULED_STEP, error: "", locationStatus: "idle", locationMessage: "" };
       this.scheduledPreview = {
         packages: { status: "idle", items: [], error: "" },
         package: { status: "idle", data: null, error: "", verified: false },

--- a/customer-app/sw.js
+++ b/customer-app/sw.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const BUILD_ID = "20260820_issue310_package_minimum_quantity_v1";
+const BUILD_ID = "20260821_issue316_scheduled_location_pin_v1";
 const CACHE_NAME = `cwf-customer-app-v2-${BUILD_ID}`;
 const APP_SHELL = [
   `./index.html?v=${BUILD_ID}`,

--- a/server/services/booking/createBookingJob.js
+++ b/server/services/booking/createBookingJob.js
@@ -10,6 +10,7 @@ const adminIdempotency = require("./adminBookingIdempotency");
 const persistedBookingReplay = require("./persistedBookingReplay");
 const { validateAdminStorePromotionRequest } = require("./adminStorePromotionPolicy");
 const { resolveUrgentCompositePreflight } = require("./urgentCompositePreflight");
+const { validateCustomerLocationPin, persistableLocationPin } = require("./customerLocationPin");
 
 function safePackagePreview(selection) {
   const line = selection.service_lines[0];
@@ -1552,8 +1553,23 @@ function createBookingJobService(dependencies = {}) {
     if (clientApp === "customer_app_v2" && allowTimeProposal == null) {
       return res.status(400).json({ error: "กรุณาเลือกเงื่อนไขการเสนอเวลา" });
     }
-    const persistedGpsLatitude = bm === "urgent" && gps_latitude != null ? Number(gps_latitude) : null;
-    const persistedGpsLongitude = bm === "urgent" && gps_longitude != null ? Number(gps_longitude) : null;
+    // Issue 316: a location pin belongs to the booking, not to the booking mode.
+    // Scheduled bookings used to have their pin discarded here, so the technician
+    // reached the site with no coordinate. Customer-app requests are validated
+    // server-side first, so a stale or hand-crafted client cannot store a broken
+    // pair - the UI is never the only thing enforcing this.
+    if (clientApp === "customer_app_v2" && (coordFieldProvided(gps_latitude) || coordFieldProvided(gps_longitude))) {
+      const submittedPin = validateCustomerLocationPin(gps_latitude, gps_longitude);
+      if (!submittedPin.ok) {
+        return res.status(400).json({
+          error: "ข้อมูลตำแหน่งไม่ถูกต้อง กรุณาปักหมุดใหม่อีกครั้ง",
+          code: "INVALID_GPS",
+        });
+      }
+    }
+    const persistedPin = persistableLocationPin(bm, gps_latitude, gps_longitude);
+    const persistedGpsLatitude = persistedPin.latitude;
+    const persistedGpsLongitude = persistedPin.longitude;
 
     // New bookings persist a canonical request fingerprint. A replay can be
     // returned before resolving mutable package/catalog/promotion state.

--- a/server/services/booking/customerLocationPin.js
+++ b/server/services/booking/customerLocationPin.js
@@ -1,0 +1,54 @@
+"use strict";
+
+// Customer location pin (Issue 316).
+//
+// A technician navigates to a job with job.gps_latitude/gps_longitude first and
+// only falls back to maps_url and then the free-text address (see openMaps in
+// app.js). Urgent bookings have always been able to send a pin; scheduled
+// bookings could not, and handlePublicBook additionally discarded any pin that
+// did arrive on a non-urgent booking:
+//
+//     const persistedGpsLatitude = bm === "urgent" && gps_latitude != null ? ... : null;
+//
+// So a scheduled job reached the technician with no coordinate at all. This
+// module makes the pin a property of the booking, not of the booking mode,
+// while keeping one single set of validation rules for every customer flow.
+
+const { validateCustomerUrgentGps } = require("../urgentPublicAdapter");
+
+// Modes a customer can pin. Anything else (admin-authored rows, legacy imports)
+// keeps its existing behaviour and is not given a pin by this module.
+const PIN_ELIGIBLE_BOOKING_MODES = new Set(["scheduled", "urgent"]);
+
+/**
+ * Validate a customer-supplied pin.
+ *
+ * Deliberately delegates to the urgent validator rather than restating the
+ * rules, so scheduled can never drift into being more permissive than urgent:
+ * both-or-neither, finite, lat -90..90, lng -180..180, and never (0,0).
+ *
+ * @returns {{ok: boolean, latitude: number|null, longitude: number|null}}
+ */
+function validateCustomerLocationPin(latitude, longitude) {
+  return validateCustomerUrgentGps(latitude, longitude);
+}
+
+/**
+ * The coordinate pair to persist for this booking, or nulls.
+ * Never throws: an invalid pair resolves to nulls so a caller that has already
+ * rejected the request cannot accidentally write a half pair.
+ */
+function persistableLocationPin(bookingMode, latitude, longitude) {
+  if (!PIN_ELIGIBLE_BOOKING_MODES.has(String(bookingMode || "").trim())) {
+    return { latitude: null, longitude: null };
+  }
+  const pin = validateCustomerLocationPin(latitude, longitude);
+  if (!pin.ok) return { latitude: null, longitude: null };
+  return { latitude: pin.latitude, longitude: pin.longitude };
+}
+
+module.exports = {
+  PIN_ELIGIBLE_BOOKING_MODES,
+  validateCustomerLocationPin,
+  persistableLocationPin,
+};

--- a/test/customerAppPageAvailability.test.js
+++ b/test/customerAppPageAvailability.test.js
@@ -281,7 +281,7 @@ test("api exposes loadCustomerAppConfig as a no-store GET to /public/customer-ap
 });
 
 test("build wiring: pageAvailability.js is registered in the HTML shell and the SW cache, with the new build id", () => {
-  const build = "20260820_issue310_package_minimum_quantity_v1";
+  const build = "20260821_issue316_scheduled_location_pin_v1";
   assert.match(indexHtml, new RegExp(`modules/pageAvailability\\.js\\?v=${build}`));
   assert.match(swSrc, new RegExp(`BUILD_ID = "${build}"`));
   assert.match(swSrc, /modules\/pageAvailability\.js\?v=\$\{BUILD_ID\}/);
@@ -294,7 +294,7 @@ test("build wiring: pageAvailability.js is registered in the HTML shell and the 
    RUNTIME tests (execute the real code in a VM — not regex assertions).
    ========================================================================== */
 
-const BUILD = "20260820_issue310_package_minimum_quantity_v1";
+const BUILD = "20260821_issue316_scheduled_location_pin_v1";
 const adminSrc = read("admin-homepage-cms.js");
 
 function reqUrlOf(req) {

--- a/test/customerAppRecovery.test.js
+++ b/test/customerAppRecovery.test.js
@@ -335,7 +335,7 @@ test("Customer App build id is consistent across shell and service worker", () =
   const sw = read("customer-app/sw.js");
   const app = read("customer-app/assets/customer-app.js");
   const manifest = read("customer-app/manifest.webmanifest");
-  const build = "20260820_issue310_package_minimum_quantity_v1";
+  const build = "20260821_issue316_scheduled_location_pin_v1";
 
   assert.match(index, new RegExp(`customer-app\\.css\\?v=${build}`));
   assert.match(index, new RegExp(`modules\\/api\\.js\\?v=${build}`));
@@ -353,7 +353,7 @@ test("Customer App build id is consistent across shell and service worker", () =
 test("store module is loaded in index.html and precached in the service worker app shell", () => {
   const index = read("customer-app/index.html");
   const sw = read("customer-app/sw.js");
-  const build = "20260820_issue310_package_minimum_quantity_v1";
+  const build = "20260821_issue316_scheduled_location_pin_v1";
 
   assert.match(index, new RegExp(`modules/store\\.js\\?v=${build}`));
   assert.match(sw, /`\.\/modules\/store\.js\?v=\$\{BUILD_ID\}`/);

--- a/test/customerAppStorePayment.test.js
+++ b/test/customerAppStorePayment.test.js
@@ -58,7 +58,7 @@ test("store falls back to the LINE hand-off when payment is unconfigured or the 
 test("payment step styles exist and the Customer App payment build id is bumped", () => {
   assert.match(cssSrc, /\.pay-method-btn/);
   assert.match(cssSrc, /\.pay-qr-img/);
-  assert.match(read("customer-app/index.html"), /modules\/store\.js\?v=20260820_issue310_package_minimum_quantity_v1/);
-  assert.match(read("customer-app/sw.js"), /BUILD_ID = "20260820_issue310_package_minimum_quantity_v1"/);
+  assert.match(read("customer-app/index.html"), /modules\/store\.js\?v=20260821_issue316_scheduled_location_pin_v1/);
+  assert.match(read("customer-app/sw.js"), /BUILD_ID = "20260821_issue316_scheduled_location_pin_v1"/);
   assert.match(storeSrc, /payment-security 20260705 loaded/);
 });

--- a/test/customerBookingAdminNotifications.test.js
+++ b/test/customerBookingAdminNotifications.test.js
@@ -313,10 +313,10 @@ test("admin/customer frontend cache versions are bumped for booking notification
   assert.doesNotMatch(adminReviewHtml, /admin-review-v2\.js\?v=20260707_customer_booking_notify_v2/);
   assert.match(adminReviewHtml, /admin-review-ai-intake\.js\?v=ai-booking-intake-customer-cards-v11-admin-alert-gate/);
   assert.doesNotMatch(adminReviewHtml, /admin-review-ai-intake\.js\?v=ai-booking-intake-customer-cards-v10/);
-  assert.match(customerIndex, /bookingScheduled\.js\?v=20260820_issue310_package_minimum_quantity_v1/);
-  assert.match(customerIndex, /state\.js\?v=20260820_issue310_package_minimum_quantity_v1/);
-  assert.match(customerSw, /const BUILD_ID = "20260820_issue310_package_minimum_quantity_v1"/);
-  assert.match(customerManifest, /20260820_issue310_package_minimum_quantity_v1/);
+  assert.match(customerIndex, /bookingScheduled\.js\?v=20260821_issue316_scheduled_location_pin_v1/);
+  assert.match(customerIndex, /state\.js\?v=20260821_issue316_scheduled_location_pin_v1/);
+  assert.match(customerSw, /const BUILD_ID = "20260821_issue316_scheduled_location_pin_v1"/);
+  assert.match(customerManifest, /20260821_issue316_scheduled_location_pin_v1/);
 });
 
 test("behavior: review queue only includes customer urgent waiting rows while preserving review statuses", () => {

--- a/test/customerBookingProductionCopy.test.js
+++ b/test/customerBookingProductionCopy.test.js
@@ -5,7 +5,7 @@ const path = require("node:path");
 const vm = require("node:vm");
 
 const ROOT = path.resolve(__dirname, "..");
-const BUILD = "20260820_issue310_package_minimum_quantity_v1";
+const BUILD = "20260821_issue316_scheduled_location_pin_v1";
 
 function read(relativePath) {
   return fs.readFileSync(path.join(ROOT, relativePath), "utf8");

--- a/test/customerBookingTicketUi.test.js
+++ b/test/customerBookingTicketUi.test.js
@@ -303,7 +303,7 @@ test("ticket handoff keeps tracking/new-booking actions, 44px controls, mobile l
   assert.match(index, /modules\/bookingTicket\.js\?v=/);
   assert.match(sw, /modules\/bookingTicket\.js\?v=\$\{BUILD_ID\}/);
   for (const source of [index, sw, manifest, appEntry]) {
-    assert.match(source, /20260820_issue310_package_minimum_quantity_v1/);
+    assert.match(source, /20260821_issue316_scheduled_location_pin_v1/);
     assert.doesNotMatch(source, /20260809_issue267_catalog_flow_v8/);
   }
 });

--- a/test/customerHistoryClaim.test.js
+++ b/test/customerHistoryClaim.test.js
@@ -845,7 +845,7 @@ test("Customer History search and preview keep 360px and 390px width contracts",
 });
 
 test("Customer App cache version is bumped consistently", () => {
-  const expected = "20260820_issue310_package_minimum_quantity_v1";
+  const expected = "20260821_issue316_scheduled_location_pin_v1";
   for (const file of [
     "customer-app/index.html",
     "customer-app/sw.js",

--- a/test/customerHomepageFeaturedRotation.test.js
+++ b/test/customerHomepageFeaturedRotation.test.js
@@ -418,6 +418,6 @@ test("compact CSS and cache build remain consistent with six-card rotation", () 
   assert.match(css, /\.homepage-featured-page\s*\{[^}]*grid-area:\s*1\s*\/\s*1/s);
   assert.match(css, /transition:\s*opacity 350ms/);
   assert.match(css, /prefers-reduced-motion:\s*reduce/);
-  const build = "20260820_issue310_package_minimum_quantity_v1";
+  const build = "20260821_issue316_scheduled_location_pin_v1";
   for (const source of [html, sw, boot, manifest]) assert.match(source, new RegExp(build));
 });

--- a/test/customerSameDayTiming.test.js
+++ b/test/customerSameDayTiming.test.js
@@ -161,7 +161,7 @@ test("customer app disables availability HTTP cache and refreshes same-day slots
 });
 
 test("customer app build and service worker cache IDs changed", () => {
-  const id = "20260820_issue310_package_minimum_quantity_v1";
+  const id = "20260821_issue316_scheduled_location_pin_v1";
   for (const file of [
     "customer-app/index.html",
     "customer-app/sw.js",

--- a/test/customerScheduledLocationPin.test.js
+++ b/test/customerScheduledLocationPin.test.js
@@ -1,0 +1,185 @@
+"use strict";
+
+// Issue 316 - the customer can pin the job site in BOTH booking flows.
+//
+// Before this change:
+//   - bookingScheduled.js had no geolocation at all, only a free-text
+//     "ลิงก์ Google Maps" input;
+//   - handlePublicBook discarded any pin that did arrive on a non-urgent
+//     booking: `bm === "urgent" && gps_latitude != null ? ... : null`.
+// So a scheduled job always reached the technician with gps_latitude = NULL,
+// and app.js openMaps() - which navigates by coordinate first - had nothing to
+// use but the free-text address.
+//
+// The pin must never be enforced by the UI alone: the server validates every
+// customer-submitted pair with the same rules for both flows.
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const vm = require("node:vm");
+
+const {
+  validateCustomerLocationPin,
+  persistableLocationPin,
+  PIN_ELIGIBLE_BOOKING_MODES,
+} = require("../server/services/booking/customerLocationPin");
+
+const ROOT = path.join(__dirname, "..");
+const read = (file) => fs.readFileSync(path.join(ROOT, file), "utf8");
+const scheduledSource = read("customer-app/modules/bookingScheduled.js");
+const urgentSource = read("customer-app/modules/bookingUrgent.js");
+
+// The scheduled module's pin helpers, lifted out and run for real.
+function loadScheduledPinHelpers() {
+  const start = scheduledSource.indexOf("function normalizePin(source) {");
+  const end = scheduledSource.indexOf("function clearLocationPin()");
+  assert.ok(start > 0 && end > start, "pin helpers not found in bookingScheduled.js");
+  const context = {};
+  vm.runInNewContext(`${scheduledSource.slice(start, end)}\n;__api = { normalizePin, hasLocationPin, formatPin };`, context);
+  return context.__api;
+}
+
+// ---------------------------------------------------------------------------
+// 1) Server: the pin is a property of the booking, not of the booking mode
+// ---------------------------------------------------------------------------
+
+test("Issue 316: a scheduled booking now persists a valid pin instead of dropping it", () => {
+  const pin = persistableLocationPin("scheduled", 13.7563, 100.5018);
+  assert.deepEqual({ ...pin }, { latitude: 13.7563, longitude: 100.5018 });
+  // urgent keeps working exactly as before
+  assert.deepEqual({ ...persistableLocationPin("urgent", 13.7563, 100.5018) }, { latitude: 13.7563, longitude: 100.5018 });
+  assert.equal(PIN_ELIGIBLE_BOOKING_MODES.has("scheduled"), true);
+  assert.equal(PIN_ELIGIBLE_BOOKING_MODES.has("urgent"), true);
+});
+
+test("Issue 316: scheduled and urgent are held to identical validation rules", () => {
+  const bad = [
+    [null, 100.5], [13.7, null], ["", 100.5], [13.7, "   "],   // half pairs
+    [0, 0], ["0", "0"],                                          // the null island
+    [91, 100.5], [-91, 100.5], [13.7, 181], [13.7, -181],        // out of range
+    ["abc", "def"], [NaN, NaN], [Infinity, 100.5],               // not finite
+  ];
+  for (const [lat, lng] of bad) {
+    for (const mode of ["scheduled", "urgent"]) {
+      const pin = persistableLocationPin(mode, lat, lng);
+      assert.equal(pin.latitude, null, `${mode} must reject ${JSON.stringify([lat, lng])}`);
+      assert.equal(pin.longitude, null, `${mode} must reject ${JSON.stringify([lat, lng])}`);
+    }
+    assert.equal(validateCustomerLocationPin(lat, lng).ok, false);
+  }
+  // no pin at all stays valid - pinning is optional in both flows
+  assert.equal(validateCustomerLocationPin(null, null).ok, true);
+  assert.equal(validateCustomerLocationPin(undefined, undefined).ok, true);
+});
+
+test("Issue 316: a booking mode that is not a customer flow still gets no pin", () => {
+  for (const mode of ["", null, undefined, "contact_admin", "offer", "admin"]) {
+    const pin = persistableLocationPin(mode, 13.7563, 100.5018);
+    assert.equal(pin.latitude, null, `mode ${JSON.stringify(mode)} must not gain a pin`);
+  }
+});
+
+test("Issue 316: handlePublicBook validates the pin server-side and no longer hardcodes urgent", () => {
+  const source = read("server/services/booking/createBookingJob.js");
+  // the old mode-gated drop is gone
+  assert.doesNotMatch(source, /bm === "urgent" && gps_latitude != null/);
+  assert.doesNotMatch(source, /bm === "urgent" && gps_longitude != null/);
+  // and is replaced by the shared helper
+  assert.match(source, /const persistedPin = persistableLocationPin\(bm, gps_latitude, gps_longitude\);/);
+  assert.match(source, /const persistedGpsLatitude = persistedPin\.latitude;/);
+  assert.match(source, /const persistedGpsLongitude = persistedPin\.longitude;/);
+  // a customer-app request with a broken pair is rejected before anything is stored
+  assert.match(source, /clientApp === "customer_app_v2" && \(coordFieldProvided\(gps_latitude\) \|\| coordFieldProvided\(gps_longitude\)\)/);
+  assert.match(source, /code: "INVALID_GPS"/);
+  assert.match(source, /ข้อมูลตำแหน่งไม่ถูกต้อง กรุณาปักหมุดใหม่อีกครั้ง/);
+  // the urgent path keeps its own pre-validation untouched
+  assert.match(source, /urgentPublicAdapter\.validateCustomerUrgentGps\(incoming\.gps_latitude, incoming\.gps_longitude\)/);
+});
+
+// ---------------------------------------------------------------------------
+// 2) Client: the scheduled flow can pin, in Thai, with real states
+// ---------------------------------------------------------------------------
+
+test("Issue 316: the scheduled pin helpers accept only a complete, sane pair", () => {
+  const { normalizePin, hasLocationPin, formatPin } = loadScheduledPinHelpers();
+  // spread first: the helpers run in a vm realm, so compare by value not identity
+  assert.deepEqual({ ...normalizePin({ gps_latitude: 13.7563, gps_longitude: 100.5018 }) }, { latitude: 13.7563, longitude: 100.5018 });
+  assert.deepEqual({ ...normalizePin({ gps_latitude: "13.7563", gps_longitude: "100.5018" }) }, { latitude: 13.7563, longitude: 100.5018 });
+  for (const source of [
+    {}, { gps_latitude: 13.7 }, { gps_longitude: 100.5 },
+    { gps_latitude: 0, gps_longitude: 0 },
+    { gps_latitude: 91, gps_longitude: 100.5 },
+    { gps_latitude: 13.7, gps_longitude: 181 },
+    { gps_latitude: "abc", gps_longitude: "def" },
+    { gps_latitude: null, gps_longitude: null },
+  ]) {
+    assert.equal(normalizePin(source), null, `must reject ${JSON.stringify(source)}`);
+    assert.equal(hasLocationPin(source), false);
+  }
+  assert.equal(formatPin({ gps_latitude: 13.756331, gps_longitude: 100.501765 }), "13.75633, 100.50177");
+  assert.equal(formatPin({}), "");
+});
+
+test("Issue 316: the scheduled step 2 UI offers the pin in Thai with loading/success/error states", () => {
+  assert.match(scheduledSource, /ปักหมุดตำแหน่งบ้าน/);
+  assert.match(scheduledSource, /data-scheduled-action="use-location"/);
+  assert.match(scheduledSource, /data-scheduled-action="clear-location"/);
+  assert.match(scheduledSource, /กำลังอ่านตำแหน่ง\.\.\./);      // loading
+  assert.match(scheduledSource, /ใช้ตำแหน่งปัจจุบัน/);           // idle
+  assert.match(scheduledSource, /ปักหมุดใหม่/);                  // already pinned
+  assert.match(scheduledSource, /ปักหมุดตำแหน่งสำเร็จ ช่างจะนำทางมาที่จุดนี้/); // success
+  assert.match(scheduledSource, /คุณปฏิเสธสิทธิ์ตำแหน่ง/);        // permission denied
+  assert.match(scheduledSource, /อ่านตำแหน่งหมดเวลา/);           // timeout
+  assert.match(scheduledSource, /เบราว์เซอร์นี้ไม่รองรับการอ่านตำแหน่ง/); // unsupported
+  assert.match(scheduledSource, /ลบหมุดแล้ว/);                    // cleared
+  // the button must be disabled while reading, so it cannot be double-tapped
+  assert.match(scheduledSource, /wizard\.locationStatus === "loading" \? "disabled" : ""/);
+  // no English leaked into the Thai UI
+  const pinBlock = scheduledSource.slice(scheduledSource.indexOf("ปักหมุดตำแหน่งบ้าน"), scheduledSource.indexOf("data-scheduled-field=\"job_zone\""));
+  assert.doesNotMatch(pinBlock, /\b(?:Use|Current|Location|Pin|Save|Remove)\b/);
+});
+
+test("Issue 316: the scheduled payload carries the pin only as a complete pair", () => {
+  assert.match(scheduledSource, /\.\.\.\(normalizePin\(d\) \? \{ gps_latitude: normalizePin\(d\)\.latitude, gps_longitude: normalizePin\(d\)\.longitude \} : \{\}\)/);
+  // editing the map link by hand must drop a now-stale pin
+  assert.match(scheduledSource, /if \(field === "maps_url" && hasLocationPin\(draft\(\)\)\)/);
+  assert.match(scheduledSource, /patch\.gps_latitude = null;/);
+  // the review step tells the customer the pin is what the technician will use
+  assert.match(scheduledSource, /hasLocationPin\(d\) \? `ปักหมุดแล้ว/);
+});
+
+test("Issue 316: the scheduled draft and wizard carry the pin fields", () => {
+  const state = read("customer-app/modules/state.js");
+  const scheduledDraft = state.slice(state.indexOf("function defaultScheduledDraft"), state.indexOf("function defaultUrgentDraft"));
+  assert.match(scheduledDraft, /gps_latitude: null/);
+  assert.match(scheduledDraft, /gps_longitude: null/);
+  assert.match(state, /locationStatus: "idle"/);
+  assert.match(state, /locationMessage: ""/);
+  // resetting the draft must clear the pin state too
+  assert.match(state, /this\.scheduledWizard = \{ step: 1, maxStep: MAX_SCHEDULED_STEP, error: "", locationStatus: "idle", locationMessage: "" \}/);
+});
+
+test("Issue 316: the urgent flow is untouched", () => {
+  assert.match(urgentSource, /data-urgent-action="use-location"/);
+  assert.match(urgentSource, /navigator\.geolocation\.getCurrentPosition/);
+  assert.match(urgentSource, /gps_latitude: latitude/);
+  assert.match(urgentSource, /root\.state\.setUrgentFlow\(\{ locationStatus: "success"/);
+});
+
+// ---------------------------------------------------------------------------
+// 3) Cache contract
+// ---------------------------------------------------------------------------
+
+test("Issue 316: the customer runtime is cache-busted and admin ids stay put", () => {
+  const BUILD = "20260821_issue316_scheduled_location_pin_v1";
+  assert.match(read("customer-app/sw.js"), new RegExp(`BUILD_ID = "${BUILD}"`));
+  assert.match(read("customer-app/assets/customer-app.js"), new RegExp(`BUILD_ID = "${BUILD}"`));
+  assert.match(read("customer-app/index.html"), new RegExp(`modules/bookingScheduled\\.js\\?v=${BUILD}`));
+  assert.match(read("customer-app/index.html"), new RegExp(`assets/customer-app\\.css\\?v=${BUILD}`));
+  assert.match(read("customer-app/manifest.webmanifest"), new RegExp(BUILD));
+  // admin runtimes did not change in this issue, so their ids must not move
+  assert.match(read("admin-add-v2.html"), /admin-add-v2\.js\?v=20260820_issue310_package_minimum_quantity_v1/);
+  assert.match(read("admin-store-catalog.html"), /admin-store-catalog\.js\?v=20260820_issue310_package_minimum_quantity_v1/);
+});

--- a/test/customerServicePackageUi.test.js
+++ b/test/customerServicePackageUi.test.js
@@ -192,7 +192,7 @@ test("build id is coordinated and service worker privacy/network behavior remain
   const app = read("customer-app/assets/customer-app.js");
   const manifest = read("customer-app/manifest.webmanifest");
   const build = sw.match(/BUILD_ID = "([^"]+)"/)[1];
-  assert.equal(build, "20260820_issue310_package_minimum_quantity_v1");
+  assert.equal(build, "20260821_issue316_scheduled_location_pin_v1");
   assert.match(index, new RegExp(build));
   assert.match(app, new RegExp(`BUILD_ID = "${build}"`));
   assert.match(manifest, new RegExp(`index\\.html\\?v=${build}#home`));

--- a/test/customerSmartAdvisor.test.js
+++ b/test/customerSmartAdvisor.test.js
@@ -1174,7 +1174,7 @@ test("Home places built-in advisor after Quick Actions and before Featured Servi
 });
 
 test("advisor module is loaded before ui.js and precached under the shared build id", () => {
-  const build = "20260820_issue310_package_minimum_quantity_v1";
+  const build = "20260821_issue316_scheduled_location_pin_v1";
   assert.ok(INDEX_SOURCE.indexOf(`modules/advisor.js?v=${build}`) < INDEX_SOURCE.indexOf(`modules/ui.js?v=${build}`));
   assert.match(SW_SOURCE, new RegExp(`BUILD_ID = "${build}"`));
   assert.match(SW_SOURCE, /modules\/advisor\.js\?v=\$\{BUILD_ID\}/);

--- a/test/customerTrackingFullReadUi.test.js
+++ b/test/customerTrackingFullReadUi.test.js
@@ -1191,7 +1191,7 @@ test("tracking UI exposes loading, not-found, rate-limit and offline states", ()
 });
 
 test("tracking assets share the full-read cache build id", () => {
-  const build = "20260820_issue310_package_minimum_quantity_v1";
+  const build = "20260821_issue316_scheduled_location_pin_v1";
   for (const file of [
     "customer-app/index.html",
     "customer-app/sw.js",

--- a/test/homepageCms.test.js
+++ b/test/homepageCms.test.js
@@ -305,7 +305,7 @@ test("customer homepage has no admin control, bottom nav is fixed five-tab, and 
   const sw = read("customer-app/sw.js");
   const app = read("customer-app/assets/customer-app.js");
   const manifest = read("customer-app/manifest.webmanifest");
-  const build = "20260820_issue310_package_minimum_quantity_v1";
+  const build = "20260821_issue316_scheduled_location_pin_v1";
 
   assert.doesNotMatch(index + ui, /โหมดแอดมิน|openCms|localStorage\.getItem\('cwfHomeCmsDemo'/);
   assert.match(index, /data-route="store"[\s\S]*ร้านค้า/);

--- a/test/servicePackageMinimumQuantity.test.js
+++ b/test/servicePackageMinimumQuantity.test.js
@@ -593,13 +593,25 @@ test("Issue 310: manual Admin Add flows and the PR #308 technician picker are un
 
 test("Issue 310: exactly the changed runtime assets get the new build id", () => {
   const BUILD = "20260820_issue310_package_minimum_quantity_v1";
+  // Admin runtimes changed in Issue 310 and have not changed since, so their ids
+  // stay pinned to that exact release.
   assert.match(read("admin-add-v2.html"), new RegExp(`admin-add-v2\\.js\\?v=${BUILD}`));
   assert.match(read("admin-store-catalog.html"), new RegExp(`admin-store-catalog\\.js\\?v=${BUILD}`));
-  assert.match(read("customer-app/sw.js"), new RegExp(`BUILD_ID = "${BUILD}"`));
-  assert.match(read("customer-app/index.html"), new RegExp(`modules/store\\.js\\?v=${BUILD}`));
-  assert.match(read("customer-app/index.html"), new RegExp(`assets/customer-app\\.css\\?v=${BUILD}`));
-  assert.match(read("customer-app/assets/customer-app.js"), new RegExp(`BUILD_ID = "${BUILD}"`));
-  assert.match(read("customer-app/manifest.webmanifest"), new RegExp(BUILD));
+
+  // The Customer App ships ONE shared build id across sw.js, index.html, the
+  // bootstrap and the manifest. Pinning the literal here would go stale on the
+  // next customer release and leave this guard permanently red (exactly the
+  // failure mode Issue 314 had to repair), so assert the invariant instead:
+  // every customer asset reference moves together, and never lags Issue 310.
+  const swBuild = /BUILD_ID = "([^"]+)"/.exec(read("customer-app/sw.js"))?.[1];
+  assert.ok(swBuild, "customer-app/sw.js must declare a BUILD_ID");
+  assert.equal(/BUILD_ID = "([^"]+)"/.exec(read("customer-app/assets/customer-app.js"))?.[1], swBuild);
+  assert.match(read("customer-app/index.html"), new RegExp(`modules/store\\.js\\?v=${swBuild}`));
+  assert.match(read("customer-app/index.html"), new RegExp(`assets/customer-app\\.css\\?v=${swBuild}`));
+  assert.match(read("customer-app/manifest.webmanifest"), new RegExp(swBuild));
+  const stale = [...read("customer-app/index.html").matchAll(/\?v=([^"']+)/g)].map((m) => m[1]).filter((id) => id !== swBuild);
+  assert.deepEqual(stale, [], `every customer asset must carry the same build id, found stragglers: ${stale.join(", ")}`);
+  assert.ok(swBuild >= BUILD, `the customer build must not regress behind Issue 310: ${swBuild}`);
   // admin-store-catalog.css did not change in this issue, so its id must not move
   assert.match(read("admin-store-catalog.html"), /admin-store-catalog\.css\?v=20260809_issue267_merchandising_v3/);
   // no debug markers were shipped with the bump


### PR DESCRIPTION
Closes #316

## SHAs

| | |
|---|---|
| Base branch | `main` |
| **Base SHA** | `efaad4b70de41e3d10c81f9d519244c255f68057` |
| **Head SHA** | `772c22b2e663d61dcc5e7af251ba1dcf43cb4220` |

`main` (`efaad4b7`) ไม่มี commit ที่ยังไม่อยู่ใน `production/home-server` (`5d561ec9`) — **สิ่งที่ audit คือเนื้อหาเดียวกับที่ลูกค้าใช้อยู่จริง**

> branch นี้แตกจาก `main` ไม่ได้รวม PR #315 (compression) ทั้งสอง PR แก้คนละเรื่องและไม่ชนกัน merge ได้อิสระต่อกัน

## คำตอบคำถาม: ปักหมุดได้ทั้ง 2 flow ไหม → **ไม่ได้**

| | จองล่วงหน้า | งานด่วน |
|---|---|---|
| ปุ่มปักหมุด | ❌ **ไม่มีเลย** | ✅ มี |
| `gps_latitude/longitude` ใน draft | ❌ ไม่มี | ✅ มี |
| Server บันทึกพิกัด | ❌ **ทิ้งทันที** | ✅ บันทึก |

## Root cause

พิกัดถูกผูกกับ **โหมดการจอง** แทนที่จะเป็นคุณสมบัติของงาน — `server/services/booking/createBookingJob.js`:

```js
const persistedGpsLatitude = bm === "urgent" && gps_latitude != null ? Number(gps_latitude) : null;
const persistedGpsLongitude = bm === "urgent" && gps_longitude != null ? Number(gps_longitude) : null;
```

แม้ client จะส่งพิกัดมา งานจองล่วงหน้าก็ถูกเขียนลง DB เป็น `NULL` เสมอ และฝั่ง UI `bookingScheduled.js` ก็ไม่มี geolocation เลย มีแค่ช่องวางลิงก์ Google Maps เอง

**ผลกระทบจริงกับช่าง:** `app.js` → `openMaps(job.gps_latitude, job.gps_longitude, job.address_text, job.maps_url)` นำทางด้วยพิกัดก่อนเป็นอันดับแรก งานจองล่วงหน้าจึงเหลือแค่ที่อยู่ข้อความ ซึ่งในไทยเป็นปัญหาจริง — ซอยลึก หมู่บ้านจัดสรร คอนโด หาไม่เจอจากที่อยู่พิมพ์

## Business outcome

ลูกค้าปักหมุดบ้านได้ทั้ง 2 flow และช่างได้พิกัดจริงไปนำทางทั้ง 2 flow ลดงานที่ช่างหาบ้านไม่เจอ โทรถามทาง หรือไปผิดจุด

## What changed

**Server** — helper ใหม่ `server/services/booking/customerLocationPin.js` เป็นเจ้าของกฎเดียว โดย **delegate validation ไปที่ validator ของงานด่วนที่มีอยู่แล้ว** แทนที่จะเขียนกฎซ้ำ เพื่อไม่ให้ scheduled หลุดไปหลวมกว่า urgent ได้เลย: ครบคู่ / finite / lat −90..90 / lng −180..180 / ไม่ใช่ (0,0)

`handlePublicBook` บันทึกผ่าน `persistableLocationPin(bm, ...)` สำหรับทุก customer flow และ **ปฏิเสธ payload ของ customer app ที่พิกัดพังด้วย `INVALID_GPS` ก่อนเขียนอะไรลง DB** — UI ไม่ใช่ด่านเดียว เส้นทาง pre-validation ของงานด่วนไม่ถูกแตะ

**Customer App (เฉพาะ flow จองล่วงหน้า)** — `ปักหมุดตำแหน่งบ้าน` พร้อมปุ่ม `ใช้ตำแหน่งปัจจุบัน` / `ปักหมุดใหม่`, แถวหมุดที่บันทึกแล้วพร้อมพิกัดและปุ่ม `ลบหมุด`, ข้อความไทยครบทุก state (กำลังอ่าน / สำเร็จ / ปฏิเสธสิทธิ์ / หมดเวลา / เบราว์เซอร์ไม่รองรับ / ลบหมุดแล้ว) ปุ่ม disabled ระหว่างอ่านตำแหน่งกันกดซ้ำ

แก้ลิงก์ Google Maps เองเมื่อไหร่ → **หมุดเดิมถูกล้างทันที** ไม่ส่งช่างไปจุดที่ลูกค้าเพิ่งเปลี่ยน หน้าสรุปแสดง `ปักหมุดแล้ว (lat, lng)` ให้ลูกค้าเห็นตรงกับที่ช่างจะได้ และ payload ส่งพิกัดเฉพาะเมื่อครบคู่และถูกต้อง

**flow งานด่วนไม่ถูกแก้เลย** — `bookingUrgent.js` ไม่มี diff แม้แต่ byte เดียว

## Tests

| Command | Result |
|---|---|
| `node --check` ไฟล์ที่เปลี่ยนทั้งหมด | ✅ OK |
| `git diff --check` | ✅ clean |
| `node --test test/customerScheduledLocationPin.test.js` | ✅ **10/10 pass** |
| **Full `npm test` (branch `772c22b2`)** | **1658 tests · 1596 pass · 1 fail · 61 skipped** |
| **Full `npm test` (base `efaad4b7`)** | **1648 tests · 1586 pass · 1 fail · 61 skipped** |

**Base-vs-Branch: +10 tests, +10 passes, failure ตัวเดิมตัวเดียวเท่ากัน** — คือ `Test 15` admin-review-v2 build-id pin ที่แดงอยู่แล้วบน `main`/Production ตั้งแต่ PR #304 (ซ่อมแยกไว้ใน PR #315) ไม่มี regression จาก branch นี้

Test ครอบคลุม: scheduled/urgent ถูกบังคับด้วยกฎ validation ชุดเดียวกันทุกกรณีพัง (half pair, 0,0, out of range, ไม่ใช่ตัวเลข) · โหมดที่ไม่ใช่ customer flow ไม่ได้หมุด · server ปฏิเสธ payload พังเอง · helper ฝั่ง client · UI ไทยครบทุก state · payload ส่งเฉพาะคู่ที่สมบูรณ์ · แก้ลิงก์แผนที่แล้วหมุดถูกล้าง · draft/wizard เก็บ field ครบ · urgent ไม่ถูกแตะ · cache contract

## Browser / Mobile QA (หน้าจริง 360×800 และ 390×844)

| Step | ผล |
|---|---|
| ปุ่มปักหมุดแสดงในขั้นตอน 2 | ✅ `ใช้ตำแหน่งปัจจุบัน` + คำอธิบายไทย |
| ปักหมุดสำเร็จ (13.756331, 100.501765) | ✅ เก็บพิกัด · เติม `maps_url` อัตโนมัติ · แถว `📍 ปักหมุดแล้ว (13.75633, 100.50177) ลบหมุด` · ปุ่มเปลี่ยนเป็น `ปักหมุดใหม่` · ข้อความ `ปักหมุดตำแหน่งสำเร็จ ช่างจะนำทางมาที่จุดนี้` |
| ปฏิเสธสิทธิ์ (code 1) | ✅ `คุณปฏิเสธสิทธิ์ตำแหน่ง...` สีแดง · ไม่เก็บหมุด |
| หมดเวลา (code 3) | ✅ `อ่านตำแหน่งหมดเวลา...` · ไม่เก็บหมุด |
| พิกัด (0,0) | ✅ ปฏิเสธ ไม่เก็บ |
| พิกัดนอกช่วง (lat 999) | ✅ ปฏิเสธ ไม่เก็บ |
| แก้ลิงก์แผนที่เอง | ✅ หมุดถูกล้างเป็น `null` ทันที |
| กด `ลบหมุด` | ✅ ล้างหมุด · แถวหายไป · ปุ่มกลับเป็น `ใช้ตำแหน่งปัจจุบัน` · ข้อความ `ลบหมุดแล้ว ช่างจะใช้ที่อยู่และลิงก์แผนที่แทน` |
| หมุดอยู่รอดหลัง re-render และ restore session | ✅ `13.756331 / 100.501765` |
| หน้าสรุป (ขั้นตอน 3) | ✅ `แผนที่ ปักหมุดแล้ว (13.75633, 100.50177)` |
| Horizontal overflow | ✅ ไม่มี ทั้งขั้นตอน 2 และ 3 ทั้งสองขนาดจอ |
| Tap target ปุ่มปักหมุด | ✅ ≥ 44px · bottom nav ไม่ถูกบัง |

Screenshot ถ่ายไว้ที่ 360×800 (สถานะปักหมุดแล้ว) — **แนบใน PR ไม่ได้** เพราะเครื่องนี้ไม่มี `gh` CLI จึงเปิด PR ผ่าน REST API ซึ่งแนบรูปไม่ได้ ตารางด้านบนวัดจาก DOM จริงและถูกล็อกไว้ใน test แล้ว

**ข้อจำกัดของ QA harness:** ปุ่มปักหมุดของ flow งานด่วน render ไม่ออกในโหมด offline เพราะขั้นตอนงานด่วนต้องผ่าน capability/kill-switch จาก backend ก่อน จึงยืนยันฝั่งบวกไม่ได้ในเครื่องมือนี้ — แต่ `git diff` ยืนยันว่า `bookingUrgent.js` **ไม่ถูกแก้เลยแม้แต่บรรทัดเดียว** และ test ล็อก contract ของ flow งานด่วนไว้แล้ว

## Migration / Cache impact

- **ไม่มี migration** คอลัมน์ `jobs.gps_latitude/gps_longitude` มีอยู่แล้วและงานด่วนใช้อยู่ — เปลี่ยนแค่ว่าใครได้เขียนลงไปบ้าง
- Customer App runtime เปลี่ยนจริง → bump build id เป็น `20260821_issue316_scheduled_location_pin_v1` ครบทั้ง `sw.js`, `index.html`, bootstrap และ manifest
- **Admin build id ไม่ขยับ** เพราะ admin runtime ไม่เปลี่ยนในงานนี้
- assertion ของ Issue 310 ปรับให้ pin admin id แบบตรงตัวไว้เหมือนเดิม แต่เปลี่ยนฝั่ง customer เป็นตรวจ **invariant** ว่าทุก asset ย้าย id พร้อมกัน แทนการ hardcode literal — กันไม่ให้ guard ค้างแบบเดียวกับที่ `Test 15` เจอ

## Unverified

- ยังไม่ได้ทดสอบบนมือถือจริงที่ขอสิทธิ์ location จาก OS จริง (QA ใช้ stub `getCurrentPosition` ครบทั้ง success / denied / timeout / เบราว์เซอร์ไม่รองรับ)
- ยังไม่ได้ยิงจอง scheduled ที่มีพิกัดผ่าน DB จริงแบบ end-to-end (ต้องมี Postgres) — ตรรกะฝั่ง server ถูกทดสอบระดับ unit และ contract แล้ว
- flow งานด่วนใน QA browser (ดูหัวข้อ QA)

## Remaining risks

1. **ลูกค้าปักหมุดตอนไม่ได้อยู่บ้าน** จะได้พิกัดผิด — บรรเทาด้วยคำอธิบายไทยที่บอกชัดว่าหมุดคือตำแหน่งบ้าน แสดงพิกัดที่ปักให้เห็น และมีปุ่ม `ลบหมุด` **ยังไม่มีแผนที่ให้ลากหมุดเอง** ซึ่งเป็นทางแก้ที่ดีกว่าแต่ต้องใช้ Maps SDK + API key และเป็นงานคนละขนาด
2. **ต้องเป็น HTTPS** `navigator.geolocation` ใช้ไม่ได้บน origin ที่ไม่ปลอดภัย Production เป็น HTTPS อยู่แล้ว แต่ถ้าทดสอบผ่าน IP ตรง ๆ ปุ่มจะขึ้นข้อความ "เบราว์เซอร์นี้ไม่รองรับ" ซึ่งถูกต้องตามพฤติกรรม
3. **งานเก่าไม่ถูกย้อนแก้** งานจองล่วงหน้าที่จองไปแล้วยังไม่มีพิกัด ไม่มี backfill (ตั้งใจ — ไม่แตะข้อมูลจริง)
4. `maps_url` ถูกเขียนทับตอนปักหมุด ถ้าลูกค้าเคยวางลิงก์เองไว้จะถูกแทน — ยอมรับได้เพราะหมุดแม่นกว่า และลูกค้าลบหมุดหรือพิมพ์ลิงก์ทับได้ตลอด
5. **failure เดิม** `Test 15` ยังแดงบน branch นี้ตามที่อธิบายไว้ (ซ่อมใน PR #315)

## Rollback

revert merge commit เดียวจบ ไม่มี migration ไม่มีข้อมูลที่ต้องย้อน งานที่จองไปแล้วพร้อมพิกัดยังใช้ได้ปกติ (คอลัมน์เดิมที่งานด่วนใช้อยู่แล้ว) client จะได้ build id เดิมกลับมาในการโหลดถัดไป

## Production status

❌ **ไม่ได้ merge** ❌ **ไม่ได้ deploy** ❌ **ไม่แตะ Production / data / config / secrets** — Draft PR รอเจ้าของยืนยันตาม Release Flow

## ต้องให้เจ้าของตัดสินใจ

1. **ต้องการแผนที่ให้ลากหมุดเองไหม** (ดู Remaining risk ข้อ 1) — ปุ่ม "ใช้ตำแหน่งปัจจุบัน" แก้เคสส่วนใหญ่แล้ว แต่ลูกค้าที่จองล่วงหน้าจากที่ทำงานจะปักผิด ถ้าเอาต้องเตรียม Maps API key และเป็นงานแยก
2. **จะ merge PR #315 (compression) กับ PR #316 นี้เรียงลำดับยังไง** — ทั้งคู่แตกจาก `main` เดียวกัน ไม่ชนกัน merge ลำดับไหนก่อนก็ได้

🤖 Generated with [Claude Code](https://claude.com/claude-code)
