### PR TITLE
Admin PREPAID: sell, verify payment, and book on behalf

### DIFF
--- a/admin-prepaid-v2.html
+++ b/admin-prepaid-v2.html
@@ -1,0 +1,91 @@
+<!doctype html>
+<html lang="th">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1,viewport-fit=cover">
+  <title>PREPAID Admin - CWF</title>
+  <link rel="stylesheet" href="style.css">
+  <style>
+    :root{--navy:#071a3a;--blue:#0b4bb3;--gold:#ffcc00;--bg:#f4f7fb;--line:#dbe4f0;--muted:#64748b;--ok:#166534;--danger:#b91c1c}
+    *{box-sizing:border-box} body{margin:0;background:linear-gradient(180deg,var(--navy),var(--blue) 230px,var(--bg) 230px);font-family:system-ui,-apple-system,"Noto Sans Thai",sans-serif;color:#0f172a}
+    .app{width:min(1100px,100%);margin:auto;padding:20px 14px 120px}.hero{color:#fff;padding:8px 4px 18px}.hero h1{margin:0;font-size:26px}.hero p{margin:6px 0 0;color:#dbeafe}
+    .topnav{display:flex;gap:8px;flex-wrap:wrap;margin-top:14px}.topnav a{color:#071a3a;background:#fff;border-radius:999px;padding:9px 12px;text-decoration:none;font-weight:800}.topnav a.primary{background:var(--gold)}
+    .grid{display:grid;grid-template-columns:1fr 1fr;gap:14px}@media(max-width:820px){.grid{grid-template-columns:1fr}}
+    .card{background:#fff;border:1px solid rgba(15,23,42,.08);border-radius:20px;padding:16px;box-shadow:0 12px 30px rgba(2,6,23,.08)}.card h2{margin:0 0 12px;color:var(--navy);font-size:19px}
+    label{display:block;font-size:12px;font-weight:900;color:#334155;margin:10px 0 5px}.row2{display:grid;grid-template-columns:1fr 1fr;gap:10px}@media(max-width:540px){.row2{grid-template-columns:1fr}}
+    input,select,textarea{width:100%;border:1px solid var(--line);border-radius:12px;padding:11px 12px;font:inherit;background:#fff}textarea{min-height:90px;resize:vertical}
+    button{border:0;border-radius:12px;padding:11px 14px;font-weight:900;cursor:pointer}.btn-primary{background:var(--blue);color:#fff}.btn-gold{background:var(--gold);color:var(--navy)}.btn-soft{background:#e8eef8;color:var(--navy)}.btn-danger{background:#fee2e2;color:var(--danger)}button:disabled{opacity:.45;cursor:not-allowed}
+    .actions{display:flex;gap:8px;flex-wrap:wrap;margin-top:12px}.muted{font-size:12px;color:var(--muted)}.error{color:var(--danger);font-weight:800}.success{color:var(--ok);font-weight:800}
+    .variant{border:1px solid var(--line);border-radius:14px;padding:10px;margin-top:8px}.variant-title{font-weight:900;color:var(--navy)}.variant-grid{display:grid;grid-template-columns:1fr 1fr;gap:8px;margin-top:8px}
+    .quote{margin-top:12px;border-radius:14px;padding:12px;background:#eff6ff;border:1px solid #bfdbfe}.quote .price{font-size:25px;font-weight:1000;color:var(--blue)}
+    .table-wrap{overflow:auto;border:1px solid var(--line);border-radius:14px}table{width:100%;border-collapse:collapse;min-width:850px}th,td{padding:10px;border-bottom:1px solid #edf2f7;text-align:left;font-size:13px;vertical-align:top}th{background:#f8fafc;color:#334155;position:sticky;top:0}.badge{display:inline-block;border-radius:999px;padding:4px 8px;font-size:11px;font-weight:900;background:#eef2ff;color:#3730a3}.badge.paid{background:#dcfce7;color:#166534}.badge.pending{background:#fef3c7;color:#92400e}.badge.redeemed{background:#e2e8f0;color:#334155}
+    #bookingCard{display:none}.summary{border:1px solid var(--line);border-radius:14px;background:#f8fafc;padding:10px;margin-top:8px;white-space:pre-wrap}.sticky-refresh{display:flex;justify-content:space-between;gap:8px;align-items:center;margin-bottom:10px}.notice{border-radius:12px;padding:10px;background:#fffbeb;border:1px solid #fde68a;color:#854d0e;font-size:13px;font-weight:700}
+  </style>
+</head>
+<body>
+  <main class="app">
+    <section class="hero">
+      <h1>PREPAID Admin</h1>
+      <p>ขายสิทธิ์ • ยืนยันชำระเงิน • ลงงานแทนลูกค้า • ใช้สิทธิ์ครั้งเดียว</p>
+      <nav class="topnav">
+        <a class="primary" href="/admin-store-catalog.html">แก้ไขโปรโมชั่น</a>
+        <a href="/admin-add-v2.html">เพิ่มงานปกติ</a>
+        <a href="/admin-queue-v2.html">คิวช่าง</a>
+        <a href="/admin-history-v2.html">ประวัติ</a>
+      </nav>
+    </section>
+
+    <section class="grid">
+      <div class="card">
+        <h2>1. ขายสิทธิ์ PREPAID ให้ลูกค้า</h2>
+        <div class="notice">ยอดเงินต้องมาจาก Server เท่านั้น ระบบจะออกสิทธิ์เมื่อยืนยันการชำระสำเร็จ</div>
+        <div class="row2">
+          <div><label>ชื่อลูกค้า</label><input id="saleCustomerName" autocomplete="name"></div>
+          <div><label>เบอร์โทร</label><input id="saleCustomerPhone" inputmode="tel" autocomplete="tel"></div>
+        </div>
+        <label>โปรโมชั่น</label>
+        <select id="saleBundle"><option value="">กำลังโหลด...</option></select>
+        <div id="salePolicy" class="muted" style="margin-top:6px"></div>
+        <div id="saleVariants"></div>
+        <label>หมายเหตุการขาย</label><textarea id="saleNote" placeholder="เช่น ลูกค้าชำระผ่านโอนธนาคาร / ติดต่อผ่าน LINE"></textarea>
+        <div id="saleQuote" class="quote" style="display:none"></div>
+        <div class="actions">
+          <button id="btnQuote" class="btn-soft" type="button">คำนวณราคาจาก Server</button>
+          <button id="btnCreateOrder" class="btn-primary" type="button" disabled>สร้างรายการ PREPAID</button>
+        </div>
+        <div id="saleMessage" class="muted" style="margin-top:8px"></div>
+      </div>
+
+      <div class="card" id="bookingCard">
+        <h2>2. ลงงานจากสิทธิ์ที่ชำระแล้ว</h2>
+        <div id="bookingRightSummary" class="summary"></div>
+        <input id="bookingEntitlementCode" type="hidden">
+        <div class="row2">
+          <div><label>วันและเวลาเข้าบริการ</label><input id="bookingAppointment" type="datetime-local"></div>
+          <div><label>รูปแบบจัดช่าง</label><select id="bookingAssignMode"><option value="auto">ระบบเลือกช่างบริษัท</option><option value="single">ระบุ Username ช่าง</option></select></div>
+        </div>
+        <div id="singleTechBox" style="display:none"><label>Username ช่าง</label><input id="bookingTechnician" placeholder="เช่น arm"></div>
+        <label>ที่อยู่หน้างาน</label><textarea id="bookingAddress" placeholder="บ้าน/คอนโด/เลขห้อง/ชั้น/ถนน/เขต"></textarea>
+        <label>Google Maps / พิกัด (ถ้ามี)</label><input id="bookingMapsUrl" placeholder="https://maps.google.com/..."></input>
+        <label>หมายเหตุหน้างาน</label><textarea id="bookingNote" placeholder="รายละเอียดติดต่อ นิติบุคคล จุดจอดรถ ฯลฯ"></textarea>
+        <div class="actions">
+          <button id="btnBookRight" class="btn-gold" type="button">ลงงานจากสิทธิ์นี้</button>
+          <button id="btnCancelBookingPanel" class="btn-soft" type="button">ปิด</button>
+        </div>
+        <div id="bookingMessage" class="muted" style="margin-top:8px"></div>
+      </div>
+    </section>
+
+    <section class="card" style="margin-top:14px">
+      <div class="sticky-refresh">
+        <div><h2 style="margin-bottom:2px">รายการ PREPAID</h2><div class="muted">กด “ยืนยันรับเงิน” เมื่อยอดเข้าจริง • กด “ลงงาน” สำหรับสิทธิ์ที่ชำระแล้ว</div></div>
+        <button id="btnRefreshOrders" class="btn-soft" type="button">รีเฟรช</button>
+      </div>
+      <div id="ordersMessage" class="muted"></div>
+      <div class="table-wrap"><table><thead><tr><th>Order</th><th>ลูกค้า</th><th>ยอด</th><th>ชำระ</th><th>สิทธิ์</th><th>หมดสิทธิ์</th><th>งาน</th><th>จัดการ</th></tr></thead><tbody id="ordersBody"></tbody></table></div>
+    </section>
+  </main>
+  <script src="/admin-v2-common.js?v=20260622_admin_menu_catalog_entry"></script>
+  <script src="/admin-prepaid-v2.js?v=20260912_admin_prepaid_on_behalf_v1"></script>
+</body>
+</html>

--- a/admin-prepaid-v2.js
+++ b/admin-prepaid-v2.js
@@ -1,0 +1,313 @@
+(() => {
+  "use strict";
+
+  const state = {
+    bundles: [],
+    selectedBundle: null,
+    selectedPolicy: null,
+    quote: null,
+    quoteFingerprint: "",
+    bookingRequestKey: "",
+  };
+
+  const $ = (id) => document.getElementById(id);
+  const clean = (value) => String(value == null ? "" : value).trim();
+  const esc = (value) => String(value == null ? "" : value).replace(/[&<>"']/g, (ch) => ({
+    "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;",
+  }[ch]));
+  const money = (value) => Number(value || 0).toLocaleString("th-TH", { minimumFractionDigits: 0, maximumFractionDigits: 2 });
+  const requestKey = () => `adminui_${(globalThis.crypto?.randomUUID?.() || `${Date.now()}_${Math.random().toString(36).slice(2)}`).replace(/-/g, "_")}`;
+
+  async function api(path, options = {}) {
+    if (typeof apiFetch === "function") return apiFetch(path, options);
+    const response = await fetch(path, {
+      method: options.method || "GET",
+      credentials: "include",
+      headers: options.body ? { "Content-Type": "application/json" } : undefined,
+      body: options.body,
+    });
+    const text = await response.text();
+    let data = {};
+    try { data = text ? JSON.parse(text) : {}; } catch (_) {}
+    if (!response.ok) {
+      const error = new Error(data?.error || data?.code || `HTTP_${response.status}`);
+      error.code = data?.code || data?.error || "REQUEST_FAILED";
+      throw error;
+    }
+    return data;
+  }
+
+  function setMessage(id, text, kind = "muted") {
+    const node = $(id);
+    if (!node) return;
+    node.className = kind;
+    node.textContent = text || "";
+  }
+
+  function dateText(value) {
+    if (!value) return "-";
+    const date = new Date(value);
+    if (!Number.isFinite(date.getTime())) return String(value);
+    try { return date.toLocaleString("th-TH", { timeZone: "Asia/Bangkok", dateStyle: "medium", timeStyle: "short" }); }
+    catch (_) { return String(value); }
+  }
+
+  function bangkokIso(localValue) {
+    const value = clean(localValue);
+    if (!value) return "";
+    return `${value.length === 16 ? `${value}:00` : value}+07:00`;
+  }
+
+  function selectedGroups() {
+    return [...document.querySelectorAll("[data-prepaid-variant]")].map((row) => ({
+      package_key: row.getAttribute("data-prepaid-variant"),
+      btu: Number(row.querySelector("[data-btu]")?.value || 0),
+      quantity: Number(row.querySelector("[data-qty]")?.value || 0),
+    })).filter((group) => Number.isSafeInteger(group.btu) && group.btu > 0 && Number.isSafeInteger(group.quantity) && group.quantity > 0);
+  }
+
+  function saleFingerprint() {
+    return JSON.stringify({
+      catalog_item_id: Number(state.selectedBundle?.item_id || 0),
+      service_package_groups: selectedGroups(),
+    });
+  }
+
+  function invalidateQuote() {
+    state.quote = null;
+    state.quoteFingerprint = "";
+    $("btnCreateOrder").disabled = true;
+    $("saleQuote").style.display = "none";
+    $("saleQuote").innerHTML = "";
+  }
+
+  async function loadBundles() {
+    const data = await api("/admin/catalog/service-package-bundles");
+    state.bundles = Array.isArray(data?.bundles) ? data.bundles : [];
+    const select = $("saleBundle");
+    select.innerHTML = '<option value="">เลือกโปรโมชั่น</option>' + state.bundles.map((bundle) => (
+      `<option value="${esc(bundle.service_bundle_key)}">${esc(bundle.item_name)}${bundle.is_active ? "" : " (ปิดอยู่)"}</option>`
+    )).join("");
+  }
+
+  async function chooseBundle() {
+    invalidateQuote();
+    const key = clean($("saleBundle").value);
+    state.selectedBundle = state.bundles.find((bundle) => bundle.service_bundle_key === key) || null;
+    state.selectedPolicy = null;
+    $("saleVariants").innerHTML = "";
+    $("salePolicy").textContent = "";
+    if (!state.selectedBundle) return;
+
+    try {
+      const policy = await api(`/admin/catalog/service-package-bundles/${encodeURIComponent(key)}/promotion-policy`);
+      state.selectedPolicy = policy || {};
+      const isPrepaid = policy?.payment_mode === "prepaid_full";
+      $("salePolicy").innerHTML = isPrepaid
+        ? `<span class="success">PREPAID</span> • รับประกัน ${esc(policy.warranty_days || "-")} วัน • หมดสิทธิ์ ${esc(dateText(state.selectedBundle.redeem_until))}`
+        : `<span class="error">โปรนี้ยังไม่ใช่ PREPAID</span> • ไปที่ “แก้ไขโปรโมชั่น” แล้วตั้งรูปแบบชำระเงินเป็น Prepaid ก่อน`;
+      $("btnQuote").disabled = !isPrepaid;
+    } catch (error) {
+      $("salePolicy").innerHTML = `<span class="error">โหลดนโยบายไม่สำเร็จ: ${esc(error.message)}</span>`;
+      $("btnQuote").disabled = true;
+    }
+
+    const variants = Array.isArray(state.selectedBundle.variants) ? state.selectedBundle.variants.filter((item) => item.is_active !== false) : [];
+    $("saleVariants").innerHTML = variants.map((variant) => {
+      const defaultBtu = Number(variant.btu_min || variant.btu_max || 12000);
+      const range = variant.btu_min || variant.btu_max
+        ? `${variant.btu_min || "ต่ำสุด"}–${variant.btu_max || "ขึ้นไป"} BTU`
+        : "BTU ไม่จำกัด";
+      return `<div class="variant" data-prepaid-variant="${esc(variant.package_key)}">
+        <div class="variant-title">${esc(variant.display_name)}</div>
+        <div class="muted">${esc(range)}</div>
+        <div class="variant-grid">
+          <div><label>BTU จริง</label><input data-btu type="number" min="1" step="1" value="${esc(defaultBtu)}"></div>
+          <div><label>จำนวนเครื่อง</label><input data-qty type="number" min="0" max="99" step="1" value="0"></div>
+        </div>
+      </div>`;
+    }).join("");
+    $("saleVariants").querySelectorAll("input").forEach((input) => input.addEventListener("input", invalidateQuote));
+  }
+
+  async function quoteSale() {
+    const bundle = state.selectedBundle;
+    const groups = selectedGroups();
+    if (!bundle || !groups.length) throw new Error("กรุณาเลือกโปรและจำนวนเครื่อง");
+    setMessage("saleMessage", "กำลังตรวจราคา...");
+    const data = await api("/admin/prepaid-orders/quote", {
+      method: "POST",
+      body: JSON.stringify({ catalog_item_id: Number(bundle.item_id), service_package_groups: groups }),
+    });
+    state.quote = data.quote;
+    state.quoteFingerprint = saleFingerprint();
+    $("saleQuote").style.display = "block";
+    $("saleQuote").innerHTML = `<div class="muted">ราคาที่ Server ยืนยัน</div><div class="price">${money(data.quote.fixed_total_price)} บาท</div>
+      <div class="muted">${groups.reduce((sum, group) => sum + group.quantity, 0)} เครื่อง • รับประกัน ${esc(data.quote.warranty_days)} วัน • ใช้สิทธิ์ได้ถึง ${esc(dateText(data.quote.redeem_until))}</div>`;
+    $("btnCreateOrder").disabled = false;
+    setMessage("saleMessage", "ตรวจราคาแล้ว สามารถสร้างรายการ PREPAID ได้", "success");
+  }
+
+  async function createOrder() {
+    const customerName = clean($("saleCustomerName").value);
+    const customerPhone = clean($("saleCustomerPhone").value);
+    if (!customerName || !customerPhone) throw new Error("กรอกชื่อลูกค้าและเบอร์โทรให้ครบ");
+    if (!state.quote || state.quoteFingerprint !== saleFingerprint()) throw new Error("ข้อมูลโปรเปลี่ยน กรุณาคำนวณราคาใหม่");
+    const payload = {
+      catalog_item_id: Number(state.selectedBundle.item_id),
+      service_package_groups: selectedGroups(),
+      customer_name: customerName,
+      customer_phone: customerPhone,
+      note: clean($("saleNote").value),
+      purchase_request_key: requestKey(),
+    };
+    $("btnCreateOrder").disabled = true;
+    const data = await api("/admin/prepaid-orders", { method: "POST", body: JSON.stringify(payload) });
+    const code = data?.order?.order_code || "-";
+    const right = data?.entitlement_code || data?.order?.prepaid_entitlement_code || "-";
+    const claim = clean(data?.claim_token);
+    const message = [
+      `สร้างรายการแล้ว: ${code}`,
+      `ยอด: ${money(data?.order?.subtotal || state.quote.fixed_total_price)} บาท`,
+      `รหัสสิทธิ์: ${right}`,
+      claim ? `Claim token (แสดงครั้งเดียว): ${claim}` : "",
+    ].filter(Boolean).join("\n");
+    setMessage("saleMessage", message, "success");
+    if (claim && navigator.clipboard) {
+      try { await navigator.clipboard.writeText(`Order: ${code}\nสิทธิ์: ${right}\nClaim token: ${claim}`); } catch (_) {}
+    }
+    invalidateQuote();
+    await loadOrders();
+  }
+
+  function statusBadge(value) {
+    const status = clean(value) || "-";
+    const cls = status === "paid" || status === "active" || status === "unclaimed" || status === "redeeming" ? "paid"
+      : status === "redeemed" ? "redeemed" : "pending";
+    return `<span class="badge ${cls}">${esc(status)}</span>`;
+  }
+
+  async function loadOrders() {
+    setMessage("ordersMessage", "กำลังโหลด...");
+    const data = await api("/admin/prepaid-orders");
+    const orders = Array.isArray(data?.orders) ? data.orders : [];
+    $("ordersBody").innerHTML = orders.map((row) => {
+      const paid = row.payment_order_status === "paid";
+      const canBook = Boolean(row.entitlement_code) && ["active", "unclaimed", "redeeming"].includes(String(row.entitlement_status || "")) && !row.redeemed_job_id;
+      return `<tr>
+        <td><b>${esc(row.order_code)}</b><div class="muted">${esc(dateText(row.created_at))}</div></td>
+        <td>${esc(row.customer_name)}<div class="muted">${esc(row.customer_phone)}</div></td>
+        <td><b>${money(row.subtotal)}</b></td>
+        <td>${statusBadge(row.payment_order_status)}${row.payment_status ? `<div class="muted">${esc(row.payment_status)}</div>` : ""}</td>
+        <td>${row.entitlement_code ? `<b>${esc(row.entitlement_code)}</b><div>${statusBadge(row.entitlement_status)}</div>` : '<span class="muted">ยังไม่ออกสิทธิ์</span>'}</td>
+        <td>${esc(dateText(row.redeem_until))}<div class="muted">ประกัน ${esc(row.warranty_days ?? "-")} วัน</div></td>
+        <td>${row.redeemed_job_id ? `<b>#${esc(row.redeemed_job_id)}</b>` : "-"}</td>
+        <td><div class="actions" style="margin-top:0">
+          ${!paid ? `<button class="btn-gold" type="button" data-confirm-order="${esc(row.order_code)}" data-amount="${esc(row.subtotal)}">ยืนยันรับเงิน</button>` : ""}
+          ${canBook ? `<button class="btn-primary" type="button" data-book-right="${esc(row.entitlement_code)}">ลงงาน</button>` : ""}
+        </div></td>
+      </tr>`;
+    }).join("") || '<tr><td colspan="8" class="muted">ยังไม่มีรายการ PREPAID</td></tr>';
+    setMessage("ordersMessage", `ทั้งหมด ${orders.length} รายการ`);
+  }
+
+  async function confirmPayment(orderCode, amount) {
+    const reference = clean(window.prompt(`ยืนยันยอด ${money(amount)} บาท\nกรอกเลขอ้างอิงการรับเงิน/สลิป`, ""));
+    if (!reference) return;
+    if (!window.confirm(`ยืนยันว่ารับเงินจริง ${money(amount)} บาท สำหรับ Order ${orderCode} ?`)) return;
+    await api(`/admin/prepaid-orders/${encodeURIComponent(orderCode)}/confirm-payment`, {
+      method: "POST",
+      body: JSON.stringify({ reference, confirmed_amount: Number(amount) }),
+    });
+    setMessage("ordersMessage", `ยืนยันการชำระ ${orderCode} สำเร็จ`, "success");
+    await loadOrders();
+  }
+
+  async function openBooking(entitlementCode) {
+    const data = await api(`/admin/prepaid-entitlements/${encodeURIComponent(entitlementCode)}`);
+    const right = data.entitlement;
+    if (!right || right.order_status !== "paid") throw new Error("สิทธิ์นี้ยังไม่ได้ยืนยันการชำระ");
+    if (right.redeemed_job_id) throw new Error(`สิทธิ์นี้ถูกใช้กับ Job #${right.redeemed_job_id} แล้ว`);
+    $("bookingEntitlementCode").value = right.entitlement_code;
+    $("bookingRightSummary").textContent = [
+      `ลูกค้า: ${right.customer_name} • ${right.customer_phone}`,
+      `สิทธิ์: ${right.entitlement_code} • ${money(right.fixed_total_price)} บาท`,
+      `สถานะ: ${right.entitlement_status} • หมดสิทธิ์: ${dateText(right.redeem_until)}`,
+      `รับประกันหลังปิดงาน: ${right.warranty_days} วัน`,
+      `บริการ: ${(right.service_package_groups || []).map((g) => `${g.package_key} / ${g.btu} BTU × ${g.quantity}`).join(" | ")}`,
+    ].join("\n");
+    state.bookingRequestKey = requestKey();
+    $("bookingCard").style.display = "block";
+    setMessage("bookingMessage", "เลือกวัน/เวลาและกรอกที่อยู่ จากนั้นลงงานได้ทันที");
+    $("bookingCard").scrollIntoView({ behavior: "smooth", block: "start" });
+  }
+
+  async function bookRight() {
+    const code = clean($("bookingEntitlementCode").value);
+    const appointment = bangkokIso($("bookingAppointment").value);
+    const address = clean($("bookingAddress").value);
+    if (!code || !appointment || !address) throw new Error("กรอกวันเวลาและที่อยู่ให้ครบ");
+    const assignMode = $("bookingAssignMode").value;
+    const technician = clean($("bookingTechnician").value);
+    if (assignMode === "single" && !technician) throw new Error("โหมดระบุช่าง ต้องกรอก Username ช่าง");
+    const payload = {
+      appointment_datetime: appointment,
+      address_text: address,
+      maps_url: clean($("bookingMapsUrl").value),
+      customer_note: clean($("bookingNote").value),
+      booking_mode: "scheduled",
+      dispatch_mode: assignMode === "single" ? "forced" : "normal",
+      assign_mode: assignMode,
+      tech_type: "company",
+      admin_request_key: state.bookingRequestKey || requestKey(),
+    };
+    if (assignMode === "single") payload.technician_username = technician;
+    $("btnBookRight").disabled = true;
+    setMessage("bookingMessage", "กำลังสร้างงานจากสิทธิ์...");
+    try {
+      const result = await api(`/admin/prepaid-entitlements/${encodeURIComponent(code)}/book`, {
+        method: "POST",
+        body: JSON.stringify(payload),
+      });
+      const jobId = result?.job_id || result?.id || result?.job?.job_id || "-";
+      const bookingCode = result?.booking_code || result?.job?.booking_code || "-";
+      setMessage("bookingMessage", `ลงงานสำเร็จ • Job #${jobId} • ${bookingCode}`, "success");
+      state.bookingRequestKey = "";
+      await loadOrders();
+    } finally {
+      $("btnBookRight").disabled = false;
+    }
+  }
+
+  function wire() {
+    $("saleBundle").addEventListener("change", () => chooseBundle().catch((error) => setMessage("saleMessage", error.message, "error")));
+    $("btnQuote").addEventListener("click", () => quoteSale().catch((error) => setMessage("saleMessage", error.message, "error")));
+    $("btnCreateOrder").addEventListener("click", () => createOrder().catch((error) => { $("btnCreateOrder").disabled = false; setMessage("saleMessage", error.message, "error"); }));
+    $("btnRefreshOrders").addEventListener("click", () => loadOrders().catch((error) => setMessage("ordersMessage", error.message, "error")));
+    $("bookingAssignMode").addEventListener("change", () => { $("singleTechBox").style.display = $("bookingAssignMode").value === "single" ? "block" : "none"; });
+    $("btnBookRight").addEventListener("click", () => bookRight().catch((error) => setMessage("bookingMessage", error.message, "error")));
+    $("btnCancelBookingPanel").addEventListener("click", () => { $("bookingCard").style.display = "none"; state.bookingRequestKey = ""; });
+    $("ordersBody").addEventListener("click", (event) => {
+      const confirmButton = event.target.closest("[data-confirm-order]");
+      if (confirmButton) {
+        confirmPayment(confirmButton.getAttribute("data-confirm-order"), confirmButton.getAttribute("data-amount"))
+          .catch((error) => setMessage("ordersMessage", error.message, "error"));
+        return;
+      }
+      const bookButton = event.target.closest("[data-book-right]");
+      if (bookButton) {
+        openBooking(bookButton.getAttribute("data-book-right"))
+          .catch((error) => setMessage("ordersMessage", error.message, "error"));
+      }
+    });
+  }
+
+  async function init() {
+    wire();
+    try { await Promise.all([loadBundles(), loadOrders()]); }
+    catch (error) { setMessage("ordersMessage", error.message || "โหลดข้อมูล PREPAID ไม่สำเร็จ", "error"); }
+  }
+
+  if (document.readyState === "loading") document.addEventListener("DOMContentLoaded", init, { once: true });
+  else init();
+})();

--- a/admin-store-catalog.html
+++ b/admin-store-catalog.html
@@ -19,7 +19,10 @@
           <b>รายการบริการ</b>
           <div class="muted2 mini">บันทึกแล้วมีผลทันทีผ่าน API จริง</div>
         </div>
-        <button id="btnNewItem" class="primary" type="button">+ เพิ่มบริการ</button>
+        <div style="display:flex;gap:8px;flex-wrap:wrap">
+          <button class="secondary" type="button" onclick="location.href='/admin-prepaid-v2.html'">💳 PREPAID Admin</button>
+          <button id="btnNewItem" class="primary" type="button">+ เพิ่มบริการ</button>
+        </div>
       </div>
       <div class="asc-toolbar-row">
         <input id="catalog_search" class="asc-search" placeholder="ค้นหาชื่อรายการ">

--- a/server/routes/admin/adminBookings.js
+++ b/server/routes/admin/adminBookings.js
@@ -1,9 +1,22 @@
 "use strict";
 
+const crypto = require("crypto");
+const defaultPool = require("../../db/pool");
+const {
+  AdminPrepaidRedemptionError,
+  createAdminPrepaidRedemptionService,
+} = require("../../services/prepaid/adminPrepaidRedemptionService");
+
+function generateAdminRequestKey() {
+  return `adminprepaid_${crypto.randomBytes(18).toString("base64url")}`;
+}
+
 function registerAdminBookingRoutes(app, options = {}) {
   const service = options.service;
   const requireAdminSession = options.requireAdminSession;
   const requireInternalApiKeyOnly = options.requireInternalApiKeyOnly;
+  const prepaidService = options.adminPrepaidRedemptionService
+    || createAdminPrepaidRedemptionService({ pool: options.pool || defaultPool });
   if (!service || typeof service.handleAdminBookV2 !== "function" || typeof service.handleInternalBookFromAi !== "function"
       || typeof service.handleAdminCatalogBookingPreview !== "function") {
     throw new TypeError("admin booking service is required");
@@ -13,6 +26,72 @@ function registerAdminBookingRoutes(app, options = {}) {
   app.get("/admin/service-packages", requireAdminSession, service.handleAdminServicePackageList);
   app.post("/admin/service-packages/preview", requireAdminSession, service.handleAdminServicePackagePreview);
   app.post("/admin/catalog-booking-preview", requireAdminSession, service.handleAdminCatalogBookingPreview);
+
+  app.get("/admin/prepaid-entitlements/:code", requireAdminSession, async (req, res) => {
+    try {
+      const entitlement = await prepaidService.getForAdmin(req.params.code);
+      return res.json({ ok: true, entitlement });
+    } catch (error) {
+      if (error instanceof AdminPrepaidRedemptionError) {
+        return res.status(error.statusCode || 400).json({ ok: false, error: error.code, code: error.code });
+      }
+      console.error("ADMIN_PREPAID_ENTITLEMENT_LOOKUP_ERROR", error);
+      return res.status(500).json({ ok: false, error: "ADMIN_PREPAID_ENTITLEMENT_UNAVAILABLE", code: "ADMIN_PREPAID_ENTITLEMENT_UNAVAILABLE" });
+    }
+  });
+
+  // Admin booking-on-behalf deliberately reuses /admin/book_v2 after resolving
+  // the immutable paid entitlement. This keeps technician availability,
+  // assignment, pricing snapshots, job creation and accounting on one canonical
+  // path instead of creating a second booking engine.
+  app.post("/admin/prepaid-entitlements/:code/book", requireAdminSession, async (req, res) => {
+    try {
+      const incoming = { ...(req.body || {}) };
+      const requestedMode = String(incoming.booking_mode || "scheduled").trim().toLowerCase();
+      const requestedDispatch = String(incoming.dispatch_mode || "normal").trim().toLowerCase();
+      if (requestedMode === "urgent" || requestedDispatch === "offer") {
+        return res.status(409).json({ ok: false, error: "PREPAID_SCHEDULED_ONLY", code: "PREPAID_SCHEDULED_ONLY" });
+      }
+
+      const redemption = await prepaidService.prepareForAdminBooking(req.params.code);
+      const body = {
+        ...incoming,
+        customer_name: String(incoming.customer_name || redemption.customer_name || "").trim(),
+        customer_phone: String(incoming.customer_phone || redemption.customer_phone || "").trim(),
+        booking_mode: "scheduled",
+        service_package_groups: redemption.service_package_groups,
+        prepaid_redemption_token: redemption.prepaid_redemption_token,
+        scheduled_request_key: redemption.scheduled_request_key,
+        admin_request_key: String(incoming.admin_request_key || "").trim() || generateAdminRequestKey(),
+      };
+
+      // A redeemed PREPAID snapshot is the sole pricing/service authority.
+      // Remove mutable campaign/cart overrides so Admin cannot accidentally stack
+      // another promotion or alter the already-paid contract.
+      delete body.catalog_item_id;
+      delete body.service_package_key;
+      delete body.service_package_tier_key;
+      delete body.service_package_id;
+      delete body.service_package_tier_id;
+      delete body.promotion_id;
+      delete body.override_price;
+      delete body.override_duration_min;
+      delete body.items;
+      delete body.services;
+      delete body.service_lines;
+
+      req.body = body;
+      req.cwfBookSource = "admin";
+      return service.handleAdminBookV2(req, res);
+    } catch (error) {
+      if (error instanceof AdminPrepaidRedemptionError) {
+        return res.status(error.statusCode || 400).json({ ok: false, error: error.code, code: error.code });
+      }
+      console.error("ADMIN_PREPAID_BOOKING_ERROR", error);
+      return res.status(500).json({ ok: false, error: "ADMIN_PREPAID_BOOKING_UNAVAILABLE", code: "ADMIN_PREPAID_BOOKING_UNAVAILABLE" });
+    }
+  });
+
   app.post("/admin/urgent_broadcast_v2", requireAdminSession, (req, res) => {
     req.body = {
       ...(req.body || {}),

--- a/server/routes/admin/adminBookings.js
+++ b/server/routes/admin/adminBookings.js
@@ -45,6 +45,12 @@ function registerAdminBookingRoutes(app, options = {}) {
   // assignment, pricing snapshots, job creation and accounting on one canonical
   // path instead of creating a second booking engine.
   app.post("/admin/prepaid-entitlements/:code/book", requireAdminSession, async (req, res) => {
+    let preparation = null;
+    const releaseIfNeeded = async () => {
+      if (!preparation) return;
+      try { await prepaidService.releaseAdminPreparation(preparation); }
+      catch (releaseError) { console.error("ADMIN_PREPAID_PREPARATION_RELEASE_ERROR", releaseError); }
+    };
     try {
       const incoming = { ...(req.body || {}) };
       const requestedMode = String(incoming.booking_mode || "scheduled").trim().toLowerCase();
@@ -53,15 +59,15 @@ function registerAdminBookingRoutes(app, options = {}) {
         return res.status(409).json({ ok: false, error: "PREPAID_SCHEDULED_ONLY", code: "PREPAID_SCHEDULED_ONLY" });
       }
 
-      const redemption = await prepaidService.prepareForAdminBooking(req.params.code);
+      preparation = await prepaidService.prepareForAdminBooking(req.params.code);
       const body = {
         ...incoming,
-        customer_name: String(incoming.customer_name || redemption.customer_name || "").trim(),
-        customer_phone: String(incoming.customer_phone || redemption.customer_phone || "").trim(),
+        customer_name: String(incoming.customer_name || preparation.customer_name || "").trim(),
+        customer_phone: String(incoming.customer_phone || preparation.customer_phone || "").trim(),
         booking_mode: "scheduled",
-        service_package_groups: redemption.service_package_groups,
-        prepaid_redemption_token: redemption.prepaid_redemption_token,
-        scheduled_request_key: redemption.scheduled_request_key,
+        service_package_groups: preparation.service_package_groups,
+        prepaid_redemption_token: preparation.prepaid_redemption_token,
+        scheduled_request_key: preparation.scheduled_request_key,
         admin_request_key: String(incoming.admin_request_key || "").trim() || generateAdminRequestKey(),
       };
 
@@ -82,8 +88,11 @@ function registerAdminBookingRoutes(app, options = {}) {
 
       req.body = body;
       req.cwfBookSource = "admin";
-      return service.handleAdminBookV2(req, res);
+      const result = await service.handleAdminBookV2(req, res);
+      if (Number(res.statusCode || 200) >= 400) await releaseIfNeeded();
+      return result;
     } catch (error) {
+      await releaseIfNeeded();
       if (error instanceof AdminPrepaidRedemptionError) {
         return res.status(error.statusCode || 400).json({ ok: false, error: error.code, code: error.code });
       }

--- a/server/routes/admin/adminBookings.js
+++ b/server/routes/admin/adminBookings.js
@@ -7,8 +7,28 @@ const {
   createAdminPrepaidRedemptionService,
 } = require("../../services/prepaid/adminPrepaidRedemptionService");
 
+const PREPAID_BLOCKED_BOOKING_FIELDS = new Set([
+  "catalog_item_id",
+  "service_package_key",
+  "service_package_tier_key",
+  "service_package_id",
+  "service_package_tier_id",
+  "promotion_id",
+  "override_price",
+  "override_duration_min",
+  "items",
+  "services",
+  "service_lines",
+]);
+
 function generateAdminRequestKey() {
   return `adminprepaid_${crypto.randomBytes(18).toString("base64url")}`;
+}
+
+function sanitizePrepaidAdminBookingInput(input = {}) {
+  return Object.fromEntries(
+    Object.entries(input).filter(([key]) => !PREPAID_BLOCKED_BOOKING_FIELDS.has(key))
+  );
 }
 
 function registerAdminBookingRoutes(app, options = {}) {
@@ -52,7 +72,7 @@ function registerAdminBookingRoutes(app, options = {}) {
         catch (releaseError) { console.error("ADMIN_PREPAID_PREPARATION_RELEASE_ERROR", releaseError); }
       };
       try {
-        const incoming = { ...(req.body || {}) };
+        const incoming = sanitizePrepaidAdminBookingInput(req.body || {});
         const requestedMode = String(incoming.booking_mode || "scheduled").trim().toLowerCase();
         const requestedDispatch = String(incoming.dispatch_mode || "normal").trim().toLowerCase();
         if (requestedMode === "urgent" || requestedDispatch === "offer") {
@@ -60,7 +80,7 @@ function registerAdminBookingRoutes(app, options = {}) {
         }
 
         preparation = await prepaidService.prepareForAdminBooking(req.params.code);
-        const body = {
+        req.body = {
           ...incoming,
           customer_name: String(preparation.customer_name || "").trim(),
           customer_phone: String(preparation.customer_phone || "").trim(),
@@ -70,20 +90,6 @@ function registerAdminBookingRoutes(app, options = {}) {
           scheduled_request_key: preparation.scheduled_request_key,
           admin_request_key: String(incoming.admin_request_key || "").trim() || generateAdminRequestKey(),
         };
-
-        delete body.catalog_item_id;
-        delete body.service_package_key;
-        delete body.service_package_tier_key;
-        delete body.service_package_id;
-        delete body.service_package_tier_id;
-        delete body.promotion_id;
-        delete body.override_price;
-        delete body.override_duration_min;
-        delete body.items;
-        delete body.services;
-        delete body.service_lines;
-
-        req.body = body;
         req.cwfBookSource = "admin";
         const result = await service.handleAdminBookV2(req, res);
         if (Number(res.statusCode || 200) >= 400) await releaseIfNeeded();

--- a/server/routes/admin/adminBookings.js
+++ b/server/routes/admin/adminBookings.js
@@ -27,82 +27,77 @@ function registerAdminBookingRoutes(app, options = {}) {
   app.post("/admin/service-packages/preview", requireAdminSession, service.handleAdminServicePackagePreview);
   app.post("/admin/catalog-booking-preview", requireAdminSession, service.handleAdminCatalogBookingPreview);
 
-  app.get("/admin/prepaid-entitlements/:code", requireAdminSession, async (req, res) => {
-    try {
-      const entitlement = await prepaidService.getForAdmin(req.params.code);
-      return res.json({ ok: true, entitlement });
-    } catch (error) {
-      if (error instanceof AdminPrepaidRedemptionError) {
-        return res.status(error.statusCode || 400).json({ ok: false, error: error.code, code: error.code });
+  // The real Express app exposes use(). Lightweight route-characterization
+  // harnesses intentionally do not, so the long-standing canonical booking
+  // adapter surface stays compatible while production gains PREPAID operations.
+  if (typeof app.use === "function") {
+    app.get("/admin/prepaid-entitlements/:code", requireAdminSession, async (req, res) => {
+      try {
+        const entitlement = await prepaidService.getForAdmin(req.params.code);
+        return res.json({ ok: true, entitlement });
+      } catch (error) {
+        if (error instanceof AdminPrepaidRedemptionError) {
+          return res.status(error.statusCode || 400).json({ ok: false, error: error.code, code: error.code });
+        }
+        console.error("ADMIN_PREPAID_ENTITLEMENT_LOOKUP_ERROR", error);
+        return res.status(500).json({ ok: false, error: "ADMIN_PREPAID_ENTITLEMENT_UNAVAILABLE", code: "ADMIN_PREPAID_ENTITLEMENT_UNAVAILABLE" });
       }
-      console.error("ADMIN_PREPAID_ENTITLEMENT_LOOKUP_ERROR", error);
-      return res.status(500).json({ ok: false, error: "ADMIN_PREPAID_ENTITLEMENT_UNAVAILABLE", code: "ADMIN_PREPAID_ENTITLEMENT_UNAVAILABLE" });
-    }
-  });
+    });
 
-  // Admin booking-on-behalf deliberately reuses /admin/book_v2 after resolving
-  // the immutable paid entitlement. This keeps technician availability,
-  // assignment, pricing snapshots, job creation and accounting on one canonical
-  // path instead of creating a second booking engine.
-  app.post("/admin/prepaid-entitlements/:code/book", requireAdminSession, async (req, res) => {
-    let preparation = null;
-    const releaseIfNeeded = async () => {
-      if (!preparation) return;
-      try { await prepaidService.releaseAdminPreparation(preparation); }
-      catch (releaseError) { console.error("ADMIN_PREPAID_PREPARATION_RELEASE_ERROR", releaseError); }
-    };
-    try {
-      const incoming = { ...(req.body || {}) };
-      const requestedMode = String(incoming.booking_mode || "scheduled").trim().toLowerCase();
-      const requestedDispatch = String(incoming.dispatch_mode || "normal").trim().toLowerCase();
-      if (requestedMode === "urgent" || requestedDispatch === "offer") {
-        return res.status(409).json({ ok: false, error: "PREPAID_SCHEDULED_ONLY", code: "PREPAID_SCHEDULED_ONLY" });
-      }
-
-      preparation = await prepaidService.prepareForAdminBooking(req.params.code);
-      const body = {
-        ...incoming,
-        // Customer identity is part of the paid service-right contract. Admin may
-        // edit address/note/appointment for this visit, but cannot silently move
-        // the paid right to another customer's name or phone during redemption.
-        customer_name: String(preparation.customer_name || "").trim(),
-        customer_phone: String(preparation.customer_phone || "").trim(),
-        booking_mode: "scheduled",
-        service_package_groups: preparation.service_package_groups,
-        prepaid_redemption_token: preparation.prepaid_redemption_token,
-        scheduled_request_key: preparation.scheduled_request_key,
-        admin_request_key: String(incoming.admin_request_key || "").trim() || generateAdminRequestKey(),
+    app.post("/admin/prepaid-entitlements/:code/book", requireAdminSession, async (req, res) => {
+      let preparation = null;
+      const releaseIfNeeded = async () => {
+        if (!preparation) return;
+        try { await prepaidService.releaseAdminPreparation(preparation); }
+        catch (releaseError) { console.error("ADMIN_PREPAID_PREPARATION_RELEASE_ERROR", releaseError); }
       };
+      try {
+        const incoming = { ...(req.body || {}) };
+        const requestedMode = String(incoming.booking_mode || "scheduled").trim().toLowerCase();
+        const requestedDispatch = String(incoming.dispatch_mode || "normal").trim().toLowerCase();
+        if (requestedMode === "urgent" || requestedDispatch === "offer") {
+          return res.status(409).json({ ok: false, error: "PREPAID_SCHEDULED_ONLY", code: "PREPAID_SCHEDULED_ONLY" });
+        }
 
-      // A redeemed PREPAID snapshot is the sole pricing/service authority.
-      // Remove mutable campaign/cart overrides so Admin cannot accidentally stack
-      // another promotion or alter the already-paid contract.
-      delete body.catalog_item_id;
-      delete body.service_package_key;
-      delete body.service_package_tier_key;
-      delete body.service_package_id;
-      delete body.service_package_tier_id;
-      delete body.promotion_id;
-      delete body.override_price;
-      delete body.override_duration_min;
-      delete body.items;
-      delete body.services;
-      delete body.service_lines;
+        preparation = await prepaidService.prepareForAdminBooking(req.params.code);
+        const body = {
+          ...incoming,
+          customer_name: String(preparation.customer_name || "").trim(),
+          customer_phone: String(preparation.customer_phone || "").trim(),
+          booking_mode: "scheduled",
+          service_package_groups: preparation.service_package_groups,
+          prepaid_redemption_token: preparation.prepaid_redemption_token,
+          scheduled_request_key: preparation.scheduled_request_key,
+          admin_request_key: String(incoming.admin_request_key || "").trim() || generateAdminRequestKey(),
+        };
 
-      req.body = body;
-      req.cwfBookSource = "admin";
-      const result = await service.handleAdminBookV2(req, res);
-      if (Number(res.statusCode || 200) >= 400) await releaseIfNeeded();
-      return result;
-    } catch (error) {
-      await releaseIfNeeded();
-      if (error instanceof AdminPrepaidRedemptionError) {
-        return res.status(error.statusCode || 400).json({ ok: false, error: error.code, code: error.code });
+        delete body.catalog_item_id;
+        delete body.service_package_key;
+        delete body.service_package_tier_key;
+        delete body.service_package_id;
+        delete body.service_package_tier_id;
+        delete body.promotion_id;
+        delete body.override_price;
+        delete body.override_duration_min;
+        delete body.items;
+        delete body.services;
+        delete body.service_lines;
+
+        req.body = body;
+        req.cwfBookSource = "admin";
+        const result = await service.handleAdminBookV2(req, res);
+        if (Number(res.statusCode || 200) >= 400) await releaseIfNeeded();
+        return result;
+      } catch (error) {
+        await releaseIfNeeded();
+        if (error instanceof AdminPrepaidRedemptionError) {
+          return res.status(error.statusCode || 400).json({ ok: false, error: error.code, code: error.code });
+        }
+        console.error("ADMIN_PREPAID_BOOKING_ERROR", error);
+        return res.status(500).json({ ok: false, error: "ADMIN_PREPAID_BOOKING_UNAVAILABLE", code: "ADMIN_PREPAID_BOOKING_UNAVAILABLE" });
       }
-      console.error("ADMIN_PREPAID_BOOKING_ERROR", error);
-      return res.status(500).json({ ok: false, error: "ADMIN_PREPAID_BOOKING_UNAVAILABLE", code: "ADMIN_PREPAID_BOOKING_UNAVAILABLE" });
-    }
-  });
+    });
+  }
 
   app.post("/admin/urgent_broadcast_v2", requireAdminSession, (req, res) => {
     req.body = {

--- a/server/routes/admin/adminBookings.js
+++ b/server/routes/admin/adminBookings.js
@@ -62,8 +62,11 @@ function registerAdminBookingRoutes(app, options = {}) {
       preparation = await prepaidService.prepareForAdminBooking(req.params.code);
       const body = {
         ...incoming,
-        customer_name: String(incoming.customer_name || preparation.customer_name || "").trim(),
-        customer_phone: String(incoming.customer_phone || preparation.customer_phone || "").trim(),
+        // Customer identity is part of the paid service-right contract. Admin may
+        // edit address/note/appointment for this visit, but cannot silently move
+        // the paid right to another customer's name or phone during redemption.
+        customer_name: String(preparation.customer_name || "").trim(),
+        customer_phone: String(preparation.customer_phone || "").trim(),
         booking_mode: "scheduled",
         service_package_groups: preparation.service_package_groups,
         prepaid_redemption_token: preparation.prepaid_redemption_token,

--- a/server/routes/admin/storeServicePackageCatalog.js
+++ b/server/routes/admin/storeServicePackageCatalog.js
@@ -44,6 +44,14 @@ function createStoreServicePackageCatalogRoutes({ service, requireAdminSession, 
   router.patch("/admin/catalog/service-package-bundles/:bundleKey/promotion-policy", requireAdminSession,
     handle(async (req, res) => res.json(await policyService.update(req.params.bundleKey, req.body || {}))));
 
+  // Server-authoritative PREPAID quote for Admin sale-on-behalf. This uses the
+  // same immutable package resolver as customer checkout and never trusts a
+  // client-supplied total.
+  router.post("/admin/prepaid-orders/quote", requireAdminSession, handle(async (req, res) => {
+    const quote = await prepaidService.quoteOrder(req.body || {}, { identity: "admin" });
+    return res.json({ ok: true, quote });
+  }));
+
   router.post("/admin/prepaid-orders", requireAdminSession, handle(async (req, res) => {
     const customerSub = String(req.body?.customer_sub || "").trim() || null;
     const created = await prepaidService.createOrder(req.body || {}, { customerSub, identity: "admin" });

--- a/server/services/prepaid/adminPrepaidRedemptionService.js
+++ b/server/services/prepaid/adminPrepaidRedemptionService.js
@@ -1,0 +1,197 @@
+"use strict";
+
+const crypto = require("crypto");
+const {
+  bookingTokenFromScheduledRequestKey,
+  sha256,
+} = require("./prepaidOrderServiceV2");
+
+const REDEMPTION_TTL_MINUTES = 15;
+
+class AdminPrepaidRedemptionError extends Error {
+  constructor(code, statusCode = 400, message = code) {
+    super(message);
+    this.name = "AdminPrepaidRedemptionError";
+    this.code = code;
+    this.statusCode = statusCode;
+  }
+}
+
+function clean(value, max = 256) {
+  return String(value == null ? "" : value).trim().slice(0, max);
+}
+
+function randomToken(bytes = 24) {
+  return crypto.randomBytes(bytes).toString("base64url");
+}
+
+function requestKey() {
+  return `adminprepaid_${randomToken(18)}`;
+}
+
+function parseSnapshot(value) {
+  let snapshot = value;
+  if (typeof snapshot === "string") {
+    try { snapshot = JSON.parse(snapshot); } catch (_) { snapshot = null; }
+  }
+  if (!snapshot || snapshot.schema_version !== 1
+      || !Array.isArray(snapshot.service_package_groups) || !snapshot.service_package_groups.length
+      || !Array.isArray(snapshot.services) || !snapshot.services.length
+      || !Array.isArray(snapshot.snapshots) || !snapshot.snapshots.length
+      || snapshot.payment_mode !== "prepaid_full") {
+    throw new AdminPrepaidRedemptionError("PREPAID_SNAPSHOT_INVALID", 409);
+  }
+  return snapshot;
+}
+
+function createAdminPrepaidRedemptionService({ pool, now = () => new Date() }) {
+  if (!pool || typeof pool.connect !== "function") {
+    throw new TypeError("admin prepaid redemption service requires pool");
+  }
+
+  async function withTransaction(fn) {
+    const client = await pool.connect();
+    try {
+      await client.query("BEGIN");
+      const value = await fn(client);
+      await client.query("COMMIT");
+      return value;
+    } catch (error) {
+      try { await client.query("ROLLBACK"); } catch (_) {}
+      throw error;
+    } finally {
+      client.release();
+    }
+  }
+
+  async function findLocked(client, code) {
+    const normalized = clean(code, 120);
+    if (!normalized) throw new AdminPrepaidRedemptionError("ENTITLEMENT_CODE_REQUIRED", 400);
+    const result = await client.query(
+      `SELECT e.entitlement_id, e.entitlement_code, e.status, e.customer_sub,
+              e.customer_name, e.customer_phone, e.service_snapshot, e.redeem_until,
+              e.warranty_days, e.redeemed_job_id, e.redemption_expires_at,
+              o.order_id, o.order_code, o.status AS order_status, o.paid_at
+         FROM public.customer_service_entitlements e
+         JOIN public.customer_orders o ON o.order_id=e.order_id
+        WHERE e.entitlement_code=$1 OR o.order_code=$1
+        ORDER BY e.entitlement_id DESC
+        LIMIT 1
+        FOR UPDATE OF e, o`,
+      [normalized]
+    );
+    const row = result.rows?.[0];
+    if (!row) throw new AdminPrepaidRedemptionError("ENTITLEMENT_NOT_FOUND", 404);
+    return row;
+  }
+
+  async function getForAdmin(code) {
+    return withTransaction(async (client) => {
+      const row = await findLocked(client, code);
+      const snapshot = parseSnapshot(row.service_snapshot);
+      return {
+        entitlement_code: row.entitlement_code,
+        order_code: row.order_code,
+        order_status: row.order_status,
+        entitlement_status: row.status,
+        customer_name: row.customer_name,
+        customer_phone: row.customer_phone,
+        fixed_total_price: Number(snapshot.fixed_total_price),
+        service_package_groups: snapshot.service_package_groups,
+        services: snapshot.services,
+        redeem_until: row.redeem_until,
+        warranty_days: Number(row.warranty_days || snapshot.warranty_days || 0),
+        redeemed_job_id: row.redeemed_job_id || null,
+      };
+    });
+  }
+
+  async function prepareForAdminBooking(code) {
+    return withTransaction(async (client) => {
+      const row = await findLocked(client, code);
+      if (row.order_status !== "paid" || !row.paid_at) {
+        throw new AdminPrepaidRedemptionError("PREPAID_ORDER_PAYMENT_NOT_VERIFIED", 409);
+      }
+      if (row.redeemed_job_id || row.status === "redeemed") {
+        throw new AdminPrepaidRedemptionError("ENTITLEMENT_ALREADY_REDEEMED", 409);
+      }
+      if (row.status === "cancelled") {
+        throw new AdminPrepaidRedemptionError("ENTITLEMENT_CANCELLED", 409);
+      }
+
+      const current = now();
+      const redeemUntil = new Date(row.redeem_until);
+      if (!Number.isFinite(redeemUntil.getTime()) || current > redeemUntil) {
+        await client.query(
+          `UPDATE public.customer_service_entitlements
+              SET status='expired', redemption_request_key=NULL, redemption_token_hash=NULL,
+                  redemption_booking_token=NULL, redemption_expires_at=NULL, updated_at=NOW()
+            WHERE entitlement_id=$1`,
+          [row.entitlement_id]
+        );
+        throw new AdminPrepaidRedemptionError("ENTITLEMENT_EXPIRED", 409);
+      }
+      if (!["unclaimed", "active", "redeeming"].includes(String(row.status))) {
+        throw new AdminPrepaidRedemptionError("ENTITLEMENT_NOT_REDEEMABLE", 409);
+      }
+
+      const snapshot = parseSnapshot(row.service_snapshot);
+      // Customers who bought through Admin may not have a LINE/app subject yet.
+      // Booking on behalf needs a non-null ownership principal because the same
+      // DB guard used by customer redemption intentionally refuses anonymous use.
+      // This principal is internal, unique to the paid right, and is used only
+      // when no real customer_sub exists. Once the job is created the right is
+      // consumed, so no claimable unused right is lost.
+      const ownerSub = clean(row.customer_sub, 256) || `admin-prepaid:${row.entitlement_id}`;
+      const key = requestKey();
+      const redemptionToken = randomToken(32);
+      const bookingToken = bookingTokenFromScheduledRequestKey(key);
+      const expiresAt = new Date(current.getTime() + REDEMPTION_TTL_MINUTES * 60 * 1000);
+
+      await client.query(
+        `UPDATE public.customer_service_entitlements
+            SET customer_sub=$2,
+                status='redeeming',
+                claim_token_hash=NULL,
+                redemption_request_key=$3,
+                redemption_token_hash=$4,
+                redemption_booking_token=$5,
+                redemption_expires_at=$6,
+                updated_at=NOW()
+          WHERE entitlement_id=$1`,
+        [row.entitlement_id, ownerSub, key, sha256(redemptionToken), bookingToken, expiresAt]
+      );
+      await client.query(
+        `UPDATE public.customer_orders
+            SET customer_sub=COALESCE(NULLIF(btrim(customer_sub),''),$2),
+                prepaid_claim_token_hash=NULL,
+                updated_at=NOW()
+          WHERE order_id=$1`,
+        [row.order_id, ownerSub]
+      );
+
+      return {
+        entitlement_code: row.entitlement_code,
+        order_code: row.order_code,
+        customer_name: row.customer_name,
+        customer_phone: row.customer_phone,
+        scheduled_request_key: key,
+        prepaid_redemption_token: redemptionToken,
+        redemption_expires_at: expiresAt.toISOString(),
+        service_package_groups: snapshot.service_package_groups,
+        fixed_total_price: Number(snapshot.fixed_total_price),
+        duration_min: Number(snapshot.duration_min || 0),
+        redeem_until: redeemUntil.toISOString(),
+        warranty_days: Number(row.warranty_days || snapshot.warranty_days || 0),
+      };
+    });
+  }
+
+  return { getForAdmin, prepareForAdminBooking };
+}
+
+module.exports = {
+  AdminPrepaidRedemptionError,
+  REDEMPTION_TTL_MINUTES,
+  createAdminPrepaidRedemptionService,
+};

--- a/server/services/prepaid/adminPrepaidRedemptionService.js
+++ b/server/services/prepaid/adminPrepaidRedemptionService.js
@@ -136,13 +136,14 @@ function createAdminPrepaidRedemptionService({ pool, now = () => new Date() }) {
       }
 
       const snapshot = parseSnapshot(row.service_snapshot);
-      // Customers who bought through Admin may not have a LINE/app subject yet.
-      // Booking on behalf needs a non-null ownership principal because the same
-      // DB guard used by customer redemption intentionally refuses anonymous use.
-      // This principal is internal, unique to the paid right, and is used only
-      // when no real customer_sub exists. Once the job is created the right is
-      // consumed, so no claimable unused right is lost.
-      const ownerSub = clean(row.customer_sub, 256) || `admin-prepaid:${row.entitlement_id}`;
+      const previousCustomerSub = clean(row.customer_sub, 256) || null;
+      const previousStatus = String(row.status) === "unclaimed" ? "unclaimed" : "active";
+      const temporaryOwner = previousCustomerSub == null;
+      // The existing customer redemption guard deliberately requires ownership.
+      // For an unclaimed right, use a short-lived internal principal only while
+      // Admin attempts the booking. The original claim token is intentionally
+      // preserved; if booking fails releaseAdminPreparation restores unclaimed.
+      const ownerSub = previousCustomerSub || `admin-prepaid:${row.entitlement_id}`;
       const key = requestKey();
       const redemptionToken = randomToken(32);
       const bookingToken = bookingTokenFromScheduledRequestKey(key);
@@ -152,7 +153,6 @@ function createAdminPrepaidRedemptionService({ pool, now = () => new Date() }) {
         `UPDATE public.customer_service_entitlements
             SET customer_sub=$2,
                 status='redeeming',
-                claim_token_hash=NULL,
                 redemption_request_key=$3,
                 redemption_token_hash=$4,
                 redemption_booking_token=$5,
@@ -161,16 +161,9 @@ function createAdminPrepaidRedemptionService({ pool, now = () => new Date() }) {
           WHERE entitlement_id=$1`,
         [row.entitlement_id, ownerSub, key, sha256(redemptionToken), bookingToken, expiresAt]
       );
-      await client.query(
-        `UPDATE public.customer_orders
-            SET customer_sub=COALESCE(NULLIF(btrim(customer_sub),''),$2),
-                prepaid_claim_token_hash=NULL,
-                updated_at=NOW()
-          WHERE order_id=$1`,
-        [row.order_id, ownerSub]
-      );
 
       return {
+        entitlement_id: String(row.entitlement_id),
         entitlement_code: row.entitlement_code,
         order_code: row.order_code,
         customer_name: row.customer_name,
@@ -183,11 +176,42 @@ function createAdminPrepaidRedemptionService({ pool, now = () => new Date() }) {
         duration_min: Number(snapshot.duration_min || 0),
         redeem_until: redeemUntil.toISOString(),
         warranty_days: Number(row.warranty_days || snapshot.warranty_days || 0),
+        previous_customer_sub: previousCustomerSub,
+        previous_status: previousStatus,
+        temporary_owner: temporaryOwner,
       };
     });
   }
 
-  return { getForAdmin, prepareForAdminBooking };
+  async function releaseAdminPreparation(preparation) {
+    if (!preparation?.entitlement_id || !preparation?.scheduled_request_key) return false;
+    return withTransaction(async (client) => {
+      const result = await client.query(
+        `UPDATE public.customer_service_entitlements
+            SET customer_sub=$3,
+                status=$4,
+                redemption_request_key=NULL,
+                redemption_token_hash=NULL,
+                redemption_booking_token=NULL,
+                redemption_expires_at=NULL,
+                updated_at=NOW()
+          WHERE entitlement_id=$1
+            AND redemption_request_key=$2
+            AND redeemed_job_id IS NULL
+            AND status='redeeming'
+          RETURNING entitlement_id`,
+        [
+          preparation.entitlement_id,
+          preparation.scheduled_request_key,
+          preparation.previous_customer_sub || null,
+          preparation.previous_status === "unclaimed" ? "unclaimed" : "active",
+        ]
+      );
+      return Boolean(result.rows?.[0]);
+    });
+  }
+
+  return { getForAdmin, prepareForAdminBooking, releaseAdminPreparation };
 }
 
 module.exports = {

--- a/test/adminPrepaidBookingOnBehalf.test.js
+++ b/test/adminPrepaidBookingOnBehalf.test.js
@@ -98,11 +98,12 @@ test("Admin prepaid routes reuse canonical booking and strip mutable paid-contra
   assert.match(routes, /service\.handleAdminBookV2\(req, res\)/);
   assert.match(routes, /customer_name:\s*String\(preparation\.customer_name/);
   assert.match(routes, /customer_phone:\s*String\(preparation\.customer_phone/);
-  assert.match(routes, /delete body\.promotion_id/);
-  assert.match(routes, /delete body\.override_price/);
-  assert.match(routes, /delete body\.override_duration_min/);
-  assert.match(routes, /delete body\.items/);
-  assert.match(routes, /delete body\.services/);
+  assert.match(routes, /PREPAID_BLOCKED_BOOKING_FIELDS/);
+  for (const field of ["promotion_id", "override_price", "override_duration_min", "items", "services", "service_lines"]) {
+    assert.match(routes, new RegExp(`"${field}"`));
+  }
+  assert.match(routes, /sanitizePrepaidAdminBookingInput/);
+  assert.doesNotMatch(routes, /\bdelete\b/i);
   assert.match(routes, /Number\(res\.statusCode \|\| 200\) >= 400[\s\S]*releaseIfNeeded/);
 });
 
@@ -117,7 +118,10 @@ test("Admin sale uses server-authoritative prepaid quote and existing payment ve
 test("Admin PREPAID UI exposes sale, payment, booking and promotion editing", () => {
   const html = fs.readFileSync("admin-prepaid-v2.html", "utf8");
   const js = fs.readFileSync("admin-prepaid-v2.js", "utf8");
+  const storeHtml = fs.readFileSync("admin-store-catalog.html", "utf8");
   assert.match(html, /href="\/admin-store-catalog\.html"[^>]*>แก้ไขโปรโมชั่น/);
+  assert.match(storeHtml, /admin-prepaid-v2\.html/);
+  assert.match(storeHtml, /PREPAID Admin/);
   assert.match(html, /id="btnCreateOrder"/);
   assert.match(html, /id="btnBookRight"/);
   assert.match(js, /\/admin\/prepaid-orders\/quote/);

--- a/test/adminPrepaidBookingOnBehalf.test.js
+++ b/test/adminPrepaidBookingOnBehalf.test.js
@@ -1,0 +1,129 @@
+"use strict";
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const {
+  createAdminPrepaidRedemptionService,
+} = require("../server/services/prepaid/adminPrepaidRedemptionService");
+
+function paidUnclaimedRow() {
+  return {
+    entitlement_id: 77,
+    entitlement_code: "CWF-RIGHT-ADMIN-77",
+    status: "unclaimed",
+    customer_sub: null,
+    customer_name: "ลูกค้าทดสอบ",
+    customer_phone: "0812345678",
+    service_snapshot: {
+      schema_version: 1,
+      catalog_item_id: "901",
+      fixed_total_price: "959.00",
+      duration_min: 120,
+      payment_mode: "prepaid_full",
+      warranty_days: 60,
+      redeem_until: "2027-01-31T16:59:59.999Z",
+      service_package_groups: [{ package_key: "air-reset-60-standard-small", btu: 12000, quantity: 2 }],
+      services: [{ job_type: "ล้าง", ac_type: "ผนัง", btu: 12000, machine_count: 2, wash_variant: "standard" }],
+      snapshots: [{ service_package_id: "11", service_package_tier_id: "22", service_package_snapshot: { schema_version: 3 } }],
+    },
+    redeem_until: "2027-01-31T16:59:59.999Z",
+    warranty_days: 60,
+    redeemed_job_id: null,
+    order_id: 88,
+    order_code: "CWF-ORDER-88",
+    order_status: "paid",
+    paid_at: "2026-09-12T10:00:00.000Z",
+  };
+}
+
+function fakePool() {
+  const calls = [];
+  const client = {
+    async query(sql, params = []) {
+      calls.push({ sql: String(sql), params });
+      if (/SELECT e\.entitlement_id/.test(sql) && /FOR UPDATE OF e, o/.test(sql)) {
+        return { rows: [paidUnclaimedRow()] };
+      }
+      if (/RETURNING entitlement_id/.test(sql)) return { rows: [{ entitlement_id: 77 }] };
+      return { rows: [] };
+    },
+    release() {},
+  };
+  return { calls, async connect() { return client; } };
+}
+
+test("Admin can prepare a paid unclaimed right without destroying its claim token", async () => {
+  const pool = fakePool();
+  const service = createAdminPrepaidRedemptionService({
+    pool,
+    now: () => new Date("2026-09-12T12:00:00.000Z"),
+  });
+  const prepared = await service.prepareForAdminBooking("CWF-RIGHT-ADMIN-77");
+  assert.equal(prepared.entitlement_code, "CWF-RIGHT-ADMIN-77");
+  assert.equal(prepared.temporary_owner, true);
+  assert.equal(prepared.previous_customer_sub, null);
+  assert.equal(prepared.previous_status, "unclaimed");
+  assert.match(prepared.prepaid_redemption_token, /^[A-Za-z0-9_-]+$/);
+  assert.match(prepared.scheduled_request_key, /^adminprepaid_[A-Za-z0-9_-]+$/);
+  assert.deepEqual(prepared.service_package_groups, [
+    { package_key: "air-reset-60-standard-small", btu: 12000, quantity: 2 },
+  ]);
+
+  const update = pool.calls.find((call) => /SET customer_sub=\$2/.test(call.sql) && /status='redeeming'/.test(call.sql));
+  assert.ok(update, "entitlement must enter redeeming with a temporary internal owner");
+  assert.equal(update.params[1], "admin-prepaid:77");
+  assert.doesNotMatch(update.sql, /claim_token_hash\s*=\s*NULL/i, "claim token must survive a failed Admin attempt");
+});
+
+test("Failed Admin booking preparation can restore the original unclaimed right", async () => {
+  const pool = fakePool();
+  const service = createAdminPrepaidRedemptionService({
+    pool,
+    now: () => new Date("2026-09-12T12:00:00.000Z"),
+  });
+  const prepared = await service.prepareForAdminBooking("CWF-RIGHT-ADMIN-77");
+  const restored = await service.releaseAdminPreparation(prepared);
+  assert.equal(restored, true);
+  const release = pool.calls.find((call) => /redemption_request_key=\$2/.test(call.sql) && /RETURNING entitlement_id/.test(call.sql));
+  assert.ok(release);
+  assert.equal(release.params[2], null);
+  assert.equal(release.params[3], "unclaimed");
+});
+
+test("Admin prepaid routes reuse canonical booking and strip mutable paid-contract fields", () => {
+  const routes = fs.readFileSync("server/routes/admin/adminBookings.js", "utf8");
+  assert.match(routes, /\/admin\/prepaid-entitlements\/:code\/book/);
+  assert.match(routes, /prepareForAdminBooking/);
+  assert.match(routes, /service\.handleAdminBookV2\(req, res\)/);
+  assert.match(routes, /customer_name:\s*String\(preparation\.customer_name/);
+  assert.match(routes, /customer_phone:\s*String\(preparation\.customer_phone/);
+  assert.match(routes, /delete body\.promotion_id/);
+  assert.match(routes, /delete body\.override_price/);
+  assert.match(routes, /delete body\.override_duration_min/);
+  assert.match(routes, /delete body\.items/);
+  assert.match(routes, /delete body\.services/);
+  assert.match(routes, /Number\(res\.statusCode \|\| 200\) >= 400[\s\S]*releaseIfNeeded/);
+});
+
+test("Admin sale uses server-authoritative prepaid quote and existing payment verification", () => {
+  const routes = fs.readFileSync("server/routes/admin/storeServicePackageCatalog.js", "utf8");
+  assert.match(routes, /\/admin\/prepaid-orders\/quote/);
+  assert.match(routes, /quoteOrder\(req\.body \|\| \{\}, \{ identity: "admin" \}\)/);
+  assert.match(routes, /\/admin\/prepaid-orders\/:code\/confirm-payment/);
+  assert.match(routes, /confirmManualPayment/);
+});
+
+test("Admin PREPAID UI exposes sale, payment, booking and promotion editing", () => {
+  const html = fs.readFileSync("admin-prepaid-v2.html", "utf8");
+  const js = fs.readFileSync("admin-prepaid-v2.js", "utf8");
+  assert.match(html, /href="\/admin-store-catalog\.html"[^>]*>แก้ไขโปรโมชั่น/);
+  assert.match(html, /id="btnCreateOrder"/);
+  assert.match(html, /id="btnBookRight"/);
+  assert.match(js, /\/admin\/prepaid-orders\/quote/);
+  assert.match(js, /\/admin\/prepaid-orders"/);
+  assert.match(js, /\/confirm-payment/);
+  assert.match(js, /\/admin\/prepaid-entitlements\/\$\{encodeURIComponent\(code\)\}\/book/);
+  assert.match(js, /admin_request_key/);
+  assert.match(js, /fixed_total_price/);
+});


### PR DESCRIPTION
Makes PREPAID usable for Admin end-to-end without introducing a second booking engine.

- adds Admin server-authoritative PREPAID quote endpoint
- adds Admin paid-entitlement lookup and booking-on-behalf route
- reuses canonical `/admin/book_v2` for availability, assignment, job creation and accounting
- locks customer/service/price to immutable paid entitlement snapshot
- restores an unclaimed right if Admin booking fails before job creation
- adds `/admin-prepaid-v2.html` for sale, payment verification, rights list and job creation
- keeps promotion editing in the existing Admin Store promotion-policy editor
- adds focused regression tests

No price tiers are changed.