### PR TITLE
Promote runner-safe AIR RESET Seed Gate to CWF home staging

### DIFF
--- a/.github/workflows/cwf-air-reset-seed-gate.yml
+++ b/.github/workflows/cwf-air-reset-seed-gate.yml
@@ -11,6 +11,9 @@ on:
 permissions:
   contents: read
 
+env:
+  GIT_CONFIG_NOSYSTEM: "1"
+
 concurrency:
   group: cwf-air-reset-seed-${{ github.event.workflow_run.head_branch }}
   cancel-in-progress: false

--- a/test/airResetSeedOperator.test.js
+++ b/test/airResetSeedOperator.test.js
@@ -37,6 +37,7 @@ test("AIR RESET seed gate runs only after successful staging or production deplo
   assert.match(workflow, /workflow_run:/);
   assert.match(workflow, /CWF Home Staging/);
   assert.match(workflow, /CWF Home Production/);
+  assert.match(workflow, /GIT_CONFIG_NOSYSTEM: "1"/);
   assert.match(workflow, /workflow_run\.conclusion == 'success'/);
   assert.match(workflow, /staging\/home-server-test/);
   assert.match(workflow, /production\/home-server/);


### PR DESCRIPTION
Promote Issue #329 correction after PR #336 / CI #58 passed.

Main head: 044d56d4a99bd6d99cf54670c446324ddb864e32
Current deployed Staging code/schema is healthy at release 4398aa5a4495bd3a1e7364893088bcaf62eef065, but AIR RESET data has not been seeded because Seed Gate checkout failed before DB access.

This promotion changes only the Seed Gate runner checkout guard plus its regression assertion on top of the already-deployed AIR RESET code/schema.

Merge after CI passes. Required post-merge evidence: CWF Home Staging DEPLOY_OK for the new release, then CWF AIR RESET Seed Gate AIR_RESET_SEED_OK (or verified already-applied state).