### PR TITLE
Correction to #330: make AIR RESET seed checkout runner-safe

### DIFF
--- a/.github/workflows/cwf-air-reset-seed-gate.yml
+++ b/.github/workflows/cwf-air-reset-seed-gate.yml
@@ -11,6 +11,9 @@ on:
 permissions:
   contents: read
 
+env:
+  GIT_CONFIG_NOSYSTEM: "1"
+
 concurrency:
   group: cwf-air-reset-seed-${{ github.event.workflow_run.head_branch }}
   cancel-in-progress: false

--- a/test/airResetSeedOperator.test.js
+++ b/test/airResetSeedOperator.test.js
@@ -37,6 +37,7 @@ test("AIR RESET seed gate runs only after successful staging or production deplo
   assert.match(workflow, /workflow_run:/);
   assert.match(workflow, /CWF Home Staging/);
   assert.match(workflow, /CWF Home Production/);
+  assert.match(workflow, /GIT_CONFIG_NOSYSTEM: "1"/);
   assert.match(workflow, /workflow_run\.conclusion == 'success'/);
   assert.match(workflow, /staging\/home-server-test/);
   assert.match(workflow, /production\/home-server/);


### PR DESCRIPTION
Third deployment correction to merged PR #330, on the SAME Issue #329 implementation branch.

Blocking finding from CWF AIR RESET Seed Gate run 34007042282 / job 101416076862:
- Staging deployment itself succeeded with `MIGRATIONS_OK pending=1 applied=1` and `DEPLOY_OK`.
- Seed Gate failed before touching DB because `actions/checkout@v4` on the self-hosted runner attempted to read `/etc/gitconfig` and received `Permission denied`.

Correction scope (2 files only):
- set `GIT_CONFIG_NOSYSTEM: "1"` in the Seed Gate workflow, matching the repository's existing self-hosted migration workflow pattern
- add a regression assertion for that runner guard

No schema, seed SQL, pricing, booking, UI, auth, payment, or job behavior changes.

Required gate: CI green, then re-promote main -> staging to trigger the corrected Seed Gate and require AIR_RESET_SEED_OK before Production.