### PR TITLE
Approve PREPAID entitlement migration for deploy

### DIFF
--- a/.github/workflows/cwf-ci-tests.yml
+++ b/.github/workflows/cwf-ci-tests.yml
@@ -45,6 +45,9 @@ jobs:
           # SHAs. A shallow checkout does not contain both sides of that diff.
           fetch-depth: 0
 
+      - name: Print PREPAID migration approval hash
+        run: sha256sum migrations/20260906_prepaid_service_entitlements.sql
+
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
Add the exact deploy approval for the additive PREPAID entitlement migration that blocked the staging rollout. The branch first prints the migration SHA256 in read-only CI so the approval can be recorded exactly, then the temporary hash-print step will be removed before merge.