### PR TITLE
[Claude] Issue #318: แสดงราคาเริ่มต้นของแพ็กเกจร้านค้า แทน "สอบถามราคา"

### DIFF
--- a/customer-app/assets/customer-app.js
+++ b/customer-app/assets/customer-app.js
@@ -3,7 +3,7 @@
 
   const App = window.CWFCustomerAppV2;
   const BOOT_TIMEOUT_MS = 3500;
-  const BUILD_ID = "20260820_issue310_package_minimum_quantity_v1";
+  const BUILD_ID = "20260821_issue318_package_starting_price_v1";
 
   function withTimeout(promise, timeoutMs) {
     return Promise.race([

--- a/customer-app/index.html
+++ b/customer-app/index.html
@@ -21,10 +21,10 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Noto+Sans+Thai:wght@400;500;600;700;800;900&display=swap" media="print" onload="this.media='all'">
   <noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Noto+Sans+Thai:wght@400;500;600;700;800;900&display=swap"></noscript>
-  <link rel="manifest" href="./manifest.webmanifest?v=20260820_issue310_package_minimum_quantity_v1">
+  <link rel="manifest" href="./manifest.webmanifest?v=20260821_issue318_package_starting_price_v1">
   <link rel="icon" type="image/png" sizes="192x192" href="./assets/icons/cwf-customer-192.png">
   <link rel="apple-touch-icon" sizes="180x180" href="./assets/icons/cwf-customer-180.png">
-  <link rel="stylesheet" href="./assets/customer-app.css?v=20260820_issue310_package_minimum_quantity_v1">
+  <link rel="stylesheet" href="./assets/customer-app.css?v=20260821_issue318_package_starting_price_v1">
 </head>
 <body class="is-app-booting">
   <div class="app-shell" data-app-shell>
@@ -62,26 +62,26 @@
     </nav>
   </div>
 
-  <script src="./modules/iconRegistry.js?v=20260820_issue310_package_minimum_quantity_v1"></script>
-  <script src="./modules/state.js?v=20260820_issue310_package_minimum_quantity_v1"></script>
-  <script src="./modules/utils.js?v=20260820_issue310_package_minimum_quantity_v1"></script>
-  <script src="./modules/customerCopy.js?v=20260820_issue310_package_minimum_quantity_v1"></script>
-  <script src="./modules/analytics.js?v=20260820_issue310_package_minimum_quantity_v1"></script>
-  <script src="./modules/api.js?v=20260820_issue310_package_minimum_quantity_v1"></script>
-  <script src="./modules/pageAvailability.js?v=20260820_issue310_package_minimum_quantity_v1"></script>
-  <script src="./modules/services.js?v=20260820_issue310_package_minimum_quantity_v1"></script>
-  <script src="./modules/advisor.js?v=20260820_issue310_package_minimum_quantity_v1"></script>
-  <script src="./modules/ui.js?v=20260820_issue310_package_minimum_quantity_v1"></script>
-  <script src="./modules/store.js?v=20260820_issue310_package_minimum_quantity_v1"></script>
-  <script src="./modules/auth.js?v=20260820_issue310_package_minimum_quantity_v1"></script>
-  <script src="./modules/pricing.js?v=20260820_issue310_package_minimum_quantity_v1"></script>
-  <script src="./modules/availability.js?v=20260820_issue310_package_minimum_quantity_v1"></script>
-  <script src="./modules/bookingTicket.js?v=20260820_issue310_package_minimum_quantity_v1"></script>
-  <script src="./modules/bookingScheduled.js?v=20260820_issue310_package_minimum_quantity_v1"></script>
-  <script src="./modules/bookingUrgent.js?v=20260820_issue310_package_minimum_quantity_v1"></script>
-  <script src="./modules/tracking.js?v=20260820_issue310_package_minimum_quantity_v1"></script>
-  <script src="./modules/profile.js?v=20260820_issue310_package_minimum_quantity_v1"></script>
-  <script src="./modules/router.js?v=20260820_issue310_package_minimum_quantity_v1"></script>
-  <script src="./assets/customer-app.js?v=20260820_issue310_package_minimum_quantity_v1"></script>
+  <script src="./modules/iconRegistry.js?v=20260821_issue318_package_starting_price_v1"></script>
+  <script src="./modules/state.js?v=20260821_issue318_package_starting_price_v1"></script>
+  <script src="./modules/utils.js?v=20260821_issue318_package_starting_price_v1"></script>
+  <script src="./modules/customerCopy.js?v=20260821_issue318_package_starting_price_v1"></script>
+  <script src="./modules/analytics.js?v=20260821_issue318_package_starting_price_v1"></script>
+  <script src="./modules/api.js?v=20260821_issue318_package_starting_price_v1"></script>
+  <script src="./modules/pageAvailability.js?v=20260821_issue318_package_starting_price_v1"></script>
+  <script src="./modules/services.js?v=20260821_issue318_package_starting_price_v1"></script>
+  <script src="./modules/advisor.js?v=20260821_issue318_package_starting_price_v1"></script>
+  <script src="./modules/ui.js?v=20260821_issue318_package_starting_price_v1"></script>
+  <script src="./modules/store.js?v=20260821_issue318_package_starting_price_v1"></script>
+  <script src="./modules/auth.js?v=20260821_issue318_package_starting_price_v1"></script>
+  <script src="./modules/pricing.js?v=20260821_issue318_package_starting_price_v1"></script>
+  <script src="./modules/availability.js?v=20260821_issue318_package_starting_price_v1"></script>
+  <script src="./modules/bookingTicket.js?v=20260821_issue318_package_starting_price_v1"></script>
+  <script src="./modules/bookingScheduled.js?v=20260821_issue318_package_starting_price_v1"></script>
+  <script src="./modules/bookingUrgent.js?v=20260821_issue318_package_starting_price_v1"></script>
+  <script src="./modules/tracking.js?v=20260821_issue318_package_starting_price_v1"></script>
+  <script src="./modules/profile.js?v=20260821_issue318_package_starting_price_v1"></script>
+  <script src="./modules/router.js?v=20260821_issue318_package_starting_price_v1"></script>
+  <script src="./assets/customer-app.js?v=20260821_issue318_package_starting_price_v1"></script>
 </body>
 </html>

--- a/customer-app/manifest.webmanifest
+++ b/customer-app/manifest.webmanifest
@@ -2,7 +2,7 @@
   "name": "CWF Customer Service",
   "short_name": "CWF Service",
   "description": "แอปลูกค้า Coldwindflow สำหรับเลือกบริการ จองคิว และติดตามงาน",
-  "start_url": "/customer-app/index.html?v=20260820_issue310_package_minimum_quantity_v1#home",
+  "start_url": "/customer-app/index.html?v=20260821_issue318_package_starting_price_v1#home",
   "scope": "/customer-app/",
   "id": "/customer-app/",
   "display": "standalone",

--- a/customer-app/modules/advisor.js
+++ b/customer-app/modules/advisor.js
@@ -371,10 +371,10 @@
     `).join("")}</div>`;
   }
 
+  // Issue 318: shared resolver, so a recommended Store service-package bundle
+  // shows its starting price instead of "สอบถามราคา".
   function priceText(item) {
-    const value = item.display_price ?? item.active_price ?? item.base_price;
-    const numeric = Number(value);
-    return Number.isFinite(numeric) && numeric > 0 ? root.utils.formatBaht(numeric) : "สอบถามราคา";
+    return root.utils.catalogPriceLabel(item);
   }
 
   function firstImage(item) {

--- a/customer-app/modules/store.js
+++ b/customer-app/modules/store.js
@@ -45,27 +45,20 @@
     return Array.from(set).sort((a, b) => a.localeCompare(b, "th"));
   }
 
+  // Issue 318: this page already resolved package prices correctly while the
+  // homepage and the Smart Advisor did not. All three now share one resolver in
+  // utils so they cannot drift apart again; behaviour here is unchanged.
   function effectiveSalePrice(item) {
-    if (item?.booking_mode === "service_package") {
-      const prices = (item.service_package_variants || []).flatMap((variant) => (variant.tiers || []))
-        .filter((tier) => tier.is_active !== false).map((tier) => Number(tier.fixed_total_price)).filter((price) => Number.isFinite(price) && price > 0);
-      if (prices.length) return Math.min(...prices);
-    }
-    const display = Number(item.display_price);
-    if (Number.isFinite(display) && display > 0) return display;
-    const base = Number(item.base_price);
-    if (Number.isFinite(base) && base > 0) return base;
-    return null;
+    const price = root.utils.catalogStartingPrice(item);
+    return price ? price.amount : null;
   }
 
   function priceIsAsk(item) {
-    return effectiveSalePrice(item) === null;
+    return root.utils.catalogPriceIsAsk(item);
   }
 
   function priceLabel(item) {
-    const sale = effectiveSalePrice(item);
-    if (sale === null) return "สอบถามราคา";
-    return `${item?.booking_mode === "service_package" ? "เริ่ม " : ""}${root.utils.formatBaht(sale)}`;
+    return root.utils.catalogPriceLabel(item);
   }
 
   function hasPromo(item) {
@@ -929,7 +922,7 @@
         <div class="store-card-price">
           <span class="price-text${priceIsAsk(item) ? " is-estimate" : ""}">${root.utils.escapeHtml(priceLabel(item))}</span>
           ${promo ? `<span class="price-strike">${root.utils.escapeHtml(root.utils.formatBaht(item.normal_price))}</span>` : ""}
-          ${unit && !priceIsAsk(item) ? `<span class="muted price-unit">/ ${root.utils.escapeHtml(unit)}</span>` : ""}
+          ${root.utils.catalogPriceUnitLabel(item) ? `<span class="muted price-unit">/ ${root.utils.escapeHtml(root.utils.catalogPriceUnitLabel(item))}</span>` : ""}
         </div>
         ${renderPromoInfo(item)}
         <div class="store-card-actions">
@@ -1907,7 +1900,7 @@
       <div class="store-detail-price" data-store-detail-price>
         <span class="price-text${priceIsAsk(item) ? " is-estimate" : ""}">${root.utils.escapeHtml(priceLabel(item))}</span>
         ${promo ? `<span class="price-strike">${root.utils.escapeHtml(root.utils.formatBaht(item.normal_price))}</span>` : ""}
-        ${unit && !priceIsAsk(item) ? `<span class="muted">/ ${root.utils.escapeHtml(unit)}</span>` : ""}
+        ${root.utils.catalogPriceUnitLabel(item) ? `<span class="muted">/ ${root.utils.escapeHtml(root.utils.catalogPriceUnitLabel(item))}</span>` : ""}
       </div>
       ${renderPromoInfo(item)}
       ${renderVariantSelector(item, siblings)}

--- a/customer-app/modules/ui.js
+++ b/customer-app/modules/ui.js
@@ -215,10 +215,11 @@
     return primary?.image_url || item?.image_url || "";
   }
 
+  // Issue 318: use the shared resolver so a Store service-package bundle shows
+  // its real starting price here instead of "สอบถามราคา". A bundle is stored
+  // with base_price = 0, so the old display/active/base lookup always missed it.
   function catalogDisplayPrice(item) {
-    const value = item?.display_price ?? item?.active_price ?? item?.base_price;
-    const n = Number(value);
-    return Number.isFinite(n) && n > 0 ? root.utils.formatBaht(n) : "สอบถามราคา";
+    return root.utils.catalogPriceLabel(item);
   }
 
   function strictCatalogCommerceDraft(item) {
@@ -308,6 +309,7 @@
     const bookable = item.booking_mode === "bookable" || item.booking_mode === "service_package";
     const campaign = featuredCampaignPresentation(item);
     const price = catalogDisplayPrice(item);
+    const priceUnit = root.utils.catalogPriceUnitLabel(item);
     const tabIndex = interactive ? "" : ` tabindex="-1"`;
     return `
       <article class="homepage-service-card campaign-theme-${campaign.theme} campaign-effect-${campaign.effect}">
@@ -321,7 +323,7 @@
           ${campaign.html}
           <div class="homepage-card-body">
             <strong>${root.utils.escapeHtml(item.item_name || "-")}</strong>
-            ${showPrice ? `<span>${root.utils.escapeHtml(price)}${item.unit_label && price !== "สอบถามราคา" ? ` / ${root.utils.escapeHtml(item.unit_label)}` : ""}</span>` : ""}
+            ${showPrice ? `<span>${root.utils.escapeHtml(price)}${priceUnit ? ` / ${root.utils.escapeHtml(priceUnit)}` : ""}</span>` : ""}
           </div>
         </button>
         <button type="button" class="${bookable ? "primary-btn" : "secondary-btn"} homepage-service-action" data-home-featured-action="${id}"${tabIndex}>

--- a/customer-app/modules/utils.js
+++ b/customer-app/modules/utils.js
@@ -41,6 +41,63 @@
     return `${n.toLocaleString("th-TH", { maximumFractionDigits: 0 })} บาท`;
   }
 
+  // --- Catalog price (Issue 318) ------------------------------------------
+  // A Store service-package bundle is stored with base_price = 0 and carries its
+  // real prices on its tiers, so any helper that only reads
+  // display_price/active_price/base_price renders "สอบถามราคา" for a package that
+  // very much has a price. The homepage cards and the Smart Advisor each had
+  // their own copy of that helper and both showed the wrong thing, while the
+  // Store page had a third copy that got it right.
+  //
+  // This is the one resolver every customer surface uses, so they cannot drift
+  // apart again.
+
+  /**
+   * Lowest price a customer can actually pay for this item, or null when there
+   * genuinely is no published price.
+   * @returns {{amount: number, isFrom: boolean}|null} isFrom marks a package,
+   * where the amount is a starting price rather than the only price.
+   */
+  function catalogStartingPrice(item) {
+    if (item && item.booking_mode === "service_package") {
+      const prices = (Array.isArray(item.service_package_variants) ? item.service_package_variants : [])
+        .flatMap((variant) => (variant && Array.isArray(variant.tiers) ? variant.tiers : []))
+        .filter((tier) => tier && tier.is_active !== false)
+        .map((tier) => Number(tier.fixed_total_price))
+        .filter((price) => Number.isFinite(price) && price > 0);
+      if (prices.length) return { amount: Math.min(...prices), isFrom: true };
+    }
+    for (const value of [item?.display_price, item?.active_price, item?.base_price]) {
+      const amount = Number(value);
+      if (Number.isFinite(amount) && amount > 0) return { amount, isFrom: false };
+    }
+    return null;
+  }
+
+  /** True when there is no published price and the customer must ask. */
+  function catalogPriceIsAsk(item) {
+    return catalogStartingPrice(item) === null;
+  }
+
+  /** Customer-facing price text, e.g. "เริ่ม 699 บาท" / "699 บาท" / "สอบถามราคา". */
+  function catalogPriceLabel(item) {
+    const price = catalogStartingPrice(item);
+    if (!price) return "สอบถามราคา";
+    return `${price.isFrom ? "เริ่ม " : ""}${formatBaht(price.amount)}`;
+  }
+
+  /**
+   * Unit suffix to show after the price, or "" when none applies.
+   * A package is deliberately unit-less: its stored unit_label is the internal
+   * token "package", and a tier can cover several machines, so "/ เครื่อง" would
+   * be wrong and "/ package" would leak English into a Thai screen.
+   */
+  function catalogPriceUnitLabel(item) {
+    if (!item || item.booking_mode === "service_package") return "";
+    if (catalogPriceIsAsk(item)) return "";
+    return String(item.unit_label || "").trim();
+  }
+
   function formatDateTime(value) {
     if (!value) return "-";
     const dt = new Date(value);
@@ -214,6 +271,10 @@
     routeTo,
     randomKey,
     formatBaht,
+    catalogStartingPrice,
+    catalogPriceIsAsk,
+    catalogPriceLabel,
+    catalogPriceUnitLabel,
     formatDateTime,
     stepCards,
     timeline,

--- a/customer-app/sw.js
+++ b/customer-app/sw.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const BUILD_ID = "20260820_issue310_package_minimum_quantity_v1";
+const BUILD_ID = "20260821_issue318_package_starting_price_v1";
 const CACHE_NAME = `cwf-customer-app-v2-${BUILD_ID}`;
 const APP_SHELL = [
   `./index.html?v=${BUILD_ID}`,

--- a/test/customerAppPageAvailability.test.js
+++ b/test/customerAppPageAvailability.test.js
@@ -281,7 +281,7 @@ test("api exposes loadCustomerAppConfig as a no-store GET to /public/customer-ap
 });
 
 test("build wiring: pageAvailability.js is registered in the HTML shell and the SW cache, with the new build id", () => {
-  const build = "20260820_issue310_package_minimum_quantity_v1";
+  const build = "20260821_issue318_package_starting_price_v1";
   assert.match(indexHtml, new RegExp(`modules/pageAvailability\\.js\\?v=${build}`));
   assert.match(swSrc, new RegExp(`BUILD_ID = "${build}"`));
   assert.match(swSrc, /modules\/pageAvailability\.js\?v=\$\{BUILD_ID\}/);
@@ -294,7 +294,7 @@ test("build wiring: pageAvailability.js is registered in the HTML shell and the 
    RUNTIME tests (execute the real code in a VM — not regex assertions).
    ========================================================================== */
 
-const BUILD = "20260820_issue310_package_minimum_quantity_v1";
+const BUILD = "20260821_issue318_package_starting_price_v1";
 const adminSrc = read("admin-homepage-cms.js");
 
 function reqUrlOf(req) {

--- a/test/customerAppRecovery.test.js
+++ b/test/customerAppRecovery.test.js
@@ -335,7 +335,7 @@ test("Customer App build id is consistent across shell and service worker", () =
   const sw = read("customer-app/sw.js");
   const app = read("customer-app/assets/customer-app.js");
   const manifest = read("customer-app/manifest.webmanifest");
-  const build = "20260820_issue310_package_minimum_quantity_v1";
+  const build = "20260821_issue318_package_starting_price_v1";
 
   assert.match(index, new RegExp(`customer-app\\.css\\?v=${build}`));
   assert.match(index, new RegExp(`modules\\/api\\.js\\?v=${build}`));
@@ -353,7 +353,7 @@ test("Customer App build id is consistent across shell and service worker", () =
 test("store module is loaded in index.html and precached in the service worker app shell", () => {
   const index = read("customer-app/index.html");
   const sw = read("customer-app/sw.js");
-  const build = "20260820_issue310_package_minimum_quantity_v1";
+  const build = "20260821_issue318_package_starting_price_v1";
 
   assert.match(index, new RegExp(`modules/store\\.js\\?v=${build}`));
   assert.match(sw, /`\.\/modules\/store\.js\?v=\$\{BUILD_ID\}`/);

--- a/test/customerAppStorePayment.test.js
+++ b/test/customerAppStorePayment.test.js
@@ -58,7 +58,7 @@ test("store falls back to the LINE hand-off when payment is unconfigured or the 
 test("payment step styles exist and the Customer App payment build id is bumped", () => {
   assert.match(cssSrc, /\.pay-method-btn/);
   assert.match(cssSrc, /\.pay-qr-img/);
-  assert.match(read("customer-app/index.html"), /modules\/store\.js\?v=20260820_issue310_package_minimum_quantity_v1/);
-  assert.match(read("customer-app/sw.js"), /BUILD_ID = "20260820_issue310_package_minimum_quantity_v1"/);
+  assert.match(read("customer-app/index.html"), /modules\/store\.js\?v=20260821_issue318_package_starting_price_v1/);
+  assert.match(read("customer-app/sw.js"), /BUILD_ID = "20260821_issue318_package_starting_price_v1"/);
   assert.match(storeSrc, /payment-security 20260705 loaded/);
 });

--- a/test/customerBookingAdminNotifications.test.js
+++ b/test/customerBookingAdminNotifications.test.js
@@ -313,10 +313,10 @@ test("admin/customer frontend cache versions are bumped for booking notification
   assert.doesNotMatch(adminReviewHtml, /admin-review-v2\.js\?v=20260707_customer_booking_notify_v2/);
   assert.match(adminReviewHtml, /admin-review-ai-intake\.js\?v=ai-booking-intake-customer-cards-v11-admin-alert-gate/);
   assert.doesNotMatch(adminReviewHtml, /admin-review-ai-intake\.js\?v=ai-booking-intake-customer-cards-v10/);
-  assert.match(customerIndex, /bookingScheduled\.js\?v=20260820_issue310_package_minimum_quantity_v1/);
-  assert.match(customerIndex, /state\.js\?v=20260820_issue310_package_minimum_quantity_v1/);
-  assert.match(customerSw, /const BUILD_ID = "20260820_issue310_package_minimum_quantity_v1"/);
-  assert.match(customerManifest, /20260820_issue310_package_minimum_quantity_v1/);
+  assert.match(customerIndex, /bookingScheduled\.js\?v=20260821_issue318_package_starting_price_v1/);
+  assert.match(customerIndex, /state\.js\?v=20260821_issue318_package_starting_price_v1/);
+  assert.match(customerSw, /const BUILD_ID = "20260821_issue318_package_starting_price_v1"/);
+  assert.match(customerManifest, /20260821_issue318_package_starting_price_v1/);
 });
 
 test("behavior: review queue only includes customer urgent waiting rows while preserving review statuses", () => {

--- a/test/customerBookingProductionCopy.test.js
+++ b/test/customerBookingProductionCopy.test.js
@@ -5,7 +5,7 @@ const path = require("node:path");
 const vm = require("node:vm");
 
 const ROOT = path.resolve(__dirname, "..");
-const BUILD = "20260820_issue310_package_minimum_quantity_v1";
+const BUILD = "20260821_issue318_package_starting_price_v1";
 
 function read(relativePath) {
   return fs.readFileSync(path.join(ROOT, relativePath), "utf8");

--- a/test/customerBookingTicketUi.test.js
+++ b/test/customerBookingTicketUi.test.js
@@ -303,7 +303,7 @@ test("ticket handoff keeps tracking/new-booking actions, 44px controls, mobile l
   assert.match(index, /modules\/bookingTicket\.js\?v=/);
   assert.match(sw, /modules\/bookingTicket\.js\?v=\$\{BUILD_ID\}/);
   for (const source of [index, sw, manifest, appEntry]) {
-    assert.match(source, /20260820_issue310_package_minimum_quantity_v1/);
+    assert.match(source, /20260821_issue318_package_starting_price_v1/);
     assert.doesNotMatch(source, /20260809_issue267_catalog_flow_v8/);
   }
 });

--- a/test/customerCatalogPriceLabel.test.js
+++ b/test/customerCatalogPriceLabel.test.js
@@ -1,0 +1,167 @@
+"use strict";
+
+// Issue 318 - a Store service-package bundle must advertise its starting price,
+// not "สอบถามราคา".
+//
+// A bundle parent is inserted with base_price = 0 and unit_label = 'package'
+// (storeServicePackageCatalogService), and carries its real prices on its tiers.
+// Three customer surfaces each had their own price helper:
+//   - ui.js catalogDisplayPrice   -> display/active/base only  => "สอบถามราคา"
+//   - advisor.js priceText        -> display/active/base only  => "สอบถามราคา"
+//   - store.js effectiveSalePrice -> package-aware             => "เริ่ม 699 บาท"
+// so the same promotion showed a price on the Store page and "ask us" on the
+// homepage and in the Smart Advisor. Fixing the two copies would have left the
+// drift possible, so there is now exactly one resolver in utils.js.
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const vm = require("node:vm");
+
+const ROOT = path.join(__dirname, "..");
+const read = (file) => fs.readFileSync(path.join(ROOT, file), "utf8");
+
+// Load the real shipped utils module.
+function loadUtils() {
+  const context = {
+    window: { CWFCustomerAppV2: {} },
+    document: { addEventListener() {}, querySelectorAll: () => [], querySelector: () => null },
+    console: { info() {}, warn() {} },
+    location: { hash: "" },
+    setTimeout, clearTimeout,
+  };
+  vm.runInNewContext(read("customer-app/modules/utils.js"), context);
+  return context.window.CWFCustomerAppV2.utils;
+}
+
+function bundle(overrides = {}) {
+  return {
+    item_id: 51, item_name: "Premium Day", booking_mode: "service_package",
+    base_price: 0, display_price: 0, active_price: null, unit_label: "package",
+    service_package_variants: [
+      { package_key: "small", tiers: [
+        { tier_key: "q1", fixed_total_price: "699.00", is_active: true },
+        { tier_key: "q2", fixed_total_price: "1399.00", is_active: true },
+      ] },
+      { package_key: "large", tiers: [
+        { tier_key: "q1", fixed_total_price: "899.00", is_active: true },
+      ] },
+    ],
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// the resolver
+// ---------------------------------------------------------------------------
+
+test("Issue 318: a package advertises its lowest active tier price, marked as a starting price", () => {
+  const utils = loadUtils();
+  const item = bundle();
+  assert.deepEqual({ ...utils.catalogStartingPrice(item) }, { amount: 699, isFrom: true });
+  assert.equal(utils.catalogPriceLabel(item), "เริ่ม 699 บาท");
+  assert.equal(utils.catalogPriceIsAsk(item), false);
+});
+
+test("Issue 318: an inactive or unpriced tier never becomes the advertised price", () => {
+  const utils = loadUtils();
+  // a cheaper but DEACTIVATED tier must not be advertised
+  const withInactive = bundle({ service_package_variants: [
+    { package_key: "small", tiers: [
+      { tier_key: "old", fixed_total_price: "199.00", is_active: false },
+      { tier_key: "q1", fixed_total_price: "699.00", is_active: true },
+    ] },
+  ] });
+  assert.equal(utils.catalogPriceLabel(withInactive), "เริ่ม 699 บาท");
+  // zero / negative / non-numeric tier prices are ignored, never shown as free
+  const junk = bundle({ service_package_variants: [
+    { package_key: "small", tiers: [
+      { tier_key: "a", fixed_total_price: "0.00", is_active: true },
+      { tier_key: "b", fixed_total_price: "-5.00", is_active: true },
+      { tier_key: "c", fixed_total_price: "ฟรี", is_active: true },
+      { tier_key: "d", fixed_total_price: "899.00", is_active: true },
+    ] },
+  ] });
+  assert.equal(utils.catalogPriceLabel(junk), "เริ่ม 899 บาท");
+});
+
+test("Issue 318: a package with nothing sellable still says สอบถามราคา", () => {
+  const utils = loadUtils();
+  for (const variants of [[], [{ package_key: "x", tiers: [] }], [{ package_key: "x", tiers: [{ fixed_total_price: "0.00", is_active: true }] }]]) {
+    const item = bundle({ service_package_variants: variants });
+    assert.equal(utils.catalogPriceLabel(item), "สอบถามราคา");
+    assert.equal(utils.catalogPriceIsAsk(item), true);
+  }
+  // and a malformed variants payload must not throw
+  assert.equal(utils.catalogPriceLabel(bundle({ service_package_variants: null })), "สอบถามราคา");
+  assert.equal(utils.catalogPriceLabel(bundle({ service_package_variants: [null, { tiers: null }] })), "สอบถามราคา");
+});
+
+test("Issue 318: ordinary catalog items keep their existing price behaviour exactly", () => {
+  const utils = loadUtils();
+  assert.equal(utils.catalogPriceLabel({ booking_mode: "bookable", display_price: 590, base_price: 0 }), "590 บาท");
+  assert.equal(utils.catalogPriceLabel({ booking_mode: "bookable", display_price: 0, active_price: 480, base_price: 700 }), "480 บาท");
+  assert.equal(utils.catalogPriceLabel({ booking_mode: "bookable", display_price: 0, active_price: 0, base_price: 700 }), "700 บาท");
+  assert.equal(utils.catalogPriceLabel({ booking_mode: "contact_admin", base_price: 0 }), "สอบถามราคา");
+  assert.equal(utils.catalogPriceLabel(null), "สอบถามราคา");
+  assert.equal(utils.catalogPriceLabel(undefined), "สอบถามราคา");
+  // no "เริ่ม" prefix outside packages - an exact price must not read as a range
+  assert.doesNotMatch(utils.catalogPriceLabel({ booking_mode: "bookable", display_price: 590 }), /เริ่ม/);
+});
+
+test("Issue 318: a package shows no unit suffix, so the internal token 'package' never leaks", () => {
+  const utils = loadUtils();
+  assert.equal(utils.catalogPriceUnitLabel(bundle()), "");
+  assert.equal(utils.catalogPriceUnitLabel({ booking_mode: "bookable", display_price: 590, unit_label: "เครื่อง" }), "เครื่อง");
+  // an item with no published price shows no unit either
+  assert.equal(utils.catalogPriceUnitLabel({ booking_mode: "bookable", base_price: 0, unit_label: "เครื่อง" }), "");
+  assert.equal(utils.catalogPriceUnitLabel(null), "");
+});
+
+// ---------------------------------------------------------------------------
+// every surface uses it
+// ---------------------------------------------------------------------------
+
+test("Issue 318: homepage cards, Smart Advisor and Store all resolve price through utils", () => {
+  const ui = read("customer-app/modules/ui.js");
+  const advisor = read("customer-app/modules/advisor.js");
+  const store = read("customer-app/modules/store.js");
+
+  assert.match(ui, /function catalogDisplayPrice\(item\) \{\s*\n\s*return root\.utils\.catalogPriceLabel\(item\);/);
+  assert.match(advisor, /function priceText\(item\) \{\s*\n\s*return root\.utils\.catalogPriceLabel\(item\);/);
+  assert.match(store, /function priceLabel\(item\) \{\s*\n\s*return root\.utils\.catalogPriceLabel\(item\);/);
+  assert.match(store, /function effectiveSalePrice\(item\) \{[\s\S]*?root\.utils\.catalogStartingPrice\(item\)/);
+  assert.match(store, /function priceIsAsk\(item\) \{\s*\n\s*return root\.utils\.catalogPriceIsAsk\(item\);/);
+
+  // no surface may keep its own display/active/base-only copy
+  for (const [name, source] of [["ui.js", ui], ["advisor.js", advisor], ["store.js", store]]) {
+    assert.doesNotMatch(source, /display_price \?\? item\??\.?active_price/, `${name} still has a private price helper`);
+  }
+  // and no surface may hand-build the unit suffix from unit_label any more
+  for (const [name, source] of [["ui.js", ui], ["store.js", store]]) {
+    assert.doesNotMatch(source, /unit && !priceIsAsk\(item\)/, `${name} still appends unit_label directly`);
+    assert.doesNotMatch(source, /item\.unit_label && price !== "สอบถามราคา"/, `${name} still appends unit_label directly`);
+  }
+});
+
+test("Issue 318: the shared resolver is exported from utils", () => {
+  const utils = read("customer-app/modules/utils.js");
+  for (const name of ["catalogStartingPrice", "catalogPriceIsAsk", "catalogPriceLabel", "catalogPriceUnitLabel"]) {
+    assert.match(utils, new RegExp(`^\\s{4}${name},$`, "m"), `${name} must be on root.utils`);
+  }
+  // utils.js loads before ui/advisor/store, so the helper is always available
+  const index = read("customer-app/index.html");
+  const order = ["modules/utils.js", "modules/advisor.js", "modules/ui.js", "modules/store.js"].map((file) => index.indexOf(file));
+  assert.ok(order.every((position) => position > 0), "all four modules must be loaded");
+  assert.ok(order[0] < order[1] && order[0] < order[2] && order[0] < order[3], "utils.js must load before its consumers");
+});
+
+test("Issue 318: the customer runtime is cache-busted and admin ids stay put", () => {
+  const BUILD = "20260821_issue318_package_starting_price_v1";
+  assert.match(read("customer-app/sw.js"), new RegExp(`BUILD_ID = "${BUILD}"`));
+  assert.match(read("customer-app/assets/customer-app.js"), new RegExp(`BUILD_ID = "${BUILD}"`));
+  assert.match(read("customer-app/index.html"), new RegExp(`modules/utils\\.js\\?v=${BUILD}`));
+  assert.match(read("customer-app/manifest.webmanifest"), new RegExp(BUILD));
+  assert.match(read("admin-add-v2.html"), /admin-add-v2\.js\?v=20260820_issue310_package_minimum_quantity_v1/);
+});

--- a/test/customerHistoryClaim.test.js
+++ b/test/customerHistoryClaim.test.js
@@ -845,7 +845,7 @@ test("Customer History search and preview keep 360px and 390px width contracts",
 });
 
 test("Customer App cache version is bumped consistently", () => {
-  const expected = "20260820_issue310_package_minimum_quantity_v1";
+  const expected = "20260821_issue318_package_starting_price_v1";
   for (const file of [
     "customer-app/index.html",
     "customer-app/sw.js",

--- a/test/customerHomepageFeaturedRotation.test.js
+++ b/test/customerHomepageFeaturedRotation.test.js
@@ -5,6 +5,7 @@ const assert = require("node:assert/strict");
 const fs = require("node:fs");
 const path = require("node:path");
 const vm = require("node:vm");
+const { catalogPriceHelpers } = require("./helpers/customerCatalogPrice");
 
 const ROOT = path.resolve(__dirname, "..");
 const UI_SOURCE = fs.readFileSync(path.join(ROOT, "customer-app/modules/ui.js"), "utf8");
@@ -165,6 +166,7 @@ function loadUi(items, { reducedMotion = false } = {}) {
     utils: {
       escapeHtml: (value) => String(value == null ? "" : value),
       formatBaht: (value) => `${value} บาท`,
+      ...catalogPriceHelpers(),
       icon: () => "<i></i>",
       stateBox: (_kind, message) => `<p>${message}</p>`,
     },
@@ -418,6 +420,6 @@ test("compact CSS and cache build remain consistent with six-card rotation", () 
   assert.match(css, /\.homepage-featured-page\s*\{[^}]*grid-area:\s*1\s*\/\s*1/s);
   assert.match(css, /transition:\s*opacity 350ms/);
   assert.match(css, /prefers-reduced-motion:\s*reduce/);
-  const build = "20260820_issue310_package_minimum_quantity_v1";
+  const build = "20260821_issue318_package_starting_price_v1";
   for (const source of [html, sw, boot, manifest]) assert.match(source, new RegExp(build));
 });

--- a/test/customerHomepageServicePackages.test.js
+++ b/test/customerHomepageServicePackages.test.js
@@ -5,6 +5,7 @@ const assert = require("node:assert/strict");
 const fs = require("node:fs");
 const path = require("node:path");
 const vm = require("node:vm");
+const { catalogPriceHelpers } = require("./helpers/customerCatalogPrice");
 
 const ROOT = path.resolve(__dirname, "..");
 const read = (name) => fs.readFileSync(path.join(ROOT, name), "utf8");
@@ -26,6 +27,7 @@ function loadUi() {
       escapeHtml: (value) => String(value == null ? "" : value),
       routeTo: (route) => routed.push(route),
       formatBaht: String,
+      ...catalogPriceHelpers(),
       icon: () => "",
       iconSlot: () => "",
       stateBox: () => "",

--- a/test/customerLegacyUiRetirement.test.js
+++ b/test/customerLegacyUiRetirement.test.js
@@ -5,6 +5,7 @@ const assert = require("node:assert/strict");
 const fs = require("node:fs");
 const path = require("node:path");
 const vm = require("node:vm");
+const { catalogPriceHelpers } = require("./helpers/customerCatalogPrice");
 
 const ROOT = path.resolve(__dirname, "..");
 const read = (file) => fs.readFileSync(path.join(ROOT, file), "utf8");
@@ -15,6 +16,7 @@ function loadHomepage(items) {
     utils: {
       escapeHtml: (value) => String(value == null ? "" : value),
       formatBaht: (value) => `${Number(value).toLocaleString("th-TH")} บาท`,
+      ...catalogPriceHelpers(),
       icon: () => "<i></i>",
       stateBox: (_kind, message) => `<p>${message}</p>`,
     },

--- a/test/customerOrdinaryCatalogQuoteFlow.test.js
+++ b/test/customerOrdinaryCatalogQuoteFlow.test.js
@@ -7,6 +7,7 @@ const vm = require("node:vm");
 
 const servicesSource = fs.readFileSync("customer-app/modules/services.js", "utf8");
 const storeSource = fs.readFileSync("customer-app/modules/store.js", "utf8");
+const { catalogPriceHelpers } = require("./helpers/customerCatalogPrice");
 
 function item(id) {
   return {
@@ -56,6 +57,7 @@ function harness(quoteCatalogBooking) {
       formatBaht(value) { return String(value); },
       escapeHtml(value) { return String(value); },
       icon() { return ""; },
+      ...catalogPriceHelpers(),
     },
   };
   const window = { CWFCustomerAppV2: root, scrollY: 0, pageYOffset: 0 };

--- a/test/customerSameDayTiming.test.js
+++ b/test/customerSameDayTiming.test.js
@@ -161,7 +161,7 @@ test("customer app disables availability HTTP cache and refreshes same-day slots
 });
 
 test("customer app build and service worker cache IDs changed", () => {
-  const id = "20260820_issue310_package_minimum_quantity_v1";
+  const id = "20260821_issue318_package_starting_price_v1";
   for (const file of [
     "customer-app/index.html",
     "customer-app/sw.js",

--- a/test/customerServicePackageUi.test.js
+++ b/test/customerServicePackageUi.test.js
@@ -192,7 +192,7 @@ test("build id is coordinated and service worker privacy/network behavior remain
   const app = read("customer-app/assets/customer-app.js");
   const manifest = read("customer-app/manifest.webmanifest");
   const build = sw.match(/BUILD_ID = "([^"]+)"/)[1];
-  assert.equal(build, "20260820_issue310_package_minimum_quantity_v1");
+  assert.equal(build, "20260821_issue318_package_starting_price_v1");
   assert.match(index, new RegExp(build));
   assert.match(app, new RegExp(`BUILD_ID = "${build}"`));
   assert.match(manifest, new RegExp(`index\\.html\\?v=${build}#home`));

--- a/test/customerSmartAdvisor.test.js
+++ b/test/customerSmartAdvisor.test.js
@@ -5,6 +5,7 @@ const assert = require("node:assert/strict");
 const fs = require("node:fs");
 const path = require("node:path");
 const vm = require("node:vm");
+const { catalogPriceHelpers } = require("./helpers/customerCatalogPrice");
 
 const ROOT = path.resolve(__dirname, "..");
 const SOURCE = fs.readFileSync(path.join(ROOT, "customer-app/modules/advisor.js"), "utf8");
@@ -243,6 +244,7 @@ function loadAdvisor(options = {}) {
     utils: {
       escapeHtml,
       formatBaht: (value) => `${value} บาท`,
+      ...catalogPriceHelpers(),
       icon: (name) => `<i data-icon="${name}"></i>`,
       routeTo: (route) => routes.push(route),
     },
@@ -1157,7 +1159,7 @@ test("Home places built-in advisor after Quick Actions and before Featured Servi
       catalog: { status: "success", items: [] },
     },
     advisor: { renderSection: () => `<section data-smart-advisor>Advisor</section>` },
-    utils: { escapeHtml, icon: () => "", formatBaht: () => "-", stateBox: () => "" },
+    utils: { escapeHtml, icon: () => "", formatBaht: () => "-", stateBox: () => "", ...catalogPriceHelpers() },
     services: { quickServices: [], WALL_AC: "ผนัง" },
   };
   vm.runInNewContext(UI_SOURCE, {
@@ -1174,7 +1176,7 @@ test("Home places built-in advisor after Quick Actions and before Featured Servi
 });
 
 test("advisor module is loaded before ui.js and precached under the shared build id", () => {
-  const build = "20260820_issue310_package_minimum_quantity_v1";
+  const build = "20260821_issue318_package_starting_price_v1";
   assert.ok(INDEX_SOURCE.indexOf(`modules/advisor.js?v=${build}`) < INDEX_SOURCE.indexOf(`modules/ui.js?v=${build}`));
   assert.match(SW_SOURCE, new RegExp(`BUILD_ID = "${build}"`));
   assert.match(SW_SOURCE, /modules\/advisor\.js\?v=\$\{BUILD_ID\}/);

--- a/test/customerTrackingFullReadUi.test.js
+++ b/test/customerTrackingFullReadUi.test.js
@@ -5,6 +5,7 @@ const assert = require("node:assert/strict");
 const fs = require("node:fs");
 const path = require("node:path");
 const vm = require("node:vm");
+const { catalogPriceHelpers } = require("./helpers/customerCatalogPrice");
 
 const ROOT = path.resolve(__dirname, "..");
 const CUSTOMER_COPY_SOURCE = fs.readFileSync(path.join(ROOT, "customer-app/modules/customerCopy.js"), "utf8");
@@ -32,6 +33,7 @@ function loadTrackingRuntime(options = {}) {
       escapeHtml,
       formatDateTime: (value) => value ? `DATE:${value}` : "-",
       formatBaht: (value) => `${Number(value) || 0} บาท`,
+      ...catalogPriceHelpers(),
       stateBox: (status, message) => `<div class="${escapeHtml(status)}">${escapeHtml(message)}</div>`,
       timeline: (items) => items.map((item) => `<div>${escapeHtml(item.title)}:${escapeHtml(item.copy)}</div>`).join(""),
     },
@@ -1191,7 +1193,7 @@ test("tracking UI exposes loading, not-found, rate-limit and offline states", ()
 });
 
 test("tracking assets share the full-read cache build id", () => {
-  const build = "20260820_issue310_package_minimum_quantity_v1";
+  const build = "20260821_issue318_package_starting_price_v1";
   for (const file of [
     "customer-app/index.html",
     "customer-app/sw.js",

--- a/test/helpers/customerCatalogPrice.js
+++ b/test/helpers/customerCatalogPrice.js
@@ -1,0 +1,43 @@
+"use strict";
+
+// Issue 318 test helper.
+//
+// Several customer-app UI suites fake `root.utils` with a small literal
+// ({ escapeHtml, formatBaht, icon, stateBox }). Since the catalog price
+// resolver moved into utils.js, those fakes have to provide it too — and
+// re-typing the logic in six stubs would recreate exactly the duplication this
+// issue removed. So the fakes borrow the REAL implementation instead.
+//
+// Not named *.test.js on purpose: `npm test` globs test/*.test.js, so this file
+// is a helper module, never a suite.
+
+const fs = require("node:fs");
+const path = require("node:path");
+const vm = require("node:vm");
+
+let cached = null;
+
+/** The real catalog price helpers, loaded once from the shipped utils module. */
+function catalogPriceHelpers() {
+  if (cached) return cached;
+  const source = fs.readFileSync(path.join(__dirname, "..", "..", "customer-app", "modules", "utils.js"), "utf8");
+  const context = {
+    window: { CWFCustomerAppV2: {} },
+    document: { addEventListener() {}, querySelector: () => null, querySelectorAll: () => [] },
+    console: { info() {}, warn() {} },
+    location: { hash: "" },
+    setTimeout,
+    clearTimeout,
+  };
+  vm.runInNewContext(source, context);
+  const utils = context.window.CWFCustomerAppV2.utils;
+  cached = {
+    catalogStartingPrice: utils.catalogStartingPrice,
+    catalogPriceIsAsk: utils.catalogPriceIsAsk,
+    catalogPriceLabel: utils.catalogPriceLabel,
+    catalogPriceUnitLabel: utils.catalogPriceUnitLabel,
+  };
+  return cached;
+}
+
+module.exports = { catalogPriceHelpers };

--- a/test/homepageCms.test.js
+++ b/test/homepageCms.test.js
@@ -305,7 +305,7 @@ test("customer homepage has no admin control, bottom nav is fixed five-tab, and 
   const sw = read("customer-app/sw.js");
   const app = read("customer-app/assets/customer-app.js");
   const manifest = read("customer-app/manifest.webmanifest");
-  const build = "20260820_issue310_package_minimum_quantity_v1";
+  const build = "20260821_issue318_package_starting_price_v1";
 
   assert.doesNotMatch(index + ui, /โหมดแอดมิน|openCms|localStorage\.getItem\('cwfHomeCmsDemo'/);
   assert.match(index, /data-route="store"[\s\S]*ร้านค้า/);

--- a/test/servicePackageMinimumQuantity.test.js
+++ b/test/servicePackageMinimumQuantity.test.js
@@ -593,13 +593,25 @@ test("Issue 310: manual Admin Add flows and the PR #308 technician picker are un
 
 test("Issue 310: exactly the changed runtime assets get the new build id", () => {
   const BUILD = "20260820_issue310_package_minimum_quantity_v1";
+  // Admin runtimes changed in Issue 310 and have not changed since, so their ids
+  // stay pinned to that exact release.
   assert.match(read("admin-add-v2.html"), new RegExp(`admin-add-v2\\.js\\?v=${BUILD}`));
   assert.match(read("admin-store-catalog.html"), new RegExp(`admin-store-catalog\\.js\\?v=${BUILD}`));
-  assert.match(read("customer-app/sw.js"), new RegExp(`BUILD_ID = "${BUILD}"`));
-  assert.match(read("customer-app/index.html"), new RegExp(`modules/store\\.js\\?v=${BUILD}`));
-  assert.match(read("customer-app/index.html"), new RegExp(`assets/customer-app\\.css\\?v=${BUILD}`));
-  assert.match(read("customer-app/assets/customer-app.js"), new RegExp(`BUILD_ID = "${BUILD}"`));
-  assert.match(read("customer-app/manifest.webmanifest"), new RegExp(BUILD));
+
+  // The Customer App ships ONE shared build id across sw.js, index.html, the
+  // bootstrap and the manifest. Pinning the literal here would go stale on the
+  // next customer release and leave this guard permanently red (the exact
+  // failure mode Test 15 had), so assert the invariant instead: every customer
+  // asset moves together, and never lags Issue 310.
+  const swBuild = /BUILD_ID = "([^"]+)"/.exec(read("customer-app/sw.js"))?.[1];
+  assert.ok(swBuild, "customer-app/sw.js must declare a BUILD_ID");
+  assert.equal(/BUILD_ID = "([^"]+)"/.exec(read("customer-app/assets/customer-app.js"))?.[1], swBuild);
+  assert.match(read("customer-app/index.html"), new RegExp(`modules/store\\.js\\?v=${swBuild}`));
+  assert.match(read("customer-app/index.html"), new RegExp(`assets/customer-app\\.css\\?v=${swBuild}`));
+  assert.match(read("customer-app/manifest.webmanifest"), new RegExp(swBuild));
+  const stale = [...read("customer-app/index.html").matchAll(/\?v=([^"']+)/g)].map((m) => m[1]).filter((id) => id !== swBuild);
+  assert.deepEqual(stale, [], `every customer asset must carry the same build id, found stragglers: ${stale.join(", ")}`);
+  assert.ok(swBuild >= BUILD, `the customer build must not regress behind Issue 310: ${swBuild}`);
   // admin-store-catalog.css did not change in this issue, so its id must not move
   assert.match(read("admin-store-catalog.html"), /admin-store-catalog\.css\?v=20260809_issue267_merchandising_v3/);
   // no debug markers were shipped with the bump


### PR DESCRIPTION
Closes #318

## SHAs

| | |
|---|---|
| Base branch | `main` |
| **Base SHA** | `efaad4b70de41e3d10c81f9d519244c255f68057` |
| **Head SHA** | `b120a35e03581bd1fd70b1ffa93383105d1ca9ee` |

`main` (`efaad4b7`) ไม่มี commit ที่ยังไม่อยู่ใน `production/home-server` (`5d561ec9`) — สิ่งที่ audit คือเนื้อหาเดียวกับที่ลูกค้าใช้อยู่จริง

## Business outcome

Premium Day (และแพ็กเกจร้านค้าทุกตัว) แสดง **ราคาเริ่มต้นจริง** ตั้งแต่หน้าแรก แทนที่จะเป็น "สอบถามราคา" ซึ่งเป็นกำแพงแรกที่ทำให้ลูกค้าเลื่อนผ่าน

## Root cause

Bundle ถูก insert ด้วย `base_price = 0` และเก็บราคาจริงไว้ที่ **tiers** แต่มี price helper อยู่ 3 ชุดแยกกัน:

| Surface | Helper | Premium Day |
|---|---|---|
| หน้าแรก (Featured cards) | `ui.js` `catalogDisplayPrice` | อ่านแค่ `display_price ?? active_price ?? base_price` → **"สอบถามราคา"** ❌ |
| Smart Advisor | `advisor.js` `priceText` | เหมือนกัน → **"สอบถามราคา"** ❌ |
| หน้าร้านค้า | `store.js` `effectiveSalePrice` | รู้จัก package → **"เริ่ม 699 บาท"** ✅ |

โปรตัวเดียวกันแสดงคนละอย่างในแต่ละหน้า และหน้าแรกซึ่งลูกค้าเห็นก่อน คือหน้าที่แสดงผิด

**ปัญหาซ้อนที่บั๊กเดิมบังไว้:** bundle เก็บ `unit_label = 'package'` — ถ้าแก้แค่ให้ราคาโผล่ การ์ดจะกลายเป็น `เริ่ม 699 บาท / package` คือ token ภายในภาษาอังกฤษหลุดขึ้นหน้าจอไทย

## What changed

แก้ 2 copy ที่พังจะยังเหลือช่องให้แตกกันอีก จึงย้าย resolver ไปไว้ที่ **`utils.js` ที่เดียว** แล้วให้ทั้ง 3 หน้าเรียกใช้:

- `catalogStartingPrice(item)` → `{ amount, isFrom }` หรือ `null`
- `catalogPriceIsAsk(item)`
- `catalogPriceLabel(item)` → `"เริ่ม 699 บาท"` / `"590 บาท"` / `"สอบถามราคา"`
- `catalogPriceUnitLabel(item)` → `""` สำหรับ package, `"เครื่อง"` สำหรับรายการปกติ

**พฤติกรรมหน้าร้านค้าไม่เปลี่ยน** — หน้าแรกกับ Smart Advisor ถูกดึงมาให้ตรงกับหน้าร้านค้า

Package ไม่มีหน่วยต่อท้ายราคาโดยตั้งใจ เพราะ tier หนึ่งครอบหลายเครื่องได้ `/ เครื่อง` จึงผิด และ `/ package` ก็เป็นภาษาอังกฤษ

เฉพาะ tier ที่ยัง active และราคา > 0 เท่านั้นที่ถูกใช้เป็นราคาโฆษณา — tier ที่ปิดใช้งาน ราคา 0 ติดลบ หรือไม่ใช่ตัวเลข ไม่มีทางกลายเป็นราคาที่โชว์ และ package ที่ไม่มีอะไรขายได้จริงยังขึ้น "สอบถามราคา" เหมือนเดิม

**ไม่แตะราคาจริง กติกาคิดเงิน หรือ tier composition เลย** — งานนี้เป็นชั้นแสดงผลล้วน ๆ

## Tests

| Command | Result |
|---|---|
| `node --check` ไฟล์ที่เปลี่ยนทั้งหมด | ✅ OK |
| `git diff --check` | ✅ clean |
| `node --test test/customerCatalogPriceLabel.test.js` | ✅ **8/8 pass** |
| **Full `npm test` (branch `b120a35e`)** | **1656 tests · 1594 pass · 1 fail · 61 skipped** |
| **Full `npm test` (base `efaad4b7`)** | **1648 tests · 1586 pass · 1 fail · 61 skipped** |

**Base-vs-Branch: +8 tests, +8 passes, failure ตัวเดิมตัวเดียวเท่ากัน** — `Test 15` admin-review-v2 build-id pin ที่แดงอยู่แล้วบน `main`/Production ตั้งแต่ PR #304 (ซ่อมแยกใน PR #315) ไม่มี regression จาก branch นี้

Test ครอบคลุม: ราคาเริ่มต้น = tier ถูกสุดที่ active · tier ปิดใช้งาน/ราคา 0/ติดลบ/ไม่ใช่ตัวเลข ไม่ถูกใช้ · package ที่ขายไม่ได้ยังขึ้น "สอบถามราคา" · payload variants พังต้องไม่ throw · รายการปกติไม่เปลี่ยนพฤติกรรมและไม่มีคำว่า "เริ่ม" โผล่ · package ไม่มีหน่วย · ทั้ง 3 หน้าเรียก resolver กลาง · ไม่มีหน้าไหนเหลือ helper ส่วนตัว · `utils.js` โหลดก่อนผู้ใช้ทุกตัวใน `index.html` · cache contract

### มี test harness 6 จุดที่ต้องแก้ (รายงานตามกติกา scope)

UI suites หลายตัว fake `root.utils` ด้วย literal เล็ก ๆ (`{ escapeHtml, formatBaht, icon, stateBox }`) พอ production code พึ่ง helper ใหม่ fake เหล่านั้นจึงพัง (12 test แดง)

การพิมพ์ logic ราคาซ้ำลงไปใน 6 stub คือการสร้าง duplication แบบเดียวกับที่ PR นี้กำลังกำจัด จึงเพิ่ม `test/helpers/customerCatalogPrice.js` ที่โหลด **implementation จริง** จาก `utils.js` มาให้ stub ยืมใช้ — ตั้งชื่อไม่ลงท้าย `.test.js` เพราะ `npm test` glob เฉพาะ `test/*.test.js` ไฟล์นี้จึงเป็น helper ไม่ใช่ suite

## Browser / Mobile QA (390×844 หน้าจริง)

ป้อน item รูปทรงเดียวกับที่ API serialise จริง (Premium Day: `base_price 0`, `unit_label 'package'`, tiers 699/1399/899) พร้อม item ปกติเป็นตัวควบคุม

**การ์ดหน้าแรก (Featured)**

| รายการ | ราคาที่แสดง | ปุ่ม |
|---|---|---|
| Premium Day ล้างแอร์ | **`เริ่ม 699 บาท`** ✅ (เดิม "สอบถามราคา") | ดูแพ็กเกจ |
| ล้างแอร์ผนังทั่วไป | `590 บาท / เครื่อง` ✅ ไม่เปลี่ยน | จอง |

**การ์ดหน้าร้านค้า**

| รายการ | ราคา | หน่วย |
|---|---|---|
| Premium Day ล้างแอร์ | **`เริ่ม 699 บาท`** | **`(ไม่มี)`** ✅ ไม่มี `/ package` หลุด |
| ล้างแอร์ผนังทั่วไป | `590 บาท` | `/ เครื่อง` ✅ ไม่เปลี่ยน |

ไม่มี horizontal overflow · bottom nav ครบ · ราคาแสดงด้วยสีน้ำเงินตาม visual language เดิม

Screenshot ถ่ายไว้ที่ 390×844 — **แนบใน PR ไม่ได้** เพราะเครื่องนี้ไม่มี `gh` CLI จึงเปิด PR ผ่าน REST API ซึ่งแนบรูปไม่ได้ ตารางด้านบนอ่านจาก DOM จริงและถูกล็อกไว้ใน test แล้ว

## Migration / Cache impact

- **ไม่มี migration** ไม่แตะ schema ไม่แตะข้อมูล
- Customer App runtime เปลี่ยนจริง → bump build id เป็น `20260821_issue318_package_starting_price_v1` ครบทั้ง `sw.js`, `index.html`, bootstrap, manifest
- **Admin build id ไม่ขยับ** เพราะ admin runtime ไม่เปลี่ยน
- assertion ของ Issue 310 ปรับเป็นตรวจ **invariant** ว่า customer asset ย้าย id พร้อมกัน แทน hardcode literal — กัน guard ค้างแบบเดียวกับที่ `Test 15` เจอ

## Unverified

- ยังไม่ได้ดูกับข้อมูล Premium Day ตัวจริงจาก Production API (ต้องมี backend + DB) — QA ใช้ item รูปทรงเดียวกับที่ `serializeCatalogRow` ส่งออกจริง ถ้าราคาที่แสดงบน Production ยังผิดหลัง deploy แปลว่า `service_package_variants` ไม่ถูกแนบมาในรายการนั้น ซึ่งเป็นคนละสาเหตุและผมตรวจต่อให้ได้
- ยังไม่ได้ทดสอบบนมือถือจริง (ใช้ emulated viewport)

## Remaining risks

1. **"เริ่ม X บาท" คือราคาต่ำสุดของ tier ที่ถูกที่สุด** ลูกค้าที่เลือกหลายเครื่องหรือ BTU ใหญ่จะจ่ายมากกว่านั้น — เป็นพฤติกรรมเดียวกับที่หน้าร้านค้าใช้มาตลอด และคำว่า "เริ่ม" สื่อชัดว่าเป็นราคาเริ่มต้น ไม่ใช่ราคาสุดท้าย ไม่ได้สร้างความเร่งด่วนหรือส่วนลดปลอม
2. **ถ้าแอดมินปิด tier ที่ถูกที่สุด** ราคาโฆษณาจะขยับขึ้นทันทีในการโหลดถัดไป — ถูกต้องตามเจตนา แต่ควรรู้ไว้ว่าราคาหน้าแรกผูกกับ tier ที่ active อยู่
3. **`test/helpers/` เป็น directory ใหม่ใน `test/`** ไม่กระทบ `npm test` glob แต่เป็น convention ใหม่ของ repo นี้
4. **failure เดิม** `Test 15` ยังแดงบน branch นี้ตามที่อธิบาย (ซ่อมใน PR #315)
5. **Build id ชนกับ PR #317** ทั้งสอง branch แตกจาก `main` เดียวกันและต่าง bump `BUILD_ID` ของ Customer App ถ้า merge ทั้งคู่จะ conflict ที่บรรทัดนั้น — แก้ง่ายมาก คือเลือก id ที่ใหม่กว่าเพียงอันเดียว (ทั้งคู่หมายถึง "customer runtime เปลี่ยน" เหมือนกัน) ผมจัดการให้ได้ตอน merge

## Rollback

revert merge commit เดียวจบ ไม่มี migration ไม่มีข้อมูล ราคาจะกลับไปเป็น "สอบถามราคา" เหมือนเดิมทันทีในการโหลดถัดไป

## Production status

❌ **ไม่ได้ merge** ❌ **ไม่ได้ deploy** ❌ **ไม่แตะ Production / data / config / secrets**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
