### PR TITLE
Fix Admin AIR RESET prepaid booking-on-behalf

### DIFF
--- a/server/services/booking/adminStorePromotionPolicy.js
+++ b/server/services/booking/adminStorePromotionPolicy.js
@@ -1,5 +1,7 @@
 "use strict";
 
+const ADMIN_STORE_BOOKING_AUTH = Symbol.for("cwf.adminStoreBookingAuthorized");
+
 class AdminStorePromotionPolicyError extends Error {
   constructor(code, statusCode = 400) {
     super(code);
@@ -11,6 +13,15 @@ class AdminStorePromotionPolicyError extends Error {
 
 function present(value) { return value != null && String(value).trim() !== ""; }
 function positive(value) { return Number(value || 0) > 0; }
+
+function authorizeAdminStoreBooking(body) {
+  Object.defineProperty(body, ADMIN_STORE_BOOKING_AUTH, {
+    value: true,
+    configurable: true,
+    enumerable: false,
+    writable: false,
+  });
+}
 
 function validateAdminStorePromotionRequest(body = {}, { createdBySource = "admin" } = {}) {
   if (createdBySource !== "admin") return { kind: null };
@@ -24,18 +35,26 @@ function validateAdminStorePromotionRequest(body = {}, { createdBySource = "admi
   if (commonConflict) throw new AdminStorePromotionPolicyError("STORE_PROMOTION_STACKING_UNSUPPORTED");
 
   if (composite) {
-    if (present(body.catalog_item_id) || present(body.service_package_key) || present(body.service_package_tier_key)
+    // catalog_item_id is the parent Store promotion identity for a composite bundle.
+    // Admin Add intentionally sends it together with service_package_groups and the
+    // composite resolver needs it to bind the request to the correct Store item.
+    if (!present(body.catalog_item_id)) {
+      throw new AdminStorePromotionPolicyError("STORE_PROMOTION_CATALOG_ITEM_REQUIRED");
+    }
+    if (present(body.service_package_key) || present(body.service_package_tier_key)
         || (Array.isArray(body.services) && body.services.length > 0)
         || (Array.isArray(body.service_lines) && body.service_lines.length > 0)) {
       throw new AdminStorePromotionPolicyError("STORE_PROMOTION_STACKING_UNSUPPORTED");
     }
+    authorizeAdminStoreBooking(body);
     return { kind: "service_package" };
   }
 
   const services = Array.isArray(body.services) ? body.services
     : (Array.isArray(body.service_lines) ? body.service_lines : []);
   if (services.length > 0) throw new AdminStorePromotionPolicyError("STORE_PROMOTION_STACKING_UNSUPPORTED");
+  authorizeAdminStoreBooking(body);
   return { kind: "bookable" };
 }
 
-module.exports = { AdminStorePromotionPolicyError, validateAdminStorePromotionRequest };
+module.exports = { ADMIN_STORE_BOOKING_AUTH, AdminStorePromotionPolicyError, validateAdminStorePromotionRequest };

--- a/server/services/booking/servicePackageBooking.js
+++ b/server/services/booking/servicePackageBooking.js
@@ -2,6 +2,8 @@
 
 const { normalizeGroups, parseMoney, formatMoney, allocateUnitMoney } = require("../packages/compositeServicePackage");
 
+const ADMIN_STORE_BOOKING_AUTH = Symbol.for("cwf.adminStoreBookingAuthorized");
+
 const PACKAGE_ERROR_STATUS = Object.freeze({
   PACKAGE_IDENTITY_REQUIRED: 400,
   TIER_IDENTITY_REQUIRED: 400,
@@ -129,18 +131,24 @@ async function resolvePackageBooking({ body, bookingMode, appointmentDatetime, r
     if (request.composite) {
       if (!resolver || typeof resolver.resolveComposite !== "function") throw packageError("PACKAGE_UNAVAILABLE", 409);
 
-      // A prepaid purchase is not a booking. Only begin-redemption can mint the
-      // one-time token/request-key pair accepted here; all other attempts to book
-      // a prepaid_full campaign are rejected before availability/job mutation.
+      // Only the server-side Admin Store validator can add this Symbol marker.
+      // It is impossible to send over JSON, so public/customer requests cannot
+      // impersonate the Admin booking-on-behalf path.
+      const adminBookingOnBehalf = body?.[ADMIN_STORE_BOOKING_AUTH] === true;
+      const effectiveIdentity = adminBookingOnBehalf ? "admin" : identity;
+
+      // Customer prepaid purchases remain redemption-only. Admin is an explicit
+      // operational override: an authenticated Admin may place the purchased
+      // promotion directly onto the technician schedule for a customer.
       if (String(body.prepaid_redemption_token || "").trim()) {
         if (typeof resolver.resolvePrepaidRedemption !== "function") {
           throw packageError("PREPAID_REDEMPTION_REQUIRED", 409);
         }
-        return await resolver.resolvePrepaidRedemption({ body, bookingMode, appointmentDatetime, identity });
+        return await resolver.resolvePrepaidRedemption({ body, bookingMode, appointmentDatetime, identity: effectiveIdentity });
       }
 
-      const booking = await resolver.resolveComposite({ body, bookingMode, appointmentDatetime, identity });
-      if (booking?.paymentMode === "prepaid_full") {
+      const booking = await resolver.resolveComposite({ body, bookingMode, appointmentDatetime, identity: effectiveIdentity });
+      if (booking?.paymentMode === "prepaid_full" && !adminBookingOnBehalf) {
         throw packageError("PREPAID_REDEMPTION_REQUIRED", 409);
       }
       return booking;

--- a/test/adminPrepaidBookingOnBehalf.test.js
+++ b/test/adminPrepaidBookingOnBehalf.test.js
@@ -1,0 +1,101 @@
+"use strict";
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const {
+  ADMIN_STORE_BOOKING_AUTH,
+  validateAdminStorePromotionRequest,
+} = require("../server/services/booking/adminStorePromotionPolicy");
+const { resolvePackageBooking } = require("../server/services/booking/servicePackageBooking");
+
+function adminBundleBody() {
+  return {
+    catalog_item_id: "900",
+    service_package_groups: [
+      { package_key: "air-reset-60-standard-small", btu: 12000, quantity: 2 },
+    ],
+    admin_request_key: "admin_airreset_booking_123456",
+    items: [],
+    promotion_id: null,
+    override_price: 0,
+    override_duration_min: 0,
+  };
+}
+
+function prepaidResolver(calls) {
+  return {
+    async resolveComposite(input) {
+      calls.push(input);
+      return {
+        bundleId: "900",
+        bundleKey: "air-reset-60-standard",
+        paymentMode: "prepaid_full",
+        fixedTotal: "959.00",
+        durationMin: 120,
+        payload: { machine_count: 2 },
+        items: [],
+      };
+    },
+  };
+}
+
+test("Admin composite Store booking accepts catalog_item_id and receives server-only authorization", () => {
+  const body = adminBundleBody();
+  const result = validateAdminStorePromotionRequest(body, { createdBySource: "admin" });
+  assert.equal(result.kind, "service_package");
+  assert.equal(body[ADMIN_STORE_BOOKING_AUTH], true);
+  assert.equal(Object.keys(body).includes(String(ADMIN_STORE_BOOKING_AUTH)), false);
+});
+
+test("Admin can put a prepaid_full Store promotion directly on the schedule", async () => {
+  const body = adminBundleBody();
+  validateAdminStorePromotionRequest(body, { createdBySource: "admin" });
+  const calls = [];
+  const result = await resolvePackageBooking({
+    body,
+    bookingMode: "scheduled",
+    appointmentDatetime: "2026-09-10T10:00:00+07:00",
+    resolver: prepaidResolver(calls),
+    // createBookingJob historically passes customer for composite groups; the
+    // server-only authorization marker must safely upgrade only authenticated Admin.
+    identity: "customer",
+  });
+  assert.equal(result.paymentMode, "prepaid_full");
+  assert.equal(result.fixedTotal, "959.00");
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].identity, "admin");
+});
+
+test("Customer cannot bypass prepaid redemption by sending the same Store payload", async () => {
+  const body = adminBundleBody();
+  delete body.admin_request_key;
+  const calls = [];
+  await assert.rejects(
+    resolvePackageBooking({
+      body,
+      bookingMode: "scheduled",
+      appointmentDatetime: "2026-09-10T10:00:00+07:00",
+      resolver: prepaidResolver(calls),
+      identity: "customer",
+    }),
+    (error) => error && error.code === "PREPAID_REDEMPTION_REQUIRED" && error.statusCode === 409
+  );
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].identity, "customer");
+});
+
+test("Client string properties cannot forge the Admin server-only Symbol authorization", async () => {
+  const body = adminBundleBody();
+  body.__cwf_admin_store_booking_authorized = true;
+  delete body.admin_request_key;
+  await assert.rejects(
+    resolvePackageBooking({
+      body,
+      bookingMode: "scheduled",
+      appointmentDatetime: "2026-09-10T10:00:00+07:00",
+      resolver: prepaidResolver([]),
+      identity: "customer",
+    }),
+    (error) => error && error.code === "PREPAID_REDEMPTION_REQUIRED"
+  );
+});


### PR DESCRIPTION
Fix the Admin Add Job path for Store composite promotions, including AIR RESET 60 prepaid_full.

- accept the required catalog_item_id together with service_package_groups
- mark validated Admin Store bookings with a server-only Symbol capability
- resolve Admin composite Store packages with Admin identity
- allow authenticated Admin booking-on-behalf for prepaid_full without weakening customer redemption enforcement
- add regression tests proving customers still require PREPAID redemption

This targets the production symptom where Admin can select the promotion and slot but /admin/book_v2 rejects the booking before job creation.