### PR TITLE
Issue #329: prepaid readiness and Admin promotion policy controls

### DIFF
--- a/.github/workflows/cwf-air-reset-seed-gate.yml
+++ b/.github/workflows/cwf-air-reset-seed-gate.yml
@@ -37,13 +37,15 @@ jobs:
           ref: ${{ github.event.workflow_run.head_sha }}
           fetch-depth: 1
 
-      - name: Apply guarded AIR RESET seed
+      - name: Apply prepaid schema and guarded AIR RESET cutover
         shell: bash
         env:
           EXPECTED_RELEASE_SHA: ${{ github.event.workflow_run.head_sha }}
         run: |
           set -Eeuo pipefail
+          bash scripts/apply-prepaid-service-entitlements-home.sh staging | tee /tmp/cwf-prepaid-migration.log
           bash scripts/apply-air-reset-60-seed.sh staging | tee /tmp/cwf-air-reset-seed.log
+          cat /tmp/cwf-prepaid-migration.log >> "$GITHUB_STEP_SUMMARY"
           cat /tmp/cwf-air-reset-seed.log >> "$GITHUB_STEP_SUMMARY"
 
   seed-production:
@@ -64,11 +66,13 @@ jobs:
           ref: ${{ github.event.workflow_run.head_sha }}
           fetch-depth: 1
 
-      - name: Apply guarded AIR RESET seed
+      - name: Apply prepaid schema and guarded AIR RESET cutover
         shell: bash
         env:
           EXPECTED_RELEASE_SHA: ${{ github.event.workflow_run.head_sha }}
         run: |
           set -Eeuo pipefail
+          bash scripts/apply-prepaid-service-entitlements-home.sh production | tee /tmp/cwf-prepaid-migration.log
           bash scripts/apply-air-reset-60-seed.sh production | tee /tmp/cwf-air-reset-seed.log
+          cat /tmp/cwf-prepaid-migration.log >> "$GITHUB_STEP_SUMMARY"
           cat /tmp/cwf-air-reset-seed.log >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/cwf-ci-tests.yml
+++ b/.github/workflows/cwf-ci-tests.yml
@@ -84,3 +84,21 @@ jobs:
         # Database-backed suites self-skip when no isolated Postgres URL is set,
         # exactly as they do locally. They are never pointed at a real database.
         run: npm test
+
+      - name: Identify failing test files
+        if: failure()
+        shell: bash
+        run: |
+          set +e
+          FAILED=0
+          for file in test/*.test.js; do
+            node --test "$file" >/tmp/cwf-test-file.log 2>&1
+            STATUS=$?
+            if [ "$STATUS" -ne 0 ]; then
+              echo "::error file=$file::isolated test file failed"
+              echo "===== $file ====="
+              tail -n 120 /tmp/cwf-test-file.log
+              FAILED=1
+            fi
+          done
+          exit "$FAILED"

--- a/.github/workflows/cwf-ci-tests.yml
+++ b/.github/workflows/cwf-ci-tests.yml
@@ -91,14 +91,30 @@ jobs:
         run: |
           set +e
           FAILED=0
+          DIAG=/tmp/cwf-failing-tests.log
+          : > "$DIAG"
           for file in test/*.test.js; do
             node --test "$file" >/tmp/cwf-test-file.log 2>&1
             STATUS=$?
             if [ "$STATUS" -ne 0 ]; then
               echo "::error file=$file::isolated test file failed"
               echo "===== $file ====="
-              tail -n 120 /tmp/cwf-test-file.log
+              tail -n 200 /tmp/cwf-test-file.log
+              {
+                echo "===== $file ====="
+                tail -n 200 /tmp/cwf-test-file.log
+                echo
+              } >> "$DIAG"
               FAILED=1
             fi
           done
           exit "$FAILED"
+
+      - name: Upload failing test diagnostics
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: cwf-failing-tests
+          path: /tmp/cwf-failing-tests.log
+          if-no-files-found: warn
+          retention-days: 1

--- a/admin-store-catalog.html
+++ b/admin-store-catalog.html
@@ -85,5 +85,6 @@
 
   <script src="/admin-v2-common.js?v=20260622_admin_menu_catalog_entry"></script>
   <script src="/admin-store-catalog.js?v=20260820_issue310_package_minimum_quantity_v1"></script>
+  <script src="/admin-store-promotion-policy-extension.js?v=20260906_issue329_promotion_policy_v1"></script>
 </body>
 </html>

--- a/admin-store-promotion-policy-extension.js
+++ b/admin-store-promotion-policy-extension.js
@@ -35,7 +35,7 @@
           <option value="book_now">จองวันบริการทันที (Book now)</option>
           <option value="prepaid_full">ชำระเต็มจำนวน เก็บสิทธิ์ไว้ใช้ภายหลัง (Prepaid)</option>
         </select>
-        <p class="muted2 mini">Prepaid ต้องมีวันหมดสิทธิ์และวันรับประกัน ระบบจะไม่อนุญาต policy ที่ข้อมูลไม่ครบ</p>
+        <p class="muted2 mini">Prepaid ต้องมีวันหมดสิทธิ์และวันรับประกัน ระบบจะเปิดขายเมื่อ backend + schema พร้อมเท่านั้น</p>
       </div>
     </div>`;
   }
@@ -163,7 +163,10 @@
       const payload = bundlePayload();
       const desiredActive = payload.is_active;
       const desiredVisible = payload.is_customer_visible;
-      // Fail closed: the parent stays hidden until the policy write succeeds.
+
+      // Production ordering is deliberate:
+      // 1) save content hidden, 2) upload media, 3) save/validate policy hidden,
+      // 4) publish LAST. Any failure before step 4 leaves the Store item hidden.
       payload.is_active = false;
       payload.is_customer_visible = false;
       const url = editingBundleKey
@@ -176,20 +179,32 @@
       const bundleKey = saved.service_bundle_key || editingBundleKey;
       if (!bundleKey) throw new Error("ระบบไม่ได้ส่งรหัสโปรโมชั่นกลับมา กรุณารีเฟรชและลองใหม่");
 
-      await apiFetch(`/admin/catalog/service-package-bundles/${encodeURIComponent(bundleKey)}/promotion-policy`, {
-        method: "PATCH",
-        body: JSON.stringify(promotionPolicyPayload(saved, desiredActive, desiredVisible)),
-      });
-
       const files = Array.from(el("bm_images")?.files || []);
       for (const file of files) {
         const formData = new FormData();
         formData.append("image", file);
         await apiFetch(`/admin/catalog/items/${saved.item_id}/images`, { method: "POST", body: formData });
       }
+
+      // Validate and persist every pricing/payment rule while still invisible.
+      await apiFetch(`/admin/catalog/service-package-bundles/${encodeURIComponent(bundleKey)}/promotion-policy`, {
+        method: "PATCH",
+        body: JSON.stringify(promotionPolicyPayload(saved, false, false)),
+      });
+
+      // Publish is the final mutation. For prepaid_full, backend readiness is
+      // checked here; if migration/backend is missing this call fails and the
+      // already-saved promotion remains hidden instead of breaking checkout.
+      if (desiredActive || desiredVisible) {
+        await apiFetch(`/admin/catalog/service-package-bundles/${encodeURIComponent(bundleKey)}/promotion-policy`, {
+          method: "PATCH",
+          body: JSON.stringify(promotionPolicyPayload(saved, desiredActive, desiredVisible)),
+        });
+      }
+
       el("bundle_modal_backdrop").classList.add("hidden");
       await Promise.all([loadServicePackages(), loadCatalogItems()]);
-      showToast("บันทึกโปรโมชั่นและนโยบายราคาแล้ว", "success");
+      showToast("บันทึกโปรโมชั่นและเปิดขายเรียบร้อย", "success");
     } catch (error) {
       box.textContent = error?.message || "บันทึกโปรโมชั่นไม่สำเร็จ ระบบคงรายการไว้ในสถานะซ่อนเพื่อความปลอดภัย";
       box.style.display = "block";

--- a/admin-store-promotion-policy-extension.js
+++ b/admin-store-promotion-policy-extension.js
@@ -1,0 +1,201 @@
+/* Issue #329: generic promotion-policy editor extension.
+ * Loaded after admin-store-catalog.js so the stable catalog editor remains unchanged.
+ */
+(() => {
+  "use strict";
+
+  const originalEnsureBundleModal = ensureBundleModal;
+  const originalRenderBundleVariantEditor = renderBundleVariantEditor;
+  const originalNewBundleVariant = newBundleVariant;
+  const originalOpenBundleModal = openBundleModal;
+
+  function policyFieldHtml() {
+    return `<div id="bm_promotion_policy_fields" class="asc-section">
+      <div class="asc-section-title">นโยบายโปรโมชั่น</div>
+      <div class="asc-grid2">
+        <div class="asc-field"><label>วิธีคิดราคา *</label>
+          <select id="bm_pricing_strategy">
+            <option value="per_variant_tier">ราคาแยกตาม Variant</option>
+            <option value="total_quantity_tier_plus_unit_modifiers">ราคารวมตามจำนวน + ส่วนเพิ่มต่อเครื่อง</option>
+          </select>
+        </div>
+        <div class="asc-field"><label>รูปแบบการเลือกระดับ *</label>
+          <select id="bm_selection_mode">
+            <option value="multi_variant">เลือก Variant ร่วมกันได้</option>
+            <option value="exclusive_level">เลือกได้ทีละระดับบริการ</option>
+          </select>
+        </div>
+      </div>
+      <div class="asc-grid2">
+        <div class="asc-field"><label>จำนวนเครื่องสูงสุดต่อการซื้อ/จอง</label><input id="bm_maximum_total_quantity" type="number" min="1" max="99" step="1" placeholder="ไม่กำหนด"></div>
+        <div class="asc-field"><label>รับประกันหลังปิดงาน (วัน)</label><input id="bm_warranty_days" type="number" min="1" max="3650" step="1" placeholder="ไม่กำหนด"></div>
+      </div>
+      <div class="asc-field"><label>รูปแบบการชำระเงิน *</label>
+        <select id="bm_payment_mode">
+          <option value="book_now">จองวันบริการทันที (Book now)</option>
+          <option value="prepaid_full">ชำระเต็มจำนวน เก็บสิทธิ์ไว้ใช้ภายหลัง (Prepaid)</option>
+        </select>
+        <p class="muted2 mini">Prepaid ต้องมีวันหมดสิทธิ์และวันรับประกัน ระบบจะไม่อนุญาต policy ที่ข้อมูลไม่ครบ</p>
+      </div>
+    </div>`;
+  }
+
+  function ensurePolicyFields() {
+    if (el("bm_promotion_policy_fields")) return;
+    const minimum = el("bm_minimum_total_quantity");
+    const anchor = minimum?.closest(".asc-field");
+    if (!anchor) return;
+    anchor.insertAdjacentHTML("afterend", policyFieldHtml());
+  }
+
+  ensureBundleModal = function ensureBundleModalWithPromotionPolicy() {
+    originalEnsureBundleModal();
+    ensurePolicyFields();
+  };
+
+  newBundleVariant = function newBundleVariantWithPromotionPolicy() {
+    return {
+      ...originalNewBundleVariant(),
+      service_level_key: null,
+      service_level_label: null,
+      unit_price_modifier: "0.00",
+    };
+  };
+
+  function appendVariantPolicyEditor(article, variant) {
+    if (!article || article.querySelector("[data-promotion-variant-policy]")) return;
+    const tierBlock = article.querySelector(".asc-bundle-tiers")?.previousElementSibling;
+    const html = `<div data-promotion-variant-policy class="asc-section">
+      <div class="asc-section-title">ระดับบริการ / ส่วนเพิ่มราคา</div>
+      <div class="asc-grid2">
+        <div class="asc-field"><label>Service level key</label><input data-variant-field="service_level_key" maxlength="80" placeholder="เช่น standard" value="${escapeHtml(variant.service_level_key || "")}"></div>
+        <div class="asc-field"><label>ชื่อลูกค้าเห็น</label><input data-variant-field="service_level_label" maxlength="120" placeholder="เช่น STANDARD" value="${escapeHtml(variant.service_level_label || "")}"></div>
+      </div>
+      <div class="asc-field"><label>ส่วนเพิ่มราคาต่อเครื่อง (บาท)</label><input data-variant-field="unit_price_modifier" inputmode="decimal" placeholder="0.00" value="${escapeHtml(variant.unit_price_modifier == null ? "0.00" : variant.unit_price_modifier)}"><p class="muted2 mini">ตัวอย่าง 18,000 BTU +100/เครื่อง ให้ใส่ 100.00</p></div>
+    </div>`;
+    if (tierBlock) tierBlock.insertAdjacentHTML("beforebegin", html);
+    else article.insertAdjacentHTML("beforeend", html);
+  }
+
+  renderBundleVariantEditor = function renderBundleVariantEditorWithPolicy() {
+    originalRenderBundleVariantEditor();
+    document.querySelectorAll("[data-bundle-variant-index]").forEach((article) => {
+      const index = Number(article.dataset.bundleVariantIndex);
+      appendVariantPolicyEditor(article, bundleVariantDrafts[index] || {});
+    });
+  };
+
+  function optionalNumber(id) {
+    const value = String(el(id)?.value || "").trim();
+    return value === "" ? null : Number(value);
+  }
+
+  function loadParentPolicy(policy = {}) {
+    ensurePolicyFields();
+    el("bm_pricing_strategy").value = policy.pricing_strategy || "per_variant_tier";
+    el("bm_selection_mode").value = policy.selection_mode || "multi_variant";
+    el("bm_maximum_total_quantity").value = policy.maximum_total_quantity == null ? "" : String(policy.maximum_total_quantity);
+    el("bm_payment_mode").value = policy.payment_mode || "book_now";
+    el("bm_warranty_days").value = policy.warranty_days == null ? "" : String(policy.warranty_days);
+  }
+
+  openBundleModal = async function openBundleModalWithPromotionPolicy(bundleKey = null) {
+    await originalOpenBundleModal(bundleKey);
+    ensurePolicyFields();
+    if (!bundleKey) {
+      loadParentPolicy();
+      bundleVariantDrafts = bundleVariantDrafts.map((variant) => ({
+        ...variant,
+        service_level_key: variant.service_level_key || null,
+        service_level_label: variant.service_level_label || null,
+        unit_price_modifier: variant.unit_price_modifier == null ? "0.00" : String(variant.unit_price_modifier),
+      }));
+      renderBundleVariantEditor();
+      return;
+    }
+    try {
+      const policy = await apiFetch(`/admin/catalog/service-package-bundles/${encodeURIComponent(bundleKey)}/promotion-policy`);
+      loadParentPolicy(policy);
+      const byKey = new Map((policy.variants || []).map((variant) => [variant.package_key, variant]));
+      bundleVariantDrafts = bundleVariantDrafts.map((variant) => ({
+        ...variant,
+        ...(byKey.get(variant.package_key) || {}),
+      }));
+      renderBundleVariantEditor();
+    } catch (error) {
+      const box = el("bundle_modal_error");
+      box.textContent = error?.message || "โหลดนโยบายโปรโมชั่นไม่สำเร็จ";
+      box.style.display = "block";
+    }
+  };
+
+  function promotionPolicyPayload(saved, desiredActive, desiredVisible) {
+    const savedVariants = Array.isArray(saved?.variants) ? saved.variants : [];
+    return {
+      pricing_strategy: el("bm_pricing_strategy").value,
+      selection_mode: el("bm_selection_mode").value,
+      maximum_total_quantity: optionalNumber("bm_maximum_total_quantity"),
+      payment_mode: el("bm_payment_mode").value,
+      warranty_days: optionalNumber("bm_warranty_days"),
+      is_active: desiredActive,
+      is_customer_visible: desiredVisible,
+      variants: savedVariants.map((savedVariant, index) => {
+        const draft = bundleVariantDrafts.find((variant) => variant.package_key === savedVariant.package_key)
+          || bundleVariantDrafts[index]
+          || {};
+        return {
+          package_key: savedVariant.package_key,
+          service_level_key: String(draft.service_level_key || "").trim() || null,
+          service_level_label: String(draft.service_level_label || "").trim() || null,
+          unit_price_modifier: String(draft.unit_price_modifier == null || draft.unit_price_modifier === "" ? "0.00" : draft.unit_price_modifier).trim(),
+        };
+      }),
+    };
+  }
+
+  saveBundle = async function saveBundleWithPromotionPolicy() {
+    if (isSaving) return;
+    const box = el("bundle_modal_error");
+    box.style.display = "none";
+    isSaving = true;
+    el("bundle_modal_save").disabled = true;
+    try {
+      const payload = bundlePayload();
+      const desiredActive = payload.is_active;
+      const desiredVisible = payload.is_customer_visible;
+      // Fail closed: the parent stays hidden until the policy write succeeds.
+      payload.is_active = false;
+      payload.is_customer_visible = false;
+      const url = editingBundleKey
+        ? `/admin/catalog/service-package-bundles/${encodeURIComponent(editingBundleKey)}`
+        : "/admin/catalog/service-package-bundles";
+      const saved = await apiFetch(url, {
+        method: editingBundleKey ? "PATCH" : "POST",
+        body: JSON.stringify(payload),
+      });
+      const bundleKey = saved.service_bundle_key || editingBundleKey;
+      if (!bundleKey) throw new Error("ระบบไม่ได้ส่งรหัสโปรโมชั่นกลับมา กรุณารีเฟรชและลองใหม่");
+
+      await apiFetch(`/admin/catalog/service-package-bundles/${encodeURIComponent(bundleKey)}/promotion-policy`, {
+        method: "PATCH",
+        body: JSON.stringify(promotionPolicyPayload(saved, desiredActive, desiredVisible)),
+      });
+
+      const files = Array.from(el("bm_images")?.files || []);
+      for (const file of files) {
+        const formData = new FormData();
+        formData.append("image", file);
+        await apiFetch(`/admin/catalog/items/${saved.item_id}/images`, { method: "POST", body: formData });
+      }
+      el("bundle_modal_backdrop").classList.add("hidden");
+      await Promise.all([loadServicePackages(), loadCatalogItems()]);
+      showToast("บันทึกโปรโมชั่นและนโยบายราคาแล้ว", "success");
+    } catch (error) {
+      box.textContent = error?.message || "บันทึกโปรโมชั่นไม่สำเร็จ ระบบคงรายการไว้ในสถานะซ่อนเพื่อความปลอดภัย";
+      box.style.display = "block";
+    } finally {
+      isSaving = false;
+      el("bundle_modal_save").disabled = false;
+    }
+  };
+})();

--- a/customer-app/index.html
+++ b/customer-app/index.html
@@ -13,10 +13,6 @@
   <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
   <meta name="apple-mobile-web-app-title" content="CWF Service">
   <title>CWF Customer Service</title>
-  <!-- Load one web font (Noto Sans Thai) so every screen renders in the same
-       typeface regardless of what the device has installed. Loaded async
-       (media=print → all onload) so a slow/unreachable font CDN never blocks
-       first paint; the UI shows the fallback stack until the font arrives. -->
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Noto+Sans+Thai:wght@400;500;600;700;800;900&display=swap" media="print" onload="this.media='all'">
@@ -34,22 +30,17 @@
           <img src="./assets/icons/cwf-customer-192.png" alt="">
           <span>CWF</span>
         </div>
-        <div>
-          <p class="eyebrow">Coldwindflow</p>
-          <h1>CWF Service</h1>
-        </div>
+        <div><p class="eyebrow">Coldwindflow</p><h1>CWF Service</h1></div>
       </div>
       <button class="icon-pill" type="button" data-route="profile" data-account-chip aria-label="เข้าสู่ระบบหรือดูบัญชี">
-        <span class="account-chip-avatar" data-account-chip-avatar aria-hidden="true"></span>
-        <span data-account-chip-label>บัญชี</span>
+        <span class="account-chip-avatar" data-account-chip-avatar aria-hidden="true"></span><span data-account-chip-label>บัญชี</span>
       </button>
     </header>
 
     <main id="app" class="app-main" tabindex="-1">
       <section class="app-boot-screen" aria-live="polite">
         <img src="./assets/icons/cwf-customer-192.png" alt="" width="72" height="72">
-        <strong>กำลังเปิด CWF Service</strong>
-        <span>เตรียมบริการและข้อมูลบัญชีของคุณ</span>
+        <strong>กำลังเปิด CWF Service</strong><span>เตรียมบริการและข้อมูลบัญชีของคุณ</span>
       </section>
     </main>
 
@@ -78,6 +69,7 @@
   <script src="./modules/availability.js?v=20260827_minimum_price_upload_cache_v1"></script>
   <script src="./modules/bookingTicket.js?v=20260827_minimum_price_upload_cache_v1"></script>
   <script src="./modules/bookingScheduled.js?v=20260827_minimum_price_upload_cache_v1"></script>
+  <script src="./modules/prepaid.js?v=20260827_minimum_price_upload_cache_v1"></script>
   <script src="./modules/bookingUrgent.js?v=20260827_minimum_price_upload_cache_v1"></script>
   <script src="./modules/tracking.js?v=20260827_minimum_price_upload_cache_v1"></script>
   <script src="./modules/profile.js?v=20260827_minimum_price_upload_cache_v1"></script>

--- a/customer-app/modules/prepaid.js
+++ b/customer-app/modules/prepaid.js
@@ -1,0 +1,480 @@
+(function () {
+  "use strict";
+
+  const root = window.CWFCustomerAppV2 = window.CWFCustomerAppV2 || {};
+  const LINE_URL = "https://lin.ee/";
+  let modal = null;
+  let omiseJsPromise = null;
+  let quoteSeq = 0;
+  const policyCache = new Map();
+
+  function esc(value) {
+    return String(value == null ? "" : value)
+      .replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;")
+      .replace(/"/g, "&quot;").replace(/'/g, "&#39;");
+  }
+
+  function baht(value) {
+    const n = Number(value || 0);
+    return `${new Intl.NumberFormat("th-TH", { maximumFractionDigits: 2 }).format(n)} บาท`;
+  }
+
+  async function request(path, options = {}) {
+    const response = await fetch(`${root.api.getApiBase()}${path}`, {
+      method: options.method || "GET",
+      credentials: "include",
+      cache: options.cache || "no-store",
+      headers: options.body ? { "Content-Type": "application/json" } : undefined,
+      body: options.body ? JSON.stringify(options.body) : undefined,
+    });
+    const text = await response.text();
+    let data = {};
+    try { data = text ? JSON.parse(text) : {}; } catch (_) {}
+    if (!response.ok) {
+      const error = new Error(data?.error || `HTTP ${response.status}`);
+      error.status = response.status;
+      error.code = data?.code || data?.error || "REQUEST_FAILED";
+      error.data = data;
+      throw error;
+    }
+    return data;
+  }
+
+  function ensureStyles() {
+    if (document.getElementById("cwf-prepaid-live-styles")) return;
+    const style = document.createElement("style");
+    style.id = "cwf-prepaid-live-styles";
+    style.textContent = `
+      .cwf-rights-pill{position:fixed;right:14px;bottom:92px;z-index:85;border:0;border-radius:999px;padding:11px 15px;background:#071b38;color:#fff;font-weight:800;box-shadow:0 10px 26px rgba(2,6,23,.24)}
+      .cwf-prepaid-backdrop{position:fixed;inset:0;z-index:220;background:rgba(2,6,23,.62);display:flex;align-items:flex-end;justify-content:center;padding:0}
+      .cwf-prepaid-sheet{width:min(680px,100%);max-height:92vh;overflow:auto;background:#f8fafc;border-radius:24px 24px 0 0;padding:18px;box-shadow:0 -18px 50px rgba(2,6,23,.22)}
+      .cwf-prepaid-head{display:flex;justify-content:space-between;gap:12px;align-items:flex-start}.cwf-prepaid-head h2{margin:0;font-size:21px}.cwf-prepaid-close{border:0;background:#e2e8f0;border-radius:999px;width:38px;height:38px;font-size:20px}
+      .cwf-prepaid-card{background:#fff;border:1px solid rgba(15,23,42,.12);border-radius:16px;padding:14px;margin-top:12px}.cwf-prepaid-muted{color:#64748b;font-size:13px}.cwf-prepaid-row{display:flex;gap:10px;align-items:center;justify-content:space-between;flex-wrap:wrap}
+      .cwf-prepaid-grid{display:grid;gap:9px}.cwf-prepaid-service{display:grid;grid-template-columns:minmax(0,1fr) 96px;gap:10px;align-items:center;border-top:1px solid #e2e8f0;padding:10px 0}.cwf-prepaid-service:first-child{border-top:0}
+      .cwf-prepaid-qty{width:88px;padding:9px;border:1px solid #cbd5e1;border-radius:10px;font-size:16px;text-align:center}.cwf-prepaid-input{width:100%;box-sizing:border-box;padding:11px;border:1px solid #cbd5e1;border-radius:11px;font-size:16px;background:#fff}
+      .cwf-prepaid-primary,.cwf-prepaid-secondary{width:100%;border:0;border-radius:12px;padding:12px 14px;font-weight:800;font-size:15px;margin-top:10px}.cwf-prepaid-primary{background:#0b5ed7;color:#fff}.cwf-prepaid-secondary{background:#e2e8f0;color:#0f172a}.cwf-prepaid-primary:disabled{opacity:.55}.cwf-prepaid-error{padding:10px;border-radius:12px;background:#fef2f2;color:#991b1b;margin-top:10px}.cwf-prepaid-success{padding:10px;border-radius:12px;background:#ecfdf5;color:#166534;margin-top:10px}
+      .cwf-prepaid-total{font-size:24px;font-weight:900}.cwf-prepaid-qr{width:min(260px,80vw);display:block;margin:12px auto;border-radius:12px}.cwf-prepaid-status{display:inline-flex;border-radius:999px;padding:5px 9px;font-size:12px;font-weight:800;background:#e2e8f0}.cwf-prepaid-status.active{background:#dcfce7;color:#166534}.cwf-prepaid-status.redeemed{background:#dbeafe;color:#1d4ed8}
+      @media(min-width:720px){.cwf-prepaid-backdrop{align-items:center;padding:24px}.cwf-prepaid-sheet{border-radius:24px;max-height:88vh}}
+    `;
+    document.head.appendChild(style);
+  }
+
+  function closeModal() {
+    if (modal) modal.remove();
+    modal = null;
+  }
+
+  function openModal(title, body) {
+    ensureStyles();
+    closeModal();
+    modal = document.createElement("div");
+    modal.className = "cwf-prepaid-backdrop";
+    modal.innerHTML = `<section class="cwf-prepaid-sheet" role="dialog" aria-modal="true"><div class="cwf-prepaid-head"><div><div class="cwf-prepaid-muted">CWF PREPAID</div><h2>${esc(title)}</h2></div><button type="button" class="cwf-prepaid-close" data-prepaid-close aria-label="ปิด">×</button></div><div data-prepaid-body>${body || ""}</div></section>`;
+    modal.addEventListener("click", (event) => {
+      if (event.target === modal || event.target.closest?.("[data-prepaid-close]")) closeModal();
+    });
+    document.body.appendChild(modal);
+    return modal.querySelector("[data-prepaid-body]");
+  }
+
+  function currentItemId(button) {
+    const raw = button.getAttribute("data-store-book") || button.getAttribute("data-store-urgent");
+    const direct = Number(raw);
+    if (Number.isSafeInteger(direct) && direct > 0) return direct;
+    const detail = Number(root.state.storeDetail?.data?.item_id || root.state.storeDetail?.itemId || 0);
+    return Number.isSafeInteger(detail) && detail > 0 ? detail : 0;
+  }
+
+  async function policyFor(itemId) {
+    if (policyCache.has(String(itemId))) return policyCache.get(String(itemId));
+    const data = await request(`/public/prepaid-policy/${encodeURIComponent(itemId)}`);
+    policyCache.set(String(itemId), data);
+    return data;
+  }
+
+  function delegateOriginal(button) {
+    button.dataset.prepaidBypass = "1";
+    button.click();
+  }
+
+  function customerContact() {
+    const customer = root.state.customer || {};
+    const profile = customer.profile || {};
+    const user = customer.user || {};
+    return {
+      name: String(user.name || customer.display_name || profile.display_name || "").trim(),
+      phone: String(profile.phone || customer.phone || user.phone || "").trim(),
+    };
+  }
+
+  function requireLogin() {
+    if (root.state.customer?.logged_in) return true;
+    const body = openModal("เข้าสู่ระบบเพื่อเก็บสิทธิ์", `<div class="cwf-prepaid-card"><b>โปร PREPAID ต้องผูกสิทธิ์กับบัญชีลูกค้า</b><p class="cwf-prepaid-muted">เข้าสู่ระบบด้วย LINE หรือ Google ก่อนชำระ เพื่อให้สิทธิ์ไม่สูญหายและป้องกันผู้อื่นนำไปใช้</p><button class="cwf-prepaid-primary" data-prepaid-login>เข้าสู่ระบบ</button></div>`);
+    body.querySelector("[data-prepaid-login]")?.addEventListener("click", () => { closeModal(); root.utils.routeTo("profile"); });
+    return false;
+  }
+
+  function packageRows(item) {
+    const variants = Array.isArray(item.service_package_variants) ? item.service_package_variants : [];
+    const btuOptions = Array.isArray(root.services?.bookableBtuOptions) ? root.services.bookableBtuOptions : [];
+    const rows = [];
+    variants.forEach((variant) => {
+      const min = Number(variant.btu_min || 0);
+      const max = Number(variant.btu_max || Number.MAX_SAFE_INTEGER);
+      btuOptions.filter((option) => Number(option.btu) >= min && Number(option.btu) <= max).forEach((option) => {
+        rows.push({
+          package_key: String(variant.package_key),
+          label: `${variant.display_name || variant.service_name || item.item_name} · ${Number(option.btu).toLocaleString("th-TH")} BTU`,
+          btu: Number(option.btu),
+          quantity: 0,
+        });
+      });
+    });
+    if (rows[0]) rows[0].quantity = 1;
+    return rows;
+  }
+
+  function selectedGroups(rows) {
+    return rows.filter((row) => Number(row.quantity) > 0).map((row) => ({
+      package_key: row.package_key,
+      btu: row.btu,
+      quantity: Number(row.quantity),
+    }));
+  }
+
+  async function openPurchase(itemId) {
+    if (!requireLogin()) return;
+    const body = openModal("กำลังโหลดโปรโมชั่น", `<div class="cwf-prepaid-card">กำลังโหลดราคาและตัวเลือก...</div>`);
+    try {
+      const item = await root.api.loadCatalogItem(itemId);
+      const actual = item?.item || item;
+      if (!actual || !Array.isArray(actual.service_package_variants) || !actual.service_package_variants.length) throw new Error("PACKAGE_NOT_AVAILABLE");
+      const rows = packageRows(actual);
+      if (!rows.length) throw new Error("PACKAGE_OPTIONS_NOT_AVAILABLE");
+      const contact = customerContact();
+      let quote = null;
+      let quoteTimer = null;
+
+      function render() {
+        body.innerHTML = `
+          <div class="cwf-prepaid-card"><b>${esc(actual.item_name || "โปรโมชั่น CWF")}</b><div class="cwf-prepaid-muted">เลือกจำนวนเครื่องตาม BTU ระบบคำนวณราคาจาก Server จริง</div><div class="cwf-prepaid-grid" data-prepaid-rows>${rows.map((row, index) => `<label class="cwf-prepaid-service"><span>${esc(row.label)}</span><input class="cwf-prepaid-qty" type="number" min="0" max="99" step="1" value="${row.quantity}" data-prepaid-qty="${index}" aria-label="จำนวนเครื่อง ${esc(row.label)}"></label>`).join("")}</div></div>
+          <div class="cwf-prepaid-card"><div class="cwf-prepaid-muted">ราคาที่ต้องชำระ</div><div class="cwf-prepaid-total" data-prepaid-total>${quote ? baht(quote.fixed_total_price) : "กำลังคำนวณ..."}</div><div class="cwf-prepaid-muted" data-prepaid-terms>${quote ? `ใช้สิทธิ์ได้ถึง ${new Date(quote.redeem_until).toLocaleDateString("th-TH")} · รับประกัน ${quote.warranty_days} วันหลังปิดงาน` : ""}</div></div>
+          <div class="cwf-prepaid-card"><label>ชื่อผู้ใช้สิทธิ์<input class="cwf-prepaid-input" data-prepaid-name value="${esc(contact.name)}" maxlength="120"></label><label style="display:block;margin-top:10px">เบอร์โทร<input class="cwf-prepaid-input" data-prepaid-phone value="${esc(contact.phone)}" maxlength="40" inputmode="tel"></label><button class="cwf-prepaid-primary" data-prepaid-buy ${quote ? "" : "disabled"}>ชำระเงินและเก็บสิทธิ์</button><div data-prepaid-error></div></div>`;
+        body.querySelectorAll("[data-prepaid-qty]").forEach((input) => input.addEventListener("input", () => {
+          const index = Number(input.dataset.prepaidQty);
+          rows[index].quantity = Math.max(0, Math.min(99, Math.floor(Number(input.value || 0))));
+          quote = null;
+          scheduleQuote();
+        }));
+        body.querySelector("[data-prepaid-buy]")?.addEventListener("click", createAndPay);
+      }
+
+      async function refreshQuote() {
+        const groups = selectedGroups(rows);
+        const seq = ++quoteSeq;
+        if (!groups.length) { quote = null; render(); return; }
+        try {
+          const data = await request("/public/prepaid-orders/quote", { method: "POST", body: { catalog_item_id: Number(actual.item_id), service_package_groups: groups } });
+          if (seq !== quoteSeq) return;
+          quote = data.quote;
+          render();
+        } catch (error) {
+          if (seq !== quoteSeq) return;
+          quote = null;
+          render();
+          const box = body.querySelector("[data-prepaid-error]");
+          if (box) box.innerHTML = `<div class="cwf-prepaid-error">${esc(error.code === "SERVICE_PACKAGE_MINIMUM_QUANTITY_NOT_MET" ? "จำนวนเครื่องยังไม่ถึงขั้นต่ำของโปรโมชั่น" : "ชุดบริการนี้ใช้โปรโมชั่นไม่ได้ กรุณาตรวจจำนวน/BTU")}</div>`;
+        }
+      }
+
+      function scheduleQuote() {
+        clearTimeout(quoteTimer);
+        const total = body.querySelector("[data-prepaid-total]");
+        if (total) total.textContent = "กำลังคำนวณ...";
+        quoteTimer = setTimeout(refreshQuote, 180);
+      }
+
+      async function createAndPay() {
+        const button = body.querySelector("[data-prepaid-buy]");
+        const errorBox = body.querySelector("[data-prepaid-error]");
+        const name = String(body.querySelector("[data-prepaid-name]")?.value || "").trim();
+        const phone = String(body.querySelector("[data-prepaid-phone]")?.value || "").trim();
+        if (!quote || !name || !phone) {
+          if (errorBox) errorBox.innerHTML = `<div class="cwf-prepaid-error">กรอกชื่อ เบอร์โทร และเลือกจำนวนเครื่องให้ครบ</div>`;
+          return;
+        }
+        button.disabled = true;
+        button.textContent = "กำลังสร้างสิทธิ์...";
+        try {
+          const purchaseKey = root.utils?.randomKey?.() || `prepaid_${cryptoRandomKey()}`;
+          const created = await request("/public/prepaid-orders", { method: "POST", body: {
+            catalog_item_id: Number(actual.item_id),
+            service_package_groups: selectedGroups(rows),
+            customer_name: name,
+            customer_phone: phone,
+            purchase_request_key: purchaseKey,
+          } });
+          renderPayment(created.order, created.entitlement_code, actual.item_name);
+        } catch (error) {
+          button.disabled = false;
+          button.textContent = "ชำระเงินและเก็บสิทธิ์";
+          if (errorBox) errorBox.innerHTML = `<div class="cwf-prepaid-error">สร้างรายการไม่สำเร็จ (${esc(error.code || error.message)})</div>`;
+        }
+      }
+
+      render();
+      await refreshQuote();
+    } catch (error) {
+      body.innerHTML = `<div class="cwf-prepaid-error">โปรโมชั่นนี้ยังไม่พร้อมใช้งาน (${esc(error.code || error.message)})</div>`;
+    }
+  }
+
+  function cryptoRandomKey() {
+    const bytes = new Uint8Array(18);
+    window.crypto.getRandomValues(bytes);
+    return Array.from(bytes, (b) => b.toString(16).padStart(2, "0")).join("");
+  }
+
+  async function ensureOmiseJs(publicKey) {
+    if (window.Omise) { window.Omise.setPublicKey(publicKey); return window.Omise; }
+    if (!omiseJsPromise) {
+      omiseJsPromise = new Promise((resolve, reject) => {
+        const script = document.createElement("script");
+        script.src = "https://cdn.omise.co/omise.js";
+        script.async = true;
+        script.onload = () => resolve(window.Omise);
+        script.onerror = () => reject(new Error("OMISE_JS_LOAD_FAILED"));
+        document.head.appendChild(script);
+      });
+    }
+    const omise = await omiseJsPromise;
+    if (!omise) throw new Error("OMISE_JS_LOAD_FAILED");
+    omise.setPublicKey(publicKey);
+    return omise;
+  }
+
+  function omiseCardToken(omise, card) {
+    return new Promise((resolve, reject) => {
+      omise.createToken("card", card, (statusCode, response) => {
+        if (statusCode === 200 && response?.id) resolve(response.id);
+        else reject(new Error(response?.message || "CARD_TOKEN_FAILED"));
+      });
+    });
+  }
+
+  async function renderPayment(order, entitlementCode, itemName) {
+    const body = modal?.querySelector("[data-prepaid-body]");
+    if (!body) return;
+    let config;
+    try { config = await root.api.getPaymentConfig(); } catch (_) { config = { enabled: false, methods: [] }; }
+    const methods = Array.isArray(config.methods) ? config.methods : [];
+    body.innerHTML = `<div class="cwf-prepaid-card"><b>${esc(itemName || "สิทธิ์บริการ CWF")}</b><div class="cwf-prepaid-muted">เลขรายการ ${esc(order.order_code)}</div><div class="cwf-prepaid-total">${baht(order.subtotal)}</div></div><div data-prepaid-payment></div>`;
+    const mount = body.querySelector("[data-prepaid-payment]");
+    if (!config.enabled || !methods.length) {
+      mount.innerHTML = `<div class="cwf-prepaid-card"><b>รายการถูกสร้างแล้ว แต่ระบบชำระออนไลน์ยังไม่พร้อม</b><p class="cwf-prepaid-muted">แจ้งเลขรายการ ${esc(order.order_code)} ให้แอดมินตรวจยอดและยืนยันการชำระ สิทธิ์จะ ACTIVE หลังตรวจสอบเงินเท่านั้น</p><button class="cwf-prepaid-secondary" data-prepaid-rights>ดูสิทธิ์ของฉัน</button></div>`;
+      mount.querySelector("[data-prepaid-rights]")?.addEventListener("click", openRights);
+      return;
+    }
+    mount.innerHTML = `<div class="cwf-prepaid-card"><b>เลือกวิธีชำระ</b>${methods.includes("promptpay") ? `<button class="cwf-prepaid-primary" data-pay-prompt>PromptPay QR</button>` : ""}${methods.includes("card") ? `<button class="cwf-prepaid-secondary" data-pay-card>บัตรเครดิต/เดบิต</button>` : ""}<div data-pay-area></div></div>`;
+    mount.querySelector("[data-pay-prompt]")?.addEventListener("click", () => payPromptPay(order.order_code, entitlementCode));
+    mount.querySelector("[data-pay-card]")?.addEventListener("click", () => cardForm(order.order_code, entitlementCode, config.public_key));
+  }
+
+  async function payPromptPay(orderCode, entitlementCode) {
+    const area = modal?.querySelector("[data-pay-area]");
+    if (!area) return;
+    area.innerHTML = `<div class="cwf-prepaid-muted" style="margin-top:10px">กำลังสร้าง QR...</div>`;
+    try {
+      const result = await root.api.payOrder(orderCode, { method: "promptpay" });
+      if (result.order?.status === "paid" || result.payment?.status === "paid") return paymentSuccess(entitlementCode);
+      const qr = result.payment?.qr_uri;
+      area.innerHTML = `${qr ? `<img class="cwf-prepaid-qr" src="${esc(qr)}" alt="PromptPay QR">` : ""}<div class="cwf-prepaid-muted">สแกน QR แล้วระบบจะตรวจสอบการชำระอัตโนมัติ</div><div data-pay-poll></div>`;
+      pollPaid(orderCode, entitlementCode, area.querySelector("[data-pay-poll]"));
+    } catch (error) {
+      area.innerHTML = `<div class="cwf-prepaid-error">เริ่มชำระไม่สำเร็จ (${esc(error?.data?.error || error.message)})</div>`;
+    }
+  }
+
+  async function pollPaid(orderCode, entitlementCode, mount) {
+    for (let attempt = 0; attempt < 80 && modal?.isConnected; attempt += 1) {
+      await new Promise((resolve) => setTimeout(resolve, 3000));
+      try {
+        const data = await root.api.getOrder(orderCode);
+        if (data.order?.status === "paid") { paymentSuccess(entitlementCode); return; }
+        if (mount) mount.textContent = "กำลังตรวจสอบการชำระเงิน...";
+      } catch (_) {}
+    }
+    if (mount) mount.innerHTML = `<div class="cwf-prepaid-error">ยังไม่พบผลชำระ กรุณาเปิด “สิทธิ์บริการ” เพื่อตรวจสอบอีกครั้ง</div>`;
+  }
+
+  function cardForm(orderCode, entitlementCode, publicKey) {
+    const area = modal?.querySelector("[data-pay-area]");
+    if (!area) return;
+    area.innerHTML = `<div style="margin-top:12px"><input class="cwf-prepaid-input" data-card-name placeholder="ชื่อบนบัตร"><input class="cwf-prepaid-input" data-card-number inputmode="numeric" autocomplete="cc-number" placeholder="เลขบัตร" style="margin-top:8px"><div class="cwf-prepaid-row" style="margin-top:8px"><input class="cwf-prepaid-input" style="flex:1" data-card-month inputmode="numeric" placeholder="MM"><input class="cwf-prepaid-input" style="flex:1" data-card-year inputmode="numeric" placeholder="YYYY"><input class="cwf-prepaid-input" style="flex:1" data-card-cvv inputmode="numeric" autocomplete="cc-csc" placeholder="CVV"></div><button class="cwf-prepaid-primary" data-card-submit>ชำระด้วยบัตร</button><div data-card-error></div></div>`;
+    area.querySelector("[data-card-submit]")?.addEventListener("click", async () => {
+      const button = area.querySelector("[data-card-submit]");
+      const errorBox = area.querySelector("[data-card-error]");
+      button.disabled = true;
+      try {
+        const omise = await ensureOmiseJs(publicKey);
+        const token = await omiseCardToken(omise, {
+          name: area.querySelector("[data-card-name]").value.trim(),
+          number: area.querySelector("[data-card-number]").value.replace(/\s+/g, ""),
+          expiration_month: Number(area.querySelector("[data-card-month]").value),
+          expiration_year: Number(area.querySelector("[data-card-year]").value),
+          security_code: area.querySelector("[data-card-cvv]").value.trim(),
+        });
+        const result = await root.api.payOrder(orderCode, { method: "card", token });
+        if (result.order?.status === "paid" || result.payment?.status === "paid") paymentSuccess(entitlementCode);
+        else pollPaid(orderCode, entitlementCode, errorBox);
+      } catch (error) {
+        errorBox.innerHTML = `<div class="cwf-prepaid-error">ชำระด้วยบัตรไม่สำเร็จ (${esc(error?.data?.error || error.message)})</div>`;
+        button.disabled = false;
+      }
+    });
+  }
+
+  function paymentSuccess(entitlementCode) {
+    const body = modal?.querySelector("[data-prepaid-body]");
+    if (!body) return;
+    body.innerHTML = `<div class="cwf-prepaid-success"><b>ชำระสำเร็จ</b><br>สิทธิ์บริการถูกเปิดใช้งานแล้ว</div><div class="cwf-prepaid-card"><div class="cwf-prepaid-muted">รหัสสิทธิ์</div><b>${esc(entitlementCode)}</b><button class="cwf-prepaid-primary" data-use-right="${esc(entitlementCode)}">เลือกวันใช้สิทธิ์</button><button class="cwf-prepaid-secondary" data-prepaid-rights>ดูสิทธิ์ทั้งหมด</button></div>`;
+    body.querySelector("[data-use-right]")?.addEventListener("click", () => useRight(entitlementCode));
+    body.querySelector("[data-prepaid-rights]")?.addEventListener("click", openRights);
+  }
+
+  function parseSnapshot(value) {
+    if (!value) return null;
+    if (typeof value === "object") return value;
+    try { return JSON.parse(value); } catch (_) { return null; }
+  }
+
+  async function openRights() {
+    if (!requireLogin()) return;
+    const body = openModal("สิทธิ์บริการของฉัน", `<div class="cwf-prepaid-card">กำลังโหลดสิทธิ์...</div>`);
+    try {
+      const data = await request("/public/service-rights");
+      const items = Array.isArray(data.items) ? data.items : [];
+      body.innerHTML = items.length ? items.map((right) => {
+        const snapshot = parseSnapshot(right.service_snapshot) || {};
+        const title = snapshot.bundle_key || "สิทธิ์บริการ CWF";
+        const statusClass = right.status === "active" || right.status === "redeeming" ? "active" : right.status === "redeemed" ? "redeemed" : "";
+        const statusLabel = right.status === "active" ? "พร้อมใช้" : right.status === "redeeming" ? "กำลังเลือกวัน" : right.status === "redeemed" ? "ใช้สิทธิ์แล้ว" : right.status === "expired" ? "หมดอายุ" : right.status;
+        return `<div class="cwf-prepaid-card"><div class="cwf-prepaid-row"><b>${esc(title)}</b><span class="cwf-prepaid-status ${statusClass}">${esc(statusLabel)}</span></div><div class="cwf-prepaid-muted">${esc(right.entitlement_code)} · มูลค่า ${baht(right.purchased_amount)}</div><div class="cwf-prepaid-muted">ใช้สิทธิ์ได้ถึง ${new Date(right.redeem_until).toLocaleDateString("th-TH")}</div>${right.booking_code ? `<div style="margin-top:6px">งาน: <b>${esc(right.booking_code)}</b></div>` : ""}${right.warranty_until ? `<div class="cwf-prepaid-muted">รับประกันถึง ${new Date(right.warranty_until).toLocaleDateString("th-TH")}</div>` : ""}${["active","redeeming"].includes(right.status) ? `<button class="cwf-prepaid-primary" data-use-right="${esc(right.entitlement_code)}">เลือกวันใช้สิทธิ์</button>` : ""}</div>`;
+      }).join("") : `<div class="cwf-prepaid-card">ยังไม่มีสิทธิ์บริการในบัญชีนี้</div>`;
+      body.querySelectorAll("[data-use-right]").forEach((button) => button.addEventListener("click", () => useRight(button.dataset.useRight)));
+    } catch (error) {
+      body.innerHTML = `<div class="cwf-prepaid-error">โหลดสิทธิ์ไม่สำเร็จ (${esc(error.code || error.message)})</div>`;
+    }
+  }
+
+  async function useRight(entitlementCode) {
+    const body = modal?.querySelector("[data-prepaid-body]") || openModal("กำลังเตรียมใช้สิทธิ์", "");
+    body.innerHTML = `<div class="cwf-prepaid-card">กำลังล็อกสิทธิ์และเปิดปฏิทินคิว...</div>`;
+    try {
+      const data = await request(`/public/service-rights/${encodeURIComponent(entitlementCode)}/begin-redemption`, { method: "POST", body: {} });
+      const r = data.redemption;
+      const preview = {
+        package_name: "สิทธิ์ PREPAID",
+        groups: r.service_package_groups,
+        fixed_total_price: r.fixed_total_price,
+        duration_min: r.duration_min,
+        redeem_until: r.redeem_until,
+        payload: { services: r.services },
+        server_verified: true,
+        prepaid: true,
+      };
+      root.state.updateDraft("scheduled", {
+        catalog_item_id: Number(r.catalog_item_id),
+        service_package_key: "",
+        service_package_tier_key: "",
+        service_package_btu: "",
+        service_package_groups: r.service_package_groups,
+        service_package_bundle_preview: preview,
+        services: r.services,
+        prepaid_redemption_token: r.prepaid_redemption_token,
+        scheduled_request_key: r.scheduled_request_key,
+        selectedSlot: null,
+        date: "",
+      });
+      root.state.setScheduledPreview("package", { status: "success", data: preview, error: "", verified: true });
+      root.state.setScheduledPreview("pricing", { status: "success", data: { duration_min: r.duration_min, fixed_total_price: r.fixed_total_price }, error: "", verified: true });
+      root.state.setScheduledWizard({ step: 1, error: "" });
+      closeModal();
+      root.utils.routeTo("scheduled");
+    } catch (error) {
+      body.innerHTML = `<div class="cwf-prepaid-error">ใช้สิทธิ์ไม่ได้ (${esc(error.code || error.message)})</div>`;
+    }
+  }
+
+  // bookingScheduled intentionally builds a strict allowlisted payload. Inject the
+  // one-time redemption capability here at the last API boundary so ordinary
+  // bookings remain byte-for-byte unchanged.
+  function installScheduledSubmitBridge() {
+    if (!root.api?.submitScheduledBooking || root.api.submitScheduledBooking.__prepaidWrapped) return;
+    const original = root.api.submitScheduledBooking.bind(root.api);
+    const wrapped = (payload) => {
+      const token = String(root.state.draft?.scheduled?.prepaid_redemption_token || "").trim();
+      return original(token ? { ...(payload || {}), prepaid_redemption_token: token } : payload);
+    };
+    wrapped.__prepaidWrapped = true;
+    root.api.submitScheduledBooking = wrapped;
+  }
+
+  async function interceptStoreClick(event) {
+    const button = event.target instanceof Element
+      ? event.target.closest("[data-store-book],[data-store-detail-book],[data-store-urgent],[data-store-detail-urgent]")
+      : null;
+    if (!button || button.disabled) return;
+    if (button.dataset.prepaidBypass === "1") { delete button.dataset.prepaidBypass; return; }
+    const itemId = currentItemId(button);
+    if (!itemId) return;
+    event.preventDefault();
+    event.stopImmediatePropagation();
+    button.disabled = true;
+    try {
+      const policy = await policyFor(itemId);
+      if (!policy.prepaid) {
+        button.disabled = false;
+        delegateOriginal(button);
+        return;
+      }
+      if (!policy.prepaid_ready) {
+        openModal("โปรโมชั่นยังไม่พร้อมรับชำระ", `<div class="cwf-prepaid-error">ระบบสิทธิ์ PREPAID ยังไม่พร้อม จึงยังไม่รับเงินเพื่อป้องกันสิทธิ์สูญหาย</div>`);
+        return;
+      }
+      await openPurchase(itemId);
+    } catch (error) {
+      openModal("ไม่สามารถเปิดโปรโมชั่นได้", `<div class="cwf-prepaid-error">กรุณาลองใหม่อีกครั้ง (${esc(error.code || error.message)})</div>`);
+    } finally {
+      button.disabled = false;
+    }
+  }
+
+  function updateRightsPill() {
+    ensureStyles();
+    let pill = document.querySelector("[data-cwf-rights-pill]");
+    if (!root.state.customer?.logged_in) { if (pill) pill.remove(); return; }
+    if (!pill) {
+      pill = document.createElement("button");
+      pill.type = "button";
+      pill.className = "cwf-rights-pill";
+      pill.dataset.cwfRightsPill = "1";
+      pill.textContent = "สิทธิ์บริการ";
+      pill.addEventListener("click", openRights);
+      document.body.appendChild(pill);
+    }
+  }
+
+  function init() {
+    ensureStyles();
+    installScheduledSubmitBridge();
+    document.addEventListener("click", interceptStoreClick, true);
+    updateRightsPill();
+    const observer = new MutationObserver(updateRightsPill);
+    observer.observe(document.body, { childList: true, subtree: false });
+    window.addEventListener("hashchange", updateRightsPill);
+  }
+
+  root.prepaid = { openRights, useRight, _test: { selectedGroups, packageRows, currentItemId } };
+  init();
+})();

--- a/customer-app/modules/prepaid.js
+++ b/customer-app/modules/prepaid.js
@@ -470,8 +470,10 @@
     installScheduledSubmitBridge();
     document.addEventListener("click", interceptStoreClick, true);
     updateRightsPill();
-    const observer = new MutationObserver(updateRightsPill);
-    observer.observe(document.body, { childList: true, subtree: false });
+    if (typeof MutationObserver === "function") {
+      const observer = new MutationObserver(updateRightsPill);
+      observer.observe(document.body, { childList: true, subtree: false });
+    }
     window.addEventListener("hashchange", updateRightsPill);
   }
 

--- a/customer-app/sw.js
+++ b/customer-app/sw.js
@@ -24,6 +24,7 @@ const APP_SHELL = [
   `./modules/availability.js?v=${BUILD_ID}`,
   `./modules/bookingTicket.js?v=${BUILD_ID}`,
   `./modules/bookingScheduled.js?v=${BUILD_ID}`,
+  `./modules/prepaid.js?v=${BUILD_ID}`,
   `./modules/bookingUrgent.js?v=${BUILD_ID}`,
   `./modules/tracking.js?v=${BUILD_ID}`,
   `./modules/profile.js?v=${BUILD_ID}`,
@@ -61,13 +62,6 @@ self.addEventListener("fetch", (event) => {
   }
   if (!url.pathname.startsWith("/customer-app/")) return;
 
-  // Secure Tracking deep link: a navigation that carries the PRIVATE tracking
-  // credential (?q= or ?token=) must NEVER touch Cache Storage — the credential
-  // would otherwise become part of a cache key. Fetch network-only and return
-  // the response directly: no cache.put, and no caches.match on this
-  // credential-bearing request. Offline → fall back to the canonical cached app
-  // shell (a credential-free key); the in-app boot re-reads ?q= from the URL.
-  // The credential is never logged.
   const hasTrackingCredential = url.searchParams.has("q") || url.searchParams.has("token");
   if (request.mode === "navigate" && hasTrackingCredential) {
     event.respondWith(

--- a/migrations/20260906_prepaid_service_entitlements.sql
+++ b/migrations/20260906_prepaid_service_entitlements.sql
@@ -185,34 +185,50 @@ AFTER INSERT OR UPDATE OF status ON public.customer_orders
 FOR EACH ROW
 EXECUTE FUNCTION public.issue_prepaid_entitlement_from_paid_order();
 
--- A normal booking token is ignored. A token reserved by begin-redemption is a
--- database capability: lock its entitlement and attach prepaid settlement before
--- the job is inserted. This makes double redemption impossible even across app
--- instances and preserves jobs.job_price/job_items for technician income.
+-- The package resolver re-validates an entitlement inside the booking
+-- transaction and writes these three transaction-local settings immediately
+-- before INSERT. The trigger consumes only that exact context; it never guesses
+-- an entitlement from customer phone/name or mutable campaign state.
 CREATE OR REPLACE FUNCTION public.guard_prepaid_job_redemption()
 RETURNS TRIGGER
 LANGUAGE plpgsql
 AS $$
 DECLARE
   ent public.customer_service_entitlements%ROWTYPE;
+  context_entitlement_id BIGINT;
+  context_customer_sub TEXT;
+  context_booking_token TEXT;
+  prepaid_paid_at TIMESTAMPTZ;
 BEGIN
-  IF NEW.booking_token IS NULL OR btrim(NEW.booking_token) = '' THEN
+  context_entitlement_id := NULLIF(current_setting('cwf.prepaid_entitlement_id', true), '')::BIGINT;
+  context_customer_sub := NULLIF(current_setting('cwf.prepaid_customer_sub', true), '');
+  context_booking_token := NULLIF(current_setting('cwf.prepaid_booking_token', true), '');
+
+  -- Ordinary bookings have no transaction-local prepaid context and must retain
+  -- their existing behavior unchanged.
+  IF context_entitlement_id IS NULL
+     AND context_customer_sub IS NULL
+     AND context_booking_token IS NULL THEN
     RETURN NEW;
+  END IF;
+
+  IF context_entitlement_id IS NULL
+     OR context_customer_sub IS NULL
+     OR context_booking_token IS NULL THEN
+    RAISE EXCEPTION 'PREPAID_REDEMPTION_CONTEXT_INVALID'
+      USING ERRCODE = 'P0001';
   END IF;
 
   SELECT * INTO ent
     FROM public.customer_service_entitlements
-   WHERE redemption_booking_token = NEW.booking_token
+   WHERE entitlement_id = context_entitlement_id
+     AND redemption_booking_token = context_booking_token
    FOR UPDATE;
 
-  IF NOT FOUND THEN
-    RETURN NEW;
-  END IF;
-
-  IF ent.status <> 'redeeming'
+  IF NOT FOUND
+     OR ent.status <> 'redeeming'
      OR ent.customer_sub IS NULL
-     OR NEW.customer_sub IS NULL
-     OR ent.customer_sub <> NEW.customer_sub
+     OR ent.customer_sub <> context_customer_sub
      OR ent.redemption_expires_at IS NULL
      OR ent.redemption_expires_at <= NOW()
      OR ent.redeem_until < NOW()
@@ -224,9 +240,28 @@ BEGIN
       USING ERRCODE = 'P0001';
   END IF;
 
+  SELECT o.paid_at INTO prepaid_paid_at
+    FROM public.customer_orders o
+   WHERE o.order_id = ent.order_id
+     AND o.order_kind = 'service_prepaid'
+     AND o.status = 'paid'
+   LIMIT 1;
+
+  IF prepaid_paid_at IS NULL THEN
+    RAISE EXCEPTION 'PREPAID_ORDER_PAYMENT_NOT_VERIFIED'
+      USING ERRCODE = 'P0001';
+  END IF;
+
+  -- Preserve full job_price/job_items for revenue and technician earnings, but
+  -- mark the customer settlement as already paid so the job is never collected
+  -- a second time and never appears in unpaid follow-up.
   NEW.prepaid_entitlement_id := ent.entitlement_id;
+  NEW.customer_sub := ent.customer_sub;
+  NEW.booking_token := context_booking_token;
   NEW.payment_source := 'prepaid_entitlement';
   NEW.customer_due := 0.00;
+  NEW.payment_status := 'paid';
+  NEW.paid_at := prepaid_paid_at;
   RETURN NEW;
 END;
 $$;

--- a/migrations/20260906_prepaid_service_entitlements.sql
+++ b/migrations/20260906_prepaid_service_entitlements.sql
@@ -12,7 +12,9 @@ ALTER TABLE public.customer_orders
   ADD COLUMN IF NOT EXISTS prepaid_redeem_until TIMESTAMPTZ,
   ADD COLUMN IF NOT EXISTS prepaid_warranty_days INTEGER,
   ADD COLUMN IF NOT EXISTS manual_payment_reference TEXT,
-  ADD COLUMN IF NOT EXISTS payment_verified_by TEXT;
+  ADD COLUMN IF NOT EXISTS payment_verified_by TEXT,
+  ADD COLUMN IF NOT EXISTS prepaid_purchase_request_key TEXT,
+  ADD COLUMN IF NOT EXISTS prepaid_purchase_fingerprint TEXT;
 
 DO $$
 BEGIN
@@ -40,6 +42,9 @@ END $$;
 CREATE UNIQUE INDEX IF NOT EXISTS uq_customer_orders_prepaid_entitlement_code
   ON public.customer_orders(prepaid_entitlement_code)
   WHERE prepaid_entitlement_code IS NOT NULL;
+CREATE UNIQUE INDEX IF NOT EXISTS uq_customer_orders_prepaid_purchase_request
+  ON public.customer_orders(prepaid_purchase_request_key)
+  WHERE order_kind='service_prepaid' AND prepaid_purchase_request_key IS NOT NULL;
 
 CREATE TABLE IF NOT EXISTS public.customer_service_entitlements (
   entitlement_id BIGSERIAL PRIMARY KEY,
@@ -117,9 +122,14 @@ BEGIN
   END IF;
 END $$;
 
-CREATE UNIQUE INDEX IF NOT EXISTS uq_jobs_prepaid_entitlement
+-- A cancelled, unfinished prepaid job remains linked for audit, but must not
+-- permanently burn the customer's right. Excluding cancelled jobs lets the same
+-- entitlement create one new live replacement job after the cancellation trigger
+-- restores the right to active.
+DROP INDEX IF EXISTS public.uq_jobs_prepaid_entitlement;
+CREATE UNIQUE INDEX uq_jobs_prepaid_entitlement
   ON public.jobs(prepaid_entitlement_id)
-  WHERE prepaid_entitlement_id IS NOT NULL;
+  WHERE prepaid_entitlement_id IS NOT NULL AND canceled_at IS NULL;
 
 -- Once a verified payment moves a prepaid order to PAID, create exactly one
 -- service entitlement in the same database transaction. Any malformed prepaid
@@ -266,5 +276,40 @@ CREATE TRIGGER trg_consume_prepaid_entitlement_after_job_insert
 AFTER INSERT ON public.jobs
 FOR EACH ROW
 EXECUTE FUNCTION public.consume_prepaid_entitlement_after_job_insert();
+
+-- Cancellation before completion restores the purchased right. The cancelled job
+-- stays linked to prepaid_entitlement_id as immutable audit history; only the
+-- entitlement's live redemption pointer is cleared. Finished jobs never restore.
+CREATE OR REPLACE FUNCTION public.restore_prepaid_entitlement_after_job_cancel()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  IF OLD.canceled_at IS NULL
+     AND NEW.canceled_at IS NOT NULL
+     AND NEW.prepaid_entitlement_id IS NOT NULL
+     AND NEW.finished_at IS NULL THEN
+    UPDATE public.customer_service_entitlements
+       SET status = CASE WHEN redeem_until < NOW() THEN 'expired' ELSE 'active' END,
+           redeemed_job_id=NULL,
+           redeemed_at=NULL,
+           redemption_token_hash=NULL,
+           redemption_request_key=NULL,
+           redemption_booking_token=NULL,
+           redemption_expires_at=NULL,
+           updated_at=NOW()
+     WHERE entitlement_id=NEW.prepaid_entitlement_id
+       AND redeemed_job_id=NEW.job_id
+       AND status='redeemed';
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_restore_prepaid_entitlement_after_job_cancel ON public.jobs;
+CREATE TRIGGER trg_restore_prepaid_entitlement_after_job_cancel
+AFTER UPDATE OF canceled_at ON public.jobs
+FOR EACH ROW
+EXECUTE FUNCTION public.restore_prepaid_entitlement_after_job_cancel();
 
 COMMIT;

--- a/migrations/20260906_prepaid_service_entitlements.sql
+++ b/migrations/20260906_prepaid_service_entitlements.sql
@@ -1,0 +1,270 @@
+BEGIN;
+
+-- PREPAID service lifecycle is additive. Existing product orders and normal jobs
+-- keep their current semantics. The columns below are populated only for
+-- order_kind='service_prepaid' / jobs redeemed from a service entitlement.
+ALTER TABLE public.customer_orders
+  ADD COLUMN IF NOT EXISTS order_kind TEXT NOT NULL DEFAULT 'product',
+  ADD COLUMN IF NOT EXISTS customer_sub TEXT,
+  ADD COLUMN IF NOT EXISTS service_entitlement_snapshot JSONB,
+  ADD COLUMN IF NOT EXISTS prepaid_entitlement_code TEXT,
+  ADD COLUMN IF NOT EXISTS prepaid_claim_token_hash TEXT,
+  ADD COLUMN IF NOT EXISTS prepaid_redeem_until TIMESTAMPTZ,
+  ADD COLUMN IF NOT EXISTS prepaid_warranty_days INTEGER,
+  ADD COLUMN IF NOT EXISTS manual_payment_reference TEXT,
+  ADD COLUMN IF NOT EXISTS payment_verified_by TEXT;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname='customer_orders_order_kind_check'
+      AND conrelid='public.customer_orders'::regclass
+  ) THEN
+    ALTER TABLE public.customer_orders
+      ADD CONSTRAINT customer_orders_order_kind_check
+      CHECK (order_kind IN ('product','service_prepaid'));
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname='customer_orders_prepaid_warranty_days_check'
+      AND conrelid='public.customer_orders'::regclass
+  ) THEN
+    ALTER TABLE public.customer_orders
+      ADD CONSTRAINT customer_orders_prepaid_warranty_days_check
+      CHECK (prepaid_warranty_days IS NULL OR prepaid_warranty_days BETWEEN 0 AND 3650);
+  END IF;
+END $$;
+
+CREATE UNIQUE INDEX IF NOT EXISTS uq_customer_orders_prepaid_entitlement_code
+  ON public.customer_orders(prepaid_entitlement_code)
+  WHERE prepaid_entitlement_code IS NOT NULL;
+
+CREATE TABLE IF NOT EXISTS public.customer_service_entitlements (
+  entitlement_id BIGSERIAL PRIMARY KEY,
+  entitlement_code TEXT NOT NULL UNIQUE,
+  order_id BIGINT NOT NULL UNIQUE REFERENCES public.customer_orders(order_id),
+  customer_sub TEXT,
+  customer_name TEXT NOT NULL,
+  customer_phone TEXT NOT NULL,
+  service_snapshot JSONB NOT NULL,
+  purchased_amount NUMERIC(12,2) NOT NULL,
+  status TEXT NOT NULL,
+  redeem_until TIMESTAMPTZ NOT NULL,
+  warranty_days INTEGER NOT NULL DEFAULT 0,
+  claim_token_hash TEXT,
+  redemption_request_key TEXT,
+  redemption_token_hash TEXT,
+  redemption_booking_token TEXT,
+  redemption_expires_at TIMESTAMPTZ,
+  redeemed_job_id BIGINT,
+  redeemed_at TIMESTAMPTZ,
+  cancelled_at TIMESTAMPTZ,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  CONSTRAINT customer_service_entitlements_status_check
+    CHECK (status IN ('unclaimed','active','redeeming','redeemed','expired','cancelled')),
+  CONSTRAINT customer_service_entitlements_amount_check CHECK (purchased_amount > 0),
+  CONSTRAINT customer_service_entitlements_warranty_days_check CHECK (warranty_days BETWEEN 0 AND 3650)
+);
+
+CREATE INDEX IF NOT EXISTS idx_customer_service_entitlements_customer_status
+  ON public.customer_service_entitlements(customer_sub, status, redeem_until DESC);
+CREATE INDEX IF NOT EXISTS idx_customer_service_entitlements_redeem_until
+  ON public.customer_service_entitlements(redeem_until)
+  WHERE status IN ('active','redeeming');
+CREATE UNIQUE INDEX IF NOT EXISTS uq_customer_service_entitlements_claim_token
+  ON public.customer_service_entitlements(claim_token_hash)
+  WHERE claim_token_hash IS NOT NULL;
+CREATE UNIQUE INDEX IF NOT EXISTS uq_customer_service_entitlements_redemption_token
+  ON public.customer_service_entitlements(redemption_token_hash)
+  WHERE redemption_token_hash IS NOT NULL;
+CREATE UNIQUE INDEX IF NOT EXISTS uq_customer_service_entitlements_redemption_booking_token
+  ON public.customer_service_entitlements(redemption_booking_token)
+  WHERE redemption_booking_token IS NOT NULL;
+CREATE UNIQUE INDEX IF NOT EXISTS uq_customer_service_entitlements_redeemed_job
+  ON public.customer_service_entitlements(redeemed_job_id)
+  WHERE redeemed_job_id IS NOT NULL;
+
+ALTER TABLE public.jobs
+  ADD COLUMN IF NOT EXISTS customer_due NUMERIC(12,2),
+  ADD COLUMN IF NOT EXISTS payment_source TEXT,
+  ADD COLUMN IF NOT EXISTS prepaid_entitlement_id BIGINT;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname='jobs_prepaid_entitlement_fk'
+      AND conrelid='public.jobs'::regclass
+  ) THEN
+    ALTER TABLE public.jobs
+      ADD CONSTRAINT jobs_prepaid_entitlement_fk
+      FOREIGN KEY (prepaid_entitlement_id)
+      REFERENCES public.customer_service_entitlements(entitlement_id);
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname='customer_service_entitlements_redeemed_job_fk'
+      AND conrelid='public.customer_service_entitlements'::regclass
+  ) THEN
+    ALTER TABLE public.customer_service_entitlements
+      ADD CONSTRAINT customer_service_entitlements_redeemed_job_fk
+      FOREIGN KEY (redeemed_job_id)
+      REFERENCES public.jobs(job_id);
+  END IF;
+END $$;
+
+CREATE UNIQUE INDEX IF NOT EXISTS uq_jobs_prepaid_entitlement
+  ON public.jobs(prepaid_entitlement_id)
+  WHERE prepaid_entitlement_id IS NOT NULL;
+
+-- Once a verified payment moves a prepaid order to PAID, create exactly one
+-- service entitlement in the same database transaction. Any malformed prepaid
+-- order makes the payment mutation fail instead of silently losing the right.
+CREATE OR REPLACE FUNCTION public.issue_prepaid_entitlement_from_paid_order()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  IF NEW.order_kind <> 'service_prepaid' OR NEW.status <> 'paid' THEN
+    RETURN NEW;
+  END IF;
+
+  IF NEW.prepaid_entitlement_code IS NULL
+     OR btrim(NEW.prepaid_entitlement_code) = ''
+     OR NEW.service_entitlement_snapshot IS NULL
+     OR NEW.prepaid_redeem_until IS NULL
+     OR NEW.prepaid_warranty_days IS NULL
+     OR NEW.subtotal IS NULL
+     OR NEW.subtotal <= 0 THEN
+    RAISE EXCEPTION 'PREPAID_ORDER_NOT_ENTITLEMENT_READY'
+      USING ERRCODE = 'P0001';
+  END IF;
+
+  INSERT INTO public.customer_service_entitlements (
+    entitlement_code, order_id, customer_sub, customer_name, customer_phone,
+    service_snapshot, purchased_amount, status, redeem_until, warranty_days,
+    claim_token_hash, created_at, updated_at
+  ) VALUES (
+    NEW.prepaid_entitlement_code,
+    NEW.order_id,
+    NULLIF(btrim(NEW.customer_sub), ''),
+    NEW.customer_name,
+    NEW.customer_phone,
+    NEW.service_entitlement_snapshot,
+    NEW.subtotal,
+    CASE WHEN NULLIF(btrim(NEW.customer_sub), '') IS NULL THEN 'unclaimed' ELSE 'active' END,
+    NEW.prepaid_redeem_until,
+    NEW.prepaid_warranty_days,
+    NEW.prepaid_claim_token_hash,
+    NOW(),
+    NOW()
+  )
+  ON CONFLICT (order_id) DO NOTHING;
+
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_issue_prepaid_entitlement_from_paid_order ON public.customer_orders;
+CREATE TRIGGER trg_issue_prepaid_entitlement_from_paid_order
+AFTER INSERT OR UPDATE OF status ON public.customer_orders
+FOR EACH ROW
+EXECUTE FUNCTION public.issue_prepaid_entitlement_from_paid_order();
+
+-- A normal booking token is ignored. A token reserved by begin-redemption is a
+-- database capability: lock its entitlement and attach prepaid settlement before
+-- the job is inserted. This makes double redemption impossible even across app
+-- instances and preserves jobs.job_price/job_items for technician income.
+CREATE OR REPLACE FUNCTION public.guard_prepaid_job_redemption()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  ent public.customer_service_entitlements%ROWTYPE;
+BEGIN
+  IF NEW.booking_token IS NULL OR btrim(NEW.booking_token) = '' THEN
+    RETURN NEW;
+  END IF;
+
+  SELECT * INTO ent
+    FROM public.customer_service_entitlements
+   WHERE redemption_booking_token = NEW.booking_token
+   FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RETURN NEW;
+  END IF;
+
+  IF ent.status <> 'redeeming'
+     OR ent.customer_sub IS NULL
+     OR NEW.customer_sub IS NULL
+     OR ent.customer_sub <> NEW.customer_sub
+     OR ent.redemption_expires_at IS NULL
+     OR ent.redemption_expires_at <= NOW()
+     OR ent.redeem_until < NOW()
+     OR NEW.appointment_datetime IS NULL
+     OR NEW.appointment_datetime > ent.redeem_until
+     OR COALESCE(NEW.booking_mode, '') <> 'scheduled'
+     OR ent.redeemed_job_id IS NOT NULL THEN
+    RAISE EXCEPTION 'PREPAID_REDEMPTION_NOT_ALLOWED'
+      USING ERRCODE = 'P0001';
+  END IF;
+
+  NEW.prepaid_entitlement_id := ent.entitlement_id;
+  NEW.payment_source := 'prepaid_entitlement';
+  NEW.customer_due := 0.00;
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_guard_prepaid_job_redemption ON public.jobs;
+CREATE TRIGGER trg_guard_prepaid_job_redemption
+BEFORE INSERT ON public.jobs
+FOR EACH ROW
+EXECUTE FUNCTION public.guard_prepaid_job_redemption();
+
+CREATE OR REPLACE FUNCTION public.consume_prepaid_entitlement_after_job_insert()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  changed INTEGER;
+BEGIN
+  IF NEW.prepaid_entitlement_id IS NULL THEN
+    RETURN NEW;
+  END IF;
+
+  UPDATE public.customer_service_entitlements
+     SET status='redeemed',
+         redeemed_job_id=NEW.job_id,
+         redeemed_at=NOW(),
+         redemption_token_hash=NULL,
+         redemption_request_key=NULL,
+         redemption_booking_token=NULL,
+         redemption_expires_at=NULL,
+         updated_at=NOW()
+   WHERE entitlement_id=NEW.prepaid_entitlement_id
+     AND status='redeeming'
+     AND redeemed_job_id IS NULL;
+
+  GET DIAGNOSTICS changed = ROW_COUNT;
+  IF changed <> 1 THEN
+    RAISE EXCEPTION 'PREPAID_REDEMPTION_CONCURRENT_CONFLICT'
+      USING ERRCODE = 'P0001';
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_consume_prepaid_entitlement_after_job_insert ON public.jobs;
+CREATE TRIGGER trg_consume_prepaid_entitlement_after_job_insert
+AFTER INSERT ON public.jobs
+FOR EACH ROW
+EXECUTE FUNCTION public.consume_prepaid_entitlement_after_job_insert();
+
+COMMIT;

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "migrate:store-service-package-bundles": "node scripts/run-store-service-package-bundles-migration.js",
     "migrate:customer-orders-payment": "node scripts/run-customer-orders-payment-migration.js",
     "migrate:customer-orders-fulfillment": "node scripts/run-customer-orders-fulfillment-migration.js",
+    "migrate:prepaid-service-entitlements": "node scripts/run-prepaid-service-entitlements-migration.js",
     "migrate:store-buy": "node scripts/run-store-buy-migrations.js",
     "test": "node --test test/*.test.js"
   },

--- a/scripts/apply-air-reset-60-seed.sh
+++ b/scripts/apply-air-reset-60-seed.sh
@@ -12,17 +12,10 @@ case "$ENVIRONMENT" in
   *) printf 'ERROR: environment must be staging or production\n' >&2; exit 2 ;;
 esac
 
-die() {
-  printf 'ERROR: %s\n' "$*" >&2
-  exit 1
-}
+die() { printf 'ERROR: %s\n' "$*" >&2; exit 1; }
 
 docker_cmd() {
-  if /usr/bin/docker info >/dev/null 2>&1; then
-    /usr/bin/docker "$@"
-  else
-    sudo -n /usr/bin/docker "$@"
-  fi
+  if /usr/bin/docker info >/dev/null 2>&1; then /usr/bin/docker "$@"; else sudo -n /usr/bin/docker "$@"; fi
 }
 
 db_query() {
@@ -32,16 +25,35 @@ db_query() {
     sh "$sql"
 }
 
-verify_seed_shape() {
+verify_prepaid_schema() {
+  local entitlements order_columns job_columns
+  entitlements="$(db_query "SELECT CASE WHEN to_regclass('public.customer_service_entitlements') IS NULL THEN 0 ELSE 1 END")"
+  order_columns="$(db_query "
+    SELECT count(*) FROM information_schema.columns
+    WHERE table_schema='public' AND table_name='customer_orders'
+      AND column_name IN (
+        'order_kind','customer_sub','service_entitlement_snapshot','prepaid_entitlement_code',
+        'prepaid_redeem_until','prepaid_warranty_days','prepaid_purchase_request_key',
+        'prepaid_purchase_fingerprint'
+      )
+  ")"
+  job_columns="$(db_query "
+    SELECT count(*) FROM information_schema.columns
+    WHERE table_schema='public' AND table_name='jobs'
+      AND column_name IN ('customer_due','payment_source','prepaid_entitlement_id')
+  ")"
+  [[ "$entitlements" == "1" && "$order_columns" == "8" && "$job_columns" == "3" ]] ||
+    die "PREPAID entitlement schema is not ready; refusing AIR RESET cutover"
+}
+
+verify_core_shape() {
   local parents variants tiers
   parents="$(db_query "
-    SELECT count(*)
-    FROM public.catalog_items
+    SELECT count(*) FROM public.catalog_items
     WHERE service_bundle_key IN ('air-reset-60-standard','air-reset-60-premium')
       AND service_package_pricing_strategy='total_quantity_tier_plus_unit_modifiers'
       AND service_package_selection_mode='multi_variant'
       AND service_package_maximum_total_quantity=4
-      AND service_package_payment_mode='book_now'
       AND service_package_warranty_days=60
       AND service_package_sell_start_at='2026-09-05T00:00:00+07:00'::timestamptz
       AND service_package_sell_end_at='2026-09-12T23:59:59.999+07:00'::timestamptz
@@ -50,8 +62,7 @@ verify_seed_shape() {
   [[ "$parents" == "2" ]] || die "AIR RESET parent verification failed: expected 2, got $parents"
 
   variants="$(db_query "
-    SELECT count(*)
-    FROM public.service_packages
+    SELECT count(*) FROM public.service_packages
     WHERE
       (package_key='air-reset-60-standard-small' AND job_type='ล้าง' AND ac_type='ผนัง'
        AND wash_variant='ล้างธรรมดา' AND btu_min IS NULL AND btu_max=12000
@@ -76,27 +87,33 @@ verify_seed_shape() {
     FROM public.service_package_tiers t
     JOIN public.service_packages p ON p.service_package_id=t.service_package_id
     WHERE
-      (
-        p.package_key IN ('air-reset-60-standard-small','air-reset-60-standard-large')
-        AND (
-          (t.tier_key='q1' AND t.service_quantity=1 AND t.fixed_total_price=550.00)
-          OR (t.tier_key='q2' AND t.service_quantity=2 AND t.fixed_total_price=959.00)
-          OR (t.tier_key='q3' AND t.service_quantity=3 AND t.fixed_total_price=1399.00)
-          OR (t.tier_key='q4' AND t.service_quantity=4 AND t.fixed_total_price=1799.00)
-        )
-      )
+      (p.package_key IN ('air-reset-60-standard-small','air-reset-60-standard-large') AND (
+        (t.tier_key='q1' AND t.service_quantity=1 AND t.fixed_total_price=550.00) OR
+        (t.tier_key='q2' AND t.service_quantity=2 AND t.fixed_total_price=959.00) OR
+        (t.tier_key='q3' AND t.service_quantity=3 AND t.fixed_total_price=1399.00) OR
+        (t.tier_key='q4' AND t.service_quantity=4 AND t.fixed_total_price=1799.00)))
       OR
-      (
-        p.package_key IN ('air-reset-60-premium-small','air-reset-60-premium-large')
-        AND (
-          (t.tier_key='q1' AND t.service_quantity=1 AND t.fixed_total_price=790.00)
-          OR (t.tier_key='q2' AND t.service_quantity=2 AND t.fixed_total_price=1490.00)
-          OR (t.tier_key='q3' AND t.service_quantity=3 AND t.fixed_total_price=2090.00)
-          OR (t.tier_key='q4' AND t.service_quantity=4 AND t.fixed_total_price=2690.00)
-        )
-      )
+      (p.package_key IN ('air-reset-60-premium-small','air-reset-60-premium-large') AND (
+        (t.tier_key='q1' AND t.service_quantity=1 AND t.fixed_total_price=790.00) OR
+        (t.tier_key='q2' AND t.service_quantity=2 AND t.fixed_total_price=1490.00) OR
+        (t.tier_key='q3' AND t.service_quantity=3 AND t.fixed_total_price=2090.00) OR
+        (t.tier_key='q4' AND t.service_quantity=4 AND t.fixed_total_price=2690.00)))
   ")"
   [[ "$tiers" == "16" ]] || die "AIR RESET tier verification failed: expected 16, got $tiers"
+}
+
+verify_prepaid_cutover() {
+  local count
+  count="$(db_query "
+    SELECT count(*) FROM public.catalog_items
+    WHERE service_bundle_key IN ('air-reset-60-standard','air-reset-60-premium')
+      AND booking_mode='service_package'
+      AND booking_flow_policy='scheduled_only'
+      AND service_package_payment_mode='prepaid_full'
+      AND service_package_warranty_days=60
+      AND is_active=TRUE AND is_customer_visible=TRUE
+  ")"
+  [[ "$count" == "2" ]] || die "AIR RESET prepaid cutover verification failed: expected 2, got $count"
 }
 
 [[ -f "$SEED_PATH" ]] || die "seed file is missing: $SEED_PATH"
@@ -104,72 +121,71 @@ actual_sha="$(sha256sum "$SEED_PATH" | awk '{print $1}')"
 [[ "$actual_sha" == "$EXPECTED_SEED_SHA" ]] || die "seed SHA mismatch"
 
 if [[ -n "${EXPECTED_RELEASE_SHA:-}" ]]; then
-  status_output="$(sudo -n /usr/local/sbin/cwf-deployctl "$ENVIRONMENT" status)" ||
-    die "could not read deployed $ENVIRONMENT status"
-  grep -Fq "$EXPECTED_RELEASE_SHA" <<<"$status_output" ||
-    die "deployed $ENVIRONMENT revision does not match $EXPECTED_RELEASE_SHA"
+  status_output="$(sudo -n /usr/local/sbin/cwf-deployctl "$ENVIRONMENT" status)" || die "could not read deployed $ENVIRONMENT status"
+  grep -Fq "$EXPECTED_RELEASE_SHA" <<<"$status_output" || die "deployed $ENVIRONMENT revision does not match $EXPECTED_RELEASE_SHA"
 fi
 
-[[ "$(docker_cmd inspect -f '{{.State.Running}}' "$DB_CONTAINER" 2>/dev/null)" == "true" ]] ||
-  die "$DB_CONTAINER is not running"
+[[ "$(docker_cmd inspect -f '{{.State.Running}}' "$DB_CONTAINER" 2>/dev/null)" == "true" ]] || die "$DB_CONTAINER is not running"
 [[ "$(db_query 'SELECT 1')" == "1" ]] || die "database connectivity check failed"
+verify_prepaid_schema
 
 required_columns="$(db_query "
-  SELECT count(*)
-  FROM information_schema.columns
-  WHERE table_schema='public'
-    AND (
-      (table_name='catalog_items' AND column_name IN (
-        'service_package_pricing_strategy',
-        'service_package_selection_mode',
-        'service_package_maximum_total_quantity',
-        'service_package_payment_mode',
-        'service_package_warranty_days'
-      ))
-      OR
-      (table_name='service_packages' AND column_name IN (
-        'service_level_key',
-        'service_level_label',
-        'unit_price_modifier'
-      ))
-    )
+  SELECT count(*) FROM information_schema.columns
+  WHERE table_schema='public' AND (
+    (table_name='catalog_items' AND column_name IN (
+      'service_package_pricing_strategy','service_package_selection_mode',
+      'service_package_maximum_total_quantity','service_package_payment_mode',
+      'service_package_warranty_days'))
+    OR
+    (table_name='service_packages' AND column_name IN (
+      'service_level_key','service_level_label','unit_price_modifier'))
+  )
 ")"
 [[ "$required_columns" == "8" ]] || die "promotion policy schema is not ready"
 
-existing_parents="$(db_query "
-  SELECT count(*) FROM public.catalog_items
-  WHERE service_bundle_key IN ('air-reset-60-standard','air-reset-60-premium')
-")"
-existing_variants="$(db_query "
-  SELECT count(*) FROM public.service_packages
-  WHERE package_key IN (
-    'air-reset-60-standard-small','air-reset-60-standard-large',
-    'air-reset-60-premium-small','air-reset-60-premium-large'
-  )
-")"
+existing_parents="$(db_query "SELECT count(*) FROM public.catalog_items WHERE service_bundle_key IN ('air-reset-60-standard','air-reset-60-premium')")"
+existing_variants="$(db_query "SELECT count(*) FROM public.service_packages WHERE package_key IN ('air-reset-60-standard-small','air-reset-60-standard-large','air-reset-60-premium-small','air-reset-60-premium-large')")"
 existing_tiers="$(db_query "
-  SELECT count(*)
-  FROM public.service_package_tiers t
-  JOIN public.service_packages p ON p.service_package_id=t.service_package_id
-  WHERE p.package_key IN (
-    'air-reset-60-standard-small','air-reset-60-standard-large',
-    'air-reset-60-premium-small','air-reset-60-premium-large'
-  )
+  SELECT count(*) FROM public.service_package_tiers t JOIN public.service_packages p ON p.service_package_id=t.service_package_id
+  WHERE p.package_key IN ('air-reset-60-standard-small','air-reset-60-standard-large','air-reset-60-premium-small','air-reset-60-premium-large')
 ")"
 
-if [[ "$existing_parents" == "2" && "$existing_variants" == "4" && "$existing_tiers" == "16" ]]; then
-  verify_seed_shape
-  printf 'AIR_RESET_SEED_ALREADY_APPLIED environment=%s\n' "$ENVIRONMENT"
-  exit 0
-fi
-
-if [[ "$existing_parents" != "0" || "$existing_variants" != "0" || "$existing_tiers" != "0" ]]; then
+if [[ "$existing_parents" == "0" && "$existing_variants" == "0" && "$existing_tiers" == "0" ]]; then
+  docker_cmd exec -i "$DB_CONTAINER" sh -ceu \
+    'exec psql -X -U "${POSTGRES_USER:?}" -d "${POSTGRES_DB:?}" -v ON_ERROR_STOP=1 --single-transaction' \
+    < "$SEED_PATH"
+elif [[ "$existing_parents" != "2" || "$existing_variants" != "4" || "$existing_tiers" != "16" ]]; then
   die "partial or unexpected AIR RESET data exists; refusing to overwrite it"
 fi
 
-docker_cmd exec -i "$DB_CONTAINER" sh -ceu \
-  'exec psql -X -U "${POSTGRES_USER:?}" -d "${POSTGRES_DB:?}" -v ON_ERROR_STOP=1 --single-transaction' \
-  < "$SEED_PATH"
+verify_core_shape
 
-verify_seed_shape
-printf 'AIR_RESET_SEED_OK environment=%s parents=2 variants=4 tiers=16\n' "$ENVIRONMENT"
+# Exact, narrow cutover. Only the two already-verified AIR RESET parent rows can
+# be made PREPAID. Price tiers/BTU modifiers are untouched.
+docker_cmd exec "$DB_CONTAINER" sh -ceu \
+  'exec psql -X -U "${POSTGRES_USER:?}" -d "${POSTGRES_DB:?}" -v ON_ERROR_STOP=1 -c "
+    BEGIN;
+    UPDATE public.catalog_items
+       SET booking_mode='"'"'service_package'"'"',
+           booking_flow_policy='"'"'scheduled_only'"'"',
+           service_package_payment_mode='"'"'prepaid_full'"'"',
+           service_package_warranty_days=60,
+           is_active=TRUE,
+           is_customer_visible=TRUE,
+           updated_at=NOW()
+     WHERE service_bundle_key IN ('"'"'air-reset-60-standard'"'"','"'"'air-reset-60-premium'"'"')
+       AND service_package_pricing_strategy='"'"'total_quantity_tier_plus_unit_modifiers'"'"'
+       AND service_package_selection_mode='"'"'multi_variant'"'"'
+       AND service_package_maximum_total_quantity=4
+       AND service_package_warranty_days=60
+       AND service_package_redeem_until='"'"'2027-01-31T23:59:59.999+07:00'"'"'::timestamptz;
+    SELECT CASE WHEN count(*)=2 THEN 1 ELSE (1/0) END
+      FROM public.catalog_items
+     WHERE service_bundle_key IN ('"'"'air-reset-60-standard'"'"','"'"'air-reset-60-premium'"'"')
+       AND booking_mode='"'"'service_package'"'"'
+       AND service_package_payment_mode='"'"'prepaid_full'"'"';
+    COMMIT;
+  "' >/dev/null
+
+verify_prepaid_cutover
+printf 'AIR_RESET_PREPAID_READY environment=%s parents=2 variants=4 tiers=16 payment_mode=prepaid_full\n' "$ENVIRONMENT"

--- a/scripts/apply-prepaid-service-entitlements-home.sh
+++ b/scripts/apply-prepaid-service-entitlements-home.sh
@@ -70,17 +70,16 @@ fi
 [[ "$(docker_cmd inspect -f '{{.State.Running}}' "$DB_CONTAINER" 2>/dev/null)" == "true" ]] || die "$DB_CONTAINER is not running"
 [[ "$(db_query 'SELECT 1')" == "1" ]] || die "database connectivity check failed"
 
-# The SQL is additive/idempotent and wraps itself in one transaction. Advisory
-# lock prevents two release-gate jobs from applying the same lifecycle migration
-# concurrently on one database.
+# Run lock + migration + unlock in the same PostgreSQL session. A session-level
+# advisory lock acquired by a separate psql process would be released as soon as
+# that process exits and would not protect the migration that follows.
 LOCK_KEY="202609060329"
-docker_cmd exec "$DB_CONTAINER" sh -ceu \
-  'exec psql -X -U "${POSTGRES_USER:?}" -d "${POSTGRES_DB:?}" -v ON_ERROR_STOP=1 -c "SELECT pg_advisory_lock('$LOCK_KEY'::bigint)"' >/dev/null
-trap 'docker_cmd exec "$DB_CONTAINER" sh -ceu '\''exec psql -X -U "${POSTGRES_USER:?}" -d "${POSTGRES_DB:?}" -v ON_ERROR_STOP=1 -c "SELECT pg_advisory_unlock('"$LOCK_KEY"'::bigint)"'\'' >/dev/null 2>&1 || true' EXIT
-
-docker_cmd exec -i "$DB_CONTAINER" sh -ceu \
-  'exec psql -X -U "${POSTGRES_USER:?}" -d "${POSTGRES_DB:?}" -v ON_ERROR_STOP=1' \
-  < "$MIGRATION_PATH"
+{
+  printf 'SELECT pg_advisory_lock(%s::bigint);\n' "$LOCK_KEY"
+  cat "$MIGRATION_PATH"
+  printf '\nSELECT pg_advisory_unlock(%s::bigint);\n' "$LOCK_KEY"
+} | docker_cmd exec -i "$DB_CONTAINER" sh -ceu \
+  'exec psql -X -U "${POSTGRES_USER:?}" -d "${POSTGRES_DB:?}" -v ON_ERROR_STOP=1'
 
 verify_schema
 printf 'PREPAID_SERVICE_ENTITLEMENTS_MIGRATION_OK environment=%s triggers=4\n' "$ENVIRONMENT"

--- a/scripts/apply-prepaid-service-entitlements-home.sh
+++ b/scripts/apply-prepaid-service-entitlements-home.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+ENVIRONMENT="${1:-}"
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+MIGRATION_PATH="$ROOT_DIR/migrations/20260906_prepaid_service_entitlements.sql"
+
+case "$ENVIRONMENT" in
+  staging) DB_CONTAINER="cwf-staging-db" ;;
+  production) DB_CONTAINER="cwf-production-db" ;;
+  *) printf 'ERROR: environment must be staging or production\n' >&2; exit 2 ;;
+esac
+
+die() { printf 'ERROR: %s\n' "$*" >&2; exit 1; }
+
+docker_cmd() {
+  if /usr/bin/docker info >/dev/null 2>&1; then /usr/bin/docker "$@"; else sudo -n /usr/bin/docker "$@"; fi
+}
+
+db_query() {
+  local sql="$1"
+  docker_cmd exec "$DB_CONTAINER" sh -ceu \
+    'exec psql -X -U "${POSTGRES_USER:?}" -d "${POSTGRES_DB:?}" -v ON_ERROR_STOP=1 -Atqc "$1"' \
+    sh "$sql"
+}
+
+verify_schema() {
+  local entitlements order_columns job_columns triggers
+  entitlements="$(db_query "SELECT CASE WHEN to_regclass('public.customer_service_entitlements') IS NULL THEN 0 ELSE 1 END")"
+  order_columns="$(db_query "
+    SELECT count(*) FROM information_schema.columns
+    WHERE table_schema='public' AND table_name='customer_orders'
+      AND column_name IN (
+        'order_kind','customer_sub','service_entitlement_snapshot','prepaid_entitlement_code',
+        'prepaid_claim_token_hash','prepaid_redeem_until','prepaid_warranty_days',
+        'manual_payment_reference','payment_verified_by','prepaid_purchase_request_key',
+        'prepaid_purchase_fingerprint'
+      )
+  ")"
+  job_columns="$(db_query "
+    SELECT count(*) FROM information_schema.columns
+    WHERE table_schema='public' AND table_name='jobs'
+      AND column_name IN ('customer_due','payment_source','prepaid_entitlement_id')
+  ")"
+  triggers="$(db_query "
+    SELECT count(*) FROM pg_trigger
+    WHERE NOT tgisinternal AND tgrelid IN ('public.customer_orders'::regclass,'public.jobs'::regclass)
+      AND tgname IN (
+        'trg_issue_prepaid_entitlement_from_paid_order',
+        'trg_guard_prepaid_job_redemption',
+        'trg_consume_prepaid_entitlement_after_job_insert',
+        'trg_restore_prepaid_entitlement_after_job_cancel'
+      )
+  ")"
+  [[ "$entitlements" == "1" ]] || die "customer_service_entitlements table missing"
+  [[ "$order_columns" == "11" ]] || die "prepaid customer_orders columns incomplete: $order_columns/11"
+  [[ "$job_columns" == "3" ]] || die "prepaid jobs columns incomplete: $job_columns/3"
+  [[ "$triggers" == "4" ]] || die "prepaid lifecycle triggers incomplete: $triggers/4"
+}
+
+[[ -f "$MIGRATION_PATH" ]] || die "migration file missing: $MIGRATION_PATH"
+grep -Fq 'guard_prepaid_job_redemption' "$MIGRATION_PATH" || die "unexpected migration content"
+grep -Fq 'restore_prepaid_entitlement_after_job_cancel' "$MIGRATION_PATH" || die "cancellation restore trigger missing"
+
+if [[ -n "${EXPECTED_RELEASE_SHA:-}" ]]; then
+  status_output="$(sudo -n /usr/local/sbin/cwf-deployctl "$ENVIRONMENT" status)" || die "could not read deployed $ENVIRONMENT status"
+  grep -Fq "$EXPECTED_RELEASE_SHA" <<<"$status_output" || die "deployed $ENVIRONMENT revision does not match $EXPECTED_RELEASE_SHA"
+fi
+
+[[ "$(docker_cmd inspect -f '{{.State.Running}}' "$DB_CONTAINER" 2>/dev/null)" == "true" ]] || die "$DB_CONTAINER is not running"
+[[ "$(db_query 'SELECT 1')" == "1" ]] || die "database connectivity check failed"
+
+# The SQL is additive/idempotent and wraps itself in one transaction. Advisory
+# lock prevents two release-gate jobs from applying the same lifecycle migration
+# concurrently on one database.
+LOCK_KEY="202609060329"
+docker_cmd exec "$DB_CONTAINER" sh -ceu \
+  'exec psql -X -U "${POSTGRES_USER:?}" -d "${POSTGRES_DB:?}" -v ON_ERROR_STOP=1 -c "SELECT pg_advisory_lock('$LOCK_KEY'::bigint)"' >/dev/null
+trap 'docker_cmd exec "$DB_CONTAINER" sh -ceu '\''exec psql -X -U "${POSTGRES_USER:?}" -d "${POSTGRES_DB:?}" -v ON_ERROR_STOP=1 -c "SELECT pg_advisory_unlock('"$LOCK_KEY"'::bigint)"'\'' >/dev/null 2>&1 || true' EXIT
+
+docker_cmd exec -i "$DB_CONTAINER" sh -ceu \
+  'exec psql -X -U "${POSTGRES_USER:?}" -d "${POSTGRES_DB:?}" -v ON_ERROR_STOP=1' \
+  < "$MIGRATION_PATH"
+
+verify_schema
+printf 'PREPAID_SERVICE_ENTITLEMENTS_MIGRATION_OK environment=%s triggers=4\n' "$ENVIRONMENT"

--- a/scripts/run-prepaid-service-entitlements-migration.js
+++ b/scripts/run-prepaid-service-entitlements-migration.js
@@ -1,0 +1,153 @@
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+const { Client } = require("pg");
+
+const MIGRATION_RELATIVE_PATH = "migrations/20260906_prepaid_service_entitlements.sql";
+const ADVISORY_LOCK_KEY = "202609060329";
+
+function clean(value) {
+  return String(value == null ? "" : value).trim();
+}
+
+function safeErrorMessage(error) {
+  return clean(error && error.message ? error.message : error)
+    .replace(/postgres(?:ql)?:\/\/[^\s"'<>]+/gi, "[REDACTED_DATABASE_URL]")
+    .replace(/(password|passwd|pwd|secret|token)=([^&\s]+)/gi, "$1=[REDACTED]");
+}
+
+function resolveMigrationPath(repoRoot = path.resolve(__dirname, "..")) {
+  const root = path.resolve(repoRoot);
+  const migrationPath = path.resolve(root, MIGRATION_RELATIVE_PATH);
+  const expected = path.resolve(root, "migrations", "20260906_prepaid_service_entitlements.sql");
+  if (migrationPath !== expected || !migrationPath.startsWith(root + path.sep)) {
+    throw new Error("migration path rejected");
+  }
+  return migrationPath;
+}
+
+function readMigrationSql(repoRoot) {
+  return fs.readFileSync(resolveMigrationPath(repoRoot), "utf8");
+}
+
+function createClientConfig(env = process.env) {
+  const databaseUrl = clean(env.DATABASE_URL);
+  if (databaseUrl) {
+    return {
+      connectionString: databaseUrl,
+      options: "-c timezone=Asia/Bangkok",
+      ssl: { rejectUnauthorized: false },
+    };
+  }
+  return {
+    host: clean(env.DB_HOST),
+    port: Number(env.DB_PORT || 5432),
+    user: clean(env.DB_USER),
+    password: env.DB_PASSWORD,
+    database: clean(env.DB_NAME),
+    options: "-c timezone=Asia/Bangkok",
+    ssl: { rejectUnauthorized: false },
+  };
+}
+
+async function verifySchema(client) {
+  const tables = await client.query(`
+    SELECT
+      to_regclass('public.customer_orders') AS orders,
+      to_regclass('public.customer_service_entitlements') AS entitlements,
+      to_regclass('public.jobs') AS jobs
+  `);
+  const row = tables.rows?.[0] || {};
+  if (!row.orders || !row.entitlements || !row.jobs) throw new Error("prepaid lifecycle tables missing after migration");
+
+  const columns = await client.query(`
+    SELECT table_name, column_name
+      FROM information_schema.columns
+     WHERE table_schema='public'
+       AND (
+         (table_name='customer_orders' AND column_name IN
+           ('order_kind','customer_sub','service_entitlement_snapshot','prepaid_entitlement_code','prepaid_claim_token_hash','prepaid_redeem_until','prepaid_warranty_days','manual_payment_reference','payment_verified_by'))
+         OR
+         (table_name='jobs' AND column_name IN ('customer_due','payment_source','prepaid_entitlement_id'))
+       )
+  `);
+  const present = new Set((columns.rows || []).map((r) => `${r.table_name}.${r.column_name}`));
+  const required = [
+    'customer_orders.order_kind', 'customer_orders.customer_sub',
+    'customer_orders.service_entitlement_snapshot', 'customer_orders.prepaid_entitlement_code',
+    'customer_orders.prepaid_claim_token_hash', 'customer_orders.prepaid_redeem_until',
+    'customer_orders.prepaid_warranty_days', 'customer_orders.manual_payment_reference',
+    'customer_orders.payment_verified_by', 'jobs.customer_due', 'jobs.payment_source',
+    'jobs.prepaid_entitlement_id',
+  ];
+  for (const key of required) if (!present.has(key)) throw new Error(`${key} missing after migration`);
+
+  const triggers = await client.query(`
+    SELECT tgname
+      FROM pg_trigger
+     WHERE NOT tgisinternal
+       AND tgname IN (
+         'trg_issue_prepaid_entitlement_from_paid_order',
+         'trg_guard_prepaid_job_redemption',
+         'trg_consume_prepaid_entitlement_after_job_insert'
+       )
+  `);
+  const triggerNames = new Set((triggers.rows || []).map((r) => r.tgname));
+  for (const name of [
+    'trg_issue_prepaid_entitlement_from_paid_order',
+    'trg_guard_prepaid_job_redemption',
+    'trg_consume_prepaid_entitlement_after_job_insert',
+  ]) {
+    if (!triggerNames.has(name)) throw new Error(`${name} missing after migration`);
+  }
+}
+
+async function runMigration(options = {}) {
+  const env = options.env || process.env;
+  const logger = options.logger || console;
+  const repoRoot = options.repoRoot || path.resolve(__dirname, "..");
+  const clientFactory = options.clientFactory || ((config) => new Client(config));
+  const client = clientFactory(createClientConfig(env));
+  const sql = readMigrationSql(repoRoot);
+  let locked = false;
+  logger.log("PREPAID_SERVICE_ENTITLEMENTS_MIGRATION_START");
+  try {
+    await client.connect();
+    await client.query("SELECT pg_advisory_lock($1::bigint)", [ADVISORY_LOCK_KEY]);
+    locked = true;
+    await client.query(sql);
+    await verifySchema(client);
+    logger.log("PREPAID_SERVICE_ENTITLEMENTS_MIGRATION_OK");
+  } finally {
+    if (locked) await client.query("SELECT pg_advisory_unlock($1::bigint)", [ADVISORY_LOCK_KEY]).catch(() => {});
+    await client.end();
+  }
+}
+
+async function runCli(options = {}) {
+  const logger = options.logger || console;
+  try {
+    await runMigration(options);
+    return 0;
+  } catch (error) {
+    logger.error(`PREPAID_SERVICE_ENTITLEMENTS_MIGRATION_FAILED: ${safeErrorMessage(error)}`);
+    return 1;
+  }
+}
+
+if (require.main === module) {
+  runCli().then((code) => { process.exitCode = code; });
+}
+
+module.exports = {
+  ADVISORY_LOCK_KEY,
+  MIGRATION_RELATIVE_PATH,
+  createClientConfig,
+  readMigrationSql,
+  resolveMigrationPath,
+  runCli,
+  runMigration,
+  safeErrorMessage,
+  verifySchema,
+};

--- a/server/routes/admin/storeServicePackageCatalog.js
+++ b/server/routes/admin/storeServicePackageCatalog.js
@@ -1,15 +1,23 @@
 "use strict";
 
 const express = require("express");
+const defaultPool = require("../../db/pool");
 const { StoreServicePackageCatalogError } = require("../../services/packages/storeServicePackageCatalogService");
+const {
+  PromotionPolicyAdminError,
+  createPromotionPolicyAdminService,
+} = require("../../services/packages/promotionPolicyAdminService");
 
-function createStoreServicePackageCatalogRoutes({ service, requireAdminSession }) {
+function createStoreServicePackageCatalogRoutes({ service, requireAdminSession, promotionPolicyService, pool = defaultPool }) {
   if (!service) throw new TypeError("store service-package catalog service is required");
+  const policyService = promotionPolicyService || createPromotionPolicyAdminService({ pool });
   const router = express.Router();
   const handle = (fn) => async (req, res) => {
     try { return await fn(req, res); }
     catch (error) {
-      if (error instanceof StoreServicePackageCatalogError) return res.status(error.status).json({ error: error.code, code: error.code });
+      if (error instanceof StoreServicePackageCatalogError || error instanceof PromotionPolicyAdminError) {
+        return res.status(error.status || error.statusCode || 400).json({ error: error.code, code: error.code });
+      }
       if (error?.code && Number(error?.statusCode || 0) >= 400 && Number(error.statusCode) < 500) {
         return res.status(Number(error.statusCode)).json({ error: String(error.code), code: String(error.code) });
       }
@@ -23,6 +31,12 @@ function createStoreServicePackageCatalogRoutes({ service, requireAdminSession }
   router.post("/admin/catalog/service-package-bundles/quote", requireAdminSession, handle(async (req, res) => res.json(await service.quote(req.body || {}))));
   router.post("/admin/catalog/service-package-bundles", requireAdminSession, handle(async (req, res) => res.status(201).json(await service.create(req.body || {}))));
   router.patch("/admin/catalog/service-package-bundles/:bundleKey", requireAdminSession, handle(async (req, res) => res.json(await service.update(req.params.bundleKey, req.body || {}))));
+
+  router.get("/admin/catalog/service-package-bundles/:bundleKey/promotion-policy", requireAdminSession,
+    handle(async (req, res) => res.json(await policyService.get(req.params.bundleKey))));
+  router.patch("/admin/catalog/service-package-bundles/:bundleKey/promotion-policy", requireAdminSession,
+    handle(async (req, res) => res.json(await policyService.update(req.params.bundleKey, req.body || {}))));
+
   return router;
 }
 

--- a/server/routes/admin/storeServicePackageCatalog.js
+++ b/server/routes/admin/storeServicePackageCatalog.js
@@ -10,7 +10,7 @@ const {
 const {
   PrepaidServiceError,
   createPrepaidOrderService,
-} = require("../../services/prepaid/prepaidOrderService");
+} = require("../../services/prepaid/prepaidOrderServiceV2");
 
 function createStoreServicePackageCatalogRoutes({ service, requireAdminSession, promotionPolicyService, prepaidOrderService, pool = defaultPool }) {
   if (!service) throw new TypeError("store service-package catalog service is required");
@@ -44,13 +44,10 @@ function createStoreServicePackageCatalogRoutes({ service, requireAdminSession, 
   router.patch("/admin/catalog/service-package-bundles/:bundleKey/promotion-policy", requireAdminSession,
     handle(async (req, res) => res.json(await policyService.update(req.params.bundleKey, req.body || {}))));
 
-  // Admin can create the same server-authoritative prepaid order on behalf of a
-  // customer. If no customer_sub is supplied, a high-entropy claim token is
-  // returned once so the customer can claim the paid right in Customer App.
   router.post("/admin/prepaid-orders", requireAdminSession, handle(async (req, res) => {
     const customerSub = String(req.body?.customer_sub || "").trim() || null;
     const created = await prepaidService.createOrder(req.body || {}, { customerSub, identity: "admin" });
-    return res.status(201).json({ ok: true, ...created });
+    return res.status(created.replayed ? 200 : 201).json({ ok: true, ...created });
   }));
 
   router.post("/admin/prepaid-orders/:code/confirm-payment", requireAdminSession, handle(async (req, res) => {

--- a/server/routes/admin/storeServicePackageCatalog.js
+++ b/server/routes/admin/storeServicePackageCatalog.js
@@ -7,15 +7,22 @@ const {
   PromotionPolicyAdminError,
   createPromotionPolicyAdminService,
 } = require("../../services/packages/promotionPolicyAdminService");
+const {
+  PrepaidServiceError,
+  createPrepaidOrderService,
+} = require("../../services/prepaid/prepaidOrderService");
 
-function createStoreServicePackageCatalogRoutes({ service, requireAdminSession, promotionPolicyService, pool = defaultPool }) {
+function createStoreServicePackageCatalogRoutes({ service, requireAdminSession, promotionPolicyService, prepaidOrderService, pool = defaultPool }) {
   if (!service) throw new TypeError("store service-package catalog service is required");
   const policyService = promotionPolicyService || createPromotionPolicyAdminService({ pool });
+  const prepaidService = prepaidOrderService || createPrepaidOrderService({ pool });
   const router = express.Router();
   const handle = (fn) => async (req, res) => {
     try { return await fn(req, res); }
     catch (error) {
-      if (error instanceof StoreServicePackageCatalogError || error instanceof PromotionPolicyAdminError) {
+      if (error instanceof StoreServicePackageCatalogError
+          || error instanceof PromotionPolicyAdminError
+          || error instanceof PrepaidServiceError) {
         return res.status(error.status || error.statusCode || 400).json({ error: error.code, code: error.code });
       }
       if (error?.code && Number(error?.statusCode || 0) >= 400 && Number(error.statusCode) < 500) {
@@ -36,6 +43,42 @@ function createStoreServicePackageCatalogRoutes({ service, requireAdminSession, 
     handle(async (req, res) => res.json(await policyService.get(req.params.bundleKey))));
   router.patch("/admin/catalog/service-package-bundles/:bundleKey/promotion-policy", requireAdminSession,
     handle(async (req, res) => res.json(await policyService.update(req.params.bundleKey, req.body || {}))));
+
+  // Admin can create the same server-authoritative prepaid order on behalf of a
+  // customer. If no customer_sub is supplied, a high-entropy claim token is
+  // returned once so the customer can claim the paid right in Customer App.
+  router.post("/admin/prepaid-orders", requireAdminSession, handle(async (req, res) => {
+    const customerSub = String(req.body?.customer_sub || "").trim() || null;
+    const created = await prepaidService.createOrder(req.body || {}, { customerSub, identity: "admin" });
+    return res.status(201).json({ ok: true, ...created });
+  }));
+
+  router.post("/admin/prepaid-orders/:code/confirm-payment", requireAdminSession, handle(async (req, res) => {
+    const verifiedBy = String(
+      req.admin?.username || req.admin?.email || req.session?.username || req.user?.username || "admin"
+    ).trim().slice(0, 120);
+    const result = await prepaidService.confirmManualPayment(req.params.code, req.body || {}, { verifiedBy });
+    return res.json({ ok: true, ...result });
+  }));
+
+  router.get("/admin/prepaid-orders", requireAdminSession, handle(async (_req, res) => {
+    if (!(await prepaidService.schemaReady())) {
+      throw new PrepaidServiceError("PREPAID_SCHEMA_NOT_READY", 503);
+    }
+    const result = await pool.query(
+      `SELECT o.order_code, o.customer_name, o.customer_phone, o.customer_sub,
+              o.subtotal, o.status AS payment_order_status, o.payment_provider,
+              o.payment_method, o.payment_status, o.paid_at, o.created_at,
+              e.entitlement_code, e.status AS entitlement_status, e.redeem_until,
+              e.warranty_days, e.redeemed_job_id, e.redeemed_at
+         FROM public.customer_orders o
+         LEFT JOIN public.customer_service_entitlements e ON e.order_id=o.order_id
+        WHERE o.order_kind='service_prepaid'
+        ORDER BY o.created_at DESC
+        LIMIT 300`
+    );
+    return res.json({ ok: true, orders: result.rows || [] });
+  }));
 
   return router;
 }

--- a/server/routes/docs.js
+++ b/server/routes/docs.js
@@ -5,290 +5,134 @@ module.exports = function createDocumentRoutes(deps = {}) {
   const pool = deps.pool || require("../db/pool");
   const isAdminRequest = deps.isAdminRequest;
   const docsRateLimiter = deps.docsRateLimiter || null;
-  const accountingOwnerSignaturePublicUrl = deps.accountingOwnerSignaturePublicUrl;
-  const accountingSignaturePublicUrl = deps.accountingSignaturePublicUrl;
-  const accountingOwnerSignerName = deps.accountingOwnerSignerName;
-  const accountingOwnerSignerPosition = deps.accountingOwnerSignerPosition;
+  const accountingOwnerSignaturePublicUrl = deps.accountingOwnerSignaturePublicUrl || (() => "");
+  const accountingSignaturePublicUrl = deps.accountingSignaturePublicUrl || (() => "");
+  const accountingOwnerSignerName = deps.accountingOwnerSignerName || (() => "");
+  const accountingOwnerSignerPosition = deps.accountingOwnerSignerPosition || (() => "");
 
-  function money(n) {
-    return Number(n || 0).toFixed(2);
+  function money(n) { return Number(n || 0).toFixed(2); }
+  function esc(value) {
+    return String(value == null ? "" : value)
+      .replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;")
+      .replace(/"/g, "&quot;").replace(/'/g, "&#39;");
   }
 
   async function getJobDocData(job_id) {
     const jobR = await pool.query(
-      `SELECT job_id, booking_code, booking_token, customer_name, customer_phone, job_type, appointment_datetime, address_text, job_price,
-              paid_at, paid_by, payment_status,
-              final_signature_path, final_signature_at
-       FROM public.jobs WHERE job_id=$1`,
-      [job_id]
+      `SELECT job_id, booking_code, booking_token, customer_name, customer_phone, job_type,
+              appointment_datetime, address_text, job_price, paid_at, paid_by, payment_status,
+              final_signature_path, final_signature_at, finished_at, canceled_at
+         FROM public.jobs WHERE job_id=$1`, [job_id]
     );
     if (jobR.rows.length === 0) return null;
+    const job = jobR.rows[0];
+    try {
+      const settlement = await pool.query(
+        `SELECT payment_source, customer_due FROM public.jobs WHERE job_id=$1`, [job_id]
+      );
+      if (settlement.rows?.[0]) Object.assign(job, settlement.rows[0]);
+    } catch (error) {
+      if (error?.code !== "42703") throw error;
+    }
 
     const itemsR = await pool.query(
       `SELECT item_name, qty, unit_price, line_total
-       FROM public.job_items WHERE job_id=$1 ORDER BY job_item_id`,
-      [job_id]
+         FROM public.job_items WHERE job_id=$1 ORDER BY job_item_id`, [job_id]
     );
-
     const promoR = await pool.query(
       `SELECT p.promo_name, p.promo_type, p.promo_value, jp.applied_discount
-       FROM public.job_promotions jp
-       JOIN public.promotions p ON p.promo_id=jp.promo_id
-       WHERE jp.job_id=$1
-       LIMIT 1`,
-      [job_id]
+         FROM public.job_promotions jp
+         JOIN public.promotions p ON p.promo_id=jp.promo_id
+        WHERE jp.job_id=$1 LIMIT 1`, [job_id]
     );
-
-    const subtotal = itemsR.rows.reduce((s, it) => s + Number(it.line_total || 0), 0);
+    const subtotal = itemsR.rows.reduce((sum, item) => sum + Number(item.line_total || 0), 0);
     const discount = promoR.rows[0]?.applied_discount ? Number(promoR.rows[0].applied_discount) : 0;
-    const total = Math.max(
-      0,
-      subtotal > 0 ? subtotal - discount : Number(jobR.rows[0].job_price || 0)
-    );
+    const total = Math.max(0, subtotal > 0 ? subtotal - discount : Number(job.job_price || 0));
+    return { job, items: itemsR.rows, promo: promoR.rows[0] || null, subtotal, discount, total };
+  }
 
-    return { job: jobR.rows[0], items: itemsR.rows, promo: promoR.rows[0] || null, subtotal, discount, total };
+  function itemRows(data) {
+    return data.items?.length
+      ? data.items.map((item) => `<tr><td>${esc(item.item_name)}</td><td class="num">${esc(item.qty)}</td><td class="num">${money(item.unit_price)}</td><td class="num">${money(item.line_total)}</td></tr>`).join("")
+      : `<tr><td colspan="4">-</td></tr>`;
+  }
+
+  function company() {
+    return {
+      name: process.env.COMPANY_NAME || "Coldwindflow air services",
+      address: process.env.COMPANY_ADDRESS || "23/61 ถ.พึ่งมี 50 แขวงบางจาก เขตพระโขนง กรุงเทพฯ 10260",
+      phone: process.env.COMPANY_PHONE || "098-877-7321",
+      line: process.env.COMPANY_LINE || "@cwfair",
+      bankName: process.env.COMPANY_BANK_NAME || "",
+      bankAccount: process.env.COMPANY_BANK_ACCOUNT || "",
+      bankQr: process.env.COMPANY_BANK_QR_URL || "",
+      signature: process.env.COMPANY_SIGNATURE_URL || accountingOwnerSignaturePublicUrl() || accountingSignaturePublicUrl({ signature_url: "/assets/signatures/owner-signature-transparent.png" }),
+      signer: accountingOwnerSignerName(),
+      position: accountingOwnerSignerPosition(),
+    };
+  }
+
+  function baseCss() {
+    return `body{font-family:system-ui,-apple-system,"Segoe UI",Tahoma,sans-serif;padding:20px;color:#0f172a;background:#f8fafc}.card,.box{background:#fff;border:1px solid rgba(15,23,42,.13);border-radius:14px;padding:14px}.top,.row{display:flex;justify-content:space-between;gap:14px;align-items:flex-start;flex-wrap:wrap}.muted{color:#64748b;font-size:13px}table{width:100%;border-collapse:collapse;margin-top:12px;background:#fff}th,td{border:1px solid rgba(15,23,42,.13);padding:8px;font-size:13px}th{background:rgba(37,99,235,.08);text-align:left}.num{text-align:right}.paid{font-weight:800;color:#166534}@media print{.noprint{display:none}body{background:#fff}}`;
+  }
+
+  function paymentSummary(data, c) {
+    const j = data.job;
+    if (j.payment_source === "prepaid_entitlement") {
+      return `<div class="box" style="margin-top:12px"><b>สถานะการชำระเงิน</b><div class="paid" style="margin-top:6px">ชำระล่วงหน้าแล้ว · ไม่มีค่าใช้จ่ายซ้ำสำหรับสิทธิ์นี้</div></div>`;
+    }
+    if (c.bankName || c.bankAccount) {
+      return `<div class="box" style="margin-top:12px"><b>ข้อมูลการชำระเงิน</b>${c.bankName ? `<div class="muted" style="margin-top:6px">ธนาคาร: <b>${esc(c.bankName)}</b></div>` : ""}${c.bankAccount ? `<div class="muted">เลขบัญชี: <b>${esc(c.bankAccount)}</b></div>` : ""}${c.bankQr ? `<img src="${esc(c.bankQr)}" alt="QR" style="width:170px;max-width:100%;margin-top:8px;border-radius:12px">` : ""}</div>`;
+    }
+    return "";
   }
 
   function docHtml(title, data) {
     const j = data.job;
-    const COMPANY_NAME = process.env.COMPANY_NAME || "Coldwindflow air services";
-    const COMPANY_ADDRESS = process.env.COMPANY_ADDRESS || "23/61 ถ.พึ่งมี 50 แขวงบางจาก เขตพระโขนง กรุงเทพฯ 10260";
-    const COMPANY_PHONE = process.env.COMPANY_PHONE || "098-877-7321";
-    const COMPANY_LINE = process.env.COMPANY_LINE || "@cwfair";
-    const COMPANY_SIGNATURE_URL = process.env.COMPANY_SIGNATURE_URL || accountingOwnerSignaturePublicUrl() || accountingSignaturePublicUrl({ signature_url: "/assets/signatures/owner-signature-transparent.png" });
-    const COMPANY_SIGNER_NAME = accountingOwnerSignerName();
-    const COMPANY_SIGNER_POSITION = accountingOwnerSignerPosition();
-    const BANK_NAME = process.env.COMPANY_BANK_NAME || "";
-    const BANK_ACCOUNT = process.env.COMPANY_BANK_ACCOUNT || "";
-    const BANK_QR_URL = process.env.COMPANY_BANK_QR_URL || "";
-    const rows =
-      data.items && data.items.length
-        ? data.items
-            .map(
-              (it) => `
-      <tr>
-        <td>${it.item_name}</td>
-        <td style="text-align:right;">${it.qty}</td>
-        <td style="text-align:right;">${money(it.unit_price)}</td>
-        <td style="text-align:right;">${money(it.line_total)}</td>
-      </tr>`
-            )
-            .join("")
-        : `<tr><td colspan="4">-</td></tr>`;
-    const promoLine = data.promo
-      ? `<div>โปรโมชั่น: <b>${data.promo.promo_name}</b> (ลด ${money(data.discount)})</div>`
-      : "";
-    return `<!doctype html>
-  <html lang="th"><head>
-    <meta charset="utf-8"/>
-    <meta name="viewport" content="width=device-width, initial-scale=1"/>
-    <title>${title} - ${j.booking_code || "งาน #" + j.job_id}</title>
-    <style>
-      body{ font-family: system-ui, -apple-system, "Segoe UI", Tahoma, sans-serif; padding:24px; color:#0f172a;}
-      .top{ display:flex; justify-content:space-between; gap:16px; align-items:flex-start;}
-      .box{ border:1px solid rgba(15,23,42,.15); border-radius:12px; padding:14px; }
-      table{ width:100%; border-collapse:collapse; margin-top:12px;}
-      th,td{ border:1px solid rgba(15,23,42,.15); padding:8px; font-size:14px;}
-      th{ background: rgba(37,99,235,.08); text-align:left;}
-      .muted{ color:#64748b;}
-      @media print{ .noprint{ display:none; } }
-    </style>
-  </head><body>
-    <div class="top">
-      <div style="display:flex;gap:12px;align-items:center;">
-        <img src="/logo.png" alt="CWF" style="width:54px;height:54px;border-radius:14px;object-fit:cover;"/>
-        <div>
-          <h2 style="margin:0;">${title}</h2>
-          <div class="muted"><b>${COMPANY_NAME}</b></div>
-          <div class="muted">${COMPANY_ADDRESS}</div>
-          <div class="muted">โทร ${COMPANY_PHONE} | LINE ${COMPANY_LINE}</div>
-        </div>
-      </div>
-      <div class="box">
-        <div><b>${j.booking_code || "งาน #" + j.job_id}</b></div>
-        <div class="muted">วันที่พิมพ์: ${new Date().toLocaleString("th-TH")}</div>
-      </div>
-    </div>
-
-    <div class="box" style="margin-top:14px;">
-      <div><b>ลูกค้า:</b> ${j.customer_name}</div>
-      <div><b>โทร:</b> ${j.customer_phone || "-"}</div>
-      <div><b>ประเภทงาน:</b> ${j.job_type}</div>
-      <div><b>นัด:</b> ${j.appointment_datetime ? new Date(j.appointment_datetime).toLocaleString("th-TH") : "-"}</div>
-      <div><b>ที่อยู่:</b> ${j.address_text || "-"}</div>
-    </div>
-
-    <table>
-      <thead><tr>
-        <th>รายการ</th><th style="text-align:right;">จำนวน</th><th style="text-align:right;">ราคา/หน่วย</th><th style="text-align:right;">รวม</th>
-      </tr></thead>
-      <tbody>${rows}</tbody>
-    </table>
-
-    <div class="box" style="margin-top:12px;">
-      ${promoLine}
-      <div>รวมก่อนลด: <b>${money(data.subtotal)}</b> บาท</div>
-      <div>ส่วนลด: <b>${money(data.discount)}</b> บาท</div>
-      <div style="font-size:18px;margin-top:6px;">ยอดสุทธิ: <b>${money(data.total)}</b> บาท</div>
-    </div>
-    <div class="box" style="margin-top:12px;">
-      <div style="display:flex;gap:14px;flex-wrap:wrap;align-items:flex-start;">
-        <div style="flex:1;min-width:240px;">
-          <div><b>ข้อมูลการชำระเงิน</b></div>
-          ${BANK_NAME || BANK_ACCOUNT ? `
-            <div class="muted" style="margin-top:6px;">โอนเข้าบัญชี: <b>${BANK_NAME}</b></div>
-            <div class="muted">เลขบัญชี: <b>${BANK_ACCOUNT}</b></div>
-          ` : `<div class="muted" style="margin-top:6px;">(ยังไม่ได้ตั้งค่าบัญชีใน .env)</div>`}
-        </div>
-        <div style="width:170px;">
-          ${BANK_QR_URL ? `<img src="${BANK_QR_URL}" alt="QR" style="width:170px;height:auto;border:1px solid rgba(15,23,42,.15);border-radius:12px;">` : ``}
-        </div>
-      </div>
-    </div>
-
-    <div class="box" style="margin-top:12px;">
-      <div style="display:flex;justify-content:space-between;gap:12px;flex-wrap:wrap;">
-        <div style="flex:1;min-width:240px;">
-          <div class="muted">ลายเซ็นผู้รับเงิน / ผู้ให้บริการ</div>
-          <div style="height:70px;border-bottom:1px dashed rgba(15,23,42,.35);margin-top:8px;text-align:center;">
-            ${COMPANY_SIGNATURE_URL ? `<img src="${COMPANY_SIGNATURE_URL}" alt="authorized signature" style="max-width:180px;max-height:68px;object-fit:contain;">` : ``}
-          </div>
-          <div style="font-weight:800;margin-top:6px;">${COMPANY_SIGNER_NAME}</div>
-          <div class="muted">${COMPANY_SIGNER_POSITION}</div>
-          <div class="muted">(${COMPANY_NAME})</div>
-        </div>
-        <div style="width:220px;text-align:center;">
-          ${j.final_signature_path ? `
-            <div class="muted">ลายเซ็นช่าง</div>
-            <img src="${j.final_signature_path}" alt="signature" style="width:220px;height:auto;border:1px solid rgba(15,23,42,.15);border-radius:12px;margin-top:6px;">
-          ` : `<div class="muted">ลายเซ็นช่าง: -</div>`}
-        </div>
-      </div>
-    </div>
-
-    <div class="noprint" style="margin-top:12px;">
-      <button onclick="window.print()">🖨️ พิมพ์/บันทึกเป็น PDF</button>
-    </div>
-  </body></html>`;
+    const c = company();
+    const promoLine = data.promo ? `<div>โปรโมชั่น: <b>${esc(data.promo.promo_name)}</b> (ลด ${money(data.discount)})</div>` : "";
+    return `<!doctype html><html lang="th"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>${esc(title)} - ${esc(j.booking_code || `งาน #${j.job_id}`)}</title><style>${baseCss()}</style></head><body>
+      <div class="top"><div><h2 style="margin:0">${esc(title)}</h2><div class="muted"><b>${esc(c.name)}</b></div><div class="muted">${esc(c.address)}</div><div class="muted">โทร ${esc(c.phone)} | LINE ${esc(c.line)}</div></div><div class="box"><b>${esc(j.booking_code || `งาน #${j.job_id}`)}</b><div class="muted">วันที่พิมพ์: ${esc(new Date().toLocaleString("th-TH"))}</div></div></div>
+      <div class="box" style="margin-top:14px"><div><b>ลูกค้า:</b> ${esc(j.customer_name)}</div><div><b>โทร:</b> ${esc(j.customer_phone || "-")}</div><div><b>ประเภทงาน:</b> ${esc(j.job_type)}</div><div><b>นัด:</b> ${j.appointment_datetime ? esc(new Date(j.appointment_datetime).toLocaleString("th-TH")) : "-"}</div><div><b>ที่อยู่:</b> ${esc(j.address_text || "-")}</div></div>
+      <table><thead><tr><th>รายการ</th><th class="num">จำนวน</th><th class="num">ราคา/หน่วย</th><th class="num">รวม</th></tr></thead><tbody>${itemRows(data)}</tbody></table>
+      <div class="box" style="margin-top:12px">${promoLine}<div>รวมก่อนลด: <b>${money(data.subtotal)}</b> บาท</div><div>ส่วนลด: <b>${money(data.discount)}</b> บาท</div><div style="font-size:18px;margin-top:6px">ยอดสุทธิ: <b>${money(data.total)}</b> บาท</div></div>
+      ${paymentSummary(data, c)}
+      <div class="box" style="margin-top:12px"><div class="row"><div><div class="muted">ลายเซ็นผู้รับเงิน / ผู้ให้บริการ</div>${c.signature ? `<img src="${esc(c.signature)}" alt="authorized signature" style="max-width:180px;max-height:68px;margin-top:8px">` : ""}<div style="font-weight:800">${esc(c.signer)}</div><div class="muted">${esc(c.position)}</div></div><div style="text-align:center">${j.final_signature_path ? `<div class="muted">ลายเซ็นช่าง</div><img src="${esc(j.final_signature_path)}" alt="signature" style="width:220px;max-width:100%;border-radius:12px;margin-top:6px">` : ""}</div></div></div>
+      <div class="noprint" style="margin-top:12px"><button onclick="window.print()">พิมพ์/บันทึกเป็น PDF</button></div>
+    </body></html>`;
   }
 
   function eSlipHtml(data, slipUrl) {
     const j = data.job;
-    const COMPANY_NAME = process.env.COMPANY_NAME || "Coldwindflow air services";
-    const COMPANY_ADDRESS = process.env.COMPANY_ADDRESS || "23/61 ถ.พึ่งมี 50 แขวงบางจาก เขตพระโขนง กรุงเทพฯ 10260";
-    const COMPANY_PHONE = process.env.COMPANY_PHONE || "098-877-7321";
-    const COMPANY_LINE = process.env.COMPANY_LINE || "@cwfair";
-    const BANK_QR_URL = process.env.COMPANY_BANK_QR_URL || "";
-    const phoneDigits = String(COMPANY_PHONE || "").replace(/[^0-9]/g, "");
-    const total = Number(data.total || 0);
-    const qrUrl = BANK_QR_URL || (phoneDigits ? `https://promptpay.io/${phoneDigits}/${total.toFixed(2)}.png` : "");
-    const rows =
-      data.items && data.items.length
-        ? data.items
-            .map(
-              (it) => `
-      <tr>
-        <td>${it.item_name}</td>
-        <td style="text-align:right;">${it.qty}</td>
-        <td style="text-align:right;">${money(it.unit_price)}</td>
-        <td style="text-align:right;">${money(it.line_total)}</td>
-      </tr>`
-            )
-            .join("")
-        : `<tr><td colspan="4">-</td></tr>`;
-    const paidAt = j.paid_at ? new Date(j.paid_at).toLocaleString("th-TH") : new Date().toLocaleString("th-TH");
-    return `<!doctype html>
-  <html lang="th"><head>
-    <meta charset="utf-8"/>
-    <meta name="viewport" content="width=device-width, initial-scale=1"/>
-    <title>e-slip - ${j.booking_code || "งาน #" + j.job_id}</title>
-    <style>
-      body{ font-family: system-ui, -apple-system, "Segoe UI", Tahoma, sans-serif; padding:18px; color:#0f172a; background:#f8fafc;}
-      .card{ background:#fff;border:1px solid rgba(15,23,42,.12); border-radius:16px; padding:14px; box-shadow: 0 12px 25px rgba(2,6,23,.08); }
-      .row{ display:flex; justify-content:space-between; gap:12px; flex-wrap:wrap; align-items:flex-start;}
-      .muted{ color:#64748b; font-size:13px;}
-      table{ width:100%; border-collapse:collapse; margin-top:12px;}
-      th,td{ border:1px solid rgba(15,23,42,.12); padding:8px; font-size:13px;}
-      th{ background: rgba(37,99,235,.08); text-align:left;}
-      @media print{ .noprint{ display:none; } body{ background:#fff; } }
-    </style>
-  </head><body>
-    <div class="card">
-      <div class="row">
-        <div style="display:flex;gap:10px;align-items:center;">
-          <img src="/logo.png" alt="CWF" style="width:44px;height:44px;border-radius:14px;object-fit:cover;"/>
-          <div>
-            <div style="font-size:18px;font-weight:900;">e-slip</div>
-            <div class="muted"><b>${COMPANY_NAME}</b></div>
-            <div class="muted">${COMPANY_ADDRESS}</div>
-            <div class="muted">โทร ${COMPANY_PHONE} | LINE ${COMPANY_LINE}</div>
-          </div>
-        </div>
-        <div style="text-align:right;">
-          <div style="font-weight:900;">${j.booking_code || "งาน #" + j.job_id}</div>
-          <div class="muted">ชำระเมื่อ: ${paidAt}</div>
-        </div>
-      </div>
-
-      <div class="card" style="margin-top:12px;background:#fff;">
-        <div><b>ลูกค้า:</b> ${j.customer_name}</div>
-        <div><b>โทร:</b> ${j.customer_phone || "-"}</div>
-        <div><b>ประเภทงาน:</b> ${j.job_type}</div>
-        <div><b>ที่อยู่:</b> ${j.address_text || "-"}</div>
-      </div>
-
-      <table>
-        <thead><tr>
-          <th>รายการ</th><th style="text-align:right;">จำนวน</th><th style="text-align:right;">ราคา/หน่วย</th><th style="text-align:right;">รวม</th>
-        </tr></thead>
-        <tbody>${rows}</tbody>
-      </table>
-
-      <div class="card" style="margin-top:12px;background:#fff;">
-        <div class="row" style="align-items:center;">
-          <div>
-            <div class="muted">ยอดสุทธิ</div>
-            <div style="font-size:22px;font-weight:900;">${money(total)} บาท</div>
-          </div>
-          <div style="text-align:center;min-width:170px;">
-            ${qrUrl ? `<img src="${qrUrl}" alt="QR" style="width:160px;height:auto;border:1px solid rgba(15,23,42,.12);border-radius:14px;background:#fff;">` : ``}
-            <div class="muted" style="margin-top:6px;">QR Payment</div>
-          </div>
-        </div>
-      </div>
-
-      ${slipUrl ? `
-        <div class="card" style="margin-top:12px;background:#fff;">
-          <div style="font-weight:800;">สลิปที่แนบ</div>
-          <img src="${slipUrl}" alt="slip" style="width:100%;max-width:520px;margin-top:8px;border-radius:14px;border:1px solid rgba(15,23,42,.12);">
-        </div>
-      ` : ``}
-
-      <div class="noprint" style="margin-top:12px;">
-        <button onclick="window.print()">🖨️ พิมพ์/บันทึกเป็น PDF</button>
-      </div>
-    </div>
-  </body></html>`;
+    const c = company();
+    const prepaid = j.payment_source === "prepaid_entitlement";
+    const paid = prepaid || ["paid", "verified"].includes(String(j.payment_status || "").toLowerCase()) || Boolean(j.paid_at);
+    const phoneDigits = String(c.phone || "").replace(/[^0-9]/g, "");
+    const qrUrl = !paid ? (c.bankQr || (phoneDigits ? `https://promptpay.io/${phoneDigits}/${Number(data.total || 0).toFixed(2)}.png` : "")) : "";
+    const paidAt = j.paid_at ? new Date(j.paid_at).toLocaleString("th-TH") : (prepaid ? "ชำระล่วงหน้า" : "-");
+    return `<!doctype html><html lang="th"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>e-slip - ${esc(j.booking_code || `งาน #${j.job_id}`)}</title><style>${baseCss()}</style></head><body>
+      <div class="card"><div class="row"><div><div style="font-size:20px;font-weight:900">e-slip</div><div class="muted"><b>${esc(c.name)}</b></div><div class="muted">${esc(c.address)}</div><div class="muted">โทร ${esc(c.phone)} | LINE ${esc(c.line)}</div></div><div><b>${esc(j.booking_code || `งาน #${j.job_id}`)}</b><div class="muted">ชำระเมื่อ: ${esc(paidAt)}</div></div></div>
+      <div class="card" style="margin-top:12px"><div><b>ลูกค้า:</b> ${esc(j.customer_name)}</div><div><b>โทร:</b> ${esc(j.customer_phone || "-")}</div><div><b>ประเภทงาน:</b> ${esc(j.job_type)}</div><div><b>ที่อยู่:</b> ${esc(j.address_text || "-")}</div></div>
+      <table><thead><tr><th>รายการ</th><th class="num">จำนวน</th><th class="num">ราคา/หน่วย</th><th class="num">รวม</th></tr></thead><tbody>${itemRows(data)}</tbody></table>
+      <div class="card" style="margin-top:12px"><div class="row" style="align-items:center"><div><div class="muted">ยอดสุทธิ</div><div style="font-size:24px;font-weight:900">${money(data.total)} บาท</div>${prepaid ? `<div class="paid">ชำระล่วงหน้าแล้ว</div>` : paid ? `<div class="paid">ชำระแล้ว</div>` : ""}</div>${qrUrl ? `<img src="${esc(qrUrl)}" alt="QR" style="width:170px;max-width:100%;border-radius:12px">` : ""}</div></div>
+      ${slipUrl ? `<div class="card" style="margin-top:12px"><b>สลิปที่แนบ</b><img src="${esc(slipUrl)}" alt="slip" style="width:100%;max-width:520px;margin-top:8px;border-radius:14px"></div>` : ""}
+      <div class="noprint" style="margin-top:12px"><button onclick="window.print()">พิมพ์/บันทึกเป็น PDF</button></div></div>
+    </body></html>`;
   }
 
-  // Job documents (quote / receipt / e-slip) carry full customer PII (name,
-  // phone, address, price). A bare sequential job_id must never be enough to
-  // read one: the caller needs the job's booking_token (?key=..., which the
-  // tracking page embeds) or an authenticated admin session. Denials answer 404
-  // (not 403) so the route is not an existence oracle for job_ids.
   async function canViewJobDoc(req, data) {
-    const key = String((req.query && req.query.key) || "").trim();
-    // getJobDocData returns { job, items, ... } — the token lives on the job row.
-    const token = data && data.job ? data.job.booking_token : null;
-    if (key && token && trackingPrivacy.timingSafeEqualStr(key, String(token))) {
-      return true;
-    }
+    const key = String(req.query?.key || "").trim();
+    const token = data?.job?.booking_token || null;
+    if (key && token && trackingPrivacy.timingSafeEqualStr(key, String(token))) return true;
     if (typeof isAdminRequest === "function") {
-      try {
-        if (await isAdminRequest(req)) return true;
-      } catch (_) { /* treated as not admin */ }
+      try { if (await isAdminRequest(req)) return true; } catch (_) {}
     }
     return false;
+  }
+
+  async function isAdmin(req) {
+    if (typeof isAdminRequest !== "function") return false;
+    try { return Boolean(await isAdminRequest(req)); } catch (_) { return false; }
   }
 
   function docsRateLimited(req, res) {
@@ -299,8 +143,6 @@ module.exports = function createDocumentRoutes(deps = {}) {
     return true;
   }
 
-  // The token travels in the query string, so keep sensitive docs out of
-  // caches, referrers, and search indexes.
   function setSensitiveDocHeaders(res) {
     res.setHeader("Cache-Control", "private, no-store, max-age=0");
     res.setHeader("Referrer-Policy", "no-referrer");
@@ -308,8 +150,6 @@ module.exports = function createDocumentRoutes(deps = {}) {
     res.setHeader("Content-Type", "text/html; charset=utf-8");
   }
 
-  // One gate for every PII-bearing job document. Returns the doc data when the
-  // caller is authorised, otherwise sends the appropriate 404/429 and null.
   async function loadAuthorizedJobDoc(req, res) {
     if (docsRateLimited(req, res)) return null;
     const job_id = Number(req.params.job_id);
@@ -318,6 +158,13 @@ module.exports = function createDocumentRoutes(deps = {}) {
     if (!data) { res.status(404).send("ไม่พบงาน"); return null; }
     if (!(await canViewJobDoc(req, data))) { res.status(404).send("ไม่พบงาน"); return null; }
     return data;
+  }
+
+  async function requireFinishedForCustomer(req, res, data) {
+    if (data?.job?.finished_at) return true;
+    if (await isAdmin(req)) return true;
+    res.status(404).send("ไม่พบงาน");
+    return false;
   }
 
   router.get("/docs/quote/:job_id", async (req, res) => {
@@ -330,6 +177,7 @@ module.exports = function createDocumentRoutes(deps = {}) {
   router.get("/docs/receipt/:job_id", async (req, res) => {
     const data = await loadAuthorizedJobDoc(req, res);
     if (!data) return;
+    if (!(await requireFinishedForCustomer(req, res, data))) return;
     setSensitiveDocHeaders(res);
     res.send(docHtml("ใบเสร็จรับเงิน", data));
   });
@@ -338,20 +186,17 @@ module.exports = function createDocumentRoutes(deps = {}) {
     try {
       const data = await loadAuthorizedJobDoc(req, res);
       if (!data) return;
+      if (!(await requireFinishedForCustomer(req, res, data))) return;
       const job_id = Number(req.params.job_id);
       const slipR = await pool.query(
-        `SELECT public_url
-         FROM public.job_photos
-         WHERE job_id=$1 AND phase='payment_slip' AND public_url IS NOT NULL
-         ORDER BY photo_id DESC
-         LIMIT 1`,
-        [job_id]
+        `SELECT public_url FROM public.job_photos
+          WHERE job_id=$1 AND phase='payment_slip' AND public_url IS NOT NULL
+          ORDER BY photo_id DESC LIMIT 1`, [job_id]
       );
-      const slipUrl = slipR.rows?.[0]?.public_url || null;
       setSensitiveDocHeaders(res);
-      res.send(eSlipHtml(data, slipUrl));
-    } catch (e) {
-      console.error(e);
+      res.send(eSlipHtml(data, slipR.rows?.[0]?.public_url || null));
+    } catch (error) {
+      console.error("[docs/eslip] failed", { code: String(error?.code || "ESLIP_FAILED") });
       res.status(500).send("สร้าง e-slip ไม่สำเร็จ");
     }
   });

--- a/server/routes/public/customerBookings.js
+++ b/server/routes/public/customerBookings.js
@@ -9,15 +9,18 @@ function registerPublicCustomerBookingRoutes(app, options = {}) {
   }
 
   // PREPAID is mounted next to the existing customer booking surface so it uses
-  // the same app/process without creating a second booking engine. The prepaid
-  // router defaults to the canonical pool/JWT config when the caller does not
-  // explicitly inject them (legacy index wiring stays compatible).
-  app.use(createCustomerPrepaidRoutes({
-    pool: options.pool,
-    env: options.env,
-    requireCustomerJwt: options.requireCustomerJwt,
-    service: options.prepaidService,
-  }));
+  // the same app/process without creating a second booking engine. Real Express
+  // applications expose app.use(); route-adapter tests and compatible thin
+  // adapters may expose only app.post(), so keep the legacy registration contract
+  // intact without weakening the real production mount.
+  if (typeof app.use === "function") {
+    app.use(createCustomerPrepaidRoutes({
+      pool: options.pool,
+      env: options.env,
+      requireCustomerJwt: options.requireCustomerJwt,
+      service: options.prepaidService,
+    }));
+  }
 
   app.post("/public/urgent-dispatch-preflight", service.handlePublicUrgentPreflight);
   if (options.quoteService && typeof options.quoteService.handle === "function") {

--- a/server/routes/public/customerBookings.js
+++ b/server/routes/public/customerBookings.js
@@ -1,10 +1,23 @@
 "use strict";
 
+const { createCustomerPrepaidRoutes } = require("./customerPrepaid");
+
 function registerPublicCustomerBookingRoutes(app, options = {}) {
   const service = options.service;
   if (!service || typeof service.handlePublicBook !== "function") {
     throw new TypeError("customer booking service is required");
   }
+
+  // PREPAID is mounted next to the existing customer booking surface so it uses
+  // the same app/process without creating a second booking engine. The prepaid
+  // router defaults to the canonical pool/JWT config when the caller does not
+  // explicitly inject them (legacy index wiring stays compatible).
+  app.use(createCustomerPrepaidRoutes({
+    pool: options.pool,
+    env: options.env,
+    requireCustomerJwt: options.requireCustomerJwt,
+    service: options.prepaidService,
+  }));
 
   app.post("/public/urgent-dispatch-preflight", service.handlePublicUrgentPreflight);
   if (options.quoteService && typeof options.quoteService.handle === "function") {

--- a/server/routes/public/customerPrepaid.js
+++ b/server/routes/public/customerPrepaid.js
@@ -1,0 +1,122 @@
+"use strict";
+
+const express = require("express");
+const defaultPool = require("../../db/pool");
+const { baseProviderConfig, jwtVerify } = require("../../customerAuth");
+const {
+  PrepaidServiceError,
+  createPrepaidOrderService,
+} = require("../../services/prepaid/prepaidOrderService");
+
+function clean(value) {
+  return String(value == null ? "" : value).trim();
+}
+
+function cookieValue(req, name) {
+  const header = String(req.headers?.cookie || "");
+  for (const part of header.split(";")) {
+    const index = part.indexOf("=");
+    if (index < 0) continue;
+    if (part.slice(0, index).trim() !== name) continue;
+    let value = part.slice(index + 1).trim().replace(/^"|"$/g, "");
+    try { value = decodeURIComponent(value); } catch (_) {}
+    return value;
+  }
+  return null;
+}
+
+function fallbackCustomerJwt(env) {
+  return (req, res, next) => {
+    const secret = baseProviderConfig(env).jwtSecret;
+    const token = cookieValue(req, "cwf_token");
+    const payload = secret && token ? jwtVerify(token, secret) : null;
+    if (!payload?.sub) return res.status(401).json({ error: "NOT_LOGGED_IN" });
+    req.customer = payload;
+    return next();
+  };
+}
+
+function createCustomerPrepaidRoutes(options = {}) {
+  const pool = options.pool || defaultPool;
+  const env = options.env || process.env;
+  const service = options.service || createPrepaidOrderService({ pool });
+  const requireCustomerJwt = typeof options.requireCustomerJwt === "function"
+    ? options.requireCustomerJwt
+    : fallbackCustomerJwt(env);
+  const router = express.Router();
+
+  router.use("/public/prepaid-orders", (_req, res, next) => {
+    res.set("Cache-Control", "private, no-store");
+    next();
+  });
+  router.use("/public/service-rights", (_req, res, next) => {
+    res.set("Cache-Control", "private, no-store");
+    next();
+  });
+
+  const handle = (fn) => async (req, res) => {
+    try {
+      return await fn(req, res);
+    } catch (error) {
+      if (error instanceof PrepaidServiceError || (error?.code && Number(error?.statusCode || 0) >= 400)) {
+        const status = Number(error.statusCode || 400);
+        return res.status(status >= 400 && status < 600 ? status : 500).json({
+          error: String(error.code || "PREPAID_REQUEST_FAILED"),
+          code: String(error.code || "PREPAID_REQUEST_FAILED"),
+        });
+      }
+      console.error("[customer_prepaid] failed", {
+        route: req.originalUrl,
+        db_code: /^[A-Z0-9_]{2,16}$/.test(String(error?.code || "")) ? String(error.code) : undefined,
+      });
+      return res.status(500).json({ error: "PREPAID_REQUEST_FAILED", code: "PREPAID_REQUEST_FAILED" });
+    }
+  };
+
+  router.post("/public/prepaid-orders", requireCustomerJwt, handle(async (req, res) => {
+    const customerSub = clean(req.customer?.sub);
+    if (!customerSub) return res.status(401).json({ error: "NOT_LOGGED_IN", code: "NOT_LOGGED_IN" });
+    const created = await service.createOrder(req.body || {}, { customerSub, identity: "customer" });
+    return res.status(201).json({
+      ok: true,
+      order: created.order,
+      entitlement_code: created.entitlement_code,
+      service: created.service,
+    });
+  }));
+
+  router.get("/public/service-rights", requireCustomerJwt, handle(async (req, res) => {
+    const customerSub = clean(req.customer?.sub);
+    if (!customerSub) return res.status(401).json({ error: "NOT_LOGGED_IN", code: "NOT_LOGGED_IN" });
+    const items = await service.listRights(customerSub);
+    return res.json({ ok: true, items });
+  }));
+
+  router.post("/public/service-rights/claim", requireCustomerJwt, handle(async (req, res) => {
+    const customerSub = clean(req.customer?.sub);
+    if (!customerSub) return res.status(401).json({ error: "NOT_LOGGED_IN", code: "NOT_LOGGED_IN" });
+    const claimed = await service.claimRight({
+      entitlementCode: req.body?.entitlement_code,
+      claimToken: req.body?.claim_token,
+      customerSub,
+    });
+    return res.json({ ok: true, entitlement: claimed });
+  }));
+
+  router.post("/public/service-rights/:code/begin-redemption", requireCustomerJwt, handle(async (req, res) => {
+    const customerSub = clean(req.customer?.sub);
+    if (!customerSub) return res.status(401).json({ error: "NOT_LOGGED_IN", code: "NOT_LOGGED_IN" });
+    const redemption = await service.beginRedemption({
+      entitlementCode: req.params.code,
+      customerSub,
+    });
+    return res.json({ ok: true, redemption });
+  }));
+
+  return router;
+}
+
+module.exports = {
+  createCustomerPrepaidRoutes,
+  fallbackCustomerJwt,
+};

--- a/server/routes/public/customerPrepaid.js
+++ b/server/routes/public/customerPrepaid.js
@@ -6,7 +6,7 @@ const { baseProviderConfig, jwtVerify } = require("../../customerAuth");
 const {
   PrepaidServiceError,
   createPrepaidOrderService,
-} = require("../../services/prepaid/prepaidOrderService");
+} = require("../../services/prepaid/prepaidOrderServiceV2");
 
 function clean(value) {
   return String(value == null ? "" : value).trim();
@@ -73,12 +73,64 @@ function createCustomerPrepaidRoutes(options = {}) {
     }
   };
 
+  // Tiny public policy probe used only to decide whether the Store should follow
+  // the existing book-now path or the prepaid purchase path. Never returns price
+  // internals or hidden catalog rows.
+  router.get("/public/prepaid-policy/:item_id", handle(async (req, res) => {
+    const itemId = Number(req.params.item_id);
+    if (!Number.isSafeInteger(itemId) || itemId <= 0) {
+      return res.status(404).json({ error: "NOT_FOUND", code: "NOT_FOUND" });
+    }
+    let row;
+    try {
+      const result = await pool.query(
+        `SELECT item_id, booking_mode, is_active, is_customer_visible,
+                service_package_sell_start_at, service_package_sell_end_at,
+                service_package_redeem_until, service_package_payment_mode,
+                service_package_warranty_days
+           FROM public.catalog_items
+          WHERE item_id=$1 LIMIT 1`, [itemId]
+      );
+      row = result.rows?.[0] || null;
+    } catch (error) {
+      if (error?.code === "42703") {
+        return res.json({ ok: true, prepaid: false, payment_mode: "book_now", prepaid_ready: false });
+      }
+      throw error;
+    }
+    const now = Date.now();
+    const onSale = row
+      && row.booking_mode === "service_package"
+      && row.is_active === true
+      && row.is_customer_visible === true
+      && (!row.service_package_sell_start_at || now >= new Date(row.service_package_sell_start_at).getTime())
+      && (!row.service_package_sell_end_at || now <= new Date(row.service_package_sell_end_at).getTime());
+    if (!onSale) return res.status(404).json({ error: "NOT_FOUND", code: "NOT_FOUND" });
+    const prepaid = String(row.service_package_payment_mode || "book_now") === "prepaid_full";
+    return res.json({
+      ok: true,
+      prepaid,
+      payment_mode: prepaid ? "prepaid_full" : "book_now",
+      prepaid_ready: prepaid ? await service.schemaReady() : true,
+      redeem_until: prepaid ? row.service_package_redeem_until : null,
+      warranty_days: prepaid && row.service_package_warranty_days != null ? Number(row.service_package_warranty_days) : null,
+    });
+  }));
+
+  router.post("/public/prepaid-orders/quote", requireCustomerJwt, handle(async (req, res) => {
+    const customerSub = clean(req.customer?.sub);
+    if (!customerSub) return res.status(401).json({ error: "NOT_LOGGED_IN", code: "NOT_LOGGED_IN" });
+    const quote = await service.quoteOrder(req.body || {}, { identity: "customer" });
+    return res.json({ ok: true, quote });
+  }));
+
   router.post("/public/prepaid-orders", requireCustomerJwt, handle(async (req, res) => {
     const customerSub = clean(req.customer?.sub);
     if (!customerSub) return res.status(401).json({ error: "NOT_LOGGED_IN", code: "NOT_LOGGED_IN" });
     const created = await service.createOrder(req.body || {}, { customerSub, identity: "customer" });
-    return res.status(201).json({
+    return res.status(created.replayed ? 200 : 201).json({
       ok: true,
+      replayed: Boolean(created.replayed),
       order: created.order,
       entitlement_code: created.entitlement_code,
       service: created.service,

--- a/server/services/booking/servicePackageBooking.js
+++ b/server/services/booking/servicePackageBooking.js
@@ -128,7 +128,22 @@ async function resolvePackageBooking({ body, bookingMode, appointmentDatetime, r
   try {
     if (request.composite) {
       if (!resolver || typeof resolver.resolveComposite !== "function") throw packageError("PACKAGE_UNAVAILABLE", 409);
-      return await resolver.resolveComposite({ body, bookingMode, appointmentDatetime, identity });
+
+      // A prepaid purchase is not a booking. Only begin-redemption can mint the
+      // one-time token/request-key pair accepted here; all other attempts to book
+      // a prepaid_full campaign are rejected before availability/job mutation.
+      if (String(body.prepaid_redemption_token || "").trim()) {
+        if (typeof resolver.resolvePrepaidRedemption !== "function") {
+          throw packageError("PREPAID_REDEMPTION_REQUIRED", 409);
+        }
+        return await resolver.resolvePrepaidRedemption({ body, bookingMode, appointmentDatetime, identity });
+      }
+
+      const booking = await resolver.resolveComposite({ body, bookingMode, appointmentDatetime, identity });
+      if (booking?.paymentMode === "prepaid_full") {
+        throw packageError("PREPAID_REDEMPTION_REQUIRED", 409);
+      }
+      return booking;
     }
     const selection = await resolver.resolveSelection(request, { identity });
     return canonicalizeSelection(selection, body, appointmentDatetime);

--- a/server/services/packages/promotionPolicyAdminService.js
+++ b/server/services/packages/promotionPolicyAdminService.js
@@ -1,0 +1,236 @@
+"use strict";
+
+const PRICING_STRATEGIES = new Set(["per_variant_tier", "total_quantity_tier_plus_unit_modifiers"]);
+const SELECTION_MODES = new Set(["multi_variant", "exclusive_level"]);
+const PAYMENT_MODES = new Set(["book_now", "prepaid_full"]);
+
+class PromotionPolicyAdminError extends Error {
+  constructor(code, message, statusCode = 400) {
+    super(message);
+    this.name = "PromotionPolicyAdminError";
+    this.code = code;
+    this.statusCode = statusCode;
+  }
+}
+
+function fail(code, message, statusCode) {
+  throw new PromotionPolicyAdminError(code, message, statusCode);
+}
+
+function clean(value, max = 160) {
+  const text = String(value == null ? "" : value).trim();
+  if (text.length > max) fail("INVALID_PROMOTION_POLICY", `text exceeds ${max} characters`);
+  return text;
+}
+
+function enumValue(value, allowed, field) {
+  const text = clean(value, 80);
+  if (!allowed.has(text)) fail("INVALID_PROMOTION_POLICY", `${field} is invalid`);
+  return text;
+}
+
+function nullableInt(value, field, min, max) {
+  if (value == null || String(value).trim() === "") return null;
+  const text = String(value).trim();
+  if (!/^\d+$/.test(text)) fail("INVALID_PROMOTION_POLICY", `${field} must be a whole number`);
+  const number = Number(text);
+  if (!Number.isSafeInteger(number) || number < min || number > max) {
+    fail("INVALID_PROMOTION_POLICY", `${field} must be between ${min} and ${max}`);
+  }
+  return number;
+}
+
+function money(value, field = "unit_price_modifier") {
+  const text = String(value == null || value === "" ? "0" : value).trim();
+  if (!/^\d{1,10}(?:\.\d{1,2})?$/.test(text)) {
+    fail("INVALID_PROMOTION_POLICY", `${field} must be a non-negative amount with at most two decimals`);
+  }
+  const number = Number(text);
+  if (!Number.isFinite(number) || number < 0 || number > 9999999999.99) {
+    fail("INVALID_PROMOTION_POLICY", `${field} is out of range`);
+  }
+  return number.toFixed(2);
+}
+
+function bool(value, field) {
+  if (typeof value !== "boolean") fail("INVALID_PROMOTION_POLICY", `${field} must be boolean`);
+  return value;
+}
+
+function normalizeVariant(raw) {
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) fail("INVALID_PROMOTION_POLICY", "variant policy must be an object");
+  const packageKey = clean(raw.package_key, 128);
+  if (!packageKey) fail("INVALID_PROMOTION_POLICY", "package_key is required");
+  return {
+    package_key: packageKey,
+    service_level_key: clean(raw.service_level_key, 80) || null,
+    service_level_label: clean(raw.service_level_label, 120) || null,
+    unit_price_modifier: money(raw.unit_price_modifier),
+  };
+}
+
+function normalizePolicy(input) {
+  if (!input || typeof input !== "object" || Array.isArray(input)) fail("INVALID_PROMOTION_POLICY", "promotion policy payload is required");
+  if (!Array.isArray(input.variants)) fail("INVALID_PROMOTION_POLICY", "variants must be an array");
+  const variants = input.variants.map(normalizeVariant);
+  if (variants.length > 99) fail("INVALID_PROMOTION_POLICY", "too many variants");
+  const keys = variants.map((variant) => variant.package_key);
+  if (new Set(keys).size !== keys.length) fail("INVALID_PROMOTION_POLICY", "duplicate package_key");
+  return {
+    pricing_strategy: enumValue(input.pricing_strategy || "per_variant_tier", PRICING_STRATEGIES, "pricing_strategy"),
+    selection_mode: enumValue(input.selection_mode || "multi_variant", SELECTION_MODES, "selection_mode"),
+    maximum_total_quantity: nullableInt(input.maximum_total_quantity, "maximum_total_quantity", 1, 99),
+    payment_mode: enumValue(input.payment_mode || "book_now", PAYMENT_MODES, "payment_mode"),
+    warranty_days: nullableInt(input.warranty_days, "warranty_days", 1, 3650),
+    is_active: bool(input.is_active, "is_active"),
+    is_customer_visible: bool(input.is_customer_visible, "is_customer_visible"),
+    variants,
+  };
+}
+
+function dto(parent, variants) {
+  return {
+    service_bundle_key: parent.service_bundle_key,
+    item_id: String(parent.item_id),
+    pricing_strategy: parent.service_package_pricing_strategy || "per_variant_tier",
+    selection_mode: parent.service_package_selection_mode || "multi_variant",
+    maximum_total_quantity: parent.service_package_maximum_total_quantity == null ? null : Number(parent.service_package_maximum_total_quantity),
+    payment_mode: parent.service_package_payment_mode || "book_now",
+    warranty_days: parent.service_package_warranty_days == null ? null : Number(parent.service_package_warranty_days),
+    is_active: Boolean(parent.is_active),
+    is_customer_visible: Boolean(parent.is_customer_visible),
+    variants: variants.map((row) => ({
+      package_key: row.package_key,
+      service_level_key: row.service_level_key || null,
+      service_level_label: row.service_level_label || null,
+      unit_price_modifier: String(row.unit_price_modifier == null ? "0.00" : row.unit_price_modifier),
+    })),
+  };
+}
+
+async function loadParent(db, bundleKey, { lock = false } = {}) {
+  const result = await db.query(
+    `SELECT item_id, service_bundle_key, is_active, is_customer_visible,
+            service_package_redeem_until, service_package_pricing_strategy,
+            service_package_selection_mode, service_package_maximum_total_quantity,
+            service_package_payment_mode, service_package_warranty_days
+       FROM public.catalog_items
+      WHERE service_bundle_key=$1${lock ? " FOR UPDATE" : ""}`,
+    [bundleKey]
+  );
+  return result.rows[0] || null;
+}
+
+async function loadVariants(db, itemId, { lock = false } = {}) {
+  const result = await db.query(
+    `SELECT service_package_id, package_key, is_active, is_customer_visible,
+            service_level_key, service_level_label, unit_price_modifier
+       FROM public.service_packages
+      WHERE catalog_item_id=$1
+      ORDER BY sort_order, service_package_id${lock ? " FOR UPDATE" : ""}`,
+    [itemId]
+  );
+  return result.rows || [];
+}
+
+function assertExactVariantSet(current, supplied) {
+  const currentKeys = current.map((row) => String(row.package_key)).sort();
+  const suppliedKeys = supplied.map((row) => String(row.package_key)).sort();
+  if (currentKeys.length !== suppliedKeys.length || currentKeys.some((key, index) => key !== suppliedKeys[index])) {
+    fail("PROMOTION_POLICY_VARIANT_SET_CHANGED", "variant set changed; reload the promotion and retry", 409);
+  }
+}
+
+function assertLevelPolicy(current, policy) {
+  if (policy.selection_mode !== "exclusive_level") return;
+  const byKey = new Map(policy.variants.map((variant) => [variant.package_key, variant]));
+  for (const row of current) {
+    if (!row.is_active && !row.is_customer_visible) continue;
+    const supplied = byKey.get(String(row.package_key));
+    if (!supplied?.service_level_key) {
+      fail("SERVICE_PACKAGE_LEVEL_REQUIRED", "active variants require service_level_key in exclusive_level mode");
+    }
+  }
+}
+
+function assertPrepaidPolicy(parent, policy) {
+  if (policy.payment_mode !== "prepaid_full") return;
+  if (!parent.service_package_redeem_until) {
+    fail("PREPAID_REDEEM_DEADLINE_REQUIRED", "prepaid promotions require redeem_until");
+  }
+  if (!policy.warranty_days) {
+    fail("PREPAID_WARRANTY_REQUIRED", "prepaid promotions require warranty_days");
+  }
+}
+
+function createPromotionPolicyAdminService({ pool }) {
+  if (!pool || typeof pool.query !== "function" || typeof pool.connect !== "function") {
+    throw new TypeError("PostgreSQL pool is required");
+  }
+
+  async function get(bundleKey) {
+    const key = clean(bundleKey, 128);
+    if (!key) fail("BUNDLE_NOT_FOUND", "bundle key is required", 404);
+    const parent = await loadParent(pool, key);
+    if (!parent) fail("BUNDLE_NOT_FOUND", "promotion bundle was not found", 404);
+    return dto(parent, await loadVariants(pool, parent.item_id));
+  }
+
+  async function update(bundleKey, input) {
+    const key = clean(bundleKey, 128);
+    if (!key) fail("BUNDLE_NOT_FOUND", "bundle key is required", 404);
+    const policy = normalizePolicy(input);
+    const client = await pool.connect();
+    try {
+      await client.query("BEGIN");
+      const parent = await loadParent(client, key, { lock: true });
+      if (!parent) fail("BUNDLE_NOT_FOUND", "promotion bundle was not found", 404);
+      const variants = await loadVariants(client, parent.item_id, { lock: true });
+      assertExactVariantSet(variants, policy.variants);
+      assertLevelPolicy(variants, policy);
+      assertPrepaidPolicy(parent, policy);
+
+      await client.query(
+        `UPDATE public.catalog_items
+            SET service_package_pricing_strategy=$2,
+                service_package_selection_mode=$3,
+                service_package_maximum_total_quantity=$4,
+                service_package_payment_mode=$5,
+                service_package_warranty_days=$6,
+                is_active=$7,
+                is_customer_visible=$8,
+                updated_at=NOW()
+          WHERE item_id=$1`,
+        [parent.item_id, policy.pricing_strategy, policy.selection_mode, policy.maximum_total_quantity,
+          policy.payment_mode, policy.warranty_days, policy.is_active, policy.is_customer_visible]
+      );
+
+      const byKey = new Map(policy.variants.map((variant) => [variant.package_key, variant]));
+      for (const row of variants) {
+        const variant = byKey.get(String(row.package_key));
+        await client.query(
+          `UPDATE public.service_packages
+              SET service_level_key=$2, service_level_label=$3, unit_price_modifier=$4, updated_at=NOW()
+            WHERE service_package_id=$1`,
+          [row.service_package_id, variant.service_level_key, variant.service_level_label, variant.unit_price_modifier]
+        );
+      }
+
+      await client.query("COMMIT");
+      return get(key);
+    } catch (error) {
+      try { await client.query("ROLLBACK"); } catch (_) {}
+      throw error;
+    } finally {
+      client.release();
+    }
+  }
+
+  return { get, update };
+}
+
+module.exports = {
+  PromotionPolicyAdminError,
+  normalizePolicy,
+  createPromotionPolicyAdminService,
+};

--- a/server/services/packages/promotionPolicyAdminService.js
+++ b/server/services/packages/promotionPolicyAdminService.js
@@ -133,6 +133,35 @@ async function loadVariants(db, itemId, { lock = false } = {}) {
   return result.rows || [];
 }
 
+async function prepaidSchemaReady(db) {
+  try {
+    const result = await db.query(`
+      SELECT
+        to_regclass('public.customer_service_entitlements') IS NOT NULL AS has_entitlements,
+        EXISTS (
+          SELECT 1 FROM information_schema.columns
+          WHERE table_schema='public' AND table_name='customer_orders'
+            AND column_name IN (
+              'order_kind','customer_sub','service_entitlement_snapshot','prepaid_entitlement_code',
+              'prepaid_redeem_until','prepaid_warranty_days','prepaid_purchase_request_key',
+              'prepaid_purchase_fingerprint'
+            )
+          GROUP BY table_name HAVING COUNT(*)=8
+        ) AS has_order_columns,
+        EXISTS (
+          SELECT 1 FROM information_schema.columns
+          WHERE table_schema='public' AND table_name='jobs'
+            AND column_name IN ('customer_due','payment_source','prepaid_entitlement_id')
+          GROUP BY table_name HAVING COUNT(*)=3
+        ) AS has_job_columns
+    `);
+    const row = result.rows?.[0] || {};
+    return Boolean(row.has_entitlements && row.has_order_columns && row.has_job_columns);
+  } catch (_) {
+    return false;
+  }
+}
+
 function assertExactVariantSet(current, supplied) {
   const currentKeys = current.map((row) => String(row.package_key)).sort();
   const suppliedKeys = supplied.map((row) => String(row.package_key)).sort();
@@ -153,13 +182,16 @@ function assertLevelPolicy(current, policy) {
   }
 }
 
-function assertPrepaidPolicy(parent, policy) {
+async function assertPrepaidPolicy(db, parent, policy) {
   if (policy.payment_mode !== "prepaid_full") return;
   if (!parent.service_package_redeem_until) {
     fail("PREPAID_REDEEM_DEADLINE_REQUIRED", "prepaid promotions require redeem_until");
   }
   if (!policy.warranty_days) {
     fail("PREPAID_WARRANTY_REQUIRED", "prepaid promotions require warranty_days");
+  }
+  if ((policy.is_active || policy.is_customer_visible) && !(await prepaidSchemaReady(db))) {
+    fail("PREPAID_SCHEMA_NOT_READY", "prepaid backend schema is not ready; keep the promotion hidden", 503);
   }
 }
 
@@ -188,7 +220,7 @@ function createPromotionPolicyAdminService({ pool }) {
       const variants = await loadVariants(client, parent.item_id, { lock: true });
       assertExactVariantSet(variants, policy.variants);
       assertLevelPolicy(variants, policy);
-      assertPrepaidPolicy(parent, policy);
+      await assertPrepaidPolicy(client, parent, policy);
 
       await client.query(
         `UPDATE public.catalog_items
@@ -233,4 +265,5 @@ module.exports = {
   PromotionPolicyAdminError,
   normalizePolicy,
   createPromotionPolicyAdminService,
+  prepaidSchemaReady,
 };

--- a/server/services/packages/servicePackageResolver.js
+++ b/server/services/packages/servicePackageResolver.js
@@ -1,15 +1,22 @@
 "use strict";
 
+const crypto = require("crypto");
 const repository = require("./servicePackageRepository");
 const { normalizeServiceType, normalizeAcType, normalizeWashVariantLabel, normalizeWashKey } = require("../../normalizers");
 const { resolveCompositeBooking } = require("./compositeServicePackage");
+const { compositeBookingFromSnapshots } = require("../booking/servicePackageBooking");
 const { JOB_TYPE_VALUES, AC_TYPE_VALUES, WASH_VARIANT_VALUES } = require("./servicePackageTaxonomy");
 
 class ServicePackageResolutionError extends Error {
-  constructor(code, message) { super(message); this.name = "ServicePackageResolutionError"; this.code = code; }
+  constructor(code, message, statusCode) {
+    super(message);
+    this.name = "ServicePackageResolutionError";
+    this.code = code;
+    if (statusCode) this.statusCode = statusCode;
+  }
 }
 
-function fail(code, message) { throw new ServicePackageResolutionError(code, message); }
+function fail(code, message, statusCode) { throw new ServicePackageResolutionError(code, message, statusCode); }
 function instant(value) { return value == null ? null : new Date(value).toISOString(); }
 function nonEmptyString(value) { return typeof value === "string" && value.length > 0; }
 function positiveIntegerString(value) { return typeof value === "string" && /^[1-9]\d*$/.test(value); }
@@ -93,6 +100,28 @@ function readSnapshot(snapshot) {
   return structuredClone(value);
 }
 
+function tokenHash(value) {
+  return crypto.createHash("sha256").update(String(value)).digest("hex");
+}
+
+function scheduledBookingToken(requestKey) {
+  return crypto.createHash("sha256").update(`scheduled_v1:${String(requestKey)}`).digest("hex").slice(0, 24);
+}
+
+function parseEntitlementSnapshot(value) {
+  let snapshot = value;
+  if (typeof snapshot === "string") {
+    try { snapshot = JSON.parse(snapshot); } catch (_) { snapshot = null; }
+  }
+  if (!snapshot || snapshot.schema_version !== 1
+      || !Array.isArray(snapshot.snapshots) || !snapshot.snapshots.length
+      || !Array.isArray(snapshot.service_package_groups) || !snapshot.service_package_groups.length
+      || !snapshot.catalog_item_id || snapshot.payment_mode !== "prepaid_full") {
+    fail("PREPAID_SNAPSHOT_INVALID", "Paid service snapshot is invalid", 409);
+  }
+  return snapshot;
+}
+
 function createServicePackageResolver({ db, packageRepository = repository, now = () => new Date() }) {
   return {
     async resolveSelection(input = {}, { identity = "customer" } = {}) {
@@ -124,6 +153,73 @@ function createServicePackageResolver({ db, packageRepository = repository, now 
     listCustomerVisible(options) { return packageRepository.listCustomerVisiblePackages(db, options); },
     resolveComposite(input) {
       return resolveCompositeBooking({ ...input, repository: packageRepository, db, now });
+    },
+
+    // Resolve only an already-paid one-time entitlement. Mutable campaign/sale
+    // state is deliberately not consulted here: the purchased immutable snapshot
+    // is the contract. The final job INSERT is still protected by DB triggers that
+    // verify ownership and atomically consume the same entitlement.
+    async resolvePrepaidRedemption({ body = {}, bookingMode, appointmentDatetime }) {
+      if (bookingMode !== "scheduled") fail("PREPAID_SCHEDULED_ONLY", "Prepaid rights can only create scheduled bookings", 409);
+      const redemptionToken = String(body.prepaid_redemption_token || "").trim();
+      const requestKey = String(body.scheduled_request_key || "").trim();
+      if (!redemptionToken || !/^[A-Za-z0-9_-]{16,128}$/.test(requestKey)) {
+        fail("PREPAID_REDEMPTION_REQUIRED", "A valid paid entitlement is required", 409);
+      }
+      const bookingToken = scheduledBookingToken(requestKey);
+      let result;
+      try {
+        result = await db.query(
+          `SELECT entitlement_id, entitlement_code, customer_sub, service_snapshot, status,
+                  redeem_until, warranty_days, redemption_request_key,
+                  redemption_booking_token, redemption_expires_at, redeemed_job_id
+             FROM public.customer_service_entitlements
+            WHERE redemption_token_hash=$1
+              AND redemption_booking_token=$2
+            LIMIT 1
+            FOR UPDATE`,
+          [tokenHash(redemptionToken), bookingToken]
+        );
+      } catch (error) {
+        if (error?.code === "42P01" || error?.code === "42703") {
+          fail("PREPAID_SCHEMA_NOT_READY", "Prepaid service schema is not ready", 503);
+        }
+        throw error;
+      }
+      const entitlement = result.rows?.[0];
+      const at = now();
+      const appointment = new Date(appointmentDatetime);
+      if (!entitlement
+          || entitlement.status !== "redeeming"
+          || !entitlement.customer_sub
+          || entitlement.redeemed_job_id
+          || entitlement.redemption_request_key !== requestKey
+          || entitlement.redemption_booking_token !== bookingToken
+          || !entitlement.redemption_expires_at
+          || at >= new Date(entitlement.redemption_expires_at)
+          || at > new Date(entitlement.redeem_until)
+          || !Number.isFinite(appointment.getTime())
+          || appointment > new Date(entitlement.redeem_until)) {
+        fail("PREPAID_REDEMPTION_NOT_ALLOWED", "Paid entitlement cannot be redeemed", 409);
+      }
+      const purchased = parseEntitlementSnapshot(entitlement.service_snapshot);
+      const booking = compositeBookingFromSnapshots({
+        body,
+        snapshots: purchased.snapshots,
+      });
+      if (!booking
+          || String(booking.bundleId) !== String(purchased.catalog_item_id)
+          || Number(booking.fixedTotal).toFixed(2) !== Number(purchased.fixed_total_price).toFixed(2)) {
+        fail("PREPAID_REDEMPTION_MISMATCH", "Booking does not match purchased service", 409);
+      }
+      return {
+        ...booking,
+        paymentMode: "prepaid_full",
+        prepaidEntitlementId: String(entitlement.entitlement_id),
+        prepaidEntitlementCode: entitlement.entitlement_code,
+        warrantyDays: Number(entitlement.warranty_days || purchased.warranty_days || 0),
+        redeemUntil: new Date(entitlement.redeem_until).toISOString(),
+      };
     },
   };
 }

--- a/server/services/packages/servicePackageResolver.js
+++ b/server/services/packages/servicePackageResolver.js
@@ -212,6 +212,19 @@ function createServicePackageResolver({ db, packageRepository = repository, now 
           || Number(booking.fixedTotal).toFixed(2) !== Number(purchased.fixed_total_price).toFixed(2)) {
         fail("PREPAID_REDEMPTION_MISMATCH", "Booking does not match purchased service", 409);
       }
+
+      // The booking service re-resolves the package inside the same DB transaction
+      // immediately before INSERT. Store the verified entitlement context in
+      // transaction-local settings so the INSERT trigger can bind the job to this
+      // exact paid right even though legacy booking code generates its own token.
+      // set_config(..., true) is transaction-local and disappears on commit/rollback.
+      await db.query(
+        `SELECT set_config('cwf.prepaid_entitlement_id',$1,true),
+                set_config('cwf.prepaid_customer_sub',$2,true),
+                set_config('cwf.prepaid_booking_token',$3,true)`,
+        [String(entitlement.entitlement_id), String(entitlement.customer_sub), bookingToken]
+      );
+
       return {
         ...booking,
         paymentMode: "prepaid_full",

--- a/server/services/prepaid/prepaidOrderService.js
+++ b/server/services/prepaid/prepaidOrderService.js
@@ -1,0 +1,462 @@
+"use strict";
+
+const crypto = require("crypto");
+const { generateOrderCode } = require("../../routes/customerOrders");
+const { createServicePackageResolver } = require("../packages/servicePackageResolver");
+
+const CLAIM_TTL_MINUTES = 15;
+const MAX_TEXT = 500;
+
+class PrepaidServiceError extends Error {
+  constructor(code, statusCode = 400, message = code) {
+    super(message);
+    this.name = "PrepaidServiceError";
+    this.code = code;
+    this.statusCode = statusCode;
+  }
+}
+
+function clean(value, max = MAX_TEXT) {
+  return String(value == null ? "" : value).trim().slice(0, max);
+}
+
+function money(value) {
+  const n = Number(value);
+  if (!Number.isFinite(n)) return null;
+  return Number(n.toFixed(2));
+}
+
+function randomToken(bytes = 32) {
+  return crypto.randomBytes(bytes).toString("base64url");
+}
+
+function sha256(value) {
+  return crypto.createHash("sha256").update(String(value)).digest("hex");
+}
+
+function generateEntitlementCode() {
+  const time = Date.now().toString(36).toUpperCase();
+  const rand = crypto.randomBytes(4).toString("hex").toUpperCase();
+  return `CWF-RIGHT-${time}-${rand}`;
+}
+
+function generateRequestKey() {
+  return `prepaid_${randomToken(24)}`;
+}
+
+function bookingTokenFromScheduledRequestKey(key) {
+  return crypto.createHash("sha256").update(`scheduled_v1:${String(key)}`).digest("hex").slice(0, 24);
+}
+
+function isSchemaError(error) {
+  return error && (error.code === "42P01" || error.code === "42703");
+}
+
+async function schemaReady(db) {
+  try {
+    const result = await db.query(`
+      SELECT
+        to_regclass('public.customer_service_entitlements') IS NOT NULL AS has_entitlements,
+        to_regclass('public.customer_orders') IS NOT NULL AS has_orders,
+        EXISTS (
+          SELECT 1 FROM information_schema.columns
+          WHERE table_schema='public' AND table_name='customer_orders'
+            AND column_name IN ('order_kind','customer_sub','service_entitlement_snapshot','prepaid_entitlement_code','prepaid_redeem_until','prepaid_warranty_days')
+          GROUP BY table_name HAVING COUNT(*)=6
+        ) AS has_order_columns,
+        EXISTS (
+          SELECT 1 FROM information_schema.columns
+          WHERE table_schema='public' AND table_name='jobs'
+            AND column_name IN ('customer_due','payment_source','prepaid_entitlement_id')
+          GROUP BY table_name HAVING COUNT(*)=3
+        ) AS has_job_columns
+    `);
+    const row = result.rows?.[0] || {};
+    return Boolean(row.has_entitlements && row.has_orders && row.has_order_columns && row.has_job_columns);
+  } catch (_) {
+    return false;
+  }
+}
+
+async function requireSchema(db) {
+  if (!(await schemaReady(db))) throw new PrepaidServiceError("PREPAID_SCHEMA_NOT_READY", 503);
+}
+
+function normalizePurchase(body = {}) {
+  const customerName = clean(body.customer_name, 120);
+  const customerPhone = clean(body.customer_phone, 40);
+  if (!customerName) throw new PrepaidServiceError("CUSTOMER_NAME_REQUIRED", 400);
+  if (!customerPhone) throw new PrepaidServiceError("CUSTOMER_PHONE_REQUIRED", 400);
+  if (!Array.isArray(body.service_package_groups) || !body.service_package_groups.length) {
+    throw new PrepaidServiceError("SERVICE_PACKAGE_GROUPS_REQUIRED", 400);
+  }
+  return {
+    customer_name: customerName,
+    customer_phone: customerPhone,
+    service_package_groups: body.service_package_groups,
+    catalog_item_id: body.catalog_item_id,
+    note: clean(body.note, 500),
+  };
+}
+
+function entitlementSnapshot(quote) {
+  if (!quote || quote.paymentMode !== "prepaid_full") {
+    throw new PrepaidServiceError("PACKAGE_PREPAID_PURCHASE_NOT_ALLOWED", 409);
+  }
+  const redeemUntil = quote.redeemUntil ? new Date(quote.redeemUntil) : null;
+  if (!redeemUntil || !Number.isFinite(redeemUntil.getTime()) || redeemUntil <= new Date()) {
+    throw new PrepaidServiceError("PACKAGE_REDEEM_WINDOW_EXCEEDED", 409);
+  }
+  const warrantyDays = Number(quote.warrantyDays);
+  if (!Number.isInteger(warrantyDays) || warrantyDays < 0 || warrantyDays > 3650) {
+    throw new PrepaidServiceError("PACKAGE_WARRANTY_INVALID", 409);
+  }
+  const total = money(quote.fixedTotal);
+  if (!(total > 0)) throw new PrepaidServiceError("INVALID_PACKAGE_PRICE", 409);
+  const groups = Array.isArray(quote.payload?.service_package_groups)
+    ? quote.payload.service_package_groups.map((group) => ({
+        package_key: String(group.package_key),
+        btu: Number(group.btu),
+        quantity: Number(group.quantity),
+      }))
+    : [];
+  const snapshots = Array.isArray(quote.items)
+    ? quote.items.map((item) => ({
+        service_package_id: String(item.packageId),
+        service_package_tier_id: String(item.tierId),
+        service_package_snapshot: item.snapshot,
+      }))
+    : [];
+  if (!groups.length || !snapshots.length) throw new PrepaidServiceError("PACKAGE_SNAPSHOT_INVALID", 409);
+  return {
+    schema_version: 1,
+    catalog_item_id: String(quote.bundleId),
+    bundle_key: String(quote.bundleKey || ""),
+    fixed_total_price: total.toFixed(2),
+    duration_min: Number(quote.durationMin || 0),
+    service_package_groups: groups,
+    snapshots,
+    payment_mode: "prepaid_full",
+    warranty_days: warrantyDays,
+    redeem_until: redeemUntil.toISOString(),
+    minimum_total_quantity: quote.minimumTotalQuantity == null ? null : Number(quote.minimumTotalQuantity),
+    maximum_total_quantity: quote.maximumTotalQuantity == null ? null : Number(quote.maximumTotalQuantity),
+    pricing_strategy: quote.pricingStrategy || null,
+    selection_mode: quote.selectionMode || null,
+  };
+}
+
+function orderItemsFromQuote(quote) {
+  return (quote.items || []).map((item) => ({
+    item_id: String(item.item_id || quote.bundleId || ""),
+    name: String(item.item_name || "สิทธิ์บริการ CWF"),
+    item_name: String(item.item_name || "สิทธิ์บริการ CWF"),
+    qty: Number(item.qty || 1),
+    unit_price: Number(item.unit_price || 0),
+    line_total: Number(item.line_total || 0),
+  }));
+}
+
+async function withTransaction(pool, fn) {
+  const client = await pool.connect();
+  try {
+    await client.query("BEGIN");
+    const value = await fn(client);
+    await client.query("COMMIT");
+    return value;
+  } catch (error) {
+    try { await client.query("ROLLBACK"); } catch (_) {}
+    throw error;
+  } finally {
+    client.release();
+  }
+}
+
+function createPrepaidOrderService({ pool }) {
+  if (!pool || typeof pool.query !== "function") throw new TypeError("prepaid order service requires pool");
+
+  async function quotePurchase(db, body, identity) {
+    const normalized = normalizePurchase(body);
+    const resolver = createServicePackageResolver({ db });
+    let quote;
+    try {
+      quote = await resolver.resolveComposite({
+        body: normalized,
+        bookingMode: "scheduled",
+        appointmentDatetime: null,
+        identity,
+        purchaseOnly: true,
+      });
+    } catch (error) {
+      if (error?.statusCode) throw error;
+      throw new PrepaidServiceError(error?.code || "PACKAGE_PREPAID_PURCHASE_NOT_ALLOWED", 409);
+    }
+    const snapshot = entitlementSnapshot(quote);
+    return { normalized, quote, snapshot };
+  }
+
+  async function createOrder(body, { customerSub = null, identity = "customer" } = {}) {
+    if (identity === "customer" && !clean(customerSub, 256)) {
+      throw new PrepaidServiceError("NOT_LOGGED_IN", 401);
+    }
+    return withTransaction(pool, async (client) => {
+      await requireSchema(client);
+      const { normalized, quote, snapshot } = await quotePurchase(client, body, identity);
+      const total = money(quote.fixedTotal);
+      const orderItems = orderItemsFromQuote(quote);
+      const entitlementCode = generateEntitlementCode();
+      const claimToken = customerSub ? null : randomToken(32);
+      const claimHash = claimToken ? sha256(claimToken) : null;
+
+      for (let attempt = 0; attempt < 5; attempt += 1) {
+        const orderCode = generateOrderCode();
+        try {
+          const inserted = await client.query(
+            `INSERT INTO public.customer_orders
+              (order_code, customer_name, customer_phone, delivery_method, install_option,
+               address, items, subtotal, status, note, order_kind, customer_sub,
+               service_entitlement_snapshot, prepaid_entitlement_code, prepaid_claim_token_hash,
+               prepaid_redeem_until, prepaid_warranty_days)
+             VALUES ($1,$2,$3,'pickup','none',NULL,$4::jsonb,$5,'pending_payment',$6,
+                     'service_prepaid',$7,$8::jsonb,$9,$10,$11,$12)
+             RETURNING order_id, order_code, customer_name, customer_phone, items, subtotal,
+                       status, created_at, prepaid_entitlement_code, prepaid_redeem_until,
+                       prepaid_warranty_days`,
+            [
+              orderCode, normalized.customer_name, normalized.customer_phone,
+              JSON.stringify(orderItems), total, normalized.note || null,
+              clean(customerSub, 256) || null, JSON.stringify(snapshot), entitlementCode,
+              claimHash, snapshot.redeem_until, snapshot.warranty_days,
+            ]
+          );
+          return {
+            order: inserted.rows[0],
+            claim_token: claimToken,
+            entitlement_code: entitlementCode,
+            service: snapshot,
+          };
+        } catch (error) {
+          if (error?.code === "23505") continue;
+          throw error;
+        }
+      }
+      throw new PrepaidServiceError("ORDER_CODE_GENERATION_FAILED", 500);
+    }).catch((error) => {
+      if (isSchemaError(error)) throw new PrepaidServiceError("PREPAID_SCHEMA_NOT_READY", 503);
+      throw error;
+    });
+  }
+
+  async function confirmManualPayment(orderCode, body = {}, { verifiedBy = "admin" } = {}) {
+    const code = clean(orderCode, 40);
+    if (!code) throw new PrepaidServiceError("ORDER_CODE_REQUIRED", 400);
+    const reference = clean(body.reference || body.payment_reference, 200);
+    if (!reference) throw new PrepaidServiceError("PAYMENT_REFERENCE_REQUIRED", 400);
+    const confirmedAmount = money(body.confirmed_amount);
+    if (!(confirmedAmount > 0)) throw new PrepaidServiceError("CONFIRMED_AMOUNT_REQUIRED", 400);
+    return withTransaction(pool, async (client) => {
+      await requireSchema(client);
+      const found = await client.query(
+        `SELECT order_id, order_code, order_kind, subtotal, status, payment_provider,
+                payment_method, payment_charge_id, payment_status, paid_at
+           FROM public.customer_orders
+          WHERE order_code=$1
+          FOR UPDATE`,
+        [code]
+      );
+      const order = found.rows?.[0];
+      if (!order) throw new PrepaidServiceError("ORDER_NOT_FOUND", 404);
+      if (order.order_kind !== "service_prepaid") throw new PrepaidServiceError("NOT_PREPAID_ORDER", 409);
+      if (money(order.subtotal) !== confirmedAmount) throw new PrepaidServiceError("PAYMENT_AMOUNT_MISMATCH", 409);
+      if (order.status === "paid") {
+        const right = await client.query(
+          `SELECT entitlement_code, status, customer_sub, redeem_until, warranty_days
+             FROM public.customer_service_entitlements WHERE order_id=$1 LIMIT 1`,
+          [order.order_id]
+        );
+        return { replayed: true, order_code: code, entitlement: right.rows?.[0] || null };
+      }
+      if (order.status === "payment_processing" || String(order.payment_status || "").startsWith("processing:")) {
+        throw new PrepaidServiceError("ONLINE_PAYMENT_PROCESSING", 409);
+      }
+      if (order.payment_charge_id) throw new PrepaidServiceError("ONLINE_PAYMENT_ALREADY_LINKED", 409);
+      if (!new Set(["pending_payment", "payment_failed"]).has(order.status)) {
+        throw new PrepaidServiceError("ORDER_NOT_PAYABLE", 409);
+      }
+      await client.query(
+        `UPDATE public.customer_orders
+            SET payment_provider='manual_admin', payment_method='promptpay',
+                payment_status='verified', status='paid', paid_at=COALESCE(paid_at,NOW()),
+                manual_payment_reference=$2, payment_verified_by=$3, updated_at=NOW()
+          WHERE order_id=$1`,
+        [order.order_id, reference, clean(verifiedBy, 120) || "admin"]
+      );
+      const right = await client.query(
+        `SELECT entitlement_code, status, customer_sub, redeem_until, warranty_days
+           FROM public.customer_service_entitlements WHERE order_id=$1 LIMIT 1`,
+        [order.order_id]
+      );
+      if (!right.rows?.[0]) throw new PrepaidServiceError("ENTITLEMENT_ISSUE_FAILED", 500);
+      return { replayed: false, order_code: code, entitlement: right.rows[0] };
+    }).catch((error) => {
+      if (isSchemaError(error)) throw new PrepaidServiceError("PREPAID_SCHEMA_NOT_READY", 503);
+      throw error;
+    });
+  }
+
+  async function listRights(customerSub) {
+    const sub = clean(customerSub, 256);
+    if (!sub) throw new PrepaidServiceError("NOT_LOGGED_IN", 401);
+    await requireSchema(pool);
+    await pool.query(
+      `UPDATE public.customer_service_entitlements
+          SET status='expired', updated_at=NOW(),
+              redemption_token_hash=NULL, redemption_request_key=NULL,
+              redemption_booking_token=NULL, redemption_expires_at=NULL
+        WHERE customer_sub=$1 AND status IN ('active','redeeming') AND redeem_until < NOW()`,
+      [sub]
+    );
+    const result = await pool.query(
+      `SELECT e.entitlement_code, e.status, e.customer_name, e.customer_phone,
+              e.service_snapshot, e.purchased_amount, e.redeem_until, e.warranty_days,
+              e.redeemed_job_id, e.redeemed_at, e.created_at,
+              j.booking_code, j.appointment_datetime, j.finished_at,
+              CASE WHEN j.finished_at IS NULL THEN NULL
+                   ELSE j.finished_at + (e.warranty_days * INTERVAL '1 day') END AS warranty_until,
+              CASE WHEN j.finished_at IS NULL THEN FALSE
+                   ELSE NOW() <= j.finished_at + (e.warranty_days * INTERVAL '1 day') END AS warranty_active
+         FROM public.customer_service_entitlements e
+         LEFT JOIN public.jobs j ON j.job_id=e.redeemed_job_id
+        WHERE e.customer_sub=$1
+        ORDER BY e.created_at DESC, e.entitlement_id DESC
+        LIMIT 200`,
+      [sub]
+    );
+    return result.rows || [];
+  }
+
+  async function claimRight({ entitlementCode, claimToken, customerSub }) {
+    const code = clean(entitlementCode, 100);
+    const token = clean(claimToken, 500);
+    const sub = clean(customerSub, 256);
+    if (!code || !token || !sub) throw new PrepaidServiceError("CLAIM_DATA_REQUIRED", 400);
+    return withTransaction(pool, async (client) => {
+      await requireSchema(client);
+      const found = await client.query(
+        `SELECT entitlement_id, entitlement_code, status, customer_sub, claim_token_hash, redeem_until
+           FROM public.customer_service_entitlements
+          WHERE entitlement_code=$1
+          FOR UPDATE`,
+        [code]
+      );
+      const right = found.rows?.[0];
+      if (!right || !right.claim_token_hash) throw new PrepaidServiceError("CLAIM_FAILED", 400);
+      const actual = Buffer.from(sha256(token), "hex");
+      const expected = Buffer.from(String(right.claim_token_hash), "hex");
+      if (actual.length !== expected.length || !crypto.timingSafeEqual(actual, expected)) {
+        throw new PrepaidServiceError("CLAIM_FAILED", 400);
+      }
+      if (right.status === "expired" || new Date(right.redeem_until) < new Date()) {
+        await client.query(`UPDATE public.customer_service_entitlements SET status='expired', updated_at=NOW() WHERE entitlement_id=$1`, [right.entitlement_id]);
+        throw new PrepaidServiceError("ENTITLEMENT_EXPIRED", 409);
+      }
+      if (right.customer_sub && right.customer_sub !== sub) throw new PrepaidServiceError("CLAIM_FAILED", 400);
+      if (right.status !== "unclaimed" && !(right.status === "active" && right.customer_sub === sub)) {
+        throw new PrepaidServiceError("CLAIM_FAILED", 400);
+      }
+      await client.query(
+        `UPDATE public.customer_service_entitlements
+            SET customer_sub=$2, status='active', claim_token_hash=NULL, updated_at=NOW()
+          WHERE entitlement_id=$1`,
+        [right.entitlement_id, sub]
+      );
+      await client.query(
+        `UPDATE public.customer_orders
+            SET customer_sub=$2, prepaid_claim_token_hash=NULL, updated_at=NOW()
+          WHERE prepaid_entitlement_code=$1`,
+        [code, sub]
+      );
+      return { entitlement_code: code, status: "active" };
+    });
+  }
+
+  async function beginRedemption({ entitlementCode, customerSub }) {
+    const code = clean(entitlementCode, 100);
+    const sub = clean(customerSub, 256);
+    if (!code || !sub) throw new PrepaidServiceError("REDEMPTION_DATA_REQUIRED", 400);
+    return withTransaction(pool, async (client) => {
+      await requireSchema(client);
+      const found = await client.query(
+        `SELECT entitlement_id, entitlement_code, status, customer_sub, service_snapshot,
+                redeem_until, warranty_days, redeemed_job_id, redemption_expires_at
+           FROM public.customer_service_entitlements
+          WHERE entitlement_code=$1 AND customer_sub=$2
+          FOR UPDATE`,
+        [code, sub]
+      );
+      const right = found.rows?.[0];
+      if (!right) throw new PrepaidServiceError("ENTITLEMENT_NOT_FOUND", 404);
+      if (right.redeemed_job_id || right.status === "redeemed") throw new PrepaidServiceError("ENTITLEMENT_ALREADY_REDEEMED", 409);
+      if (right.status === "cancelled") throw new PrepaidServiceError("ENTITLEMENT_CANCELLED", 409);
+      if (new Date(right.redeem_until) < new Date()) {
+        await client.query(
+          `UPDATE public.customer_service_entitlements
+              SET status='expired', redemption_token_hash=NULL, redemption_request_key=NULL,
+                  redemption_booking_token=NULL, redemption_expires_at=NULL, updated_at=NOW()
+            WHERE entitlement_id=$1`,
+          [right.entitlement_id]
+        );
+        throw new PrepaidServiceError("ENTITLEMENT_EXPIRED", 409);
+      }
+      if (!new Set(["active", "redeeming"]).has(right.status)) {
+        throw new PrepaidServiceError("ENTITLEMENT_NOT_REDEEMABLE", 409);
+      }
+      const requestKey = generateRequestKey();
+      const redemptionToken = randomToken(32);
+      const bookingToken = bookingTokenFromScheduledRequestKey(requestKey);
+      const expires = new Date(Date.now() + CLAIM_TTL_MINUTES * 60 * 1000);
+      const snapshot = right.service_snapshot;
+      if (!snapshot || snapshot.schema_version !== 1 || !Array.isArray(snapshot.service_package_groups) || !snapshot.service_package_groups.length) {
+        throw new PrepaidServiceError("PACKAGE_SNAPSHOT_INVALID", 409);
+      }
+      await client.query(
+        `UPDATE public.customer_service_entitlements
+            SET status='redeeming', redemption_request_key=$2,
+                redemption_token_hash=$3, redemption_booking_token=$4,
+                redemption_expires_at=$5, updated_at=NOW()
+          WHERE entitlement_id=$1`,
+        [right.entitlement_id, requestKey, sha256(redemptionToken), bookingToken, expires]
+      );
+      return {
+        entitlement_code: code,
+        scheduled_request_key: requestKey,
+        prepaid_redemption_token: redemptionToken,
+        redemption_expires_at: expires.toISOString(),
+        catalog_item_id: snapshot.catalog_item_id,
+        service_package_groups: snapshot.service_package_groups,
+        fixed_total_price: snapshot.fixed_total_price,
+        redeem_until: snapshot.redeem_until,
+        warranty_days: snapshot.warranty_days,
+      };
+    });
+  }
+
+  return {
+    schemaReady: () => schemaReady(pool),
+    createOrder,
+    confirmManualPayment,
+    listRights,
+    claimRight,
+    beginRedemption,
+  };
+}
+
+module.exports = {
+  CLAIM_TTL_MINUTES,
+  PrepaidServiceError,
+  bookingTokenFromScheduledRequestKey,
+  createPrepaidOrderService,
+  entitlementSnapshot,
+  generateEntitlementCode,
+  sha256,
+};

--- a/server/services/prepaid/prepaidOrderServiceV2.js
+++ b/server/services/prepaid/prepaidOrderServiceV2.js
@@ -1,0 +1,547 @@
+"use strict";
+
+const crypto = require("crypto");
+const { generateOrderCode } = require("../../routes/customerOrders");
+const { createServicePackageResolver } = require("../packages/servicePackageResolver");
+
+const CLAIM_TTL_MINUTES = 15;
+const MAX_TEXT = 500;
+const REQUEST_KEY_RE = /^[A-Za-z0-9_-]{16,128}$/;
+
+class PrepaidServiceError extends Error {
+  constructor(code, statusCode = 400, message = code) {
+    super(message);
+    this.name = "PrepaidServiceError";
+    this.code = code;
+    this.statusCode = statusCode;
+  }
+}
+
+function clean(value, max = MAX_TEXT) {
+  return String(value == null ? "" : value).trim().slice(0, max);
+}
+
+function money(value) {
+  const n = Number(value);
+  if (!Number.isFinite(n)) return null;
+  return Number(n.toFixed(2));
+}
+
+function randomToken(bytes = 32) {
+  return crypto.randomBytes(bytes).toString("base64url");
+}
+
+function sha256(value) {
+  return crypto.createHash("sha256").update(String(value)).digest("hex");
+}
+
+function canonicalJson(value) {
+  if (Array.isArray(value)) return `[${value.map(canonicalJson).join(",")}]`;
+  if (value && typeof value === "object") {
+    return `{${Object.keys(value).sort().map((key) => `${JSON.stringify(key)}:${canonicalJson(value[key])}`).join(",")}}`;
+  }
+  return JSON.stringify(value);
+}
+
+function generateEntitlementCode() {
+  return `CWF-RIGHT-${Date.now().toString(36).toUpperCase()}-${crypto.randomBytes(4).toString("hex").toUpperCase()}`;
+}
+
+function generateRequestKey(prefix = "prepaid") {
+  return `${prefix}_${randomToken(24)}`;
+}
+
+function bookingTokenFromScheduledRequestKey(key) {
+  return crypto.createHash("sha256").update(`scheduled_v1:${String(key)}`).digest("hex").slice(0, 24);
+}
+
+function isSchemaError(error) {
+  return error && (error.code === "42P01" || error.code === "42703");
+}
+
+async function schemaReady(db) {
+  try {
+    const result = await db.query(`
+      SELECT
+        to_regclass('public.customer_service_entitlements') IS NOT NULL AS has_entitlements,
+        to_regclass('public.customer_orders') IS NOT NULL AS has_orders,
+        EXISTS (
+          SELECT 1 FROM information_schema.columns
+          WHERE table_schema='public' AND table_name='customer_orders'
+            AND column_name IN (
+              'order_kind','customer_sub','service_entitlement_snapshot','prepaid_entitlement_code',
+              'prepaid_redeem_until','prepaid_warranty_days','prepaid_purchase_request_key',
+              'prepaid_purchase_fingerprint'
+            )
+          GROUP BY table_name HAVING COUNT(*)=8
+        ) AS has_order_columns,
+        EXISTS (
+          SELECT 1 FROM information_schema.columns
+          WHERE table_schema='public' AND table_name='jobs'
+            AND column_name IN ('customer_due','payment_source','prepaid_entitlement_id')
+          GROUP BY table_name HAVING COUNT(*)=3
+        ) AS has_job_columns
+    `);
+    const row = result.rows?.[0] || {};
+    return Boolean(row.has_entitlements && row.has_orders && row.has_order_columns && row.has_job_columns);
+  } catch (_) {
+    return false;
+  }
+}
+
+async function requireSchema(db) {
+  if (!(await schemaReady(db))) throw new PrepaidServiceError("PREPAID_SCHEMA_NOT_READY", 503);
+}
+
+function normalizeGroups(body = {}) {
+  if (!Array.isArray(body.service_package_groups) || !body.service_package_groups.length) {
+    throw new PrepaidServiceError("SERVICE_PACKAGE_GROUPS_REQUIRED", 400);
+  }
+  const groups = body.service_package_groups.map((raw) => {
+    const packageKey = clean(raw?.package_key, 128);
+    const btu = Number(raw?.btu);
+    const quantity = Number(raw?.quantity);
+    if (!packageKey || !Number.isSafeInteger(btu) || btu <= 0 || !Number.isSafeInteger(quantity) || quantity <= 0 || quantity > 99) {
+      throw new PrepaidServiceError("INVALID_SERVICE_PACKAGE_GROUP", 400);
+    }
+    return { package_key: packageKey, btu, quantity };
+  });
+  const total = groups.reduce((sum, group) => sum + group.quantity, 0);
+  if (total < 1 || total > 99) throw new PrepaidServiceError("INVALID_TOTAL_QUANTITY", 400);
+  return groups;
+}
+
+function normalizeQuoteInput(body = {}) {
+  const catalogItemId = Number(body.catalog_item_id);
+  if (!Number.isSafeInteger(catalogItemId) || catalogItemId <= 0) {
+    throw new PrepaidServiceError("CATALOG_ITEM_REQUIRED", 400);
+  }
+  return { catalog_item_id: catalogItemId, service_package_groups: normalizeGroups(body) };
+}
+
+function normalizePurchase(body = {}, identity = "customer") {
+  const quote = normalizeQuoteInput(body);
+  const customerName = clean(body.customer_name, 120);
+  const customerPhone = clean(body.customer_phone, 40);
+  if (!customerName) throw new PrepaidServiceError("CUSTOMER_NAME_REQUIRED", 400);
+  if (!customerPhone) throw new PrepaidServiceError("CUSTOMER_PHONE_REQUIRED", 400);
+  let requestKey = clean(body.purchase_request_key, 128);
+  if (identity === "customer") {
+    if (!REQUEST_KEY_RE.test(requestKey)) throw new PrepaidServiceError("INVALID_PURCHASE_REQUEST_KEY", 400);
+  } else if (!REQUEST_KEY_RE.test(requestKey)) {
+    requestKey = generateRequestKey("adminprepaid");
+  }
+  return {
+    ...quote,
+    customer_name: customerName,
+    customer_phone: customerPhone,
+    note: clean(body.note, 500),
+    purchase_request_key: requestKey,
+  };
+}
+
+function entitlementSnapshot(quote) {
+  if (!quote || quote.paymentMode !== "prepaid_full") {
+    throw new PrepaidServiceError("PACKAGE_PREPAID_PURCHASE_NOT_ALLOWED", 409);
+  }
+  const redeemUntil = quote.redeemUntil ? new Date(quote.redeemUntil) : null;
+  if (!redeemUntil || !Number.isFinite(redeemUntil.getTime()) || redeemUntil <= new Date()) {
+    throw new PrepaidServiceError("PACKAGE_REDEEM_WINDOW_EXCEEDED", 409);
+  }
+  const warrantyDays = Number(quote.warrantyDays);
+  if (!Number.isInteger(warrantyDays) || warrantyDays < 1 || warrantyDays > 3650) {
+    throw new PrepaidServiceError("PACKAGE_WARRANTY_INVALID", 409);
+  }
+  const total = money(quote.fixedTotal);
+  if (!(total > 0)) throw new PrepaidServiceError("INVALID_PACKAGE_PRICE", 409);
+  const groups = (quote.payload?.service_package_groups || []).map((group) => ({
+    package_key: String(group.package_key),
+    btu: Number(group.btu),
+    quantity: Number(group.quantity),
+  }));
+  const services = (quote.payload?.services || []).map((line) => ({
+    job_type: line.job_type,
+    ac_type: line.ac_type,
+    btu: Number(line.btu),
+    machine_count: Number(line.machine_count),
+    wash_variant: line.wash_variant || "",
+    repair_variant: line.repair_variant || "",
+  }));
+  const snapshots = (quote.items || []).map((item) => ({
+    service_package_id: String(item.packageId),
+    service_package_tier_id: String(item.tierId),
+    service_package_snapshot: item.snapshot,
+  }));
+  if (!groups.length || !snapshots.length || !services.length) {
+    throw new PrepaidServiceError("PACKAGE_SNAPSHOT_INVALID", 409);
+  }
+  return {
+    schema_version: 1,
+    catalog_item_id: String(quote.bundleId),
+    bundle_key: String(quote.bundleKey || ""),
+    fixed_total_price: total.toFixed(2),
+    duration_min: Number(quote.durationMin || 0),
+    service_package_groups: groups,
+    services,
+    snapshots,
+    payment_mode: "prepaid_full",
+    warranty_days: warrantyDays,
+    redeem_until: redeemUntil.toISOString(),
+    minimum_total_quantity: quote.minimumTotalQuantity == null ? null : Number(quote.minimumTotalQuantity),
+    maximum_total_quantity: quote.maximumTotalQuantity == null ? null : Number(quote.maximumTotalQuantity),
+    pricing_strategy: quote.pricingStrategy || null,
+    selection_mode: quote.selectionMode || null,
+  };
+}
+
+function orderItemsFromQuote(quote) {
+  return (quote.items || []).map((item) => ({
+    item_id: String(item.item_id || quote.bundleId || ""),
+    name: String(item.item_name || "สิทธิ์บริการ CWF"),
+    item_name: String(item.item_name || "สิทธิ์บริการ CWF"),
+    qty: Number(item.qty || 1),
+    unit_price: Number(item.unit_price || 0),
+    line_total: Number(item.line_total || 0),
+  }));
+}
+
+function publicQuote(snapshot) {
+  return {
+    catalog_item_id: Number(snapshot.catalog_item_id),
+    fixed_total_price: Number(snapshot.fixed_total_price),
+    duration_min: Number(snapshot.duration_min),
+    service_package_groups: snapshot.service_package_groups,
+    services: snapshot.services,
+    payment_mode: snapshot.payment_mode,
+    warranty_days: snapshot.warranty_days,
+    redeem_until: snapshot.redeem_until,
+    minimum_total_quantity: snapshot.minimum_total_quantity,
+    maximum_total_quantity: snapshot.maximum_total_quantity,
+  };
+}
+
+async function withTransaction(pool, fn) {
+  const client = await pool.connect();
+  try {
+    await client.query("BEGIN");
+    const value = await fn(client);
+    await client.query("COMMIT");
+    return value;
+  } catch (error) {
+    try { await client.query("ROLLBACK"); } catch (_) {}
+    throw error;
+  } finally {
+    client.release();
+  }
+}
+
+function createPrepaidOrderService({ pool }) {
+  if (!pool || typeof pool.query !== "function") throw new TypeError("prepaid order service requires pool");
+
+  async function quotePurchase(db, body, identity = "customer") {
+    const normalized = normalizeQuoteInput(body);
+    const resolver = createServicePackageResolver({ db });
+    let quote;
+    try {
+      quote = await resolver.resolveComposite({
+        body: normalized,
+        bookingMode: "scheduled",
+        appointmentDatetime: null,
+        identity,
+        purchaseOnly: true,
+      });
+    } catch (error) {
+      if (error?.statusCode) throw error;
+      throw new PrepaidServiceError(error?.code || "PACKAGE_PREPAID_PURCHASE_NOT_ALLOWED", 409);
+    }
+    const snapshot = entitlementSnapshot(quote);
+    return { normalized, quote, snapshot };
+  }
+
+  async function quoteOrder(body, { identity = "customer" } = {}) {
+    await requireSchema(pool);
+    const { snapshot } = await quotePurchase(pool, body, identity);
+    return publicQuote(snapshot);
+  }
+
+  async function createOrder(body, { customerSub = null, identity = "customer" } = {}) {
+    const sub = clean(customerSub, 256) || null;
+    if (identity === "customer" && !sub) throw new PrepaidServiceError("NOT_LOGGED_IN", 401);
+    const normalized = normalizePurchase(body, identity);
+    return withTransaction(pool, async (client) => {
+      await requireSchema(client);
+      await client.query("SELECT pg_advisory_xact_lock(hashtext($1))", [normalized.purchase_request_key]);
+      const { quote, snapshot } = await quotePurchase(client, normalized, identity);
+      const total = money(quote.fixedTotal);
+      const fingerprint = sha256(canonicalJson({
+        customer_sub: sub,
+        customer_name: normalized.customer_name,
+        customer_phone: normalized.customer_phone,
+        catalog_item_id: normalized.catalog_item_id,
+        groups: normalized.service_package_groups,
+        fixed_total_price: snapshot.fixed_total_price,
+      }));
+      const existing = await client.query(
+        `SELECT order_id, order_code, customer_name, customer_phone, items, subtotal, status,
+                created_at, prepaid_entitlement_code, prepaid_redeem_until,
+                prepaid_warranty_days, prepaid_purchase_fingerprint
+           FROM public.customer_orders
+          WHERE order_kind='service_prepaid' AND prepaid_purchase_request_key=$1
+          FOR UPDATE`,
+        [normalized.purchase_request_key]
+      );
+      if (existing.rows?.[0]) {
+        if (String(existing.rows[0].prepaid_purchase_fingerprint || "") !== fingerprint) {
+          throw new PrepaidServiceError("PURCHASE_REQUEST_KEY_REUSED", 409);
+        }
+        return {
+          replayed: true,
+          order: existing.rows[0],
+          claim_token: null,
+          entitlement_code: existing.rows[0].prepaid_entitlement_code,
+          service: snapshot,
+        };
+      }
+
+      const entitlementCode = generateEntitlementCode();
+      const claimToken = sub ? null : randomToken(32);
+      const claimHash = claimToken ? sha256(claimToken) : null;
+      for (let attempt = 0; attempt < 5; attempt += 1) {
+        const orderCode = generateOrderCode();
+        try {
+          const inserted = await client.query(
+            `INSERT INTO public.customer_orders
+              (order_code, customer_name, customer_phone, delivery_method, install_option,
+               address, items, subtotal, status, note, order_kind, customer_sub,
+               service_entitlement_snapshot, prepaid_entitlement_code, prepaid_claim_token_hash,
+               prepaid_redeem_until, prepaid_warranty_days, prepaid_purchase_request_key,
+               prepaid_purchase_fingerprint)
+             VALUES ($1,$2,$3,'pickup','none',NULL,$4::jsonb,$5,'pending_payment',$6,
+                     'service_prepaid',$7,$8::jsonb,$9,$10,$11,$12,$13,$14)
+             RETURNING order_id, order_code, customer_name, customer_phone, items, subtotal,
+                       status, created_at, prepaid_entitlement_code, prepaid_redeem_until,
+                       prepaid_warranty_days`,
+            [
+              orderCode, normalized.customer_name, normalized.customer_phone,
+              JSON.stringify(orderItemsFromQuote(quote)), total, normalized.note || null,
+              sub, JSON.stringify(snapshot), entitlementCode, claimHash,
+              snapshot.redeem_until, snapshot.warranty_days,
+              normalized.purchase_request_key, fingerprint,
+            ]
+          );
+          return {
+            replayed: false,
+            order: inserted.rows[0],
+            claim_token: claimToken,
+            entitlement_code: entitlementCode,
+            service: snapshot,
+          };
+        } catch (error) {
+          if (error?.code === "23505" && attempt < 4) continue;
+          throw error;
+        }
+      }
+      throw new PrepaidServiceError("ORDER_CODE_GENERATION_FAILED", 500);
+    }).catch((error) => {
+      if (isSchemaError(error)) throw new PrepaidServiceError("PREPAID_SCHEMA_NOT_READY", 503);
+      throw error;
+    });
+  }
+
+  async function confirmManualPayment(orderCode, body = {}, { verifiedBy = "admin" } = {}) {
+    const code = clean(orderCode, 40);
+    const reference = clean(body.reference || body.payment_reference, 200);
+    const confirmedAmount = money(body.confirmed_amount);
+    if (!code) throw new PrepaidServiceError("ORDER_CODE_REQUIRED", 400);
+    if (!reference) throw new PrepaidServiceError("PAYMENT_REFERENCE_REQUIRED", 400);
+    if (!(confirmedAmount > 0)) throw new PrepaidServiceError("CONFIRMED_AMOUNT_REQUIRED", 400);
+    return withTransaction(pool, async (client) => {
+      await requireSchema(client);
+      const found = await client.query(
+        `SELECT order_id, order_code, order_kind, subtotal, status, payment_provider,
+                payment_method, payment_charge_id, payment_status, paid_at
+           FROM public.customer_orders WHERE order_code=$1 FOR UPDATE`,
+        [code]
+      );
+      const order = found.rows?.[0];
+      if (!order) throw new PrepaidServiceError("ORDER_NOT_FOUND", 404);
+      if (order.order_kind !== "service_prepaid") throw new PrepaidServiceError("NOT_PREPAID_ORDER", 409);
+      if (money(order.subtotal) !== confirmedAmount) throw new PrepaidServiceError("PAYMENT_AMOUNT_MISMATCH", 409);
+      if (order.status === "paid") {
+        const right = await client.query(
+          `SELECT entitlement_code, status, customer_sub, redeem_until, warranty_days
+             FROM public.customer_service_entitlements WHERE order_id=$1 LIMIT 1`, [order.order_id]
+        );
+        return { replayed: true, order_code: code, entitlement: right.rows?.[0] || null };
+      }
+      if (order.status === "payment_processing" || String(order.payment_status || "").startsWith("processing:")) {
+        throw new PrepaidServiceError("ONLINE_PAYMENT_PROCESSING", 409);
+      }
+      if (order.payment_charge_id) throw new PrepaidServiceError("ONLINE_PAYMENT_ALREADY_LINKED", 409);
+      if (!new Set(["pending_payment", "payment_failed"]).has(order.status)) {
+        throw new PrepaidServiceError("ORDER_NOT_PAYABLE", 409);
+      }
+      await client.query(
+        `UPDATE public.customer_orders
+            SET payment_provider='manual_admin', payment_method='promptpay', payment_status='verified',
+                status='paid', paid_at=COALESCE(paid_at,NOW()), manual_payment_reference=$2,
+                payment_verified_by=$3, updated_at=NOW()
+          WHERE order_id=$1`,
+        [order.order_id, reference, clean(verifiedBy, 120) || "admin"]
+      );
+      const right = await client.query(
+        `SELECT entitlement_code, status, customer_sub, redeem_until, warranty_days
+           FROM public.customer_service_entitlements WHERE order_id=$1 LIMIT 1`, [order.order_id]
+      );
+      if (!right.rows?.[0]) throw new PrepaidServiceError("ENTITLEMENT_ISSUE_FAILED", 500);
+      return { replayed: false, order_code: code, entitlement: right.rows[0] };
+    });
+  }
+
+  async function listRights(customerSub) {
+    const sub = clean(customerSub, 256);
+    if (!sub) throw new PrepaidServiceError("NOT_LOGGED_IN", 401);
+    await requireSchema(pool);
+    await pool.query(
+      `UPDATE public.customer_service_entitlements
+          SET status='expired', updated_at=NOW(), redemption_token_hash=NULL,
+              redemption_request_key=NULL, redemption_booking_token=NULL, redemption_expires_at=NULL
+        WHERE customer_sub=$1 AND status IN ('active','redeeming') AND redeem_until < NOW()`, [sub]
+    );
+    const result = await pool.query(
+      `SELECT e.entitlement_code, e.status, e.customer_name, e.customer_phone,
+              e.service_snapshot, e.purchased_amount, e.redeem_until, e.warranty_days,
+              e.redeemed_job_id, e.redeemed_at, e.created_at,
+              j.booking_code, j.appointment_datetime, j.finished_at, j.canceled_at,
+              CASE WHEN j.finished_at IS NULL THEN NULL
+                   ELSE j.finished_at + (e.warranty_days * INTERVAL '1 day') END AS warranty_until,
+              CASE WHEN j.finished_at IS NULL THEN FALSE
+                   ELSE NOW() <= j.finished_at + (e.warranty_days * INTERVAL '1 day') END AS warranty_active
+         FROM public.customer_service_entitlements e
+         LEFT JOIN public.jobs j ON j.job_id=e.redeemed_job_id
+        WHERE e.customer_sub=$1
+        ORDER BY e.created_at DESC, e.entitlement_id DESC LIMIT 200`, [sub]
+    );
+    return result.rows || [];
+  }
+
+  async function claimRight({ entitlementCode, claimToken, customerSub }) {
+    const code = clean(entitlementCode, 100);
+    const token = clean(claimToken, 500);
+    const sub = clean(customerSub, 256);
+    if (!code || !token || !sub) throw new PrepaidServiceError("CLAIM_DATA_REQUIRED", 400);
+    return withTransaction(pool, async (client) => {
+      await requireSchema(client);
+      const found = await client.query(
+        `SELECT entitlement_id, status, customer_sub, claim_token_hash, redeem_until
+           FROM public.customer_service_entitlements WHERE entitlement_code=$1 FOR UPDATE`, [code]
+      );
+      const right = found.rows?.[0];
+      if (!right || !right.claim_token_hash) throw new PrepaidServiceError("CLAIM_FAILED", 400);
+      const actual = Buffer.from(sha256(token), "hex");
+      const expected = Buffer.from(String(right.claim_token_hash), "hex");
+      if (actual.length !== expected.length || !crypto.timingSafeEqual(actual, expected)) {
+        throw new PrepaidServiceError("CLAIM_FAILED", 400);
+      }
+      if (right.status === "expired" || new Date(right.redeem_until) < new Date()) {
+        await client.query(`UPDATE public.customer_service_entitlements SET status='expired', updated_at=NOW() WHERE entitlement_id=$1`, [right.entitlement_id]);
+        throw new PrepaidServiceError("ENTITLEMENT_EXPIRED", 409);
+      }
+      if (right.customer_sub && right.customer_sub !== sub) throw new PrepaidServiceError("CLAIM_FAILED", 400);
+      if (right.status !== "unclaimed" && !(right.status === "active" && right.customer_sub === sub)) {
+        throw new PrepaidServiceError("CLAIM_FAILED", 400);
+      }
+      await client.query(
+        `UPDATE public.customer_service_entitlements
+            SET customer_sub=$2, status='active', claim_token_hash=NULL, updated_at=NOW()
+          WHERE entitlement_id=$1`, [right.entitlement_id, sub]
+      );
+      await client.query(
+        `UPDATE public.customer_orders SET customer_sub=$2, prepaid_claim_token_hash=NULL, updated_at=NOW()
+          WHERE prepaid_entitlement_code=$1`, [code, sub]
+      );
+      return { entitlement_code: code, status: "active" };
+    });
+  }
+
+  async function beginRedemption({ entitlementCode, customerSub }) {
+    const code = clean(entitlementCode, 100);
+    const sub = clean(customerSub, 256);
+    if (!code || !sub) throw new PrepaidServiceError("REDEMPTION_DATA_REQUIRED", 400);
+    return withTransaction(pool, async (client) => {
+      await requireSchema(client);
+      const found = await client.query(
+        `SELECT entitlement_id, status, customer_sub, service_snapshot, redeem_until,
+                warranty_days, redeemed_job_id
+           FROM public.customer_service_entitlements
+          WHERE entitlement_code=$1 AND customer_sub=$2 FOR UPDATE`, [code, sub]
+      );
+      const right = found.rows?.[0];
+      if (!right) throw new PrepaidServiceError("ENTITLEMENT_NOT_FOUND", 404);
+      if (right.redeemed_job_id || right.status === "redeemed") throw new PrepaidServiceError("ENTITLEMENT_ALREADY_REDEEMED", 409);
+      if (right.status === "cancelled") throw new PrepaidServiceError("ENTITLEMENT_CANCELLED", 409);
+      if (new Date(right.redeem_until) < new Date()) {
+        await client.query(
+          `UPDATE public.customer_service_entitlements
+              SET status='expired', redemption_token_hash=NULL, redemption_request_key=NULL,
+                  redemption_booking_token=NULL, redemption_expires_at=NULL, updated_at=NOW()
+            WHERE entitlement_id=$1`, [right.entitlement_id]
+        );
+        throw new PrepaidServiceError("ENTITLEMENT_EXPIRED", 409);
+      }
+      if (!new Set(["active", "redeeming"]).has(right.status)) {
+        throw new PrepaidServiceError("ENTITLEMENT_NOT_REDEEMABLE", 409);
+      }
+      const snapshot = typeof right.service_snapshot === "string" ? JSON.parse(right.service_snapshot) : right.service_snapshot;
+      if (!snapshot || snapshot.schema_version !== 1 || !Array.isArray(snapshot.service_package_groups)
+          || !snapshot.service_package_groups.length || !Array.isArray(snapshot.services) || !snapshot.services.length) {
+        throw new PrepaidServiceError("PACKAGE_SNAPSHOT_INVALID", 409);
+      }
+      const requestKey = generateRequestKey("prepaid");
+      const redemptionToken = randomToken(32);
+      const bookingToken = bookingTokenFromScheduledRequestKey(requestKey);
+      const expires = new Date(Date.now() + CLAIM_TTL_MINUTES * 60 * 1000);
+      await client.query(
+        `UPDATE public.customer_service_entitlements
+            SET status='redeeming', redemption_request_key=$2, redemption_token_hash=$3,
+                redemption_booking_token=$4, redemption_expires_at=$5, updated_at=NOW()
+          WHERE entitlement_id=$1`,
+        [right.entitlement_id, requestKey, sha256(redemptionToken), bookingToken, expires]
+      );
+      return {
+        entitlement_code: code,
+        scheduled_request_key: requestKey,
+        prepaid_redemption_token: redemptionToken,
+        redemption_expires_at: expires.toISOString(),
+        catalog_item_id: Number(snapshot.catalog_item_id),
+        service_package_groups: snapshot.service_package_groups,
+        services: snapshot.services,
+        duration_min: Number(snapshot.duration_min),
+        fixed_total_price: Number(snapshot.fixed_total_price),
+        redeem_until: snapshot.redeem_until,
+        warranty_days: snapshot.warranty_days,
+      };
+    });
+  }
+
+  return {
+    schemaReady: () => schemaReady(pool),
+    quoteOrder,
+    createOrder,
+    confirmManualPayment,
+    listRights,
+    claimRight,
+    beginRedemption,
+  };
+}
+
+module.exports = {
+  CLAIM_TTL_MINUTES,
+  PrepaidServiceError,
+  REQUEST_KEY_RE,
+  bookingTokenFromScheduledRequestKey,
+  createPrepaidOrderService,
+  entitlementSnapshot,
+  generateEntitlementCode,
+  sha256,
+};

--- a/test/airResetBookNow.test.js
+++ b/test/airResetBookNow.test.js
@@ -4,6 +4,7 @@ const test = require("node:test");
 const assert = require("node:assert/strict");
 const fs = require("node:fs");
 const { resolveCompositeBooking } = require("../server/services/packages/compositeServicePackage");
+const { resolvePackageBooking } = require("../server/services/booking/servicePackageBooking");
 
 function tiers(prefix, prices) {
   return Object.entries(prices).map(([quantity, price], index) => ({
@@ -36,7 +37,7 @@ function parent(level) {
     service_package_pricing_strategy: "total_quantity_tier_plus_unit_modifiers",
     service_package_selection_mode: "multi_variant",
     service_package_maximum_total_quantity: 4,
-    service_package_payment_mode: "book_now",
+    service_package_payment_mode: "prepaid_full",
     service_package_warranty_days: 60,
     booking_flow_policy: "scheduled_only",
     job_type: "wash",
@@ -114,20 +115,54 @@ const repository = {
 
 const group = (package_key, btu, quantity) => ({ package_key, btu, quantity });
 
-function quote({ catalogItemId, groups, now = "2026-09-10T05:00:00.000Z", appointment = "2026-12-20T03:00:00.000Z", identity = "customer" }) {
+function purchaseQuote({ catalogItemId, groups, now = "2026-09-10T05:00:00.000Z", identity = "customer" }) {
   return resolveCompositeBooking({
     body: { catalog_item_id: catalogItemId, service_package_groups: groups },
     bookingMode: "scheduled",
-    appointmentDatetime: appointment,
+    appointmentDatetime: null,
     repository,
     db: {},
     identity,
     now: () => new Date(now),
+    purchaseOnly: true,
   });
 }
 
-test("AIR RESET STANDARD books now through the normal scheduled flow with mixed BTU", async () => {
-  const result = await quote({
+function bookingResolver(now = "2026-09-10T05:00:00.000Z") {
+  return {
+    resolveComposite: ({ body, bookingMode, appointmentDatetime, identity }) => resolveCompositeBooking({
+      body,
+      bookingMode,
+      appointmentDatetime,
+      repository,
+      db: {},
+      identity,
+      now: () => new Date(now),
+    }),
+    resolvePrepaidRedemption: async ({ body, bookingMode, appointmentDatetime, identity }) => ({
+      redeemed: true,
+      token: body.prepaid_redemption_token,
+      bookingMode,
+      appointmentDatetime,
+      identity,
+    }),
+  };
+}
+
+function directBooking({ catalogItemId, groups, token = null, appointment = "2026-12-20T03:00:00.000Z", identity = "customer" }) {
+  const body = { catalog_item_id: catalogItemId, service_package_groups: groups };
+  if (token) body.prepaid_redemption_token = token;
+  return resolvePackageBooking({
+    body,
+    bookingMode: "scheduled",
+    appointmentDatetime: appointment,
+    resolver: bookingResolver(),
+    identity,
+  });
+}
+
+test("AIR RESET STANDARD prepaid quote preserves mixed-BTU advertised pricing", async () => {
+  const result = await purchaseQuote({
     catalogItemId: 901,
     groups: [
       group("air-reset-60-standard-small", 12000, 1),
@@ -135,59 +170,68 @@ test("AIR RESET STANDARD books now through the normal scheduled flow with mixed 
     ],
   });
   assert.equal(result.fixedTotal, "1059.00");
-  assert.equal(result.paymentMode, "book_now");
+  assert.equal(result.paymentMode, "prepaid_full");
   assert.equal(result.warrantyDays, 60);
   assert.equal(result.payload.machine_count, 2);
   assert.equal(result.payload.service_package_groups.length, 2);
 });
 
-test("AIR RESET PREMIUM books now with server-authoritative modifier pricing", async () => {
-  const result = await quote({
+test("AIR RESET PREMIUM prepaid quote uses server-authoritative modifier pricing", async () => {
+  const result = await purchaseQuote({
     catalogItemId: 902,
     groups: [group("air-reset-60-premium-large", 18000, 2)],
   });
   assert.equal(result.fixedTotal, "1890.00");
-  assert.equal(result.paymentMode, "book_now");
+  assert.equal(result.paymentMode, "prepaid_full");
   assert.equal(result.payload.machine_count, 2);
 });
 
-test("Admin booking-on-behalf uses the same AIR RESET price contract", async () => {
-  const result = await quote({
+test("Admin purchase-on-behalf uses the same AIR RESET prepaid price contract", async () => {
+  const result = await purchaseQuote({
     catalogItemId: 901,
     groups: [group("air-reset-60-standard-small", 12000, 2)],
     identity: "admin",
   });
   assert.equal(result.fixedTotal, "959.00");
-  assert.equal(result.paymentMode, "book_now");
+  assert.equal(result.paymentMode, "prepaid_full");
 });
 
-test("AIR RESET direct booking respects sale and service windows", async () => {
-  const groups = [group("air-reset-60-standard-small", 12000, 1)];
-  assert.equal((await quote({ catalogItemId: 901, groups, appointment: "2027-01-31T16:59:59.000Z" })).fixedTotal, "550.00");
+test("AIR RESET prepaid cannot create a normal booking without a funded redemption token", async () => {
   await assert.rejects(
-    quote({ catalogItemId: 901, groups, now: "2026-09-13T00:00:00.000Z" }),
+    directBooking({ catalogItemId: 901, groups: [group("air-reset-60-standard-small", 12000, 1)] }),
+    { code: "PREPAID_REDEMPTION_REQUIRED" }
+  );
+});
+
+test("AIR RESET redemption token is routed only through the prepaid redemption resolver", async () => {
+  const result = await directBooking({
+    catalogItemId: 901,
+    groups: [group("air-reset-60-standard-small", 12000, 1)],
+    token: "redeem_capability_123456",
+  });
+  assert.equal(result.redeemed, true);
+  assert.equal(result.token, "redeem_capability_123456");
+  assert.equal(result.bookingMode, "scheduled");
+});
+
+test("AIR RESET purchase respects sale window and advertised 1-4 maximum", async () => {
+  const groups = [group("air-reset-60-standard-small", 12000, 1)];
+  assert.equal((await purchaseQuote({ catalogItemId: 901, groups })).fixedTotal, "550.00");
+  await assert.rejects(
+    purchaseQuote({ catalogItemId: 901, groups, now: "2026-09-13T00:00:00.000Z" }),
     { code: "SERVICE_PACKAGE_NOT_AVAILABLE" }
   );
   await assert.rejects(
-    quote({ catalogItemId: 901, groups, appointment: "2027-01-31T17:00:00.000Z" }),
-    { code: "PACKAGE_REDEEM_WINDOW_EXCEEDED" }
-  );
-});
-
-test("AIR RESET direct booking blocks quantity above the advertised 1-4 range", async () => {
-  await assert.rejects(
-    quote({ catalogItemId: 901, groups: [group("air-reset-60-standard-small", 12000, 5)] }),
+    purchaseQuote({ catalogItemId: 901, groups: [group("air-reset-60-standard-small", 12000, 5)] }),
     { code: "SERVICE_PACKAGE_MAXIMUM_QUANTITY_EXCEEDED" }
   );
 });
 
-test("AIR RESET seed is data configuration, not hard-coded runtime business logic", () => {
+test("AIR RESET cutover is data configuration and preserves advertised price contract", () => {
   const seed = fs.readFileSync("data-seeds/20260906_air_reset_60_book_now.sql", "utf8");
   assert.match(seed, /air-reset-60-standard/);
   assert.match(seed, /air-reset-60-premium/);
   assert.match(seed, /total_quantity_tier_plus_unit_modifiers/);
-  assert.match(seed, /'book_now'/);
-  assert.match(seed, /4, 'book_now', 60/);
   assert.match(seed, /550\.00::numeric/);
   assert.match(seed, /959\.00::numeric/);
   assert.match(seed, /1490\.00::numeric/);
@@ -195,11 +239,18 @@ test("AIR RESET seed is data configuration, not hard-coded runtime business logi
   assert.match(seed, /100\.00::numeric/);
   assert.match(seed, /200\.00::numeric/);
 
+  const cutover = fs.readFileSync("scripts/apply-air-reset-60-seed.sh", "utf8");
+  assert.match(cutover, /air-reset-60-standard/);
+  assert.match(cutover, /air-reset-60-premium/);
+  assert.match(cutover, /service_package_payment_mode='prepaid_full'/);
+  assert.match(cutover, /booking_mode='service_package'/);
+  assert.match(cutover, /service_package_warranty_days=60/);
+
   const runtime = fs.readFileSync("server/services/packages/promotionPricingPolicy.js", "utf8");
   assert.doesNotMatch(runtime, /AIR RESET|air-reset/i);
 });
 
-test("Customer Store and Admin Add Job already submit service-package groups into real booking routes", () => {
+test("Customer Store and Admin Add Job keep service-package groups on real booking routes", () => {
   const store = fs.readFileSync("customer-app/modules/store.js", "utf8");
   const admin = fs.readFileSync("admin-add-v2.js", "utf8");
   const booking = fs.readFileSync("server/services/booking/createBookingJob.js", "utf8");

--- a/test/airResetSeedOperator.test.js
+++ b/test/airResetSeedOperator.test.js
@@ -21,16 +21,23 @@ test("AIR RESET data is not admitted to the schema-only expand migration lane", 
   assert.doesNotMatch(seed, /\b(?:UPDATE|DELETE FROM|TRUNCATE|DROP TABLE|DROP COLUMN)\b/i);
 });
 
-test("AIR RESET seed operator pins content, release revision and atomic application", () => {
+test("AIR RESET prepaid cutover pins seed and release, verifies schema and preserves advertised data", () => {
   const sha = crypto.createHash("sha256").update(seed).digest("hex");
   assert.equal(sha, "bc82b1bdf995284ec8a37393ed22161363e6d0aec840dc8df31bda8f43d8ae55");
   assert.match(operator, new RegExp(sha));
   assert.match(operator, /EXPECTED_RELEASE_SHA/);
   assert.match(operator, /cwf-deployctl.*status/);
-  assert.match(operator, /--single-transaction/);
+  assert.match(operator, /verify_prepaid_schema/);
   assert.match(operator, /partial or unexpected AIR RESET data exists; refusing to overwrite it/);
-  assert.match(operator, /AIR_RESET_SEED_OK environment=%s parents=2 variants=4 tiers=16/);
-  assert.match(operator, /AIR_RESET_SEED_ALREADY_APPLIED/);
+  assert.match(operator, /service_package_payment_mode='"'"'prepaid_full'"'"'/);
+  assert.match(operator, /booking_mode='"'"'service_package'"'"'/);
+  assert.match(operator, /AIR_RESET_PREPAID_READY environment=%s parents=2 variants=4 tiers=16 payment_mode=prepaid_full/);
+  assert.match(operator, /550\.00/);
+  assert.match(operator, /959\.00/);
+  assert.match(operator, /1490\.00/);
+  assert.match(operator, /2690\.00/);
+  assert.match(operator, /unit_price_modifier=100/);
+  assert.match(operator, /unit_price_modifier=200/);
 });
 
 test("AIR RESET seed gate runs only after successful staging or production deployment", () => {
@@ -43,6 +50,6 @@ test("AIR RESET seed gate runs only after successful staging or production deplo
   assert.match(workflow, /production\/home-server/);
   assert.match(workflow, /ref: \$\{\{ github\.event\.workflow_run\.head_sha \}\}/);
   assert.match(workflow, /EXPECTED_RELEASE_SHA: \$\{\{ github\.event\.workflow_run\.head_sha \}\}/);
-  assert.match(workflow, /apply-air-reset-60-seed\.sh staging/);
-  assert.match(workflow, /apply-air-reset-60-seed\.sh production/);
+  assert.match(workflow, /apply-prepaid-service-entitlements-home\.sh staging[\s\S]*apply-air-reset-60-seed\.sh staging/);
+  assert.match(workflow, /apply-prepaid-service-entitlements-home\.sh production[\s\S]*apply-air-reset-60-seed\.sh production/);
 });

--- a/test/customerTrackingPrivacy.test.js
+++ b/test/customerTrackingPrivacy.test.js
@@ -274,7 +274,6 @@ test("tracking selection references keep one absolute expiry across select and r
   const initial = trackingPrivacy.verifyTrackingSelectionReference(reference, secret, { now: issuedAt });
   assert.ok(initial.expires_at <= Math.floor(issuedAt / 1000) + (15 * 60));
 
-  // /public/track/select and subsequent refreshes return this same reference.
   const afterSelect = trackingPrivacy.verifyTrackingSelectionReference(reference, secret, { now: issuedAt + 5 * 60_000 });
   const afterRefresh = trackingPrivacy.verifyTrackingSelectionReference(reference, secret, { now: issuedAt + 14 * 60_000 });
   assert.equal(afterSelect.expires_at, initial.expires_at);
@@ -305,7 +304,6 @@ test("selection review limiter is stable per verified job and distinct across jo
   assert.notEqual(otherKey, firstKey);
   assert.equal(trackingPrivacy.selectionReviewLimiterKey(null), "");
 
-  // A fresh lookup/reference for the same job cannot reset the shared budget.
   const limiter = trackingPrivacy.createPublicLookupRateLimiter({ windowMs: 60_000, max: 1 });
   assert.equal(limiter.check(firstKey).allowed, true);
   assert.equal(limiter.check(secondKey).allowed, false);
@@ -391,11 +389,8 @@ test("rate limiter caps its key map (LRU) so it cannot grow without bound", () =
 });
 
 test("clientIpKey uses the framework-resolved req.ip and IGNORES raw X-Forwarded-For", () => {
-  // req.ip is derived under the app's `trust proxy` setting; the raw header is
-  // attacker-controlled and must not create a fresh identity.
   assert.equal(trackingPrivacy.clientIpKey({ ip: "203.0.113.7", headers: { "x-forwarded-for": "1.1.1.1, 2.2.2.2" } }), "203.0.113.7");
   assert.equal(trackingPrivacy.clientIpKey({ headers: { "x-forwarded-for": "9.9.9.9" }, socket: { remoteAddress: "10.0.0.5" } }), "10.0.0.5");
-  // Spoofing XFF cannot change the key when req.ip is stable.
   const a = trackingPrivacy.clientIpKey({ ip: "203.0.113.7", headers: { "x-forwarded-for": "1.1.1.1" } });
   const b = trackingPrivacy.clientIpKey({ ip: "203.0.113.7", headers: { "x-forwarded-for": "8.8.8.8" } });
   assert.equal(a, b);
@@ -408,7 +403,7 @@ function docsFakePool(job) {
     async query(sql) {
       const s = String(sql);
       if (s.includes("FROM public.jobs WHERE job_id=$1")) return { rows: job ? [job] : [] };
-      return { rows: [] }; // job_items, job_promotions, job_photos
+      return { rows: [] };
     },
   };
 }
@@ -429,9 +424,9 @@ function startDocsServer({ job, isAdmin = false } = {}) {
   return new Promise((resolve) => server.listen(0, "127.0.0.1", () => resolve(server)));
 }
 const durl = (s) => `http://127.0.0.1:${s.address().port}`;
-const JOB = { job_id: 7, booking_code: "CWFJOB7", booking_token: "tok_secret_77", customer_name: "ลูกค้า", customer_phone: "0810000000", job_type: "ล้างแอร์", address_text: "บ้านเลขที่ลับ", job_price: 500 };
+const JOB = { job_id: 7, booking_code: "CWFJOB7", booking_token: "tok_secret_77", customer_name: "ลูกค้า", customer_phone: "0810000000", job_type: "ล้างแอร์", address_text: "บ้านเลขที่ลับ", job_price: 500, finished_at: "2026-07-10T12:00:00.000Z" };
 
-test("job documents (quote/receipt/eslip) 404 on a bare job_id, 200 with the exact token key", async () => {
+test("finished job documents 404 on a bare job_id and 200 with the exact token key", async () => {
   const server = await startDocsServer({ job: JOB });
   try {
     for (const doc of ["quote", "receipt", "eslip"]) {
@@ -440,7 +435,7 @@ test("job documents (quote/receipt/eslip) 404 on a bare job_id, 200 with the exa
       const wrong = await fetch(`${durl(server)}/docs/${doc}/7?key=tok_wrong`);
       assert.equal(wrong.status, 404, `${doc} wrong key must 404`);
       const ok = await fetch(`${durl(server)}/docs/${doc}/7?key=tok_secret_77`);
-      assert.equal(ok.status, 200, `${doc} correct key must 200`);
+      assert.equal(ok.status, 200, `${doc} correct key must 200 after completion`);
       assert.match(ok.headers.get("cache-control") || "", /no-store/);
       assert.equal(ok.headers.get("referrer-policy"), "no-referrer");
       assert.match(ok.headers.get("x-robots-tag") || "", /noindex/);
@@ -448,8 +443,20 @@ test("job documents (quote/receipt/eslip) 404 on a bare job_id, 200 with the exa
   } finally { server.close(); }
 });
 
+test("customer quote remains available before completion but receipt and e-slip stay hidden", async () => {
+  const server = await startDocsServer({ job: { ...JOB, finished_at: null } });
+  try {
+    const quote = await fetch(`${durl(server)}/docs/quote/7?key=tok_secret_77`);
+    assert.equal(quote.status, 200);
+    for (const doc of ["receipt", "eslip"]) {
+      const res = await fetch(`${durl(server)}/docs/${doc}/7?key=tok_secret_77`);
+      assert.equal(res.status, 404, `${doc} must stay hidden until technician completion`);
+    }
+  } finally { server.close(); }
+});
+
 test("job documents open for an authenticated admin without any key", async () => {
-  const server = await startDocsServer({ job: JOB, isAdmin: true });
+  const server = await startDocsServer({ job: { ...JOB, finished_at: null }, isAdmin: true });
   try {
     const res = await fetch(`${durl(server)}/docs/receipt/7`);
     assert.equal(res.status, 200);
@@ -526,15 +533,10 @@ test("all three job-doc routes share one gate helper + sensitive headers", () =>
 });
 
 test("the customer app keeps document access token-only and injects review credentials from memory", () => {
-  // The receipt URL still carries the booking_token as ?key=, but it is now
-  // constructed at click time from state (receiptUrl(data)) instead of being
-  // interpolated into rendered HTML — see Blocker 1.
   assert.match(trackingClientSrc, /`\/docs\/receipt\/\$\{encodeURIComponent\(data\.job_id\)\}\?key=\$\{encodeURIComponent\(data\.booking_token\)\}`/);
-  // Documents remain token-only; selected jobs may use an opaque review reference.
   assert.match(trackingClientSrc, /if \(!canUseTokenActions\(data\)\) return "";/);
   assert.match(trackingClientSrc, /const reviewToken = canUseTokenActions\(data\)/);
   assert.match(trackingClientSrc, /if \(!catalogReview\.eligible \|\| !canUseTokenActions\(data\)\) return "";/);
-  // Neither credential may be embedded in rendered HTML or hidden inputs.
   assert.doesNotMatch(trackingClientSrc, /name="booking_token"/);
   assert.match(trackingClientSrc, /payload\.booking_token = token/);
   assert.match(trackingClientSrc, /payload\.selection_ref = selectionReference/);

--- a/test/prepaidServiceEntitlements.test.js
+++ b/test/prepaidServiceEntitlements.test.js
@@ -1,0 +1,98 @@
+"use strict";
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const crypto = require("node:crypto");
+const fs = require("node:fs");
+
+const prepaid = require("../server/services/prepaid/prepaidOrderServiceV2");
+const { resolvePackageBooking } = require("../server/services/booking/servicePackageBooking");
+
+test("scheduled prepaid booking token is deterministic and domain separated", () => {
+  const key = "scheduled_request_123456789";
+  const expected = crypto.createHash("sha256").update(`scheduled_v1:${key}`).digest("hex").slice(0, 24);
+  assert.equal(prepaid.bookingTokenFromScheduledRequestKey(key), expected);
+});
+
+test("direct composite prepaid booking is rejected while redemption capability is delegated", async () => {
+  const body = {
+    catalog_item_id: 901,
+    service_package_groups: [{ package_key: "air-reset-60-standard-small", btu: 12000, quantity: 1 }],
+    scheduled_request_key: "scheduled_request_123456789",
+  };
+  const resolver = {
+    resolveComposite: async () => ({ paymentMode: "prepaid_full" }),
+    resolvePrepaidRedemption: async () => ({ ok: true }),
+  };
+  await assert.rejects(
+    resolvePackageBooking({ body, bookingMode: "scheduled", appointmentDatetime: "2026-12-01T03:00:00.000Z", resolver }),
+    { code: "PREPAID_REDEMPTION_REQUIRED" }
+  );
+  const redeemed = await resolvePackageBooking({
+    body: { ...body, prepaid_redemption_token: "paid_right_token_123456789" },
+    bookingMode: "scheduled",
+    appointmentDatetime: "2026-12-01T03:00:00.000Z",
+    resolver,
+  });
+  assert.equal(redeemed.ok, true);
+});
+
+test("prepaid resolver binds the verified right to transaction-local DB context", () => {
+  const resolver = fs.readFileSync("server/services/packages/servicePackageResolver.js", "utf8");
+  assert.match(resolver, /set_config\('cwf\.prepaid_entitlement_id',\$1,true\)/);
+  assert.match(resolver, /set_config\('cwf\.prepaid_customer_sub',\$2,true\)/);
+  assert.match(resolver, /set_config\('cwf\.prepaid_booking_token',\$3,true\)/);
+  assert.match(resolver, /\[String\(entitlement\.entitlement_id\), String\(entitlement\.customer_sub\), bookingToken\]/);
+});
+
+test("migration consumes only transaction-bound paid entitlement and preserves job value", () => {
+  const migration = fs.readFileSync("migrations/20260906_prepaid_service_entitlements.sql", "utf8");
+  assert.match(migration, /current_setting\('cwf\.prepaid_entitlement_id', true\)/);
+  assert.match(migration, /current_setting\('cwf\.prepaid_customer_sub', true\)/);
+  assert.match(migration, /current_setting\('cwf\.prepaid_booking_token', true\)/);
+  assert.match(migration, /FOR UPDATE/);
+  assert.match(migration, /ent\.customer_sub <> context_customer_sub/);
+  assert.match(migration, /o\.order_kind = 'service_prepaid'/);
+  assert.match(migration, /o\.status = 'paid'/);
+  assert.match(migration, /NEW\.prepaid_entitlement_id := ent\.entitlement_id/);
+  assert.match(migration, /NEW\.customer_sub := ent\.customer_sub/);
+  assert.match(migration, /NEW\.booking_token := context_booking_token/);
+  assert.match(migration, /NEW\.customer_due := 0\.00/);
+  assert.match(migration, /NEW\.payment_status := 'paid'/);
+  assert.match(migration, /NEW\.paid_at := prepaid_paid_at/);
+  assert.doesNotMatch(migration, /NEW\.job_price\s*:=\s*0/);
+  assert.match(migration, /PREPAID_REDEMPTION_CONCURRENT_CONFLICT/);
+});
+
+test("unfinished cancellation restores right but finished cancellation never does", () => {
+  const migration = fs.readFileSync("migrations/20260906_prepaid_service_entitlements.sql", "utf8");
+  assert.match(migration, /NEW\.canceled_at IS NOT NULL/);
+  assert.match(migration, /NEW\.prepaid_entitlement_id IS NOT NULL/);
+  assert.match(migration, /NEW\.finished_at IS NULL/);
+  assert.match(migration, /CASE WHEN redeem_until < NOW\(\) THEN 'expired' ELSE 'active' END/);
+});
+
+test("release gate migrates entitlement schema before AIR RESET cutover in both environments", () => {
+  const workflow = fs.readFileSync(".github/workflows/cwf-air-reset-seed-gate.yml", "utf8");
+  const stagingMigration = workflow.indexOf("apply-prepaid-service-entitlements-home.sh staging");
+  const stagingCutover = workflow.indexOf("apply-air-reset-60-seed.sh staging");
+  const productionMigration = workflow.indexOf("apply-prepaid-service-entitlements-home.sh production");
+  const productionCutover = workflow.indexOf("apply-air-reset-60-seed.sh production");
+  assert.ok(stagingMigration >= 0 && stagingCutover > stagingMigration);
+  assert.ok(productionMigration >= 0 && productionCutover > productionMigration);
+});
+
+test("migration advisory lock and SQL execute in the same psql session", () => {
+  const script = fs.readFileSync("scripts/apply-prepaid-service-entitlements-home.sh", "utf8");
+  assert.match(script, /printf 'SELECT pg_advisory_lock\(%s::bigint\);\\n' "\$LOCK_KEY"[\s\S]*cat "\$MIGRATION_PATH"[\s\S]*printf '\\nSELECT pg_advisory_unlock\(%s::bigint\);\\n' "\$LOCK_KEY"[\s\S]*\| docker_cmd exec -i/);
+  assert.doesNotMatch(script, /trap .*pg_advisory_unlock/);
+});
+
+test("customer redemption carries both one-time token and stable scheduled request key", () => {
+  const prepaidUi = fs.readFileSync("customer-app/modules/prepaid.js", "utf8");
+  const scheduledUi = fs.readFileSync("customer-app/modules/bookingScheduled.js", "utf8");
+  assert.match(prepaidUi, /prepaid_redemption_token: r\.prepaid_redemption_token/);
+  assert.match(prepaidUi, /scheduled_request_key: r\.scheduled_request_key/);
+  assert.match(prepaidUi, /prepaid_redemption_token: token/);
+  assert.match(scheduledUi, /scheduled_request_key: ensureScheduledRequestKey\(\)/);
+});

--- a/test/promotionPolicyAdminService.test.js
+++ b/test/promotionPolicyAdminService.test.js
@@ -57,7 +57,10 @@ test("Issue #329 promotion policy rejects invalid max, warranty, modifier, dupli
 test("Admin Store loads generic promotion-policy extension after the stable editor", () => {
   const html = fs.readFileSync("admin-store-catalog.html", "utf8");
   const js = fs.readFileSync("admin-store-promotion-policy-extension.js", "utf8");
-  assert.match(html, /admin-store-catalog\.js[^\n]+admin-store-promotion-policy-extension\.js/s);
+  const baseIndex = html.indexOf("/admin-store-catalog.js");
+  const extensionIndex = html.indexOf("/admin-store-promotion-policy-extension.js");
+  assert.ok(baseIndex >= 0, "base Admin Store script must be present");
+  assert.ok(extensionIndex > baseIndex, "promotion policy extension must load after the base editor");
   assert.match(js, /bm_pricing_strategy/);
   assert.match(js, /bm_payment_mode/);
   assert.match(js, /bm_warranty_days/);

--- a/test/promotionPolicyAdminService.test.js
+++ b/test/promotionPolicyAdminService.test.js
@@ -1,0 +1,75 @@
+"use strict";
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const {
+  PromotionPolicyAdminError,
+  normalizePolicy,
+} = require("../server/services/packages/promotionPolicyAdminService");
+
+function valid(overrides = {}) {
+  return {
+    pricing_strategy: "total_quantity_tier_plus_unit_modifiers",
+    selection_mode: "multi_variant",
+    maximum_total_quantity: 4,
+    payment_mode: "book_now",
+    warranty_days: 60,
+    is_active: true,
+    is_customer_visible: true,
+    variants: [
+      { package_key: "small", service_level_key: "standard", service_level_label: "STANDARD", unit_price_modifier: "0" },
+      { package_key: "large", service_level_key: "standard", service_level_label: "STANDARD", unit_price_modifier: "100" },
+    ],
+    ...overrides,
+  };
+}
+
+test("Issue #329 promotion policy normalizes generic pricing/payment/warranty fields", () => {
+  const value = normalizePolicy(valid());
+  assert.equal(value.pricing_strategy, "total_quantity_tier_plus_unit_modifiers");
+  assert.equal(value.selection_mode, "multi_variant");
+  assert.equal(value.maximum_total_quantity, 4);
+  assert.equal(value.payment_mode, "book_now");
+  assert.equal(value.warranty_days, 60);
+  assert.equal(value.variants[1].unit_price_modifier, "100.00");
+});
+
+test("Issue #329 promotion policy accepts prepaid_full as a generic configuration value", () => {
+  const value = normalizePolicy(valid({ payment_mode: "prepaid_full" }));
+  assert.equal(value.payment_mode, "prepaid_full");
+});
+
+test("Issue #329 promotion policy rejects invalid max, warranty, modifier, duplicates and enums", () => {
+  const cases = [
+    valid({ maximum_total_quantity: 100 }),
+    valid({ warranty_days: 0 }),
+    valid({ payment_mode: "cash_later" }),
+    valid({ pricing_strategy: "air_reset" }),
+    valid({ variants: [{ package_key: "x", unit_price_modifier: "-1" }] }),
+    valid({ variants: [{ package_key: "x" }, { package_key: "x" }] }),
+  ];
+  for (const payload of cases) {
+    assert.throws(() => normalizePolicy(payload), (error) => error instanceof PromotionPolicyAdminError);
+  }
+});
+
+test("Admin Store loads generic promotion-policy extension after the stable editor", () => {
+  const html = fs.readFileSync("admin-store-catalog.html", "utf8");
+  const js = fs.readFileSync("admin-store-promotion-policy-extension.js", "utf8");
+  assert.match(html, /admin-store-catalog\.js[^\n]+admin-store-promotion-policy-extension\.js/s);
+  assert.match(js, /bm_pricing_strategy/);
+  assert.match(js, /bm_payment_mode/);
+  assert.match(js, /bm_warranty_days/);
+  assert.match(js, /unit_price_modifier/);
+  assert.match(js, /payload\.is_active = false/);
+  assert.match(js, /payload\.is_customer_visible = false/);
+  assert.match(js, /\/promotion-policy/);
+});
+
+test("Admin promotion-policy routes are permission guarded", () => {
+  const source = fs.readFileSync("server/routes/admin/storeServicePackageCatalog.js", "utf8");
+  assert.match(source, /\/promotion-policy\", requireAdminSession/);
+  assert.match(source, /policyService\.get/);
+  assert.match(source, /policyService\.update/);
+});


### PR DESCRIPTION
Continuation of Issue #329 after the merged book-now milestone in PR #330.

Current audit findings:
- Production book-now AIR RESET 60 supports Customer scheduled booking and Admin booking-on-behalf.
- Prepaid pay-now/use-later entitlement lifecycle is still deferred and Issue #329 remains open.
- Admin Store could not yet create/edit the generic promotion policy fields that were added to the schema.

This draft PR starts the remaining readiness work without touching Production.

Included so far:
- generic Admin promotion-policy service for pricing strategy, selection mode, max quantity, payment mode, warranty days, service levels and per-unit modifiers
- permission-guarded Admin policy GET/PATCH endpoints
- Admin Store policy editor extension
- fail-closed UI save: promotion parent stays hidden until policy persistence succeeds
- validation/tests for policy fields

Still required before this PR can be considered merge-ready:
- prepaid pending order + admin payment confirmation + immutable service-right snapshot
- My Rights / ownership enforcement
- atomic one-time redemption to exactly one job with customer due=0 and technician earnings unchanged
- completion-based warranty UI and server receipt/e-slip completion gate
- lifecycle/concurrency/regression tests and PWA/cache assessment

No Production DB, deploy, restart, merge, data or configuration changes are authorized by this PR.