### PR TITLE
[Codex] Issue #325: make CI diff gate promotion-safe

### DIFF
--- a/.github/workflows/cwf-ci-tests.yml
+++ b/.github/workflows/cwf-ci-tests.yml
@@ -75,7 +75,7 @@ jobs:
         run: |
           set -euo pipefail
           if [ "$EVENT_NAME" = "pull_request" ]; then
-            git diff --check "$PR_BASE_SHA" "$PR_HEAD_SHA"
+            git diff --check "$PR_BASE_SHA...$PR_HEAD_SHA"
           else
             git diff --check "$PUSH_BEFORE_SHA" "$PUSH_HEAD_SHA"
           fi

--- a/test/repositoryShippableArtifacts.test.js
+++ b/test/repositoryShippableArtifacts.test.js
@@ -132,7 +132,10 @@ test("Issue 320: CI runs the suite on pull requests into every deploy branch", (
   assert.match(workflow, /run: npm ci --no-audit --no-fund/);
   assert.match(workflow, /run: npm test/);
   assert.match(workflow, /fetch-depth: 0/, "the diff gate needs both compared commits");
-  assert.match(workflow, /git diff --check \"\$PR_BASE_SHA\" \"\$PR_HEAD_SHA\"/);
+  assert.match(workflow, /git diff --check \"\$PR_BASE_SHA\.\.\.\$PR_HEAD_SHA\"/,
+    "pull requests must check only head changes since the merge-base, including promotion PRs");
+  assert.doesNotMatch(workflow, /git diff --check \"\$PR_BASE_SHA\" \"\$PR_HEAD_SHA\"/,
+    "a two-dot PR diff incorrectly includes base-only branch changes");
   assert.match(workflow, /git diff --check \"\$PUSH_BEFORE_SHA\" \"\$PUSH_HEAD_SHA\"/);
   assert.doesNotMatch(workflow, /git diff --check[^\n]*(?:\|\|\s*true|;\s*true)/,
     "the whitespace/conflict-marker gate must fail the workflow, never swallow errors");


### PR DESCRIPTION
Closes #325

## Root cause

The fail-closed whitespace gate used a two-dot base/head tree diff. On divergent long-lived promotion branches this includes base-only differences which Git's merge result preserves, so Staging PR #324 was blocked by its own branch-specific `db.js`.

## Fix

- Pull requests: `git diff --check "$PR_BASE_SHA...$PR_HEAD_SHA"`
- Push events remain exact before/head.
- Contract test now requires three-dot and rejects the incorrect two-dot form.

No application, database, config, dependency, UI or deployment code changed.

## Verification

- Actual `origin/staging/home-server-test...origin/main` diff check: PASS
- Focused repository contract: **8/8 PASS**
- Full `npm test`: **1689 total · 1628 pass · 0 fail · 61 skipped**
- `git diff --check`: PASS

## Rollback

Revert this PR; no data/schema impact.

Owner has authorized correction and continued deployment through Staging to Production after CI succeeds.